### PR TITLE
Fixing botpress start path parameter

### DIFF
--- a/src/cli/start.js
+++ b/src/cli/start.js
@@ -19,7 +19,7 @@ module.exports = function(projectPath, options) {
     projectPath = '.'
   }
 
-  projectPath = path.resolve('.')
+  projectPath = path.resolve(projectPath)
 
   try {
     botpress = require(path.join(projectPath, 'node_modules', 'botpress'))


### PR DESCRIPTION
Hello,

botpress start some/path/ was not working as it was always resolving the current directory (https://github.com/botpress/botpress/blob/master/src/cli/start.js#L22)

Cheers,

Damien