### PR TITLE
feat(core): improve notifications empty state

### DIFF
--- a/packages/core/botpress/src/web/components/Notifications/Hub.jsx
+++ b/packages/core/botpress/src/web/components/Notifications/Hub.jsx
@@ -25,7 +25,7 @@ class NotificationHub extends NotificationComponent {
   renderEmptyPanel() {
     return (
       <MenuItem header className={styles.empty}>
-        <div>You have no notifications !</div>
+        <div>You have no notifications!</div>
       </MenuItem>
     )
   }
@@ -63,16 +63,17 @@ class NotificationHub extends NotificationComponent {
       >
         <MenuItem header className={classnames(styles.topMenu, 'bp-top-menu')}>
           <span>
-            <strong>Notifications</strong>
-            &nbsp; &middot; &nbsp; total of {notifications.length}
+            <strong>Notifications {!isEmpty && `(${notifications.length})`}</strong>
           </span>
-          <div className="pull-right">
-            <a href="#" onClick={this.markAllAsRead}>
-              Mark all as read
-            </a>
-            &nbsp; &middot; &nbsp;
-            <a href="/notifications">Show all</a>
-          </div>
+          {!isEmpty && (
+            <div className="pull-right">
+              <a href="#" onClick={this.markAllAsRead}>
+                Mark all as read
+              </a>
+              &nbsp; &middot; &nbsp;
+              <a href="/notifications">Show all</a>
+            </div>
+          )}
         </MenuItem>
         {isEmpty && this.renderEmptyPanel()}
         {this.renderMenuItems(displayedNotifications)}

--- a/packages/core/botpress/src/web/views/Notifications/index.jsx
+++ b/packages/core/botpress/src/web/views/Notifications/index.jsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { connect } from 'react-redux'
 import { ListGroup, ListGroupItem, Panel, Button, Tooltip, OverlayTrigger } from 'react-bootstrap'
 import _ from 'lodash'
@@ -26,7 +27,6 @@ class NotificationHub extends NotificationComponent {
   render() {
     const notifications = this.props.notifications || []
     const unreadCount = _.filter(notifications, { read: false }).length
-    const canTrash = notifications.length > 0
 
     const trashTip = <Tooltip id="ttip">Delete all</Tooltip>
     const readTip = <Tooltip id="ttip">Mark all as read</Tooltip>
@@ -34,24 +34,30 @@ class NotificationHub extends NotificationComponent {
     return (
       <ContentWrapper>
         <PageHeader>
-          <span> Notifications</span>
+          <span>Notifications</span>
         </PageHeader>
-        <Panel>
-          <Panel.Body>
-            <div className="pull-right">
-              <OverlayTrigger placement="left" overlay={readTip}>
-                <Button disabled={unreadCount === 0} onClick={this.markAllAsRead}>
-                  <em className="glyphicon glyphicon-eye-open" />
-                </Button>
-              </OverlayTrigger>
-              <OverlayTrigger placement="left" overlay={trashTip}>
-                <Button className={styles['bar-btn']} disabled={!canTrash} onClick={this.trashAll}>
-                  <em className="glyphicon glyphicon-trash" />
-                </Button>
-              </OverlayTrigger>
-            </div>
-          </Panel.Body>
-        </Panel>
+        {notifications.length > 0 ? (
+          <Panel>
+            <Panel.Body>
+              <div className="pull-right">
+                <OverlayTrigger placement="left" overlay={readTip}>
+                  <Button disabled={unreadCount === 0} onClick={this.markAllAsRead}>
+                    <em className="glyphicon glyphicon-eye-open" />
+                  </Button>
+                </OverlayTrigger>
+                <OverlayTrigger placement="left" overlay={trashTip}>
+                  <Button className={styles['bar-btn']} onClick={this.trashAll}>
+                    <em className="glyphicon glyphicon-trash" />
+                  </Button>
+                </OverlayTrigger>
+              </div>
+            </Panel.Body>
+          </Panel>
+        ) : (
+          <div className={styles.empty}>
+            <p>You have no notifications!</p>
+          </div>
+        )}
         <ListGroup
           style={{
             padding: 0

--- a/packages/core/botpress/src/web/views/Notifications/style.scss
+++ b/packages/core/botpress/src/web/views/Notifications/style.scss
@@ -51,3 +51,24 @@
 .mark-read-btn:hover {
   cursor: pointer;
 }
+
+.empty {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  p {
+    display: block;
+    margin: 0;
+    padding: 0;
+    font-size: 18px;
+    color: #9a9a9a;
+  }
+}


### PR DESCRIPTION
- No longer shows "Mark all as read" and "Show all" when there are no notifications, as they're moot.
- Changes `Notifications  ·   total of 2` to display as `Notifications (2)` as that's a more common and concise way to display the notification count.
- In the Notification view, shows an empty state instead of disabled controls, as there's no point in showing the controls if you can't do anything with them.


### Notification popover

###### Before

<img width="407" alt="screen shot 2018-08-17 at 01 43 16" src="https://user-images.githubusercontent.com/170270/44229479-62e98a80-a1c2-11e8-8777-6cf54c23af6d.png">



###### After

<img width="402" alt="screen shot 2018-08-17 at 01 43 37" src="https://user-images.githubusercontent.com/170270/44229426-3b92bd80-a1c2-11e8-8a57-752a3d6c9a94.png">

### Notification view

###### Before

<img width="1069" alt="screen shot 2018-08-17 at 01 43 01" src="https://user-images.githubusercontent.com/170270/44229488-6c72f280-a1c2-11e8-9452-2d7165c40957.png">

###### After

<img width="1072" alt="screen shot 2018-08-17 at 01 43 54" src="https://user-images.githubusercontent.com/170270/44229413-30d82880-a1c2-11e8-87e7-87f5b800efe2.png">


