### PR TITLE
Added support for Postgres SSL connections.

### DIFF
--- a/src/cli/templates/init/botfile.js
+++ b/src/cli/templates/init/botfile.js
@@ -39,6 +39,7 @@ module.exports = {
     port: process.env.PG_PORT || 5432,
     user: process.env.PG_USER || '',
     password: process.env.PG_PASSWORD || '',
-    database: process.env.PG_DB || ''
+    database: process.env.PG_DB || '',
+    ssl: process.env.PG_SSL || false
   }
 }

--- a/src/database.js
+++ b/src/database.js
@@ -42,7 +42,8 @@ module.exports = ({ sqlite, postgres }) => {
           port: postgres.port,
           user: postgres.user,
           password: postgres.password,
-          database: postgres.database
+          database: postgres.database,
+          ssl: postgres.ssl
         },
         useNullAsDefault: true
       })


### PR DESCRIPTION
Heroku's Postgres module doesn't support non-SSL connections, this adds support for that.