### PR TITLE
fix(core): remove 'buttons' fields when actions empty (ref #690)

### DIFF
--- a/packages/core/botpress-builtins/src/renderers/builtin_carousel.js
+++ b/packages/core/botpress-builtins/src/renderers/builtin_carousel.js
@@ -7,11 +7,8 @@ export default data => [
   {
     on: 'facebook',
     template_type: 'generic',
-    elements: data.items.map(card => ({
-      title: card.title,
-      image_url: card.image ? url.resolve(data.BOT_URL, card.image) : null,
-      subtitle: card.subtitle,
-      buttons: (card.actions || []).map(a => {
+    elements: data.items.map(card => {
+      const buttons = (card.actions || []).map(a => {
         if (a.action === 'Say something') {
           return {
             type: 'postback',
@@ -26,7 +23,15 @@ export default data => [
           }
         }
       })
-    })),
+      const buttonsWrapper = card.actions ? { buttons } : {}
+
+      return {
+        title: card.title,
+        image_url: card.image ? url.resolve(data.BOT_URL, card.image) : null,
+        subtitle: card.subtitle,
+        ...buttonsWrapper
+      }
+    }),
 
     typing: data.typing
   },


### PR DESCRIPTION
@epaminond @slvnperron 
- remove 'buttons' fields from 'generic' template for FB when `card actions` is empty 