### PR TITLE
Allow loading UMM content from a folder

### DIFF
--- a/src/umm/index.js
+++ b/src/umm/index.js
@@ -71,7 +71,14 @@ module.exports = ({ logger, middlewares, botfile, projectLocation, db }) => {
   }
 
   function saveDocument(content) {
-    return fs.writeFileSync(storagePath, content, 'utf8')
+    if (_.isObject(content)) {
+      return Promise.map(Object.keys(content), fileName => {
+        const filePath = path.join(storagePath, fileName + '.yml')
+        return fs.writeFileAsync(filePath, content[fileName], 'utf8')
+      })
+    }
+
+    return fs.writeFileAsync(storagePath, content, 'utf8')
   }
 
   async function getDocument() {

--- a/src/umm/index.js
+++ b/src/umm/index.js
@@ -13,6 +13,7 @@ module.exports = ({ logger, middlewares, botfile, projectLocation, db }) => {
 
   const processors = {} // A map of all the platforms that can process outgoing messages
   const templates = {} // A map of all the platforms templates
+  const storagePath = getStoragePath()
 
   function registerConnector({ platform, processOutgoing, templates }) {
 
@@ -70,11 +71,10 @@ module.exports = ({ logger, middlewares, botfile, projectLocation, db }) => {
   }
 
   function saveDocument(content) {
-    return fs.writeFileSync(getStoragePath(), content, 'utf8')
+    return fs.writeFileSync(storagePath, content, 'utf8')
   }
 
   async function getDocument() {
-    const storagePath = getStoragePath()
     const stats = await fs.statAsync(storagePath)
 
     if (stats.isDirectory()) {
@@ -89,7 +89,7 @@ module.exports = ({ logger, middlewares, botfile, projectLocation, db }) => {
       return Promise.props(contents)
     }
 
-    return fs.readFileAsync(getStoragePath(), 'utf8')
+    return fs.readFileAsync(storagePath, 'utf8')
   }
 
   function doSendBloc(bloc) {


### PR DESCRIPTION
If content.yml is not present, it looks for a content folder and load all .yml files inside that folder. Also works if the ```umm.contentPath``` in the ```botfile.js``` is a folder

To call the bloc, use a dot notation ```file.bloc```. For example, if we have a greetings.yml file and we wanna reply with the welcome bloc inside it:

```js
event.reply('#greetings.welcome')
```

Need suggestion on how to implement the ```saveDocument``` to save multiple content files.
Also, now there's too many synchronous fs calls, should I modify the function that uses fs to use ```async/await``` ?

@slvnperron botpress/v12#108