### PR TITLE
fix(core): make the page header color darker

### DIFF
--- a/packages/core/botpress/src/web/components/Layout/PageHeader.scss
+++ b/packages/core/botpress/src/web/components/Layout/PageHeader.scss
@@ -8,7 +8,7 @@
   padding: 10px;
   z-index: 20;
   line-height: 30px;
-  color: $content-color-light;
+  color: $content-color-normal;
   font-size: 18px;
 
   .icon {
@@ -18,7 +18,7 @@
   }
 
   a {
-    color: $content-color-lighter;
+    color: $content-color-light;
   }
 }
 

--- a/packages/core/botpress/src/web/views/FlowBuilder/topbar.scss
+++ b/packages/core/botpress/src/web/views/FlowBuilder/topbar.scss
@@ -1,13 +1,3 @@
 .rename {
   font-size: 90%;
 }
-
-.title {
-  color: black;
-  border-left: 3px solid #55c1b2;
-  padding-left: 10px;
-  margin-left: -10px;
-}
-
-.name {
-}


### PR DESCRIPTION
It's currently too light for being a header text.

This also unifies the "Flows" view header style with the rest so it doesn't suddenly completely change when you go there.


### Before

<img width="378" alt="screen shot 2018-08-17 at 02 19 34" src="https://user-images.githubusercontent.com/170270/44230077-41899e00-a1c4-11e8-8b50-483d7d608db6.png">

<img width="458" alt="screen shot 2018-08-17 at 02 19 22" src="https://user-images.githubusercontent.com/170270/44230076-41899e00-a1c4-11e8-9dc3-60a6fc4c0f8e.png">

### After

<img width="377" alt="screen shot 2018-08-17 at 02 18 43" src="https://user-images.githubusercontent.com/170270/44230086-4f3f2380-a1c4-11e8-82d6-6f838ed44527.png">
<img width="458" alt="screen shot 2018-08-17 at 02 19 01" src="https://user-images.githubusercontent.com/170270/44230087-4f3f2380-a1c4-11e8-8832-f06fbed04e94.png">