### PR TITLE
Allow to use modules from scoped npm packages

### DIFF
--- a/packages/core/botpress/src/util.js
+++ b/packages/core/botpress/src/util.js
@@ -101,8 +101,29 @@ const getInMemoryDb = () =>
 const safeId = (length = 10) => generate('1234567890abcdefghijklmnopqrsuvwxyz', length)
 
 const botpressPackageRegex = /^(botpress-.+)|(@botpress\/.+)/i
-const isBotpressPackage = pkg => botpressPackageRegex.test(pkg)
-const getModuleShortname = pkg => pkg.replace(/^@botpress\//i, '').replace(/^botpress-/i, '')
+
+const isBotpressPackage = pkg => {
+  const [ scope, name ] = getPackageName(pkg)
+  const isBotpress = (scope === 'botpress' || name.startsWith('botpress-'))
+  return isBotpress
+}
+
+const getModuleShortname = pkg => {
+  const [ , name ] = getPackageName(pkg)
+  const withoutPrefix = name.replace(/^botpress-/i, '')
+  return withoutPrefix
+}
+
+const getPackageName = pkg => {
+  const isScoped = pkg.startsWith('@')
+
+  if (isScoped) {
+    const [ scope, name ] = pkg.match(/^@(.*)\/(.*)/).slice(1)
+    return [ scope, name ]
+  } else {
+    return [ null, pkg ];
+  }
+}
 
 module.exports = {
   print,

--- a/packages/core/botpress/src/util.js
+++ b/packages/core/botpress/src/util.js
@@ -100,8 +100,6 @@ const getInMemoryDb = () =>
 
 const safeId = (length = 10) => generate('1234567890abcdefghijklmnopqrsuvwxyz', length)
 
-const botpressPackageRegex = /^(botpress-.+)|(@botpress\/.+)/i
-
 const isBotpressPackage = pkg => {
   const [ scope, name ] = getPackageName(pkg)
   const isBotpress = (scope === 'botpress' || name.startsWith('botpress-'))
@@ -138,6 +136,5 @@ module.exports = {
   getInMemoryDb,
   safeId,
   isBotpressPackage,
-  getModuleShortname,
-  botpressPackageRegex
+  getModuleShortname
 }

--- a/packages/core/botpress/tests/util.js
+++ b/packages/core/botpress/tests/util.js
@@ -1,0 +1,48 @@
+/* eslint-env babel-eslint, node, mocha */
+
+import { expect } from 'chai'
+import { isBotpressPackage } from '../src/util'
+import { getModuleShortname } from '../src/util'
+
+describe('Botpress modules detection', () => {
+  let logger, queue
+
+  describe('isBotpressPackage', function() {
+    it('detects @botpress/foo', function() {
+      const result = isBotpressPackage('@botpress/foo')
+      expect(result).to.equal(true)
+    })
+
+    it('detects botpress-foo', function() {
+      const result = isBotpressPackage('botpress-foo')
+      expect(result).to.equal(true)
+    })
+
+    it('detects @myorg/botpress-foo', function() {
+      const result = isBotpressPackage('@myorg/botpress-foo')
+      expect(result).to.equal(true)
+    })
+
+    it('rejects @myorg/foo', function() {
+      const result = isBotpressPackage('@myorg/foo')
+      expect(result).to.equal(false)
+    })
+  })
+
+  describe('getModuleShortname', function() {
+    it('@botpress/foo -> foo', function() {
+      const shortName = getModuleShortname('@botpress/foo')
+      expect(shortName).to.equal('foo')
+    })
+
+    it('botpress-foo -> foo', function() {
+      const shortName = getModuleShortname('botpress-foo')
+      expect(shortName).to.equal('foo')
+    })
+
+    it('@myorg/botpress-foo -> foo', function() {
+      const shortName = getModuleShortname('@myorg/botpress-foo')
+      expect(shortName).to.equal('foo')
+    })
+  })
+})


### PR DESCRIPTION
```
Botpress modules detection
  isBotpressPackage
    ✓ detects @botpress/foo
    ✓ detects botpress-foo
    ✓ detects @myorg/botpress-foo
    ✓ rejects @myorg/foo
  getModuleShortname
    ✓ @botpress/foo -> foo
    ✓ botpress-foo -> foo
    ✓ @myorg/botpress-foo -> foo
```