### PR TITLE
Build automatically

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 emails_tpl="extensions/enterprise/pro/emails/templates"
 
 echo "Cleaning old build"

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "win32"
   ],
   "scripts": {
+    "prepare": "npm run compile",
     "compile": "./build.sh",
     "test": "BABEL_ENV=tests mocha --compilers js:babel-core/register --require tests/index.js tests/** extensions/**/tests/**",
     "watch": "npm-watch",


### PR DESCRIPTION
To ensure the code is freshly built when developers `npm link` or even `npm publish`, this adds a run script `prepare` which tells npm@>=4 to build the project.