### PR TITLE
add __dirname fix to webpack.js to support versionCheck

### DIFF
--- a/src/cli/templates/create/webpack.js
+++ b/src/cli/templates/create/webpack.js
@@ -8,26 +8,33 @@ var nodeConfig = {
   output: {
     path: './bin',
     filename: 'node.bundle.js',
-    libraryTarget: 'commonjs2'
+    libraryTarget: 'commonjs2',
+    publicPath: __dirname
   },
   externals: [nodeExternals(), 'botpress'],
   target: 'node',
+  node: {
+    __dirname: false
+  },
   resolve: {
     extensions: ['', '.js']
   },
   module: {
-    loaders: [{
-      test: /\.js$/,
-      loader: 'babel-loader',
-      exclude: /node_modules/,
-      query: {
-        presets: ['latest', 'stage-0'],
-        plugins: ['transform-object-rest-spread', 'transform-async-to-generator']
+    loaders: [
+      {
+        test: /\.js$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+        query: {
+          presets: ['latest', 'stage-0'],
+          plugins: ['transform-object-rest-spread', 'transform-async-to-generator']
+        }
+      },
+      {
+        test: /\.json$/,
+        loader: 'json-loader'
       }
-    }, {
-      test: /\.json$/,
-      loader: 'json-loader'
-    }]
+    ]
   }
 }
 
@@ -45,32 +52,41 @@ var webConfig = {
     extensions: ['', '.js', '.jsx']
   },
   externals: {
-    'react': 'React',
+    react: 'React',
     'react-dom': 'ReactDOM'
   },
   module: {
-    loaders: [{
-      test: /\.jsx?$/,
-      loader: 'babel-loader',
-      exclude: /node_modules/,
-      query: {
-        presets: ['latest', 'stage-0', 'react'],
-        plugins: ['transform-object-rest-spread', 'transform-decorators-legacy']
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+        query: {
+          presets: ['latest', 'stage-0', 'react'],
+          plugins: ['transform-object-rest-spread', 'transform-decorators-legacy']
+        }
+      },
+      {
+        test: /\.scss$/,
+        loaders: [
+          'style',
+          'css?modules&importLoaders=1&localIdentName=' + pkg.name + '__[name]__[local]___[hash:base64:5]',
+          'sass'
+        ]
+      },
+      {
+        test: /\.css$/,
+        loaders: ['style', 'css']
+      },
+      {
+        test: /\.woff|\.woff2|\.svg|.eot|\.ttf/,
+        loader: 'file?name=../fonts/[name].[ext]'
+      },
+      {
+        test: /\.json$/,
+        loader: 'json-loader'
       }
-    }, {
-      test: /\.scss$/,
-      loaders: ['style', 'css?modules&importLoaders=1&localIdentName=' 
-        + pkg.name + '__[name]__[local]___[hash:base64:5]', 'sass']
-    }, {
-      test: /\.css$/,
-      loaders: ['style', 'css']
-    }, {
-      test: /\.woff|\.woff2|\.svg|.eot|\.ttf/,
-      loader: 'file?name=../fonts/[name].[ext]'
-    }, {
-      test: /\.json$/,
-      loader: 'json-loader'
-    }]
+    ]
   }
 }
 
@@ -90,7 +106,9 @@ const liteConfig = Object.assign({}, webConfig, {
 
 var compiler = webpack([nodeConfig, webConfig, liteConfig])
 var postProcess = function(err, stats) {
-  if (err) { throw err }
+  if (err) {
+    throw err
+  }
   console.log(stats.toString('minimal'))
 }
 


### PR DESCRIPTION
In all the modules that I have seen, they use the `botpress-version-manager`

however, when calling: `checkVersion(bp, __dirname)`
it will fail, because `__dirname` is set to `/`

all the modules have setting in `webpack.js` to fix this, so I suggest we add it to the base file

https://github.com/botpress/botpress-messenger/blob/8be6bcd7ec32a36cae257fc85d0b23e24076015e/webpack.js#L16-L18