### PR TITLE
fix(qna): handle IME-composing in QNA-form

### DIFF
--- a/packages/functionals/botpress-qna/src/views/FormControlIme.js
+++ b/packages/functionals/botpress-qna/src/views/FormControlIme.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react'
+import { FormControl } from 'react-bootstrap'
+import omit from 'lodash/omit'
+
+// This component is basically a wrapper over FormControl intended to workaround
+// onChange firing before IME composition ends (https://github.com/facebook/react/issues/3926)
+export class FormControlIme extends Component {
+  onChange = e => {
+    if (e.nativeEvent.isComposing) {
+      return
+    }
+    this.props.onChange(event)
+  }
+
+  setValueFromProps = () => {
+    this.input.value = this.props.value
+  }
+
+  componentDidMount = this.setValueFromProps
+  componentDidUpdate = this.setValueFromProps
+
+  render() {
+    return (
+      <FormControl
+        {...omit(this.props, 'value')}
+        inputRef={ref => (this.input = ref)}
+        onChange={this.onChange}
+        onCompositionEnd={this.onChange}
+      />
+    )
+  }
+}

--- a/packages/functionals/botpress-qna/src/views/QuestionsEditor.js
+++ b/packages/functionals/botpress-qna/src/views/QuestionsEditor.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 
-import { FormGroup, FormControl, ButtonToolbar, Button, InputGroup, Glyphicon } from 'react-bootstrap'
+import { FormGroup, ButtonToolbar, Button, InputGroup, Glyphicon } from 'react-bootstrap'
+import { FormControlIme } from './FormControlIme'
 
 import classnames from 'classnames'
 
@@ -69,7 +70,7 @@ export default class QuestionsEditor extends Component {
     return (
       <FormGroup>
         <InputGroup>
-          <FormControl
+          <FormControlIme
             inputRef={this.onInputRendered(index)}
             placeholder="Question"
             value={data}

--- a/packages/functionals/botpress-qna/src/views/index.js
+++ b/packages/functionals/botpress-qna/src/views/index.js
@@ -5,7 +5,6 @@ import {
   Col,
   FormGroup,
   ControlLabel,
-  FormControl,
   InputGroup,
   Glyphicon,
   Checkbox,
@@ -27,6 +26,7 @@ import some from 'lodash/some'
 import get from 'lodash/get'
 import Promise from 'bluebird'
 
+import { FormControlIme } from './FormControlIme'
 import ArrayEditor from './ArrayEditor'
 import QuestionsEditor from './QuestionsEditor'
 import QuestionsBulkImport from './QuestionsBulkImport'
@@ -189,7 +189,7 @@ export default class QnaAdmin extends Component {
     return (
       <FormGroup controlId={this.getFormControlId(index, 'answer')}>
         <ControlLabel>Answer:</ControlLabel>
-        <FormControl
+        <FormControlIme
           componentClass="textarea"
           placeholder="Answer"
           value={answer}
@@ -501,7 +501,7 @@ export default class QnaAdmin extends Component {
                   <form>
                     <FormGroup>
                       <ControlLabel>CSV file</ControlLabel>
-                      <FormControl
+                      <FormControlIme
                         type="file"
                         accept=".csv"
                         onChange={e => this.setState({ csvToUpload: e.target.files[0] })}
@@ -533,7 +533,7 @@ export default class QnaAdmin extends Component {
           </FormGroup>
           <FormGroup>
             <InputGroup>
-              <FormControl placeholder="Filter questions" value={this.state.filter} onChange={this.onFilterChange} />
+              <FormControlIme placeholder="Filter questions" value={this.state.filter} onChange={this.onFilterChange} />
               <InputGroup.Addon>
                 <Glyphicon glyph="search" />
               </InputGroup.Addon>


### PR DESCRIPTION
Fixing an IME issue for controlled inputs within QNA-module.
An issue occurs due to `onChange` firing before IME composition ends (see https://github.com/facebook/react/issues/3926).