### PR TITLE
chore(meta): update the license identifier in package.json

### DIFF
--- a/bench/package.json
+++ b/bench/package.json
@@ -9,7 +9,7 @@
   },
   "keywords": ["botpress", "benchmark"],
   "author": "Botpress, Inc.",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "devDependencies": {},
   "dependencies": {
     "artillery": "^1.6.0-20"

--- a/packages/channels/botpress-channel-messenger/package.json
+++ b/packages/channels/botpress-channel-messenger/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/botpress/modules"
   },
   "author": "Botpress",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "peerDependencies": {
     "botpress": ">= 10.0.0"
   },

--- a/packages/channels/botpress-channel-microsoft/package.json
+++ b/packages/channels/botpress-channel-microsoft/package.json
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "author": "Botpress",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "devDependencies": {
     "babel-core": "^6.18.2",
     "babel-loader": "^6.2.7",

--- a/packages/channels/botpress-channel-slack/package.json
+++ b/packages/channels/botpress-channel-slack/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/botpress/modules"
   },
   "author": "Botpress",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "peerDependencies": {
     "botpress": ">= 10.0.0"
   },

--- a/packages/channels/botpress-channel-telegram/package.json
+++ b/packages/channels/botpress-channel-telegram/package.json
@@ -19,7 +19,7 @@
     "compile": "node webpack.js --compile"
   },
   "author": "Botpress",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "peerDependencies": {
     "botpress": ">= 10.0.0"
   },

--- a/packages/channels/botpress-channel-twilio/package.json
+++ b/packages/channels/botpress-channel-twilio/package.json
@@ -23,7 +23,7 @@
     "compile": "node webpack.js --compile"
   },
   "author": "Botpress Team",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "peerDependencies": {
     "botpress": ">= 10.0.0"
   },

--- a/packages/channels/botpress-channel-web/package.json
+++ b/packages/channels/botpress-channel-web/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/botpress/modules"
   },
   "author": "Botpress",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "peerDependencies": {
     "botpress": ">= 10.0.0"
   },

--- a/packages/core/botpress-builtins/package.json
+++ b/packages/core/botpress-builtins/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "repository": "https://github.com/botpress/botpress",
   "author": "Botpress, Inc.",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "private": false,
   "scripts": {
     "watch": "babel src --out-dir dist --source-maps --watch",

--- a/packages/core/botpress-util-roles/package.json
+++ b/packages/core/botpress-util-roles/package.json
@@ -4,7 +4,7 @@
   "description": "Botpress utility package that handles roles checking",
   "main": "dist/index.js",
   "author": "Botpress, Inc.",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "private": false,
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/packages/core/botpress-util-sdk/package.json
+++ b/packages/core/botpress-util-sdk/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "repository": "https://github.com/botpress/botpress",
   "author": "Botpress, Inc.",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "private": false,
   "scripts": {
     "watch": "babel src --out-dir dist --source-maps --watch",

--- a/packages/core/botpress/package.json
+++ b/packages/core/botpress/package.json
@@ -148,7 +148,7 @@
     "chatbot",
     "conversational"
   ],
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "main": "lib/index.js",
   "repository": "git+https://github.com/botpress/botpress.git",
   "os": [

--- a/packages/core/botpress/src/about.js
+++ b/packages/core/botpress/src/about.js
@@ -11,7 +11,7 @@ module.exports = projectLocation => {
       version: packageJson.version,
       description: packageJson.description || '<no description>',
       author: packageJson.author || '<no author>',
-      license: packageJson.license || 'AGPL-v3.0'
+      license: packageJson.license || 'AGPL-3.0-only'
     }
   }
 

--- a/packages/core/botpress/src/cli/templates/create-default/package.json
+++ b/packages/core/botpress/src/cli/templates/create-default/package.json
@@ -20,7 +20,7 @@
     "compile": "node webpack.js --compile"
   },
   "author": "<%= author %>",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "devDependencies": {
     "babel-core": "^6.25.0",
     "babel-eslint": "^8.0.2",

--- a/packages/core/botpress/src/cli/templates/init-default/package.json
+++ b/packages/core/botpress/src/cli/templates/init-default/package.json
@@ -24,5 +24,5 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "<%= author %>",
-  "license": "AGPL-3.0"
+  "license": "AGPL-3.0-only"
 }

--- a/packages/core/botpress/src/licensing.js
+++ b/packages/core/botpress/src/licensing.js
@@ -19,8 +19,8 @@ module.exports = ({ projectLocation, bp }) => {
 
     return {
       agpl: {
-        name: 'AGPL-3.0',
-        licensedUnder: license === 'AGPL-3.0',
+        name: 'AGPL-3.0-only',
+        licensedUnder: license === 'AGPL-3.0-only',
         text: agplContent
       },
       botpress: {
@@ -35,7 +35,7 @@ module.exports = ({ projectLocation, bp }) => {
     const packageJsonPath = resolveProjectFile('package.json', projectLocation, true)
 
     const licensePath = resolveProjectFile('LICENSE', projectLocation, true)
-    const licenseFileName = license === 'AGPL-3.0' ? 'LICENSE_AGPL3' : 'LICENSE_BOTPRESS'
+    const licenseFileName = license === 'AGPL-3.0-only' ? 'LICENSE_AGPL3' : 'LICENSE_BOTPRESS'
     const licenseContent = fs.readFileSync(path.join(licensesPath, licenseFileName))
 
     const pkg = JSON.parse(fs.readFileSync(packageJsonPath))

--- a/packages/dev-bot/package.json
+++ b/packages/dev-bot/package.json
@@ -27,5 +27,5 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Eugene Mirotin <eugene@botpress.io>",
-  "license": "AGPL-3.0"
+  "license": "AGPL-3.0-only"
 }

--- a/packages/functionals/botpress-analytics/package.json
+++ b/packages/functionals/botpress-analytics/package.json
@@ -30,7 +30,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Botpress",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "dependencies": {
     "bluebird": "^3.4.6",
     "botpress-version-manager": "^1.0.2",

--- a/packages/functionals/botpress-audience/package.json
+++ b/packages/functionals/botpress-audience/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/botpress/modules"
   },
   "author": "Botpress",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "peerDependencies": {
     "botpress": ">= 10.0.0"
   },

--- a/packages/functionals/botpress-broadcast/package.json
+++ b/packages/functionals/botpress-broadcast/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/botpress/modules"
   },
   "author": "Botpress",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "peerDependencies": {
     "botpress": ">= 10.0.0"
   },

--- a/packages/functionals/botpress-hitl/package.json
+++ b/packages/functionals/botpress-hitl/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/botpress/modules",
   "author": "Botpress",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "peerDependencies": {
     "botpress": ">= 10.0.0"
   },

--- a/packages/functionals/botpress-nlu/package.json
+++ b/packages/functionals/botpress-nlu/package.json
@@ -25,7 +25,7 @@
     "compile": "node webpack.js --compile"
   },
   "author": "Botpress, Inc.",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "peerDependencies": {
     "botpress": ">= 10.0.0"
   },

--- a/packages/functionals/botpress-qna/package.json
+++ b/packages/functionals/botpress-qna/package.json
@@ -25,7 +25,7 @@
     "compile": "node webpack.js --compile"
   },
   "author": "Botpress, Inc.",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "peerDependencies": {
     "@botpress/nlu": ">= 10.0.0",
     "botpress": ">= 10.0.0"

--- a/packages/functionals/botpress-scheduler/package.json
+++ b/packages/functionals/botpress-scheduler/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/botpress/modules",
   "author": "Botpress Team",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "peerDependencies": {
     "botpress": ">= 10.0.0"
   },

--- a/packages/functionals/botpress-terminal/package.json
+++ b/packages/functionals/botpress-terminal/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "author": "Botpress Team",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "peerDependencies": {
     "botpress": ">= 10.0.0"
   },

--- a/packages/skills/botpress-skill-choice/package.json
+++ b/packages/skills/botpress-skill-choice/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "author": "Botpress Team",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "peerDependencies": {
     "botpress": ">= 10.0.10"
   },


### PR DESCRIPTION
The identifier `AGPL-3.0` has been deprecated in [SPDX](https://spdx.org/licenses/) and you now have to choose either [`AGPL-3.0-only`](https://spdx.org/licenses/AGPL-3.0-only.html) or [`AGPL-3.0-or-later`](https://spdx.org/licenses/AGPL-3.0-or-later.html) I went with `AGPL-3.0-only` as that's what you currently use.