### PR TITLE
fix(qna): reverse results obtained from QNA-Maker (#934)

### DIFF
--- a/packages/functionals/botpress-qna/src/providers/qnaMaker.js
+++ b/packages/functionals/botpress-qna/src/providers/qnaMaker.js
@@ -135,10 +135,10 @@ export default class Storage {
   async all({ limit, offset } = {}) {
     let questions = await this.fetchQuestions()
     if (typeof limit !== 'undefined' && typeof offset !== 'undefined') {
-      questions = questions.slice(offset, offset + limit)
+      questions = questions.reverse().slice(offset, offset + limit)
     }
 
-    return questions.reverse().map(qna => ({ id: qna.id, data: qnaItemData(qna) }))
+    return questions.map(qna => ({ id: qna.id, data: qnaItemData(qna) }))
   }
 
   async answersOn(question) {


### PR DESCRIPTION
Reversing results worked fine without pagination. But with pagination it only reversed results of the current page, not pages sequence.