### PR TITLE
Implemented Lightweight Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ For learn all about Botpress, please read our full [Documentation](https://botpr
 - [Deploying your bot to **Heroku**](https://botpress.io/docs/deploy/heroku.html)
 - [How to create your own Module](https://botpress.io/docs/modules/how.html)
 
-## [🎓 Examples](botpress.io/examples)
+## [🎓 Examples](https://botpress.io/examples)
 
 ## Modules
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
-1.0.10 / 2017-07-05
+1.0.11 / 2017-07-05
 ==================
 
-  * 1.0.10
+  * 1.0.11
   * There's a new kind of views that botpress can now serve: **Lightweight Views**. The purpose of these is so that modules can serve UIs that don't require any of the heavy botpress styling & APIs. The default Botpress view weighs about 1.5mb and each module about 500kb. The lightweight views weigh about 200kb total.
 
 1.0.9 / 2017-06-24

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+1.0.10 / 2017-07-05
+==================
+
+  * 1.0.10
+  * There's a new kind of views that botpress can now serve: **Lightweight Views**. The purpose of these is so that modules can serve UIs that don't require any of the heavy botpress styling & APIs. The default Botpress view weighs about 1.5mb and each module about 500kb. The lightweight views weigh about 200kb total.
+
 1.0.9 / 2017-06-24
 ==================
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,124 @@
+1.0.9 / 2017-06-24
+==================
+
+  * 1.0.9
+  * Added built-in fallback handler
+
+1.0.8 / 2017-06-22
+==================
+
+  * 1.0.8
+  * Merge branch 'master' into next
+
+1.0.7 / 2017-06-20
+==================
+
+  * Fixed webpack
+  * 1.0.7
+  * Better evaluation of arrays
+  * Rendering error
+  * Fixed issue with plugins with dots
+  * 1.0.6
+  * Uglify the build
+  * Update README.md
+  * Add count method to users
+  * Fetch list of users from userId + limit
+  * Add id value to user
+  * Fix on update + list of users + getTags
+  * Subproject sync
+  * Merge branch 'master' into next
+  * Loads the bot's .env file
+  * Ability to tag users
+  * Removed node-sass and theming
+  * Updatyed enterprise
+  * Loading config from module-name.config.yml
+  * Merge branch 'next'
+  * Switched to sitemap-general for prefix
+  * changed sitemap location
+  * Added robots.txt
+
+1.0.5 / 2017-06-08
+==================
+
+  * 1.0.5
+  * Added support for heroku postgres by default
+
+1.0.4 / 2017-06-08
+==================
+
+  * 1.0.4
+  * init creates a botpress 1 bot
+  * Added UMM Support Image
+  * 1.0.3
+  * Update README.md
+
+1.0.3 / 2017-06-07
+==================
+
+  * Removed middleware loading
+  * 1.0.2
+  * 1.0.1
+
+1.0.1 / 2017-06-07
+==================
+
+  * Added missing modules
+  * Merge branch 'master' into next
+  * Merge pull request [#155](https://github.com/botpress/botpress/issues/155) from botpress/next
+    Upcoming Botpress 1.0
+  * Added some examples
+  * Added proactive umm example
+  * Fixed typo
+  * Fixed typos
+  * Inject database to UMM
+  * Wired up proactive UMM sender + refactoring
+  * Proactive UMM sender
+  * Support for UMM in convos
+  * Anchors plugin
+  * Postgres warning heroku
+  * Botfile configuration
+  * Added dynamic css injection
+  * gitbook version
+  * Attempt at fixing style
+  * Removing gitbook
+  * Moved style
+  * Listeners (bp.hear) now add regex matchings to event (`event.captured`)
+  * Doc: umm
+  * Doc: structure
+  * Doc: flow
+  * Doc: events
+  * doc: database
+  * doc: convoersations
+  * Documentation refactoring
+  * Custom book CSS
+  * Added Hints plugin
+  * Changed contentPath in botfile
+  * No longer need to load middlewares manually
+  * Revamped botfile comments
+  * Removed incomplete examples
+  * TLDR Styling
+  * doc: Hello world demo
+  * Added a few plugins
+  * Up you'll get
+  * Added gitbook to ignored files
+
+1.0.0 / 2017-06-03
+==================
+
+  * 1.0.0
+  * Botfile documentation
+  * Moved old documentation to new layout
+  * UMM Documentation
+  * CLI Reference
+  * Introduction documentation
+  * Deploying documentation
+  * Database helper documentation
+  * Flow documentation
+  * Advanced documentation
+  * moved modules documentation
+  * Added fundamentals documentation
+  * /Doc -> Setup
+  * New documentation readme
+  * Added docs tutorials
+  * New doc summary
+  * Removed old /docs

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -47,3 +47,5 @@
   - [Exposing an API](./modules/api.md)
   - [Configuration](./modules/config.md)
   - [Module Icon](./modules/icon.md)
+  - [Light Views](./modules/light_views.md)
+  

--- a/docs/modules/light_views.md
+++ b/docs/modules/light_views.md
@@ -1,0 +1,15 @@
+# Serving lightweight views
+
+**Lightweight Views** are views that are, as their name say, lightweight. They do not inherit all the default Botpress interface (which is heavy). They contain no styling and no built-in libraries. The only thing they have is direct access to `bp` which contains a reference to the EventBus (WebSocket) and Axios.
+
+Lightweight views are bundled apart from the traditional module bundle.
+
+Here's how to create one:
+
+1. Create a react component under a `.jsx` file that exports the component class by default (`export default`)
+
+2. In your module's `webpack.js` file, locate the `lite` configuration. In the `entry` object, name your view and point to the file.
+
+3. Re-bundle your module (`npm run compile`)
+
+See the [botpress-web](https://github.com/botpress/botpress-web) module for an example

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "botpress",
   "description": "The world's first CMS for bots. Easily create, manage and extend chatbots.",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "author": "Botpress",
   "bin": {
     "bp": "./bin/botpress",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "botpress",
   "description": "The world's first CMS for bots. Easily create, manage and extend chatbots.",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "author": "Botpress",
   "bin": {
     "bp": "./bin/botpress",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prompt": "^1.0.0",
     "react-codemirror": "^1.0.0",
     "socket.io": "^1.5.0",
+    "socket.io-client": "^2.0.3",
     "socketio-jwt": "^4.5.0",
     "source-map-support": "^0.4.6",
     "sqlite3": "^3.1.8",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "sinon": "^1.17.7",
     "style-loader": "^0.13.1",
     "tmp": "0.0.31",
+    "uglifyjs-webpack-plugin": "^0.4.3",
     "webpack": "^1.13.2",
     "webpack-node-externals": "^1.5.4"
   },

--- a/src/cli/templates/create/webpack.js
+++ b/src/cli/templates/create/webpack.js
@@ -74,8 +74,21 @@ var webConfig = {
   }
 }
 
+const liteConfig = Object.assign({}, webConfig, {
+  // Add your lite views here, see example below
+  entry: {
+    // example: './src/views/example.lite.jsx'
+  },
+  output: {
+    path: './bin/lite',
+    publicPath: '/js/lite-modules/',
+    filename: '[name].bundle.js',
+    libraryTarget: 'assign',
+    library: ['botpress', pkg.name]
+  }
+})
 
-var compiler = webpack([nodeConfig, webConfig])
+var compiler = webpack([nodeConfig, webConfig, liteConfig])
 var postProcess = function(err, stats) {
   if (err) { throw err }
   console.log(stats.toString('minimal'))
@@ -89,5 +102,6 @@ if (process.argv.indexOf('--compile') !== -1) {
 
 module.exports = {
   web: webConfig,
-  node: nodeConfig
+  node: nodeConfig,
+  lite: liteConfig
 }

--- a/src/server/socket.js
+++ b/src/server/socket.js
@@ -18,7 +18,7 @@ module.exports = bp => {
     }
 
     admin.on('connection', function(socket) {
-      const visitorId = _.get('socket', 'handshake.query.visitorId')
+      const visitorId = _.get(socket, 'handshake.query.visitorId')
       bp.stats.track('socket', 'connected')
 
       socket.on('event', function(event) {
@@ -32,8 +32,12 @@ module.exports = bp => {
     })
 
     guest.on('connection', function(socket) {
-      const visitorId = _.get('socket', 'handshake.query.visitorId')
+      const visitorId = _.get(socket, 'handshake.query.visitorId')
       bp.stats.track('socket', 'connected')
+
+      if (visitorId && visitorId.length > 0) {
+        socket.join('visitor:' + visitorId)
+      }
 
       socket.on('event', function(event) {
         bp.events.emit(event.name, event.data, 'client', {

--- a/src/server/socket.js
+++ b/src/server/socket.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import socketio from 'socket.io'
 import socketioJwt from 'socketio-jwt'
 
@@ -6,18 +7,41 @@ module.exports = bp => {
   async function install(server) {
     const io = socketio(server)
 
+    const admin = io.of('/admin')
+    const guest = io.of('/guest')
+
     if (bp.botfile.login.enabled) {
-      io.use(socketioJwt.authorize({
+      admin.use(socketioJwt.authorize({
         secret: await bp.security.getSecret(),
         handshake: true
       }))
     }
 
-    io.on('connection', function(socket) {
+    admin.on('connection', function(socket) {
+      const visitorId = _.get('socket', 'handshake.query.visitorId')
       bp.stats.track('socket', 'connected')
 
       socket.on('event', function(event) {
-        bp.events.emit(event.name, event.data, 'client', { socketId: socket.id })
+        bp.events.emit(event.name, event.data, 'client', {
+          visitorId: visitorId,
+          socketId: socket.id,
+          guest: false,
+          admin: true
+        })
+      })
+    })
+
+    guest.on('connection', function(socket) {
+      const visitorId = _.get('socket', 'handshake.query.visitorId')
+      bp.stats.track('socket', 'connected')
+
+      socket.on('event', function(event) {
+        bp.events.emit(event.name, event.data, 'client', {
+          socketId: socket.id,
+          visitorId: visitorId,
+          guest: true,
+          admin: false
+        })
       })
     })
 
@@ -26,16 +50,18 @@ module.exports = bp => {
         return // we sent this ourselves
       }
 
+      let c = event.startsWith('guest.') ? guest : admin
+
       if (data && (data.__socketId || data.__room)) {
         // Send only to this socketId or room
-        return io.to(data.__socketId || data.__room).emit('event', {
+        return c.to(data.__socketId || data.__room).emit('event', {
           name: event,
           data: data
         })
       }
 
       // broadcast event to the front-end clients
-      io.emit('event', {
+      c.emit('event', {
         name: event,
         data: data
       })

--- a/src/web/components/Injected/index.jsx
+++ b/src/web/components/Injected/index.jsx
@@ -2,8 +2,6 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
 
-import _ from 'lodash'
-
 export default class InjectedComponent extends Component {
 
   static propTypes: {
@@ -41,7 +39,7 @@ export default class InjectedComponent extends Component {
 
     try {
       const Component = this.props.component
-      const passthroughProps = _.omit(this.props, 'component')
+      const passthroughProps = Object.assign({}, this.props, { component: null })
       const element = <Component key={this.componentId} {...passthroughProps} />
       ReactDOM.render(element, node)
     } catch (err) {

--- a/src/web/components/PluginInjectionSite/module.jsx
+++ b/src/web/components/PluginInjectionSite/module.jsx
@@ -85,6 +85,7 @@ export default class InjectedModuleView extends React.Component {
     const { moduleComponent } = this.state
 
     if (!!this.state.error) {
+      console.log('Error rendering plugin', this.state.error)
       return (this.props.onNotFound && this.props.onNotFound(this.state.error)) || null
     }
 

--- a/src/web/components/PluginInjectionSite/module.jsx
+++ b/src/web/components/PluginInjectionSite/module.jsx
@@ -36,7 +36,7 @@ export default class InjectedModuleView extends React.Component {
       }
 
       if (isLite) {
-        script.src = `/js/lite-modules/${moduleName}/${subView}.js`
+        script.src = `/js/modules/${moduleName}/${subView}`
       } else {
         script.src = `/js/modules/${moduleName}.js`
       }
@@ -52,13 +52,17 @@ export default class InjectedModuleView extends React.Component {
 
   setViewInState(moduleName, viewName, isLite) {
 
+    const fullModuleName = moduleName.startsWith('botpress-')
+      ? moduleName
+      : 'botpress-' + moduleName
+
     const module = isLite 
-      ? window.botpress && window.botpress[moduleName].default
-      : window.botpress && window.botpress[moduleName] && window.botpress[moduleName][viewName]
+      ? window.botpress && window.botpress[fullModuleName].default
+      : window.botpress && window.botpress[fullModuleName] && window.botpress[fullModuleName][viewName]
 
     if (!module) {
       this.setState({
-        error: new Error(`Subview "${viewName}" doesn't exist for module "${moduleName}"`),
+        error: new Error(`Subview "${viewName}" doesn't exist for module "${fullModuleName}"`),
         moduleComponent: null
       })
     } else {

--- a/src/web/components/PluginInjectionSite/module.jsx
+++ b/src/web/components/PluginInjectionSite/module.jsx
@@ -101,5 +101,3 @@ export default class InjectedModuleView extends React.Component {
     return <InjectedComponent component={moduleComponent} name={this.props.moduleName} bp={bp}/>
   }
 }
-
-// <InjectedModuleView moduleName={} viewName={} onNotFound={}/>

--- a/src/web/components/PluginInjectionSite/module.jsx
+++ b/src/web/components/PluginInjectionSite/module.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import _ from 'lodash'
 import axios from 'axios'
 
 import InjectedComponent from '~/components/Injected'
@@ -15,9 +14,10 @@ export default class InjectedModuleView extends React.Component {
     }
   }
 
-  loadModule(modName, viewName) {
+  loadModule(modName, viewName, lite) {
     const moduleName = modName || this.props.moduleName
     const subView = viewName || this.props.viewName || 'default'
+    const isLite = lite || this.props.lite || false
 
     if (moduleName === this.state.moduleName && subView == this.state.viewName) {
       return
@@ -31,28 +31,39 @@ export default class InjectedModuleView extends React.Component {
       script.onload = () => {
         script.onload = null
         setImmediate(() => {
-          this.setViewInState(moduleName, subView)
+          this.setViewInState(moduleName, subView, isLite)
         })
       }
-      script.src = `/js/modules/${moduleName}.js`
+
+      if (isLite) {
+        script.src = `/js/lite-modules/${moduleName}/${subView}.js`
+      } else {
+        script.src = `/js/modules/${moduleName}.js`
+      }
+      
       document.getElementsByTagName("head")[0].appendChild(script)
     } else {
       this.setState({ moduleComponent: null })
       setImmediate(() => {
-        this.setViewInState(moduleName, subView)
+        this.setViewInState(moduleName, subView, isLite)
       })
     }
   }
 
-  setViewInState(moduleName, viewName) {
-    if (_.isNil(_.get(window, `botpress.${moduleName}.${viewName}`))) {
+  setViewInState(moduleName, viewName, isLite) {
+
+    const module = isLite 
+      ? window.botpress && window.botpress[moduleName].default
+      : window.botpress && window.botpress[moduleName] && window.botpress[moduleName][viewName]
+
+    if (!module) {
       this.setState({
         error: new Error(`Subview "${viewName}" doesn't exist for module "${moduleName}"`),
         moduleComponent: null
       })
     } else {
       this.setState({
-        moduleComponent: window.botpress[moduleName][viewName],
+        moduleComponent: module,
         error: null
       })
     }
@@ -63,7 +74,7 @@ export default class InjectedModuleView extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.loadModule(nextProps.moduleName, nextProps.viewName)
+    this.loadModule(nextProps.moduleName, nextProps.viewName, nextProps.lite)
   }
 
   render() {

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -14,7 +14,6 @@
 
 <body>
     <div id="app"></div>
-    <script src="/socket.io/socket.io.js"></script>
     <script src="/js/env.js"></script>
     <script src="/js/web.bundle.js"></script>
 </body>

--- a/src/web/lite.html
+++ b/src/web/lite.html
@@ -8,15 +8,12 @@
     <meta name="keywords" content="">
     <link rel="icon" type="image/png" href="/img/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="/img/favicon-16x16.png" sizes="16x16" />
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link href="/style/custom-theme.css" rel="stylesheet">
 </head>
 
 <body>
     <div id="app"></div>
-    <script src="/socket.io/socket.io.js"></script>
     <script src="/js/env.js"></script>
-    <script src="/js/web.bundle.js"></script>
+    <script src="/js/lite.bundle.js"></script>
 </body>
 
 </html>

--- a/src/web/lite.jsx
+++ b/src/web/lite.jsx
@@ -1,0 +1,23 @@
+import React from 'expose?React!react'
+import ReactDOM from 'expose?ReactDOM!react-dom'
+
+import InjectedModuleView from '~/components/PluginInjectionSite/module'
+
+console.log(window.location)
+
+const moduleName = 'botpress-messenger-views'
+const subView = 'hello.bundle'
+
+const LiteView = props => {
+  const moduleView = <InjectedModuleView
+    moduleName={moduleName}
+    viewName={subView}
+    lite={true}
+    onNotFound={() => {
+      console.log('View NOT FOUND')
+    }} />
+
+  return moduleView
+}
+
+ReactDOM.render(<LiteView />, document.getElementById('app'))

--- a/src/web/lite.jsx
+++ b/src/web/lite.jsx
@@ -3,21 +3,28 @@ import ReactDOM from 'expose?ReactDOM!react-dom'
 
 import InjectedModuleView from '~/components/PluginInjectionSite/module'
 
-console.log(window.location)
-
-const moduleName = 'botpress-messenger-views'
-const subView = 'hello.bundle'
+const { m, v } = parseQueryString()
 
 const LiteView = props => {
-  const moduleView = <InjectedModuleView
-    moduleName={moduleName}
-    viewName={subView}
+  return <InjectedModuleView
+    moduleName={m}
+    viewName={v}
     lite={true}
-    onNotFound={() => {
-      console.log('View NOT FOUND')
-    }} />
-
-  return moduleView
+    onNotFound={() => <h1>Module ${m} with view ${v} not found</h1>} />
 }
 
 ReactDOM.render(<LiteView />, document.getElementById('app'))
+
+function parseQueryString() {
+  let queryString = window.location.search || '?'
+  queryString = queryString.substring(1)
+
+  let params = {}, queries, temp, i, l
+  queries = queryString.split('&')
+
+  for(i = 0, l = queries.length; i < l; i++) {
+    temp = queries[i].split('=')
+    params[temp[0]] = temp[1]
+  }
+  return params
+}

--- a/src/web/util/Auth.js
+++ b/src/web/util/Auth.js
@@ -61,6 +61,7 @@ export const getUniqueVisitorId = () => {
   const localUserId = localStorage.getItem('bp/socket/user')
   if (localUserId) {
     userId = localUserId
+    window.__BP_VISITOR_ID = localUserId
   } else {
     localStorage.setItem('bp/socket/user', userId)
   }

--- a/src/web/util/Auth.js
+++ b/src/web/util/Auth.js
@@ -1,5 +1,6 @@
 import EventEmitter2 from 'eventemitter2'
 import axios from 'axios'
+import uuid from 'uuid'
 
 const storageKey = 'bp/token'
 export const authEvents = (new EventEmitter2())
@@ -53,4 +54,15 @@ export const login = (user, password) => {
       throw new Error(result.data.reason)
     }
   })
+}
+
+export const getUniqueVisitorId = () => {
+  let userId = uuid.v4()
+  const localUserId = localStorage.getItem('bp/socket/user')
+  if (localUserId) {
+    userId = localUserId
+  } else {
+    localStorage.setItem('bp/socket/user', userId)
+  }
+  return userId
 }

--- a/src/web/util/EventBus.js
+++ b/src/web/util/EventBus.js
@@ -57,7 +57,7 @@ class EventBus extends EventEmitter2 {
       this.guestSocket.disconnect()
     }
 
-    let socketUrl = window.location.origin 
+    let socketUrl = window.location.origin
     
     this.adminSocket = io(socketUrl + '/admin', { query })
     this.adminSocket.on('event', this.dispatchSocketEvent)

--- a/src/web/util/EventBus.js
+++ b/src/web/util/EventBus.js
@@ -1,8 +1,9 @@
 /* global io */
 
 import EventEmitter2 from 'eventemitter2'
+import io from 'socket.io-client'
 
-import { getToken, authEvents } from '~/util/Auth'
+import { getToken, authEvents, getUniqueVisitorId } from '~/util/Auth'
 
 class EventBus extends EventEmitter2 {
 
@@ -30,28 +31,39 @@ class EventBus extends EventEmitter2 {
       return
     }
 
-    if (this.socket) {
-      this.socket.emit('event', { name, data: data })
-    }
+    let c = name.startsWith('guest.') ? this.guestSocket : this.adminSocket
+    c && c.emit('event', { name, data: data })
   }
 
   setup() {
-    let query = ''
+    let query = {
+      visitorId: getUniqueVisitorId()
+    }
+
     if (window.AUTH_ENABLED) {
       const token = getToken()
       if (!!token) {
-        query = 'token=' + token.token
+        Object.assign(query, { token: token.token })
       }
     }
 
-    if (this.socket) {
-      this.socket.off('event', this.dispatchEvent)
-      this.socket.disconnect()
+    if (this.adminSocket) {
+      this.adminSocket.off('event', this.dispatchEvent)
+      this.adminSocket.disconnect()
     }
 
-    let socketUrl = window.location.origin
-    const socket = this.socket = io.connect(socketUrl, { query })
-    socket.on('event', this.dispatchSocketEvent)
+    if (this.guestSocket) {
+      this.guestSocket.off('event', this.dispatchEvent)
+      this.guestSocket.disconnect()
+    }
+
+    let socketUrl = window.location.origin 
+    
+    this.adminSocket = io(socketUrl + '/admin', { query })
+    this.adminSocket.on('event', this.dispatchSocketEvent)
+
+    this.guestSocket = io(socketUrl + '/guest')
+    this.guestSocket.on('event', this.dispatchSocketEvent)
   }
 }
 

--- a/webpack.js
+++ b/webpack.js
@@ -92,7 +92,7 @@ var webConfig = {
       to: path.resolve(__dirname, './lib/web/index.html')
     }, {
       from: path.resolve(__dirname, './src/web/lite.html'),
-      to: path.resolve(__dirname, './lib/web/lite.html')
+      to: path.resolve(__dirname, './lib/web/lite/index.html')
     },
     {
       from: path.resolve(__dirname, './src/web/img'),

--- a/webpack.js
+++ b/webpack.js
@@ -56,8 +56,8 @@ var webConfig = {
   bail: true,
   devtool: 'source-map',
   entry: {
-    web: './src/web/index.jsx'
-    // lite: './src/web/lite.jsx'
+    web: './src/web/index.jsx',
+    lite: './src/web/lite.jsx'
   },
   output: {
     path: './lib/web/js',
@@ -90,9 +90,9 @@ var webConfig = {
     new CopyWebpackPlugin([{
       from: path.resolve(__dirname, './src/web/index.html'),
       to: path.resolve(__dirname, './lib/web/index.html')
-    // }, {
-    //   from: path.resolve(__dirname, './src/web/lite.html'),
-    //   to: path.resolve(__dirname, './lib/web/lite.html')
+    }, {
+      from: path.resolve(__dirname, './src/web/lite.html'),
+      to: path.resolve(__dirname, './lib/web/lite.html')
     },
     {
       from: path.resolve(__dirname, './src/web/img'),

--- a/webpack.js
+++ b/webpack.js
@@ -4,6 +4,7 @@ var CopyWebpackPlugin = require('copy-webpack-plugin')
 var autoprefixer = require('autoprefixer')
 // var HardSourceWebpackPlugin = require('hard-source-webpack-plugin')
 var nodeExternals = require('webpack-node-externals')
+const UglifyJSPlugin = require('uglifyjs-webpack-plugin')
 
 var ExtensionsPlugin = require('./extensions/extensions-plugin')
 
@@ -54,11 +55,14 @@ var nodeConfig = {
 var webConfig = {
   bail: true,
   devtool: 'source-map',
-  entry: ['./src/web/index.jsx'],
+  entry: {
+    web: './src/web/index.jsx',
+    lite: './src/web/lite.jsx'
+  },
   output: {
     path: './lib/web/js',
     publicPath: '/js/',
-    filename: 'web.bundle.js'
+    filename: '[name].bundle.js'
   },
   resolve: {
     extensions: ['', '.js', '.jsx', '.css'],
@@ -70,11 +74,27 @@ var webConfig = {
   plugins: [
     ExtensionsPlugin.beforeResolve,
     ExtensionsPlugin.afterResolve,
+    new webpack.DefinePlugin({
+      BP_EDITION: JSON.stringify(process.env.BOTPRESS_EDITION || 'lite'),
+      'process.env': {
+        'NODE_ENV': JSON.stringify('production')
+      }
+    }),
+    new UglifyJSPlugin({
+      compress: { warnings: false },
+      comments: false,
+      minimize: false,
+      sourceMap: true
+    }),
     new webpack.NoErrorsPlugin(),
     new CopyWebpackPlugin([{
       from: path.resolve(__dirname, './src/web/index.html'),
       to: path.resolve(__dirname, './lib/web/index.html')
     }, {
+      from: path.resolve(__dirname, './src/web/lite.html'),
+      to: path.resolve(__dirname, './lib/web/lite.html')
+    },
+    {
       from: path.resolve(__dirname, './src/web/img'),
       to: path.resolve(__dirname, './lib/web/img')
     }, {
@@ -100,7 +120,7 @@ var webConfig = {
       query: {
         presets: ['latest', 'stage-0', 'react'],
         plugins: ['transform-object-rest-spread', 'transform-decorators-legacy'],
-        compact: false,
+        compact: true,
         babelrc: false,
         cacheDirectory: true
       }
@@ -118,7 +138,7 @@ var webConfig = {
       loader: "json-loader"
     }]
   },
-  postcss: [ autoprefixer({ browsers: ['last 2 versions'] }) ]
+  postcss: [autoprefixer({ browsers: ['last 2 versions'] })]
 }
 
 var compiler = webpack([webConfig, nodeConfig])

--- a/yarn.lock
+++ b/yarn.lock
@@ -1737,6 +1737,12 @@ debug@2.6.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0:
   dependencies:
     ms "0.7.2"
 
+debug@~2.6.4:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -1970,6 +1976,23 @@ engine.io-client@1.8.2:
     xmlhttprequest-ssl "1.5.3"
     yeast "0.1.2"
 
+engine.io-client@~3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.1.1.tgz#415a9852badb14fa008fa3ef1e31608db6761325"
+  dependencies:
+    component-emitter "1.2.1"
+    component-inherit "0.0.3"
+    debug "~2.6.4"
+    engine.io-parser "~2.1.1"
+    has-cors "1.1.0"
+    indexof "0.0.1"
+    parsejson "0.0.3"
+    parseqs "0.0.5"
+    parseuri "0.0.5"
+    ws "~2.3.1"
+    xmlhttprequest-ssl "1.5.3"
+    yeast "0.1.2"
+
 engine.io-parser@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-1.3.2.tgz#937b079f0007d0893ec56d46cb220b8cb435220a"
@@ -1980,6 +2003,16 @@ engine.io-parser@1.3.2:
     blob "0.0.4"
     has-binary "0.1.7"
     wtf-8 "1.0.0"
+
+engine.io-parser@~2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-2.1.1.tgz#e0fb3f0e0462f7f58bb77c1a52e9f5a7e26e4668"
+  dependencies:
+    after "0.8.2"
+    arraybuffer.slice "0.0.6"
+    base64-arraybuffer "0.1.5"
+    blob "0.0.4"
+    has-binary2 "~1.0.2"
 
 engine.io@1.8.2:
   version "1.8.2"
@@ -2741,6 +2774,12 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-binary2@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-binary2/-/has-binary2-1.0.2.tgz#e83dba49f0b9be4d026d27365350d9f03f54be98"
+  dependencies:
+    isarray "2.0.1"
+
 has-binary@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/has-binary/-/has-binary-0.1.7.tgz#68e61eb16210c9545a0a5cce06a873912fe1e68c"
@@ -3150,6 +3189,10 @@ isarray@0.0.1:
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isarray@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.1.tgz#a37d94ed9cda2d59865c9f76fe596ee1f338741e"
 
 isemail@1.x.x:
   version "1.2.0"
@@ -3910,6 +3953,10 @@ ms@0.7.1:
 ms@0.7.2, ms@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
 mustache@^2.3.0:
   version "2.3.0"
@@ -5420,7 +5467,7 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
-safe-buffer@^5.0.1:
+safe-buffer@^5.0.1, safe-buffer@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
@@ -5626,6 +5673,24 @@ socket.io-client@1.7.2:
     socket.io-parser "2.3.1"
     to-array "0.1.4"
 
+socket.io-client@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.0.3.tgz#6caf4aff9f85b19fd91b6ce13d69adb564f8873b"
+  dependencies:
+    backo2 "1.0.2"
+    base64-arraybuffer "0.1.5"
+    component-bind "1.0.0"
+    component-emitter "1.2.1"
+    debug "~2.6.4"
+    engine.io-client "~3.1.0"
+    has-cors "1.1.0"
+    indexof "0.0.1"
+    object-component "0.0.3"
+    parseqs "0.0.5"
+    parseuri "0.0.5"
+    socket.io-parser "~3.1.1"
+    to-array "0.1.4"
+
 socket.io-parser@2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-2.3.1.tgz#dd532025103ce429697326befd64005fcfe5b4a0"
@@ -5634,6 +5699,15 @@ socket.io-parser@2.3.1:
     debug "2.2.0"
     isarray "0.0.1"
     json3 "3.3.2"
+
+socket.io-parser@~3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.1.2.tgz#dbc2282151fc4faebbe40aeedc0772eba619f7f2"
+  dependencies:
+    component-emitter "1.2.1"
+    debug "~2.6.4"
+    has-binary2 "~1.0.2"
+    isarray "2.0.1"
 
 socket.io@^1.5.0:
   version "1.7.2"
@@ -6097,6 +6171,10 @@ ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
 
+ultron@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.0.tgz#b07a2e6a541a815fc6a34ccd4533baec307ca864"
+
 uncontrollable@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-4.0.3.tgz#06ec76cb9e02914756085d9cea0354fc746b09b4"
@@ -6424,6 +6502,13 @@ ws@1.1.1:
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"
+
+ws@~2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-2.3.1.tgz#6b94b3e447cb6a363f785eaf94af6359e8e81c80"
+  dependencies:
+    safe-buffer "~5.0.1"
+    ultron "~1.1.0"
 
 wtf-8@1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,6 +39,10 @@ acorn@^4.0.1:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
 
+addressparser@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/addressparser/-/addressparser-1.0.1.tgz#47afbe1a2a9262191db6838e4fd1d39b40821746"
+
 after@0.8.2, after@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
@@ -203,11 +207,11 @@ async@^0.9.0, async@~0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
 
-async@^1.3.0, async@^1.5.0:
+async@^1.3.0, async@^1.4.0, async@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.0.1, async@^2.1.4:
+async@^2.0.1, async@^2.1.2, async@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/async/-/async-2.1.4.tgz#2d2160c7788032e4dd6cbe2502f1f9a2c8f6cde4"
   dependencies:
@@ -472,6 +476,12 @@ babel-plugin-check-es2015-constants@^6.22.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
   dependencies:
     babel-runtime "^6.22.0"
+
+babel-plugin-root-import@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-root-import/-/babel-plugin-root-import-5.1.0.tgz#80ea1cd5945b463a5e3f7e204a69478c573e328c"
+  dependencies:
+    slash "^1.0.0"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -1067,7 +1077,7 @@ bluebird@^2.10.2:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
 
-bluebird@^3.0.0, bluebird@^3.4.6:
+bluebird@^3.0.0, bluebird@^3.1.1, bluebird@^3.4.6:
   version "3.4.7"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
 
@@ -1085,6 +1095,10 @@ body-parser@^1.15.2:
     qs "6.2.1"
     raw-body "~2.2.0"
     type-is "~1.6.14"
+
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
 
 boom@2.x.x:
   version "2.10.1"
@@ -1153,6 +1167,18 @@ buffer@^4.9.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+buildmail@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/buildmail/-/buildmail-4.0.1.tgz#877f7738b78729871c9a105e3b837d2be11a7a72"
+  dependencies:
+    addressparser "1.0.1"
+    libbase64 "0.1.0"
+    libmime "3.0.0"
+    libqp "1.1.0"
+    nodemailer-fetch "1.6.0"
+    nodemailer-shared "1.1.0"
+    punycode "1.4.1"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -1242,6 +1268,27 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+cheerio@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.22.0.tgz#a9baa860a3f9b595a6b81b1a86873121ed3a269e"
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash.assignin "^4.0.9"
+    lodash.bind "^4.1.4"
+    lodash.defaults "^4.0.1"
+    lodash.filter "^4.4.0"
+    lodash.flatten "^4.2.0"
+    lodash.foreach "^4.3.0"
+    lodash.map "^4.4.0"
+    lodash.merge "^4.4.0"
+    lodash.pick "^4.2.1"
+    lodash.reduce "^4.4.0"
+    lodash.reject "^4.4.0"
+    lodash.some "^4.4.0"
+
 chokidar@^1.0.0, chokidar@^1.4.3, chokidar@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.6.1.tgz#2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2"
@@ -1314,6 +1361,10 @@ coa@~1.0.1:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+codemirror@^5.18.2:
+  version "5.26.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.26.0.tgz#bcbee86816ed123870c260461c2b5c40b68746e5"
 
 color-convert@^1.3.0:
   version "1.9.0"
@@ -1440,6 +1491,12 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
+consolidate@^0.14.2:
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/consolidate/-/consolidate-0.14.5.tgz#5a25047bc76f73072667c8cb52c989888f494c63"
+  dependencies:
+    bluebird "^3.1.1"
+
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
@@ -1500,11 +1557,27 @@ cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
     parse-json "^2.2.0"
     require-from-string "^1.1.0"
 
+create-react-class@^15.5.1:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
   dependencies:
     lru-cache "^4.0.1"
+    which "^1.2.9"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
     which "^1.2.9"
 
 cryptiles@2.x.x:
@@ -1543,6 +1616,15 @@ css-loader@^0.25.0:
     postcss-modules-values "^1.1.0"
     source-list-map "^0.1.4"
 
+css-select@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
 css-selector-tokenizer@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz#6445f582c7930d241dcc5007a43d6fcb8f073152"
@@ -1550,6 +1632,10 @@ css-selector-tokenizer@^0.6.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-what@2.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
 cssesc@^0.1.0:
   version "0.1.0"
@@ -1621,6 +1707,14 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+datauri@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/datauri/-/datauri-1.0.5.tgz#d0975d1ab6c8f2e0ce3ca43baa4539be12d289a0"
+  dependencies:
+    image-size "^0.3.5"
+    mimer "^0.2.1"
+    semver "^5.0.3"
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -1660,6 +1754,10 @@ deep-equal@^1.0.0:
 deep-equal@~0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-0.2.2.tgz#84b745896f34c684e98f2ce0e42abaf43bba017d"
+
+deep-extend@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.5.0.tgz#6ef4a09b05f98b0e358d6d93d4ca3caec6672803"
 
 deep-extend@~0.4.0:
   version "0.4.1"
@@ -1734,9 +1832,37 @@ dom-helpers@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-2.4.0.tgz#9bb4b245f637367b1fa670274272aa28fe06c367"
 
+dom-serializer@0, dom-serializer@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+  dependencies:
+    domelementtype "~1.1.1"
+    entities "~1.1.1"
+
 domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
+
+domelementtype@1, domelementtype@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+
+domelementtype@~1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
+
+domhandler@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
+  dependencies:
+    domelementtype "1"
+
+domutils@1.5.1, domutils@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
 
 dotenv@^4.0.0:
   version "4.0.0"
@@ -1781,6 +1907,17 @@ ee-first@1.1.1:
 electron-to-chromium@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.2.1.tgz#63ac7579a1c5bedb296c8607621f2efc9a54b968"
+
+email-templates@^2.5.4:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/email-templates/-/email-templates-2.6.0.tgz#f15f92ae1f5ece7aae5d471f167608388603acda"
+  dependencies:
+    bluebird "^3.0.0"
+    consolidate "^0.14.2"
+    debug "^2.2.0"
+    glob "^6.0.0"
+    juice "^4.1.0"
+    lodash "^4.0.1"
 
 emoji-annotation-to-unicode@^0.2.4:
   version "0.2.4"
@@ -1863,7 +2000,7 @@ enhanced-resolve@~0.9.0:
     memory-fs "^0.2.0"
     tapable "^0.1.8"
 
-"entities@~ 1.1.1":
+entities@^1.1.1, "entities@~ 1.1.1", entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
@@ -2001,6 +2138,10 @@ espree@^3.3.1:
 esprima@^2.6.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+
+esprima@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
 esrecurse@^4.1.0:
   version "4.1.0"
@@ -2164,9 +2305,9 @@ fastparse@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.8.tgz#02f1b6e0ea0d46c24e0b51a2d24df069563a5ad6"
+fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -2294,6 +2435,10 @@ formatio@1.1.1:
   resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
   dependencies:
     samsam "~1.1"
+
+formidable@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
 
 forwarded@~0.1.0:
   version "0.1.0"
@@ -2482,7 +2627,7 @@ glob@7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^6.0.4:
+glob@^6.0.0, glob@^6.0.4:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
   dependencies:
@@ -2557,6 +2702,16 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6,
 growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
+
+handlebars@^4.0.6:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.10.tgz#3d30c718b09a3d96f23ea4cc1f403c4d3ba9ff4f"
+  dependencies:
+    async "^1.4.0"
+    optimist "^0.6.1"
+    source-map "^0.4.4"
+  optionalDependencies:
+    uglify-js "^2.6"
 
 har-validator@~2.0.6:
   version "2.0.6"
@@ -2653,9 +2808,24 @@ hosted-git-info@^2.1.4:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.1.5.tgz#0ba81d90da2e25ab34a332e6ec77936e1598118b"
 
+howler@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/howler/-/howler-2.0.4.tgz#cbd5db875f9833e1aa6084568951d788fc687f92"
+
 html-comment-regex@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.1.tgz#668b93776eaae55ebde8f3ad464b307a4963625e"
+
+htmlparser2@^3.9.1, htmlparser2@^3.9.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
 
 http-errors@~1.5.1:
   version "1.5.1"
@@ -2672,6 +2842,17 @@ http-signature@~1.1.0:
     assert-plus "^0.2.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
+
+httpntlm@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/httpntlm/-/httpntlm-1.6.1.tgz#ad01527143a2e8773cfae6a96f58656bb52a34b2"
+  dependencies:
+    httpreq ">=0.4.22"
+    underscore "~1.7.0"
+
+httpreq@>=0.4.22:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/httpreq/-/httpreq-0.4.23.tgz#0f460fe0c781029bcad7f47cad08de6cc1130212"
 
 https-browserify@0.0.1:
   version "0.0.1"
@@ -2707,6 +2888,10 @@ ignore-by-default@^1.0.0:
 ignore@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.2.tgz#1c51e1ef53bab6ddc15db4d9ac4ec139eceb3410"
+
+image-size@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.3.5.tgz#83240eab2fb5b00b04aab8c74b0471e9cba7ad8c"
 
 immutable@^3.8.1:
   version "3.8.1"
@@ -2792,6 +2977,10 @@ invariant@^2.0.0, invariant@^2.1.0, invariant@^2.2.0, invariant@^2.2.1:
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+
+ip@^1.1.2:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
 
 ipaddr.js@1.2.0:
   version "1.2.0"
@@ -3014,7 +3203,14 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@~3.7.0:
+js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.8.4:
+  version "3.8.4"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^3.1.1"
+
+js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:
@@ -3107,6 +3303,18 @@ jsprim@^1.2.2:
     extsprintf "1.0.2"
     json-schema "0.2.3"
     verror "1.3.6"
+
+juice@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/juice/-/juice-4.1.0.tgz#f54177a6576e7a82d108a6fd0b92ebb043470d81"
+  dependencies:
+    cheerio "^0.22.0"
+    commander "2.9.0"
+    cross-spawn "^5.0.1"
+    deep-extend "^0.5.0"
+    mensch "^0.3.3"
+    slick "1.12.2"
+    web-resource-inliner "^4.1.0"
 
 jwa@^1.1.4:
   version "1.1.5"
@@ -3244,6 +3452,22 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+libbase64@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/libbase64/-/libbase64-0.1.0.tgz#62351a839563ac5ff5bd26f12f60e9830bb751e6"
+
+libmime@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/libmime/-/libmime-3.0.0.tgz#51a1a9e7448ecbd32cda54421675bb21bc093da6"
+  dependencies:
+    iconv-lite "0.4.15"
+    libbase64 "0.1.0"
+    libqp "1.1.0"
+
+libqp@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/libqp/-/libqp-1.1.0.tgz#f5e6e06ad74b794fb5b5b66988bf728ef1dedbe8"
+
 liftoff@~2.2.0:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/liftoff/-/liftoff-2.2.5.tgz#998c2876cff484b103e4423b93d356da44734c91"
@@ -3331,6 +3555,14 @@ lodash.assign@^4.0.3, lodash.assign@^4.0.6, lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
+lodash.assignin@^4.0.9:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
+
+lodash.bind@^4.1.4:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
+
 lodash.camelcase@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz#932c8b87f8a4377897c67197533282f97aeac298"
@@ -3353,6 +3585,10 @@ lodash.create@3.1.1:
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
 
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+
 lodash.deburr@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-3.2.0.tgz#6da8f54334a366a7cf4c4c76ef8d80aa1b365ed5"
@@ -3366,6 +3602,22 @@ lodash.defaults@^3.1.2:
     lodash.assign "^3.0.0"
     lodash.restparam "^3.0.0"
 
+lodash.defaults@^4.0.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+
+lodash.filter@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
+
+lodash.flatten@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+
+lodash.foreach@^4.3.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+
 lodash.indexof@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/lodash.indexof/-/lodash.indexof-4.0.5.tgz#53714adc2cddd6ed87638f893aa9b6c24e31ef3c"
@@ -3377,6 +3629,10 @@ lodash.isarguments@^3.0.0:
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
@@ -3390,9 +3646,17 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
+lodash.map@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
+
 lodash.memoize@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+
+lodash.merge@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
 lodash.once@^4.0.0:
   version "4.1.1"
@@ -3410,13 +3674,33 @@ lodash.padstart@^4.1.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.padstart/-/lodash.padstart-4.6.1.tgz#d2e3eebff0d9d39ad50f5cbd1b52a7bce6bb611b"
 
+lodash.pick@^4.2.1:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+
 lodash.pickby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
 
+lodash.reduce@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
+
+lodash.reject@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
+
 lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
+
+lodash.some@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
+
+lodash.unescape@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
 
 lodash.uniq@^4.3.0:
   version "4.5.0"
@@ -3428,7 +3712,7 @@ lodash.words@^3.0.0:
   dependencies:
     lodash._root "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.0:
+lodash@^4.0.0, lodash@^4.0.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3444,7 +3728,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -3471,6 +3755,13 @@ lru-cache@^4.0.1:
 macaddress@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
+
+mailcomposer@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/mailcomposer/-/mailcomposer-4.0.1.tgz#0e1c44b2a07cf740ee17dc149ba009f19cadfeb4"
+  dependencies:
+    buildmail "4.0.1"
+    libmime "3.0.0"
 
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
@@ -3504,6 +3795,10 @@ memory-fs@~0.3.0:
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
+
+mensch@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/mensch/-/mensch-0.3.3.tgz#e200ff4dd823717f8e0563b32e3f5481fca262b2"
 
 meow@^3.7.0:
   version "3.7.0"
@@ -3560,6 +3855,10 @@ mime@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
+mimer@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/mimer/-/mimer-0.2.1.tgz#c63c5a17fe86423f5161a85d55c3ed5189baaffc"
+
 "minimatch@2 || 3", minimatch@3, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
@@ -3611,6 +3910,10 @@ ms@0.7.1:
 ms@0.7.2, ms@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
+
+mustache@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.0.tgz#4028f7778b17708a489930a6e52ac3bca0da41d0"
 
 mute-stream@0.0.5:
   version "0.0.5"
@@ -3774,6 +4077,55 @@ node-uuid@^1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.7.tgz#6da5a17668c4b3dd59623bda11cf7fa4c1f60a6f"
 
+nodemailer-direct-transport@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/nodemailer-direct-transport/-/nodemailer-direct-transport-3.3.2.tgz#e96fafb90358560947e569017d97e60738a50a86"
+  dependencies:
+    nodemailer-shared "1.1.0"
+    smtp-connection "2.12.0"
+
+nodemailer-fetch@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz#79c4908a1c0f5f375b73fe888da9828f6dc963a4"
+
+nodemailer-shared@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz#cf5994e2fd268d00f5cf0fa767a08169edb07ec0"
+  dependencies:
+    nodemailer-fetch "1.6.0"
+
+nodemailer-smtp-pool@2.8.2:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/nodemailer-smtp-pool/-/nodemailer-smtp-pool-2.8.2.tgz#2eb94d6cf85780b1b4725ce853b9cbd5e8da8c72"
+  dependencies:
+    nodemailer-shared "1.1.0"
+    nodemailer-wellknown "0.1.10"
+    smtp-connection "2.12.0"
+
+nodemailer-smtp-transport@2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/nodemailer-smtp-transport/-/nodemailer-smtp-transport-2.7.2.tgz#03d71c76314f14ac7dbc7bf033a6a6d16d67fb77"
+  dependencies:
+    nodemailer-shared "1.1.0"
+    nodemailer-wellknown "0.1.10"
+    smtp-connection "2.12.0"
+
+nodemailer-wellknown@0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/nodemailer-wellknown/-/nodemailer-wellknown-0.1.10.tgz#586db8101db30cb4438eb546737a41aad0cf13d5"
+
+nodemailer@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-2.7.2.tgz#f242e649aeeae39b6c7ed740ef7b061c404d30f9"
+  dependencies:
+    libmime "3.0.0"
+    mailcomposer "4.0.1"
+    nodemailer-direct-transport "3.3.2"
+    nodemailer-shared "1.1.0"
+    nodemailer-smtp-pool "2.8.2"
+    nodemailer-smtp-transport "2.7.2"
+    socks "1.1.9"
+
 nodemon@^1.3.8:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.11.0.tgz#226c562bd2a7b13d3d7518b49ad4828a3623d06c"
@@ -3855,6 +4207,12 @@ npm-watch@^0.1.6:
     gauge "~2.7.1"
     set-blocking "~2.0.0"
 
+nth-check@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
+  dependencies:
+    boolbase "~1.0.0"
+
 nuclear-js-react-addons@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/nuclear-js-react-addons/-/nuclear-js-react-addons-0.4.1.tgz#23e8b0a00c20e90b6bfe4cfcc7b627d5a61c4cfb"
@@ -3891,6 +4249,10 @@ object-assign@^2.0.0:
 object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
+
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
 object-component@0.0.3:
   version "0.0.3"
@@ -3929,7 +4291,7 @@ onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
 
-optimist@~0.6.0:
+optimist@^0.6.1, optimist@~0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
   dependencies:
@@ -4518,6 +4880,13 @@ prompt@^1.0.0:
     utile "0.3.x"
     winston "2.1.x"
 
+prop-types@^15.5.4, prop-types@^15.5.8:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
 proxy-addr@~1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.3.tgz#dc97502f5722e888467b3fa2297a7b1ff47df074"
@@ -4554,7 +4923,7 @@ punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
 
-punycode@^1.2.4, punycode@^1.4.1:
+punycode@1.4.1, punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
@@ -4634,6 +5003,13 @@ react-addons-css-transition-group@^15.3.1:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
+react-addons-update@^15.4.2:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/react-addons-update/-/react-addons-update-15.6.0.tgz#67f8d5a3d3d8ac7ccfa452565a8310065178e748"
+  dependencies:
+    fbjs "^0.8.9"
+    object-assign "^4.1.0"
+
 react-bootstrap-button-loader@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/react-bootstrap-button-loader/-/react-bootstrap-button-loader-1.0.7.tgz#2ae97c5620facaea0b516f2a97810483cd198732"
@@ -4653,6 +5029,17 @@ react-bootstrap@^0.30.3:
     react-prop-types "^0.4.0"
     uncontrollable "^4.0.1"
     warning "^3.0.0"
+
+react-codemirror@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-codemirror/-/react-codemirror-1.0.0.tgz#91467b53b1f5d80d916a2fd0b4c7adb85a9001ba"
+  dependencies:
+    classnames "^2.2.5"
+    codemirror "^5.18.2"
+    create-react-class "^15.5.1"
+    lodash.debounce "^4.0.8"
+    lodash.isequal "^4.5.0"
+    prop-types "^15.5.4"
 
 react-dom@^15.3.1:
   version "15.4.2"
@@ -4937,7 +5324,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@2, request@2.x, request@^2.61.0, request@^2.79.0:
+request@2, request@2.x, request@^2.61.0, request@^2.78.0, request@^2.79.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -5073,11 +5460,11 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@~5.3.0:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.0.3, semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
-"semver@2.x || 3.x || 4 || 5", semver@4.3.2:
+semver@4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.2.tgz#c7a07158a80bedd052355b770d82d6640f803be7"
 
@@ -5132,6 +5519,16 @@ sha.js@2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.2.6.tgz#17ddeddc5f722fb66501658895461977867315ba"
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
 shelljs@^0.7.0, shelljs@^0.7.5:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.6.tgz#379cccfb56b91c8601e4793356eb5382924de9ad"
@@ -5181,9 +5578,24 @@ sliced@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/sliced/-/sliced-0.0.5.tgz#5edc044ca4eb6f7816d50ba2fc63e25d8fe4707f"
 
+slick@1.12.2:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/slick/-/slick-1.12.2.tgz#bd048ddb74de7d1ca6915faa4a57570b3550c2d7"
+
 slide@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+
+smart-buffer@^1.0.4:
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-1.1.15.tgz#7f114b5b65fab3e2a35aa775bb12f0d1c649bf16"
+
+smtp-connection@2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/smtp-connection/-/smtp-connection-2.12.0.tgz#d76ef9127cb23c2259edb1e8349c2e8d5e2d74c1"
+  dependencies:
+    httpntlm "1.6.1"
+    nodemailer-shared "1.1.0"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -5242,6 +5654,13 @@ socketio-jwt@^4.5.0:
     jsonwebtoken "^5.0.0"
     xtend "~2.1.2"
 
+socks@1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-1.1.9.tgz#628d7e4d04912435445ac0b6e459376cb3e6d691"
+  dependencies:
+    ip "^1.1.2"
+    smart-buffer "^1.0.4"
+
 sort-keys@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
@@ -5251,6 +5670,10 @@ sort-keys@^1.0.0:
 source-list-map@^0.1.4, source-list-map@^0.1.6, source-list-map@~0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
+
+source-list-map@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-1.1.2.tgz#9889019d1024cce55cdc069498337ef6186a11a1"
 
 source-map-support@^0.4.2, source-map-support@^0.4.6:
   version "0.4.11"
@@ -5264,15 +5687,15 @@ source-map@0.1.x:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
-
-source-map@~0.4.1:
+source-map@^0.4.4, source-map@~0.4.1:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
     amdefine ">=0.0.4"
+
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -5646,7 +6069,7 @@ ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
-uglify-js@~2.7.3:
+uglify-js@^2.6, uglify-js@~2.7.3:
   version "2.7.5"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.7.5.tgz#4612c0c7baaee2ba7c487de4904ae122079f2ca8"
   dependencies:
@@ -5658,6 +6081,13 @@ uglify-js@~2.7.3:
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
+
+uglifyjs-webpack-plugin@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.3.tgz#a672a7d6655f94dfa7e09670d48030f37cc93267"
+  dependencies:
+    source-map "^0.5.6"
+    webpack-sources "^0.2.3"
 
 uid-number@~0.0.6:
   version "0.0.6"
@@ -5680,6 +6110,10 @@ undefsafe@0.0.3:
 underscore@1.x:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+
+underscore@~1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
 
 uniq@^1.0.1:
   version "1.0.1"
@@ -5835,6 +6269,18 @@ watchpack@^0.2.1:
     chokidar "^1.0.0"
     graceful-fs "^4.1.2"
 
+web-resource-inliner@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/web-resource-inliner/-/web-resource-inliner-4.1.0.tgz#a97aeb899c3d3c7f812dec6d5910843032667943"
+  dependencies:
+    async "^2.1.2"
+    chalk "^1.1.3"
+    datauri "^1.0.4"
+    htmlparser2 "^3.9.2"
+    lodash.unescape "^4.0.1"
+    request "^2.78.0"
+    xtend "^4.0.0"
+
 webpack-core@~0.6.0, webpack-core@~0.6.9:
   version "0.6.9"
   resolved "https://registry.yarnpkg.com/webpack-core/-/webpack-core-0.6.9.tgz#fc571588c8558da77be9efb6debdc5a3b172bdc2"
@@ -5851,6 +6297,13 @@ webpack-sources@^0.1.0, webpack-sources@^0.1.2:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-0.1.4.tgz#ccc2c817e08e5fa393239412690bb481821393cd"
   dependencies:
     source-list-map "~0.1.7"
+    source-map "~0.5.3"
+
+webpack-sources@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-0.2.3.tgz#17c62bfaf13c707f9d02c479e0dcdde8380697fb"
+  dependencies:
+    source-list-map "^1.1.1"
     source-map "~0.5.3"
 
 webpack@^1.13.2:


### PR DESCRIPTION
# What's new

There's a new kind of views that botpress can now serve: **Lightweight Views**. The purpose of these is so that modules can serve UIs that don't require any of the heavy botpress styling & APIs.

The default Botpress view weighs about 1.5mb and each module about 500kb. The lightweight views weigh about 200kb total.

## How to create a lightweight view

In your module's Webpack, simply check the `lite` section and add your lite files there

Then to serve up your lightweight views, visit: `http://127.0.0.1/lite/?m=SHORT_MODULE&v=VIEW_NAME`

Where `SHORT_MODULE` is the short name of your module, i.e. `botpress-messenger` = `messenger`