### PR TITLE
fix(nlu): LUIS should fetch not only top-scored one

### DIFF
--- a/packages/functionals/botpress-nlu/src/providers/luis.js
+++ b/packages/functionals/botpress-nlu/src/providers/luis.js
@@ -358,7 +358,7 @@ export default class LuisProvider extends Provider {
     const res = await axios.get(`https://${this.appRegion}.api.cognitive.microsoft.com/luis/v2.0/apps/${this.appId}`, {
       params: {
         q: incomingEvent.text,
-        verbose: false,
+        verbose: true,
         spellCheck: false,
         staging: !this.isProduction
       },


### PR DESCRIPTION
Without this Luis-response doesn't contain list of non top-scored intents which isn't consistent comparing to native provider.