### PR TITLE
fix(core): copy botpress README before publishing (resovle #729)

### DIFF
--- a/packages/core/botpress/package.json
+++ b/packages/core/botpress/package.json
@@ -151,13 +151,9 @@
   "license": "AGPL-3.0-only",
   "main": "lib/index.js",
   "repository": "git+https://github.com/botpress/botpress.git",
-  "os": [
-    "darwin",
-    "linux",
-    "win32"
-  ],
+  "os": ["darwin", "linux", "win32"],
   "scripts": {
-    "prepublishOnly": "npm run compile-prod",
+    "prepublishOnly": "rm README.md && cp ../../../README.md README.md && run compile-prod",
     "compile": "./build.sh",
     "compile-prod": "NODE_ENV=production ./build.sh",
     "test": "BABEL_ENV=tests mocha --compilers js:babel-core/register --require tests/index.js tests/**",
@@ -167,9 +163,7 @@
   },
   "watch": {
     "compile": {
-      "patterns": [
-        "src"
-      ],
+      "patterns": ["src"],
       "extensions": "js,jsx,scss,json,html"
     }
   }


### PR DESCRIPTION
Not only symlink didn't work but it also prevents package from being installed correctly now (the symlink gets packed, but the original README - not).
This one is intended to fix things.