### PR TITLE
feat(cli): implement --inspect|-i flags for start (resolve #91)

### DIFF
--- a/packages/core/botpress/src/cli/index.js
+++ b/packages/core/botpress/src/cli/index.js
@@ -43,6 +43,7 @@ program
     collectArgs,
     []
   )
+  .option('-i, --inspect', 'Inspect bot with "debugger"')
   .action(start)
 
 program

--- a/packages/core/botpress/src/cli/start.js
+++ b/packages/core/botpress/src/cli/start.js
@@ -92,7 +92,7 @@ module.exports = (projectPath, options) => {
       setTimeout(() => process.exit(), 100)
     })
   } else {
-    const bot = new Botpress({ botfile })
+    const bot = new Botpress({ botfile, options })
     bot.start()
   }
 }


### PR DESCRIPTION
@slvnperron @emirotin @epaminond I implemented `--inspect` mode which allows [using chrome-dev-tools](https://nodejs.org/en/docs/guides/debugging-getting-started/) to debug node.
Breakpoints only work when placing `debugger` command for me though (UI-breakpoints don't stop code execution).