### PR TITLE
Hot-Reloading of modules

### DIFF
--- a/modules/analytics/src/backend/index.ts
+++ b/modules/analytics/src/backend/index.ts
@@ -31,8 +31,8 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
 }
 
 const onModuleUnmount = async (bp: typeof sdk) => {
-  bp.events.unregisterMiddleware('analytics.incoming')
-  bp.events.unregisterMiddleware('analytics.outgoing')
+  bp.events.removeMiddleware('analytics.incoming')
+  bp.events.removeMiddleware('analytics.outgoing')
   bp.http.deleteRouterForBot('analytics')
 }
 

--- a/modules/analytics/src/backend/index.ts
+++ b/modules/analytics/src/backend/index.ts
@@ -1,5 +1,5 @@
 import 'bluebird-global'
-import { SDK } from 'botpress'
+import * as sdk from 'botpress'
 import _ from 'lodash'
 
 import Analytics from './analytics'
@@ -11,30 +11,36 @@ const analyticsByBot: AnalyticsByBot = {}
 
 const interactionsToTrack = ['message', 'text', 'button', 'template', 'quick_reply', 'postback']
 
-const onServerStarted = async (bp: SDK) => {
+const onServerStarted = async (bp: typeof sdk) => {
   await setup(bp, interactionsToTrack)
 }
 
-const onServerReady = async (bp: SDK) => {
+const onServerReady = async (bp: typeof sdk) => {
   await api(bp, analyticsByBot)
 }
 
-const onBotMount = async (bp: SDK, botId: string) => {
+const onBotMount = async (bp: typeof sdk, botId: string) => {
   const analytics = new Analytics(bp, botId)
   analyticsByBot[botId] = analytics
   await analytics.start()
 }
 
-const onBotUnmount = async (bp: SDK, botId: string) => {
+const onBotUnmount = async (bp: typeof sdk, botId: string) => {
   await analyticsByBot[botId].stop()
   delete analyticsByBot[botId]
 }
 
-const entryPoint: SDK.ModuleEntryPoint = {
+const onModuleUnmount = async (bp: typeof sdk) => {
+  bp.events.unregisterMiddleware('analytics.incoming')
+  bp.events.unregisterMiddleware('analytics.outgoing')
+}
+
+const entryPoint: sdk.ModuleEntryPoint = {
   onServerStarted,
   onServerReady,
   onBotMount,
   onBotUnmount,
+  onModuleUnmount,
   definition: {
     name: 'analytics',
     fullName: 'Analytics',

--- a/modules/analytics/src/backend/index.ts
+++ b/modules/analytics/src/backend/index.ts
@@ -33,6 +33,7 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
 const onModuleUnmount = async (bp: typeof sdk) => {
   bp.events.unregisterMiddleware('analytics.incoming')
   bp.events.unregisterMiddleware('analytics.outgoing')
+  bp.http.deleteRouterForBot('analytics')
 }
 
 const entryPoint: sdk.ModuleEntryPoint = {

--- a/modules/basic-skills/src/backend/index.ts
+++ b/modules/basic-skills/src/backend/index.ts
@@ -15,6 +15,10 @@ const onServerReady = async (bp: SDK) => {
   await choice.setup(bp)
 }
 
+const onModuleUnmount = async (bp: typeof sdk) => {
+  bp.http.deleteRouterForBot('basic-skills')
+}
+
 const skillsToRegister: sdk.Skill[] = [
   {
     id: 'choice',
@@ -31,6 +35,7 @@ const skillsToRegister: sdk.Skill[] = [
 const entryPoint: sdk.ModuleEntryPoint = {
   onServerStarted,
   onServerReady,
+  onModuleUnmount,
   definition: {
     name: 'basic-skills',
     menuIcon: 'fiber_smart_record',

--- a/modules/channel-messenger/src/backend/index.ts
+++ b/modules/channel-messenger/src/backend/index.ts
@@ -25,7 +25,7 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
 }
 
 const onModuleUnmount = async (bp: typeof sdk) => {
-  bp.events.unregisterMiddleware('messenger.sendMessages')
+  bp.events.removeMiddleware('messenger.sendMessages')
   bp.http.deleteRouterForBot('channel-messenger')
 }
 

--- a/modules/channel-messenger/src/backend/index.ts
+++ b/modules/channel-messenger/src/backend/index.ts
@@ -26,6 +26,7 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
 
 const onModuleUnmount = async (bp: typeof sdk) => {
   bp.events.unregisterMiddleware('messenger.sendMessages')
+  bp.http.deleteRouterForBot('channel-messenger')
 }
 
 const entryPoint: sdk.ModuleEntryPoint = {

--- a/modules/channel-messenger/src/backend/index.ts
+++ b/modules/channel-messenger/src/backend/index.ts
@@ -24,11 +24,16 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
   await service.unmountBot(botId)
 }
 
+const onModuleUnmount = async (bp: typeof sdk) => {
+  bp.events.unregisterMiddleware('messenger.sendMessages')
+}
+
 const entryPoint: sdk.ModuleEntryPoint = {
   onServerReady,
   onServerStarted,
-  onBotMount: onBotMount,
-  onBotUnmount: onBotUnmount,
+  onBotMount,
+  onBotUnmount,
+  onModuleUnmount,
   definition: {
     name: 'channel-messenger',
     noInterface: true,

--- a/modules/channel-telegram/src/backend/index.ts
+++ b/modules/channel-telegram/src/backend/index.ts
@@ -35,11 +35,16 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
   delete clients[botId]
 }
 
+const onModuleUnmount = async (bp: typeof sdk) => {
+  bp.events.unregisterMiddleware('telegram.sendMessages')
+}
+
 const entryPoint: sdk.ModuleEntryPoint = {
   onServerStarted,
   onServerReady,
   onBotMount,
   onBotUnmount,
+  onModuleUnmount,
   definition: {
     name: 'channel-telegram',
     menuIcon: 'none', // no interface = true

--- a/modules/channel-telegram/src/backend/index.ts
+++ b/modules/channel-telegram/src/backend/index.ts
@@ -36,7 +36,7 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
 }
 
 const onModuleUnmount = async (bp: typeof sdk) => {
-  bp.events.unregisterMiddleware('telegram.sendMessages')
+  bp.events.removeMiddleware('telegram.sendMessages')
 }
 
 const entryPoint: sdk.ModuleEntryPoint = {

--- a/modules/channel-web/src/backend/index.ts
+++ b/modules/channel-web/src/backend/index.ts
@@ -15,9 +15,14 @@ const onServerStarted = async (bp: typeof sdk) => {
 
 const onServerReady = async (bp: typeof sdk) => {}
 
+const onModuleUnmount = async (bp: typeof sdk) => {
+  bp.events.unregisterMiddleware('web.sendMessages')
+}
+
 const entryPoint: sdk.ModuleEntryPoint = {
   onServerStarted,
   onServerReady,
+  onModuleUnmount,
   definition: {
     name: 'channel-web',
     menuIcon: 'chrome_reader_mode',

--- a/modules/channel-web/src/backend/index.ts
+++ b/modules/channel-web/src/backend/index.ts
@@ -17,6 +17,7 @@ const onServerReady = async (bp: typeof sdk) => {}
 
 const onModuleUnmount = async (bp: typeof sdk) => {
   bp.events.unregisterMiddleware('web.sendMessages')
+  bp.http.deleteRouterForBot('channel-web')
 }
 
 const entryPoint: sdk.ModuleEntryPoint = {

--- a/modules/channel-web/src/backend/index.ts
+++ b/modules/channel-web/src/backend/index.ts
@@ -16,7 +16,7 @@ const onServerStarted = async (bp: typeof sdk) => {
 const onServerReady = async (bp: typeof sdk) => {}
 
 const onModuleUnmount = async (bp: typeof sdk) => {
-  bp.events.unregisterMiddleware('web.sendMessages')
+  bp.events.removeMiddleware('web.sendMessages')
   bp.http.deleteRouterForBot('channel-web')
 }
 

--- a/modules/hitl/src/backend/index.ts
+++ b/modules/hitl/src/backend/index.ts
@@ -23,9 +23,15 @@ const onServerReady = async (bp: SDK) => {
   await api(bp, db)
 }
 
+const onModuleUnmount = async (bp: typeof sdk) => {
+  bp.events.unregisterMiddleware('hitl.captureInMessages')
+  bp.events.unregisterMiddleware('hitl.captureOutMessages')
+}
+
 const entryPoint: sdk.ModuleEntryPoint = {
   onServerStarted,
   onServerReady,
+  onModuleUnmount,
   definition: {
     name: 'hitl',
     menuIcon: 'feedback',

--- a/modules/hitl/src/backend/index.ts
+++ b/modules/hitl/src/backend/index.ts
@@ -24,8 +24,8 @@ const onServerReady = async (bp: SDK) => {
 }
 
 const onModuleUnmount = async (bp: typeof sdk) => {
-  bp.events.unregisterMiddleware('hitl.captureInMessages')
-  bp.events.unregisterMiddleware('hitl.captureOutMessages')
+  bp.events.removeMiddleware('hitl.captureInMessages')
+  bp.events.removeMiddleware('hitl.captureOutMessages')
   bp.http.deleteRouterForBot('hitl')
 }
 

--- a/modules/hitl/src/backend/index.ts
+++ b/modules/hitl/src/backend/index.ts
@@ -26,6 +26,7 @@ const onServerReady = async (bp: SDK) => {
 const onModuleUnmount = async (bp: typeof sdk) => {
   bp.events.unregisterMiddleware('hitl.captureInMessages')
   bp.events.unregisterMiddleware('hitl.captureOutMessages')
+  bp.http.deleteRouterForBot('hitl')
 }
 
 const entryPoint: sdk.ModuleEntryPoint = {

--- a/modules/nlu/src/backend/index.ts
+++ b/modules/nlu/src/backend/index.ts
@@ -39,11 +39,16 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
   delete nluByBot[botId]
 }
 
+const onModuleUnmount = async (bp: typeof sdk) => {
+  bp.events.unregisterMiddleware('nlu.incoming')
+}
+
 const entryPoint: sdk.ModuleEntryPoint = {
   onServerStarted,
   onServerReady,
   onBotMount,
   onBotUnmount,
+  onModuleUnmount,
   definition: {
     name: 'nlu',
     moduleView: {

--- a/modules/nlu/src/backend/index.ts
+++ b/modules/nlu/src/backend/index.ts
@@ -40,7 +40,7 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
 }
 
 const onModuleUnmount = async (bp: typeof sdk) => {
-  bp.events.unregisterMiddleware('nlu.incoming')
+  bp.events.removeMiddleware('nlu.incoming')
   bp.http.deleteRouterForBot('nlu')
 }
 

--- a/modules/nlu/src/backend/index.ts
+++ b/modules/nlu/src/backend/index.ts
@@ -41,6 +41,7 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
 
 const onModuleUnmount = async (bp: typeof sdk) => {
   bp.events.unregisterMiddleware('nlu.incoming')
+  bp.http.deleteRouterForBot('nlu')
 }
 
 const entryPoint: sdk.ModuleEntryPoint = {

--- a/modules/qna/src/backend/index.ts
+++ b/modules/qna/src/backend/index.ts
@@ -25,6 +25,7 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
 
 const onModuleUnmount = async (bp: typeof sdk) => {
   bp.events.unregisterMiddleware('qna.incoming')
+  bp.http.deleteRouterForBot('qna')
 }
 
 const onFlowChanged = async (bp: typeof sdk, botId: string, newFlow: sdk.Flow) => {

--- a/modules/qna/src/backend/index.ts
+++ b/modules/qna/src/backend/index.ts
@@ -24,7 +24,7 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
 }
 
 const onModuleUnmount = async (bp: typeof sdk) => {
-  bp.events.unregisterMiddleware('qna.incoming')
+  bp.events.removeMiddleware('qna.incoming')
   bp.http.deleteRouterForBot('qna')
 }
 

--- a/modules/qna/src/backend/index.ts
+++ b/modules/qna/src/backend/index.ts
@@ -23,6 +23,10 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
   botScopedStorage.delete(botId)
 }
 
+const onModuleUnmount = async (bp: typeof sdk) => {
+  bp.events.unregisterMiddleware('qna.incoming')
+}
+
 const onFlowChanged = async (bp: typeof sdk, botId: string, newFlow: sdk.Flow) => {
   const oldFlow = await bp.ghost.forBot(botId).readFileAsObject<sdk.Flow>('./flows', newFlow.location)
   const qnaStorage = await botScopedStorage.get(botId)
@@ -54,6 +58,7 @@ const entryPoint: sdk.ModuleEntryPoint = {
   onServerReady,
   onBotMount,
   onBotUnmount,
+  onModuleUnmount,
   onFlowChanged,
   definition: {
     name: 'qna',

--- a/src/bp/bootstrap.ts
+++ b/src/bp/bootstrap.ts
@@ -35,8 +35,6 @@ async function start() {
   const resolver = new ModuleResolver(logger)
 
   for (const entry of globalConfig.modules) {
-    let originalRequirePaths: string[] = []
-
     try {
       if (!entry.enabled) {
         modulesLog += os.EOL + `${chalk.dim('⊝')} ${entry.location} ${chalk.gray('(disabled)')}`
@@ -44,18 +42,7 @@ async function start() {
       }
 
       const moduleLocation = await resolver.resolve(entry.location)
-
-      // We bump temporarily bump the module's node_modules in priority
-      // So that it loads the local versions of its own dependencies
-      originalRequirePaths = global.require.getPaths()
-      global.require.overwritePaths([
-        path.join(moduleLocation, 'node_production_modules'),
-        path.join(moduleLocation, 'node_modules'),
-        ...originalRequirePaths
-      ])
-      const req = require(moduleLocation)
-      global.require.overwritePaths(originalRequirePaths)
-      originalRequirePaths = []
+      const req = await resolver.requireModule(moduleLocation)
 
       const rawEntry = (req.default ? req.default : req) as sdk.ModuleEntryPoint
       const entryPoint = ModuleLoader.processModuleEntryPoint(rawEntry, entry.location)
@@ -65,10 +52,6 @@ async function start() {
     } catch (err) {
       modulesLog += os.EOL + `${chalk.redBright('⊗')} ${entry.location} ${chalk.gray('(error)')}`
       loadingErrors.push(new FatalError(err, `Fatal error loading module "${entry.location}"`))
-    } finally {
-      if (originalRequirePaths.length) {
-        global.require.overwritePaths(originalRequirePaths)
-      }
     }
   }
 

--- a/src/bp/bootstrap.ts
+++ b/src/bp/bootstrap.ts
@@ -42,7 +42,7 @@ async function start() {
       }
 
       const moduleLocation = await resolver.resolve(entry.location)
-      const req = await resolver.requireModule(moduleLocation)
+      const req = resolver.requireModule(moduleLocation)
 
       const rawEntry = (req.default ? req.default : req) as sdk.ModuleEntryPoint
       const entryPoint = ModuleLoader.processModuleEntryPoint(rawEntry, entry.location)

--- a/src/bp/bootstrap.ts
+++ b/src/bp/bootstrap.ts
@@ -42,9 +42,8 @@ async function start() {
       }
 
       const moduleLocation = await resolver.resolve(entry.location)
-      const req = resolver.requireModule(moduleLocation)
+      const rawEntry = resolver.requireModule(moduleLocation)
 
-      const rawEntry = (req.default ? req.default : req) as sdk.ModuleEntryPoint
       const entryPoint = ModuleLoader.processModuleEntryPoint(rawEntry, entry.location)
       modules.push(entryPoint)
       process.LOADED_MODULES[entryPoint.definition.name] = moduleLocation

--- a/src/bp/core/api.ts
+++ b/src/bp/core/api.ts
@@ -39,6 +39,7 @@ const http = (httpServer: HTTPServer): typeof sdk.http => {
       const defaultRouterOptions = { checkAuthentication: true, enableJsonBodyParser: true }
       return httpServer.createRouterForBot(routerName, options || defaultRouterOptions)
     },
+    deleteRouterForBot: httpServer.deleteRouterForBot.bind(httpServer),
     async getAxiosConfigForBot(botId: string, options?: sdk.AxiosOptions): Promise<any> {
       return httpServer.getAxiosConfigForBot(botId, options)
     },

--- a/src/bp/core/api.ts
+++ b/src/bp/core/api.ts
@@ -56,6 +56,7 @@ const event = (eventEngine: EventEngine): typeof sdk.events => {
     registerMiddleware(middleware: sdk.IO.MiddlewareDefinition) {
       eventEngine.register(middleware)
     },
+    unregisterMiddleware: eventEngine.unregister.bind(eventEngine),
     sendEvent(event: sdk.IO.Event): void {
       eventEngine.sendEvent(event)
     },

--- a/src/bp/core/api.ts
+++ b/src/bp/core/api.ts
@@ -57,7 +57,7 @@ const event = (eventEngine: EventEngine): typeof sdk.events => {
     registerMiddleware(middleware: sdk.IO.MiddlewareDefinition) {
       eventEngine.register(middleware)
     },
-    unregisterMiddleware: eventEngine.unregister.bind(eventEngine),
+    removeMiddleware: eventEngine.removeMiddleware.bind(eventEngine),
     sendEvent(event: sdk.IO.Event): void {
       eventEngine.sendEvent(event)
     },

--- a/src/bp/core/module-loader.ts
+++ b/src/bp/core/module-loader.ts
@@ -116,7 +116,7 @@ export class ModuleLoader {
 
     await this._unloadModule(absoluteLocation, moduleName)
 
-    const req = await resolver.requireModule(absoluteLocation)
+    const req = resolver.requireModule(absoluteLocation)
     const entryPoint = (req.default ? req.default : req) as ModuleEntryPoint
     const isModuleLoaded = await this._loadModule(entryPoint, moduleName)
 

--- a/src/bp/core/module-loader.ts
+++ b/src/bp/core/module-loader.ts
@@ -158,7 +158,7 @@ export class ModuleLoader {
         await Promise.mapSeries(BotService.getMountedBots(), x => loadedModule.onBotUnmount!(api, x))
       }
 
-      await loadedModule.onModuleUnmount(api)
+      await (loadedModule.onModuleUnmount && loadedModule.onModuleUnmount(api))
 
       this.entryPoints.delete(moduleName)
       delete require.cache[require.resolve(moduleLocation)]

--- a/src/bp/core/modules/resolver.ts
+++ b/src/bp/core/modules/resolver.ts
@@ -100,4 +100,23 @@ export default class ModuleResolver {
 
     throw new ConfigurationError(`Could not find module at path "${modulePath}"`)
   }
+
+  async requireModule(moduleLocation) {
+    let originalRequirePaths = global.require.getPaths()
+
+    try {
+      // We bump temporarily bump the module's node_modules in priority
+      // So that it loads the local versions of its own dependencies
+
+      global.require.overwritePaths([
+        path.join(moduleLocation, 'node_production_modules'),
+        path.join(moduleLocation, 'node_modules'),
+        ...originalRequirePaths
+      ])
+
+      return require(moduleLocation)
+    } finally {
+      global.require.overwritePaths(originalRequirePaths)
+    }
+  }
 }

--- a/src/bp/core/modules/resolver.ts
+++ b/src/bp/core/modules/resolver.ts
@@ -105,7 +105,7 @@ export default class ModuleResolver {
     let originalRequirePaths = global.require.getPaths()
 
     try {
-      // We bump temporarily bump the module's node_modules in priority
+      // We temporarily bump the module's node_modules in priority
       // So that it loads the local versions of its own dependencies
       global.require.overwritePaths([
         path.join(moduleLocation, 'node_production_modules'),

--- a/src/bp/core/modules/resolver.ts
+++ b/src/bp/core/modules/resolver.ts
@@ -1,4 +1,4 @@
-import { Logger } from 'botpress/sdk'
+import { Logger, ModuleEntryPoint } from 'botpress/sdk'
 import { TYPES } from 'core/types'
 import { ConfigurationError } from 'errors'
 import fs from 'fs'
@@ -101,20 +101,20 @@ export default class ModuleResolver {
     throw new ConfigurationError(`Could not find module at path "${modulePath}"`)
   }
 
-  requireModule(moduleLocation: string): any {
+  requireModule(moduleLocation: string): ModuleEntryPoint {
     let originalRequirePaths = global.require.getPaths()
 
     try {
       // We bump temporarily bump the module's node_modules in priority
       // So that it loads the local versions of its own dependencies
-
       global.require.overwritePaths([
         path.join(moduleLocation, 'node_production_modules'),
         path.join(moduleLocation, 'node_modules'),
         ...originalRequirePaths
       ])
 
-      return require(moduleLocation)
+      const req = require(moduleLocation)
+      return req.default ? req.default : req
     } finally {
       global.require.overwritePaths(originalRequirePaths)
     }

--- a/src/bp/core/modules/resolver.ts
+++ b/src/bp/core/modules/resolver.ts
@@ -101,7 +101,7 @@ export default class ModuleResolver {
     throw new ConfigurationError(`Could not find module at path "${modulePath}"`)
   }
 
-  async requireModule(moduleLocation) {
+  requireModule(moduleLocation: string): any {
     let originalRequirePaths = global.require.getPaths()
 
     try {

--- a/src/bp/core/routers/bots/index.ts
+++ b/src/bp/core/routers/bots/index.ts
@@ -18,7 +18,7 @@ import { LogsService } from 'core/services/logs/service'
 import MediaService from 'core/services/media'
 import { NotificationsService } from 'core/services/notification/service'
 import { WorkspaceService } from 'core/services/workspace-service'
-import { RequestHandler, Router } from 'express'
+import { RequestHandler, Router, Express } from 'express'
 import { AppLifecycle, AppLifecycleEvents } from 'lifecycle'
 import _ from 'lodash'
 import moment from 'moment'
@@ -101,6 +101,22 @@ export class BotsRouter extends CustomRouter {
     }
 
     next()
+  }
+
+  /**
+   * There is no built-in API in express to remove routes at runtime. Therefore, it is recommended to use this method in development only.
+   * A good explanation is available here: https://github.com/expressjs/express/issues/2596
+   */
+  deleteRouter(path: string, app: Express) {
+    const relPath = '/mod/' + path
+
+    // We need to access the global stack and dig in it to find the desired stack
+    const mainRouterStack = app._router.stack
+    const botRouter = mainRouterStack.find(x => x.name === 'router' && x.regexp.exec('/api/v1/bots/:botId'))
+
+    if (botRouter) {
+      botRouter.handle.stack = botRouter.handle.stack.filter(x => !x.regexp.exec(relPath))
+    }
   }
 
   getNewRouter(path: string, options?: RouterOptions) {

--- a/src/bp/core/routers/modules.ts
+++ b/src/bp/core/routers/modules.ts
@@ -40,9 +40,10 @@ export class ModulesRouter extends CustomRouter {
 
         if (module) {
           await this.moduleLoader.reloadModule(module.location, moduleName)
+          return res.sendStatus(200)
         }
 
-        res.sendStatus(200)
+        res.sendStatus(404)
       })
     )
 

--- a/src/bp/core/routers/modules.ts
+++ b/src/bp/core/routers/modules.ts
@@ -6,7 +6,8 @@ import { ModuleLoader } from '../module-loader'
 import { SkillService } from '../services/dialog/skill/service'
 
 import { CustomRouter } from './customRouter'
-import { checkTokenHeader } from './util'
+import { checkTokenHeader, assertSuperAdmin } from './util'
+import { ConfigProvider } from 'core/config/config-loader'
 
 export class ModulesRouter extends CustomRouter {
   private checkTokenHeader!: RequestHandler
@@ -15,7 +16,8 @@ export class ModulesRouter extends CustomRouter {
     logger: Logger,
     private authService: AuthService,
     private moduleLoader: ModuleLoader,
-    private skillService: SkillService
+    private skillService: SkillService,
+    private configProvider: ConfigProvider
   ) {
     super('Modules', logger, Router({ mergeParams: true }))
     this.checkTokenHeader = checkTokenHeader(this.authService, TOKEN_AUDIENCE)
@@ -26,6 +28,23 @@ export class ModulesRouter extends CustomRouter {
     this.router.get('/', (req, res) => {
       res.json(this.moduleLoader.getLoadedModules())
     })
+
+    this.router.get(
+      '/reload/:moduleName',
+      this.checkTokenHeader,
+      assertSuperAdmin,
+      this.asyncMiddleware(async (req, res, next) => {
+        const moduleName = req.params.moduleName
+        const config = await this.configProvider.getBotpressConfig()
+        const module = config.modules.find(x => x.location.endsWith(moduleName))
+
+        if (module) {
+          await this.moduleLoader.reloadModule(module.location, moduleName)
+        }
+
+        res.sendStatus(200)
+      })
+    )
 
     this.router.get(
       '/botTemplates',

--- a/src/bp/core/server.ts
+++ b/src/bp/core/server.ts
@@ -113,7 +113,14 @@ export default class HTTPServer {
 
     this.app.use(debugRequestMw)
 
-    this.modulesRouter = new ModulesRouter(this.logger, this.authService, moduleLoader, skillService)
+    this.modulesRouter = new ModulesRouter(
+      this.logger,
+      this.authService,
+      moduleLoader,
+      skillService,
+      this.configProvider
+    )
+
     this.authRouter = new AuthRouter(
       this.logger,
       this.authService,

--- a/src/bp/core/server.ts
+++ b/src/bp/core/server.ts
@@ -283,6 +283,10 @@ export default class HTTPServer {
     return this.botsRouter.getNewRouter(router, options)
   }
 
+  deleteRouterForBot(router: string): void {
+    return this.botsRouter.deleteRouter(router, this.app)
+  }
+
   createShortLink(name: string, destination: string, params: any) {
     this.shortlinksRouter.createShortLink(name, destination, params)
   }

--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -440,4 +440,10 @@ export class BotService {
   private _invalidateBotIds(): void {
     this._botIds = undefined
   }
+
+  public static getMountedBots() {
+    const bots: string[] = []
+    BotService._mountedBots.forEach((isMounted, bot) => isMounted && bots.push(bot))
+    return bots
+  }
 }

--- a/src/bp/core/services/middleware/event-engine.ts
+++ b/src/bp/core/services/middleware/event-engine.ts
@@ -143,9 +143,19 @@ export class EventEngine {
     }
   }
 
-  unregister(middlewareName: string): void {
-    this.incomingMiddleware = this.incomingMiddleware.filter(x => x.name !== middlewareName)
-    this.outgoingMiddleware = this.outgoingMiddleware.filter(x => x.name !== middlewareName)
+  removeMiddleware(middlewareName: string): void {
+    const mw = [...this.incomingMiddleware, ...this.outgoingMiddleware].find(x => x.name === middlewareName)
+    if (!mw) {
+      return
+    }
+
+    if (mw.direction === 'incoming') {
+      debugIncoming('unregister %o', middlewareName)
+      this.incomingMiddleware = this.incomingMiddleware.filter(x => x.name !== middlewareName)
+    } else {
+      debugOutgoing('unregister %o', middlewareName)
+      this.outgoingMiddleware = this.outgoingMiddleware.filter(x => x.name !== middlewareName)
+    }
   }
 
   async sendEvent(event: sdk.IO.Event) {

--- a/src/bp/core/services/middleware/event-engine.ts
+++ b/src/bp/core/services/middleware/event-engine.ts
@@ -143,6 +143,11 @@ export class EventEngine {
     }
   }
 
+  unregister(middlewareName: string): void {
+    this.incomingMiddleware = this.incomingMiddleware.filter(x => x.name !== middlewareName)
+    this.outgoingMiddleware = this.outgoingMiddleware.filter(x => x.name !== middlewareName)
+  }
+
   async sendEvent(event: sdk.IO.Event) {
     this.validateEvent(event)
 

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -959,6 +959,13 @@ declare module 'botpress/sdk' {
     export function createRouterForBot(routerName: string, options?: RouterOptions): any & RouterExtension
 
     /**
+     * This method is meant to unregister a router before unloading a module. It is meant to be used in a development environment.
+     * It could cause unpredictable behaviour in production
+     * @param routerName The name of the router (must have been registered with createRouterForBot)
+     */
+    export function deleteRouterForBot(routerName: string)
+
+    /**
      * Returns the required configuration to make an API call to another module by specifying only the relative path.
      * @param botId - The ID of the bot for which to get the configuration
      * @returns The configuration to use

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -1001,8 +1001,8 @@ declare module 'botpress/sdk' {
      */
     export function registerMiddleware(middleware: IO.MiddlewareDefinition): void
 
-    /** Unregisters the specified middleware from the chain. This is mostly used in case of a module being reloaded */
-    export function unregisterMiddleware(middlewareName): void
+    /** Removes the specified middleware from the chain. This is mostly used in case of a module being reloaded */
+    export function removeMiddleware(middlewareName): void
 
     /**
      * Send an event through the incoming or outgoing middleware chain

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -72,6 +72,11 @@ declare module 'botpress/sdk' {
    * of the module. The path to the module must also be specified in the global botpress config.
    */
   export interface ModuleEntryPoint {
+    /**
+     * Called when the module is unloaded, before being reloaded
+     * onBotUnmount is called for each bots before this one is called
+     * */
+    onModuleUnmount: ((bp: typeof import('botpress/sdk')) => void)
     /** Called once the core is initialized. Usually for middlewares / database init */
     onServerStarted: ((bp: typeof import('botpress/sdk')) => void)
     /** This is called once all modules are initialized, usually for routing and logic */

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -994,6 +994,9 @@ declare module 'botpress/sdk' {
      */
     export function registerMiddleware(middleware: IO.MiddlewareDefinition): void
 
+    /** Unregisters the specified middleware from the chain. This is mostly used in case of a module being reloaded */
+    export function unregisterMiddleware(middlewareName): void
+
     /**
      * Send an event through the incoming or outgoing middleware chain
      * @param event - The event to send

--- a/src/bp/ui-admin/src/Pages/Server/Modules.jsx
+++ b/src/bp/ui-admin/src/Pages/Server/Modules.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { Container, Button, Alert } from 'reactstrap'
+import { connect } from 'react-redux'
+
+import api from '../../api'
+import _ from 'lodash'
+import { fetchModules } from '../../reducers/modules'
+
+class Modules extends React.Component {
+  state = {}
+
+  componentDidMount() {
+    this.props.fetchModules()
+  }
+
+  reloadModule = async moduleName => {
+    try {
+      await api.getSecured().get(`/modules/reload/${moduleName}`)
+
+      this.setState({ successMsg: `Module reloaded successfully` })
+
+      window.setTimeout(() => {
+        this.setState({ successMsg: undefined })
+      }, 2000)
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  render() {
+    return (
+      <Container style={{ marginTop: 50, padding: 20 }}>
+        {this.state.successMsg && <Alert type="success">{this.state.successMsg}</Alert>}
+        <h3>Module Reloading</h3>
+        <div className="bp_table ">
+          {this.props.modules.map(module => (
+            <div className="bp_table-row">
+              <div className="actions">
+                <Button color="primary" size="sm" onClick={() => this.reloadModule(module.name)}>
+                  Reload
+                </Button>
+              </div>
+              <div className="title">{module.name}</div>
+            </div>
+          ))}
+        </div>
+      </Container>
+    )
+  }
+}
+
+const mapStateToProps = state => ({
+  ...state.modules
+})
+
+export default connect(
+  mapStateToProps,
+  { fetchModules }
+)(Modules)

--- a/src/bp/ui-admin/src/reducers/index.js
+++ b/src/bp/ui-admin/src/reducers/index.js
@@ -6,6 +6,7 @@ import versioning from './versioning'
 import bots from './bots'
 import roles from './roles'
 import monitoring from './monitoring'
+import modules from './modules'
 
 export default combineReducers({
   routing: routerReducer,
@@ -14,5 +15,6 @@ export default combineReducers({
   bots,
   user,
   roles,
-  monitoring
+  monitoring,
+  modules
 })

--- a/src/bp/ui-admin/src/reducers/modules.js
+++ b/src/bp/ui-admin/src/reducers/modules.js
@@ -1,0 +1,28 @@
+import api from '../api'
+
+export const FETCH_MODULES_RECEIVED = 'bots/FETCH_MODULES_RECEIVED'
+
+const initialState = { modules: [] }
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case FETCH_MODULES_RECEIVED:
+      return {
+        ...state,
+        modules: action.modules
+      }
+
+    default:
+      return state
+  }
+}
+
+export const fetchModules = () => {
+  return async dispatch => {
+    const { data } = await api.getSecured().get('/modules')
+    dispatch({
+      type: FETCH_MODULES_RECEIVED,
+      modules: data
+    })
+  }
+}

--- a/src/bp/ui-admin/src/routes/index.jsx
+++ b/src/bp/ui-admin/src/routes/index.jsx
@@ -19,6 +19,7 @@ import Workspace from '../Pages/Workspace'
 import MyAccount from '../Pages/MyAccount'
 import Bot from '../Pages/Bot'
 import Debug from '../Pages/Server/Debug'
+import Modules from '../Pages/Server/Modules'
 
 export const makeMainRoutes = () => {
   const auth = new Auth()
@@ -44,6 +45,7 @@ export const makeMainRoutes = () => {
               <Route path="/server" component={Server} />
               <Route path="/bot" component={Bot} />
               <Route path="/debug" component={Debug} />
+              <Route path="/modules" component={Modules} />
               <Redirect from="/" to="/workspace/bots" />
             </Switch>
           </PrivateRoute>


### PR DESCRIPTION
These changes would make it a lot easier for developers to work on modules. This would allow hot reloading of modules, removing the barrier of having to reboot the whole server when you are making a single change.

I'm not absolutely sure to have tackled all tasks involved in reloading modules, so i'm asking for your insight here.

There is no UI implementation, only a backend route (requiring superadmin) that allows the reloading of module: http://localhost:3000/api/v1/modules/reload/qna