### PR TITLE
Add ability to create server-side shortlinks

### DIFF
--- a/src/server/api.js
+++ b/src/server/api.js
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 import bodyParser from 'body-parser'
 import { Router } from 'express'
+import qs from 'query-string'
 
 import ServiceLocator from '+/ServiceLocator'
 import anonymousApis from './anonymous'
@@ -119,6 +120,29 @@ module.exports = bp => {
       installProtector(routers[name])
       return routers[name]
     }
+
+    const links = {}
+
+    bp.createShortlink = (name, destination, params) => {
+      name = name.toLowerCase()
+
+      if (links[name]) {
+        throw new Error(`There's already a shortlink named "${name}"`)
+      }
+
+      const q = params ? '?' + qs.stringify(params) : ''
+      links[name] = `${destination}${q}`
+    }
+
+    app.use(`/s/:name`, (req, res) => {
+      const name = req.params.name.toLowerCase()
+
+      if (!links[name]) {
+        return res.status(404).send({ error: `Shortlink "${name}" not registered` })
+      }
+
+      res.redirect(links[name])
+    })
   }
 
   const installMaybeUse = app => {

--- a/src/server/api.js
+++ b/src/server/api.js
@@ -134,7 +134,7 @@ module.exports = bp => {
       links[name] = `${destination}${q}`
     }
 
-    app.use(`/s/:name`, (req, res) => {
+    app.get(`/s/:name`, (req, res) => {
       const name = req.params.name.toLowerCase()
 
       if (!links[name]) {


### PR DESCRIPTION
Example of usage:

```js
const config = {
    botName: 'Batman',
    botAvatarUrl: '',
    botConvoTitle: 'Nanananana',
    botConvoDescription: "Ask me anything, I'm here to help!",
    backgroundColor: '#ffffff',
    textColorOnBackground: '#666666',
    foregroundColor: '#000000',
    textColorOnForeground: '#ffffff'
  }

  bp.createShortlink('chat_fullscreen', '/lite', {
    m: 'platform-webchat',
    v: 'fullscreen',
    options: JSON.stringify({ config: config })
  })
```

Navigating to `localhost:3000/s/chat_fullscreen` will redirect to the long, ugly webchat URL