### PR TITLE
Use upsert to set KVs

### DIFF
--- a/src/database/kvs.js
+++ b/src/database/kvs.js
@@ -13,6 +13,36 @@ module.exports = (knex, options = {}) => {
   const getSetCallback = options.betweenGetAndSetCallback || (() => Promise.resolve())
   const tableName = options.tableName || 'kvs'
 
+  const upsert = (key, value) => {
+    let sql
+
+    const params = {
+      tableName,
+      keyCol: 'key',
+      valueCol: 'value',
+      modifiedOnCol: 'modified_on',
+      key,
+      value: JSON.stringify(value),
+      now: helpers(knex).date.now()
+    }
+
+    if (helpers(knex).isLite()) {
+      sql = `
+        INSERT OR REPLACE INTO :tableName: (:keyCol:, :valueCol:, :modifiedOnCol:)
+        VALUES (:key, :value, :now)
+      `
+    } else {
+      sql = `
+        INSERT INTO :tableName: (:keyCol:, :valueCol:, :modifiedOnCol:)
+        VALUES (:key, :value, :now)
+        ON CONFLICT (:keyCol:) DO UPDATE
+          SET :valueCol: = :value, :modifiedOnCol: = :now
+      `
+    }
+
+    return knex.raw(sql, params)
+  }
+
   const get = (key, path) => {
     return knex(tableName).where({ key }).limit(1).then().get(0).then(row => {
       if (!row) {
@@ -28,24 +58,11 @@ module.exports = (knex, options = {}) => {
     })
   }
 
-  const _set = (key, value, operation = 'update') => {
-    const now = helpers(knex).date.now()
-
-    if (operation === 'update') {
-      return knex(tableName).where({ key }).update({
-        value: JSON.stringify(value),
-        modified_on: now
-      }).then()
-    } else {
-      return knex(tableName).insert({
-        key: key,
-        value: JSON.stringify(value),
-        modified_on: now
-      }).then()
-    }
-  }
-
   const set = (key, value, path) => {
+    if (!path) {
+      return upsert(key, value)
+    }
+
     const setValue = obj => {
       if (path) {
         _.set(obj, path, value)
@@ -60,12 +77,9 @@ module.exports = (knex, options = {}) => {
         return getSetCallback()
           .then(() => {
             if (!_.isNil(original)) {
-              const newObj = setValue(Object.assign({}, original))
-              return _set(key, newObj, 'update')
+              return upsert(key, setValue(Object.assign({}, original)))
             } else {
-              const obj = setValue({})
-              return _set(key, obj, 'insert')
-                .catch(() => _set(key, obj, 'update'))
+              return upsert(key, setValue({}))
             }
           })
       })


### PR DESCRIPTION
Changes `kvs.set` to use an upsert strategy instead of get+set. Getting and setting is still required for cases where the user the `path` feature of `kvs.set`.

I also kept the call to `getSetCallback` when possible, but it isn't triggered if `path` isn't used (we're not getting – so no point in calling it?). I'm pointing this out partly because I don't know what' is the use case of `getSetCallback`; I wasn't sure what to do with it.

I didn't try it in the context of an app, but the tests pass and this part looks well covered.

Fixes botpress/v12#136 