### PR TITLE
cleanup DB in acordance with .ghost-revisions files

### DIFF
--- a/src/server/secured.js
+++ b/src/server/secured.js
@@ -256,7 +256,7 @@ module.exports = (bp, app) => {
   })
 
   app.secure('read', 'bot/ghost_content').get('/ghost_content/status', async (req, res) => {
-    res.send(await bp.ghostManager.getPending())
+    res.send(bp.ghostManager.getPending())
   })
 
   app.secure('read', 'bot/flows').get('/flows/all', async (req, res) => {

--- a/src/web/views/GhostContent/index.js
+++ b/src/web/views/GhostContent/index.js
@@ -11,7 +11,7 @@ import ContentWrapper from '~/components/Layout/ContentWrapper'
 import PageHeader from '~/components/Layout/PageHeader'
 import Loading from '~/components/Util/Loading'
 
-const transformData = data => mapValues(groupBy(data, 'folder'), entries => groupBy(entries, 'file'))
+const transformData = data => mapValues(data, entries => groupBy(entries, 'file'))
 
 export default class GhostView extends Component {
   state = {
@@ -69,7 +69,34 @@ export default class GhostView extends Component {
     const { data } = this.state
     const folders = Object.keys(data).sort()
 
-    return <ul>{folders.map(folder => this.renderFolder(folder, data[folder]))}</ul>
+    if (!folders.length) {
+      return (
+        <Alert bsStyle="success">
+          <p>You don't have any ghost content in your DB, DB is in sync with the bot source code.</p>
+          <p>
+            Don't know what is ghost content? <a href="#">Read here</a> about this feature.
+          </p>
+        </Alert>
+      )
+    }
+
+    return (
+      <div>
+        <Alert bsStyle="warning">
+          <p>
+            Below is the list of ghost content present in the DB. You need to eventually sync it up with the bot source
+            code.&nbsp;
+            <strong>
+              <a href="#">Show me</a> how to do it
+            </strong>.
+          </p>
+          <p>
+            Don't know what is ghost content? <a href="#">Read here</a> about this feature.
+          </p>
+        </Alert>
+        <ul>{folders.map(folder => this.renderFolder(folder, data[folder]))}</ul>
+      </div>
+    )
   }
 
   renderBody() {


### PR DESCRIPTION
> Knock-knock!
Who's there?
Ghost content server sync!

This is the last but one major part for this feature.

Now the server does the following:

* upon startup:
  * read all the known (handled by developers) revisions from the `.ghost-revisions` folder
  * read all the revisions recorded in the DB (called _pending_)
  * delete from the DB revision IDs seen in the file
  * if there are **no pending revisions left** sync the DB with the file system:
    * update the content for every file on the FS
    * delete the content for files no longer on the FS
  * otherwise keep track of the revisions that are still pending (an in-memory cached value)
* upon recording the new revision update the cached list of the pending revisions
* for pending status API now use the cached value (not a significant performance improvement for the most cases, but I ave it anyway, and it makes the response / status page much faster) 

Now the only major remaining thing is the CLI utility to support auth and sync of the pending ghost content back to the FS (using the same pending endpoint with slight improvements)
