### PR TITLE
feat(analytics): graph accepts fnAvg to customize avgValue calculation

### DIFF
--- a/packages/functionals/botpress-analytics/src/views/custom.jsx
+++ b/packages/functionals/botpress-analytics/src/views/custom.jsx
@@ -242,7 +242,7 @@ export default class CustomMetrics extends React.Component {
     return (
       <div>
         <div className={style.customCount} style={{ height: '50px' }}>
-          {avgPerDay}%
+          {metric.percent === null ? avgPerDay : metric.percent.toFixed(1)}%
         </div>
         <div className={style.customCountSmall} style={{ height: '25px' }}>
           Abs Average: {absAvg}%


### PR DESCRIPTION
This is intended to handle graphs with `fnAvg` key:

- allows to customize the way avg value get's calculated
- allows to calculate it based on number of uniq records within given period

@slvnperron , @emirotin I spent some time thinking on how to implement it best but still I feel this is hacky. Let me know if you have better ideas for it.