### PR TITLE
fix(core): remove unused module import

### DIFF
--- a/packages/core/botpress/src/web/lite.jsx
+++ b/packages/core/botpress/src/web/lite.jsx
@@ -14,7 +14,6 @@ import { fetchModules } from './actions'
 import InjectedModuleView from '~/components/PluginInjectionSite/module'
 import { moduleViewNames } from '~/util/Modules'
 import { getToken, getUniqueVisitorId } from '~/util/Auth'
-import { fromPromise } from 'rxjs/observable/fromPromise'
 
 const token = getToken()
 if (token) {


### PR DESCRIPTION
@epaminond @slvnperron 
I've removed unused module. This is fix for watching bug in `core/botpress` module. To reproduce you only need run `yarn watch` in `core/botpress`