### PR TITLE
feat(core): migration for modules

### DIFF
--- a/docs/guide/website/versioned_docs/version-11.5.1/developers/create-module.md
+++ b/docs/guide/website/versioned_docs/version-11.5.1/developers/create-module.md
@@ -318,7 +318,14 @@ export default class Database {
 
 ### Migration
 
-Database migration isn't available at the moment, it should be added in a future iteration
+The method `bp.database.runMigrations` method can be used to run module-specific migrations.
+
+**Example**
+
+```js
+// NOTE: The path to module migration must be absolute path (to prevent errors)
+bp.database.runMigrations('moduleName', '/path/to/mod/migrations')
+```
 
 ### Knex extension
 

--- a/src/bp/common/knex.ts
+++ b/src/bp/common/knex.ts
@@ -14,4 +14,5 @@ export interface KnexExtension {
     returnColumns?: string | string[],
     idColumnName?: string
   ): Promise<T>
+  runMigrations(moduleName: string, directory: string): Promise<any>
 }

--- a/src/bp/core/database/helpers.ts
+++ b/src/bp/core/database/helpers.ts
@@ -143,6 +143,13 @@ export const patchKnex = (knex: Knex): Knex & KnexExtension => {
     get: obj => (isLite ? obj && JSON.parse(obj) : obj)
   }
 
+  const runMigrations = (moduleName, directory) => knex.migrate.latest({
+    directory,
+    tableName: `knex_${moduleName}_migrations`,
+    //@ts-ignore
+    loadExtensions: ['.js']
+  })
+
   const extensions: KnexExtension = {
     isLite,
     location,
@@ -151,7 +158,8 @@ export const patchKnex = (knex: Knex): Knex & KnexExtension => {
     json,
     bool,
     createTableIfNotExists,
-    insertAndRetrieve
+    insertAndRetrieve,
+    runMigrations
   }
 
   return Object.assign(knex, extensions)


### PR DESCRIPTION
@epaminond @slvnperron @allardy @EFF 

I've implemented migration for modules but I don't know where to write about it in docs. Could someone show me the place?

**Example of usage:**
```js
// Path to migrations folder must be absolute
bp.database.runMigrations('mod', path.resolve(__dirname, './migrations'))
```