### PR TITLE
Show hidden intents Checkbox should not be 100% wide

### DIFF
--- a/packages/functionals/botpress-nlu/src/views/style.scss
+++ b/packages/functionals/botpress-nlu/src/views/style.scss
@@ -40,6 +40,9 @@ footer {
       padding: 5px;
       font-size: 14px;
     }
+    .checkbox input {
+        width: auto;
+    }
   }
 
   .list {


### PR DESCRIPTION
All inputs within the filter on the NLU intents page were set to 100% width.

This caused the 'Show hidden intents' checkbox to be shown incorrectly in chrome: it was displayed over the text instead of left of it.

This small css change fixes it.