### PR TITLE
fix(channel-web): last_heard_on

### DIFF
--- a/packages/channels/botpress-channel-web/config.json
+++ b/packages/channels/botpress-channel-web/config.json
@@ -9,5 +9,5 @@
   "uploadsS3AWSAccessKey": "your-aws-key-name",
   "uploadsS3AWSAccessSecret": "secret-key",
   "startNewConvoOnTimeout": false,
-  "recentConversationLifetime": "6 hours"
+  "recentConversationLifetime": "6 hours" // Only works if "startNewConvoOnTimeout" is true
 }

--- a/packages/channels/botpress-channel-web/src/socket.js
+++ b/packages/channels/botpress-channel-web/src/socket.js
@@ -38,7 +38,12 @@ module.exports = async (bp, config) => {
 
     const typing = parseTyping(event)
 
-    const conversationId = _.get(event, 'raw.conversationId') || (await getOrCreateRecentConversation(user.id))
+    const conversationId =
+      _.get(event, 'raw.conversationId') ||
+      (await getOrCreateRecentConversation(user.id, {
+        ignoreLifetimeExpiry: true,
+        originatesFromUserMessage: false
+      }))
 
     const socketId = user.userId.replace(/webchat:/gi, '')
 


### PR DESCRIPTION
1) `Last Heard` now only updated on user messages (not bot messages)
2) Get Recent Conversation has option to ignore lifetime expiry
3) When the bot sends a message, lifetime expiry is ignored when appending message to most recent conversation. This fixes the "onBeforeEnd" conversation race condition.