### PR TITLE
fixed botpress start path parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "win32"
   ],
   "scripts": {
-    "compile": "rm -rf lib/ && babel src/ -d lib/ -s && cp -a src/cli/templates/. lib/cli/templates && node webpack.js --compile",
+    "compile": "rm -rf lib/ && ./node_modules/.bin/babel src/ -d lib/ -s && cp -a src/cli/templates/. lib/cli/templates && node webpack.js --compile",
     "test": "mocha test",
     "watch": "npm-watch"
   },

--- a/src/cli/start.js
+++ b/src/cli/start.js
@@ -19,7 +19,7 @@ module.exports = function(projectPath, options) {
     projectPath = '.'
   }
 
-  projectPath = path.resolve('.')
+  projectPath = path.resolve(projectPath)
 
   try {
     botpress = require(path.join(projectPath, 'node_modules', 'botpress'))


### PR DESCRIPTION
Hello,

`botpress start some/path/` was not working as it was always resolving the current directory (https://github.com/botpress/botpress/blob/master/src/cli/start.js#L22)

Cheers,

Damien