### PR TITLE
feat(chat): added 'ref' query into [host]/s/chat (resolve #721)

### DIFF
--- a/packages/channels/botpress-channel-web/README.md
+++ b/packages/channels/botpress-channel-web/README.md
@@ -265,7 +265,7 @@ This **URL is public** (no authentication required) so you can share it we other
 To embedded the web interface to a website, you simply need to add this script at the end of the `<body>` tag. Don't forget to set the `host` correctly to match the public hostname of your bot.
 
 ```html
-<script src="<host>/api/channel-web/inject.js"></script>
+<script src="<host>/api/botpress-platform-webchat/inject.js"></script>
 <script>window.botpressWebChat.init({ host: '<host>' })</script>
 ```
 
@@ -289,9 +289,13 @@ window.botpressWebChat.init({
 
 You can also use `window.botpressWebChat.configure` method to modify web chat options after it's initialized.
 
-### Page –> Bot interractions
+### Page –> Bot interactions
 
 You can open/close sidebar programmatically by calling `window.botpressWebChat.sendEvent` with `{ type: 'show' }` or `{ type: 'hide' }`.
+
+### Modify url
+
+You can add `ref` query parameter to url(example `bot/s/chat?ref=[content]`) and all content will be set to user state as `webchatUrlQuery`. User state could be fetched via [DialogStateManager](https://botpress.io/docs/latest/reference/DialogStateManager.html).
 
 ## Configuring file uploads
 

--- a/packages/channels/botpress-channel-web/src/api.js
+++ b/packages/channels/botpress-channel-web/src/api.js
@@ -98,7 +98,7 @@ module.exports = async (bp, config) => {
     res.send(injectStyle)
   })
 
-  const pkg = require('../package.json');
+  const pkg = require('../package.json')
   const modulePath = bp._loadedModules[pkg.name].root
   const staticFolder = path.join(modulePath, './static')
   router.use('/static', serveStatic(staticFolder))
@@ -281,6 +281,20 @@ module.exports = async (bp, config) => {
       res.status(200).send({})
     })
   )
+
+  router.get('/:userId/reference', async (req, res) => {
+    try {
+      const { params: { userId }, query: { ref: webchatUrlQuery } } = req
+      const state = await bp.dialogEngine.stateManager.getState(userId)
+      const newState = { ...state, webchatUrlQuery }
+
+      await bp.dialogEngine.stateManager.setState(userId, newState)
+
+      res.status(200)
+    } catch (error) {
+      res.status(500)
+    }
+  })
 
   return router
 }

--- a/packages/core/botpress/src/server/api.js
+++ b/packages/core/botpress/src/server/api.js
@@ -187,9 +187,15 @@ bp.createShortlink('chat', '/lite', {
 
     app.get(`/s/:name`, (req, res) => {
       const name = req.params.name.toLowerCase()
+      const query = qs.stringify(req.query)
 
       if (!links[name]) {
         return res.status(404).send({ error: `Shortlink "${name}" not registered` })
+      }
+
+      if (query) {
+        const hasQuery = /\?/g.test(links[name])
+        links[name] = links[name].concat(`${hasQuery ? '&' : '?'}${query}`)
       }
 
       res.redirect(links[name])

--- a/packages/core/botpress/src/web/lite.jsx
+++ b/packages/core/botpress/src/web/lite.jsx
@@ -12,14 +12,15 @@ import store from './store'
 import { fetchModules } from './actions'
 import InjectedModuleView from '~/components/PluginInjectionSite/module'
 import { moduleViewNames } from '~/util/Modules'
-import { getToken } from '~/util/Auth'
+import { getToken, getUniqueVisitorId } from '~/util/Auth'
 
 const token = getToken()
 if (token) {
   axios.defaults.headers.common['Authorization'] = `Bearer ${token.token}`
 }
 
-const { m, v } = queryString.parse(location.search)
+const { m, v, ref } = queryString.parse(location.search)
+
 const alternateModuleNames = {
   'platform-webchat': 'channel-web'
 }
@@ -28,6 +29,17 @@ const moduleName = alternateModuleNames[m] || m
 class LiteView extends React.Component {
   componentDidMount() {
     this.props.fetchModules()
+    this.sendQueries()
+  }
+
+  sendQueries() {
+    if (!ref) {
+      return
+    }
+
+    const userId = window.__BP_VISITOR_ID || getUniqueVisitorId()
+
+    axios.get(`/api/botpress-platform-webchat/${userId}/reference?ref=${ref}`)
   }
 
   render() {


### PR DESCRIPTION
@epaminond @slvnperron @emirotin Implemented `ref` query for url `[host]/s/chat`. Query content will be set into user state as `webchatUrlQuery`