### PR TITLE
feat(nlu): masking sensitive text for entities

### DIFF
--- a/docs/guide/docs/build/nlu.md
+++ b/docs/guide/docs/build/nlu.md
@@ -94,7 +94,8 @@ To enable debugging of the NLU module, make sure that `debugModeEnabled` is set 
 
 ##### Example of debugging message
 
-NLU Extraction 
+NLU Extraction
+
 ```js
 { text: 'they there bud',
   intent: 'hello',
@@ -114,6 +115,7 @@ Entity Extraction helps you extract and normalize known entities from phrases.
 Attached to NLU extraction, you will find an entities property which is an array of [System](#system-entities) and [Custom](#custom-entities) entities.
 
 #### Using entities
+
 You may access and use data by looking up the `event.nlu.entities` variable in your hooks, flow transitions or actions.
 
 ##### Example of extracted entity:
@@ -171,8 +173,8 @@ At the moment, Duckling is hosted on our remote servers. If you don't want your 
 
 ##### Example
 
-|             User said             |    Type    | Value |   Unit   |
-| :-------------------------------: | :--------: | :---: | :------: |
+|             User said             |    Type    | Value |  Unit   |
+| :-------------------------------: | :--------: | :---: | :-----: |
 | _"Add 5 lbs of sugar to my cart"_ | "quantity" |   5   | "pound" |
 
 ```js
@@ -203,9 +205,15 @@ An example of placeholder entity would be : Please tell **Sarah** that **she's l
 
 ### Custom Entities
 
-As of today we provide 2 types of custom entites: [pattern](#pattern-extraction) and [list](#list-extraction) entitites. To define a custom entity, head to the __Entity section__ of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on __create new entity__
+As of today we provide 2 types of custom entites: [pattern](#pattern-extraction) and [list](#list-extraction) entitites. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
 
 <img src="/docs/assets/nlu-create-entity.png">
+
+### Sensitive Informations
+
+Communication between users and bots are stored in the database, which means that sometimes personal informations (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
+
+When checked, the information will still be displayed in the chat window, but the sensitive information will be replaced by `*****` before being stored. The original value is still available from `event.nlu.entities`
 
 #### Pattern extraction
 
@@ -219,9 +227,9 @@ Given a Pattern Entity definition with `[A-Z]{3}-[0-9]{4}-[A-Z]{3}` as pattern:
 
 Extraction will go like:
 
-|             User said             |Type|Value|
-| :-------------------------------: | :---: | :-----------: |
-| _"Find product BHZ-1234-UYT"_ | "SKU" |"BHZ-1234-UYT"|
+|           User said           | Type  |     Value      |
+| :---------------------------: | :---: | :------------: |
+| _"Find product BHZ-1234-UYT"_ | "SKU" | "BHZ-1234-UYT" |
 
 ```js
 { name: 'SKU',
@@ -245,42 +253,46 @@ Extraction will go like:
 
 List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurences** of your entity with corresponding synonyms.
 
-Let's take __Airport Codes__ as an example:
+Let's take **Airport Codes** as an example:
 
 ![create slot](assets/nlu-list-entity.png)
 
 Extraction will go like:
 
-|             User said             |Type|Value|
-| :-------------------------------: | :---: | :-----------: |
-| _"Find a flight from SFO to Mumbai"_ | "Airport Codes" |["SFO", "BOM"]|
+|              User said               |      Type       |     Value      |
+| :----------------------------------: | :-------------: | :------------: |
+| _"Find a flight from SFO to Mumbai"_ | "Airport Codes" | ["SFO", "BOM"] |
 
 ```js
-[
-  { name: 'Airport Codes',
+;[
+  {
+    name: 'Airport Codes',
     type: 'list',
-    meta:
-    { confidence: 1,
+    meta: {
+      confidence: 1,
       provider: 'native',
       source: 'SFO',
       start: 19,
       end: 22,
-      raw: {} },
+      raw: {}
+    },
     data: {
       extras: {},
       value: 'SFO',
       unit: 'string'
     }
   },
-  { name: 'Airport Codes',
+  {
+    name: 'Airport Codes',
     type: 'list',
-    meta:
-    { confidence: 1,
+    meta: {
+      confidence: 1,
       provider: 'native',
       source: 'Mumbai',
       start: 26,
       end: 32,
-      raw: {} },
+      raw: {}
+    },
     data: {
       extras: {},
       value: 'BOM',
@@ -290,15 +302,15 @@ Extraction will go like:
 ]
 ```
 
-## Slots 
+## Slots
 
-Slots are another major concept in Botpress NLU. You can think of them as necessary __parameters__ to complete the action associated to an intent.
+Slots are another major concept in Botpress NLU. You can think of them as necessary **parameters** to complete the action associated to an intent.
 
 ### Slot Tagging
 
 Botpress Native NLU will tag each _words_ (tokens) of user input. If it's correctly identified as an intent slot it will be attached to NLU extraction event. Each identified slot will be accessible in the `event.nlu.slots` map using its name as key.
 
-To define a slot for a particular intent, head to the __Intent section__ of the Understanding Module in your Botpress Studio side bar. From there select the intent you want to add slots to, then you'll be able to define your slots. Go ahead and click on __create a slot__
+To define a slot for a particular intent, head to the **Intent section** of the Understanding Module in your Botpress Studio side bar. From there select the intent you want to add slots to, then you'll be able to define your slots. Go ahead and click on **create a slot**
 
 ![create slot](assets/nlu-create-slot.png)
 
@@ -311,6 +323,7 @@ Let's use a `find_flight` intent. In order to book a flight, we'll define 2 slot
 User said : `I would like to go to SFO from Mumbai`
 
 `event.nlu.slots` will look like
+
 ```js
 slots : {
   airport_to: {
@@ -328,10 +341,9 @@ slots : {
 
 ### Slot Filling
 
- As of now when you define an intent slot, it is considered as optional. If it's mandatory for a desired task, you'll have to handle slot filling yourself in your conversational flow design using [Botpress Flow Builder](/docs/build/dialogs). We plan to add suppport for __required slots__ with automatic slot filling.
+As of now when you define an intent slot, it is considered as optional. If it's mandatory for a desired task, you'll have to handle slot filling yourself in your conversational flow design using [Botpress Flow Builder](/docs/build/dialogs). We plan to add suppport for **required slots** with automatic slot filling.
 
- **TODO provide example**
-
+**TODO provide example**
 
 ## External NLU Providers
 
@@ -343,16 +355,16 @@ If for some reason you want to use an external provider, you can do so by using 
 
 ### Example
 
-You can enable **Recast AI** by removing the `.` prefix to the `hooks/before_incoming_middleware/.05_recast_nlu.js` file. 
+You can enable **Recast AI** by removing the `.` prefix to the `hooks/before_incoming_middleware/.05_recast_nlu.js` file.
 
 > Feel free to contribute to Botpress to add new external NLU providers
 
 ##### Features by Providers
 
 |  Provider  | Intent | Entity | Slot tagging | Lang | Context | Sentiment |
-| :--------: | :----: | :----: | :--: | :--: | :-----: | :--:   |
-|   Native   |   X    |   X    |  X   |  X   |         |    |
-| DialogFlow |   X    |   X    |  X   |      |    X    |    |
-|    Luis    |   X    |   X    |      |      |         |  X  |
-|   Recast   |   X    |   X    |      |  X   |         |  X |
-|   Rasa     |   X    |   X    |      |      |         |    |
+| :--------: | :----: | :----: | :----------: | :--: | :-----: | :-------: |
+|   Native   |   X    |   X    |      X       |  X   |         |           |
+| DialogFlow |   X    |   X    |      X       |      |    X    |           |
+|    Luis    |   X    |   X    |              |      |         |     X     |
+|   Recast   |   X    |   X    |              |  X   |         |     X     |
+|    Rasa    |   X    |   X    |              |      |         |           |

--- a/modules/nlu/src/backend/middleware.ts
+++ b/modules/nlu/src/backend/middleware.ts
@@ -28,6 +28,7 @@ export const registerMiddleware = async (bp: typeof sdk, botScopedNlu: EngineByB
       try {
         const metadata = await botCtx.extract(event)
         Object.assign(event, { nlu: metadata })
+        removeSensitiveText(event)
       } catch (err) {
         bp.logger.warn('Error extracting metadata for incoming text: ' + err.message)
       } finally {
@@ -35,4 +36,20 @@ export const registerMiddleware = async (bp: typeof sdk, botScopedNlu: EngineByB
       }
     }
   })
+
+  function removeSensitiveText(event) {
+    if (!event.nlu.entities || !event.payload.text) {
+      return
+    }
+
+    try {
+      const sensitiveEntities = event.nlu.entities.filter(ent => ent.sensitive)
+      for (const entity of sensitiveEntities) {
+        const stars = '*'.repeat(entity.data.value.length)
+        event.payload.text = event.payload.text.replace(entity.data.value, stars)
+      }
+    } catch (err) {
+      bp.logger.warn('Error removing sensitive informations: ' + err.message)
+    }
+  }
 }

--- a/modules/nlu/src/backend/pipelines/entities/pattern_extractor.ts
+++ b/modules/nlu/src/backend/pipelines/entities/pattern_extractor.ts
@@ -10,6 +10,7 @@ export const extractPatternEntities = (input: string, entityDefs: sdk.NLU.Entity
       return extractPattern(input, regex).map(res => ({
         name: entityDef.name,
         type: entityDef.type, // pattern
+        sensitive: entityDef.sensitive,
         meta: {
           confidence: 1, // pattern always has 1 confidence
           provider: 'native',
@@ -21,7 +22,7 @@ export const extractPatternEntities = (input: string, entityDefs: sdk.NLU.Entity
         data: {
           extras: {},
           value: res.value,
-          unit: 'string',
+          unit: 'string'
         }
       }))
     } catch (error) {
@@ -30,32 +31,32 @@ export const extractPatternEntities = (input: string, entityDefs: sdk.NLU.Entity
   })
 }
 
-const _extractEntitiesFromOccurence = (input: string, occurence: sdk.NLU.EntityDefOccurence, entityDef: sdk.NLU.EntityDefinition): sdk.NLU.Entity[] => {
-  const pattern = [
-    occurence.name,
-    ...occurence.synonyms
-  ].map(escapeRegex).join('|')
+const _extractEntitiesFromOccurence = (
+  input: string,
+  occurence: sdk.NLU.EntityDefOccurence,
+  entityDef: sdk.NLU.EntityDefinition
+): sdk.NLU.Entity[] => {
+  const pattern = [occurence.name, ...occurence.synonyms].map(escapeRegex).join('|')
 
   try {
     const regex = new RegExp(pattern, 'i')
-    return extractPattern(input, regex)
-      .map(extracted => ({
-        name: entityDef.name,
-        type: 'list',
-        meta: {
-          confidence: 1, // extrated with synonyme as patterns
-          provider: 'native',
-          source: extracted.value,
-          start: extracted.sourceIndex,
-          end: extracted.sourceIndex + extracted.value.length,
-          raw: {}
-        },
-        data: {
-          extras: {},
-          value: occurence.name, // cannonical value,
-          unit: 'string'
-        }
-      }))
+    return extractPattern(input, regex).map(extracted => ({
+      name: entityDef.name,
+      type: 'list',
+      meta: {
+        confidence: 1, // extrated with synonyme as patterns
+        provider: 'native',
+        source: extracted.value,
+        start: extracted.sourceIndex,
+        end: extracted.sourceIndex + extracted.value.length,
+        raw: {}
+      },
+      data: {
+        extras: {},
+        value: occurence.name, // cannonical value,
+        unit: 'string'
+      }
+    }))
   } catch (error) {
     throw Error(`Something is wrong with one of ${entityDef.name}'s occurence`)
   }
@@ -63,7 +64,7 @@ const _extractEntitiesFromOccurence = (input: string, occurence: sdk.NLU.EntityD
 
 export const extractListEntities = (input: string, entityDefs: sdk.NLU.EntityDefinition[]): sdk.NLU.Entity[] => {
   return flatMap(entityDefs, entityDef => {
-    return flatMap((entityDef.occurences || []), occurence => {
+    return flatMap(entityDef.occurences || [], occurence => {
       return _extractEntitiesFromOccurence(input, occurence, entityDef)
     })
   })

--- a/modules/nlu/src/backend/validation.ts
+++ b/modules/nlu/src/backend/validation.ts
@@ -33,6 +33,7 @@ export const EntityDefCreateSchema = Joi.object().keys({
   type: Joi.string()
     .valid(['system', 'pattern', 'list'])
     .required(),
+  sensitive: Joi.boolean(),
   occurences: Joi.array()
     .items(EntityDefOccurenceSchema)
     .default([]),

--- a/modules/nlu/src/views/entities/EntityEditor.jsx
+++ b/modules/nlu/src/views/entities/EntityEditor.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import style from './style.scss'
-import { ListGroupItem, Glyphicon, Label, FormControl } from 'react-bootstrap'
+import { ListGroupItem, Glyphicon, Label, FormControl, OverlayTrigger, Tooltip } from 'react-bootstrap'
 import _ from 'lodash'
 import { WithContext as ReactTags } from 'react-tag-input'
 import classNames from 'classnames'
@@ -25,7 +25,7 @@ export default class EntityEditor extends React.Component {
       return {
         currentEntity: props.entity,
         currentOccurence: props.entity.occurences && props.entity.occurences[0],
-        pattern: props.entity.pattern,
+        pattern: props.entity.pattern
       }
     } else if (props.entity === undefined) {
       return DEFAULT_STATE
@@ -162,32 +162,57 @@ export default class EntityEditor extends React.Component {
     }
   }
 
+  handleSensitiveChanged = event => {
+    const sensitive = event.target.checked
+
+    this.setState({ sensitive }, () => {
+      this.props.onUpdate({ ...this.state.currentEntity, sensitive })
+    })
+  }
+
   render() {
     const { currentEntity } = this.state
     return (
       <div className={style.container}>
         <div className={style.header}>
           <div>
-            {!currentEntity && <h1>No entities have been created yet</h1>}
+            <div style={{ display: 'inline-block' }}>
+              {!currentEntity && <h1>No entities have been created yet</h1>}
+              {currentEntity && (
+                <h1>
+                  entities /<span className={style.entity}>{this.state.currentEntity.name}</span>
+                </h1>
+              )}
+            </div>
             {currentEntity && (
-              <h1>
-                entities /
-                <span className={style.entity}>{this.state.currentEntity.name}</span>
-              </h1>
+              <div style={{ display: 'inline-block', float: 'right' }}>
+                <input type="checkbox" value={currentEntity.sensitive} onChange={this.handleSensitiveChanged} />{' '}
+                Sensitive
+                <OverlayTrigger
+                  placement="left"
+                  overlay={<Tooltip> Sensitive informations are replaced by * before saving in the database</Tooltip>}
+                >
+                  <Glyphicon glyph="question-sign" style={{ marginLeft: 10 }} />
+                </OverlayTrigger>
+              </div>
             )}
           </div>
         </div>
-        {
-          currentEntity && currentEntity.type === 'list' && this.renderOccurences()
-        }
-        {
-          currentEntity && currentEntity.type === 'pattern' && (
+        {currentEntity && currentEntity.type === 'list' && this.renderOccurences()}
+        {currentEntity &&
+          currentEntity.type === 'pattern' && (
             <div>
-              <FormControl tabIndex="1" autoFocus type="text" placeholder="Enter a valid pattern. Try: howdy[0-9]+" value={this.state.pattern} onChange={this.handlePatternChange} />
+              <FormControl
+                tabIndex="1"
+                autoFocus
+                type="text"
+                placeholder="Enter a valid pattern. Try: howdy[0-9]+"
+                value={this.state.pattern}
+                onChange={this.handlePatternChange}
+              />
               {!this.isPatternValid(this.state.pattern) && <Label bsStyle="danger">pattern invalid</Label>}
             </div>
-          )
-        }
+          )}
       </div>
     )
   }

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -243,6 +243,7 @@ declare module 'botpress/sdk' {
       id: string
       name: string
       type: EntityType
+      sensitive?: boolean
       occurences?: EntityDefOccurence[]
       pattern?: string
     }


### PR DESCRIPTION
Added a sensitive checkbox on the entities page. When enabled, entities will be replaced by *** in the payload text so it is not persisted in the database. The text is still visible for the user