### PR TITLE
Remove local botpress-botkit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "babel-polyfill": "^6.23.0",
     "bluebird": "^3.4.6",
     "body-parser": "^1.15.2",
-    "botpress-botkit": "file:///Users/Daehli/travail/botpress/fork/botpress-botkit",
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
     "dotenv": "^4.0.0",


### PR DESCRIPTION
A dependency declaration for a local `botpress-botkit` was added to `package.json` in d314a3af9e42b5e865783c7924cae2d89bc938e8:

```
"botpress-botkit": "file:///Users/Daehli/travail/botpress/fork/botpress-botkit"
```

This PR removes that line.

`botpress-botkit` is not mentioned in any other file, so this seems safe to do.

@slvnperron @daehli