### PR TITLE
Ghost content better ux

### DIFF
--- a/src/botpress.js
+++ b/src/botpress.js
@@ -170,7 +170,8 @@ class botpress {
     const ghostManager = createGhostManager({
       projectLocation,
       logger,
-      db
+      db,
+      enabled: !!_.get(botfile, 'ghostContent.enabled')
     })
     const contentManager = await createContentManager({
       logger,

--- a/src/cli/templates/init/botfile.js
+++ b/src/cli/templates/init/botfile.js
@@ -54,6 +54,13 @@ module.exports = {
   },
 
   /*
+    By default ghost content management is only activated in production
+   */
+  ghostContent: {
+    enabled: process.env.NODE_ENV === 'production' || process.env.BOTPRESS_GHOST_ENABLED
+  },
+
+  /*
     Access control of admin panel
   */
   login: {

--- a/src/cli/templates/init/package.json
+++ b/src/cli/templates/init/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "start": "botpress start",
+    "ghost-sync": "botpress ghost-sync",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "<%= author %>",

--- a/src/ghost-content/transparent.js
+++ b/src/ghost-content/transparent.js
@@ -1,0 +1,38 @@
+/*
+  Transparent Ghost Content Manager hs the same API but
+  proxies all calls directly to the FS.
+  It's used while in development.
+*/
+
+import path from 'path'
+import fs from 'fs'
+import Promise from 'bluebird'
+
+import { normalizeFolder as _normalizeFolder } from './util'
+
+Promise.promisifyAll(fs)
+
+module.exports = ({ logger, projectLocation }) => {
+  const normalizeFolder = _normalizeFolder(projectLocation)
+
+  logger.info('[Ghost Content Manager] (transparent) Initialized')
+
+  return {
+    addFolder: (folder, filesGlob) => {
+      const { normalizedFolderName } = normalizeFolder(folder)
+      logger.debug(`[Ghost Content Manager] (transparent) Added folder ${normalizedFolderName}, doing nothing.`)
+    },
+    recordRevision: (folder, file, content) => {
+      const { folderPath } = normalizeFolder(folder)
+      const filePath = path.join(folderPath, file)
+      return fs.writeFileAsync(filePath, content)
+    },
+    readFile: (folder, file) => {
+      const { folderPath } = normalizeFolder(folder)
+      const filePath = path.join(folderPath, file)
+      return fs.readFileAsync(filePath, 'utf-8')
+    },
+    getPending: () => ({}),
+    getPendingWithContent: () => ({})
+  }
+}

--- a/src/ghost-content/util.js
+++ b/src/ghost-content/util.js
@@ -1,0 +1,9 @@
+import path from 'path'
+
+export const normalizeFolder = projectLocation => folder => {
+  const folderPath = path.resolve(projectLocation, folder)
+  return {
+    folderPath,
+    normalizedFolderName: path.relative(projectLocation, folderPath)
+  }
+}

--- a/src/server/static.js
+++ b/src/server/static.js
@@ -78,7 +78,8 @@ module.exports = bp => {
     }
 
     app.use('/js/env.js', (req, res) => {
-      const { tokenExpiry, enabled } = bp.botfile.login
+      const { tokenExpiry, enabled: authEnabled } = bp.botfile.login
+      const { enabled: ghostEnabled } = bp.botfile.ghostContent
       const optOutStats = !!bp.botfile.optOutStats
       const appName = bp.botfile.appName || 'Botpress'
 
@@ -87,13 +88,14 @@ module.exports = bp => {
       res.send(`(function(window) {
         window.NODE_ENV = "${process.env.NODE_ENV || 'development'}";
         window.DEV_MODE = ${util.isDeveloping};
-        window.AUTH_ENABLED = ${enabled};
+        window.AUTH_ENABLED = ${!!authEnabled};
         window.AUTH_TOKEN_DURATION = ${ms(tokenExpiry)};
         window.OPT_OUT_STATS = ${optOutStats};
         window.SHOW_GUIDED_TOUR = ${isFirstRun};
         window.BOTPRESS_VERSION = "${version}";
         window.APP_NAME = "${appName}";
-      })(window || {})`)
+        window.GHOST_ENABLED = ${!!ghostEnabled}
+      })(typeof window != 'undefined' ? window : {})`)
     })
 
     serveCustomTheme(app)

--- a/src/web/components/Layout/Sidebar.jsx
+++ b/src/web/components/Layout/Sidebar.jsx
@@ -127,7 +127,8 @@ class Sidebar extends React.Component {
         <ul className="nav">
           {this.renderBasicItem('Dashboard', 'dashboard', dashboardRules, dashboardPaths, 'dashboard')}
           {this.renderBasicItem('Modules', 'manage', modulesRules, modulesPaths, 'build')}
-          {this.renderBasicItem('Ghost Content', 'ghost-content', ghostRules, ghostPaths, 'content_copy')}
+          {window.GHOST_ENABLED &&
+            this.renderBasicItem('Ghost Content', 'ghost-content', ghostRules, ghostPaths, 'content_copy')}
           {this.renderBasicItem('Content', 'content', contentRules, contentPaths, 'description')}
           {this.renderBasicItem('Flows', 'flows', flowsRules, flowsPaths, 'device_hub')}
           {this.renderBasicItem('Middleware', 'middleware', middlewareRules, middlewarePaths, 'settings')}

--- a/src/web/components/Layout/Sidebar.jsx
+++ b/src/web/components/Layout/Sidebar.jsx
@@ -59,9 +59,6 @@ const BASIC_MENU_ITEMS = [
   }
 ].filter(Boolean)
 
-// const ummPaths = ['/umm']
-// const ummRules = { res: 'umm', op: 'read' }
-
 class Sidebar extends React.Component {
   static contextTypes = {
     router: PropTypes.object.isRequired

--- a/src/web/components/Layout/Sidebar.jsx
+++ b/src/web/components/Layout/Sidebar.jsx
@@ -9,7 +9,58 @@ import ReactSidebar from 'react-sidebar'
 import SidebarHeader from './SidebarHeader'
 import RulesChecker from '+/views/RulesChecker'
 
+import GhostChecker from '~/views/GhostContent/Checker'
+
 const style = require('./Sidebar.scss')
+
+const BASIC_MENU_ITEMS = [
+  {
+    name: 'Dashboard',
+    path: 'dashboard',
+    activePaths: ['', '/', '/dashboard'],
+    rule: { res: 'dashboard', op: 'read' },
+    icon: 'dashboard'
+  },
+  {
+    name: 'Modules',
+    path: 'manage',
+    activePaths: ['/manage'],
+    rule: { res: 'modules/list', op: 'read' },
+    icon: 'dashboard'
+  },
+  window.GHOST_ENABLED && {
+    name: 'Ghost Content',
+    path: 'ghost-content',
+    activePaths: ['/ghost-content'],
+    rule: { res: 'ghost_content', op: 'read' },
+    icon: 'content_copy',
+    renderSuffix: () => <GhostChecker />
+  },
+  {
+    name: 'Content',
+    path: 'content',
+    activePaths: ['/content'],
+    rule: { res: 'content', op: 'read' },
+    icon: 'description'
+  },
+  {
+    name: 'Flows',
+    path: 'flows',
+    activePaths: ['/flows'],
+    rule: { res: 'flows', op: 'read' },
+    icon: 'device_hub'
+  },
+  {
+    name: 'Middleware',
+    path: 'middleware',
+    activePaths: ['/middleware'],
+    rule: { res: 'middleware', op: 'read' },
+    icon: 'settings'
+  }
+].filter(Boolean)
+
+// const ummPaths = ['/umm']
+// const ummRules = { res: 'umm', op: 'read' }
 
 class Sidebar extends React.Component {
   static contextTypes = {
@@ -73,26 +124,24 @@ class Sidebar extends React.Component {
     )
   }
 
-  getActiveClassNames = condition => {
-    return classnames({
+  getActiveClassNames = condition =>
+    classnames({
       'bp-sidebar-active': condition,
       [style.active]: condition
     })
-  }
 
-  renderBasicItem(name, path, rule, activePaths, icon) {
-    const isAt = paths => {
-      return paths.includes(location.pathname)
-    }
+  renderBasicItem = ({ name, path, activePaths, rule, icon, renderSuffix }) => {
+    const isAt = paths => paths.includes(location.pathname)
 
     const className = this.getActiveClassNames(isAt(activePaths))
 
     return (
-      <RulesChecker res={rule.res} op={rule.op}>
+      <RulesChecker res={rule.res} op={rule.op} key={name}>
         <li className={className} key={path}>
           <Link to={path} title={name}>
             <i className="icon material-icons">{icon}</i>
             {name}
+            {renderSuffix && renderSuffix()}
           </Link>
         </li>
       </RulesChecker>
@@ -101,39 +150,17 @@ class Sidebar extends React.Component {
 
   render() {
     const modules = this.props.modules
-    const items = modules.filter(x => !x.noInterface).map(this.renderModuleItem)
+    const moduleItems = modules.filter(x => !x.noInterface).map(this.renderModuleItem)
 
     const emptyClassName = classnames(style.empty, 'bp-empty')
-
-    const dashboardRules = { res: 'dashboard', op: 'read' }
-    const modulesRules = { res: 'modules/list', op: 'read' }
-    const ummRules = { res: 'umm', op: 'read' }
-    const contentRules = { res: 'content', op: 'read' }
-    const ghostRules = { res: 'ghost_content', op: 'read' }
-    const flowsRules = { res: 'flows', op: 'read' }
-    const middlewareRules = { res: 'middleware', op: 'read' }
-
-    const dashboardPaths = ['', '/', '/dashboard']
-    const modulesPaths = ['/manage']
-    const ummPaths = ['/umm']
-    const contentPaths = ['/content']
-    const ghostPaths = ['/ghost-content']
-    const flowsPaths = ['/flows']
-    const middlewarePaths = ['/middleware']
 
     const sidebarContent = (
       <div className={classnames(style.sidebar, 'bp-sidebar')}>
         <SidebarHeader />
         <ul className="nav">
-          {this.renderBasicItem('Dashboard', 'dashboard', dashboardRules, dashboardPaths, 'dashboard')}
-          {this.renderBasicItem('Modules', 'manage', modulesRules, modulesPaths, 'build')}
-          {window.GHOST_ENABLED &&
-            this.renderBasicItem('Ghost Content', 'ghost-content', ghostRules, ghostPaths, 'content_copy')}
-          {this.renderBasicItem('Content', 'content', contentRules, contentPaths, 'description')}
-          {this.renderBasicItem('Flows', 'flows', flowsRules, flowsPaths, 'device_hub')}
-          {this.renderBasicItem('Middleware', 'middleware', middlewareRules, middlewarePaths, 'settings')}
-          {items}
-          <li className={emptyClassName} key="empty" />
+          {BASIC_MENU_ITEMS.map(this.renderBasicItem)}
+          {moduleItems}
+          <li className={emptyClassName} />
         </ul>
       </div>
     )

--- a/src/web/views/GhostContent/About.js
+++ b/src/web/views/GhostContent/About.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { getHost } from './util'
+
+const AboutGhostContent = () => (
+  <section>
+    <p>Some of the bot's behavior is determined by the content coming from the files (Content / Forms, Flows).</p>
+    <p>For your convenience Botpress provides the GUI tools to edit these files while in development.</p>
+    <p>
+      We also provide the same tools in production, but there's a caveat. If we would write the same change to the
+      server's file system they could easily be lost due to the nature of ephemeral server instances (when the new
+      version of the bot is deployed the old server instance may be simply shut down by the cloud hosting platform).
+    </p>
+    <p>
+      To address this issue we give you the Ghost COntent feature. In production your changes are saved to the database
+      which is persisted between deployments. But how do you get these changes back to your bot's codebase?
+    </p>
+    <p>
+      To do so you run a special command from your bot folder, <code>npm run ghost-sync -- {getHost()}</code>. This will
+      fetch the updated content from the server, apply it to the local file system, and also record the revision IDs in
+      a special file.
+    </p>
+    <p>The synchronisation is finalized after these updated files are redeployed.</p>
+  </section>
+)
+
+export default AboutGhostContent

--- a/src/web/views/GhostContent/About.js
+++ b/src/web/views/GhostContent/About.js
@@ -15,9 +15,9 @@ const AboutGhostContent = () => (
       which is persisted between deployments. But how do you get these changes back to your bot's codebase?
     </p>
     <p>
-      To do so you run a special command from your bot folder, <code>npm run ghost-sync -- {getHost()}</code>. This will
-      fetch the updated content from the server, apply it to the local file system, and also record the revision IDs in
-      a special file.
+      To do so you run a special command from your bot folder,&nbsp;
+      <code>./node_modules/.bin/botpress ghost-sync {getHost()}</code>. This will fetch the updated content from the
+      server, apply it to the local file system, and also record the revision IDs in a special file.
     </p>
     <p>The synchronisation is finalized after these updated files are redeployed.</p>
   </section>

--- a/src/web/views/GhostContent/Checker.js
+++ b/src/web/views/GhostContent/Checker.js
@@ -1,0 +1,46 @@
+import React, { Component } from 'react'
+
+import { fetchStatus } from './util'
+
+const CHECK_INTERVAL_SEC = 5
+
+class GhostContentStatusChecker extends Component {
+  state = {
+    hasPending: false
+  }
+
+  fetch = () => {
+    fetchStatus()
+      .then(data => {
+        const hasPending = data && !!Object.keys(data).length
+        this.setState({ hasPending })
+      })
+      .catch(() => {
+        // do nothing
+      })
+  }
+
+  componentDidMount() {
+    this.fetch()
+    this.checkInterval = setInterval(this.fetch, CHECK_INTERVAL_SEC * 1000)
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.checkInterval)
+  }
+
+  render() {
+    const { hasPending } = this.state
+    return (
+      hasPending && (
+        <span>
+          &nbsp;<i className="icon material-icons" title="You have Ghost Content, see how to sync it.">
+            warning
+          </i>
+        </span>
+      )
+    )
+  }
+}
+
+export default GhostContentStatusChecker

--- a/src/web/views/GhostContent/index.js
+++ b/src/web/views/GhostContent/index.js
@@ -9,7 +9,7 @@ import PageHeader from '~/components/Layout/PageHeader'
 import Loading from '~/components/Util/Loading'
 import About from './About'
 
-import { fetchStatus } from './util'
+import { fetchStatus, getHost } from './util'
 
 export default class GhostView extends Component {
   state = {
@@ -81,7 +81,7 @@ export default class GhostView extends Component {
   }
 
   renderContent() {
-    const { data } = this.state
+    const { data, showSyncHelp } = this.state
     const folders = Object.keys(data).sort()
 
     if (!folders.length) {
@@ -115,6 +115,16 @@ export default class GhostView extends Component {
             </Button>
           </p>
         </Alert>
+        {showSyncHelp && (
+          <Alert bsStyle="info" onDismiss={this.hideSyncHelp}>
+            <p>
+              <strong>To pull the pending ghost content run in your bot's project folder:</strong>
+            </p>
+            <p>
+              <code>./node_modules/.bin/botpress ghost-sync {getHost()}</code>
+            </p>
+          </Alert>
+        )}
         <ul>{folders.map(folder => this.renderFolder(folder, data[folder]))}</ul>
       </div>
     )

--- a/src/web/views/GhostContent/index.js
+++ b/src/web/views/GhostContent/index.js
@@ -1,9 +1,6 @@
 import React, { Component } from 'react'
 import classnames from 'classnames'
-import axios from 'axios'
-import groupBy from 'lodash/groupBy'
 import sortBy from 'lodash/sortBy'
-import mapValues from 'lodash/mapValues'
 
 import { Alert, Button } from 'react-bootstrap'
 
@@ -11,7 +8,7 @@ import ContentWrapper from '~/components/Layout/ContentWrapper'
 import PageHeader from '~/components/Layout/PageHeader'
 import Loading from '~/components/Util/Loading'
 
-const transformData = data => mapValues(data, entries => groupBy(entries, 'file'))
+import { fetchStatus } from './util'
 
 export default class GhostView extends Component {
   state = {
@@ -23,10 +20,9 @@ export default class GhostView extends Component {
   fetch() {
     this.setState({ loading: true })
 
-    axios
-      .get('/ghost_content/status')
-      .then(({ data }) => {
-        this.setState({ data: transformData(data), loading: false, error: null })
+    fetchStatus()
+      .then(data => {
+        this.setState({ data, loading: false, error: null })
       })
       .catch(error => {
         this.setState({ error: error.message || 'Unknown', loading: false })

--- a/src/web/views/GhostContent/index.js
+++ b/src/web/views/GhostContent/index.js
@@ -2,11 +2,12 @@ import React, { Component } from 'react'
 import classnames from 'classnames'
 import sortBy from 'lodash/sortBy'
 
-import { Alert, Button } from 'react-bootstrap'
+import { Alert, Button, Modal } from 'react-bootstrap'
 
 import ContentWrapper from '~/components/Layout/ContentWrapper'
 import PageHeader from '~/components/Layout/PageHeader'
 import Loading from '~/components/Util/Loading'
+import About from './About'
 
 import { fetchStatus } from './util'
 
@@ -14,7 +15,25 @@ export default class GhostView extends Component {
   state = {
     loading: true,
     data: null,
-    error: null
+    error: null,
+    showAbout: false,
+    showSyncHelp: false
+  }
+
+  showAbout = () => {
+    this.setState({ showAbout: true })
+  }
+
+  hideAbout = () => {
+    this.setState({ showAbout: false })
+  }
+
+  showSyncHelp = () => {
+    this.setState({ showSyncHelp: true })
+  }
+
+  hideSyncHelp = () => {
+    this.setState({ showSyncHelp: false })
   }
 
   fetch() {
@@ -70,7 +89,10 @@ export default class GhostView extends Component {
         <Alert bsStyle="success">
           <p>You don't have any ghost content in your DB, DB is in sync with the bot source code.</p>
           <p>
-            Don't know what is ghost content? <a href="#">Read here</a> about this feature.
+            Don't know what is ghost content?&nbsp;
+            <Button bsSize="small" bsStyle="link" onClick={this.showAbout}>
+              Read about this feature
+            </Button>.
           </p>
         </Alert>
       )
@@ -82,12 +104,15 @@ export default class GhostView extends Component {
           <p>
             Below is the list of ghost content present in the DB. You need to eventually sync it up with the bot source
             code.&nbsp;
-            <strong>
-              <a href="#">Show me</a> how to do it
-            </strong>.
+            <Button bsSize="small" bsStyle="info" onClick={this.showSyncHelp}>
+              Show me how to do it
+            </Button>
           </p>
           <p>
-            Don't know what is ghost content? <a href="#">Read here</a> about this feature.
+            Don't know what is ghost content?&nbsp;
+            <Button bsSize="small" bsStyle="link" onClick={this.showAbout}>
+              Read about this feature
+            </Button>
           </p>
         </Alert>
         <ul>{folders.map(folder => this.renderFolder(folder, data[folder]))}</ul>
@@ -123,6 +148,18 @@ export default class GhostView extends Component {
       <ContentWrapper>
         <PageHeader>Ghost Content</PageHeader>
         {this.renderBody()}
+
+        <Modal show={this.state.showAbout} onHide={this.hideAbout}>
+          <Modal.Header closeButton>
+            <Modal.Title>Ghost Content</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <About />
+          </Modal.Body>
+          <Modal.Footer>
+            <Button onClick={this.hideAbout}>Close</Button>
+          </Modal.Footer>
+        </Modal>
       </ContentWrapper>
     )
   }

--- a/src/web/views/GhostContent/util.js
+++ b/src/web/views/GhostContent/util.js
@@ -1,0 +1,11 @@
+import axios from 'axios'
+
+import groupBy from 'lodash/groupBy'
+import mapValues from 'lodash/mapValues'
+
+const transformData = data => mapValues(data, entries => groupBy(entries, 'file'))
+
+export const fetchStatus = () =>
+  axios.get('/ghost_content/status').then(({ data }) => {
+    return transformData(data)
+  })

--- a/src/web/views/GhostContent/util.js
+++ b/src/web/views/GhostContent/util.js
@@ -9,3 +9,8 @@ export const fetchStatus = () =>
   axios.get('/ghost_content/status').then(({ data }) => {
     return transformData(data)
   })
+
+export const getHost = () => {
+  const { protocol, host } = document.location
+  return `${protocol}//${host}`
+}


### PR DESCRIPTION
A bunch of changes:
* don't save ghost content to the DB in dev mode by default (configurable in botfile), and hide the menu item when the feature is disabled
* a warning icon shown next to the menu item when there is ghost content 
* modal with feature explanation
* command how to run sync

The last thing that needs to be implemented for proper UX is git clean status check for better CLI experience