### PR TITLE
Use the correct json path so outgoing/bot messages are saved to the db

### DIFF
--- a/modules/analytics/src/backend/db.ts
+++ b/modules/analytics/src/backend/db.ts
@@ -59,7 +59,7 @@ export default class AnalyticsDb {
     const interactionRow = {
       ts: this.knex.date.now(),
       type: event.type,
-      text: event.text,
+      text: event.payload.text,
       channel: event.channel,
       user_id: event.target,
       direction: 'out'


### PR DESCRIPTION
This commit relates to an issue I raised on the community site a while back that I thought was being taken care of by someone else:

https://help.botpress.io/t/persisting-the-conversation-of-a-json-channel-chat/1022/3

I spotted this today after updating my production server to use postgres and discovered that the text of the bot messages were still empty in the analytics_interactions table.