### PR TITLE
Changed bp.hear to support array of conditions

### DIFF
--- a/docs/foundamentals/events.md
+++ b/docs/foundamentals/events.md
@@ -18,7 +18,7 @@ There exists a special built-in middleware that allows your bot to listen for me
 
 Utility function to easily register incoming middlewares. 
 
-The condition can be a string, a regex or an object. In case of an object, all conditions must match for the handler to be called.
+The condition can be a string, a regex, an object or an array of these. In case of an object, all conditions must match for the handler to be called. In case of an array, it acts as an OR meaning the first condition to match will cause the handler to be called.
 
 The handler takes the MiddlewareEvent as the first argument and takes the `next` middleware caller as the second argument. If the `next` argument is not specified in your handler, botpress assumes you wanted to call it and calls it at the end of the synchronous execution of the handler.
 
@@ -50,6 +50,17 @@ bp.hear({
   platform: 'sms'
 }, event => {
   // all the conditions matched
+})
+```
+
+#### Examples (array)
+
+```js
+bp.hear([
+    {'nlp.metadata.intentName': 'getting_started'}, // first condition
+    {'type': 'postback', 'text': 'getting_started'} // second condition
+  ], event => {
+    // one of the conditions matched
 })
 ```
 

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -32,7 +32,17 @@ const matches = function(conditions, event) {
 
 const hear = function(conditions, callback) {
   return (event, next) => {
-    const result = matches(conditions, event)
+    let result = false;
+    if (_.isArray(conditions)) {
+      for (let conditionsItem of conditions) {
+        if (matches(conditionsItem, event)) {
+          result = true;
+          break;
+        }
+      }
+    } else {
+      result = matches(conditions, event);
+    }
 
     if (result && _.isFunction(callback)) {
       if (callback.length <= 1) {

--- a/tests/listeners.js
+++ b/tests/listeners.js
@@ -61,6 +61,16 @@ describe('hear', function() {
       hearNo(t => t === 'hello, world')(event)
     ])
   })
+  
+  it('condition is array', () => {
+    return Promise.all([
+      hearYes([{ text: /world/, platform: 'twitter' }, { text: /world/, type: 'message' }])(event),
+      hearYes([{ text: /world/, type: 'message' }, { text: /world/, platform: 'twitter' }])(event),
+      hearNo([{ text: /banana/, type: 'message' }, { text: /world/, platform: 'twitter' }])(event),
+      hearYes([t => t === 'Hello world', 'world'])(event),
+      hearNo([{ text: /banana/, type: 'message' }, /hello/])(event),
+    ])
+  })
 
   it('Many conditions', () => {
     return Promise.all([


### PR DESCRIPTION
The first argument "conditions" of the function bp.hear now support array.
In case of an array, it acts as an OR meaning the first condition to match will cause the handler to be called.
Added tests and docs.