### PR TITLE
fix module view

### DIFF
--- a/src/web/components/Layout/Sidebar.jsx
+++ b/src/web/components/Layout/Sidebar.jsx
@@ -111,10 +111,7 @@ class Sidebar extends React.Component {
     const modules = this.props.modules
     const items = modules.filter(x => !x.noInterface).map(this.renderModuleItem)
 
-    const emptyClassName = classnames({
-      [style.empty]: true,
-      'bp-empty': true
-    })
+    const emptyClassName = classnames(style.empty, 'bp-empty')
 
     const dashboardRules = { res: 'dashboard', op: 'read' }
     const modulesRules = { res: 'modules/list', op: 'read' }

--- a/src/web/views/Manage/index.jsx
+++ b/src/web/views/Manage/index.jsx
@@ -139,7 +139,7 @@ class ManageView extends React.Component {
   renderModules() {
     let modules = this.state.modules
 
-    if (this.state.search && this.state.search !== '') {
+    if (this.state.search) {
       modules = this.getResultFromSearch(modules)
     }
 

--- a/src/web/views/Module/index.jsx
+++ b/src/web/views/Module/index.jsx
@@ -33,25 +33,6 @@ class ModuleView extends React.Component {
     )
   }
 
-  renderWrapper(children) {
-    if (this.props.modules.size <= 0) {
-      return null
-    }
-
-    const module = this.props.modules.find(value => value.get('name') === this.props.params.moduleName)
-
-    return (
-      <ContentWrapper>
-        <PageHeader>
-          <span>
-            {module && module.menuText} {this.renderLink(module)}
-          </span>
-        </PageHeader>
-        {children}
-      </ContentWrapper>
-    )
-  }
-
   renderNotFound(err) {
     return (
       <div className="panel panel-warning">
@@ -75,31 +56,39 @@ class ModuleView extends React.Component {
   }
 
   render() {
-    const { moduleName, subView } = this.props.params
-
     const modules = this.props.modules
-    const module = _.find(modules, { name: moduleName })
-
-    if (!module) {
-      return this.renderWrapper(this.renderNotFound())
-    }
-
-    const moduleView = (
-      <InjectedModuleView moduleName={moduleName} viewName={subView} onNotFound={this.renderNotFound} />
-    )
-
-    if (!moduleView) {
+    if (!modules) {
       return null
     }
 
-    return this.renderWrapper(moduleView, module.menuText)
+    const { moduleName, subView } = this.props.params
+    const module = _.find(modules, { name: moduleName })
+
+    const contents = module ? (
+      <InjectedModuleView moduleName={moduleName} viewName={subView} onNotFound={this.renderNotFound} />
+    ) : (
+      this.renderNotFound()
+    )
+
+    const header = module ? (
+      <span>
+        {module.menuText} {this.renderLink(module)}
+      </span>
+    ) : (
+      `Module ${moduleName} Not Found`
+    )
+
+    return (
+      <ContentWrapper>
+        <PageHeader>{header}</PageHeader>
+        {contents}
+      </ContentWrapper>
+    )
   }
 }
 
-const mapStateToProps = (state, ownProps) => ({
+const mapStateToProps = state => ({
   modules: state.modules
 })
 
-const mapDispatchToProps = (dispatch, ownProps) => {}
-
-export default connect(mapStateToProps, mapDispatchToProps)(ModuleView)
+export default connect(mapStateToProps)(ModuleView)


### PR DESCRIPTION
I've investigated and fixed the bug I've fond couple of days ago with module pages being completely broken.
It was indeed related to migration to Redux — pieces of the code were still written as if dealing with Immutable.js, specifically see `.size` and `.get` there.
There were other logical problems that were less critical (like duplicate lookup for the module)