### PR TITLE
Initial saving of flows to ghost-manager

### DIFF
--- a/migrations/001-ghost_content-deleted.js
+++ b/migrations/001-ghost_content-deleted.js
@@ -1,0 +1,9 @@
+exports.up = knex =>
+  knex.schema.table('ghost_content', t => {
+    t.boolean('deleted').defaultTo(0)
+  })
+
+exports.down = knex =>
+  knex.schema.table('ghost_content', t => {
+    t.dropColumn('deleted')
+  })

--- a/src/botpress.js
+++ b/src/botpress.js
@@ -190,7 +190,7 @@ class botpress {
     })
 
     const dialogStateManager = StateManager({ db })
-    const flowProvider = new FlowProvider({ logger, projectLocation, botfile })
+    const flowProvider = new FlowProvider({ logger, projectLocation, botfile, ghostManager })
     const dialogJanitor = new DialogJanitor({ db, middlewares, botfile })
     const dialogEngine = new DialogEngine(flowProvider, dialogStateManager, null, logger)
 

--- a/src/cli/ghost-sync.js
+++ b/src/cli/ghost-sync.js
@@ -29,9 +29,9 @@ const writeRevisions = async (revisionsFile, revisions) => {
   })
 }
 
-const writeFile = folderPath => async ({ file, content }) => {
+const writeFile = folderPath => async ({ file, content, deleted }) => {
   const filePath = path.join(folderPath, file)
-  return fs.writeFileAsync(filePath, content)
+  return deleted ? fs.unlinkAsync(filePath) : fs.writeFileAsync(filePath, content)
 }
 
 const updateFolder = projectLocation => async ({ files, revisions }, folder) => {

--- a/src/content/service.js
+++ b/src/content/service.js
@@ -102,7 +102,7 @@ module.exports = async ({ botfile, projectLocation, logger, ghostManager }) => {
     const items = (await listCategoryItems(categoryId)).map(item =>
       _.pick(item, 'id', 'formData', 'createdBy', 'createdOn')
     )
-    await ghostManager.recordRevision(formDataDir, fileById[categoryId], JSON.stringify(items, null, 2))
+    await ghostManager.upsertFile(formDataDir, fileById[categoryId], JSON.stringify(items, null, 2))
   }
 
   const dumpAllDataToFiles = () => Promise.map(categories, ({ id }) => dumpDataToFile(id))
@@ -128,7 +128,7 @@ module.exports = async ({ botfile, projectLocation, logger, ghostManager }) => {
         .where({ categoryId: category.id })
         .count('* as count')
         .get(0)
-        .then(row => (row && row.count) || 0)
+        .then(row => (row && Number(row.count)) || 0)
 
       return {
         id: category.id,
@@ -201,8 +201,7 @@ module.exports = async ({ botfile, projectLocation, logger, ghostManager }) => {
   const categoryItemsCount = () => {
     return knex('content_items')
       .count('id as count')
-      .get(0)
-      .get('count')
+      .then(([res]) => Number(res.count))
   }
 
   const deleteCategoryItems = async ids => {

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -11,7 +11,7 @@ const initializeCoreDatabase = knex => {
     throw new Error('You must initialize the database before')
   }
 
-  return Promise.mapSeries(tables, fn => fn(knex))
+  return Promise.mapSeries(tables, fn => fn(knex)).then(() => knex.migrate.latest())
 }
 
 const createKnex = async ({ sqlite, postgres }) => {

--- a/src/dialog/provider.js
+++ b/src/dialog/provider.js
@@ -9,7 +9,7 @@ import mkdirp from 'mkdirp'
 import { validateFlowSchema } from './validator'
 
 export default class FlowProvider extends EventEmitter2 {
-  constructor({ logger, botfile, projectLocation }) {
+  constructor({ logger, botfile, projectLocation, ghostManager }) {
     super({
       wildcard: true,
       maxListeners: 100
@@ -18,107 +18,70 @@ export default class FlowProvider extends EventEmitter2 {
     this.logger = logger
     this.botfile = botfile
     this.projectLocation = projectLocation
+    this.ghostManager = ghostManager
+    this.flowsDir = this.botfile.flowsDir || './flows'
+
+    mkdirp.sync(path.dirname(this.flowsDir))
+    this.ghostManager.addRootFolder(this.flowsDir, '**/*.json')
   }
 
   async loadAll() {
-    const relDir = this.botfile.flowsDir || './flows'
-    const flowsDir = path.resolve(this.projectLocation, relDir)
+    const flowFiles = await this.ghostManager.directoryListing(this.flowsDir, '.flow.json')
 
-    if (!fs.existsSync(flowsDir)) {
-      return []
-    }
-
-    const searchOptions = { cwd: flowsDir }
-
-    const flowFiles = await Promise.fromCallback(callback => glob('**/*.flow.json', searchOptions, callback))
-
-    const flows = []
-
-    flowFiles.forEach(file => {
-      const filePath = path.resolve(flowsDir, './' + file)
-      const flow = JSON.parse(fs.readFileSync(filePath))
-
-      flow.name = file // e.g. 'login.flow.json' or 'shapes/circle.flow.json'
+    const flows = await Promise.map(flowFiles, async flowPath => {
+      const flow = JSON.parse(await this.ghostManager.readFile(this.flowsDir, flowPath))
 
       const schemaError = validateFlowSchema(flow)
-      if (schemaError) {
-        return this.logger.warn(schemaError)
+      if (!flow || schemaError) {
+        return flow ? this.logger.warn(schemaError) : null
       }
 
-      const uiEqPath = path.resolve(flowsDir, './' + file.replace(/\.flow/g, '.ui'))
-      let uiEq = {}
-
-      if (fs.existsSync(uiEqPath)) {
-        uiEq = JSON.parse(fs.readFileSync(uiEqPath))
-      }
+      const uiEq = JSON.parse(await this.ghostManager.readFile(this.flowsDir, this._uiPath(flowPath)))
 
       Object.assign(flow, { links: uiEq.links })
 
       // Take position from UI files or create default position
-      const unplacedNodes = []
-      flow.nodes.forEach(node => {
-        const uiNode = _.find(uiEq.nodes, { id: node.id }) || {}
+      let unplacedIndex = -1
+      flow.nodes = flow.nodes.map(node => {
+        const position = _.get(_.find(uiEq.nodes, { id: node.id }), 'position')
+        const placingStep = 250
+        unplacedIndex = position ? unplacedIndex : unplacedIndex + 1
 
-        Object.assign(node, uiNode.position)
-
-        if (_.isNil(node.x) || _.isNil(node.y)) {
-          unplacedNodes.push(node)
+        return {
+          ...node,
+          x: position ? position.x : 50 + unplacedIndex * placingStep,
+          y: position ? position.y : (_.maxBy(flow.nodes, 'y') || { y: 0 }).y + placingStep
         }
       })
 
-      const unplacedY = (_.maxBy(flow.nodes, 'y') || { y: 0 }).y + 250
-      let unplacedX = 50
-
-      unplacedNodes.forEach(node => {
-        node.y = unplacedY
-        node.x = unplacedX
-        unplacedX += 250
-      })
-
-      return flows.push({
-        location: file,
-        version: flow.version,
-        name: flow.name,
+      return {
+        name: flowPath,
+        location: flowPath,
         nodes: _.filter(flow.nodes, node => !!node),
-        catchAll: flow.catchAll,
-        startNode: flow.startNode,
-        links: flow.links,
-        skillData: flow.skillData
-      })
+        ..._.pick(flow, 'version', 'catchAll', 'startNode', 'links', 'skillData')
+      }
     })
 
-    return flows
+    return flows.filter(Boolean)
   }
 
   async saveFlows(flows) {
     const flowsToSave = await Promise.mapSeries(flows, flow => this._prepareSaveFlow(flow))
 
     for (const { flowPath, uiPath, flowContent, uiContent } of flowsToSave) {
-      if (flowPath.includes('/')) {
-        mkdirp.sync(path.dirname(flowPath))
-      }
-
-      fs.writeFileSync(flowPath, JSON.stringify(flowContent, null, 2))
-      fs.writeFileSync(uiPath, JSON.stringify(uiContent, null, 2))
+      this.ghostManager.upsertFile(this.flowsDir, flowPath, JSON.stringify(flowContent, null, 2))
+      this.ghostManager.upsertFile(this.flowsDir, uiPath, JSON.stringify(uiContent, null, 2))
     }
 
-    const flowsDir = path.resolve(this.projectLocation, this.botfile.flowsDir || './flows')
-
-    const searchOptions = { cwd: flowsDir }
-    const flowFiles = await Promise.fromCallback(callback => glob('**/*.flow.json', searchOptions, callback))
-
-    flowFiles
-      .map(fileName => path.resolve(flowsDir, './' + fileName))
-      .filter(filePath => !flowsToSave.find(flow => flow.flowPath === filePath || flow.uiPath === filePath))
-      .map(filePath => fs.unlinkSync(filePath))
+    const pathsToOmit = _.flatten(flowsToSave.map(flow => [flow.flowPath, flow.uiPath]))
+    const flowFiles = await this.ghostManager.directoryListing(this.flowsDir, '.json', pathsToOmit)
+    await Promise.all(flowFiles.map(filePath => this.ghostManager.deleteFile(this.flowsDir, filePath)))
 
     this.emit('flowsChanged')
   }
 
   async _prepareSaveFlow(flow) {
-    flow = Object.assign({}, flow, {
-      version: '0.1'
-    })
+    flow = Object.assign({}, flow, { version: '0.1' })
 
     const schemaError = validateFlowSchema(flow)
     if (schemaError) {
@@ -127,33 +90,21 @@ export default class FlowProvider extends EventEmitter2 {
 
     // What goes in the ui.json file
     const uiContent = {
-      nodes: flow.nodes.map(node => ({
-        id: node.id,
-        position: { x: node.x, y: node.y }
-      })),
+      nodes: flow.nodes.map(node => ({ id: node.id, position: _.pick(node, 'x', 'y') })),
       links: flow.links
     }
 
     // What goes in the .flow.json file
     const flowContent = {
-      version: flow.version,
-      startNode: flow.startNode,
-      catchAll: flow.catchAll,
-      nodes: flow.nodes,
-      skillData: flow.skillData
+      ..._.pick(flow, 'version', 'catchAll', 'startNode', 'skillData'),
+      nodes: flow.nodes.map(node => _.omit(node, 'x', 'y', 'lastModified'))
     }
 
-    flowContent.nodes.forEach(node => {
-      // We remove properties that don't belong in the .flow.json file
-      delete node['x']
-      delete node['y']
-      delete node['lastModified']
-    })
+    const flowPath = flow.location
+    return { flowPath, uiPath: this._uiPath(flowPath), flowContent, uiContent }
+  }
 
-    const relDir = this.botfile.flowsDir || './flows'
-    const flowPath = path.resolve(this.projectLocation, relDir, './' + flow.location)
-    const uiPath = flowPath.replace(/\.flow\.json/i, '.ui.json')
-
-    return { flowPath, uiPath, flowContent, uiContent }
+  _uiPath(flowPath) {
+    return flowPath.replace(/\.flow\.json/i, '.ui.json')
   }
 }

--- a/src/ghost-content/README.md
+++ b/src/ghost-content/README.md
@@ -66,7 +66,7 @@ await ghostManager.addRootFolder(formDataDir, '**/*.json')
 
 This method call reconciles the ghost content DB table in accordance with the `$rootFolder/.ghost-revisions` file, and if the folder is in the _clean state_ (no revisions in the DB that are not listed in the `.ghost-revisions` files) it updates the DB with the fresh files content from the file system.
 
-### recordRevision(rootFolder: string, file: string, content: string) => Promise<void>
+### upsertFile(rootFolder: string, file: string, content: string) => Promise<void>
 
 Use this method whenever you want to store the content for the given file.
 
@@ -81,20 +81,34 @@ The method automatically records the revision ID for this operation which you no
 Example:
 ```js
 // record the new content for the `trivia_questions.json` file inside of the `formDataDir` folder
-await ghostManager.recordRevision(formDataDir, 'trivia_questions.json', JSON.stringify(triviaQuestions, null, 2))
+await ghostManager.upsertFile(formDataDir, 'trivia_questions.json', JSON.stringify(triviaQuestions, null, 2))
 ```
 
 > Note that you should record the JSON files in indented form (the `null, 2`) params ensure that to simplify the git diffs.
 
-> Note that the `file` param is not normalized, it's your responsibility to refer to the same file consistently across all calls to `recordRevision` and `readFile`.
+> Note that the `file` param is not normalized, it's your responsibility to refer to the same file consistently across all calls to `upsertFile` and `readFile`.
 
 ### readFile(rootFolder: string, file: string) => Promise<string>
 
 `rootFolder` and `file` have the same meaning as above.
 
-Resolves with the content recorded for `file` in the most recent call to `recordRevision` (or the original file content from the disk, recorded on `addRootFolder` call). By design there's no way to read older revisions content (this may change in the future).
+Resolves with the content recorded for `file` in the most recent call to `upsertFile` (or the original file content from the disk, recorded on `addRootFolder` call). By design there's no way to read older revisions content (this may change in the future).
 
 The promise will be rejected if the file's content cannot be found (which in the clean state is effectively equivalent to the fact the file `file` does not exist in `folder`)
+
+### deleteFile(rootFolder: string, file: string) => Promise
+
+`rootFolder` and `file` have the same meaning as above.
+
+Marks file as deleted and updates it's content to `null`. File gets actually deleted on next ghost-sync.
+
+The promise will be rejected if the file's content cannot be found (which in the clean state is effectively equivalent to the fact the file `file` does not exist in `folder`)
+
+### directoryListing(rootFolder: string, fileEndingPattern: string) => Promise<array>
+
+`rootFolder` has the same meaning as above while `fileEndingPattern` is an ending we expect files to have.
+
+Returns files with paths relative to rootFolder found in the directry specified.
 
 ### getPending => object
 


### PR DESCRIPTION
There's still some work to do here:
- ~add documentation to new methods within ghost-content api~
- ~retest carefully whether everything works for different scenarios including "transparent" mode~
- ~check whether some refactoring can be applied to related parts of code~