### PR TITLE
fix(builtins): allow choices with 1 item

### DIFF
--- a/modules/basic-skills/src/views/choice.jsx
+++ b/modules/basic-skills/src/views/choice.jsx
@@ -54,7 +54,7 @@ export default class TemplateModule extends React.Component {
         keywords: this.state.keywords,
         config: this.state.config
       })
-    if (this.choices && this.choices.length > 1) {
+    if (this.choices && this.choices.length > 0) {
       this.props.onValidChanged && this.props.onValidChanged(true)
     }
   }


### PR DESCRIPTION
Skill-choice [can be created with 1 choice](https://github.com/botpress/botpress/blob/master/modules/builtin/src/content-types/single_choice.js#L52) but [can't be selected](https://github.com/botpress/botpress/blob/master/modules/basic-skills/src/views/choice.jsx#L57) in this case without any notices which is confusing.

I've made it possible to select this kind of choice. If this isn't wished behavior, I believe we should restrict creating choices with less than 2 items.