### PR TITLE
Ya small fixes

### DIFF
--- a/modules/qna/src/backend/providers/nlu.ts
+++ b/modules/qna/src/backend/providers/nlu.ts
@@ -63,12 +63,13 @@ export default class Storage implements QnaStorage {
 
       if (question.data.enabled && !matchedIntent) {
         const intent = {
+          name: getIntentId(question.id),
           entities: [],
           contexts: [question.data.category || 'global'],
           utterances: normalizeQuestions(question.data.questions)
         }
 
-        await axios.post(`/mod/nlu/intents/${getIntentId(question.id)}`, intent, this.axiosConfig)
+        await axios.post(`/mod/nlu/intents`, intent, this.axiosConfig)
         this.bp.logger.info(`Created NLU intent for QNA ${question.id}`)
       }
     }
@@ -78,14 +79,14 @@ export default class Storage implements QnaStorage {
     id = id || getQuestionId(data)
     if (data.enabled) {
       const intent = {
+        name: getIntentId(id),
         entities: [],
         contexts: [data.category || 'global'],
         utterances: normalizeQuestions(data.questions)
       }
 
       await this.checkForDuplicatedQuestions(intent.utterances, id)
-
-      await axios.post(`/mod/nlu/intents/${getIntentId(id)}`, intent, this.axiosConfig)
+      await axios.post(`/mod/nlu/intents`, intent, this.axiosConfig)
     } else {
       await axios.delete(`/mod/nlu/intents/${getIntentId(id)}`, this.axiosConfig)
     }
@@ -103,13 +104,14 @@ export default class Storage implements QnaStorage {
 
       if (data.enabled) {
         const intent = {
+          name: getIntentId(id),
           entities: [],
           contexts: [data.category || 'global'],
           utterances: normalizeQuestions(data.questions)
         }
 
         await this.checkForDuplicatedQuestions(intent.utterances)
-        await axios.post(`/mod/nlu/intents/${getIntentId(id)}`, intent, this.axiosConfig)
+        await axios.post(`/mod/nlu/intents`, intent, this.axiosConfig)
       }
 
       await this.bp.ghost

--- a/src/bp/core/routers/bots/index.ts
+++ b/src/bp/core/routers/bots/index.ts
@@ -212,7 +212,7 @@ export class BotsRouter extends CustomRouter {
       this.needPermissions('read', 'bot.flows'),
       this.asyncMiddleware(async (req, res) => {
         const botId = req.params.botId
-        const actions = await this.actionService.forBot(botId).listActions({ includeMetadata: true })
+        const actions = await this.actionService.forBot(botId).listActions()
         res.send(Serialize(actions))
       })
     )

--- a/src/bp/core/services/action/action-service.ts
+++ b/src/bp/core/services/action/action-service.ts
@@ -64,7 +64,7 @@ export class ScopedActionService {
     })
   }
 
-  async listActions({ includeMetadata = false } = {}): Promise<ActionDefinition[]> {
+  async listActions(): Promise<ActionDefinition[]> {
     if (this._actionsCache) {
       return this._actionsCache
     }
@@ -79,10 +79,8 @@ export class ScopedActionService {
     )
 
     const actions: ActionDefinition[] = (await Promise.map(globalActionsFiles, async file =>
-      this.getActionDefinition(file, 'global', includeMetadata)
-    )).concat(
-      await Promise.map(localActionsFiles, async file => this.getActionDefinition(file, 'local', includeMetadata))
-    )
+      this.getActionDefinition(file, 'global', true)
+    )).concat(await Promise.map(localActionsFiles, async file => this.getActionDefinition(file, 'local', true)))
 
     this._actionsCache = actions
     return actions

--- a/src/bp/core/services/dialog/dialog-engine.ts
+++ b/src/bp/core/services/dialog/dialog-engine.ts
@@ -22,7 +22,7 @@ export class DialogEngine {
     @inject(TYPES.Logger) private logger: Logger,
     @inject(TYPES.FlowService) private flowService: FlowService,
     @inject(TYPES.InstructionProcessor) private instructionProcessor: InstructionProcessor
-  ) { }
+  ) {}
 
   public async processEvent(sessionId: string, event: IO.IncomingEvent): Promise<IO.IncomingEvent> {
     const botId = event.botId
@@ -96,6 +96,7 @@ export class DialogEngine {
 
     event.state.context.currentFlow = targetFlow.name
     event.state.context.currentNode = targetNode.name
+    event.state.context.queue = undefined
     event.state.context.hasJumped = true
   }
 

--- a/src/bp/core/services/dialog/instruction/strategy.ts
+++ b/src/bp/core/services/dialog/instruction/strategy.ts
@@ -84,9 +84,9 @@ export class ActionStrategy implements InstructionStrategy {
     args = {
       ...args,
       event,
-      user: _.get(event, 'state.user') || {},
-      session: _.get(event, 'state.session') || {},
-      temp: _.get(event, 'state.temp') || {}
+      user: _.get(event, 'state.user', {}),
+      session: _.get(event, 'state.session', {}),
+      temp: _.get(event, 'state.temp', {})
     }
 
     const eventDestination = _.pick(event, ['channel', 'target', 'botId', 'threadId'])
@@ -112,9 +112,9 @@ export class ActionStrategy implements InstructionStrategy {
 
     const actionArgs = {
       event,
-      user: _.get(event, 'state.user') || {},
-      session: _.get(event, 'state.session') || {},
-      temp: _.get(event, 'state.temp') || {}
+      user: _.get(event, 'state.user', {}),
+      session: _.get(event, 'state.session', {}),
+      temp: _.get(event, 'state.temp', {})
     }
 
     args = _.mapValues(args, value => renderRecursive(value, actionArgs))

--- a/src/bp/core/services/dialog/instruction/strategy.ts
+++ b/src/bp/core/services/dialog/instruction/strategy.ts
@@ -110,7 +110,14 @@ export class ActionStrategy implements InstructionStrategy {
       throw new Error(`Action "${actionName}" has invalid arguments (not a valid JSON string): ${argsStr}`)
     }
 
-    args = _.mapValues(args, value => renderRecursive(value, { event }))
+    const actionArgs = {
+      event,
+      user: _.get(event, 'state.user') || {},
+      session: _.get(event, 'state.session') || {},
+      temp: _.get(event, 'state.temp') || {}
+    }
+
+    args = _.mapValues(args, value => renderRecursive(value, actionArgs))
 
     const hasAction = await this.actionService.forBot(botId).hasAction(actionName)
     if (!hasAction) {

--- a/src/bp/core/services/hook/hook-service.ts
+++ b/src/bp/core/services/hook/hook-service.ts
@@ -95,7 +95,7 @@ export namespace Hooks {
 
     constructor(bp: typeof sdk, sessionId: string, event: IO.Event, suggestions: IO.Suggestion[]) {
       this.timeout = 1000
-      this.args = { bp, event, suggestions }
+      this.args = { bp, sessionId, event, suggestions }
       this.folder = 'before_suggestions_election'
     }
   }

--- a/src/bp/ui-studio/src/web/components/Layout/Sidebar.scss
+++ b/src/bp/ui-studio/src/web/components/Layout/Sidebar.scss
@@ -42,6 +42,7 @@
   a {
     text-decoration: none;
     padding: 0 15px;
+    white-space: nowrap;
 
     :global(.icon) {
       display: inline;


### PR DESCRIPTION
1. Schema was changed in NLU, so QNA needs to be also updated for insert/update
2. Fixes an issue when a flow is ongoing and you want to jump somewhere else, remaining transitions were still executed on the new flow
3. When starting the bot and talking with it, when an action is executed, the action service loads actions in cache without metadatas. .When editing the flow editor later, missing metadata crashes the flow editor / or displays empty actions
4. Variables in actions (ex: {{event.preview}} doesn't handle user, temp, etc. need to use full path currently