### PR TITLE
fix(cli): make the init command cancelable

### DIFF
--- a/packages/core/botpress/src/cli/init.js
+++ b/packages/core/botpress/src/cli/init.js
@@ -177,7 +177,14 @@ module.exports = async program => {
     prompt.start()
 
     prompt.get(schema, (err, result) => {
-      // TODO: ignore err altogether?
+      if (err) {
+        if (err.message !== 'canceled') {
+          console.error(err)
+        }
+
+        process.exit(1)
+      }
+
       generate(result)
     })
   }


### PR DESCRIPTION
Previously if you pressed Ctrl+C to cancel it would still scaffold out the template.

It now also prints other potential errors from the prompt.