### PR TITLE
Archive/10.x - Messenger Module - Fixing Attachments and User IDs

### DIFF
--- a/packages/channels/botpress-channel-messenger/src/db.js
+++ b/packages/channels/botpress-channel-messenger/src/db.js
@@ -38,7 +38,7 @@ function hasAttachment(url) {
     .where('url', url)
     .count('url as count')
     .then(ret => {
-      return ret && ret[0] && ret[0].count === 1
+      return ret && ret[0] && (ret[0].count === "1" || ret[0].count === 1)
     })
 }
 

--- a/packages/channels/botpress-channel-messenger/src/umm.js
+++ b/packages/channels/botpress-channel-messenger/src/umm.js
@@ -85,7 +85,7 @@ function processOutgoing({ event, blocName, instruction }) {
   // PRE-PROCESSING
   ////////
 
-  const optionsList = ['quick_replies', 'waitRead', 'waitDelivery', 'typing', 'tag', '__platformSpecific', 'on']
+  const optionsList = ['quick_replies', 'waitRead', 'waitDelivery', 'typing', 'tag', '__platformSpecific', 'on', 'isReusable', 'attachmentId']
 
   const options = _.pick(instruction, optionsList)
 

--- a/packages/channels/botpress-channel-messenger/src/users.js
+++ b/packages/channels/botpress-channel-messenger/src/users.js
@@ -3,8 +3,7 @@ const _ = require('lodash')
 module.exports = function(bp, messenger) {
   function profileToDbEntry(profile) {
     return {
-      id: /**'facebook:' + */ profile.id,
-      //userId: profile.id,
+      id: profile.id,
       platform: 'facebook',
       gender: profile.gender,
       timezone: profile.timezone,

--- a/packages/channels/botpress-channel-messenger/src/users.js
+++ b/packages/channels/botpress-channel-messenger/src/users.js
@@ -3,8 +3,8 @@ const _ = require('lodash')
 module.exports = function(bp, messenger) {
   function profileToDbEntry(profile) {
     return {
-      id: 'facebook:' + profile.id,
-      userId: profile.id,
+      id: /**'facebook:' + */ profile.id,
+      //userId: profile.id,
       platform: 'facebook',
       gender: profile.gender,
       timezone: profile.timezone,
@@ -24,7 +24,7 @@ module.exports = function(bp, messenger) {
       first_name: db.first_name,
       last_name: db.last_name,
       userId: db.userId,
-      id: 'facebook:' + db.userId
+      id: db.id
     };
   }
 


### PR DESCRIPTION
Both these fixes are very small, so added them to a single pull request.

---
**Issue:** Messenger UserId was prefixed with the facebook platform twice, and Id once. This is instead of the intended behavior of once and not prefixed. This meant that Messenger users could not be tagged.

**Resolution:** Messenger platform no-longer handles that responsibility, as Botpress already does it when the user profile is passed internally, hence the duplication.

 ---

**Issue:** Messenger was not storing media attachment_id for content reuse. This meant content such as video was being pulled from Botpress every-time instead of from the copy that Facebook already stored.

**Resolution:** 

- Messenger module now grabs the isReusable and attachementId argument to population it's options.
- Modules now correctly checks database for existing attachment_id. As Postgres database was returning count as a string, rather than a number. 