### PR TITLE
fix(npmignore): fix ignore nested folders

### DIFF
--- a/packages/core/botpress/.npmignore
+++ b/packages/core/botpress/.npmignore
@@ -1,11 +1,11 @@
 # Ignore everything:
 *
 
-#Except for the themes directories and files:
-!/lib/*
-!/licenses/*
-!/bin/*
-!/migrations/*
+#Except for the directories and files:
+!/lib/**
+!/licenses/**
+!/bin/**
+!/migrations/**
 !/package.json
 !/CHANGELOG.md
 !/LICENSE

--- a/templates/create-default/.npmignore
+++ b/templates/create-default/.npmignore
@@ -1,3 +1,2 @@
-src/
 webpack.config.js
 *.log


### PR DESCRIPTION
@emirotin @epaminond previous version of `.npmignore` ignores nested `files/folders` and needs re-publishing since a bug occurred.
To test test what will be ignored with this version you can install `botpress-test` package (that I published to make sure it works fine this time).