### PR TITLE
Add incremental build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ lib/
 /src/web/__modules.jsx
 /src/web/__landing.jsx
 !/src/web/views/logs
+.cache/
 
 # for vim 
 *.swp

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "expose-loader": "^0.7.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
+    "hard-source-webpack-plugin": "^0.3.7",
     "history": "^2.1.2",
     "json-loader": "^0.5.4",
     "keymirror": "^0.1.1",

--- a/webpack.js
+++ b/webpack.js
@@ -2,6 +2,7 @@ var webpack = require('webpack')
 var path = require('path')
 var CopyWebpackPlugin = require('copy-webpack-plugin')
 var autoprefixer = require('autoprefixer')
+var HardSourceWebpackPlugin = require('hard-source-webpack-plugin')
 
 var webConfig = {
   bail: true,
@@ -26,7 +27,16 @@ var webConfig = {
     }, {
       from: path.resolve(__dirname, './src/web/img'),
       to: path.resolve(__dirname, './lib/web/img')
-    }])
+    }]),
+    new HardSourceWebpackPlugin({
+      cacheDirectory: __dirname + '/.cache/',
+      recordsPath: __dirname + '/.cache/records.json',
+      environmentPaths: {
+        root: process.cwd(),
+        directories: ['node_modules'],
+        files: ['package.json', 'webpack.js'],
+      }
+    })
   ],
   module: {
     loaders: [{


### PR DESCRIPTION
Here is a PR to propose the use of the awesome `hard-source-webpack-plugin` (https://www.npmjs.com/package/hard-source-webpack-plugin) to the `webpack.js` config.
On my machine (2015  Macbook pro, 8Go , core i5 and OSX Sierra) the average build (compile task) was about 12s.

After `hard-source-webpack-plugin` installed, and after a first build it falls to and average of 5s for the build.

It also perfectly works with the `watch` task.