### PR TITLE
fix(nlu): disabling duckling when unreachable on server start

### DIFF
--- a/docs/guide/docs/build/nlu.md
+++ b/docs/guide/docs/build/nlu.md
@@ -169,7 +169,7 @@ Botpress Native NLU offers a handful of system entity extraction thanks to [Face
 
 At the moment, Duckling is hosted on our remote servers. If you don't want your data to be sent to our servers, you can either disable this feature by setting `ducklingEnabled` to `false` or host your own duckling server and change the `ducklingURL` to the `data/global/config/nlu.json` config file.
 
-**Note** We will eventually ship with a CLI version of duckling making it easy to enable it on your premise.
+For instructions on how to host your own Duckling server, please check the section [Hosting & Environment](../deploy/hosting)
 
 ##### Example
 

--- a/docs/guide/docs/deploy/hosting.md
+++ b/docs/guide/docs/deploy/hosting.md
@@ -236,6 +236,31 @@ sudo npm install -g pm2
 sudo pm2 startup
 ```
 
+## Using your own instance of Duckling
+
+We use Duckling to extract system entities (for example: time, email, sum of money, etc.). If your Botpress server can't access the internet or if you want to own your own server, there is a couple of steps that you need to follow. Those steps are different depending on your OS and are described below.
+
+When you have the duckling binary, simply edit the file `data/global/config/nlu.json` and set the parameter `ducklingURL` to where you run Duckling, for example, if it's on the same server as Botpress (and if you use the default port of 8000), you would set:
+
+```js
+{
+  ...
+  "ducklingURL": "http://localhost:8000"
+}
+```
+
+#### Linux and Mac users
+
+Duckling must be compiled to run correctly on your specific system. Therefore, you will need to install the software development tools and build it from source.
+Please follow the instructions on the [GitHub page of Duckling[(https://github.com/facebook/duckling)
+
+We may provide some binaries in the future for common OS
+
+#### Windows users
+
+If you run Botpress on windows, there is a zip file available [here](https://s3.amazonaws.com/botpress-binaries/tools/duckling/duckling-windows.zip).
+Simply double-click on run-duckling.bat (the bat file simply sets the code page of the console to UTF-8, then runs the executable). The folder `zoneinfo` includes the Olson timezones which are already available by default on other OS.
+
 ## Environment Variables
 
 Most of these variables can be set in the configuration file `data/global/botpress.config.json`. Infrastructure configuration (like the database, cluster mode, etc) aren't available in the configuration file, since they are required before the config is loaded.

--- a/modules/nlu/src/backend/engine.ts
+++ b/modules/nlu/src/backend/engine.ts
@@ -17,14 +17,14 @@ import { FastTextLanguageId } from './pipelines/language/ft_lid'
 import CRFExtractor from './pipelines/slots/crf_extractor'
 import { generateTrainingSequence } from './pipelines/slots/pre-processor'
 import Storage from './storage'
-import { EntityExtractor, LanguageIdentifier, Model, MODEL_TYPES, SlotExtractor } from './typings'
+import { Engine, EntityExtractor, LanguageIdentifier, Model, MODEL_TYPES, SlotExtractor } from './typings'
 
 const debug = DEBUG('nlu')
 const debugExtract = debug.sub('extract')
 const debugIntents = debugExtract.sub('intents')
 const debugEntities = debugExtract.sub('entities')
 
-export default class ScopedEngine {
+export default class ScopedEngine implements Engine {
   public readonly storage: Storage
   public confidenceTreshold: number = 0.7
 

--- a/modules/nlu/src/backend/index.ts
+++ b/modules/nlu/src/backend/index.ts
@@ -18,7 +18,7 @@ const onServerStarted = async (bp: typeof sdk) => {
   Storage.ghostProvider = (botId?: string) => (botId ? bp.ghost.forBot(botId) : bp.ghost.forGlobal())
 
   const globalConfig = (await bp.config.getModuleConfig('nlu')) as Config
-  DucklingEntityExtractor.configure(globalConfig.ducklingEnabled, globalConfig.ducklingURL)
+  await DucklingEntityExtractor.configure(globalConfig.ducklingEnabled, globalConfig.ducklingURL, bp.logger)
 
   await registerMiddleware(bp, nluByBot)
 }

--- a/modules/nlu/src/backend/typings.ts
+++ b/modules/nlu/src/backend/typings.ts
@@ -28,7 +28,7 @@ export type EngineByBot = { [botId: string]: Engine }
 export interface Engine {
   sync(forceRetrain: boolean): Promise<string>
   checkSyncNeeded(): Promise<boolean>
-  extract(text: string): Promise<sdk.IO.EventUnderstanding>
+  extract(text: string, includedContexts: string[]): Promise<sdk.IO.EventUnderstanding>
 }
 
 export interface EntityExtractor {


### PR DESCRIPTION
Would prevent some cases I see in the community forum where users don't understand why the server can't answer basic questions. 

Real basic, simply checks if the server is reachable & answers correctly before enabling it.

![image](https://user-images.githubusercontent.com/42552874/54695850-1ae86880-4b01-11e9-884a-fcbf7da70668.png)
![image](https://user-images.githubusercontent.com/42552874/54695863-20de4980-4b01-11e9-83ec-281145e5341f.png)
