### PR TITLE
feat(audience): various improvement to the Audience admin view

### DIFF
--- a/packages/functionals/botpress-audience/src/views/style.scss
+++ b/packages/functionals/botpress-audience/src/views/style.scss
@@ -26,9 +26,22 @@
   margin-right: 3px;
 }
 
+.usersTableWrapper {
+  overflow: auto;
+}
+
 .usersTable {
+  thead > tr > th {
+    white-space: nowrap;
+  }
+
   tbody > tr > td {
     vertical-align: middle;
+
+    &:nth-child(2) {
+      min-width: 100px;
+      word-break: break-all;
+    }
   }
 
   a {


### PR DESCRIPTION
- Don't show the "Next" button when there's nothing more to load. The existing logic was faulty.
- Don't show empty information in the popover in the "Information" column. And if all the information is empty, don't show the popover.
- The table now better adapts to smaller screen sizes.
- Converted some `.then` to use async/await for improved code readability.


#### Before

<img width="737" alt="screen shot 2018-08-29 at 02 21 09" src="https://user-images.githubusercontent.com/170270/44745570-49393300-ab32-11e8-8dd0-d731685f7765.png">

#### After

<img width="736" alt="screen shot 2018-08-29 at 02 21 26" src="https://user-images.githubusercontent.com/170270/44745575-4c342380-ab32-11e8-8628-cae0d86fbe39.png">
