### PR TITLE
fix: make DB initialization in all modules in init() block

### DIFF
--- a/docs/recipes/modules.md
+++ b/docs/recipes/modules.md
@@ -103,7 +103,8 @@ That's it - wasn't too difficult, right?
 
 Botpress can work with two databses (`DB`): sqlite OR Postgres.
 Main process with `DB` is located within [core module](https://github.com/botpress/botpress/tree/master/packages/core/botpress/src/database).
-But other modules may have their own `DB` logic.
+But other modules may have their own `DB` logic. If your module uses a `DB`
+you need initialize all your `DB tables` in `init block` of your `src/index.js`
 
 ### DB migration
 

--- a/packages/channels/botpress-channel-messenger/src/index.js
+++ b/packages/channels/botpress-channel-messenger/src/index.js
@@ -1,15 +1,11 @@
-import path from 'path'
-import fs from 'fs'
 import _ from 'lodash'
 
-import Promise from 'bluebird'
-
 import Messenger from './messenger'
-import actions from './actions'
 import outgoing from './outgoing'
 import incoming from './incoming'
 import Users from './users'
 import UMM from './umm'
+import DB from './db'
 
 let messenger = null
 const outgoingPending = outgoing.pending
@@ -106,7 +102,7 @@ module.exports = {
     }
   },
 
-  init: function(bp) {
+  init: async function(bp) {
     bp.middlewares.register({
       name: 'messenger.sendMessages',
       type: 'outgoing',
@@ -119,6 +115,9 @@ module.exports = {
     })
 
     bp.messenger = {}
+
+    const knex = await bp.db.get()
+    await DB(knex).initialize()
 
     UMM(bp) // Initializes Messenger in the UMM
   },

--- a/packages/channels/botpress-channel-web/src/index.js
+++ b/packages/channels/botpress-channel-web/src/index.js
@@ -32,16 +32,15 @@ module.exports = {
     // Setup the socket events
     await socket(bp, config)
 
+    const knex = await bp.db.get()
+    db(knex, config).initialize()
+
     // Initialize UMM
     return umm(bp)
   },
 
   ready: async function(bp, configurator) {
     const config = await configurator.loadAll()
-
-    // Initialize the database
-    const knex = await bp.db.get()
-    db(knex, config).initialize()
 
     // Setup the APIs
     await api(bp, config)

--- a/packages/functionals/botpress-analytics/src/index.js
+++ b/packages/functionals/botpress-analytics/src/index.js
@@ -71,7 +71,7 @@ module.exports = {
       custom: CustomAnalytics({ bp })
     }
 
-    bp.db.get().then(knex => {
+    return bp.db.get().then(knex => {
       db = DB(knex, bp)
       return db.initializeDb().then(() => (analytics = new Analytics(bp, knex)))
     })

--- a/packages/functionals/botpress-broadcast/src/daemon.js
+++ b/packages/functionals/botpress-broadcast/src/daemon.js
@@ -229,14 +229,10 @@ function sendBroadcasts() {
     })
 }
 
-module.exports = botpress => {
+module.exports = (botpress, k) => {
   bp = botpress
 
-  bp.db.get().then(k => {
-    const { initialize } = DB(k)
-    knex = k
-    initialize()
-  })
+  knex = k
 
   setInterval(scheduleToOutbox, SCHEDULE_TO_OUTBOX_INTERVAL)
   setInterval(sendBroadcasts, SEND_BROADCAST_INTERVAL)

--- a/packages/functionals/botpress-broadcast/src/index.js
+++ b/packages/functionals/botpress-broadcast/src/index.js
@@ -3,19 +3,19 @@ import checkVersion from 'botpress-version-manager'
 
 import daemon from './daemon'
 import DB from './db'
-import moment from 'moment'
 
 let db = null
 let knex = null
 
 module.exports = {
-  init: function(bp) {
+  init: async function(bp) {
     checkVersion(bp, bp.botpressPath)
-    daemon(bp)
-    bp.db.get().then(_knex => {
-      knex = _knex
-      db = DB(knex)
-    })
+
+    knex = await bp.db.get()
+    db = DB(knex)
+    await db.initialize()
+
+    daemon(bp, knex)
   },
   ready: function(bp) {
     const router = bp.getRouter('botpress-broadcast')

--- a/packages/functionals/botpress-hitl/src/index.js
+++ b/packages/functionals/botpress-hitl/src/index.js
@@ -85,10 +85,9 @@ module.exports = {
 
     config = await configurator.loadAll()
 
-    bp.db
-      .get()
-      .then(knex => (db = DB(knex)))
-      .then(() => db.initialize())
+    const knex = await bp.db.get()
+    db = DB(knex)
+    return db.initialize()
   },
 
   ready: function(bp) {


### PR DESCRIPTION
@epaminond @slvnperron 
- remove `db.initialize()` to `init() {}` because I found case when `db tables` has not created but migration start run