### PR TITLE
fix(single_choice): parse answer with nlu

### DIFF
--- a/modules/basic-skills/src/actions/choice_parse_answer.js
+++ b/modules/basic-skills/src/actions/choice_parse_answer.js
@@ -21,12 +21,12 @@ const validateChoice = async data => {
     choice = _.get(element, `formData.choices.${index}.value`)
   }
 
-  if (!choice && config.matchNLU && typeof _.get(event.nlu, 'intent.is') === 'function') {
+  if (!choice && config.matchNLU) {
     choice = _.findKey(data.keywords, keywords => {
       const intents = keywords
         .filter(x => x.toLowerCase().startsWith(INTENT_PREFIX))
         .map(x => x.substr(INTENT_PREFIX.length))
-      return _.some(intents, k => event.nlu.intent.is(k))
+      return _.some(intents, k => event.nlu.intent.name === k)
     })
   }
 


### PR DESCRIPTION
The `is` function is not defined in the intent given by the event, instead I just compared the name of the intent received by the event and if one of the parametrized intent names is equal, it matches