### PR TITLE
Fixed incorrect bp.db.set 

### DIFF
--- a/packages/channels/botpress-channel-microsoft/src/index.js
+++ b/packages/channels/botpress-channel-microsoft/src/index.js
@@ -98,7 +98,7 @@ module.exports = {
       }
 
       await bp.db.saveUser(user)
-      await bp.db.set(userAddressKey(user.id), _.get(session, 'message.address'))
+      await bp.kvs.set(userAddressKey(user.id), _.get(session, 'message.address'))
 
       bp.middlewares.sendIncoming({
         type: session.message.type,


### PR DESCRIPTION
The `bp.db.set` is incorrect. Use `bp.kvs` directly instead (`bp.db.kvs` is deprecated and will be removed in Botpress 11)