### PR TITLE
fix(messenger): added possibility to set text

### DIFF
--- a/packages/channels/botpress-channel-messenger/src/incoming.js
+++ b/packages/channels/botpress-channel-messenger/src/incoming.js
@@ -78,7 +78,9 @@ module.exports = (bp, messenger) => {
 
         if (mConfig.displayGetStarted && mConfig.autoResponseOption == 'autoResponseTextRenderer') {
           try {
-            await bp.renderers.sendToUser(profile.id, mConfig.autoResponseTextRenderer)
+            const options = mConfig.autoResponseText ? { text: mConfig.autoResponseText } : {}
+
+            await bp.renderers.sendToUser(profile.id, mConfig.autoResponseTextRenderer, options)
           } catch (err) {
             logger.warn('unavailable "autoResponseTextRenderer"')
           }


### PR DESCRIPTION
@slvnperron @epaminond @emirotin 
- possibility to send `text` or `content`; 

user must set 

for send text

```
"autoResponseOption": "autoResponseTextRenderer",
"autoResponseText": "Hi human",
"autoResponseTextRenderer": "#builtin_text",
```

for send content

```
"autoResponseOption": "autoResponseTextRenderer",
"autoResponseText": "",
"autoResponseTextRenderer": "#!builtin_text-AY5SSW",