### PR TITLE
fix(users): attributes were overwritten when updating

### DIFF
--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -116,10 +116,8 @@ export default async (bp: typeof sdk, db: Database) => {
       }
 
       await bp.users.getOrCreateUser('web', userId) // Create the user if it doesn't exist
-
       const payload = req.body || {}
-      const { timezone } = payload
-      const isValidTimezone = _.isNumber(timezone) && timezone >= -12 && timezone <= 14 && timezone % 0.5 === 0
+
       let { conversationId = undefined } = req.query || {}
       conversationId = conversationId && parseInt(conversationId)
 
@@ -133,8 +131,17 @@ export default async (bp: typeof sdk, db: Database) => {
         return res.status(400).send(ERR_MSG_TYPE)
       }
 
-      if (timezone && isValidTimezone) {
-        await bp.users.updateAttributes('web', userId, { timezone })
+      if (payload.type === 'visit') {
+        const { timezone } = payload
+        const isValidTimezone = _.isNumber(timezone) && timezone >= -12 && timezone <= 14 && timezone % 0.5 === 0
+
+        const newAttributes = {
+          ...(isValidTimezone && { timezone })
+        }
+
+        if (Object.getOwnPropertyNames(newAttributes).length) {
+          await bp.users.updateAttributes('web', userId, newAttributes)
+        }
       }
 
       if (!conversationId) {

--- a/src/bp/core/api.ts
+++ b/src/bp/core/api.ts
@@ -117,6 +117,7 @@ const users = (userRepo: UserRepository): typeof sdk.users => {
   return {
     getOrCreateUser: userRepo.getOrCreate.bind(userRepo),
     updateAttributes: userRepo.updateAttributes.bind(userRepo),
+    setAttributes: userRepo.setAttributes.bind(userRepo),
     getAllUsers: userRepo.getAllUsers.bind(userRepo),
     getUserCount: userRepo.getUserCount.bind(userRepo)
   }

--- a/src/bp/core/repositories/users.ts
+++ b/src/bp/core/repositories/users.ts
@@ -7,7 +7,8 @@ import Database from '../database'
 import { TYPES } from '../types'
 export interface UserRepository {
   getOrCreate(channel: string, id: string): Knex.GetOrCreateResult<User>
-  updateAttributes(channel: string, id: string, attributes: any, overwrite?: boolean): Promise<void>
+  updateAttributes(channel: string, id: string, attributes: any): Promise<void>
+  setAttributes(channel: string, id: string, attributes: any): Promise<void>
   getAllUsers(paging?: Paging): Promise<any>
   getUserCount(): Promise<any>
 }
@@ -81,23 +82,33 @@ export class KnexUserRepository implements UserRepository {
     return this.database.knex.json.get(user.attributes)
   }
 
-  async updateAttributes(channel: string, user_id: string, attributes: any, overwrite?: boolean): Promise<void> {
+  async setAttributes(channel: string, user_id: string, attributes: any): Promise<void> {
     channel = channel.toLowerCase()
-
-    if (this.dataRetentionService.hasPolicy()) {
-      const originalAttributes = await this.getAttributes(channel, user_id)
-      await this.dataRetentionService.updateExpirationForChangedFields(channel, user_id, originalAttributes, attributes)
-    }
-
-    if (!overwrite) {
-      const originalAttributes = await this.getAttributes(channel, user_id)
-      attributes = { ...originalAttributes, ...attributes }
-    }
+    await this._dataRetentionUpdate(channel, user_id, attributes)
 
     await this.database
       .knex(this.tableName)
       .update({ attributes: this.database.knex.json.set(attributes) })
       .where({ channel, user_id })
+  }
+
+  async updateAttributes(channel: string, user_id: string, attributes: any): Promise<void> {
+    channel = channel.toLowerCase()
+    await this._dataRetentionUpdate(channel, user_id, attributes)
+
+    const originalAttributes = await this.getAttributes(channel, user_id)
+
+    await this.database
+      .knex(this.tableName)
+      .update({ attributes: this.database.knex.json.set({ ...originalAttributes, ...attributes }) })
+      .where({ channel, user_id })
+  }
+
+  private async _dataRetentionUpdate(channel: string, user_id: string, attributes: any) {
+    if (this.dataRetentionService.hasPolicy()) {
+      const originalAttributes = await this.getAttributes(channel, user_id)
+      await this.dataRetentionService.updateExpirationForChangedFields(channel, user_id, originalAttributes, attributes)
+    }
   }
 
   async getAllUsers(paging?: Paging) {

--- a/src/bp/core/services/middleware/state-manager.ts
+++ b/src/bp/core/services/middleware/state-manager.ts
@@ -46,7 +46,7 @@ export class StateManager {
     const { user, context, session, temp } = event.state
     const sessionId = SessionIdFactory.createIdFromEvent(event)
 
-    await this.userRepo.updateAttributes(event.channel, event.target, _.omitBy(user, _.isNil))
+    await this.userRepo.updateAttributes(event.channel, event.target, _.omitBy(user, _.isNil), true)
 
     // Take last 5 messages only
     if (session && session.lastMessages) {

--- a/src/bp/core/services/middleware/state-manager.ts
+++ b/src/bp/core/services/middleware/state-manager.ts
@@ -46,7 +46,7 @@ export class StateManager {
     const { user, context, session, temp } = event.state
     const sessionId = SessionIdFactory.createIdFromEvent(event)
 
-    await this.userRepo.updateAttributes(event.channel, event.target, _.omitBy(user, _.isNil), true)
+    await this.userRepo.setAttributes(event.channel, event.target, _.omitBy(user, _.isNil))
 
     // Take last 5 messages only
     if (session && session.lastMessages) {

--- a/src/bp/core/services/retention/janitor.ts
+++ b/src/bp/core/services/retention/janitor.ts
@@ -43,7 +43,7 @@ export class DataRetentionJanitor extends Janitor {
       await Promise.mapSeries(expired, async ({ channel, user_id, field_path }) => {
         const { result: user } = await this.userRepo.getOrCreate(channel, user_id)
 
-        await this.userRepo.updateAttributes(channel, user.id, _.omit(user.attributes, field_path), true)
+        await this.userRepo.setAttributes(channel, user.id, _.omit(user.attributes, field_path))
         await this.dataRetentionService.delete(channel, user_id, field_path)
       })
 

--- a/src/bp/core/services/retention/janitor.ts
+++ b/src/bp/core/services/retention/janitor.ts
@@ -43,7 +43,7 @@ export class DataRetentionJanitor extends Janitor {
       await Promise.mapSeries(expired, async ({ channel, user_id, field_path }) => {
         const { result: user } = await this.userRepo.getOrCreate(channel, user_id)
 
-        await this.userRepo.updateAttributes(channel, user.id, _.omit(user.attributes, field_path))
+        await this.userRepo.updateAttributes(channel, user.id, _.omit(user.attributes, field_path), true)
         await this.dataRetentionService.delete(channel, user_id, field_path)
       })
 

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -1016,15 +1016,14 @@ declare module 'botpress/sdk' {
     export function getOrCreateUser(channel: string, userId: string): GetOrCreateResult<User>
 
     /**
-     * Update attributes of a specific user.
-     * If overwrite is set, the whole user's attributes will be overwritten with the given payload. Otherwise, it will only merge them
+     * Merge the specified attributes to the existing attributes of the user
      */
-    export function updateAttributes(
-      channel: string,
-      userId: string,
-      attributes: any,
-      overwrite?: boolean
-    ): Promise<void>
+    export function updateAttributes(channel: string, userId: string, attributes: any): Promise<void>
+
+    /**
+     * Overwrite all the attributes of the user with the specified payload
+     */
+    export function setAttributes(channel: string, userId: string, attributes: any): Promise<void>
     export function getAllUsers(paging?: Paging): Promise<any>
     export function getUserCount(): Promise<any>
   }

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -1016,9 +1016,15 @@ declare module 'botpress/sdk' {
     export function getOrCreateUser(channel: string, userId: string): GetOrCreateResult<User>
 
     /**
-     * Update attributes of a specific user
+     * Update attributes of a specific user.
+     * If overwrite is set, the whole user's attributes will be overwritten with the given payload. Otherwise, it will only merge them
      */
-    export function updateAttributes(channel: string, userId: string, attributes: any): Promise<void>
+    export function updateAttributes(
+      channel: string,
+      userId: string,
+      attributes: any,
+      overwrite?: boolean
+    ): Promise<void>
     export function getAllUsers(paging?: Paging): Promise<any>
     export function getUserCount(): Promise<any>
   }


### PR DESCRIPTION
Attributes were getting overwritten when the timezone was set in channel web. This change makes the updateAttributes method act like a merge, with an optional property to replace them. 