### PR TITLE
feat(core): added posibility to customize 'bp'

### DIFF
--- a/src/bp/core/api.ts
+++ b/src/bp/core/api.ts
@@ -4,6 +4,7 @@ import { inject, injectable } from 'inversify'
 import Knex from 'knex'
 import { Memoize } from 'lodash-decorators'
 import MLToolkit from 'ml/toolkit'
+import _ from 'lodash'
 
 import { container } from './app.inversify'
 import { BotLoader } from './bot-loader'
@@ -183,7 +184,7 @@ const cms = (cmsService: CMSService): typeof sdk.cms => {
  * Socket.IO API to emit payloads to front-end clients
  */
 export class RealTimeAPI implements RealTimeAPI {
-  constructor(private realtimeService: RealtimeService) {}
+  constructor(private realtimeService: RealtimeService) { }
 
   sendPayload(payload: RealTimePayload) {
     this.realtimeService.sendToSocket(payload)
@@ -238,6 +239,16 @@ export class BotpressAPIProvider {
     this.mlToolkit = MLToolkit
   }
 
+  private custom = {}
+
+  defineCustomProperty(path: string, instance: object | Function, options = { overwrite: false }): any {
+    if (!options.overwrite && _.has(this.custom, path)) {
+      throw new Error('You are trying to overwrite existing property.')
+    }
+
+    _.set(this.custom, path, instance)
+  }
+
   @Memoize()
   async create(loggerName: string): Promise<typeof sdk> {
     return {
@@ -263,7 +274,9 @@ export class BotpressAPIProvider {
       notifications: this.notifications,
       ghost: this.ghost,
       bots: this.bots,
-      cms: this.cms
+      cms: this.cms,
+      defineCustomProperty: this.defineCustomProperty,
+      custom: this.custom,
     }
   }
 }

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -967,4 +967,29 @@ declare module 'botpress/sdk' {
       contentElementId?: string
     ): Promise<string>
   }
+
+  /*
+    It's place where module will save all custom instance
+  */
+  export const custom: any
+
+  export type DefineOptions = {
+    /**
+     * Default behavior doesn't allow overwrite existing instance but you can change it
+     * @default false
+     */
+    overwrite: boolean
+  }
+
+  /**
+   * This method help attach the custom instance
+   * @param path - path to place where you want to save instance
+   * @param instance - module instance
+   * @param options - Additional options
+   * 
+   * @example bp.defineCustomProperty('skill', instance, { overwrite: true })
+   * 
+   * @returns undefined
+   */
+  export function defineCustomProperty(path: string, instance: object | Function, options?: DefineOptions): any
 }


### PR DESCRIPTION
@slvnperron @epaminond @EFF @allardy 
I'm working on a migration custom module from v10 to v11. I met one problem. I've created my own instance and attached to 'bp'. But when I've tried using this instance in actions I've mentioned that I can't find this instance. To fix it I've added method which can attach custom instance to 'bp'.