### PR TITLE
fix(core): use bot's NODE_ENV not botpress's(resolve #591)

### DIFF
--- a/packages/core/botpress/src/config-manager/index.js
+++ b/packages/core/botpress/src/config-manager/index.js
@@ -14,6 +14,7 @@ import fs from 'fs'
 import json5 from 'json5'
 
 import ModuleConfiguration from './module'
+import { isDeveloping } from '../util'
 
 const validations = {
   any: (value, validation) => validation(value),
@@ -63,7 +64,7 @@ const amendOptions = options => {
 
 export default class ConfigurationManager {
   constructor(options) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (isDeveloping) {
       const schema = Joi.object().keys({
         configLocation: Joi.string()
           .min(1)

--- a/packages/core/botpress/src/security/index.js
+++ b/packages/core/botpress/src/security/index.js
@@ -3,9 +3,10 @@ import Joi from 'joi'
 import RootAuthentication from './root'
 import CloudAuthentication from './cloud'
 import NoneAuthentication from './none'
+import { isDeveloping } from '../util'
 
 module.exports = async options => {
-  if (process.env.NODE_ENV !== 'production') {
+  if (isDeveloping) {
     const schema = Joi.object().keys({
       dataLocation: Joi.string()
         .min(1)

--- a/packages/core/botpress/src/server/non-secured.js
+++ b/packages/core/botpress/src/server/non-secured.js
@@ -8,10 +8,6 @@ module.exports = (bp, app) => {
     res.send('pong')
   })
 
-  app.get('/api/bot/production', (req, res) => {
-    res.send(!util.isDeveloping)
-  })
-
   app.get('/api/license', async (req, res) => {
     res.send(await bp.licensing.getLicensing())
   })

--- a/packages/core/botpress/src/util.js
+++ b/packages/core/botpress/src/util.js
@@ -5,7 +5,7 @@ import fs from 'fs'
 import knex from 'knex'
 import generate from 'nanoid/generate'
 
-const IS_DEV = process.env.NODE_ENV !== 'production'
+const IS_DEV = eval("process.env.NODE_ENV !== 'production'") /* eslint-disable-line no-eval */
 
 const NPM_CMD = /^win/.test(process.platform) ? 'npm.cmd' : 'npm'
 
@@ -101,13 +101,13 @@ const getInMemoryDb = () =>
 const safeId = (length = 10) => generate('1234567890abcdefghijklmnopqrsuvwxyz', length)
 
 const isBotpressPackage = pkg => {
-  const [ scope, name ] = getPackageName(pkg)
-  const isBotpress = (scope === 'botpress' || name.startsWith('botpress-'))
+  const [scope, name] = getPackageName(pkg)
+  const isBotpress = scope === 'botpress' || name.startsWith('botpress-')
   return isBotpress
 }
 
 const getModuleShortname = pkg => {
-  const [ , name ] = getPackageName(pkg)
+  const [, name] = getPackageName(pkg)
   const withoutPrefix = name.replace(/^botpress-/i, '')
   return withoutPrefix
 }
@@ -116,10 +116,10 @@ const getPackageName = pkg => {
   const isScoped = pkg.startsWith('@')
 
   if (isScoped) {
-    const [ scope, name ] = pkg.match(/^@(.*)\/(.*)/).slice(1)
-    return [ scope, name ]
+    const [scope, name] = pkg.match(/^@(.*)\/(.*)/).slice(1)
+    return [scope, name]
   } else {
-    return [ null, pkg ];
+    return [null, pkg]
   }
 }
 

--- a/packages/core/botpress/src/web/actions/index.js
+++ b/packages/core/botpress/src/web/actions/index.js
@@ -161,12 +161,9 @@ export const fetchUser = authEnabled => dispatch => {
 // Bot
 export const botInfoReceived = createAction('BOT/INFO_RECEIVED')
 export const fetchBotInformation = () => dispatch => {
-  axios.all([axios.get('/api/bot/information'), axios.get('/api/bot/production')]).then(
-    axios.spread((information, production) => {
-      const info = Object.assign({}, information.data, { production: production.data })
-      dispatch(botInfoReceived(info))
-    })
-  )
+  axios.get('/api/bot/information').then(information => {
+    dispatch(botInfoReceived(information.data))
+  })
 }
 
 // Modules

--- a/packages/core/botpress/src/web/components/Layout/SidebarFooter.jsx
+++ b/packages/core/botpress/src/web/components/Layout/SidebarFooter.jsx
@@ -153,9 +153,7 @@ class SidebarFooter extends React.Component {
       return null
     }
 
-    const isProduction = this.props.botInformation && this.props.botInformation.production
-
-    const production = isProduction ? 'in production' : 'in development'
+    const production = window.DEV_MODE ? 'in development' : 'in production'
 
     const name = this.props.botInformation && this.props.botInformation.name
 

--- a/packages/core/botpress/yarn.lock
+++ b/packages/core/botpress/yarn.lock
@@ -71,6 +71,10 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@botpress/util-roles@^10.17.2":
+  version "10.17.2"
+  resolved "https://registry.yarnpkg.com/@botpress/util-roles/-/util-roles-10.17.2.tgz#9931fb31cae584ccf2e6e0c00be4e2b811954ee4"
+
 "@sinonjs/formatio@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"


### PR DESCRIPTION
It seems there are several places where we relied on NODE_ENV of botpress-build not of the bot itself.