### PR TITLE
fix(core): improve .npmignore (ref #513)

### DIFF
--- a/packages/core/botpress/.npmignore
+++ b/packages/core/botpress/.npmignore
@@ -1,7 +1,11 @@
-src/**
-extensions/**
-test/**
-docs/**
-assets/**
-dev-bot/**
+# Ignore everything:
+*
 
+#Except for the themes directories and files:
+!/lib/*
+!/licenses/*
+!/bin/*
+!/migrations/*
+!/package.json
+!/CHANGELOG.md
+!/LICENSE


### PR DESCRIPTION
This fix will ignore all directories and files except these:
- `/lib`
- `/licenses`
- `/bin`
- `/migrations`
- `package.json`
- `README` (and its variants)
- `CHANGELOG` (and its variants)
- `LICENSE / LICENCE`