### PR TITLE
fixed broken links 

### DIFF
--- a/docs/guide/docs/tutorials.md
+++ b/docs/guide/docs/tutorials.md
@@ -109,7 +109,7 @@ To enable Postgres, you can edit the configuration or pass 2 environment variabl
 Botpress allows you to build a powerful tool for autonomous communication with your users.
 However there may be cases where it is difficult or very resource-consuming to implement a conversation flow within the bot. At this point you may consider having a human take over the conversation and continue to communicate with your user.
 
-The [Human-in-the-Loop (hitl)](https://github.com/botpress/botpress/tree/master/modules/hitl) module allows you to do just that!
+The [Human-in-the-Loop (hitl)](https://botpress.io/docs/10.50/recipes/hitl/) module allows you to do just that!
 
 Human-in-the-Loop is currently supported on `channel-web` and `channel-messenger`.
 

--- a/docs/guide/docs/tutorials.md
+++ b/docs/guide/docs/tutorials.md
@@ -307,11 +307,11 @@ There are many scenarios when dealing with language and depend on your needs, so
 
 In our case, we will keep things simple and just a add a Choice for the user to pick from at the beginning of the conversation.
 
-You can then store the user's choice in the `state` by preparing a [simple action](/docs/build/code) for this purpose. Let's assume we offer the choice between English and Arabic, after the user chooses their language, we will set `state.language` either to "En" or "Ar".
+You can then store the user's choice in the `state` by preparing a [simple action](https://botpress.io/docs/build/code/) for this purpose. Let's assume we offer the choice between English and Arabic, after the user chooses their language, we will set `state.language` either to "En" or "Ar".
 
 ### Adopting content schema
 
-Botpress allows you to define a [custom content type](/docs/build/content) that will allow you to store text in multiple languages. Here's an example of a `translate_text` content-type:
+Botpress allows you to define a [custom content type](https://botpress.io/docs/build/content/) that will allow you to store text in multiple languages. Here's an example of a `translate_text` content-type:
 
 ```js
 function renderElement(data, channel) {


### PR DESCRIPTION
I changed the relative urls in the docs/tuturials.md file to working absolute references to the correct pages on the botpress site.  