### PR TITLE
fix lint warnings

### DIFF
--- a/extensions/lite/actions/index.js
+++ b/extensions/lite/actions/index.js
@@ -7,9 +7,9 @@ const {
 } = actionTypes
 
 const fetchRules = () => {
-	reactor.dispatch(RULES_RECEIVED, { rules: null })
+  reactor.dispatch(RULES_RECEIVED, { rules: null })
 }
 
 module.exports = {
-	fetchRules
+  fetchRules
 }

--- a/extensions/lite/views/Routes/index.jsx
+++ b/extensions/lite/views/Routes/index.jsx
@@ -4,9 +4,9 @@ import { Route, IndexRoute } from 'react-router'
 import Login from '~/views/Login'
 
 const addSecuredRoutes = (extraRoutes) => {
-	return <Route path="/">
-		{extraRoutes}
-	</Route>
+  return <Route path="/">
+    {extraRoutes}
+  </Route>
 }
 
 const addLoginRoutes = (extraRoutes) => {
@@ -17,13 +17,13 @@ const addLoginRoutes = (extraRoutes) => {
 }
 
 const addUnsecuredRoutes = (extraRoutes) => {
-	return <Route path="/unsecured">
-		{extraRoutes}
-	</Route>
+  return <Route path="/unsecured">
+    {extraRoutes}
+  </Route>
 }
 
 module.exports = {
-	addSecuredRoutes,
-	addUnsecuredRoutes,
-	addLoginRoutes
+  addSecuredRoutes,
+  addUnsecuredRoutes,
+  addLoginRoutes
 }

--- a/src/botpress.js
+++ b/src/botpress.js
@@ -77,7 +77,7 @@ class botpress {
     /**
      * Setup env with dotenv *before* requiring the botfile config
      */
-    this._setupEnv();
+    this._setupEnv()
 
     /**
      * The botfile config object

--- a/src/web/components/Injected/index.jsx
+++ b/src/web/components/Injected/index.jsx
@@ -50,7 +50,10 @@ export default class InjectedComponent extends Component {
             <p>{err.message}</p>
         </div>
         {/* TODO Put documentation / help here */}
-        <div className="panel-footer">Developer? <a href="https://github.com/botpress/botpress/tree/master/docs">click here</a> to see why this might happen</div>
+        <div className="panel-footer">
+          Developer? <a href="https://github.com/botpress/botpress/tree/master/docs">click here</a>
+          to see why this might happen
+        </div>
       </div>
 
       ReactDOM.render(element, node)

--- a/src/web/components/Layout/HelpButton.jsx
+++ b/src/web/components/Layout/HelpButton.jsx
@@ -53,7 +53,9 @@ export default class HelpButton extends React.Component {
           </li>
           <li className={btnClass('btn3')} style={{ bottom: (basePosition + 120) + 'px' }}>
             <OverlayTrigger placement="left" overlay={tutorials}>
-              <a href='https://www.youtube.com/watch?v=HTpUmDz9kRY' target='_blank'><i className="icon material-icons">video_library</i></a>
+              <a href='https://www.youtube.com/watch?v=HTpUmDz9kRY' target='_blank'>
+                <i className="icon material-icons">video_library</i>
+              </a>
             </OverlayTrigger>
           </li>
         </ul>

--- a/src/web/components/Modules/index.jsx
+++ b/src/web/components/Modules/index.jsx
@@ -62,7 +62,7 @@ class ModuleComponent extends Component {
     const isLoaded = this.props.isLoaded
     const iconPath = `/img/modules/${name}.png`
 
-    const hasCustomIcon = icon  === 'custom' && isLoaded
+    const hasCustomIcon = icon === 'custom' && isLoaded
     const moduleIcon = hasCustomIcon
       ? <img className={classnames(style.customIcon, 'bp-custom-icon')} src={iconPath} />
       : <i className="icon material-icons">{icon === "custom" ? "extension" : icon}</i>
@@ -146,15 +146,16 @@ class ModuleComponent extends Component {
 }))
 export default class ModulesComponent extends Component {
   render() {
-    var installedModules = {};
+    var installedModules = {}
     this.props.installedModules.map((module)=>{
       const name = module.get("name")
       installedModules[name] = true
-    });
+    })
     return (
       <div>
         {_.values(_.map(this.props.modules, module => {
-          return <ModuleComponent key={module.name} module={module} refresh={this.props.refresh} isLoaded={installedModules[module.name]}/>
+          return <ModuleComponent key={module.name} module={module}
+            refresh={this.props.refresh} isLoaded={installedModules[module.name]}/>
         }))}
       </div>
     )

--- a/src/web/components/Notifications/Hub.jsx
+++ b/src/web/components/Notifications/Hub.jsx
@@ -55,7 +55,8 @@ export default class NotificationHub extends NotificationComponent {
       <span className={className}>{unreadCount}</span>
     </span>
 
-    return <NavDropdown id="notificationsDropdown" noCaret={!unreadCount} title={label} className={classnames(styles.dropdown, 'bp-notifications-dropdown')}>
+    return <NavDropdown id="notificationsDropdown" noCaret={!unreadCount}
+        title={label} className={classnames(styles.dropdown, 'bp-notifications-dropdown')}>
       <MenuItem header className={classnames(styles.topMenu, 'bp-top-menu')}>
         <span>
           <strong>Notifications</strong>

--- a/src/web/components/Tour/index.jsx
+++ b/src/web/components/Tour/index.jsx
@@ -61,14 +61,15 @@ export default class GuidedTour extends React.Component {
     return <div>
       <p>{emojify(':tada:', 100)}</p>
       <p className={style.big}>Congratulations on choosing Botpress for your next bot!</p>
-      <p>Botpress is the most effective way for developers to create a bot. 
+      <p>Botpress is the most effective way for developers to create a bot.
       This very short tour will help you get started quickly.</p>
       <hr />
-      <p>First, you should know that a Botpress bot is just a regular Node.js application. 
-      There is no black magic, and everything your bot does is done either through code you write or 
+      <p>First, you should know that a Botpress bot is just a regular Node.js application.
+      There is no black magic, and everything your bot does is done either through code you write or
       done for you by pre-made modules (thanks to our awesome community).</p>
-      <p>By default, your bot's entry point is the <code>index.js</code> file, but you can arrange your code base as you wish. 
-      Again, <span className={style.emp}>your bot is just a regular node program.</span></p>
+      <p>By default, your bot's entry point is the <code>index.js</code> file, but you can arrange
+      your code base as you wish. Again, <span className={style.emp}>your bot is just a regular
+      node program.</span></p>
     </div>
   }
 
@@ -79,8 +80,8 @@ export default class GuidedTour extends React.Component {
       <p>Whenever there's a piece of functionality that you need for your bot, think modules.</p>
       <hr />
       <p>You can install modules via this graphical interface or from the command line interface.</p>
-      <p>If there's no module for the generic feature you are looking for, please consider creating one 
-      or contributing to an existing module to add that feature. Botpress relies heavily on the community to thrive. 
+      <p>If there's no module for the generic feature you are looking for, please consider creating one
+      or contributing to an existing module to add that feature. Botpress relies heavily on the community to thrive.
       Every single contribution is needed, even if it's tiny {emojify(':blush:')}!</p>
       <p>Installing a module from the CLI is as simple as typing <code>botpress install messenger</code></p>
     </div>
@@ -91,11 +92,15 @@ export default class GuidedTour extends React.Component {
       <p>{emojify(':rocket:', 100)}</p>
       <p className={style.big}>Before you deploy your bot...</p>
       <ul className={style.left}>
-        <li>We recommend you <a target="_blank" href="https://botpress.io/docs/foundamentals/database.html#postgres">enable the Postgres database</a> for production environments</li>
-        <li>Do <strong>not</strong> store keys, passwords or any sensitive information in your botfile. Use environment variables instead.</li>
-        <li>Switch to the <b>Botpress License</b> (the default license is AGPL), which is 100% free for all bots and more permissive than AGPL.</li>
+        <li>We recommend you <a target="_blank" href="https://botpress.io/docs/foundamentals/database.html#postgres">
+        enable the Postgres database</a> for production environments</li>
+        <li>Do <strong>not</strong> store keys, passwords or any sensitive information in your botfile.
+        Use environment variables instead.</li>
+        <li>Switch to the <b>Botpress License</b> (the default license is AGPL), which is 100%
+        free for all bots and more permissive than AGPL.</li>
       </ul>
-      <p>Deployment tutorials are <a href="https://botpress.io/docs/deploy/heroku.html" target="_blank">available here.</a></p>
+      <p>Deployment tutorials are <a href="https://botpress.io/docs/deploy/heroku.html" target="_blank">available
+      here.</a></p>
     </div>
   }
 

--- a/src/web/views/Login/index.jsx
+++ b/src/web/views/Login/index.jsx
@@ -104,7 +104,8 @@ export default class LoginPage extends Component {
                 </FormGroup>
                 <FormGroup>
                   <ControlLabel>Password</ControlLabel>
-                  <FormControl type="password" placeholder="" value={this.state.password} onChange={::this.handlePasswordChange}/>
+                  <FormControl type="password" placeholder="" value={this.state.password}
+                    onChange={::this.handlePasswordChange}/>
                 </FormGroup>
                 <Button className="pull-right" type="submit">Login</Button>
                 <Decorators.ForgotPassword />

--- a/src/web/views/Middleware/index.jsx
+++ b/src/web/views/Middleware/index.jsx
@@ -15,16 +15,20 @@ const documentation = `
   #### **Documentation**
 
   A middleware chain is simply a collection of middleware functions that are called in a predertermined order.
-  
-  Every middleware has to be registered to appear and you will be able to  do so with the \`bp.middlewares.register()\` method.
+
+  Every middleware has to be registered to appear and you will be able to  do so with
+  the \`bp.middlewares.register()\` method.
 
   For more details about middleware, look at the [documentation](https://botpress.io/docs/advanced/middleware.html).
-  
+
   ##### **Ordering middleware**
 
-  All middleware functions that are registered (usually every modules are registered in their initialization). You must load them using \`bp.middlewares.load()\` in your \`index.js\`, which will create the incoming and outgoing chains automatically.
+  All middleware functions that are registered (usually every modules are registered in their initialization).
+  You must load them using \`bp.middlewares.load()\` in your \`index.js\`, which will create the incoming
+  and outgoing chains automatically.
 
-  By default, middleware functions are ordered by ascending order according to their \`order\` property set on registration. The order can then be manually overwritten here by using **drag-n-drop**.
+  By default, middleware functions are ordered by ascending order according to their \`order\` property
+  set on registration. The order can then be manually overwritten here by using **drag-n-drop**.
 
   You can also re-order them programmatically using middleware function customizations.
   `

--- a/src/web/views/Module/index.jsx
+++ b/src/web/views/Module/index.jsx
@@ -31,7 +31,7 @@ export default class ModuleView extends React.Component {
     }
 
     const module = this.props.modules.find((value) => value.get('name') === this.props.params.moduleName).toJS()
-    
+
     return <ContentWrapper>
       <PageHeader><span>{module.menuText} {this.renderLink(module)}</span></PageHeader>
       {children}
@@ -44,7 +44,10 @@ export default class ModuleView extends React.Component {
         <div className="panel-heading">Module not found</div>
         <div className="panel-body">
           <h4>The module is not properly registered</h4>
-          <p>It seems like you are trying to load a module that has not been registered. Please make sure the module is registered then restart the bot.</p>
+          <p>
+            It seems like you are trying to load a module that has not been registered.
+            Please make sure the module is registered then restart the bot.
+          </p>
           {err && <p>{err}</p>}
           <p>
             {/* TODO update doc & help */}
@@ -57,7 +60,7 @@ export default class ModuleView extends React.Component {
 
   render() {
     const { moduleName, subView } = this.props.params
-    
+
     const modules = this.props.modules.toJS()
     const module = _.find(modules, { name: moduleName })
 


### PR DESCRIPTION
when running `npm run lint` in development environment, I encountered a bunch of lint errors and warnings. this PR fixes the following:
* removed extra semi-colons
* fixed lines longer than 120 chars
* replaced tabs with spaces

note: there are still errors for `no-eval` and for `package.json` files