### PR TITLE
Fix flows saving

### DIFF
--- a/src/server/static.js
+++ b/src/server/static.js
@@ -94,7 +94,7 @@ module.exports = bp => {
         window.SHOW_GUIDED_TOUR = ${isFirstRun};
         window.BOTPRESS_VERSION = "${version}";
         window.APP_NAME = "${appName}";
-        window.GHOST_ENABLED = ${!!ghostEnabled}
+        window.GHOST_ENABLED = ${!!ghostEnabled};
       })(typeof window != 'undefined' ? window : {})`)
     })
 


### PR DESCRIPTION
The important change here is the call to `mkdirp`
The less important:
- now waits for files saved (previously the save operations were started async and were not awaited)
- replaced the deprecated exists method with access method, and also calling it async now

The double callbacks to `access` ensure we're only handling the access error (caused if dir does not exist, for example), but don't swallow any other error from the promise chain