### PR TITLE
fix(code): empty dashboard when user signed in

### DIFF
--- a/packages/core/botpress/src/web/components/Middlewares/index.jsx
+++ b/packages/core/botpress/src/web/components/Middlewares/index.jsx
@@ -117,7 +117,7 @@ class Middlewares extends Component {
   }
 
   refresh = () => {
-    if (this.initialized || !this.props.user || !this.props.user.id) {
+    if (this.initialized || !this.props.user || this.props.user.id == null) {
       return
     }
     this.initialized = true

--- a/packages/core/botpress/src/web/views/Dashboard/index.jsx
+++ b/packages/core/botpress/src/web/views/Dashboard/index.jsx
@@ -44,7 +44,7 @@ class Dashboard extends React.Component {
   }
 
   refresh = () => {
-    if (this.initialized || !this.props.user || !this.props.user.id) {
+    if (this.initialized || !this.props.user || this.props.user.id == null) {
       return
     }
 


### PR DESCRIPTION
@emirotin @epaminond @slvnperron Hi. We had incorrect logic, because `this.props.user === {}` by default and for first user `!this.props.user.id === true` because `this.props.user.id === 0`