### PR TITLE
fix(builtins): allow $ in variable names

### DIFF
--- a/packages/core/botpress-builtins/src/actions/storage/index.js
+++ b/packages/core/botpress-builtins/src/actions/storage/index.js
@@ -14,7 +14,7 @@ export const setUserVariable = baseAction(
     ...Annotate('Storage', 'Set user variable', "Stores a variable under this user's storage, with optional expiry"),
     name: Joi.string()
       .required()
-      .token()
+      .regex(/^[a-z0-9_$]+$/i, 'token with allowed $')
       .description('The name of the variable.'),
     value: Joi.any()
       .optional()
@@ -41,12 +41,12 @@ export const getUserVariable = baseAction(
     ),
     name: Joi.string()
       .required()
-      .token()
+      .regex(/^[a-z0-9_$]+$/i, 'token with allowed $')
       .description('The name of the variable.'),
     output: Joi.string()
       .required()
       .default('$r')
-      .token()
+      .regex(/^[a-z0-9_$]+$/i, 'token with allowed $')
       .description('The state variable to output to')
   })
 )
@@ -61,7 +61,7 @@ export const resetUserVariable = baseAction(
     ...Annotate('Storage', 'Reset user variable', 'Deletes a user variable'),
     name: Joi.string()
       .required()
-      .token()
+      .regex(/^[a-z0-9_$]+$/i, 'token with allowed $')
       .description('The name of the variable.')
   })
 )
@@ -80,7 +80,7 @@ export const setConversationVariable = baseAction(
     ),
     name: Joi.string()
       .required()
-      .token()
+      .regex(/^[a-z0-9_$]+$/i, 'token with allowed $')
       .description('The name of the variable.'),
     value: Joi.any()
       .optional()
@@ -107,12 +107,12 @@ export const getConversationVariable = baseAction(
     ),
     name: Joi.string()
       .required()
-      .token()
+      .regex(/^[a-z0-9_$]+$/i, 'token with allowed $')
       .description('The name of the variable.'),
     output: Joi.string()
       .required()
       .default('$r')
-      .token()
+      .regex(/^[a-z0-9_$]+$/i, 'token with allowed $')
       .description('The state variable to output to')
   })
 )
@@ -127,7 +127,7 @@ export const resetConversationVariable = baseAction(
     ...Annotate('Storage', 'Reset conversation variable', 'Deletes a conversation variable'),
     name: Joi.string()
       .required()
-      .token()
+      .regex(/^[a-z0-9_$]+$/i, 'token with allowed $')
       .description('The name of the variable.')
   })
 )
@@ -141,7 +141,7 @@ export const setGlobalVariable = baseAction(
     ...Annotate('Storage', 'Set global variable', 'Stores a variable globally, with optional expiry'),
     name: Joi.string()
       .required()
-      .token()
+      .regex(/^[a-z0-9_$]+$/i, 'token with allowed $')
       .description('The name of the variable.'),
     value: Joi.any()
       .optional()
@@ -167,12 +167,12 @@ export const getGlobalVariable = baseAction(
     ),
     name: Joi.string()
       .required()
-      .token()
+      .regex(/^[a-z0-9_$]+$/i, 'token with allowed $')
       .description('The name of the variable.'),
     output: Joi.string()
       .required()
       .default('$r')
-      .token()
+      .regex(/^[a-z0-9_$]+$/i, 'token with allowed $')
       .description('The state variable to output to')
   })
 )
@@ -186,7 +186,7 @@ export const resetGlobalVariable = baseAction(
     ...Annotate('Storage', 'Reset global variable', 'Deletes a global variable'),
     name: Joi.string()
       .required()
-      .token()
+      .regex(/^[a-z0-9_$]+$/i, 'token with allowed $')
       .description('The name of the variable.')
   })
 )

--- a/packages/dev-bot/generated/flows/main.flow.json
+++ b/packages/dev-bot/generated/flows/main.flow.json
@@ -55,7 +55,7 @@
     {
       "id": "a54a82eb7c",
       "name": "entry",
-      "onEnter": ["getUserVariable {\"name\":\"nickname\"}"],
+      "onEnter": ["getUserVariable {\"name\":\"nickname\",\"output\":\"$r\"}"],
       "onReceive": null,
       "next": [
         {
@@ -80,7 +80,7 @@
       "onEnter": ["say #!builtin_text-z0J9qh"],
       "onReceive": [
         "setUserVariable {\"name\":\"nickname\",\"value\":\"{{event.text}}\",\"expiry\":\"never\"}",
-        "getUserVariable {\"name\":\"nickname\"}"
+        "getUserVariable {\"name\":\"nickname\",\"output\":\"$r\"}"
       ]
     }
   ]

--- a/templates/init-default/generated/flows/main.flow.json
+++ b/templates/init-default/generated/flows/main.flow.json
@@ -55,7 +55,7 @@
     {
       "id": "a54a82eb7c",
       "name": "entry",
-      "onEnter": ["getUserVariable {\"name\":\"nickname\"}"],
+      "onEnter": ["getUserVariable {\"name\":\"nickname\",\"output\":\"$r\"}"],
       "onReceive": null,
       "next": [
         {
@@ -80,7 +80,7 @@
       "onEnter": ["say #!builtin_text-z0J9qh"],
       "onReceive": [
         "setUserVariable {\"name\":\"nickname\",\"value\":\"{{event.text}}\",\"expiry\":\"never\"}",
-        "getUserVariable {\"name\":\"nickname\"}"
+        "getUserVariable {\"name\":\"nickname\",\"output\":\"$r\"}"
       ]
     }
   ]


### PR DESCRIPTION
The `token` schema from Joi doesn't allow for `$` sign thus `$r` variable was invalid and the template bot didn't work throwing
```
error: [notification::botpress] DialogEngine: ERROR function "getUserVariable" thrown an error: Invalid options provided to action {
  "name": "nickname",
  "output" [1]: -- missing --
}

[1] "output" is required
``` 

After fixing it I've also found out that `.default` didn't work for some reason. I don't know why but to get me unblocked I've fixed it by explicitly providing `output: $r`.