### PR TITLE
Exclude react from the bundle by default

### DIFF
--- a/webpack.js
+++ b/webpack.js
@@ -13,6 +13,10 @@ var webConfig = {
     publicPath: '/js/',
     filename: 'web.bundle.js'
   },
+  externals: {
+    'react': 'react',
+    'react-dom': 'reactDOM'
+  },
   resolve: {
     extensions: ['', '.js', '.jsx', '.css'],
     alias: {


### PR DESCRIPTION
I have added the 'externals' configuration option to exclude react and reactDOM.