### PR TITLE
fix(util-roles): fix resources export

### DIFF
--- a/packages/core/botpress-util-roles/package.json
+++ b/packages/core/botpress-util-roles/package.json
@@ -8,6 +8,8 @@
   "private": false,
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "babel-plugin-transform-export-extensions": "^6.22.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "jest": "^22.4.3",
     "rimraf": "^2.6.2"

--- a/packages/core/botpress-util-roles/src/index.test.js
+++ b/packages/core/botpress-util-roles/src/index.test.js
@@ -137,7 +137,6 @@ test('enrichResources', () => {
     }
   ]
 
-  enrichResources(resources)
-
-  expect(resources).toEqual(enrichedResources)
+  expect(enrichResources(resources)).not.toBe(resources)
+  expect(enrichResources(resources)).toEqual(enrichedResources)
 })

--- a/packages/core/botpress-util-roles/src/resources.js
+++ b/packages/core/botpress-util-roles/src/resources.js
@@ -5,12 +5,14 @@ const _enrichResources = (resources, parent) => {
   if (!resources) {
     return
   }
-  resources.forEach(r => {
-    Object.assign(r, {
+  return resources.map(r => {
+    const fullName = parent != null ? `${parent}.${r.name}` : r.name
+    return {
+      ...r,
       displayName: r.name,
-      name: parent != null ? `${parent}.${r.name}` : r.name
-    })
-    _enrichResources(r.children, r.name)
+      name: fullName,
+      children: _enrichResources(r.children, fullName)
+    }
   })
 }
 

--- a/packages/core/botpress-util-roles/yarn.lock
+++ b/packages/core/botpress-util-roles/yarn.lock
@@ -420,7 +420,11 @@ babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
 
-babel-plugin-syntax-object-rest-spread@^6.13.0:
+babel-plugin-syntax-export-extensions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz#70a1484f0f9089a4e84ad44bac353c95b9b12721"
+
+babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
@@ -611,6 +615,20 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-export-extensions@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz#53738b47e75e8218589eea946cbbd39109bbe653"
+  dependencies:
+    babel-plugin-syntax-export-extensions "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"


### PR DESCRIPTION
also make the enrichResources not modify
the passed object

The previous commit exported `null` because the method didn't return anything.