### PR TITLE
fix the bug when content editing form would reset its state, closes #290

### DIFF
--- a/src/web/views/Content/List/index.js
+++ b/src/web/views/Content/List/index.js
@@ -88,6 +88,9 @@ export default class ListView extends Component {
   }
 
   renderMessage = m => {
+    const { handleEdit } = this.props
+    const _handleEdit = () => handleEdit(m.id, m.categoryId)
+
     const checked = _.includes(this.state.checkedIds, m.id)
     const className = classnames(style.item, {
       [style.selected]: checked
@@ -98,16 +101,16 @@ export default class ListView extends Component {
         <td style={{ width: '2%', minWidth: '34px' }}>
           <Checkbox checked={checked} onClick={() => this.handleCheckboxChanged(m.id, m.categoryId)} />
         </td>
-        <td style={{ width: '16%' }} onClick={() => this.props.handleModalShow(m.id, m.categoryId)}>
+        <td style={{ width: '16%' }} onClick={_handleEdit}>
           {'#!' + m.id}
         </td>
-        <td style={{ width: '8%' }} onClick={() => this.props.handleModalShow(m.id, m.categoryId)}>
+        <td style={{ width: '8%' }} onClick={_handleEdit}>
           {m.categoryId}
         </td>
-        <td style={{ width: '58%' }} onClick={() => this.props.handleModalShow(m.id, m.categoryId)}>
+        <td style={{ width: '58%' }} onClick={_handleEdit}>
           {m.previewText}
         </td>
-        <td style={{ width: '18%' }} onClick={() => this.props.handleModalShow(m.id, m.categoryId)}>
+        <td style={{ width: '18%' }} onClick={_handleEdit}>
           {moment(m.createdOn).format('MMMM Do YYYY, h:mm')}
         </td>
       </tr>

--- a/src/web/views/Content/modal.jsx
+++ b/src/web/views/Content/modal.jsx
@@ -9,19 +9,13 @@ import Form from 'react-jsonschema-form'
 
 import style from './style.scss'
 
-export default class AddMessageModal extends React.Component {
-  state = {
-    loading: true
-  }
-
-  componentDidMount() {
-    this.setState({
-      loading: false
-    })
-  }
-
-  handleSubmit = event => {
+export default class CreateOrEditModal extends React.Component {
+  handleUpdate = event => {
     this.props.handleCreateOrUpdate(event.formData)
+  }
+
+  handleEdit = event => {
+    this.props.handleEdit(event.formData)
   }
 
   render() {
@@ -37,7 +31,8 @@ export default class AddMessageModal extends React.Component {
             schema={this.props.schema}
             uiSchema={this.props.uiSchema}
             formData={this.props.formData}
-            onSubmit={this.handleSubmit}
+            onSubmit={this.handleUpdate}
+            onChange={this.handleEdit}
           />
           <button
             className={classnames('bp-button', 'bp-button-danger', style.cancel)}


### PR DESCRIPTION
So this should fix botpress/v12#154 

The issue is not _directly_ related to Redux but is probably caused by that changes indeed.
Here's the explanation:
* there's a constant poll for available modules (seems to be every 3 or 5 seconds?)
* whenever it happens the state is updated, which causes the entire components tree (or a big part of it) to be re-rendered, which is OK on its own, React is specifically good at handling such things
* the problem is this re-renders the content editing modal, which re-renders the inner form with the same initial content

The fix is explained in the form docs though it's not emphasized enough IMO (see [here](https://github.com/mozilla-services/react-jsonschema-form#form-initialization), the _Warning_ part). But it's the common thing called controlled components which means you have to listen to all change events and re-push the new data back into the controlled component by doing `setState` on the parent.

So the actual fix here is listening to `onChange` on the form, the rest is cosmetics.
