### PR TITLE
add knex migrations

### DIFF
--- a/migrations/001-ghost_content-deleted.js
+++ b/migrations/001-ghost_content-deleted.js
@@ -1,0 +1,9 @@
+exports.up = knex =>
+  knex.schema.table('ghost_content', t => {
+    t.boolean('deleted').defaultTo(0)
+  })
+
+exports.down = knex =>
+  knex.schema.table('ghost_content', t => {
+    t.dropColumn('deleted')
+  })

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -11,7 +11,7 @@ const initializeCoreDatabase = knex => {
     throw new Error('You must initialize the database before')
   }
 
-  return Promise.mapSeries(tables, fn => fn(knex))
+  return Promise.mapSeries(tables, fn => fn(knex)).then(() => knex.migrate.latest())
 }
 
 const createKnex = async ({ sqlite, postgres }) => {


### PR DESCRIPTION
@epaminond please reject this one if you don't need it bit we should start using migrations anyway so maybe it's a good start.
It's not critical right now because of version X that's not supported (so we can have backward-incompat changes) but that will do our lives easier with existing bots already having some ghost content