### PR TITLE
Added support for Postgres connection strings

### DIFF
--- a/docs/creating-your-bot/how-to-use-the-database.md
+++ b/docs/creating-your-bot/how-to-use-the-database.md
@@ -25,7 +25,8 @@ postgres: {
   port: process.env.PG_PORT || 5432,
   user: process.env.PG_USER || '',
   password: process.env.PG_PASSWORD || '',
-  database: process.env.PG_DB || ''
+  database: process.env.PG_DB || '',
+  ssl: process.env.PG_SSL || false
 }
 ```
 
@@ -36,6 +37,18 @@ The connection parameters are self-explanatory.
 ### Using Postgres on Heroku
 
 TODO: Contributions to this documentation are welcomed
+
+Heroku provides Postgres databases, however these dbs do not have static authentication details.  Thankfully, Heroku puts a connection string in the environment variables for you that stays up to date with your postgres instance.  To add your Heroku Postgres db connection, use the `connection` property in the `postgres` configuration object.
+
+```js
+postgres: {
+  enabled: process.env.DATABASE === 'postgres',
+  connection: process.env.DATABASE_URL,
+  ssl: process.env.PG_SSL || false
+}
+```
+
+Also make sure to enable SSL by setting the `PG_SSL` env variable to `true`.
 
 ### Tables
 

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -22,18 +22,30 @@ module.exports = ({ sqlite, postgres }) => {
     }
 
     if (postgres.enabled) {
-      knex = require('knex')({
-        client: 'pg',
-        connection: {
-          host: postgres.host,
-          port: postgres.port,
-          user: postgres.user,
-          password: postgres.password,
-          database: postgres.database,
-          ssl: postgres.ssl
-        },
-        useNullAsDefault: true
-      })
+
+      // If we're passing in a postgres connection string, 
+      // use that instead of the other params
+      if (postgres.connection) {
+        knex = require('knex')({
+          client: 'pg',
+          connection: postgres.connection,
+          useNullAsDefault: true
+        })
+      } else {
+        knex = require('knex')({
+          client: 'pg',
+          connection: {
+            host: postgres.host,
+            port: postgres.port,
+            user: postgres.user,
+            password: postgres.password,
+            database: postgres.database,
+            ssl: postgres.ssl
+          },
+          useNullAsDefault: true
+        })
+      }
+      
     } else {
       knex = require('knex')({
         client: 'sqlite3',


### PR DESCRIPTION
Added support to pass Postgres connection strings, since this is how Heroku gives access to their Postgres Databases (auth credentials are not static).  Also added the SSL config to the docs since that was missing and is required for Heroku.