### PR TITLE
feat(telegram): support for action button, single choices and images. Little code refactors

### DIFF
--- a/packages/channels/botpress-channel-telegram/README.md
+++ b/packages/channels/botpress-channel-telegram/README.md
@@ -16,7 +16,7 @@ npm install @botpress/channel-telegram
 
 To setup connexion of your chatbot to Telegram, you need to fill the connexion settings directly in the module interface. In fact, you only need to follow this step and your bot will be active.
 
-{{BOOT ROOT DIR}}/config/channel-telegram.json
+{{BOT ROOT DIR}}/config/channel-telegram.json
 ```json
 {
   "botToken": "451660170:AAHM2CD-Z8Kt3AwqcQLnaUgIk5bUJay3s0M"

--- a/packages/channels/botpress-channel-telegram/README.md
+++ b/packages/channels/botpress-channel-telegram/README.md
@@ -8,24 +8,22 @@ Botpress Team would really appreciate to have some help from the community to wo
 
 ## Installation
 
-```js
+```sh
 npm install @botpress/channel-telegram
 ```
 
 ## Get started
 
-To setup connexion of your chatbot to Messenger, you need to fill the connexion settings directly in the module interface. In fact, you only need to follow  steps and your bot will be active.
+To setup connexion of your chatbot to Telegram, you need to fill the connexion settings directly in the module interface. In fact, you only need to follow this step and your bot will be active.
 
-botfile.js
-```js
-config: {
-    'botpress-telegram': {
-      botToken: '451660170:AAHM2CD-Z8Kt3AwqcQLnaUgIk5bUJay3s0M'
-    }
-  }
+{{BOOT ROOT DIR}}/config/channel-telegram.json
+```json
+{
+  "botToken": "451660170:AAHM2CD-Z8Kt3AwqcQLnaUgIk5bUJay3s0M"
+}
 ```
 
-You can also set the `TELEGRAM_TOKEN` environement variable
+You can also set the `TELEGRAM_TOKEN` environment variable
 
 ### How to create an Telegram Bot Token
 

--- a/packages/channels/botpress-channel-telegram/src/actions.js
+++ b/packages/channels/botpress-channel-telegram/src/actions.js
@@ -26,6 +26,27 @@ const createText = ({ chatId, userId }, text, options = {}) => {
   }
 }
 
+const createPhoto = ({ chatId, userId }, photo, options = {}) => {
+  validateChatId(chatId)
+  validateText(photo) // TODO Refactor validators
+
+  if (options.caption) {
+    validateText(options.caption)
+  }
+
+  return {
+    platform: 'telegram',
+    type: 'photo',
+    text: 'Attachment (photo): ' + photo,
+    raw: {
+      chatId: chatId,
+      to: userId,
+      photo: photo,
+      options: options
+    }
+  }
+}
+
 const createEditMessage = (text, options = {}) => {
   return {
     platform: 'telegram',
@@ -40,5 +61,6 @@ const createEditMessage = (text, options = {}) => {
 
 module.exports = {
   createText,
+  createPhoto,
   createEditMessage
 }

--- a/packages/channels/botpress-channel-telegram/src/index.js
+++ b/packages/channels/botpress-channel-telegram/src/index.js
@@ -2,8 +2,6 @@ import outgoing from './outgoing'
 import actions from './actions'
 import umm from './umm'
 
-const path = require('path')
-const fs = require('fs')
 const _ = require('lodash')
 const Promise = require('bluebird')
 
@@ -47,7 +45,7 @@ module.exports = {
     botToken: { type: 'string', required: true, default: '', env: 'TELEGRAM_TOKEN' }
   },
 
-  init: function(bp, config) {
+  init: function(bp) {
     bp.middlewares.register({
       name: 'telegram.sendMessages',
       type: 'outgoing',

--- a/packages/channels/botpress-channel-telegram/src/outgoing.js
+++ b/packages/channels/botpress-channel-telegram/src/outgoing.js
@@ -22,6 +22,18 @@ const handleText = (event, next, telegram) => {
   return handlePromise(next, telegram.sendText(chatId, text, options))
 }
 
+const handlePhoto = (event, next, telegram) => {
+  if (event.platform !== 'telegram' || event.type !== 'photo') {
+    return next()
+  }
+
+  const chatId = event.raw.chatId
+  const photo = event.raw.photo
+  const options = event.raw.options
+
+  return handlePromise(next, telegram.sendPhoto(chatId, photo, options))
+}
+
 const handleEditMessageText = (event, next, telegram) => {
   if (event.platform !== 'telegram' || event.type !== 'edited_message_text') {
     return next()
@@ -38,6 +50,7 @@ const handleEditMessageText = (event, next, telegram) => {
 
 module.exports = {
   text: handleText,
+  photo: handlePhoto,
   edited_message_text: handleEditMessageText,
   pending: {}
 }

--- a/packages/channels/botpress-channel-telegram/src/telegram.js
+++ b/packages/channels/botpress-channel-telegram/src/telegram.js
@@ -1,7 +1,6 @@
 process.env.NTBA_FIX_319 = true // See https://github.com/yagop/node-telegram-bot-api/issues/319
 
 const TelegramBot = require('node-telegram-bot-api')
-const Promise = require('bluebird')
 
 import incoming from './incoming'
 
@@ -71,26 +70,20 @@ class Telegram {
     this.validateBeforeSending(chatId, options)
     Telegram.validateText(text)
 
-    return Promise.fromCallback(() => {
-      this.bot.sendMessage(chatId, text, options)
-    })
+    return this.bot.sendMessage(chatId, text, options)
   }
 
   sendPhoto(chatId, photo, options) {
     this.validateBeforeSending(chatId, options)
 
-    return Promise.fromCallback(() => {
-      this.bot.sendPhoto(chatId, photo, options)
-    })
+    return this.bot.sendPhoto(chatId, photo, options)
   }
 
   sendEditMessage(text, options = {}) {
     this.validateBeforeSending(options.chat_id, options)
     Telegram.validateText(text)
 
-    return Promise.fromCallback(() => {
-      this.bot.editMessageText(text, options)
-    })
+    return this.bot.editMessageText(text, options)
   }
 
   startPolling(bp) {

--- a/packages/channels/botpress-channel-telegram/src/telegram.js
+++ b/packages/channels/botpress-channel-telegram/src/telegram.js
@@ -76,6 +76,14 @@ class Telegram {
     })
   }
 
+  sendPhoto(chatId, photo, options) {
+    this.validateBeforeSending(chatId, options)
+
+    return Promise.fromCallback(() => {
+      this.bot.sendPhoto(chatId, photo, options)
+    })
+  }
+
   sendEditMessage(text, options = {}) {
     this.validateBeforeSending(options.chat_id, options)
     Telegram.validateText(text)

--- a/packages/channels/botpress-channel-telegram/src/umm.js
+++ b/packages/channels/botpress-channel-telegram/src/umm.js
@@ -54,6 +54,10 @@ function processOutgoing({ event, blocName, instruction }) {
     return actions.createText({ chatId: event.chat.id, userId: getUserId(event) }, instruction.text, options)
   }
 
+  if (!_.isNil(instruction.photo)) {
+    return actions.createPhoto({ chatId: event.chat.id, userId: getUserId(event) }, instruction.photo, options)
+  }
+
   if (!_.isNil(instruction.options) && !_.isNil(instruction.options.reply_markup)) {
     return actions.createText(
       { chatId: event.chat.id, userId: getUserId(event) },

--- a/packages/channels/botpress-channel-telegram/src/umm.js
+++ b/packages/channels/botpress-channel-telegram/src/umm.js
@@ -54,6 +54,13 @@ function processOutgoing({ event, blocName, instruction }) {
     return actions.createText({ chatId: event.chat.id, userId: getUserId(event) }, instruction.text, options)
   }
 
+  if (!_.isNil(instruction.options) && !_.isNil(instruction.options.reply_markup)) {
+    return actions.createText(
+      { chatId: event.chat.id, userId: getUserId(event) },
+      instruction.title,
+      instruction.options
+    )
+  }
   ////////////
   /// POST-PROCESSING
   ////////////

--- a/packages/core/botpress-builtins/src/renderers/builtin_action-button.js
+++ b/packages/core/botpress-builtins/src/renderers/builtin_action-button.js
@@ -106,6 +106,31 @@ export default data => {
           })
         }
       ]
+    },
+    {
+      on: 'telegram',
+      title: data.title,
+      options: {
+        reply_markup: JSON.stringify({
+          inline_keyboard: [data].map(d => {
+            if (d.action === 'Say something') {
+              return [
+                {
+                  text: d.title,
+                  callback_data: d.title.substring(0, 64) // 1-64 bytes
+                }
+              ]
+            } else if (d.action === 'Open URL') {
+              return [
+                {
+                  text: d.title,
+                  url: d.url
+                }
+              ]
+            }
+          })
+        })
+      }
     }
   ]
 }

--- a/packages/core/botpress-builtins/src/renderers/builtin_action-button.js
+++ b/packages/core/botpress-builtins/src/renderers/builtin_action-button.js
@@ -1,6 +1,3 @@
-// TODO
-// Add card support to Telegram
-
 export default data => {
   if (data.action === 'Pick location') {
     throw new Error('Action-button renderers do not support "Pick location" type at the moment')

--- a/packages/core/botpress-builtins/src/renderers/builtin_image.js
+++ b/packages/core/botpress-builtins/src/renderers/builtin_image.js
@@ -1,6 +1,5 @@
 // TODO
 // Add image support to Twilio (SMS)
-// Add image support to Telegram
 
 import url from 'url'
 import mime from 'mime'

--- a/packages/core/botpress-builtins/src/renderers/builtin_image.js
+++ b/packages/core/botpress-builtins/src/renderers/builtin_image.js
@@ -35,5 +35,13 @@ export default data => [
         image_url: data.image
       }
     ]
+  },
+  {
+    on: 'telegram',
+    photo: url.resolve(data.BOT_URL, data.image),
+    options: {
+      caption: data.title,
+      parse_mode: 'Markdown'
+    }
   }
 ]

--- a/packages/core/botpress-builtins/src/renderers/builtin_single-choice.js
+++ b/packages/core/botpress-builtins/src/renderers/builtin_single-choice.js
@@ -49,5 +49,20 @@ export default data => [
         }))
       }
     ]
+  },
+  {
+    on: 'telegram',
+    title: data.text,
+    options: {
+      parse_mode: 'Markdown',
+      reply_markup: JSON.stringify({
+        keyboard: [
+          takeVisible(data.choices).map(choice => ({
+            text: choice.title
+          }))
+        ],
+        one_time_keyboard: true
+      })
+    }
   }
 ]

--- a/packages/core/botpress-builtins/src/renderers/builtin_single-choice.js
+++ b/packages/core/botpress-builtins/src/renderers/builtin_single-choice.js
@@ -1,8 +1,3 @@
-// TODO
-// Add buttons support to Telegram
-
-import url from 'url'
-
 const SKIP_CHOICE_PREFIX = /^!skip |^!hide |^!hidden /i
 
 const takeVisible = choices => {


### PR DESCRIPTION
Hi,

I've been working to improve the Telegram support in Botpress.

- I've added support for **action buttons**, **single-choice** and **image** builtin types. I would like to add another renderers and API calls in the next weeks (attached documents, etc.).
- I've refactored some parts of the code (deleting *dead code* and old comments).
- I've updated the README. The explanation of how to configure the Telegram API token didn't work.

## Example of the new *data types* working:

*Single choice:*
![image](https://user-images.githubusercontent.com/11785050/44628906-fea89280-a948-11e8-9e8c-099532316f09.png)

*Button (URL) and image*:
![image](https://user-images.githubusercontent.com/11785050/44628914-14b65300-a949-11e8-8577-5611e21d28f4.png)

I hope it helps. If you need anything, do not hesitate to ask me.
