### PR TITLE
feat(channel-web): carousel acts as quick-replies

### DIFF
--- a/packages/channels/botpress-channel-web/README.md
+++ b/packages/channels/botpress-channel-web/README.md
@@ -187,7 +187,8 @@ String
 
 #### `element.buttons` (optional)
 
-Object | `{ url: 'string', title: 'string' }`
+Object | `{ url: 'string', title: 'string', text: 'string', payload: 'string' }`
+When provided with `payload` instead of `url`, acts similarly to quick replies.
 
 #### `settings` (optional)
 

--- a/packages/channels/botpress-channel-web/src/views/web/messages/carousel.jsx
+++ b/packages/channels/botpress-channel-web/src/views/web/messages/carousel.jsx
@@ -13,6 +13,8 @@ export default class CarouselMessage extends Component {
     this.state = { hover: false }
   }
 
+  handleSendPostBack = (text, payload) => this.props.onSendData({ type: 'quick_reply', text, data: { payload } })
+
   render() {
     const CarouselElement = el => {
       return (
@@ -29,6 +31,16 @@ export default class CarouselMessage extends Component {
                   return (
                     <a href={btn.url} target="_blank" className={style.action}>
                       <i className={style.external} />
+                      {btn.title || btn}
+                    </a>
+                  )
+                } else if (btn.payload) {
+                  return (
+                    <a
+                      href
+                      onClick={() => this.handleSendPostBack(btn.text || btn.title, btn.payload)}
+                      className={style.action}
+                    >
                       {btn.title || btn}
                     </a>
                   )

--- a/packages/channels/botpress-channel-web/src/views/web/messages/index.jsx
+++ b/packages/channels/botpress-channel-web/src/views/web/messages/index.jsx
@@ -264,7 +264,7 @@ class Message extends Component {
   }
 
   render_carousel() {
-    return <CarouselMessage carousel={this.props.data.message_raw} />
+    return <CarouselMessage onSendData={this.props.onSendData} carousel={this.props.data.message_raw} />
   }
 
   render_typing() {


### PR DESCRIPTION
@slvnperron , this implements handling for renderer like this:

```js
  '#carousel': ({ payload, text }) => [
    {
      on: 'webchat',
      type: 'carousel',
      typing: '1s',
      text: 'Test',
      elements: [{ title: 'Test', buttons: [{ payload, text, title: 'Send' }]}]
    }
  ],
```

The result looks something like this:
![image](https://user-images.githubusercontent.com/1932290/40267505-24c41a7e-5b66-11e8-993f-f0f0915b86f5.png)

`text` get's sent to the webchat along with payload that can be handled on the server.