### PR TITLE
Lite version loads special plugins with flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "prepend-file": "^1.3.1",
     "prompt": "^1.0.0",
     "prompt-confirm": "^1.2.0",
+    "query-string": "^5.0.1",
     "randomstring": "^1.1.5",
     "react-codemirror": "^1.0.0",
     "react-jsonschema-form": "^0.49.0",

--- a/src/server/secured.js
+++ b/src/server/secured.js
@@ -20,6 +20,7 @@ module.exports = (bp, app) => {
       return {
         name: module.name,
         homepage: module.homepage,
+        isPlugin: module.settings.isPlugin,
         menuText: module.settings.menuText || module.name,
         menuIcon: module.settings.menuIcon || 'view_module',
         noInterface: !!module.settings.noInterface,

--- a/src/web/components/PluginInjectionSite/index.jsx
+++ b/src/web/components/PluginInjectionSite/index.jsx
@@ -1,26 +1,13 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-import _ from 'lodash'
 
 import InjectedModuleView from '~/components/PluginInjectionSite/module'
-
-const collectModules = (modules, injectionSite) =>
-  _.flatten(
-    (modules || []).filter(Boolean).map(module => {
-      const plugins = _.filter(module.plugins || [], { position: injectionSite })
-
-      return plugins.map(plugin => ({ moduleName: module.name, viewName: plugin.entry }))
-    })
-  )
+import { moduleViewNames } from '~/util/Modules'
 
 class InjectionSite extends React.Component {
   static contextTypes = {
     router: PropTypes.object.isRequired
-  }
-
-  state = {
-    plugins: []
   }
 
   renderNotFound = () => {
@@ -29,7 +16,7 @@ class InjectionSite extends React.Component {
 
   render() {
     const { site: injectionSite, modules } = this.props
-    const plugins = collectModules(modules, injectionSite)
+    const plugins = moduleViewNames(modules, injectionSite)
 
     return (
       <div className="bp-plugins bp-injection-site">

--- a/src/web/index.jsx
+++ b/src/web/index.jsx
@@ -1,13 +1,10 @@
 import 'babel-polyfill'
 import React from 'expose-loader?React!react'
 import ReactDOM from 'expose-loader?ReactDOM!react-dom'
-
-import { createStore, applyMiddleware, compose } from 'redux'
 import { Provider } from 'react-redux'
-import thunk from 'redux-thunk'
 
-import reducer from './reducers'
-import * as actions from '~/actions'
+import reducers from './reducers' // App won't load without importing it here
+import store from './store'
 
 require('bootstrap/dist/css/bootstrap.css')
 require('storm-react-diagrams/dist/style.min.css')
@@ -16,15 +13,6 @@ require('./theme.scss')
 
 // Do not use "import App from ..." as hoisting will screw up styling
 const App = require('./components/App').default
-
-const composeEnhancers =
-  typeof window === 'object' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
-    ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({ name: 'Botpress', actionCreators: actions })
-    : compose
-
-const enhancer = composeEnhancers(applyMiddleware(thunk))
-
-const store = createStore(reducer, enhancer)
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/web/store.js
+++ b/src/web/store.js
@@ -1,0 +1,13 @@
+import { createStore, applyMiddleware, compose } from 'redux'
+import thunk from 'redux-thunk'
+import * as actions from '~/actions'
+import reducers from './reducers'
+
+const composeEnhancers =
+  typeof window === 'object' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+    ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({ name: 'Botpress', actionCreators: actions })
+    : compose
+
+const enhancer = composeEnhancers(applyMiddleware(thunk))
+
+export default createStore(reducers, enhancer)

--- a/src/web/util.js
+++ b/src/web/util.js
@@ -1,3 +1,5 @@
+import _ from 'lodash'
+
 export const hashCode = str => {
   let hash = 0
   if (str.length === 0) {

--- a/src/web/util/Modules.js
+++ b/src/web/util/Modules.js
@@ -1,0 +1,11 @@
+import _ from 'lodash'
+
+export const moduleViewNames = (modules = [], position = 'overlay') =>
+  _.flatten(
+    (modules || []).filter(Boolean).map(module =>
+      _.filter(module.plugins || [], { position }).map(plugin => ({
+        moduleName: module.name,
+        viewName: plugin.entry
+      }))
+    )
+  )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2207,6 +2207,10 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
 deep-eql@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
@@ -6127,6 +6131,14 @@ query-string@^4.1.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
   dependencies:
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
+
+query-string@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.0.1.tgz#6e2b86fe0e08aef682ecbe86e85834765402bd88"
+  dependencies:
+    decode-uri-component "^0.2.0"
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 


### PR DESCRIPTION
Fixes https://github.com/botpress/botpress/pull/340 and reverts https://github.com/botpress/botpress/pull/387.

@slvnperron it seems importing `reducers from './reducers'` is required in `index.js` even though it's not used there. Adding it fixes build.

For build time didn't change. Do you still have problems with it on this branch?