### PR TITLE
Change node minimum version to 4.6 to be compatible with dotenv module

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "webpack-node-externals": "^1.5.4"
   },
   "engines": {
-    "node": ">=4.0"
+    "node": ">=4.6.0"
   },
   "homepage": "https://github.com/botpress/botpress#readme",
   "keywords": [


### PR DESCRIPTION
Hi,

Because of Yarn Error dotenv@4.0.0: The engine "node" is incompatible with this module. Expected version ">=4.6.0", I suggest to change the min. version to 4.6 for yarn users.

Regards,
Maxime

