### PR TITLE
UMM deprecation-warning doesn't always appear on bot start

### DIFF
--- a/packages/core/botpress/src/botpress.js
+++ b/packages/core/botpress/src/botpress.js
@@ -299,12 +299,6 @@ class botpress {
       configManager,
       cloud,
       renderers,
-      get umm() {
-        logger.warn(
-          'DEPRECATION NOTICE – bp.umm is deprecated and will be removed in `botpress@3.0` – Please see bp.renderers instead.'
-        )
-        return renderers
-      },
       users,
       ghostManager,
       contentManager,
@@ -313,6 +307,13 @@ class botpress {
       dialogJanitor,
       messages,
       skills: skillsManager
+    })
+
+    Object.defineProperty(this, 'umm', {
+      get() {
+        logger.warn('DEPRECATION NOTICE – bp.umm is deprecated and will be removed – Please see bp.renderers instead.')
+        return renderers
+      }
     })
 
     const loadedModules = await modules._load(moduleDefinitions, this)


### PR DESCRIPTION
I appears calling `_.assign` or `Object.assign` to assign getter-property _calls_ all the getters. E.g. consider following case that will show up `console.log` statement:

```javascript
_.assign({}, {
  get x() {
    console.log('_.assign calls getter function')
    // Do smth
  }
})
```

This may confuse users as in botpress/v12#282.