### PR TITLE
force min node 6.10 everywhere

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 Make sure these checkboxes are checked before raising an issue, thank you!
 
-- [] Check that you are using node version >= `6.5`
+- [] Check that you are using node version >= `6.10`
 - [] Search the [documentation](https://botpress.io/docs)
 
 Please also fill in these fields:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The best way to get quickly get started using Botpress is to watch our [video tu
 
 ## Installation
 
-Botpress requires [node](https://nodejs.org) (version >= 4.6) and uses [npm](https://www.npmjs.com) as package manager.
+Botpress requires [node](https://nodejs.org) (version >= 6.10) and uses [npm](https://www.npmjs.com) as package manager.
 
 ```
 npm install -g botpress
@@ -136,13 +136,13 @@ This is a non-exclusive list of modules Botpress has. See [the full list of modu
 Thanks you for your interest in Botpress. Here are some of the many ways to contribute.
 
   - Check out our [contributing guide](/.github/CONTRIBUTING.md)
-  - Look at our [code of conduct](/.github/CODE_OF_CONDUCT.md) 
-  - Engage with us on Social Media 
+  - Look at our [code of conduct](/.github/CODE_OF_CONDUCT.md)
+  - Engage with us on Social Media
     - Follow us on [Twitter](https://twitter.com/getbotpress)
     - Like us on [Facebook](https://www.facebook.com/botpress)
     - Join our channel on [Slack](https://slack.botpress.io)
-  - Answer and ask questions on the Slack community 
-  - [Donate](/.github/DONATE.md) to the project 
+  - Answer and ask questions on the Slack community
+  - [Donate](/.github/DONATE.md) to the project
   - [Write and edit the documentation](/.github/CONTRIBUTING.md)
   - Check misspelling in our docs.
 

--- a/package.json
+++ b/package.json
@@ -125,9 +125,7 @@
     "webpack": "^3.8.1",
     "webpack-node-externals": "^1.6.0"
   },
-  "engines": {
-    "node": ">=4.6.0 <9.0.0"
-  },
+  "engines": { "node": ">=6.10.0 <9.0.0" },
   "homepage": "https://github.com/botpress/botpress#readme",
   "keywords": [
     "bots",


### PR DESCRIPTION
I've mentioned this in misc refactorings PR but didn't actually implement there (have no idea why).
As we're bundling for node >= 6.10 and Node 4 is no longer officially supported seems logical to enforce Node 6 (LTS) as the minimal required version.