### PR TITLE
fix(core): fix botconfig compilation

### DIFF
--- a/build/jsonschemas.js
+++ b/build/jsonschemas.js
@@ -26,5 +26,5 @@ module.exports = () => {
   }
 
   writeSchema('BotpressConfig', 'botpress.config.schema.json')
-  writeSchema('BotConfig', 'bot.config.schema.json')
+  writeSchema('BotConfigWriter', 'bot.config.schema.json')
 }


### PR DESCRIPTION
Without this fix I'm getting an error below while running `yarn build` on `11.5.x` branch.

```
[23:36:28] Error: type BotConfig not found
    at JsonSchemaGenerator.getSchemaForSymbol (/home/epaminond/private/projects/2015.08.08_keenethics/projects/botpress/botpress/node_modules/typescript-json-schema/typescript-json-schema.js:822:13)
    at Object.generateSchema (/home/epaminond/private/projects/2015.08.08_keenethics/projects/botpress/botpress/node_modules/typescript-json-schema/typescript-json-schema.js:1032:22)
    at writeSchema (/home/epaminond/private/projects/2015.08.08_keenethics/projects/botpress/botpress/build/jsonschemas.js:21:28)
    at module.exports (/home/epaminond/private/projects/2015.08.08_keenethics/projects/botpress/botpress/build/jsonschemas.js:32:3)
    at buildSchemas (/home/epaminond/private/projects/2015.08.08_keenethics/projects/botpress/botpress/build/gulp.core.js:57:3)
    at bound (domain.js:395:14)
    at runBound (domain.js:408:12)
    at asyncRunner (/home/epaminond/private/projects/2015.08.08_keenethics/projects/botpress/botpress/node_modules/async-done/index.js:55:18)
    at process._tickCallback (internal/process/next_tick.js:61:11)
```