### PR TITLE
add the primitive view to see the ghost content status

### DIFF
--- a/src/botpress.js
+++ b/src/botpress.js
@@ -234,6 +234,7 @@ class botpress {
       convo,
       umm,
       users,
+      ghostManager,
       contentManager,
       dialogEngine,
       dialogJanitor,

--- a/src/ghost-content/index.js
+++ b/src/ghost-content/index.js
@@ -106,9 +106,18 @@ module.exports = ({ logger, db, projectLocation }) => {
       .get('content')
   }
 
+  const getPending = async () => {
+    const knex = await db.get()
+    return knex('ghost_revisions')
+      .join('ghost_content', 'ghost_content.id', '=', 'ghost_revisions.content_id')
+      .select('ghost_content.folder', 'ghost_content.file', 'ghost_revisions.revision', 'ghost_revisions.created_on')
+      .then()
+  }
+
   return {
     addFolder,
     recordRevision,
-    readFile
+    readFile,
+    getPending
   }
 }

--- a/src/server/secured.js
+++ b/src/server/secured.js
@@ -255,6 +255,10 @@ module.exports = (bp, app) => {
     res.sendStatus(200)
   })
 
+  app.secure('read', 'bot/ghost_content').get('/ghost_content/status', async (req, res) => {
+    res.send(await bp.ghostManager.getPending())
+  })
+
   app.secure('read', 'bot/flows').get('/flows/all', async (req, res) => {
     const flows = await bp.dialogEngine.getFlows()
     return res.send(flows)

--- a/src/web/components/Layout/Sidebar.jsx
+++ b/src/web/components/Layout/Sidebar.jsx
@@ -109,6 +109,7 @@ class Sidebar extends React.Component {
     const modulesRules = { res: 'modules/list', op: 'read' }
     const ummRules = { res: 'umm', op: 'read' }
     const contentRules = { res: 'content', op: 'read' }
+    const ghostRules = { res: 'ghost_content', op: 'read' }
     const flowsRules = { res: 'flows', op: 'read' }
     const middlewareRules = { res: 'middleware', op: 'read' }
 
@@ -116,6 +117,7 @@ class Sidebar extends React.Component {
     const modulesPaths = ['/manage']
     const ummPaths = ['/umm']
     const contentPaths = ['/content']
+    const ghostPaths = ['/ghost-content']
     const flowsPaths = ['/flows']
     const middlewarePaths = ['/middleware']
 
@@ -125,6 +127,7 @@ class Sidebar extends React.Component {
         <ul className="nav">
           {this.renderBasicItem('Dashboard', 'dashboard', dashboardRules, dashboardPaths, 'dashboard')}
           {this.renderBasicItem('Modules', 'manage', modulesRules, modulesPaths, 'build')}
+          {this.renderBasicItem('Ghost Content', 'ghost-content', ghostRules, ghostPaths, 'content_copy')}
           {this.renderBasicItem('Content', 'content', contentRules, contentPaths, 'description')}
           {this.renderBasicItem('Flows', 'flows', flowsRules, flowsPaths, 'device_hub')}
           {this.renderBasicItem('Middleware', 'middleware', middlewareRules, middlewarePaths, 'settings')}

--- a/src/web/components/Routes/index.jsx
+++ b/src/web/components/Routes/index.jsx
@@ -10,6 +10,7 @@ import Manage from '~/views/Manage'
 import Middleware from '~/views/Middleware'
 import UMM from '~/views/UMM'
 import Content from '~/views/Content'
+import GhostContent from '~/views/GhostContent'
 import FlowBuilder from '~/views/FlowBuilder'
 import Module from '~/views/Module'
 import Notifications from '~/views/Notifications'
@@ -39,6 +40,7 @@ export default () => {
         <Route path="manage" component={Manage} />
         <Route path="middleware" component={Middleware} />
         <Route path="content" component={Content} />
+        <Route path="ghost-content" component={GhostContent} />
         <Route path="flows" component={FlowBuilder} />
         <Route path="umm" component={UMM} />
         <Route path="modules/:moduleName(/:subView)" component={Module} />

--- a/src/web/components/Util/Loading.js
+++ b/src/web/components/Util/Loading.js
@@ -1,0 +1,6 @@
+import React from 'react'
+import { ProgressBar } from 'react-bootstrap'
+
+const Loading = () => <ProgressBar active color="info" now={100} />
+
+export default Loading

--- a/src/web/views/GhostContent/index.js
+++ b/src/web/views/GhostContent/index.js
@@ -1,0 +1,106 @@
+import React, { Component } from 'react'
+import classnames from 'classnames'
+import axios from 'axios'
+import groupBy from 'lodash/groupBy'
+import sortBy from 'lodash/sortBy'
+import mapValues from 'lodash/mapValues'
+
+import { Alert, Button } from 'react-bootstrap'
+
+import ContentWrapper from '~/components/Layout/ContentWrapper'
+import PageHeader from '~/components/Layout/PageHeader'
+import Loading from '~/components/Util/Loading'
+
+const transformData = data => mapValues(groupBy(data, 'folder'), entries => groupBy(entries, 'file'))
+
+export default class GhostView extends Component {
+  state = {
+    loading: true,
+    data: null,
+    error: null
+  }
+
+  fetch() {
+    this.setState({ loading: true })
+
+    axios
+      .get('/ghost_content/status')
+      .then(({ data }) => {
+        this.setState({ data: transformData(data), loading: false, error: null })
+      })
+      .catch(error => {
+        this.setState({ error: error.message || 'Unknown', loading: false })
+      })
+  }
+
+  componentDidMount() {
+    this.fetch()
+  }
+
+  renderRevision({ folder, file, revision, created_on: createdOn }) {
+    return (
+      <li key={`${folder}/${file}/${revision}`}>
+        {revision}, created {createdOn}
+      </li>
+    )
+  }
+
+  renderFile(folder, file, data) {
+    data = sortBy(data, 'created_on')
+    return (
+      <li key={`${folder}/${file}`}>
+        <strong>{file}</strong>
+        <ul>{data.map(datum => this.renderRevision(datum))}</ul>
+      </li>
+    )
+  }
+
+  renderFolder(folder, data) {
+    const files = Object.keys(data).sort()
+    return (
+      <li key={folder}>
+        <strong>{folder}</strong>
+        <ul>{files.map(file => this.renderFile(folder, file, data[file]))}</ul>
+      </li>
+    )
+  }
+
+  renderContent() {
+    const { data } = this.state
+    const folders = Object.keys(data).sort()
+
+    return <ul>{folders.map(folder => this.renderFolder(folder, data[folder]))}</ul>
+  }
+
+  renderBody() {
+    const { loading, error } = this.state
+
+    if (loading) {
+      return <Loading />
+    }
+
+    if (error) {
+      return (
+        <Alert bsStyle="danger">
+          <p>Error fetching status dta: {error}.</p>
+          <p>
+            <Button bsStyle="info" onClick={() => this.fetch()}>
+              Try again
+            </Button>
+          </p>
+        </Alert>
+      )
+    }
+
+    return this.renderContent()
+  }
+
+  render() {
+    return (
+      <ContentWrapper>
+        <PageHeader>Ghost Content</PageHeader>
+        {this.renderBody()}
+      </ContentWrapper>
+    )
+  }
+}


### PR DESCRIPTION
This creates a very primitive view to see the pending ghost content revisions:
![](https://monosnap.com/file/kAug6NtYxqg4aMPDGw4UnXcTOr6jZQ.png)

I will later improve the design and add the instructions about using the CLI to merge it into the repo