### PR TITLE
Use botpress-platform-webchat by default

### DIFF
--- a/src/cli/templates/init/package.json
+++ b/src/cli/templates/init/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "botpress": "1.x",
-    "botpress-web": "1.x"
+    "botpress-platform-webchat": "^0.3"
   },
   "scripts": {
     "start": "botpress start",


### PR DESCRIPTION
@slvnperron , it seems `botpress-platform-webchat` that supports integration isn't released yet. Should I reference `0.3`, or should I make a link to master branch?