### PR TITLE
fix(core): correctly get author information from bots

### DIFF
--- a/packages/core/botpress/src/about.js
+++ b/packages/core/botpress/src/about.js
@@ -10,7 +10,7 @@ module.exports = projectLocation => {
       name: packageJson.name,
       version: packageJson.version,
       description: packageJson.description || '<no description>',
-      author: packageJson.author || '<no author>',
+      author: (typeof packageJson.author === 'object' ? packageJson.author.name : packageJson.author) || '<no author>',
       license: packageJson.license || 'AGPL-v3.0'
     }
   }


### PR DESCRIPTION
It currently works if the `author` field is a string, but it can also be an object (which is quite common), and that would cause the Botpress server to crash on startup.

For example: https://github.com/sindresorhus/is/blob/b2bb3e7d3717de9734a3881156b1f8ab00236fe9/package.json#L7-L11