### PR TITLE
Developer/issues 396 pass helpers to modules

### DIFF
--- a/docs/modules/config.md
+++ b/docs/modules/config.md
@@ -75,7 +75,7 @@ module.exports = {
     console.log(config) // prints { accessToken: 'user_token', selectedMode: 'understanding' }
   },
 
-  ready: function(bp, configuration) {
+  ready: function(bp, configuration, helpers) {
     // more code ...
   }
 }
@@ -85,7 +85,7 @@ module.exports = {
 
 The configuration is persisted in the database. In fact, it is persisted using the built-in Key-Value store.
 
-## Can I overwrite the configuration at run time? / Can I use environement variables to set configuration? <a class="toc" id="toc-can-i-overwrite-the-configuration-at-run-time-can-i-use-environement-variables-to-set-configuration" href="#toc-can-i-overwrite-the-configuration-at-run-time-can-i-use-environement-variables-to-set-configuration"></a>
+## Can I overwrite the configuration at run time? / Can I use environment variables to set configuration? <a class="toc" id="toc-can-i-overwrite-the-configuration-at-run-time-can-i-use-environement-variables-to-set-configuration" href="#toc-can-i-overwrite-the-configuration-at-run-time-can-i-use-environement-variables-to-set-configuration"></a>
 
 
 You may overwrite the configuration or provide default values from environement variables. To do so, simply assign a value to the `env` property of the configuration key. In the example above, `accessToken` can be overwritten by the `WIT_TOKEN` environement variable.

--- a/docs/modules/config.md
+++ b/docs/modules/config.md
@@ -70,7 +70,7 @@ module.exports = {
     selectedMode: { type: 'choice', validation: ['understanding', 'stories'], default: 'understanding' }
   },
 
-  init: async function(bp, configuration) {
+  init: async function(bp, configuration, helpers) {
     const config = await config.loadAll()
     console.log(config) // prints { accessToken: 'user_token', selectedMode: 'understanding' }
   },

--- a/src/botpress.js
+++ b/src/botpress.js
@@ -24,7 +24,7 @@ import createUMM from './umm'
 import createUsers from './users'
 import createContentManager from './content/service'
 import createConversations from './conversations'
-import createDatabaseHelpers from './database/helpers'
+import createHelpers from './helpers'
 import stats from './stats'
 import packageJson from '../package.json'
 import createEmails from '+/emails'
@@ -195,7 +195,7 @@ class botpress {
     server.start().then(() => {
       events.emit('ready')
       for (let mod of _.values(loadedModules)) {
-        mod.handlers.ready && mod.handlers.ready(this, mod.configuration, createDatabaseHelpers)
+        mod.handlers.ready && mod.handlers.ready(this, mod.configuration, createHelpers)
       }
 
       const { port } = botfile

--- a/src/botpress.js
+++ b/src/botpress.js
@@ -24,6 +24,7 @@ import createUMM from './umm'
 import createUsers from './users'
 import createContentManager from './content/service'
 import createConversations from './conversations'
+import createDatabaseHelpers from './database/helpers'
 import stats from './stats'
 import packageJson from '../package.json'
 import createEmails from '+/emails'
@@ -194,7 +195,7 @@ class botpress {
     server.start().then(() => {
       events.emit('ready')
       for (let mod of _.values(loadedModules)) {
-        mod.handlers.ready && mod.handlers.ready(this, mod.configuration)
+        mod.handlers.ready && mod.handlers.ready(this, mod.configuration, createDatabaseHelpers)
       }
 
       const { port } = botfile

--- a/src/cli/templates/create/src/index.js
+++ b/src/cli/templates/create/src/index.js
@@ -5,20 +5,18 @@
 */
 
 module.exports = {
-
-  config: { },
+  config: {},
 
   init: async function(bp, configurator) {
     // This is called before ready.
     // At this point your module is just being initialized, it is not loaded yet.
   },
 
-  ready: async function(bp, configurator) {
+  ready: async function(bp, configurator, helpers) {
     // Your module's been loaded by Botpress.
     // Serve your APIs here, execute logic, etc.
 
     const config = await configurator.loadAll()
     // Do fancy stuff here :)
-
   }
 }

--- a/src/cli/templates/create/src/index.js
+++ b/src/cli/templates/create/src/index.js
@@ -7,7 +7,7 @@
 module.exports = {
   config: {},
 
-  init: async function(bp, configurator) {
+  init: async function(bp, configurator, helpers) {
     // This is called before ready.
     // At this point your module is just being initialized, it is not loaded yet.
   },

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,3 @@
+var database = require('./database/helpers')
+
+module.exports = { database }

--- a/src/modules.js
+++ b/src/modules.js
@@ -6,6 +6,7 @@ import _ from 'lodash'
 import moment from 'moment'
 import axios from 'axios'
 import { createConfig } from './configurator'
+import helpers from './helpers'
 
 import { print, isDeveloping, npmCmd, resolveModuleRootPath, resolveFromDir, resolveProjectFile } from './util'
 
@@ -55,7 +56,7 @@ module.exports = (logger, projectLocation, dataLocation, kvs) => {
       }
 
       try {
-        loader.init && loader.init(botpress, mod.configuration)
+        loader.init && loader.init(botpress, mod.configuration, helpers)
       } catch (err) {
         logger.warn('Error during module initialization: ', err)
       }


### PR DESCRIPTION
3rd version of PR; alternate versions of:
* #398 
* #403 

This is like #398 because it passed the helper to the modules, but it creates a `helpers` objects, which can be added to in the future.

In this code, there is only a `helpers.database`