### PR TITLE
fix(webchat): move webchatUrlQuery to event.raw.data (ref #721)

### DIFF
--- a/packages/channels/botpress-channel-web/README.md
+++ b/packages/channels/botpress-channel-web/README.md
@@ -352,7 +352,7 @@ You can open/close sidebar programmatically by calling `window.botpressWebChat.s
 
 ### Modify url
 
-You can add `ref` query parameter to url(example `bot/s/chat?ref=[content]`) and all content will be set to user state as `webchatUrlQuery`. User state could be fetched via [DialogStateManager](https://botpress.io/docs/latest/reference/DialogStateManager.html).
+You can add `ref` query parameter to url(example `bot/s/chat?ref=[content]`) and content will be available within events as `event.raw.data.webchatUrlQuery`.
 
 ## Configuring file uploads
 

--- a/packages/channels/botpress-channel-web/src/api.js
+++ b/packages/channels/botpress-channel-web/src/api.js
@@ -330,20 +330,6 @@ module.exports = async (bp, config) => {
     res.sendStatus(200)
   })
 
-  router.get('/:userId/reference', async (req, res) => {
-    try {
-      const { params: { userId }, query: { ref: webchatUrlQuery } } = req
-      const state = await bp.dialogEngine.stateManager.getState(`webchat:${userId}`)
-      const newState = { ...state, webchatUrlQuery }
-
-      await bp.dialogEngine.stateManager.setState(`webchat:${userId}`, newState)
-
-      res.status(200)
-    } catch (error) {
-      res.status(500)
-    }
-  })
-
   const getMessageContent = message => {
     switch (message.message_type) {
       case 'file':

--- a/packages/channels/botpress-channel-web/src/views/web/index.jsx
+++ b/packages/channels/botpress-channel-web/src/views/web/index.jsx
@@ -439,12 +439,13 @@ export default class Web extends React.Component {
     return this.props.bp.axios.post(url, data, config).then()
   }
 
-  handleSendData = data => {
+  handleSendData = payload => {
     const userId = window.__BP_VISITOR_ID
     const url = `${BOT_HOSTNAME}/api/botpress-platform-webchat/messages/${userId}`
     const config = { params: { conversationId: this.state.currentConversationId } }
 
-    return this.props.bp.axios.post(url, data, config).then()
+    const { ref: webchatUrlQuery } = queryString.parse(location.search)
+    return this.props.bp.axios.post(url, { ...payload, data: { ...payload.data, webchatUrlQuery } }, config).then()
   }
 
   handleSwitchConvo = convoId => {

--- a/packages/core/botpress/src/web/lite.jsx
+++ b/packages/core/botpress/src/web/lite.jsx
@@ -13,7 +13,7 @@ import store from './store'
 import { fetchModules } from './actions'
 import InjectedModuleView from '~/components/PluginInjectionSite/module'
 import { moduleViewNames } from '~/util/Modules'
-import { getToken, getUniqueVisitorId } from '~/util/Auth'
+import { getToken } from '~/util/Auth'
 
 const token = getToken()
 if (token) {
@@ -25,7 +25,7 @@ if (window.BOTPRESS_XX && axios && axios.defaults) {
   axios.defaults.headers.common['X-Botpress-Bot-Id'] = parseBotId()
 }
 
-const { m, v, ref } = queryString.parse(location.search)
+const { m, v } = queryString.parse(location.search)
 
 const alternateModuleNames = {
   'platform-webchat': 'channel-web'
@@ -35,18 +35,6 @@ const moduleName = alternateModuleNames[m] || m
 class LiteView extends React.Component {
   componentDidMount() {
     this.props.fetchModules()
-    this.sendQueries()
-  }
-
-  sendQueries() {
-    if (!ref) {
-      return
-    }
-
-    const userId = window.__BP_VISITOR_ID || getUniqueVisitorId()
-
-    // TODO: why don't we have module-specific code inside of that module?
-    axios.get(`/api/botpress-platform-webchat/${userId}/reference?ref=${ref}`)
   }
 
   render() {


### PR DESCRIPTION
State is reset on flow end which may lead to `webchatUrlQuery` being undefined event though it was passed within url. Here I've moved `webchatUrlQuery` from `state` to `event.raw.data`.