### PR TITLE
DB Logs

### DIFF
--- a/packages/core/botpress/src/botpress.js
+++ b/packages/core/botpress/src/botpress.js
@@ -195,6 +195,8 @@ class botpress {
       botpressPath: this.botpressPath
     })
 
+    await db.get() // Running migrations
+
     const janitor = createJanitor({ db, logger })
 
     logger.enableDbStorageIfNeeded({ db, janitor })

--- a/packages/core/botpress/src/botpress.js
+++ b/packages/core/botpress/src/botpress.js
@@ -200,6 +200,8 @@ class botpress {
     logger.enableDbStorageIfNeeded({ db, janitor })
     logger.info(`Starting botpress version ${version}`)
 
+    janitor.start()
+
     const kvs = db._kvs
 
     const cloud = await createCloud({ projectLocation, botfile, logger })

--- a/packages/core/botpress/src/botpress.js
+++ b/packages/core/botpress/src/botpress.js
@@ -51,6 +51,7 @@ import createUsers from './users'
 import createContentManager from './content/service'
 import defaultGetItemProviders from './content/getItemProviders'
 import createHelpers from './helpers'
+import createJanitor from './janitor'
 import stats from './stats'
 
 import EventBus from './bus'
@@ -194,7 +195,9 @@ class botpress {
       botpressPath: this.botpressPath
     })
 
-    logger.enableDbStorageIfNeeded(db)
+    const janitor = createJanitor({ db, logger })
+
+    logger.enableDbStorageIfNeeded({ db, janitor })
     logger.info(`Starting botpress version ${version}`)
 
     const kvs = db._kvs
@@ -331,6 +334,7 @@ class botpress {
       licensing,
       modules,
       db,
+      janitor,
       kvs,
       configManager,
       cloud,

--- a/packages/core/botpress/src/cli/create.js
+++ b/packages/core/botpress/src/cli/create.js
@@ -54,7 +54,6 @@ const assertDoesntExist = file => {
  */
 const loadTemplate = async name => {
   const templatePath = path.join(__dirname, 'cli/templates/' + name)
-  const infoFile = path.join(templatePath, 'info.json')
 
   if (!fs.existsSync) {
     console.log(templateNotFoundError(name))

--- a/packages/core/botpress/src/cli/init.js
+++ b/packages/core/botpress/src/cli/init.js
@@ -1,4 +1,3 @@
-import { spawn } from 'child_process'
 import prompt from 'prompt'
 import chalk from 'chalk'
 import path from 'path'
@@ -71,7 +70,6 @@ const assertDoesntExist = file => {
  */
 const loadTemplate = async name => {
   const templatePath = path.join(__dirname, 'cli/templates/' + name)
-  const infoFile = path.join(templatePath, 'info.json')
 
   if (!fs.existsSync) {
     console.log(templateNotFoundError(name))

--- a/packages/core/botpress/src/database/logs.js
+++ b/packages/core/botpress/src/database/logs.js
@@ -1,0 +1,15 @@
+/*
+  Tables storing ghost content and its revisions
+*/
+
+import helpers from './helpers'
+
+module.exports = knex => {
+  const h = helpers(knex)
+  return h.createTableIfNotExists('logs', table => {
+    table.increments('id')
+    table.string('level')
+    table.text('message')
+    table.timestamp('created_on')
+  })
+}

--- a/packages/core/botpress/src/database/logs.js
+++ b/packages/core/botpress/src/database/logs.js
@@ -1,5 +1,5 @@
 /*
-  Tables storing ghost content and its revisions
+  Table storing bot logs
 */
 
 import helpers from './helpers'

--- a/packages/core/botpress/src/database/tables.js
+++ b/packages/core/botpress/src/database/tables.js
@@ -3,5 +3,6 @@ module.exports = [
   require('./tags.js'),
   require('./notifications.js'),
   require('./sessions.js'),
-  require('./ghost.js')
+  require('./ghost.js'),
+  require('./logs.js')
 ]

--- a/packages/core/botpress/src/janitor/index.js
+++ b/packages/core/botpress/src/janitor/index.js
@@ -1,0 +1,71 @@
+import Promise from 'bluebird'
+import nanoid from 'nanoid'
+import moment from 'moment'
+import { findIndex } from 'lodash'
+
+import helpers from '../database/helpers'
+
+const DEFAULTS = {
+  timestampColumn: 'created_on'
+}
+
+const createJanitor = ({ db, logger, intervalMin = 1 }) => {
+  const tasks = []
+  let currentPromise = null
+
+  // TODO: impplement `debuounce` param which, when set,
+  // prevents the specific task form running too often
+  // The goal is to have the interval reasonably low (1/5/10s)
+  // for some tasks like dialog sessions
+  // but don't run other tasks like logs more often than every 1/5/10min
+  const runTask = async ({ table, ttl, timestampColumn }) => {
+    logger.info(`[DB Janitor] Running for table "${table}"`)
+    const knex = await db.get()
+    const outdatedCondition = helpers(knex).date.isBefore(timestampColumn, moment().subtract(ttl, 'seconds'))
+    return knex(table)
+      .where(outdatedCondition)
+      .del()
+      .then()
+  }
+
+  const runTasks = () => {
+    logger.debug('[DB Janitor] Running tasks')
+    if (currentPromise) {
+      // don't run the tasks if the previous batch didn't finish yet
+      logger.debug('[DB Janitor] Skipping the current run, previous operation still running')
+      return
+    }
+    currentPromise = Promise.each(tasks, runTask)
+      .catch(err => {
+        logger.error('[DB Janitor] Error:', err.message)
+      })
+      .finally(() => {
+        currentPromise = null
+      })
+  }
+
+  const intervalId = setInterval(runTasks, intervalMin * 60 * 1000)
+  logger.info('[DB Janitor] Started')
+
+  const add = opts => {
+    logger.info(`[DB Janitor] Added table "${opts.table}"`)
+    const id = nanoid()
+    tasks.push(Object.assign({ id }, DEFAULTS, opts))
+    return id
+  }
+
+  const remove = id => {
+    const i = findIndex(tasks, { id })
+    const [opts] = tasks.splice(i, 1)
+    logger.info(`[DB Janitor] Removed table "${opts.table}"`)
+  }
+
+  const stop = () => {
+    clearInterval(intervalId)
+    logger.info('[DB Janitor] Stopped')
+  }
+
+  return { add, remove, stop }
+}
+
+export default createJanitor

--- a/packages/core/botpress/src/janitor/index.js
+++ b/packages/core/botpress/src/janitor/index.js
@@ -27,7 +27,7 @@ const createJanitor = ({ db, logger, intervalMs = ms('1m') }) => {
   // for some tasks like dialog sessions
   // but don't run other tasks like logs more often than every 1/5/10min
   const runTask = async ({ table, ttl, timestampColumn }) => {
-    logger.info(`[DB Janitor] Running for table "${table}"`)
+    logger.debug(`[DB Janitor] Running for table "${table}"`)
     const knex = await db.get()
     const outdatedCondition = helpers(knex).date.isBefore(timestampColumn, moment().subtract(ttl, 'ms'))
     return knex(table)
@@ -80,7 +80,7 @@ const createJanitor = ({ db, logger, intervalMs = ms('1m') }) => {
    * @returns {string} The id of the added task.
    */
   const add = options => {
-    logger.info(`[DB Janitor] Added table "${options.table}"`)
+    logger.debug(`[DB Janitor] Added table "${options.table}"`)
     const id = nanoid()
     tasks.push(Object.assign({ id }, DEFAULTS, options))
     return id
@@ -99,7 +99,7 @@ const createJanitor = ({ db, logger, intervalMs = ms('1m') }) => {
       return
     }
     const [{ table }] = tasks.splice(i, 1)
-    logger.info(`[DB Janitor] Removed table "${table}"`)
+    logger.debug(`[DB Janitor] Removed table "${table}"`)
   }
 
   /**

--- a/packages/core/botpress/src/logger/db-transport.js
+++ b/packages/core/botpress/src/logger/db-transport.js
@@ -8,7 +8,11 @@ export default class DbTransport extends winston.Transport {
   constructor(opts) {
     super(opts)
     this.name = 'DBLogger'
-    this.opts = opts
+    this.db = opts.db
+    opts.janitor.add({
+      table: 'logs',
+      ttl: opts.ttl
+    })
   }
 
   log(level, message, meta, callback) {
@@ -16,7 +20,7 @@ export default class DbTransport extends winston.Transport {
       message += ' ' + JSON.stringify(meta)
     }
 
-    this.opts.db
+    this.db
       .get()
       .then(knex =>
         knex('logs').insert({

--- a/packages/core/botpress/src/logger/db-transport.js
+++ b/packages/core/botpress/src/logger/db-transport.js
@@ -17,7 +17,7 @@ export default class DbTransport extends winston.Transport {
 
   log(level, message, meta, callback) {
     if (!isEmpty(meta)) {
-      message += ' ' + JSON.stringify(meta)
+      message += ` (meta=${JSON.stringify(meta)})`
     }
 
     this.db

--- a/packages/core/botpress/src/logger/db-transport.js
+++ b/packages/core/botpress/src/logger/db-transport.js
@@ -1,0 +1,47 @@
+import winston from 'winston'
+
+import { isEmpty } from 'lodash'
+
+import helpers from '../database/helpers'
+
+export default class DbTransport extends winston.Transport {
+  constructor(opts) {
+    super(opts)
+    this.name = 'DBLogger'
+    this.opts = opts
+  }
+
+  log(level, message, meta, callback) {
+    if (!isEmpty(meta)) {
+      message += ' ' + JSON.stringify(meta)
+    }
+
+    this.opts.db
+      .get()
+      .then(knex =>
+        knex('logs').insert({
+          level,
+          message,
+          created_on: helpers(knex).date.now()
+        })
+      )
+      .then(() => {
+        this.emit('logged')
+        callback(null, true)
+      })
+      .catch(err => {
+        callback(err, false)
+      })
+  }
+
+  static async _query(db, limit = null, order = 'desc') {
+    const knex = await db.get()
+    let q = knex('logs')
+      .select('created_on as timestamp', 'level', 'message')
+      .orderBy('created_on', order)
+    if (limit) {
+      q = q.limit(limit)
+    }
+    return q.then()
+  }
+}

--- a/packages/core/botpress/src/logger/db-transport.js
+++ b/packages/core/botpress/src/logger/db-transport.js
@@ -1,18 +1,58 @@
 import winston from 'winston'
+import ms from 'ms'
+import Promise from 'bluebird'
 
 import { isEmpty } from 'lodash'
 
 import helpers from '../database/helpers'
+
+const LOGS_FLUSH_INTERVAL = ms('2s')
+const LOGS_CHUNK_SIZE = 1000
 
 export default class DbTransport extends winston.Transport {
   constructor(opts) {
     super(opts)
     this.name = 'DBLogger'
     this.db = opts.db
+
     opts.janitor.add({
       table: 'logs',
       ttl: opts.ttl
     })
+
+    this.flushInterval = setInterval(this.flush, LOGS_FLUSH_INTERVAL)
+  }
+
+  flushPromise = null
+  batches = []
+
+  doFlush = async () => {
+    const batch = this.batches.shift()
+
+    try {
+      if (!batch || !batch.length) {
+        return
+      }
+
+      const knex = await this.db.get()
+      await knex.batchInsert('logs', batch, LOGS_CHUNK_SIZE).then()
+    } catch (err) {
+      // We put the logs back on the queue in position 1
+      // so that the next call will insert them in the right order
+      // This works since `batchInsert` wraps the op in a transaction
+      this.batches.unshift(batch)
+    }
+  }
+
+  flush = async () => {
+    if (this.flushPromise) {
+      return // Previous flush is not done running
+    }
+
+    this.flushPromise = this.doFlush()
+
+    await this.flushPromise
+    this.flushPromise = null
   }
 
   log(level, message, meta, callback) {
@@ -22,19 +62,23 @@ export default class DbTransport extends winston.Transport {
 
     this.db
       .get()
-      .then(knex =>
-        knex('logs').insert({
+      .then(knex => {
+        const row = {
           level,
           message,
-          created_on: helpers(knex).date.now()
-        })
-      )
-      .then(() => {
+          created_on: helpers(knex).date.format(new Date())
+        }
+
+        if (this.batches.length) {
+          this.batches[this.batches.length - 1].push(row)
+        } else {
+          this.batches.push([row])
+        }
         this.emit('logged')
         callback(null, true)
       })
       .catch(err => {
-        callback(err, false)
+        callback(err, null)
       })
   }
 

--- a/packages/core/botpress/src/logger/index.js
+++ b/packages/core/botpress/src/logger/index.js
@@ -14,6 +14,7 @@
  */
 
 import moment from 'moment'
+import ms from 'ms'
 import winston from 'winston'
 import Promise from 'bluebird'
 
@@ -37,7 +38,7 @@ module.exports = logConfig => {
   logger.enableDbStorageIfNeeded = ({ db, janitor }) => {
     if (logConfig.enabled) {
       _db = db
-      const ttl = (logConfig.keepDays || 30) * 24 * 3600
+      const ttl = ms(`${logConfig.keepDays || 30}days`)
       logger.add(DbTransport, { ttl, db, janitor })
     }
   }

--- a/packages/core/botpress/src/logger/index.js
+++ b/packages/core/botpress/src/logger/index.js
@@ -34,13 +34,11 @@ module.exports = logConfig => {
     ]
   })
 
-  logger.enableDbStorageIfNeeded = db => {
+  logger.enableDbStorageIfNeeded = ({ db, janitor }) => {
     if (logConfig.enabled) {
       _db = db
-      logger.add(DbTransport, {
-        ttl: logConfig.keepDays * 24 * 3600,
-        db
-      })
+      const ttl = (logConfig.keepDays || 30) * 24 * 3600
+      logger.add(DbTransport, { ttl, db, janitor })
     }
   }
 

--- a/packages/core/botpress/src/server/secured.js
+++ b/packages/core/botpress/src/server/secured.js
@@ -128,7 +128,8 @@ module.exports = (bp, app) => {
         )
       })
       .catch(err => {
-        console.log(err)
+        console.error(err)
+        res.sendStatus(500)
       })
   })
 

--- a/packages/core/botpress/src/web/views/Logs/index.jsx
+++ b/packages/core/botpress/src/web/views/Logs/index.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Row, Col, Button, Checkbox, Panel, Glyphicon } from 'react-bootstrap'
+import { Button, Checkbox, Panel } from 'react-bootstrap'
 import axios from 'axios'
 import _ from 'lodash'
 import classnames from 'classnames'
@@ -28,7 +28,7 @@ class LoggerView extends Component {
 
   componentWillUnmount() {
     clearInterval(this.refreshInterval)
-    this.setState({ cancelLoading: true })
+    this.cancelLoading = true
   }
 
   loadMore = () => {
@@ -63,7 +63,7 @@ class LoggerView extends Component {
   }
 
   getArchiveKey() {
-    axios.get('/api/logs/key').then(({ data }) => this.setState({ archiveUrl: 'api/logs/archive/' + data.secret }))
+    axios.get('/api/logs/key').then(({ data }) => this.setState({ archiveUrl: '/api/logs/archive/' + data.secret }))
   }
 
   queryLogs = () => {
@@ -74,7 +74,7 @@ class LoggerView extends Component {
         }
       })
       .then(result => {
-        if (this.state.cancelLoading) {
+        if (this.cancelLoading) {
           return
         }
         this.setState({
@@ -90,21 +90,6 @@ class LoggerView extends Component {
     }
 
     return this.state.logs.filter(x => _.isString(x.message)).map(this.renderLine)
-  }
-
-  downloadArchive = () => {
-    axios({
-      url: this.state.archiveUrl,
-      method: 'GET',
-      responseType: 'blob'
-    }).then(response => {
-      const url = window.URL.createObjectURL(new Blob([response.data]))
-      const link = document.createElement('a')
-      link.href = url
-      link.setAttribute('download', 'logs.txt')
-      document.body.appendChild(link)
-      link.click()
-    })
   }
 
   render() {
@@ -130,7 +115,7 @@ class LoggerView extends Component {
               </Checkbox>
             </form>
             <div className="pull-right">
-              <Button onClick={this.downloadArchive}>Export logs archive</Button>
+              <Button href={this.state.archiveUrl}>Export logs archive</Button>
             </div>
           </Panel.Body>
         </Panel>

--- a/packages/core/botpress/src/web/views/Logs/index.jsx
+++ b/packages/core/botpress/src/web/views/Logs/index.jsx
@@ -32,7 +32,7 @@ class LoggerView extends Component {
   }
 
   loadMore = () => {
-    this.setState({ limit: this.state.limit + 50, logs: null })
+    this.setState(({ limit }) => ({ limit: limit + 50 }))
   }
 
   toggleAutoRefresh = () => {

--- a/packages/core/botpress/src/web/views/Logs/index.jsx
+++ b/packages/core/botpress/src/web/views/Logs/index.jsx
@@ -50,7 +50,7 @@ class LoggerView extends Component {
     const message = line.message.replace(/\[\d\d?m/gi, '')
 
     return (
-      <li key={`log_event_${index}`} className={styles.line}>
+      <li key={`${index}.${message}`} className={styles.line}>
         <span className={styles.time}>{time}</span>
         <span className={styles['level-' + line.level]}>{line.level + ': '}</span>
         <span className={styles.message}>{message}</span>

--- a/packages/core/botpress/yarn.lock
+++ b/packages/core/botpress/yarn.lock
@@ -78,6 +78,10 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@botpress/util-roles@^10.19.0":
+  version "10.19.0"
+  resolved "https://registry.yarnpkg.com/@botpress/util-roles/-/util-roles-10.19.0.tgz#189f42db7e8e814d47022fb072fbe66cca3549b6"
+
 "@sinonjs/formatio@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"

--- a/packages/dev-bot/botfile.js
+++ b/packages/dev-bot/botfile.js
@@ -1,4 +1,3 @@
-const isProd = process.env.NODE_ENV === 'production'
 const port = process.env.BOTPRESS_PORT || process.env.PORT || 3000
 const botUrl = process.env.BOTPRESS_URL || `http://localhost:${port}`
 
@@ -52,12 +51,11 @@ module.exports = {
   mediaDir: './generated/media',
 
   /*
-    By default logs are enabled and available in `dataDir`
+    By default logs are enabled and stored in the DB for 30 days
    */
-  disableFileLogs: false,
-  log: {
-    file: 'bot.log',
-    maxSize: 1e6 // 1mb
+  logs: {
+    enabled: true,
+    keepDays: 30
   },
 
   /*

--- a/templates/init-default/botfile.js
+++ b/templates/init-default/botfile.js
@@ -1,15 +1,20 @@
-const isProd = process.env.NODE_ENV === 'production'
 const port = process.env.BOTPRESS_PORT || process.env.PORT || 3000
 const botUrl = process.env.BOTPRESS_URL || `http://localhost:${port}`
 
 module.exports = {
+  /*
+    Botpress minimal supported version.
+    Don't forget to change it when updating to the next major version.
+   */
+  version: '<%= version %>',
+
   /*
     The bot's base URL where the bot is reachable from the internet
    */
   botUrl: botUrl,
 
   /*
-    The botpress environment, useful to disambiguate multiple 
+    The botpress environment, useful to disambiguate multiple
     instances of the same bot running in different environments.
     e.g. "dev", "staging", "production"
    */
@@ -57,12 +62,11 @@ module.exports = {
   mediaDir: './generated/media',
 
   /*
-    By default logs are enabled and available in `dataDir`
+    By default logs are enabled and stored in the DB
    */
-  disableFileLogs: false,
-  log: {
-    file: 'bot.log',
-    maxSize: 1e6 // 1mb
+  logs: {
+    enabled: true,
+    keepDays: 30
   },
 
   /*
@@ -84,15 +88,6 @@ module.exports = {
     Botpress collects some anonymous usage statistics to help us put our efforts at the right place
    */
   optOutStats: false,
-
-  /*
-    Where the notifications are stored.
-    TODO: These should be stored in the database
-   */
-  notification: {
-    file: 'notifications.json',
-    maxLength: 50
-  },
 
   /*
     By default ghost content management is only activated in production


### PR DESCRIPTION
This implements the logs storage in the DB.
Missing from this PR:
- [x] logs churning (the new generic janitor mechanism to be later used across the botpress https://github.com/botpress/v12/issues/316)
- [ ] actually checking the compatible bp version in the botfile https://github.com/botpress/v12/issues/315
- [ ] migration instructions in the docs https://github.com/botpress/v12/issues/313

I've implemented the logs janitor. I won't implement it for other places in the same PR as it needs some thinking — some tables have timestamps without milliseconds and timezones.

The other two items sprun from the needs of this PR but will also go as separate PRs later.