### PR TITLE
Allow convo.say('Simple string message');

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig: http://EditorConfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{package.json,package-lock.json,*.yml}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,18 +16,30 @@ As contributors you should be respectful and considerate of others - both contri
 ### Your Responsibilities
 * Ensure contributions are unit tested and that all tests pass before submitting any pull-request
 
+  Before you run the tests, you need a PostgreSQL server running on your machine. If you have
+  [Docker](https://www.docker.com/) installed, you can run
+
+  ```
+  docker run -p 5432:5432 -e POSTGRES_USER=$USER postgres
+  ```
+
+  at the command prompt, to automatically download and start a PostgreSQL server. You don't need to
+  understand or install PostgreSQL Server yourself. (Press `CTRL-c` to stop it.)
+
   To run the tests run
   ```
   npm run test
   ```
-  at a command prompt
+  at a command prompt.
+
 * Ensure that the code lints cleanly
 
   To lint the code run
   ```
   npm run lint
   ```
-  at a command prompt
+  at a command prompt.
+
 * If you do find any issues or think of a feature please [create a Github issue](https://help.github.com/articles/creating-an-issue/) for this first. Discuss things transparently and get community feedback.
 
 # Your First Contribution

--- a/src/conversations.js
+++ b/src/conversations.js
@@ -374,7 +374,7 @@ class Conversation extends EventEmmiter {
     } else {
       message = isBlocCall(arguments)
         ? formatBloc(...arguments)
-        : formatMessage(msg)
+        : formatMessage(msg, this.initialEvent)
     }
 
     this._outgoing.push(message)

--- a/tests/conversations.js
+++ b/tests/conversations.js
@@ -110,7 +110,7 @@ describe('conversations', function() {
       incoming(eventFrom(user(1)))
     })
 
-    it('does not process if different plaform', function(done) {
+    it('does not process if different platform', function(done) {
       const convo = conversations.start(eventFrom(user(1)))
 
       const newEvent = eventFrom(user(1))
@@ -283,7 +283,7 @@ describe('conversations', function() {
       
     })
 
-    it('Other thread doesnt get call if no switch', function(done) {
+    it('Other thread doesn\'t get call if no switch', function(done) {
       conversations.start(eventFrom(user(1)), convo => {
 
         const thread = convo.createThread('hello')

--- a/tests/conversations.js
+++ b/tests/conversations.js
@@ -304,4 +304,15 @@ describe('conversations', function() {
 
   })
 
+  it('convo.say() supports simple string', function(done) {
+    const convo = conversations.start(eventFrom(user(1)))
+
+    outgoing = event => {
+      expect(event).property('text').to.equal('Hello')
+      done()
+    }
+
+    convo.say('Hello')
+  })
+
 })


### PR DESCRIPTION
Hi! Nice project!

I want to use [i18next](https://www.i18next.com/) for translating strings, instead of using the UMM blocs. I noticed that when I use `convo.say()` like this:

```js
const translatedString = t('my_translation_key');  // t() returns the translated string, a simple String
convo.say(translatedString);
```
... then botpress breaks with this stacktrace:

```
Unhandled rejection TypeError: Cannot read property 'platform' of undefined                                                                                                                                                           [93/1479]
    at formatMessage (/botpress/src/conversations.js:13:17)
    at Conversation._callee4$ (/botpress/src/conversations.js:377:11)
    at tryCatch (/botpress/node_modules/regenerator-runtime/runtime.js:65:40)
    at Generator.invoke [as _invoke] (/botpress/node_modules/regenerator-runtime/runtime.js:303:22)
    at Generator.prototype.(anonymous function) [as next] (/botpress/node_modules/regenerator-runtime/runtime.js:117:21)
    at step (/botpress/src/conversations.js:25:202)
    at /botpress/src/conversations.js:25:459
    at Promise._execute (/botpress/node_modules/bluebird/js/release/debuggability.js:300:9)
    at Promise._resolveFromExecutor (/botpress/node_modules/bluebird/js/release/promise.js:483:18)
    at new Promise (/botpress/node_modules/bluebird/js/release/promise.js:79:10)
    at Conversation.<anonymous> (/botpress/src/conversations.js:25:99)
    at Conversation.say (/botpress/src/conversations.js:622:22)
    at Context.<anonymous> (/botpress/tests/conversations.js:315:11)
    at callFnAsync (/botpress/node_modules/mocha/lib/runnable.js:371:21)
    at Test.Runnable.run (/botpress/node_modules/mocha/lib/runnable.js:318:7)
    at Runner.runTest (/botpress/node_modules/mocha/lib/runner.js:443:10)
    at /botpress/node_modules/mocha/lib/runner.js:549:12
    at next (/botpress/node_modules/mocha/lib/runner.js:361:14)
    at /botpress/node_modules/mocha/lib/runner.js:371:7
    at next (/botpress/node_modules/mocha/lib/runner.js:295:14)
    at /botpress/node_modules/mocha/lib/runner.js:334:7
    at done (/botpress/node_modules/mocha/lib/runnable.js:295:5)
    at callFn (/botpress/node_modules/mocha/lib/runnable.js:366:7)                                           
    at Hook.Runnable.run (/botpress/node_modules/mocha/lib/runnable.js:340:7)
    at next (/botpress/node_modules/mocha/lib/runner.js:309:10)
    at Immediate.<anonymous> (/botpress/node_modules/mocha/lib/runner.js:339:5)
    at runCallback (timers.js:781:20)           
    at tryOnImmediate (timers.js:743:5)           
    at processImmediate [as _immediateCallback] (timers.js:714:5)    
```

This PR fixes that, so it works as expected.

Also, to be able to run the tests, I figured out the easiest one-liner to run PostgreSQL with docker, and added it to `CONTRIBUTIONS.md`. And added an [EditorConfig](http://EditorConfig.org) config file to tell IDE:s about the 2 space indent you have going :) Hope that's OK!