### PR TITLE
Rename compute form data

### DIFF
--- a/dev-bot/forms/trivia-collection.form.js
+++ b/dev-bot/forms/trivia-collection.form.js
@@ -16,7 +16,7 @@ module.exports = {
     }
   },
 
-  computeFormData: (formData, computeFormData) => Promise.map(formData, computeFormData.bind(null, 'trivia')),
+  computeData: (formData, computeData) => Promise.map(formData, computeData.bind(null, 'trivia')),
   computePreviewText: async (formData, computePreviewText) => {
     const triviaPreviews = await Promise.map(formData, computePreviewText.bind(null, 'trivia'))
     return `Trivia Collection [${triviaPreviews.join(', ')}]`

--- a/dev-bot/forms/trivia.form.js
+++ b/dev-bot/forms/trivia.form.js
@@ -38,7 +38,7 @@ module.exports = {
     }
   },
 
-  computeFormData: formData => {
+  computeData: formData => {
     const good = { payload: 'TRIVIA_GOOD', text: formData.good }
     const bad = formData.bad.map(i => ({ payload: 'TRIVIA_BAD', text: i }))
     const choices = [good, ...bad]

--- a/docs/foundamentals/content.md
+++ b/docs/foundamentals/content.md
@@ -371,7 +371,7 @@ Internally when the content item is requested by the bot engine (from the botpre
 
 ### `compute*` helper methods
 
-When dealing with content refs you may want to keep your custom `computeFormData`, `computePreviewText`, and `computeMetadata` methods DRY. How can one reuse these methods defined in another content type form definition?
+When dealing with content refs you may want to keep your custom `computeData`, `computePreviewText`, and `computeMetadata` methods DRY. How can one reuse these methods defined in another content type form definition?
 
 To aid this task Botpress provides you with the helper methods passed as the 2nd arguments to your function. It's best illustrated with the example:
 

--- a/docs/foundamentals/content.md
+++ b/docs/foundamentals/content.md
@@ -44,7 +44,7 @@ Your file must export an object with the following properties:
 
   ummBloc: '#trivia-question', // string, optional
   uiSchema: {}, // object, optional
-  computeFormData: function() {}, // function, optional
+  computeData: function() {}, // function, optional
   computePreviewText: function() {}, // function, optional
   computeMetadata: function() {} // function, optional
 }
@@ -84,23 +84,23 @@ Optionally, you can assign a UMM bloc to a content category. When doing so, Botp
 
 For example, if you have a category called `trivia`, generating trivia questions (content) would generate blocs that look like `#!trivia-h73k41`, which you can use anywhere as a regular UMM bloc (e.g. `event.reply('#!trivia-h73k41')`).
 
-#### Field `computeFormData(data, computeFormDataHelper) -> Object|Promise<Object>` (_Optional_) <a class="toc" id="toc-field-ummbloc-optional" href="#toc-field-ummbloc-optional"></a>
+#### Field `computeData(data, computeDataHelper) -> Object|Promise<Object>` (_Optional_) <a class="toc" id="toc-field-ummbloc-optional" href="#toc-field-ummbloc-optional"></a>
 
 
 Optionally, you can transform the raw data coming from the form, so that you can persist that manipulated version of it.
 
-If you provide `computeFormData`, Botpress will use it to manipulate the data, and that modified data will be used by the UMM engine (if using `ummBloc`).
+If you provide `computeData`, Botpress will use it to manipulate the data, and that modified data will be used by the UMM engine (if using `ummBloc`).
 
-The second argument to the function, `computeFormDataHelper`, is an async function `async computeFormDataHelper(categoryId, contentItem)` that you can use if you want to call the `computeFormData` on the content from another category. It's mostly useful when used with the **Content Refs** (see below).
+The second argument to the function, `computeDataHelper`, is an async function `async computeDataHelper(categoryId, contentItem)` that you can use if you want to call the `computeData` on the content from another category. It's mostly useful when used with the **Content Refs** (see below).
 
-##### Example A (Trivia) <a class="toc" id="toc-field-computeformdata-data-object-promise-optional" href="#toc-field-computeformdata-data-object-promise-optional"></a>
+##### Example A (Trivia) <a class="toc" id="toc-field-computedata-data-object-promise-optional" href="#toc-field-computedata-data-object-promise-optional"></a>
 
 
 ```js
 const _ = require('lodash')
 // ...
 
-computeFormData: formData => {
+computeData: formData => {
   const good = { payload: 'TRIVIA_GOOD', text: formData.good }
   const bad = formData.bad.map(i => ({ payload: 'TRIVIA_BAD', text: i }))
   const choices = [good, ...bad]
@@ -115,7 +115,7 @@ computeFormData: formData => {
 ##### Example B
 
 ```js
-computeFormData: data => {
+computeData: data => {
   return {
     full_name: data.first_name + ' ' + data.last_name
   }
@@ -214,7 +214,7 @@ module.exports = {
     }
   },
 
-  computeFormData: formData => {
+  computeData: formData => {
     const good = { payload: 'TRIVIA_GOOD', text: formData.good }
     const bad = formData.bad.map(i => ({ payload: 'TRIVIA_BAD', text: i }))
     const choices = [good, ...bad]
@@ -383,7 +383,7 @@ module.exports = {
   id: 'trivia',
   // ...
 
-  computeFormData: formData => {
+  computeData: formData => {
     const good = { payload: 'TRIVIA_GOOD', text: formData.good }
     const bad = formData.bad.map(i => ({ payload: 'TRIVIA_BAD', text: i }))
     const choices = [good, ...bad]
@@ -406,7 +406,7 @@ module.exports = {
   id: 'trivia-collection',
   // ...
 
-  computeFormData: (formData, computeFormDataHelper) => Promise.map(formData, computeFormDataHelper.bind(null, 'trivia')),
+  computeData: (formData, computeDataHelper) => Promise.map(formData, computeDataHelper.bind(null, 'trivia')),
   computePreviewText: async (formData, computePreviewTextHelper) => {
     const triviaPreviews = await Promise.map(formData, computePreviewTextHelper.bind(null, 'trivia'))
     return `Trivia Collection [${triviaPreviews.join(', ')}]`

--- a/src/content/service.js
+++ b/src/content/service.js
@@ -169,12 +169,12 @@ module.exports = async ({ botfile, projectLocation, logger, ghostManager }) => {
     return data
   }
 
-  const computeFormData = async (categoryId, formData) => {
+  const computeData = async (categoryId, formData) => {
     const category = categoryById[categoryId]
     if (!category) {
       throw new Error(`Unknown category ${categoryId}`)
     }
-    return !category.computeFormData ? formData : category.computeFormData(formData, computeFormData)
+    return !category.computeData ? formData : category.computeData(formData, computeData)
   }
 
   const computeMetadata = async (categoryId, formData) => {
@@ -200,7 +200,7 @@ module.exports = async ({ botfile, projectLocation, logger, ghostManager }) => {
 
     const expandedFormData = await resolveRefs(formData)
 
-    const data = await computeFormData(category.id, expandedFormData)
+    const data = await computeData(category.id, expandedFormData)
     const metadata = await computeMetadata(category.id, expandedFormData)
     const previewText = await computePreviewText(category.id, expandedFormData)
 
@@ -213,7 +213,7 @@ module.exports = async ({ botfile, projectLocation, logger, ghostManager }) => {
     }
 
     if (data == null) {
-      throw new Error('computeFormData must return a valid object')
+      throw new Error('computeData must return a valid object')
     }
 
     return {


### PR DESCRIPTION
I suggest renaming `computeFormData` to `computeData` as the current name is misleading IMO. The _form data_ is the raw data used in the form, it's not transformed. What this method does instead is transforming the _form data_ into the _real data_ used by the bot-related code.