### PR TITLE
fix doBoth race conditions

### DIFF
--- a/tests/database_base.js
+++ b/tests/database_base.js
@@ -70,7 +70,7 @@ module.exports = {
   sqlite: sqlite,
   postgres: postgres,
   createSampleTable: createSampleTable,
-  doBoth: fn => () => fn && fn(postgres).then(fn(sqlite)),
+  doBoth: fn => () => fn && fn(postgres).then(() => fn(sqlite)),
   itBoth: itBoth(() => emptyTable),
   run: (name, cb) => {
     describe('Setup', () => {


### PR DESCRIPTION
If I correctly understand the intent of `doBoth` it should first run the tests in PG and _then_ do them for SQLite.
The error here is that instead it's been actually running them in parallel, effectively the code was equivalent to

```
const pgResult = fn(postgres)
const sqliteResult = fn(sqlite) // this starts immediately
return pgResult.then(pgResult)
``` 

By doing this change I've fixed some tests that's been constantly throwing errors on Linux.
Also that errors didn't cause the tests to be failing, I assume likely because the sqlite portion wasn't actually part of the promise chain and didn't cause it to be rejected. 

Still there's at least one test that fails _sometimes_. But the test suite is overall much more stable for me now.