### PR TITLE
fix migrations crashing the app on startup

### DIFF
--- a/modules/nlu/yarn.lock
+++ b/modules/nlu/yarn.lock
@@ -2681,6 +2681,11 @@ hoek@5.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-5.0.4.tgz#0f7fa270a1cafeb364a4b2ddfaa33f864e4157da"
   integrity sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==
 
+hoek@6.x.x:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-6.1.2.tgz#99e6d070561839de74ee427b61aa476bd6bddfd6"
+  integrity sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q==
+
 hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
@@ -3070,6 +3075,15 @@ joi@13.x.x:
   integrity sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==
   dependencies:
     hoek "5.x.x"
+    isemail "3.x.x"
+    topo "3.x.x"
+
+joi@^14.3.1:
+  version "14.3.1"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-14.3.1.tgz#164a262ec0b855466e0c35eea2a885ae8b6c703c"
+  integrity sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==
+  dependencies:
+    hoek "6.x.x"
     isemail "3.x.x"
     topo "3.x.x"
 

--- a/src/bp/core/database/index.ts
+++ b/src/bp/core/database/index.ts
@@ -34,6 +34,7 @@ export default class Database {
       this.tables.push(table)
     })
 
+    // FIXME: Get migrations status and notify when DB is outdated instead of running migrations on startup.
     await this.runMigrations()
   }
 
@@ -83,12 +84,14 @@ export default class Database {
     await this.bootstrap()
   }
 
-  runMigrations() {
-    return this.knex.migrate.latest({
-      directory: path.resolve(__dirname, './migrations'),
-      tableName: 'knex_core_migrations',
-      // @ts-ignore
-      loadExtensions: ['.js']
-    })
+  runMigrations(): Promise<void> {
+    return this.knex.migrate
+      .latest({
+        directory: path.resolve(__dirname, './migrations'),
+        tableName: 'knex_core_migrations',
+        // @ts-ignore
+        loadExtensions: ['.js']
+      })
+      .then(() => this.logger.debug('Migrations done'))
   }
 }

--- a/src/bp/core/database/interfaces.ts
+++ b/src/bp/core/database/interfaces.ts
@@ -7,7 +7,7 @@ export abstract class Table {
   abstract get name(): string
 }
 
-export abstract class DatabaseMigration {
-  abstract up(knex: Knex): Promise<void>
-  abstract down(knex: Knex): Promise<void>
+export interface DatabaseMigration {
+  up(knex: Knex): Promise<void>
+  down(knex: Knex): Promise<void>
 }

--- a/src/bp/core/database/migrations/example.ts
+++ b/src/bp/core/database/migrations/example.ts
@@ -1,0 +1,11 @@
+import { DatabaseMigration } from '../interfaces'
+
+/**
+ * Necessary to force the Typescript Compiler to generate the migrations folder.
+ * Empty folders and hidden files are ignored by the tsc.
+ * This also doubles up as a migration template.
+ */
+export const migration: DatabaseMigration = {
+  up: async knex => {},
+  down: async knex => {}
+}


### PR DESCRIPTION
* TSC could not generate `migrations/` because it ignores empty folders and hidden files
* Knex.migrate could not read the up and down properties because `DatabaseMigration` class was wrapping them in a parent object.
* **FIXME**: I don't think we should run migrations on startup. We should have tasks for that. Gulp tasks to be exact.