### PR TITLE
Extend functionality of message queue

### DIFF
--- a/extensions/lite/queue/index.js
+++ b/extensions/lite/queue/index.js
@@ -45,6 +45,16 @@ export default class Queue {
     return this.queue.shift()
   }
 
+  cancelAll(job) {
+    const jobQueueId = this.getQueueId(job)
+    this.queue = this.queue.filter(item => this.getQueueId(item.job) !== jobQueueId)
+  }
+
+  peek(job) {
+    const jobQueueId = this.getQueueId(job)
+    return this.queue.find(item => this.getQueueId(item.job) === jobQueueId)
+  }
+
   async tick() {
     const toDequeueIdx = _.findIndex(this.queue, el => {
       const queueId = this.getQueueId(el.job)

--- a/extensions/lite/tests/queue.js
+++ b/extensions/lite/tests/queue.js
@@ -129,4 +129,32 @@ describe('Lite Queues', () => {
     expect(order).to.length(3)
     expect(order).to.deep.equal([1, 2, 3])
   })
+
+  it('Cancels all only for requested user', async () => {
+    const userListA = []
+    const userListB = []
+    queue.subscribe(async event => {
+      await Promise.delay(1)
+      if (event.userId === 'a') {
+        userListA.push(event.id)
+      }
+      if (event.userId === 'b') {
+        userListB.push(event.id)
+      }
+    })
+
+    for (let i = 0; i < 10; i++) {
+      queue.enqueue({ userId: 'a', id: i })
+    }
+    queue.cancelAll({ userId: 'a' })
+    for (let i = 10; i < 20; i++) {
+      queue.enqueue({ userId: 'b', id: i })
+    }
+
+    await Promise.delay(25)
+
+    expect(userListA).to.length.below(10)
+    expect(userListB).to.length(10)
+    expect(userListB).to.deep.equal([10, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+  })
 })

--- a/src/botpress.js
+++ b/src/botpress.js
@@ -218,8 +218,16 @@ class botpress {
     outgoingQueue.subscribe(job => middlewares.sendOutgoingImmediately(job.event))
 
     const messages = {
-      in: { enqueue: event => incomingQueue.enqueue({ event }) },
-      out: { enqueue: event => outgoingQueue.enqueue({ event }) }
+      in: {
+        enqueue: event => incomingQueue.enqueue({ event }),
+        cancelAll: event => incomingQueue.cancelAll({ event }),
+        peek: event => incomingQueue.peek({ event })
+      },
+      out: {
+        enqueue: event => outgoingQueue.enqueue({ event }),
+        cancelAll: event => outgoingQueue.cancelAll({ event }),
+        peek: event => outgoingQueue.peek({ event })
+      }
     }
 
     middlewares.register(renderers.incomingMiddleware)


### PR DESCRIPTION
A use case we ran into was needing to be able to see if there are
currently any messages related to the event in the queue, in order to
see if the user has interrupted the bot, or vice-versa.  Along with
this, we also wanted the capability to cancel the requests that were
found.  Both of these were added as `peek` and `cancelAll` which both
require the current event.

This is in response to my issue I opened botpress/v12#223