### PR TITLE
fix(core): fix returning to previous flow

### DIFF
--- a/src/bp/core/services/dialog/dialog-engine.ts
+++ b/src/bp/core/services/dialog/dialog-engine.ts
@@ -188,8 +188,13 @@ export class DialogEngine {
         currentFlow: flow.name,
         currentNode: startNode.name,
         // We keep a reference of the previous flow so we can return to it later on.
+        // TODO: drop previousFlow/previousNode in favor of jumpPoints
         previousFlow: event.state.context.currentFlow,
-        previousNode: event.state.context.currentNode
+        previousNode: event.state.context.currentNode,
+        jumpPoints: [...event.state.context.jumpPoints, {
+          flow: event.state.context.currentFlow,
+          node: event.state.context.currentNode
+        }]
       }
 
       this._logEnterFlow(
@@ -202,14 +207,16 @@ export class DialogEngine {
       )
     } else if (transitionTo.indexOf('#') === 0) {
       // Return to the parent node (coming from a flow)
-      const parentFlow = this._findFlow(event.botId, event.state.context.previousFlow!)
+      const jumpPoints = event.state.context.jumpPoints
+      const prevJumpPoint = jumpPoints.pop()
+      const parentFlow = this._findFlow(event.botId, prevJumpPoint.flow)
       const specificNode = transitionTo.split('#')[1]
       let parentNode
 
       if (specificNode) {
         parentNode = this._findNode(event.botId, parentFlow, specificNode)
       } else {
-        parentNode = this._findNode(event.botId, parentFlow, event.state.context.previousNode!)
+        parentNode = this._findNode(event.botId, parentFlow, prevJumpPoint.node)
       }
 
       const builder = new InstructionsQueueBuilder(parentNode, parentFlow)
@@ -219,6 +226,7 @@ export class DialogEngine {
         ...context,
         currentNode: parentNode.name,
         currentFlow: parentFlow.name,
+        jumpPoints,
         queue
       }
 
@@ -264,7 +272,11 @@ export class DialogEngine {
       currentFlow: subflow.name,
       currentNode: subflowStartNode.name,
       previousFlow: parentFlow.name,
-      previousNode: parentNode.name
+      previousNode: parentNode.name,
+      jumpPoints: [...(event.state.context.jumpPoints || []), {
+        flow: parentFlow.name,
+        node: parentNode.name
+      }]
     }
 
     return this.processEvent(sessionId, event)

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -463,6 +463,13 @@ declare module 'botpress/sdk' {
       context: DialogContext
     }
 
+    export interface JumpPoint {
+      /** The name of the previous flow to return to when we exit a subflow */
+      flow: string
+      /** The name of the previous node to return to when we exit a subflow */
+      node: string
+    }
+
     export interface DialogContext {
       /** The name of the previous flow to return to when we exit a subflow */
       previousFlow?: string
@@ -472,6 +479,8 @@ declare module 'botpress/sdk' {
       currentNode?: string
       /** The name of the current active flow */
       currentFlow?: string
+      /** An array of jump-points to return when we exit subflow */
+      jumpPoints?: JumpPoint[]
       /** The instructions queue to be processed by the dialog engine */
       queue?: any
       /**


### PR DESCRIPTION
An issue was that `previousFlow` didn't have correct value in case current flow had a skill-choice.
This wouldn't work even without skill-choice in case you had more than 1 jump-points: only last one gets saved.

`previousFlow` was just a string so it only contained last "previous" flow. What I tried to do is to implement `jumpPoints` array that would keep a track of all flows/nodes where transitioned occurred to be able to jump back later.

I believe `previousFlow` and `previousNode` could be dropped later on, but the logic with them is quite tricky due to multiple reassignments.