### PR TITLE
Fix unit test on windows

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,31 +17,30 @@ As contributors you should be respectful and considerate of others - both contri
 * Ensure contributions are unit tested and that all tests pass before submitting any pull-request
 
   Before you run the tests, you need a PostgreSQL server running on your machine. If you have
-  [Docker](https://www.docker.com/) installed, you can run
+  [Docker](https://www.docker.com/) installed, you can run the following at the command prompt,
+  to automatically download and start a PostgreSQL server. You don't need to
+  understand or install PostgreSQL Server yourself.
 
+  To run local PostgreSQL server at the command prompt.
   ```
   docker run -p 5432:5432 -e POSTGRES_USER=$USER postgres
   ```
-  notes on running docker command on Windows:
-  * Windows CMD: replace `$USER` with `%USERNAME%`
+  notes:
+  * Press `CTRL-c` to stop it.
+  * Windows Command Prompt: replace `$USER` with `%USERNAME%`
   * Windows PowerShell: replace `$USER` with `$env:UserName`
 
-  at the command prompt, to automatically download and start a PostgreSQL server. You don't need to
-  understand or install PostgreSQL Server yourself. (Press `CTRL-c` to stop it.)
-
-  To run the tests run
+  To run the tests run at the command prompt.
   ```
   npm run test
   ```
-  at a command prompt.
 
 * Ensure that the code lints cleanly
 
-  To lint the code run
+  To lint the code run at the command prompt.
   ```
   npm run lint
   ```
-  at a command prompt.
 
 * If you do find any issues or think of a feature please [create a Github issue](https://help.github.com/articles/creating-an-issue/) for this first. Discuss things transparently and get community feedback.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,6 +22,9 @@ As contributors you should be respectful and considerate of others - both contri
   ```
   docker run -p 5432:5432 -e POSTGRES_USER=$USER postgres
   ```
+  notes on running docker command on Windows:
+  * Windows CMD: replace `$USER` with `%USERNAME%`
+  * Windows PowerShell: replace `$USER` with `$env:UserName`
 
   at the command prompt, to automatically download and start a PostgreSQL server. You don't need to
   understand or install PostgreSQL Server yourself. (Press `CTRL-c` to stop it.)


### PR DESCRIPTION
botpress/v12#132 update documentation to tell Windows developers how to run unit tests
* provide the correct variable for `$USER` in Windows