### PR TITLE
Fix HITL reading session ID after insert

### DIFF
--- a/packages/functionals/botpress-hitl/src/db.js
+++ b/packages/functionals/botpress-hitl/src/db.js
@@ -64,6 +64,7 @@ function createUserSession(event) {
 
   return knex('hitl_sessions')
     .insert(session)
+    .returning('id')
     .then(results => {
       session.id = results[0]
       session.is_new_session = true


### PR DESCRIPTION
This is more evident when running under Postgres, because the following query trying to bind `session.id` (`undefined`) fails.

Tested on both Postgres and SQLite.