### PR TITLE
fix(qna): fix answers ordering (came from c21d0ac)

### DIFF
--- a/packages/functionals/botpress-qna/src/providers/qnaMaker.js
+++ b/packages/functionals/botpress-qna/src/providers/qnaMaker.js
@@ -148,7 +148,7 @@ export default class Storage {
       { baseURL: this.knowledgebase.hostName, headers: { Authorization: `EndpointKey ${this.endpointKey}` } }
     )
 
-    return _.orderBy(answers, ['score'], ['asc']).map(answer => ({
+    return _.orderBy(answers, ['score'], ['desc']).map(answer => ({
       ..._.pick(answer, ['questions', 'answer', 'id']),
       confidence: answer.score / 100,
       ...qnaItemData(answer)


### PR DESCRIPTION
Missed this change in https://github.com/botpress/botpress/commit/c21d0ac7b2f1353db32b22de2fcd35649d73bfe0 and it's changing the logic we had. Reverting that change.