### PR TITLE
Ghost content manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "source-map-support": "^0.4.6",
     "sqlite3": "3.1.8",
     "universal-analytics": "^0.4.8",
-    "uuid": "^3.0.0",
+    "uuid": "^3.1.0",
     "vm2": "^3.5.2",
     "winston": "^2.2.0"
   },

--- a/src/botpress.js
+++ b/src/botpress.js
@@ -17,6 +17,7 @@ import createNotifications from './notifications'
 import createHearMiddleware from './hear'
 import createFallbackMiddleware from './fallback'
 import createDatabase from './database'
+import createGhostManager from './ghost-content'
 import createLicensing from './licensing'
 import createAbout from './about'
 import createModules from './modules'
@@ -164,10 +165,16 @@ class botpress {
     const mediator = createMediator(this)
     const convo = createConversations({ logger, middleware: middlewares })
     const users = createUsers({ db })
+    const ghostManager = createGhostManager({
+      projectLocation,
+      logger,
+      db
+    })
     const contentManager = await createContentManager({
       logger,
       projectLocation,
-      botfile
+      botfile,
+      ghostManager
     })
     const umm = createUMM({
       logger,

--- a/src/content/service.js
+++ b/src/content/service.js
@@ -102,7 +102,7 @@ module.exports = async ({ botfile, projectLocation, logger, ghostManager }) => {
     const items = (await listCategoryItems(categoryId)).map(item =>
       _.pick(item, 'id', 'formData', 'createdBy', 'createdOn')
     )
-    fs.writeFileSync(fileById[categoryId], JSON.stringify(items, null, 2))
+    await ghostManager.recordRevision(formDataDir, fileById[categoryId], JSON.stringify(items, null, 2))
   }
 
   const dumpAllDataToFiles = () => Promise.map(categories, ({ id }) => dumpDataToFile(id))
@@ -253,13 +253,14 @@ module.exports = async ({ botfile, projectLocation, logger, ghostManager }) => {
     return category
   }
 
-  const readDataFromFile = (filePath, fileName) => {
-    if (!fs.existsSync(filePath)) {
-      logger.warn(`Form content file ${filePath} not found`)
+  const readDataForFile = async fileName => {
+    const json = await ghostManager.readFile(formDataDir, fileName)
+    if (!json) {
+      logger.warn(`Form content file ${fileName} not found`)
       return []
     }
+
     try {
-      const json = fs.readFileSync(filePath, 'utf-8')
       const data = JSON.parse(json)
       if (!Array.isArray(data)) {
         throw new Error(`${fileName} expected to contain array, contents ignored`)
@@ -273,14 +274,15 @@ module.exports = async ({ botfile, projectLocation, logger, ghostManager }) => {
   }
 
   const loadData = async (category, fileName) => {
-    const filePath = path.resolve(formDataDir, './' + fileName)
-    fileById[category.id] = filePath
+    fileById[category.id] = fileName
 
     logger.debug(`Loading data for ${category.id} from ${fileName}`)
     let data = []
     try {
-      data = readDataFromFile(filePath, fileName)
-    } catch (e) {}
+      data = await readDataForFile(fileName)
+    } catch (err) {
+      logger.warn(`Error reading data from ${fileName}`, err)
+    }
 
     data = await Promise.map(data, async item => ({
       ...item,
@@ -303,6 +305,7 @@ module.exports = async ({ botfile, projectLocation, logger, ghostManager }) => {
     }
 
     mkdirp.sync(formDataDir)
+    await ghostManager.addFolder(formDataDir, '**/*.json')
 
     const files = await Promise.fromCallback(callback => glob('**/*.form.js', { cwd: formDir }, callback))
 

--- a/src/content/service.js
+++ b/src/content/service.js
@@ -42,7 +42,7 @@ const prepareDb = async () => {
   return knex
 }
 
-module.exports = async ({ botfile, projectLocation, logger }) => {
+module.exports = async ({ botfile, projectLocation, logger, ghostManager }) => {
   const categories = []
   const categoryById = {}
   const fileById = {}

--- a/src/database/ghost.js
+++ b/src/database/ghost.js
@@ -1,0 +1,26 @@
+/*
+  Tables storing ghost content and its revisions
+*/
+
+import helpers from './helpers'
+
+module.exports = knex => {
+  const h = helpers(knex)
+  return h
+    .createTableIfNotExists('ghost_content', table => {
+      table.increments('id')
+      table.string('folder')
+      table.string('file')
+      table.text('content')
+      table.timestamp('modified_on').defaultTo(knex.fn.now())
+    })
+    .then(() =>
+      h.createTableIfNotExists('ghost_revisions', table => {
+        table.increments('id')
+        table.integer('content_id').references('ghost_content.id')
+        table.string('revision')
+        table.timestamp('created_on').defaultTo(knex.fn.now())
+        table.string('created_by')
+      })
+    )
+}

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -63,7 +63,7 @@ module.exports = ({ sqlite, postgres }) => {
       knex = createKnex({ sqlite, postgres })
     }
 
-    return await knex
+    return knex
   }
 
   const saveUser = ({ id, platform, gender, timezone, locale, picture_url, first_name, last_name }) => {
@@ -115,7 +115,7 @@ module.exports = ({ sqlite, postgres }) => {
       kvsInstance = createKvs()
     }
 
-    return await kvsInstance
+    return kvsInstance
   }
 
   const kvsGet = (...args) => getKvs().then(instance => instance.get.apply(null, args))

--- a/src/database/kvs.js
+++ b/src/database/kvs.js
@@ -88,13 +88,12 @@ module.exports = (knex, options = {}) => {
     })
   }
 
-  const bootstrap = () => {
-    return helpers(knex).createTableIfNotExists(tableName, table => {
+  const bootstrap = () =>
+    helpers(knex).createTableIfNotExists(tableName, table => {
       table.string('key').primary()
       table.text('value')
       table.timestamp('modified_on')
     })
-  }
 
   return { get, set, bootstrap }
 }

--- a/src/database/tables.js
+++ b/src/database/tables.js
@@ -1,3 +1,8 @@
 import { table_factories } from '+/database'
 
-module.exports = [require('./users.js'), require('./tags.js'), require('./notifications.js')].concat(table_factories)
+module.exports = [
+  require('./users.js'),
+  require('./tags.js'),
+  require('./notifications.js'),
+  require('./ghost.js')
+].concat(table_factories)

--- a/src/dialog/engine.js
+++ b/src/dialog/engine.js
@@ -62,14 +62,14 @@ class DialogEngine {
         this._trace(`catchAll #${i}, evaluation only of "${catchAllNext[i].condition}"`, context, state)
         if (await this._evaluateCondition(catchAllNext[i].condition, state)) {
           this._trace(`catchAll #${i} matched, processing node ${catchAllNext[i].node}`, context, state)
-          return await this._processNode(stateId, context, catchAllNext[i].node, event)
+          return this._processNode(stateId, context, catchAllNext[i].node, event)
         }
       }
       this._trace('No catchAll next matched', context, state)
     }
 
     this._trace('Processing node ' + context.node, context, state)
-    return await this._processNode(stateId, context, context.node, event)
+    return this._processNode(stateId, context, context.node, event)
   }
 
   async reloadFlows() {
@@ -230,9 +230,8 @@ class DialogEngine {
           // Node "END" or "end" ends the flow (reserved keyword)
           await this._endFlow(stateId)
           return {}
-        } else {
-          return await this._processNode(stateId, context, nextNodes[i].node, event)
         }
+        return this._processNode(stateId, context, nextNodes[i].node, event)
       }
     }
 
@@ -298,7 +297,7 @@ class DialogEngine {
 
     if (context.flowStack.length >= MAX_STACK_SIZE) {
       throw new Error(
-        `Exceeded maximum flow stack size (${MAX_STACK_SIZE}). 
+        `Exceeded maximum flow stack size (${MAX_STACK_SIZE}).
          This might be due to an unexpected infinite loop in your flows.
          Current flow: ${subflow}
          Current node: ${subflowNode}`

--- a/src/ghost-content/README.md
+++ b/src/ghost-content/README.md
@@ -25,7 +25,7 @@ Ghost Content feature is designed to answer both questions.
 With the introduction of the feature the botpress server behaves like that:
 * all changes are not saved to the files anymore, instead they go to the database. This DB is referred to as the ghost version of the content from the files
 * each change gets its unique random UUID recorded in the DB
-* the repository also contains the list of UUIDs (in a file) indicates which of these changes were already incorporated back into the codebase (see below how)
+* the repository also contains the list of UUIDs (in a file) indicating which of these changes were already incorporated back into the codebase (see below how)
 * all parts that need to read from the content files now _always_ read the ghost version from the DB
 * upon server start the following actions are taken:
   * the server finds all the revisions IDs still in the DB

--- a/src/ghost-content/README.md
+++ b/src/ghost-content/README.md
@@ -1,0 +1,37 @@
+# Ghost Content Design Document
+
+Ghost Content is the term referencing the generic approach implemented for managing different types of content, including content types (forms), flows, and potentially others.
+
+## The problem
+
+There are certain parts of the bot code that may change more often than the bot's code.
+For such parts it's often common for less technical members of the team, or for engineers who simply prefer faster feedback cycles, to use the GUI tools to manage the content and observe the behaviour change on the live bot.
+At the moment Botpress provides two such features:
+* Content Manager
+* Flow Editor
+
+Both let you change the files that belong to the bot code through the help of the UI in the Botpress admin panel.
+
+This all works good before you want to deploy the new version of your bot (including some code changes made by the developers).
+
+It opens two problems:
+1) certain hosting platforms (including Heroku, or Google Cloud, or any Docker-based deployment pipeline) will package the new version of your code as a comleteley new container. Which means all of your changes to the local files is gone as soon as you make the new successful deployment (the old container is shut down and thrown away)
+2) What if your updated version of the code has some changes to the same content files that have been edited on the server through the UI.
+
+Ghost Content feature is designed to answer both questions.
+
+## Feature overview
+
+With the introduction of the feature the botpress server behaves like that:
+* all changes are not saved to the files anymore, instead they go to the database. This DB is referred to as the ghost version of the content from the files
+* each change gets its unique random UUID recorded in the DB
+* the repository also contains the list of UUIDs (in a file) indicates which of these changes were already incorporated back into the codebase (see below how)
+* all parts that need to read from the content files now _always_ read the ghost version from the DB
+* upon server start the following actions are taken:
+  * the server finds all the revisions IDs still in the DB
+  * it parses the UUIDs list from the bot code and deletes from the DB the IDs that are already in that file
+  * if there are any IDs remaining in the DB the server generates persisted alert shown in the Botpress admin panel instructing the user to fetch the ghost content and merge it into the source code of their bot (see below how)
+  * otherwise (if all the revisions are said to be reflected in the sources already) the server reads the corresponding files and saves their content to the ghost content DB (which makes it effectively available to the running application)
+* how the ghost content can be incorporated back into the bot's source code:
+  * the main secenario is using the botpress CLI, it will get the package from the server API, and add all the IDs to the UUIDs list, dump the new content into its place in the bot source code directory
+  * alternatively the UI may eventually be present with download links, but it's not likely to happen in the first order

--- a/src/ghost-content/index.js
+++ b/src/ghost-content/index.js
@@ -1,0 +1,12 @@
+module.exports = async ({ logger, db, projectLocation }) => {
+  logger.info('Ghost Content Manager initialized')
+
+  const addFolder = async folder => {}
+
+  const recordVersion = async (folder, file, content) => {}
+
+  return {
+    addFolder,
+    recordVersion
+  }
+}

--- a/src/ghost-content/index.js
+++ b/src/ghost-content/index.js
@@ -1,12 +1,113 @@
-module.exports = async ({ logger, db, projectLocation }) => {
+import path from 'path'
+import fs from 'fs'
+import Promise from 'bluebird'
+import glob from 'glob'
+import uuid from 'uuid'
+import get from 'lodash/get'
+
+Promise.promisifyAll(fs)
+const globAsync = Promise.promisify(glob)
+
+module.exports = ({ logger, db, projectLocation }) => {
   logger.info('Ghost Content Manager initialized')
 
-  const addFolder = async folder => {}
+  const upsert = ({ knex, tableName, where, data, idField = 'id' }) =>
+    knex(tableName)
+      .where(where)
+      .select(idField)
+      .then(res => {
+        const id = get(res, '0.id')
+        return id
+          ? knex(tableName)
+              .where(idField, id)
+              .update(data)
+              .then()
+          : knex(tableName)
+              .insert(Object.assign({}, where, data))
+              .then()
+      })
 
-  const recordVersion = async (folder, file, content) => {}
+  const recordFile = async (folderPath, folder, file) => {
+    const knex = await db.get()
+    const filePath = path.join(folderPath, file)
+    await fs.readFileAsync(filePath, 'utf-8').then(content =>
+      upsert({
+        knex,
+        tableName: 'ghost_content',
+        where: { folder, file },
+        data: { content }
+      })
+    )
+  }
+
+  const normalizeFolder = folder => {
+    const folderPath = path.resolve(projectLocation, folder)
+    return {
+      folderPath,
+      folder: path.relative(projectLocation, folderPath)
+    }
+  }
+
+  const addFolder = async (folder, filesGlob) => {
+    const f = normalizeFolder(folder)
+    const files = await globAsync(filesGlob, { cwd: f.folderPath })
+    await Promise.map(files, file => recordFile(f.folderPath, f.folder, file))
+  }
+
+  const recordRevision = async (folder, file, content) => {
+    const knex = await db.get()
+
+    const f = normalizeFolder(folder)
+    folder = f.folder
+
+    const id = await knex('ghost_content')
+      .where({ folder, file })
+      .select('id')
+      .get(0)
+      .get('id')
+
+    if (!id) {
+      throw new Error(`No Ghost content for file: ${file} in folder: ${folder}. Cannot record the new revision.`)
+    }
+
+    const revision = uuid.v4()
+
+    return knex.transaction(trx => {
+      knex('ghost_content')
+        .transacting(trx)
+        .where({ id })
+        .update({ content })
+        .then(() =>
+          knex('ghost_revisions')
+            .transacting(trx)
+            .insert({
+              content_id: id,
+              revision,
+              created_by: 'admin'
+            })
+            .then()
+        )
+        .then(trx.commit)
+        .catch(err => {
+          logger.error(err)
+          trx.rollback()
+        })
+    })
+  }
+
+  const readFile = async (folder, file) => {
+    const knex = await db.get()
+    const f = normalizeFolder(folder)
+    return knex('ghost_content')
+      .select('content')
+      .where({ folder: f.folder, file })
+      .get(0)
+      .get('content')
+  }
 
   return {
     addFolder,
-    recordVersion
+    recordRevision,
+    readFile
   }
 }


### PR DESCRIPTION
Before the feature is usable by the end users several PRs need to be accumulated.
So I've created a base branch for this story, `ghost-content`, and will send all PRs to it until the entire branch can be merged into develop/x

This first PR implements the generic content manager and switches the content manager to use it.
It's unusable as is because:
* during runtime all the changes are saved to the DB
* but on server restart these changes are erased and replaced with the content from the filesystem

So my next PR will block overwrites and check the hanging revisions.

And then finally I'll work on the tools to pull the ghost content back into the repo.