### PR TITLE
Audience: Added filtering/search for users to the audience tab.

### DIFF
--- a/packages/functionals/botpress-audience/src/views/SearchEntry.jsx
+++ b/packages/functionals/botpress-audience/src/views/SearchEntry.jsx
@@ -33,11 +33,11 @@ export default class SearchEntry extends React.Component {
   }
 
   addRow() {
-    this.props.updateRows(this.props.index, true)
+    this.props.updateRows.addRow()
   }
 
   removeRow() {
-    this.props.updateRows(this.props.index, false)
+    this.props.updateRows.disableRow(this.props.index)
   }
 
   render() {
@@ -60,7 +60,8 @@ export default class SearchEntry extends React.Component {
           {this.renderSearch()}
         </Col>
         <Col sm={3} md={2}>
-          {this.props.lastItem ? this.renderButtons() : null}
+          {/* {this.props.lastItem ? this.renderButtons() : null} */}
+          {this.renderButtons()}
         </Col>
       </FormGroup>
     )

--- a/packages/functionals/botpress-audience/src/views/SearchEntry.jsx
+++ b/packages/functionals/botpress-audience/src/views/SearchEntry.jsx
@@ -1,0 +1,128 @@
+import React from 'react'
+
+import { Col, Button, ButtonGroup, FormGroup, FormControl, Glyphicon } from 'react-bootstrap'
+
+import SearchName from './SearchTypes/SearchName'
+import SearchGender from './SearchTypes/SearchGender'
+import SearchPlatforms from './SearchTypes/SearchPlatforms'
+import SearchTags from './SearchTypes/SearchTags'
+
+export default class SearchEntry extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      type: this.props.type || 'First Name',
+      options: ['First Name', 'Last Name', 'Gender', 'Platforms', 'Tags'] //'Gender', 'Platform', 'Tags'
+    }
+
+    this.handleChange = this.handleChange.bind(this)
+    this.renderSearch = this.renderSearch.bind(this)
+    this.renderButtons = this.renderButtons.bind(this)
+
+    this.addRow = this.addRow.bind(this)
+    this.removeRow = this.removeRow.bind(this)
+  }
+
+  handleChange(e) {
+    if (e.target) {
+      this.setState({
+        [e.target.name]: e.target.value
+      })
+    }
+  }
+
+  addRow() {
+    this.props.updateRows(this.props.index, true)
+  }
+
+  removeRow() {
+    this.props.updateRows(this.props.index, false)
+  }
+
+  render() {
+    return (
+      <FormGroup controlId="formBasicText">
+        <Col sm={4} md={2}>
+          <FormControl
+            componentClass="select"
+            placeholder="select"
+            value={this.state.type}
+            onChange={this.handleChange}
+            name="type"
+          >
+            {this.state.options.map(item => {
+              return <option key={item}>{item}</option>
+            })}
+          </FormControl>
+        </Col>
+        <Col sm={5} md={8}>
+          {this.renderSearch()}
+        </Col>
+        <Col sm={3} md={2}>
+          {this.props.lastItem ? this.renderButtons() : null}
+        </Col>
+      </FormGroup>
+    )
+  }
+
+  renderButtons() {
+    return (
+      <ButtonGroup>
+        <Button onClick={this.addRow} bsStyle="info">
+          <Glyphicon glyph="plus" />
+        </Button>
+        {this.props.index != 0 ? (
+          <Button onClick={this.removeRow} bsStyle="danger">
+            <Glyphicon glyph="minus" />
+          </Button>
+        ) : null}
+      </ButtonGroup>
+    )
+  }
+
+  renderSearch() {
+    switch (this.state.type) {
+      case this.state.options[0]: //First Name
+        return (
+          <SearchName
+            type="first"
+            key={this.props.index}
+            index={this.props.index}
+            updateSearch={this.props.updateSearch}
+          />
+        )
+
+      case this.state.options[1]: //Last Name
+        return (
+          <SearchName
+            type="last"
+            key={this.props.index}
+            index={this.props.index}
+            updateSearch={this.props.updateSearch}
+          />
+        )
+      case this.state.options[2]: //Gender
+        return <SearchGender key={this.props.index} index={this.props.index} updateSearch={this.props.updateSearch} />
+      case this.state.options[3]: //Platforms
+        return (
+          <SearchPlatforms
+            key={this.props.index}
+            index={this.props.index}
+            platforms={[
+              ...new Set(
+                this.props.users.map(item => {
+                  return item.platform || item.channel
+                })
+              )
+            ]}
+            updateSearch={this.props.updateSearch}
+          />
+        )
+      case this.state.options[4]: //Tags
+        return <SearchTags index={this.props.index} tags={this.props.tags} updateSearch={this.props.updateSearch} />
+      default:
+        return null
+    }
+  }
+}

--- a/packages/functionals/botpress-audience/src/views/SearchPanel.jsx
+++ b/packages/functionals/botpress-audience/src/views/SearchPanel.jsx
@@ -144,7 +144,7 @@ export default class SearchPanel extends React.Component {
       search: [
         {
           eval: true,
-          id: this.state.search.length + 1
+          id: 0
         }
       ]
     })

--- a/packages/functionals/botpress-audience/src/views/SearchPanel.jsx
+++ b/packages/functionals/botpress-audience/src/views/SearchPanel.jsx
@@ -1,0 +1,132 @@
+import React from 'react'
+
+import SearchEntry from './SearchEntry'
+import { Button, ControlLabel, Form } from 'react-bootstrap'
+
+import _ from 'lodash'
+
+export default class SearchPanel extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.getTagList = this.getTagList.bind(this)
+    this.updateSearch = this.updateSearch.bind(this)
+    this.searchUsers = this.searchUsers.bind(this)
+    this.updateRows = this.updateRows.bind(this)
+
+    this.state = {
+      search: [
+        {
+          eval: true,
+          id: 0
+        }
+      ],
+      users: [],
+      tags: this.getTagList(props.users)
+    }
+  }
+
+  getTagList(users) {
+    if (!users || !users.tags) {
+      return ['No tags found']
+    }
+    const tags = [
+      ...new Set(
+        _.concat(
+          ...users.map(user => {
+            if (user.tags) {
+              return user.tags.map(tag => {
+                return tag.tag
+              })
+            }
+            return false
+          })
+        )
+      )
+    ].sort()
+
+    if (tags.length <= 0) {
+      return ['No tags found']
+    }
+
+    return tags
+  }
+
+  renderSearchEntries() {
+    return this.state.search.map((e, i) => {
+      return (
+        <SearchEntry
+          key={e.id}
+          index={i}
+          updateSearch={this.updateSearch}
+          updateRows={this.updateRows}
+          lastItem={e.id == this.state.search.length - 1}
+          users={this.props.users}
+          tags={this.state.tags}
+        />
+      )
+    })
+  }
+
+  updateSearch(func) {
+    const new_search = [...this.state.search]
+    new_search[func.id] = func
+    this.setState({
+      search: new_search
+    })
+  }
+
+  searchUsers(e) {
+    e.preventDefault()
+
+    if (!this.props.user) {
+      this.props.updateUsers([])
+    }
+
+    const all_users = this.props.users
+
+    const no_cond = this.state.search.length
+
+    const valid_users = []
+
+    all_users.forEach(user => {
+      let passing = 0
+      this.state.search.forEach(func => {
+        passing += func.eval(user)
+      })
+      if (passing == no_cond) {
+        valid_users.push(user)
+      }
+    })
+
+    this.props.updateUsers(valid_users)
+  }
+
+  updateRows(index, addRow = true) {
+    const new_search = [...this.state.search]
+
+    if (addRow) {
+      new_search.push(true)
+    } else {
+      new_search.splice(index, 1)
+    }
+
+    this.setState({
+      search: new_search
+    })
+  }
+
+  render() {
+    return (
+      <Form horizontal onSubmit={this.searchUsers}>
+        <ControlLabel>Search Users</ControlLabel>
+
+        {this.renderSearchEntries()}
+
+        <Button type="submit" onSubmit={this.searchUsers}>
+          Search
+        </Button>
+      </Form>
+    )
+  }
+}

--- a/packages/functionals/botpress-audience/src/views/SearchPanel.jsx
+++ b/packages/functionals/botpress-audience/src/views/SearchPanel.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import SearchEntry from './SearchEntry'
-import { Button, ControlLabel, Form, Glyphicon } from 'react-bootstrap'
+import { Button, ControlLabel, Form, Glyphicon, ButtonGroup } from 'react-bootstrap'
 
 import _ from 'lodash'
 
@@ -14,6 +14,7 @@ export default class SearchPanel extends React.Component {
     this.searchUsers = this.searchUsers.bind(this)
     this.addRow = this.addRow.bind(this)
     this.disableRow = this.disableRow.bind(this)
+    this.resetSearch = this.resetSearch.bind(this)
 
     this.state = {
       search: [
@@ -138,16 +139,33 @@ export default class SearchPanel extends React.Component {
     })
   }
 
+  resetSearch() {
+    this.setState({
+      search: [
+        {
+          eval: true,
+          id: this.state.search.length + 1
+        }
+      ]
+    })
+
+    this.props.updateUsers(this.props.users)
+  }
+
   render() {
     return (
       <Form horizontal onSubmit={this.searchUsers}>
         <ControlLabel>Search Users</ControlLabel>
 
         {this.renderSearchEntries()}
-
-        <Button type="submit" onSubmit={this.searchUsers}>
-          Search
-        </Button>
+        <ButtonGroup>
+          <Button type="submit" onSubmit={this.searchUsers} bsStyle="info">
+            Search
+          </Button>
+          <Button onClick={this.resetSearch} bsStyle="danger">
+            Reset
+          </Button>
+        </ButtonGroup>
       </Form>
     )
   }

--- a/packages/functionals/botpress-audience/src/views/SearchPanel.jsx
+++ b/packages/functionals/botpress-audience/src/views/SearchPanel.jsx
@@ -156,9 +156,6 @@ export default class SearchPanel extends React.Component {
         <Button type="submit" onSubmit={this.searchUsers}>
           Search
         </Button>
-        {/* <Button onClick={this.addRow} bsStyle="info">
-          <Glyphicon glyph="plus" />
-        </Button> */}
       </Form>
     )
   }

--- a/packages/functionals/botpress-audience/src/views/SearchPanel.jsx
+++ b/packages/functionals/botpress-audience/src/views/SearchPanel.jsx
@@ -22,13 +22,11 @@ export default class SearchPanel extends React.Component {
           id: 0
         }
       ],
-      users: [],
       tags: this.getTagList(props.users)
     }
   }
 
   componentDidUpdate(props) {
-    console.log('Update', props.users)
     if (this.props.users !== props.users) {
       this.setState({
         tags: this.getTagList(props)
@@ -38,9 +36,7 @@ export default class SearchPanel extends React.Component {
 
   getAllUserTagNames(users) {
     return users.map(user => {
-      console.log('User: ', user)
       if (user.tags) {
-        console.log('Tags: ', user.tags)
         return user.tags.map(tag => {
           return tag.tag
         })
@@ -50,15 +46,11 @@ export default class SearchPanel extends React.Component {
   }
 
   getTagList(users) {
-    console.log('Tag List?', users)
     if (!users) {
       return ['No tags found']
     }
 
-    const tags = _.union(
-      //Join lists of user tag names
-      ...this.getAllUserTagNames(users)
-    )
+    const tags = _.union(...this.getAllUserTagNames(users))
 
     if (tags.length === 0) {
       return ['No tags found']

--- a/packages/functionals/botpress-audience/src/views/SearchPanel.jsx
+++ b/packages/functionals/botpress-audience/src/views/SearchPanel.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import SearchEntry from './SearchEntry'
-import { Button, ControlLabel, Form, Glyphicon, ButtonGroup } from 'react-bootstrap'
+import { Button, ControlLabel, Form, ButtonGroup } from 'react-bootstrap'
 
 import _ from 'lodash'
 

--- a/packages/functionals/botpress-audience/src/views/SearchTypes/SearchGender.jsx
+++ b/packages/functionals/botpress-audience/src/views/SearchTypes/SearchGender.jsx
@@ -1,0 +1,47 @@
+import React from 'react'
+
+import { FormControl } from 'react-bootstrap'
+
+export default class SearchGender extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      genders: ['Male', 'Female', 'Other', 'Unknown', 'All'],
+      selected: 'All'
+    }
+
+    this.handleChange = this.handleChange.bind(this)
+    this.searchGender = this.searchGender.bind(this)
+
+    props.updateSearch({
+      eval: this.searchGender,
+      id: props.index
+    })
+  }
+
+  handleChange(e) {
+    this.setState({
+      [e.target.name]: e.target.value
+    })
+  }
+
+  searchGender(user) {
+    switch (this.state.selected) {
+      case 'All':
+        return true
+      default:
+        return this.state.selected.toLowerCase() === user.gender.toLowerCase()
+    }
+  }
+
+  render() {
+    return (
+      <FormControl componentClass="select" value={this.state.selected} onChange={this.handleChange} name="selected">
+        {this.state.genders.map(gender => {
+          return <option key={gender}>{gender}</option>
+        })}
+      </FormControl>
+    )
+  }
+}

--- a/packages/functionals/botpress-audience/src/views/SearchTypes/SearchName.jsx
+++ b/packages/functionals/botpress-audience/src/views/SearchTypes/SearchName.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+
+import { FormControl } from 'react-bootstrap'
+
+export default class SearchName extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      name: props.name || ''
+    }
+
+    this.handleChange = this.handleChange.bind(this)
+    this.searchNames = this.searchNames.bind(this)
+
+    props.updateSearch({
+      eval: this.searchNames,
+      id: props.index
+    })
+  }
+
+  handleChange(e) {
+    this.setState({
+      [e.target.name]: e.target.value
+    })
+  }
+
+  searchNames(user) {
+    console.log()
+
+    if (!user || this.state.name === '') {
+      return true
+    }
+
+    if (this.props.type === 'first') {
+      return user.first_name && user.first_name.indexOf(this.state.name) >= 0
+    } else {
+      return user.last_name && user.last_name.indexOf(this.state.name) >= 0
+    }
+  }
+
+  render() {
+    return (
+      <FormControl
+        type="text"
+        placeholder={`Search ${this.props.type} name...`}
+        value={this.state.name}
+        onChange={this.handleChange}
+        name="name"
+      />
+    )
+  }
+}

--- a/packages/functionals/botpress-audience/src/views/SearchTypes/SearchPlatforms.jsx
+++ b/packages/functionals/botpress-audience/src/views/SearchTypes/SearchPlatforms.jsx
@@ -1,0 +1,47 @@
+import React from 'react'
+
+import { FormControl } from 'react-bootstrap'
+
+export default class SearchPlatforms extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      selected: 'All',
+      platforms: [...this.props.platforms, 'All']
+    }
+
+    this.handleChange = this.handleChange.bind(this)
+
+    this.searchPlatforms = this.searchPlatforms.bind(this)
+
+    this.props.updateSearch({
+      eval: this.searchPlatforms,
+      id: props.index
+    })
+  }
+
+  handleChange(e) {
+    this.setState({
+      selected: e.target.value
+    })
+  }
+
+  searchPlatforms(user) {
+    if (this.state.selected === 'All') {
+      return true
+    } else {
+      return user.platform === this.state.selected || user.channel === this.state.selected
+    }
+  }
+
+  render() {
+    return (
+      <FormControl componentClass="select" value={this.state.selected} onChange={this.handleChange}>
+        {this.state.platforms.map(item => {
+          return <option key={item}>{item}</option>
+        })}
+      </FormControl>
+    )
+  }
+}

--- a/packages/functionals/botpress-audience/src/views/SearchTypes/SearchTags.jsx
+++ b/packages/functionals/botpress-audience/src/views/SearchTypes/SearchTags.jsx
@@ -1,0 +1,83 @@
+import React from 'react'
+
+import { FormControl, Col } from 'react-bootstrap'
+
+import _ from 'lodash'
+
+export default class SearchTags extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      tag_name: '',
+      tag_value: ''
+    }
+
+    console.log('Test tag list:', this.props.tags)
+    this.handleChange = this.handleChange.bind(this)
+    this.searchTags = this.searchTags.bind(this)
+
+    this.props.updateSearch({
+      eval: this.searchTags,
+      id: this.props.index
+    })
+  }
+
+  handleChange(e) {
+    this.setState({
+      [e.target.name]: e.target.value
+    })
+  }
+
+  searchTags(user) {
+    if (this.state.tag_name === '') {
+      return true
+    }
+
+    const tag = this.findTag(user.tags, this.state.tag_name)
+
+    if (tag && (this.state.tag_value === '' || this.state.tag_value === tag.value)) {
+      return true
+    }
+
+    return false
+  }
+
+  findTag(tags, target) {
+    return (
+      _.filter(tags, tag => {
+        return tag.tag === target.toUpperCase()
+      })[0] || null
+    )
+  }
+
+  render() {
+    return (
+      <div>
+        <Col sm={6}>
+          <FormControl
+            name="tag_name"
+            // type='text'
+            componentClass="select"
+            placeholder="Tag name"
+            value={this.state.tag_name}
+            onChange={this.handleChange}
+          >
+            {this.props.tags.map(tag => {
+              return <option key={tag}>{tag}</option>
+            })}
+          </FormControl>
+        </Col>
+        <Col sm={6}>
+          <FormControl
+            name="tag_value"
+            type="text"
+            placeholder="Tag value"
+            value={this.state.tag_value}
+            onChange={this.handleChange}
+          />
+        </Col>
+      </div>
+    )
+  }
+}

--- a/packages/functionals/botpress-audience/src/views/index.jsx
+++ b/packages/functionals/botpress-audience/src/views/index.jsx
@@ -170,7 +170,7 @@ export default class AudienceModule extends React.Component {
         <tr key={key}>
           <td style={{ width: '10%' }}>{this.renderProfilePicture(picture_url)}</td>
           <td style={{ width: '24%' }}>{user.id}</td>
-          <td style={{ width: '15%' }}>{this.renderName(first_name, last_name)}</td>
+          <td style={{ width: '15%' }}>{this.renderName(user.first_name, user.last_name)}</td>
           <td style={{ width: '10%' }}>{_.upperFirst(user.platform)}</td>
           <td style={{ width: '15%' }}>{this.renderCreatedOn(user.created_at)}</td>
           <td style={{ width: '21%' }}>{this.renderTags(user.tags)}</td>

--- a/packages/functionals/botpress-audience/src/views/index.jsx
+++ b/packages/functionals/botpress-audience/src/views/index.jsx
@@ -62,7 +62,7 @@ export default class AudienceModule extends React.Component {
   }
 
   async fetchCount() {
-    const { data } = await this.getAxios().get('/mod/audience/users/count')
+    const { data } = await this.getAxios().get('/api/botpress-audience/users/count')
 
     this.setState({
       count: data

--- a/packages/functionals/botpress-audience/src/views/index.jsx
+++ b/packages/functionals/botpress-audience/src/views/index.jsx
@@ -172,7 +172,7 @@ export default class AudienceModule extends React.Component {
           <td style={{ width: '24%' }}>{user.id}</td>
           <td style={{ width: '15%' }}>{this.renderName(user.first_name, user.last_name)}</td>
           <td style={{ width: '10%' }}>{_.upperFirst(user.platform)}</td>
-          <td style={{ width: '15%' }}>{this.renderCreatedOn(user.created_at)}</td>
+          <td style={{ width: '15%' }}>{this.renderCreatedOn(user.created_on)}</td>
           <td style={{ width: '21%' }}>{this.renderTags(user.tags)}</td>
           <td style={{ width: '5%' }}>{this.renderExtra(user.locale, user.timezone, user.gender)}</td>
         </tr>

--- a/packages/functionals/botpress-audience/src/views/index.jsx
+++ b/packages/functionals/botpress-audience/src/views/index.jsx
@@ -162,13 +162,13 @@ export default class AudienceModule extends React.Component {
 
   renderUsers(users) {
     return _.mapValues(users, (user, key) => {
-      const picture_url = _.get(_.find(user.attributes, { key: 'picture_url' }), 'value')
-      const first_name = _.get(_.find(user.attributes, { key: 'first_name' }), 'value')
-      const last_name = _.get(_.find(user.attributes, { key: 'last_name' }), 'value')
+      //const picture_url = _.get(_.find(user.attributes, { key: 'picture_url' }), 'value')
+      //const first_name = _.get(_.find(user.attributes, { key: 'first_name' }), 'value')
+      //const last_name = _.get(_.find(user.attributes, { key: 'last_name' }), 'value')
 
       return (
         <tr key={key}>
-          <td style={{ width: '10%' }}>{this.renderProfilePicture(picture_url)}</td>
+          <td style={{ width: '10%' }}>{this.renderProfilePicture(user.picture_url)}</td>
           <td style={{ width: '24%' }}>{user.id}</td>
           <td style={{ width: '15%' }}>{this.renderName(user.first_name, user.last_name)}</td>
           <td style={{ width: '10%' }}>{_.upperFirst(user.platform)}</td>

--- a/packages/functionals/botpress-audience/src/views/index.jsx
+++ b/packages/functionals/botpress-audience/src/views/index.jsx
@@ -45,11 +45,10 @@ export default class AudienceModule extends React.Component {
     this.setState({ loading: true })
 
     try {
-      const { data } = await this.getAxios().post('/mod/audience/users', {
+      const { data } = await this.getAxios().post('/api/botpress-audience/users', {
         from: this.state.page * LIMIT_PER_PAGE,
         limit: LIMIT_PER_PAGE
       })
-
       this.setState({
         loading: false,
         users: data,
@@ -141,7 +140,7 @@ export default class AudienceModule extends React.Component {
     return <div className={style.image}>{picture}</div>
   }
 
-  renderExtra({ locale, timezone, gender }) {
+  renderExtra(locale, timezone, gender) {
     if (!locale && !timezone && gender === 'unknown') {
       return 'No info'
     }
@@ -170,12 +169,12 @@ export default class AudienceModule extends React.Component {
       return (
         <tr key={key}>
           <td style={{ width: '10%' }}>{this.renderProfilePicture(picture_url)}</td>
-          <td style={{ width: '24%' }}>{user.user_id}</td>
+          <td style={{ width: '24%' }}>{user.id}</td>
           <td style={{ width: '15%' }}>{this.renderName(first_name, last_name)}</td>
-          <td style={{ width: '10%' }}>{_.upperFirst(user.channel)}</td>
+          <td style={{ width: '10%' }}>{_.upperFirst(user.platform)}</td>
           <td style={{ width: '15%' }}>{this.renderCreatedOn(user.created_at)}</td>
           <td style={{ width: '21%' }}>{this.renderTags(user.tags)}</td>
-          <td style={{ width: '5%' }}>{this.renderExtra(user.attributes)}</td>
+          <td style={{ width: '5%' }}>{this.renderExtra(user.locale, user.timezone, user.gender)}</td>
         </tr>
       )
     })

--- a/packages/functionals/botpress-audience/src/views/index.jsx
+++ b/packages/functionals/botpress-audience/src/views/index.jsx
@@ -140,7 +140,7 @@ export default class AudienceModule extends React.Component {
     return <div className={style.image}>{picture}</div>
   }
 
-  renderExtra(locale, timezone, gender) {
+  renderExtra({ locale, timezone, gender }) {
     if (!locale && !timezone && gender === 'unknown') {
       return 'No info'
     }
@@ -174,7 +174,7 @@ export default class AudienceModule extends React.Component {
           <td style={{ width: '10%' }}>{_.upperFirst(user.platform)}</td>
           <td style={{ width: '15%' }}>{this.renderCreatedOn(user.created_on)}</td>
           <td style={{ width: '21%' }}>{this.renderTags(user.tags)}</td>
-          <td style={{ width: '5%' }}>{this.renderExtra(user.locale, user.timezone, user.gender)}</td>
+          <td style={{ width: '5%' }}>{this.renderExtra(user)}</td>
         </tr>
       )
     })
@@ -206,14 +206,14 @@ export default class AudienceModule extends React.Component {
   renderPagination() {
     const previous =
       this.state.page > 0 ? (
-        <Pager.Item previous onClick={this.handlePreviousClicked}>
+        <Pager.Item previous onClick={::this.handlePreviousClicked}>
           &larr; Previous
         </Pager.Item>
       ) : null
 
     const next =
       this.state.count > (this.state.page + 1) * LIMIT_PER_PAGE ? (
-        <Pager.Item next onClick={this.handleNextClicked}>
+        <Pager.Item next onClick={::this.handleNextClicked}>
           Next &rarr;
         </Pager.Item>
       ) : null


### PR DESCRIPTION
You can now filter users in the Audience tab by the following features. You can also use multiple different filters in unison:

- First Name
- Last Name
- Gender
- Platform
- Tags

![image](https://user-images.githubusercontent.com/7109835/48027933-07221280-e1af-11e8-9f7b-92d565848991.png)

Can easily make new search filters by creating new React views. Each search type is self-contained, and handles its own filtering.

These changes have not been fully tested with the 11.00 version. User data structure passed to the audience tab has changed. This feature was tested on the 10.50 version, with Slack, Facebook and Web users.
