### PR TITLE
Fix bad sqlite3 version for node 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "socket.io-client": "^2.0.3",
     "socketio-jwt": "^4.5.0",
     "source-map-support": "^0.4.6",
-    "sqlite3": "^3.1.8",
+    "sqlite3": "3.1.8",
     "universal-analytics": "^0.4.8",
     "uuid": "^3.0.0",
     "winston": "^2.2.0"


### PR DESCRIPTION
After this fix, `npm install botpress-messenger` will succeed on a new bot, although `botpress install messenger` still fails for me due to npm warnings.

This root of problem is mapbox/node-sqlite3#865. The newest version, `3.1.9`, does not build correctly on Node 8.x, and hasn't been fixed in a month. I locked the version to `3.1.8` which does build.
Partially fixes botpress/v12#120.