### PR TITLE
fix(webchat): botName and enableReset options (resolve #1572)

### DIFF
--- a/docs/guide/docs/tutorials/webchat-embedding.md
+++ b/docs/guide/docs/tutorials/webchat-embedding.md
@@ -48,7 +48,6 @@ window.botpressWebChat.init({
   botId: '<botId>', //The ID for your bot
   botName: 'Bot', // Name of your bot
   botAvatarUrl: null, // Default avatar URL of the image (e.g., 'https://avatars3.githubusercontent.com/u/1315508?v=4&s=400' )
-  botConvoTitle: 'Technical Support', // Title of the first conversation with the bot
   botConvoDescription: '',
   backgroundColor: '#ffffff', // Color of the background
   textColorOnBackground: '#666666', // Color of the text on the background
@@ -61,11 +60,12 @@ window.botpressWebChat.init({
   enableArrowNavigation: false, //Whether or to to support arrow navigation (e.g scroll conversation, focus on buttons)
   externalAuthToken: 'my jwt token', // Defines a token that is sent with each messages to Botpress
   userId: null, // Allows you to override the default user id. Make sure it is not possible to guess it!
+  enableReset: false, // Whether or not reset button will be shown to the user
   extraStylesheet: '/assets/modules/channel-web/examples/my-theme.css' // Define a custom style sheet to override Botpress styling
 })
 ```
 
-There is an example on how to customize the web chat with your custom CSS bundled with your default Botpress installation. Start the server, then head over to `http://localhost:3000/assets/modules/channel-web/examples/styled-webchat.html` for an example.
+There is an example on how to customize the web chat with your custom CSS bundled with your default Botpress installation. Start the server, then head over to `http://localhost:3000/assets/modules/channel-web/examples/styled-webchat.html` for an example. You can also check example [sources at the github](https://github.com/botpress/botpress/tree/master/modules/channel-web/assets/examples).
 
 ## Advanced
 

--- a/modules/channel-web/src/views/full/index.jsx
+++ b/modules/channel-web/src/views/full/index.jsx
@@ -18,7 +18,7 @@ export class WebBotpressUIInjection extends React.Component {
     script.onload = () =>
       window.botpressWebChat.init({
         hideWidget: true,
-        botConvoTitle: 'Bot Emulator',
+        botName: 'Bot Emulator',
         botConvoDescription: 'Test your bot live',
         enableReset: true,
         enableTranscriptDownload: true,

--- a/modules/channel-web/src/views/lite/main.jsx
+++ b/modules/channel-web/src/views/lite/main.jsx
@@ -38,7 +38,7 @@ const defaultOptions = {
   textColorOnBackground: '#666666',
   foregroundColor: '#000000',
   textColorOnForeground: '#ffffff',
-  enableReset: false,
+  enableReset: true,
   extraStylesheet: '',
   showConversationsButton: true,
   showUserName: false,

--- a/modules/channel-web/src/views/lite/side/header.jsx
+++ b/modules/channel-web/src/views/lite/side/header.jsx
@@ -58,7 +58,7 @@ class Header extends React.Component {
   }
 
   renderTitle = () => {
-    const title = this.props.showConvos ? 'Conversations' : this.props.botInfo.name || this.props.config.botName
+    const title = this.props.showConvos ? 'Conversations' : this.props.config.botName || this.props.botInfo.name
     const description = this.props.config.botConvoDescription
     const hasDescription = description && description.length > 0
 
@@ -77,7 +77,7 @@ class Header extends React.Component {
     return (
       !this.props.showConvos &&
       !this.props.showBotInfo &&
-      this.props.config && (
+      this.props.config.enableReset && (
         <span
           tabIndex="-1"
           ref={el => (this.btnEls[0] = el)}


### PR DESCRIPTION
* `botConvoTitle` isn't used - so I removed it
* `enableReset` wasn't working - so I fixed it
* `botInfo.name` took priority over `config.botName` which didn't make sense: `config.botName` would never apply, changed it to be vice versa