### PR TITLE
fix(cms): added missing properties to simplify multilang

### DIFF
--- a/src/bp/core/api.ts
+++ b/src/bp/core/api.ts
@@ -174,12 +174,8 @@ const ghost = (ghostService: GhostService): typeof sdk.ghost => {
 
 const cms = (cmsService: CMSService, mediaService: MediaService): typeof sdk.cms => {
   return {
-    getContentElement(botId: string, id: string): Promise<any> {
-      return cmsService.getContentElement(botId, id)
-    },
-    getContentElements(botId: string, ids: string[]): Promise<any[]> {
-      return cmsService.getContentElements(botId, ids)
-    },
+    getContentElement: cmsService.getContentElement.bind(cmsService),
+    getContentElements: cmsService.getContentElements.bind(cmsService),
     listContentElements: cmsService.listContentElements.bind(cmsService),
     deleteContentElements: cmsService.deleteContentElements.bind(cmsService),
     getAllContentTypes(botId?: string): Promise<any[]> {
@@ -188,14 +184,7 @@ const cms = (cmsService: CMSService, mediaService: MediaService): typeof sdk.cms
     renderElement(contentId: string, args: any, eventDestination: sdk.IO.EventDestination): Promise<any> {
       return cmsService.renderElement(contentId, args, eventDestination)
     },
-    createOrUpdateContentElement(
-      botId: string,
-      contentTypeId: string,
-      formData: string,
-      contentElementId?: string
-    ): Promise<string> {
-      return cmsService.createOrUpdateContentElement(botId, contentTypeId, formData, contentElementId)
-    },
+    createOrUpdateContentElement: cmsService.createOrUpdateContentElement.bind(cmsService),
     async saveFile(botId: string, fileName: string, content: Buffer): Promise<string> {
       return mediaService.saveFile(botId, fileName, content)
     },

--- a/src/bp/core/services/cms.ts
+++ b/src/bp/core/services/cms.ts
@@ -193,25 +193,22 @@ export class CMSService implements IDisposeOnExit {
     const dbElements = await query.offset(from)
     const elements: ContentElement[] = dbElements.map(this.transformDbItemToApi)
 
-    if (language) {
-      return elements.map(el => {
-        return { ...el, formData: this.getOriginalProps(el.formData, this.getContentType(el.contentType), language) }
-      })
-    }
-    return elements
+    return Promise.map(elements, el => this.translateIfRequired(el, language))
   }
 
-  async getContentElement(botId: string, id: string): Promise<ContentElement> {
+  async getContentElement(botId: string, id: string, language?: string): Promise<ContentElement> {
     const element = await this.memDb(this.contentTable)
       .where({ botId, id })
       .get(0)
 
-    return this.transformDbItemToApi(element)
+    return this.translateIfRequired(this.transformDbItemToApi(element), language)
   }
 
-  async getContentElements(botId: string, ids: string[]): Promise<ContentElement[]> {
+  async getContentElements(botId: string, ids: string[], language?: string): Promise<ContentElement[]> {
     const elements = await this.memDb(this.contentTable).where(builder => builder.where({ botId }).whereIn('id', ids))
-    return Promise.map(elements, this.transformDbItemToApi)
+
+    const apiElements: ContentElement[] = elements.map(this.transformDbItemToApi)
+    return Promise.map(apiElements, el => this.translateIfRequired(el, language))
   }
 
   async countContentElements(botId: string): Promise<number> {
@@ -267,8 +264,9 @@ export class CMSService implements IDisposeOnExit {
   private async _createOrUpdateContentElement(
     botId: string,
     contentTypeId: string,
-    formData: string,
-    contentElementId?: string
+    formData: object,
+    contentElementId?: string,
+    language?: string
   ): Promise<string> {
     process.ASSERT_LICENSED()
     contentTypeId = contentTypeId.toLowerCase()
@@ -279,6 +277,20 @@ export class CMSService implements IDisposeOnExit {
     }
 
     const { languages, defaultLanguage } = await this.configProvider.getBotConfig(botId)
+
+    // If language is specified, we update only the one specified. This is mostly for requests made with the SDK
+    if (language) {
+      // If we are editing an existing content elements, we need to fetch other translations to merge them so they aren't lost
+      if (contentElementId) {
+        formData = {
+          ...(await this.getContentElement(botId, contentElementId)).formData,
+          ...this.getTranslatedProps(formData, language)
+        }
+      } else {
+        formData = this.getTranslatedProps(formData, language)
+      }
+    }
+
     const contentElement = {
       formData,
       ...(await this.fillComputedProps(contentType, formData, languages, defaultLanguage))
@@ -360,6 +372,17 @@ export class CMSService implements IDisposeOnExit {
     await this.ghost.forBot(botId).upsertFile(this.elementsDir, fileName, content)
   }
 
+  private translateIfRequired(element: ContentElement, language?: string) {
+    if (!language) {
+      return element
+    }
+
+    return {
+      ...element,
+      formData: this.getOriginalProps(element.formData, this.getContentType(element.contentType), language)
+    }
+  }
+
   private transformDbItemToApi(item: any): ContentElement {
     if (!item) {
       return item
@@ -419,7 +442,7 @@ export class CMSService implements IDisposeOnExit {
     }
   }
 
-  private async fillComputedProps(contentType: ContentType, formData: string, languages: string[], defaultLanguage) {
+  private async fillComputedProps(contentType: ContentType, formData: object, languages: string[], defaultLanguage) {
     if (formData == undefined) {
       throw new Error('"formData" must be a valid object')
     }
@@ -427,10 +450,7 @@ export class CMSService implements IDisposeOnExit {
     const expandedFormData = await this.resolveRefs(formData)
     const previews = this.computePreviews(contentType.id, expandedFormData, languages, defaultLanguage)
 
-    return {
-      formData,
-      previews
-    }
+    return { previews }
   }
 
   private computePreviews(contentTypeId, formData, languages, defaultLang) {

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -1144,11 +1144,12 @@ declare module 'botpress/sdk' {
      * Returns a single Content Element
      * @param botId - The ID of the bot
      * @param id - The element id
+     * @param language - If language is set, it will return only the desired language with the base properties
      * @returns A content element
      */
-    export function getContentElement(botId: string, id: string): Promise<ContentElement>
+    export function getContentElement(botId: string, id: string, language?: string): Promise<ContentElement>
 
-    export function getContentElements(botId: string, ids: string[]): Promise<ContentElement[]>
+    export function getContentElements(botId: string, ids: string[], language?: string): Promise<ContentElement[]>
 
     /**
      *
@@ -1188,11 +1189,21 @@ declare module 'botpress/sdk' {
       eventDestination: IO.EventDestination
     ): Promise<object[]>
 
+    /**
+     * Updates an existing content element, or creates it if its current ID isn't defined
+     *
+     * @param botId The ID of the bot
+     * @param contentTypeId Only used when creating an element (the ID of the content type (renderer))
+     * @param formData The content of your element. May includes translations or not (see language parameter)
+     * @param contentElementId If not specified, will be treated as a new element and will be inserted
+     * @param language When language is set, only that language will be updated on this element. Otherwise, replaces all content
+     */
     export function createOrUpdateContentElement(
       botId: string,
       contentTypeId: string,
-      formData: string,
-      contentElementId?: string
+      formData: object,
+      contentElementId?: string,
+      language?: string
     ): Promise<string>
 
     export function saveFile(botId: string, fileName: string, content: Buffer): Promise<string>


### PR DESCRIPTION
I've added the language param for other methods of the CMS api, which will set the properties of the specified language. For example, if you have an element which is translated in EN and FR, you could just call the SDK with the formData elements without the $en property, and only the language specified will be updated.

Otherwise, it is required to fetch all translations and manually update them