### PR TITLE
fix(cms): logic error when fetching content renderer

### DIFF
--- a/src/bp/core/services/cms.ts
+++ b/src/bp/core/services/cms.ts
@@ -539,11 +539,13 @@ export class CMSService implements IDisposeOnExit {
         ...args,
         ...content.formData
       }
-    } else if (args.text) {
+    } else {
       contentTypeRenderer = await this.getContentType(contentId)
-      args = {
-        ...args,
-        text: renderTemplate(args.text, args)
+      if (args.text) {
+        args = {
+          ...args,
+          text: renderTemplate(args.text, args)
+        }
       }
     }
 


### PR DESCRIPTION
Fix for an issue just introduced with 11.8, when rendering custom elements which doesn't have the text property. 