### PR TITLE
fix: determining END Node

### DIFF
--- a/src/dialog/engine.js
+++ b/src/dialog/engine.js
@@ -307,7 +307,7 @@ class DialogEngine {
     for (let i = 0; i < nextNodes.length; i++) {
       if (await this._evaluateCondition(nextNodes[i].condition, userState, event)) {
         this._trace('??', 'MTCH', `cond = "${nextNodes[i].condition}"`, context)
-        if (/end/i.test(nextNodes[i].node)) {
+        if (/^END$/i.test(nextNodes[i].node)) {
           // Node "END" or "end" ends the flow (reserved keyword)
           return this._endFlow(stateId)
         } else {


### PR DESCRIPTION
change the regex to ^END$   otherwise it fires for multiple words containing END  - hard to debug! :+1: 