### PR TITLE
Avoid knex warning during migration

### DIFF
--- a/packages/core/botpress/migrations/003-ghost_content-file_folder_uniq_index.js
+++ b/packages/core/botpress/migrations/003-ghost_content-file_folder_uniq_index.js
@@ -2,7 +2,7 @@ exports.up = knex => {
   if (knex.client.config.client === 'sqlite3') {
     return
   }
-  knex.raw(`
+  return knex.raw(`
     ALTER TABLE ghost_content DROP CONSTRAINT IF EXISTS ghost_content_folder_file_unique;
     ALTER TABLE ghost_content ADD CONSTRAINT ghost_content_folder_file_unique UNIQUE (folder, file);
   `)


### PR DESCRIPTION
Avoid this warning: `Knex:warning - migration 003-ghost_content-file_folder_uniq_index.js did not return a promise`