### PR TITLE
fix(messenger): fix GET_STARTED event (ref #589)

### DIFF
--- a/packages/channels/botpress-channel-messenger/README.md
+++ b/packages/channels/botpress-channel-messenger/README.md
@@ -206,7 +206,7 @@ You can listen to incoming event easily with Botpress by using `bp` built-in `he
 
 ```js
 bp.hear({ platform: 'facebook', type: 'postback', text: 'GET_STARTED' }, (event, next) => {
-      bp.messenger.sendText(event.user.id, 'Welcome on Botpress!!!')
+      bp.messenger.api.sendTextMessage(event.user.id, 'Welcome on Botpress!!!')
    }
 })
 ```
@@ -427,7 +427,7 @@ const options = {
   waitRead: true
 }
 
-bp.messenger.sendText(userId, text, options)
+bp.messenger.api.sendTextMessage(userId, text, options)
 .then(() => {
   // the message was read because of `waitRead` option
 })

--- a/packages/channels/botpress-channel-messenger/src/incoming.js
+++ b/packages/channels/botpress-channel-messenger/src/incoming.js
@@ -75,7 +75,7 @@ module.exports = (bp, messenger) => {
         const mConfig = messenger.getConfig()
 
         if (mConfig.displayGetStarted && mConfig.autoResponseOption == 'autoResponseText') {
-          bp.messenger.sendText(profile.id, mConfig.autoResponseText)
+          bp.messenger.api.sendTextMessage(profile.id, mConfig.autoResponseText)
         }
 
         if (mConfig.displayGetStarted && mConfig.autoResponseOption == 'autoResponsePostback') {

--- a/packages/channels/botpress-channel-messenger/src/index.js
+++ b/packages/channels/botpress-channel-messenger/src/index.js
@@ -123,6 +123,6 @@ module.exports = {
   ready: async function(bp, config) {
     await initializeMessenger(bp, config)
     incoming(bp, messenger)
-    bp.messenger._internal = messenger
+    bp.messenger.api = messenger
   }
 }

--- a/packages/functionals/botpress-hitl/README.md
+++ b/packages/functionals/botpress-hitl/README.md
@@ -70,12 +70,12 @@ A basic implementation example that shows how easy it is to implement a help req
     })
 
     bp.hear(/HITL_STOP/, (event, next) => {
-      bp.messenger.sendText(event.user.id, 'Human in the loop disabled. Bot resumed.')
+      bp.messenger.api.sendTextMessage(event.user.id, 'Human in the loop disabled. Bot resumed.')
       bp.hitl.unpause(event.platform, event.user.id)
     })
 
     bp.hear({ type: 'message', text: /.+/i }, (event, next) => {
-      bp.messenger.sendText(event.user.id, 'You said: ' + event.text)
+      bp.messenger.api.sendTextMessage(event.user.id, 'You said: ' + event.text)
     })
   }
 ```


### PR DESCRIPTION
@epaminond @emirotin @slvnperron 
Please check is it right changes in readme because I'm not sure.
For unknown reasons `bp.messenger.sendText()` has error messege: ` TypeError: bp.messenger.sendText is not a function` I change to `messenger.sendTextMessage` and all works fine.