### PR TITLE
feat(nlu): added unit property to LUIS entity

### DIFF
--- a/packages/functionals/botpress-nlu/src/providers/luis.js
+++ b/packages/functionals/botpress-nlu/src/providers/luis.js
@@ -395,6 +395,7 @@ export default class LuisProvider extends Provider {
           _.get(entity, 'resolution.value') ||
           _.get(entity, 'resolution.values.0') ||
           entity.entity,
+        unit: _.get(entity, 'resolution.unit'),
         original: entity.entity,
         confidence: null,
         position: entity.startIndex,


### PR DESCRIPTION
Some LUIS entity return data about their unit (number and date, etc.)
e.g.:  https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-reference-prebuilt-age