### PR TITLE
feat(core): improve the Logs admin view

### DIFF
--- a/packages/core/botpress/src/web/util.js
+++ b/packages/core/botpress/src/web/util.js
@@ -33,3 +33,14 @@ export const moveCursorToEnd = el => {
 }
 
 export const prettyId = (length = 10) => generate('1234567890abcdef', length)
+
+export const downloadBlob = (name, blob) => {
+  const url = window.URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.setAttribute('download', name)
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  window.URL.revokeObjectURL(url)
+}

--- a/packages/core/botpress/src/web/views/Logs/index.jsx
+++ b/packages/core/botpress/src/web/views/Logs/index.jsx
@@ -31,7 +31,7 @@ class LoggerView extends Component {
   }
 
   loadMore = () => {
-    this.setState(({ limit }) => ({ limit: limit + 50 }))
+    this.setState(({ limit }) => ({ limit: limit + 200 }))
   }
 
   toggleAutoRefresh = () => {
@@ -45,7 +45,7 @@ class LoggerView extends Component {
   }
 
   renderLine(line, index) {
-    const time = moment(new Date(line.timestamp)).format('MMM DD HH:mm:ss')
+    const time = moment(new Date(line.timestamp)).format('YYYY-MM-DD HH:mm:ss')
     const message = line.message.replace(/\[\d\d?m/gi, '')
 
     return (

--- a/packages/core/botpress/src/web/views/Logs/index.jsx
+++ b/packages/core/botpress/src/web/views/Logs/index.jsx
@@ -7,6 +7,7 @@ import moment from 'moment'
 
 import PageHeader from '~/components/Layout/PageHeader'
 import ContentWrapper from '~/components/Layout/ContentWrapper'
+import {downloadBlob} from '~/util'
 
 import styles from './style.scss'
 
@@ -61,22 +62,21 @@ class LoggerView extends Component {
     return <div style={{ marginTop: '20px' }} className="whirl traditional" />
   }
 
-  queryLogs = () => {
-    axios
-      .get('/api/logs', {
-        params: {
-          limit: this.state.limit
-        }
-      })
-      .then(result => {
-        if (this.cancelLoading) {
-          return
-        }
-        this.setState({
-          logs: result.data,
-          hasMore: result.data && result.data.length >= this.state.limit
-        })
-      })
+  queryLogs = async () => {
+    const {data} = await axios.get('/api/logs', {
+      params: {
+        limit: this.state.limit
+      }
+    })
+
+    if (this.cancelLoading) {
+      return
+    }
+
+    this.setState({
+      logs: data,
+      hasMore: data && data.length >= this.state.limit
+    })
   }
 
   renderLines() {
@@ -87,19 +87,9 @@ class LoggerView extends Component {
     return this.state.logs.filter(x => _.isString(x.message)).map(this.renderLine)
   }
 
-  downloadArchive = () => {
-    axios({
-      url: '/api/logs/archive/',
-      method: 'GET',
-      responseType: 'blob'
-    }).then(response => {
-      const url = window.URL.createObjectURL(new Blob([response.data]))
-      const link = document.createElement('a')
-      link.href = url
-      link.setAttribute('download', 'logs.txt')
-      document.body.appendChild(link)
-      link.click()
-    })
+  downloadArchive = async () => {
+    const {data} = await axios.get('/api/logs/archive/', {responseType: 'blob'});
+    downloadBlob('logs.txt', data);
   }
 
   render() {
@@ -110,7 +100,7 @@ class LoggerView extends Component {
     return (
       <ContentWrapper>
         <PageHeader>
-          <span> Logs</span>
+          <span>Logs</span>
         </PageHeader>
         <Panel className={styles.panel}>
           <Panel.Body>
@@ -121,11 +111,11 @@ class LoggerView extends Component {
                 inline
                 onChange={this.toggleAutoRefresh}
               >
-                Auto refresh
+                Auto-refresh
               </Checkbox>
             </form>
             <div className="pull-right">
-              <Button onClick={this.downloadArchive}>Export logs archive</Button>
+              <Button onClick={this.downloadArchive}>Download log archive</Button>
             </div>
           </Panel.Body>
         </Panel>

--- a/packages/core/botpress/src/web/views/Logs/style.scss
+++ b/packages/core/botpress/src/web/views/Logs/style.scss
@@ -9,7 +9,13 @@
   border-top: #b1b1b1 2px solid;
   min-height: 300px;
   position: relative;
-  font-family: Courier;
+  font-family:
+    'SFMono-Regular',
+    'Ubuntu Mono',
+    'Consolas',
+    'DejaVu Sans Mono',
+    'Menlo',
+    'monospace';
   font-style: normal;
   font-variant: normal;
 }


### PR DESCRIPTION
1. Load more entries when the user clicks the "Load more" button. I wanted to look back a little bit in history, and it was annoying that it loaded so few entries per click.
2. Use the standard date format for the logs. This makes it both easier to read since the logs are now always vertically aligned, and more also more machine friendly.
3. Use a nicer monospace font when available. This is the font stack from: https://github.com/sindresorhus/modern-normalize/blob/c9be8dc5ad31769a88e69a6613f9b1b245004fd6/modern-normalize.css#L104-L110