### PR TITLE
Fix remaining eslint errors on master

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "compile": "./build.sh",
     "test": "BABEL_ENV=tests mocha --compilers js:babel-core/register --require tests/index.js tests/** extensions/**/tests/**",
     "watch": "npm-watch",
-    "lint": "eslint {src,extensions}/**/*.js*"
+    "lint": "eslint {src,extensions}/**/*.{js,jsx}"
   },
   "watch": {
     "compile": {

--- a/src/botpress.js
+++ b/src/botpress.js
@@ -77,6 +77,7 @@ class botpress {
     /**
      * The botfile config object
      */
+    // eslint-disable-next-line no-eval
     this.botfile = eval('require')(botfile)
 
     this.stats = stats(this.botfile)
@@ -210,6 +211,7 @@ class botpress {
       middlewares.load()
     }
 
+    // eslint-disable-next-line no-eval
     const projectEntry = eval('require')(projectLocation)
     if (typeof projectEntry === 'function') {
       projectEntry.call(projectEntry, this)

--- a/src/cli/migrations/0.1.js
+++ b/src/cli/migrations/0.1.js
@@ -7,6 +7,7 @@ import util from '../../util'
 
 module.exports = bot_path => {
   const botfilePath = path.join(bot_path, 'botfile.js')
+  // eslint-disable-next-line no-eval
   const botfile = eval('require')(botfilePath)
   const dbLocation = path.resolve(path.join(bot_path, botfile.dataDir, 'db.sqlite'))
 

--- a/src/cli/start.js
+++ b/src/cli/start.js
@@ -22,6 +22,7 @@ module.exports = function(projectPath, options) {
   projectPath = path.resolve(projectPath)
 
   try {
+    // eslint-disable-next-line no-eval
     Botpress = eval('require')(path.join(projectPath, 'node_modules', 'botpress')).Botpress()
   } catch (err) {
     util.print('error', err.message)

--- a/src/content/service.js
+++ b/src/content/service.js
@@ -27,6 +27,7 @@ module.exports = ({ db, botfile, projectLocation, logger }) => {
     files.forEach(file => {
       try {
         const filePath = path.resolve(formDir, './' + file)
+        // eslint-disable-next-line no-eval
         const category = eval('require')(filePath) // Dynamic loading require eval for Webpack
         const requiredFields = ['id', 'title', 'jsonSchema']
 

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -32,16 +32,16 @@ const matches = function(conditions, event) {
 
 const hear = function(conditions, callback) {
   return (event, next) => {
-    let result = false;
+    let result = false
     if (_.isArray(conditions)) {
       for (let conditionsItem of conditions) {
         if (matches(conditionsItem, event)) {
-          result = true;
-          break;
+          result = true
+          break
         }
       }
     } else {
-      result = matches(conditions, event);
+      result = matches(conditions, event)
     }
 
     if (result && _.isFunction(callback)) {

--- a/src/modules.js
+++ b/src/modules.js
@@ -40,6 +40,7 @@ module.exports = (logger, projectLocation, dataLocation, kvs) => {
     const loadedModules = {}
 
     moduleDefinitions.forEach(mod => {
+      // eslint-disable-next-line no-eval
       const loader = eval('require')(mod.entry)
 
       if (typeof loader !== 'object') {
@@ -86,6 +87,7 @@ module.exports = (logger, projectLocation, dataLocation, kvs) => {
         'which means botpress can\'t load any module for the bot.')
     }
 
+    // eslint-disable-next-line no-eval
     const botPackage = eval('require')(packagePath)
 
     let deps = botPackage.dependencies || {}
@@ -106,6 +108,7 @@ module.exports = (logger, projectLocation, dataLocation, kvs) => {
         return result
       }
 
+      // eslint-disable-next-line no-eval
       const modulePackage = eval('require')(path.join(root, 'package.json'))
       if (!modulePackage.botpress) {
         return result


### PR DESCRIPTION
There were some eslint errors on `master`, and this PR fixes them.

- Some were from `.json` files, which eslint doesn't understand anyway, so I disabled eslint for `.json`.
- Some were about your use of `eval` :)
  - I checked that every occurance of `eval` was last committed by @slvnperron, before adding `// eslint-disable-next-line no-eval` to those places.
  - Please double-check all `eval`s are still on purpose.