### PR TITLE
Added support for "@botpress/" modules

### DIFF
--- a/src/cli/create.js
+++ b/src/cli/create.js
@@ -8,7 +8,6 @@ import util from '../util'
 import stats from '../stats'
 
 const MODULE_NAME_CONVENTION_BEGINS = 'botpress-'
-const MODULE_NAME_REGEX = new RegExp(/^botpress-.*/g)
 
 const introductionText = 'This program will bootstrap a new Botpress module'
 const doneText = 'The module is boostrapped successfully.'
@@ -34,8 +33,8 @@ const generateTemplate = (directory, filename, variables = {}) => {
 }
 
 const prefixModuleNameWithBotpress = name => {
-  if (!MODULE_NAME_REGEX.test(name)) {
-    util.print('warn', 'the name of your module needs to begin by "botpress-"')
+  if (!util.isBotpressPackage(name)) {
+    util.print('warn', 'the name of your module needs to begin by "botpress-" or "@botpress/"')
     util.print('warn', 'we renamed your module to ' + chalk.bold(MODULE_NAME_CONVENTION_BEGINS + name))
     name = MODULE_NAME_CONVENTION_BEGINS + name
   }

--- a/src/configurator.js
+++ b/src/configurator.js
@@ -3,6 +3,7 @@ import fs from 'fs'
 import path from 'path'
 import yaml from 'js-yaml'
 import Promise from 'bluebird'
+import util from './util'
 
 const validations = {
   any: (value, validation) => validation(value),
@@ -73,7 +74,8 @@ const validateSave = (options, object) => {
 }
 
 const validateName = name => {
-  if (!name || !/^[A-Z0-9._-]+$/i.test(name)) {
+  const shortName = util.getModuleShortname(name)
+  if (!name || !/^[A-Z0-9._-]+$/i.test(shortName)) {
     throw new Error(`Invalid configuration name: ${name}. The name must only contain letters, _ and -`)
   }
 }

--- a/src/configurator.js
+++ b/src/configurator.js
@@ -74,7 +74,7 @@ const validateSave = (options, object) => {
 }
 
 const validateName = name => {
-  const shortName = util.getModuleShortname(name)
+  const shortName = name && util.getModuleShortname(name)
   if (!name || !/^[A-Z0-9._-]+$/i.test(shortName)) {
     throw new Error(`Invalid configuration name: ${name}. The name must only contain letters, _ and -`)
   }

--- a/src/modules.js
+++ b/src/modules.js
@@ -7,6 +7,7 @@ import moment from 'moment'
 import axios from 'axios'
 import { createConfig } from './configurator'
 import helpers from './helpers'
+import util from './util'
 
 import { print, isDeveloping, npmCmd, resolveModuleRootPath, resolveFromDir, resolveProjectFile } from './util'
 
@@ -98,7 +99,7 @@ module.exports = (logger, projectLocation, dataLocation, kvs) => {
     return _.reduce(
       deps,
       (result, value, key) => {
-        if (!/^botpress-/i.test(key)) {
+        if (!util.isBotpressPackage(key)) {
           return result
         }
         const entry = resolveFromDir(projectLocation, key)
@@ -136,7 +137,7 @@ module.exports = (logger, projectLocation, dataLocation, kvs) => {
     const { dependencies } = JSON.parse(fs.readFileSync(packagePath))
     const prodDeps = _.keys(dependencies)
 
-    return _.filter(prodDeps, dep => /botpress-.+/i.test(dep))
+    return _.filter(prodDeps, util.isBotpressPackage)
   }
 
   const mapModuleList = modules => {

--- a/src/server/secured.js
+++ b/src/server/secured.js
@@ -18,7 +18,8 @@ module.exports = (bp, app) => {
   app.secure('read', 'modules/list').get('/api/modules', (req, res) => {
     const modules = _.map(bp._loadedModules, module => {
       return {
-        name: module.name,
+        name: util.getModuleShortname(module.name),
+        fullName: module.name,
         homepage: module.homepage,
         isPlugin: module.settings.isPlugin,
         menuText: module.settings.menuText || module.name,

--- a/src/server/static.js
+++ b/src/server/static.js
@@ -10,7 +10,7 @@ import util from '../util'
 module.exports = bp => {
   const serveModule = (app, module) => {
     const name = module.name
-    const shortName = module.name.replace(/botpress-/i, '')
+    const shortName = util.getModuleShortname(module.name)
 
     if (module.settings.menuIcon === 'custom') {
       const iconRequestPath = `/img/modules/${name}.png`

--- a/src/util.js
+++ b/src/util.js
@@ -100,7 +100,7 @@ const getInMemoryDb = () =>
 
 const safeId = (length = 10) => generate('1234567890abcdefghijklmnopqrsuvwxyz', length)
 
-const botpressPackageRegex = /^(botpress-.+)|(@botpress\/.+)/gi
+const botpressPackageRegex = /^(botpress-.+)|(@botpress\/.+)/i
 const isBotpressPackage = pkg => botpressPackageRegex.test(pkg)
 const getModuleShortname = pkg => pkg.replace(/^@botpress\//i, '').replace(/^botpress-/i, '')
 

--- a/src/util.js
+++ b/src/util.js
@@ -100,6 +100,10 @@ const getInMemoryDb = () =>
 
 const safeId = (length = 10) => generate('1234567890abcdefghijklmnopqrsuvwxyz', length)
 
+const botpressPackageRegex = /^(botpress-.+)|(@botpress\/.+)/gi
+const isBotpressPackage = pkg => botpressPackageRegex.test(pkg)
+const getModuleShortname = pkg => pkg.replace(/^@botpress\//i, '').replace(/^botpress-/i, '')
+
 module.exports = {
   print,
   resolveFromDir,
@@ -111,5 +115,8 @@ module.exports = {
   getBotpressVersion,
   collectArgs,
   getInMemoryDb,
-  safeId
+  safeId,
+  isBotpressPackage,
+  getModuleShortname,
+  botpressPackageRegex
 }

--- a/src/web/actions/index.js
+++ b/src/web/actions/index.js
@@ -180,7 +180,7 @@ export const requestEditSkill = nodeId => (dispatch, getState) => {
   flow &&
     dispatch(
       editSkill({
-        skillId: 'botpress-skill-' + node.skill,
+        skillId: 'skill-' + node.skill,
         flowName: node.flow,
         nodeId: nodeId,
         data: flow.skillData

--- a/src/web/components/PluginInjectionSite/module.jsx
+++ b/src/web/components/PluginInjectionSite/module.jsx
@@ -66,15 +66,7 @@ export default class InjectedModuleView extends React.Component {
       return window.botpress && window.botpress[name] && window.botpress[name][prop]
     }
 
-    let module = null
-
-    for (const name of lookupNames) {
-      const m = viewResolve(name)
-      if (m) {
-        module = m
-        break
-      }
-    }
+    const module = viewResolve(lookupNames.find(viewResolve))
 
     if (!module) {
       this.setState({

--- a/src/web/components/PluginInjectionSite/module.jsx
+++ b/src/web/components/PluginInjectionSite/module.jsx
@@ -2,6 +2,13 @@ import React from 'react'
 import { withRouter } from 'react-router'
 import axios from 'axios'
 
+/*****
+  DO NOT REQUIRE HEAVY DEPENDENCIES HERE
+  Avoid requiring lodash here
+  We're trying to keep these files as js-vanilla as possible
+  To keep `lite.bundle.js` as small as possible
+*****/
+
 import InjectedComponent from '~/components/Injected'
 import EventBus from '~/util/EventBus'
 

--- a/src/web/components/PluginInjectionSite/module.jsx
+++ b/src/web/components/PluginInjectionSite/module.jsx
@@ -31,10 +31,12 @@ export default class InjectedModuleView extends React.Component {
         })
       }
 
+      const shortName = moduleName.replace(/^botpress-/i, '').replace(/^@botpress\//i, '')
+
       if (isLite) {
-        script.src = `/js/modules/${moduleName}/${subView}`
+        script.src = `/js/modules/${shortName}/${subView}`
       } else {
-        script.src = `/js/modules/${moduleName}.js`
+        script.src = `/js/modules/${shortName}`
       }
 
       document.getElementsByTagName('head')[0].appendChild(script)
@@ -47,15 +49,29 @@ export default class InjectedModuleView extends React.Component {
   }
 
   setViewInState(moduleName, viewName, isLite) {
-    const fullModuleName = moduleName.startsWith('botpress-') ? moduleName : 'botpress-' + moduleName
+    const lookupNames =
+      moduleName.startsWith('@botpress/') || moduleName.startsWith('botpress-')
+        ? [moduleName]
+        : ['@botpress/' + moduleName, 'botpress-' + moduleName]
 
-    const module = isLite
-      ? window.botpress && window.botpress[fullModuleName].default
-      : window.botpress && window.botpress[fullModuleName] && window.botpress[fullModuleName][viewName]
+    const viewResolve = name => {
+      const prop = isLite ? 'default' : viewName
+      return window.botpress && window.botpress[name] && window.botpress[name][prop]
+    }
+
+    let module = null
+
+    for (const name of lookupNames) {
+      const m = viewResolve(name)
+      if (m) {
+        module = m
+        break
+      }
+    }
 
     if (!module) {
       this.setState({
-        error: new Error(`Subview "${viewName}" doesn't exist for module "${fullModuleName}"`),
+        error: new Error(`Subview "${viewName}" doesn't exist for module "${moduleName}"`),
         moduleComponent: null
       })
     } else {

--- a/src/web/components/Routes/index.jsx
+++ b/src/web/components/Routes/index.jsx
@@ -41,7 +41,6 @@ export default () => {
         <Route path="content" component={Content} />
         <Route path="version-control" component={GhostContent} />
         <Route path="flows(/:flow)" component={FlowBuilder} />
-        <Route path="modules/@botpress/:moduleName(/:subView)" component={Module} />
         <Route path="modules/:moduleName(/:subView)" component={Module} />
         <Route path="notifications" component={Notifications} />
         <Route path="logs" component={Logs} />

--- a/src/web/components/Routes/index.jsx
+++ b/src/web/components/Routes/index.jsx
@@ -41,6 +41,7 @@ export default () => {
         <Route path="content" component={Content} />
         <Route path="version-control" component={GhostContent} />
         <Route path="flows(/:flow)" component={FlowBuilder} />
+        <Route path="modules/@botpress/:moduleName(/:subView)" component={Module} />
         <Route path="modules/:moduleName(/:subView)" component={Module} />
         <Route path="notifications" component={Notifications} />
         <Route path="logs" component={Logs} />

--- a/src/web/index.jsx
+++ b/src/web/index.jsx
@@ -1,6 +1,9 @@
 import 'babel-polyfill'
 import React from 'expose-loader?React!react'
 import ReactDOM from 'expose-loader?ReactDOM!react-dom'
+import ReactBootstrap from 'expose-loader?ReactBootstrap!react-bootstrap'
+import PropTypes from 'expose-loader?PropTypes!prop-types'
+
 import { Provider } from 'react-redux'
 
 import store from './store'

--- a/src/web/reducers/flows.js
+++ b/src/web/reducers/flows.js
@@ -348,7 +348,10 @@ reducer = reduceReducers(
       // 2. creates a new "skill" node
       // 3. puts that new node in the "insert buffer", waiting for user to place it on the canvas
       [insertNewSkill]: (state, { payload }) => {
-        const skillId = payload.skillId.replace(/^botpress-skill-/i, '')
+        const skillId = payload.skillId
+          .replace(/^botpress-skill-/i, '')
+          .replace(/^@botpress\/skill-/i, '')
+          .replace(/^skill-/i, '')
         const flowRandomId = prettyId(6)
         const flowName = `skills/${skillId}-${flowRandomId}.flow.json`
 

--- a/src/web/reducers/skills.js
+++ b/src/web/reducers/skills.js
@@ -18,7 +18,7 @@ const reducer = handleActions(
   {
     [modulesReceived]: (state, { payload }) => ({
       ...state,
-      installed: payload.filter(module => module.name.startsWith('botpress-skill-')).map(module => ({
+      installed: payload.filter(module => module.name.startsWith('skill-')).map(module => ({
         id: module.name,
         name: module.menuText,
         icon: module.menuIcon


### PR DESCRIPTION
We used to only support modules starting with `botpress-...`. Now, with the `@botpress` npm organization, modules can (should) be named `@botpress/...`