### PR TITLE
fix(nlu): fix Luis NLU fetching success training status

### DIFF
--- a/packages/functionals/botpress-nlu/src/providers/luis.js
+++ b/packages/functionals/botpress-nlu/src/providers/luis.js
@@ -311,7 +311,7 @@ export default class LuisProvider extends Provider {
 
       const models = res.data
 
-      const percent = (models.length - _.filter(models, m => m.details.status === 'InProgress').length) / models.length
+      const percent = _.filter(models, m => m.details.status === 'Success').length / models.length
 
       const error = _.find(models, m => m.details.status === 'Fail')
 


### PR DESCRIPTION
An issue here was that we were assuming syncing is `Success` if it wasn't `InProgress`. But it could also be in other statuses (like `Queued`).