### PR TITLE
fix(diagram): fix link recreating itself when moving after deletion

### DIFF
--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.jsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.jsx
@@ -450,7 +450,7 @@ export default class FlowBuilder extends Component {
           _.includes(['standard', 'skill-call'], element.type)
         ) {
           this.props.removeFlowNode(element.id)
-        } else if (element.linkType === 'default') {
+        } else if (element.type === 'default') {
           element.remove()
           this.checkForLinksUpdate()
         } else {


### PR DESCRIPTION
Minor fix for an annoying bug, where the links recreate themselves when you move the node right after deleting the link