### PR TITLE
fix(web): add padding to greeting message

### DIFF
--- a/packages/channels/botpress-channel-web/src/views/web/side/style.scss
+++ b/packages/channels/botpress-channel-web/src/views/web/side/style.scss
@@ -457,6 +457,7 @@
   font-size: 22px;
   color: #9a9a9a;
   margin-top: -30px;
+  padding: 0 25px;
 }
 
 // Animations


### PR DESCRIPTION
Quick improvements on the greeting message style
Before :
![capture d ecran 2018-10-16 a 14 32 10](https://user-images.githubusercontent.com/27001825/47018124-5ba81400-d154-11e8-94ec-3cfd0305e068.png)
After :
![capture d ecran 2018-10-16 a 14 32 02](https://user-images.githubusercontent.com/27001825/47018130-606cc800-d154-11e8-9480-3db623d52e1a.png)
