### PR TITLE
fix(core): jumpTo executes the target flow catchAll transitions

### DIFF
--- a/src/bp/core/services/dialog/instruction/factory.test.ts
+++ b/src/bp/core/services/dialog/instruction/factory.test.ts
@@ -45,7 +45,7 @@ describe('Instruction Factory', () => {
 
     it('Returns transitions in order', () => {
       const flow = {}
-      const value = InstructionFactory.createTransition(node, flow)
+      const value = InstructionFactory.createTransition(flow, node)
       expect(value).toEqual([
         { type: 'transition', fn: 'abc {}', node: 'x' },
         { type: 'transition', fn: 'def {}', node: 'y' }
@@ -58,7 +58,7 @@ describe('Instruction Factory', () => {
           next: [{ condition: 'xyz {}', node: 'a' }]
         }
       }
-      const value = InstructionFactory.createTransition(node, flow)
+      const value = InstructionFactory.createTransition(flow, node)
       expect(value).toEqual([
         { type: 'transition', fn: 'xyz {}', node: 'a' },
         { type: 'transition', fn: 'abc {}', node: 'x' },
@@ -73,7 +73,7 @@ describe('Instruction Factory', () => {
           next: [{ condition: 'xyz {}', node: 'abc' }, { condition: 'xyz {}', node: 'bcd' }]
         }
       }
-      const value = InstructionFactory.createTransition(node, flow)
+      const value = InstructionFactory.createTransition(flow, node)
       expect(value).toEqual([{ type: 'transition', fn: 'xyz {}', node: 'bcd' }])
     })
   })

--- a/src/bp/core/services/dialog/instruction/factory.ts
+++ b/src/bp/core/services/dialog/instruction/factory.ts
@@ -30,13 +30,12 @@ export class InstructionFactory {
     )
   }
 
-  static createTransition(node, flow): Instruction[] {
+  static createTransition(flow, node?): Instruction[] {
     const nodeNext = _.get(node, 'next', []) || []
     let flowNext = _.get(flow, 'catchAll.next', []) || []
 
-    // Skip transitions that contains the current node
-    // To prevent infinite loop
-    flowNext = flowNext.filter(n => n.node !== node.name)
+    // Skip transitions that contains the current node to prevent infinite looping
+    flowNext = flowNext.filter(n => n.node !== ((node && node.name) || undefined))
 
     return [...flowNext, ...nodeNext].map(
       (x): Instruction => ({

--- a/src/bp/core/services/dialog/instruction/queue.ts
+++ b/src/bp/core/services/dialog/instruction/queue.ts
@@ -6,12 +6,6 @@ import { InstructionFactory } from './factory'
 export class InstructionQueue {
   instructions: Instruction[] = []
 
-  constructor(instructions?: any) {
-    if (instructions) {
-      this.instructions = instructions
-    }
-  }
-
   clear() {
     this.instructions = []
   }

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -418,11 +418,21 @@ declare module 'botpress/sdk' {
     }
 
     export interface DialogContext {
+      /** The name of the previous flow to return to when we exit a subflow */
       previousFlow?: string
+      /** The name of the previous node to return to when we exit a subflow */
       previousNode?: string
+      /** The name of the current active node */
       currentNode?: string
+      /** The name of the current active flow */
       currentFlow?: string
+      /** The instructions queue to be processed by the dialog engine */
       queue?: any
+      /**
+       * Indicate that the context has just jumped to another flow.
+       * This is used to execute the target flow catchAll transitions.
+       */
+      hasJumped?: boolean
     }
 
     export interface CurrentSession {


### PR DESCRIPTION
When jumpTo is called (e.g. QnA suggestedReplies), the target flow catchAll transition are executed before any other instructions. This way we can check things like user authentication or any other condition that gives access to the target flow.