### PR TITLE
fix(analytics): upgrade module to work with 11.x

### DIFF
--- a/modules/analytics/README.md
+++ b/modules/analytics/README.md
@@ -2,31 +2,34 @@
 
 Analytics for Botpress provides an interface to view graphs and data of your chatbot typical usage. By using this module, you can have a look to your total users, retention, daily active users, busy hours and a lot more...
 
-<img src='./assets/preview.png' width='300px'>
-
-## Installation
-
-```
-npm install --save @botpress/analytics
-```
-
 ## Usage
 
-This module has some built-in analytics available from the box but also allows you to set up your own custom analytics.
+This module has some built-in analytics available from the box but also allows you to set up your own custom analytics. For latter you need to:
 
-For latter you need to:
+1. Register graphs like this:
 
-1. Register graphs by calling `bp.analytics.custom.addGraph`
-2. Calling `bp.analytics.custom.increment(name, count=1)` and `bp.analytics.custom.set(name, count=1)` to register events that get displayed in analytics
+```js
+const axiosConfig = await bp.http.getAxiosConfigForBot(botId)
+const graphDefinition = { /* ... */ }
+axios.post('/mod/analytics/graphs', graphDefinition, axiosConfig)
+```
 
-`bp.analytics.custom.addGraph` accepts an object with following keys:
+`graphDefinition` is an object with following keys:
 
 - name (String)
 - type (one of 'count', 'countUniq', 'percent', 'piechart')
 - description (String)
 - variables ([String]),
-- fn: (Function that is used to calculate result)
-- fnAvg: (Function) => that gets used for 'percent' type to calculate average value
+- fn: (String function definition) that is used to calculate result - optional
+- fnAvg: (String function definition) that gets used for 'percent' type to calculate average value - optional
+
+2. Calling `increment`, `decrement` and `set` APIs to register events that get displayed in analytics like this:
+
+```js
+await axios.post('/mod/analytics/custom_metrics/set', { name: `${metric}~${value}`, count: 1 }, axiosConfig)
+await axios.post('/mod/analytics/custom_metrics/increment', { name: `${metric}~${value}`, count: 1 }, axiosConfig)
+await axios.post('/mod/analytics/custom_metrics/decrement', { name: `${metric}~${value}`, count: 1 }, axiosConfig)
+```
 
 ## License
 

--- a/modules/analytics/src/backend/analytics.ts
+++ b/modules/analytics/src/backend/analytics.ts
@@ -1,21 +1,25 @@
+import { SDK } from 'botpress'
 import fs from 'fs'
 import _ from 'lodash'
 import moment from 'moment'
 import ms from 'ms'
 
-import { SDK } from '.'
+import CustomAnalytics from './custom-analytics'
 import Stats from './stats'
 import { UpdateTask } from './task'
+import { CustomAnalytics as CustomAnalyticsType } from './typings'
 
 export default class Analytics {
   private _knex
   private _stats
   private _task
+  public custom: CustomAnalyticsType
 
   constructor(private bp: SDK, private botId: string) {
     this._knex = bp['database']
     this._stats = new Stats(this._knex)
     this._task = new UpdateTask(this.bp, this._getInterval())
+    this.custom = CustomAnalytics({ bp, botId })
   }
 
   public async start() {

--- a/modules/analytics/src/backend/db.ts
+++ b/modules/analytics/src/backend/db.ts
@@ -32,6 +32,7 @@ export default class AnalyticsDb {
       })
       .then(() => {
         return this.knex.createTableIfNotExists('analytics_custom', table => {
+          table.string('botId')
           table.string('date')
           table.string('name')
           table.integer('count')

--- a/modules/analytics/src/backend/index.ts
+++ b/modules/analytics/src/backend/index.ts
@@ -1,32 +1,17 @@
 import 'bluebird-global'
-import * as sdk from 'botpress/sdk'
+import { SDK } from 'botpress'
 import _ from 'lodash'
 
 import Analytics from './analytics'
 import api from './api'
-import CustomAnalytics from './custom-analytics'
 import setup from './setup'
 import { AnalyticsByBot } from './typings'
 
 const analyticsByBot: AnalyticsByBot = {}
 
-export type Extension = {
-  analytics: {
-    custom: {
-      getAll: Function
-    }
-  }
-}
-
-export type SDK = typeof sdk & Extension
-
 const interactionsToTrack = ['message', 'text', 'button', 'template', 'quick_reply', 'postback']
 
 const onServerStarted = async (bp: SDK) => {
-  bp.analytics = {
-    custom: CustomAnalytics({ bp })
-  }
-
   await setup(bp, interactionsToTrack)
 }
 
@@ -45,7 +30,7 @@ const onBotUnmount = async (bp: SDK, botId: string) => {
   delete analyticsByBot[botId]
 }
 
-const entryPoint: sdk.ModuleEntryPoint = {
+const entryPoint: SDK.ModuleEntryPoint = {
   onServerStarted,
   onServerReady,
   onBotMount,

--- a/modules/analytics/src/backend/typings.ts
+++ b/modules/analytics/src/backend/typings.ts
@@ -1,3 +1,11 @@
 import Analytics from './analytics'
 
 export type AnalyticsByBot = { [botId: string]: Analytics }
+
+export type CustomAnalytics = {
+  getAll: Function
+  addGraph: Function
+  increment: Function
+  decrement: Function
+  set: Function
+}


### PR DESCRIPTION
I've updated Analytics module to work with botpress `11.x`.
Tried to implement API accessible via http, but not sure whether function serialization makes sense.