### PR TITLE
fix(channel-web): handle missing payload.data

### DIFF
--- a/packages/channels/botpress-channel-web/src/api.js
+++ b/packages/channels/botpress-channel-web/src/api.js
@@ -283,7 +283,7 @@ module.exports = async (bp, config) => {
           conversationId
         }
       },
-      ...payload.data
+      ...(payload.data || {})
     )
   }
 


### PR DESCRIPTION
This causes error while receiving messages even on fresh installation.