### PR TITLE
fix(core): fill computed data upon loading content items

### DIFF
--- a/packages/core/botpress/src/content/service.js
+++ b/packages/core/botpress/src/content/service.js
@@ -574,6 +574,8 @@ module.exports = async ({ botfile, projectLocation, logger, ghostManager }) => {
         throw new VError(err, `[Content Manager] Could not register Content Element "${file}"`)
       }
     }
+
+    await recomputeCategoriesMetadata()
   }
 
   /**


### PR DESCRIPTION
This seems to be an issue introduced during refactoring some time ago.
Before this fix the content is loaded into in-memory SQLite DB without the computed data, metadata and preview text.

It's not noticeable in the bots produced by `bp init` because the template calls this method itself when registering builtins.
But it's the core's responsibility to ensure the content loaded by the core is in usable shape in the DB — thus the fix.

Discovered when working on botpress/v12#278