### PR TITLE
proposal: command palette for quick access

### DIFF
--- a/modules/nlu/src/backend/index.ts
+++ b/modules/nlu/src/backend/index.ts
@@ -39,6 +39,11 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
   delete nluByBot[botId]
 }
 
+const shortcuts = [
+  { name: 'Intents - Create Intent', action: 'link', arg: '/modules/nlu/Intents#create' },
+  { name: 'Entities - Create Entity', action: 'link', arg: '/modules/nlu/Entities#create' }
+]
+
 const entryPoint: sdk.ModuleEntryPoint = {
   onServerStarted,
   onServerReady,
@@ -52,7 +57,8 @@ const entryPoint: sdk.ModuleEntryPoint = {
     menuIcon: 'fiber_smart_record',
     menuText: 'NLU',
     fullName: 'NLU',
-    homepage: 'https://botpress.io'
+    homepage: 'https://botpress.io',
+    shortcuts
   }
 }
 

--- a/modules/nlu/src/backend/index.ts
+++ b/modules/nlu/src/backend/index.ts
@@ -40,8 +40,8 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
 }
 
 const shortcuts = [
-  { name: 'Intents - Create Intent', action: 'link', arg: '/modules/nlu/Intents#create' },
-  { name: 'Entities - Create Entity', action: 'link', arg: '/modules/nlu/Entities#create' }
+  { name: 'Intents - Create Intent', action: 'goto', arg: '/modules/nlu/Intents#create' },
+  { name: 'Entities - Create Entity', action: 'goto', arg: '/modules/nlu/Entities#create' }
 ]
 
 const entryPoint: sdk.ModuleEntryPoint = {

--- a/modules/nlu/src/views/full/entities/index.jsx
+++ b/modules/nlu/src/views/full/entities/index.jsx
@@ -15,6 +15,13 @@ export class EntitiesComponent extends React.Component {
     this.fetchEntities()
   }
 
+  componentDidUpdate() {
+    if (window.location.hash === '#create') {
+      this.setState({ createModalVisible: true })
+    }
+    window.location.hash = ''
+  }
+
   fetchEntities = () => {
     this.props.bp.axios.get('/mod/nlu/entities').then(res => {
       const customEntities = res.data.filter(r => r.type !== 'system')

--- a/modules/nlu/src/views/full/intents/index.jsx
+++ b/modules/nlu/src/views/full/intents/index.jsx
@@ -19,6 +19,13 @@ export class IntentsComponent extends React.Component {
     this.checkForIntentSearch()
   }
 
+  componentDidUpdate() {
+    if (window.location.hash === '#create') {
+      this.createNewIntent()
+    }
+    window.location.hash = ''
+  }
+
   // Deprecated, will be fixed when we fix the whole NLU UI
   componentWillReceiveProps(nextProps) {
     if (nextProps.intent !== this.props.intent) {

--- a/modules/qna/src/backend/index.ts
+++ b/modules/qna/src/backend/index.ts
@@ -49,6 +49,12 @@ const onFlowChanged = async (bp: typeof sdk, botId: string, newFlow: sdk.Flow) =
   }
 }
 
+const shortcuts = [
+  { name: 'Create New Question', action: 'link', arg: '/modules/qna#create' },
+  { name: 'Import CSV', action: 'link', arg: '/modules/qna#importcsv' },
+  { name: 'Export CSV', action: 'link', arg: '/modules/qna#exportcsv' }
+]
+
 const entryPoint: sdk.ModuleEntryPoint = {
   onServerStarted,
   onServerReady,
@@ -60,7 +66,8 @@ const entryPoint: sdk.ModuleEntryPoint = {
     menuIcon: 'question_answer',
     menuText: 'Q&A',
     fullName: 'QNA',
-    homepage: 'https://botpress.io'
+    homepage: 'https://botpress.io',
+    shortcuts
   }
 }
 

--- a/modules/qna/src/backend/index.ts
+++ b/modules/qna/src/backend/index.ts
@@ -50,9 +50,9 @@ const onFlowChanged = async (bp: typeof sdk, botId: string, newFlow: sdk.Flow) =
 }
 
 const shortcuts = [
-  { name: 'Create New Question', action: 'link', arg: '/modules/qna#create' },
-  { name: 'Import CSV', action: 'link', arg: '/modules/qna#importcsv' },
-  { name: 'Export CSV', action: 'link', arg: '/modules/qna#exportcsv' }
+  { name: 'Create New Question', action: 'goto', arg: '/modules/qna#create' },
+  { name: 'Import CSV', action: 'goto', arg: '/modules/qna#importcsv' },
+  { name: 'Export CSV', action: 'goto', arg: '/modules/qna#exportcsv' }
 ]
 
 const entryPoint: sdk.ModuleEntryPoint = {

--- a/modules/qna/src/views/full/index.jsx
+++ b/modules/qna/src/views/full/index.jsx
@@ -98,6 +98,17 @@ export default class QnaAdmin extends Component {
     this.fetchCategories()
   }
 
+  componentDidUpdate() {
+    if (window.location.hash.length) {
+      if (window.location.hash === '#create') {
+        this.setState({ showQnAModal: true })
+      } else if (window.location.hash === '#importcsv') {
+        this.setState({ importCsvModalShow: true })
+      }
+      window.location.hash = ''
+    }
+  }
+
   filterOrFetch() {
     const { hash } = window.location
     const searchCmd = '#search:'

--- a/proposal.md
+++ b/proposal.md
@@ -1,1 +1,42 @@
-**Include your feature proposal here**
+DX Enhancements - Command Palette
+
+This change would add a Command Palette, similar to VSCode and other dev tools.
+Most commands would be built-in and it would allow modules to register new commands.
+
+### Example of Built-in Shortcuts
+
+- Open bot (one entry for each bot)
+- Open Flow Editor
+- Navigate to module (one per module)
+- Reload module (one per module, if super admin)
+- Back to admin
+- Content Editor
+- Create (Text|Carousel|etc) Element
+- Insert Skill (Choice|slot|etc)
+- Open documentation for (X)
+
+### Example of Module Shortcuts
+
+- Create new QNA
+- Create new intent
+- Create new entity
+- Open Webchat (open /s/bot_name in new window)
+
+### Implementation for modules
+
+The modification involves adding a `commandPalette` definition to the ModuleEntryPoint. The name of the module would be automatically prepended to the command name.
+
+- Commands with a # sign would be redirected to the module page, and the hash sign would be appended to the URL. The module can then detect the change in the URL and trigger the desired action. (since it's all front-end stuff)
+- Setting the command to a complete URL would open a new window
+
+```js
+const commandPalette = [
+  // Open the module view and append the hash at the end
+  { name: 'Create QNA', command: '#createqna' },
+  { name: 'Import CSV', command: '#importcsv' },
+  { name: 'Export CSV', command: '#exportcsv' },
+
+  // Or, a link to the outside world
+  { name: 'Documentation', command: 'https://botpress.io/docs/build/content/' }
+]
+```

--- a/src/bp/core/module-loader.ts
+++ b/src/bp/core/module-loader.ts
@@ -40,7 +40,8 @@ const MODULE_SCHEMA = joi.object().keys({
       }),
     menuIcon: joi.string().optional(),
     menuText: joi.string().optional(),
-    homepage: joi.string().optional()
+    homepage: joi.string().optional(),
+    shortcuts: joi.array().optional()
   })
 })
 

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -118,6 +118,22 @@ declare module 'botpress/sdk' {
     menuText?: string
     /** Optionnaly specify a link to your page or github repo */
     homepage?: string
+    shortcuts?: QuickShortcut[]
+  }
+
+  export interface QuickShortcut {
+    /** The label displayed in the command palette. The module name is automatically prepended */
+    name: string
+    /**
+     * These define how the parameters will be interpreted
+     * link: using history.router to redirect without refreshing the page
+     * externalLink: using window.location to reload the page to the destination
+     * popup: using window.open to open the request in a new tab
+     * runCmd: execute the function
+     */
+    action: 'link' | 'externalLink' | 'popup' | 'runCmd'
+    /** Any argument that the selected action can take  */
+    arg: any
   }
 
   /**

--- a/src/bp/ui-studio/package.json
+++ b/src/bp/ui-studio/package.json
@@ -23,6 +23,7 @@
     "query-string": "^6.4.0",
     "react": "^16.4.0",
     "react-bootstrap": "^0.32.1",
+    "react-command-palette": "^0.0.6-0",
     "react-dock": "^0.2.4",
     "react-dom": "^16.4.0",
     "react-emoji": "^0.4.4",

--- a/src/bp/ui-studio/src/web/components/Layout/index.jsx
+++ b/src/bp/ui-studio/src/web/components/Layout/index.jsx
@@ -26,6 +26,7 @@ import { isInputFocused } from '~/keyboardShortcuts'
 
 import layout from './Layout.styl'
 import StatusBar from './StatusBar'
+import Commander from '../Shared/Commander'
 
 class Layout extends React.Component {
   state = {
@@ -86,6 +87,7 @@ class Layout extends React.Component {
     return (
       <HotKeys handlers={keyHandlers}>
         <DocumentationModal />
+        <Commander {...this.props} />
         <div style={{ display: 'flex' }}>
           <Sidebar />
           <main className={layout.main} id="main" tabIndex={9999}>

--- a/src/bp/ui-studio/src/web/components/Shared/Commander.jsx
+++ b/src/bp/ui-studio/src/web/components/Shared/Commander.jsx
@@ -1,0 +1,162 @@
+import CommandPalette from 'react-command-palette'
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+import { fetchContentCategories } from '~/actions'
+
+class Commander extends React.Component {
+  state = {}
+  commands = []
+
+  componentDidMount() {
+    if (!this.props.contentTypes) {
+      this.props.fetchContentCategories()
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      prevProps.modules !== this.props.modules ||
+      prevProps.bots !== this.props.bots ||
+      prevProps.contentTypes !== this.props.contentTypes
+    ) {
+      this.updateCommands()
+    }
+  }
+
+  updateCommands() {
+    if (!this.props.modules || !this.props.bots || !this.props.contentTypes) {
+      return
+    }
+
+    this.commands = []
+
+    this.addCommand({ name: 'Flow Editor', action: 'link', arg: '/flows/main' })
+    this.addCommand({ name: 'Content Editor', action: 'link', arg: '/content' })
+    this.addCommand({ name: 'Back to Admin', action: 'externalLink', arg: `${window.location.origin}/admin` })
+    this.addCommand({ name: 'Documentation', action: 'openPopup', arg: `https://botpress.io/docs/introduction/` })
+
+    this.addCommand({
+      name: 'Open Webchat in popup',
+      action: 'openPopup',
+      arg: `${window.location.origin}/s/${window.BOT_ID}`
+    })
+
+    this.props.contentTypes.map(x =>
+      this.addCommand({ name: `Create new ${x.title}`, action: 'link', arg: `/content/#${x.id}` })
+    )
+
+    this.props.modules.map(module => {
+      if (!module.noInterface) {
+        if (module.name !== 'nlu') {
+          this.addCommand({ name: `${module.fullName}`, action: 'link', arg: `/modules/${module.name}` })
+        } else {
+          this.addCommand({
+            name: `${module.fullName} - Intents`,
+            action: 'link',
+            arg: `/modules/${module.name}/Intents`
+          })
+          this.addCommand({
+            name: `${module.fullName} - Entities`,
+            action: 'link',
+            arg: `/modules/${module.name}/Entities`
+          })
+        }
+      }
+
+      this.addCommand({ name: `${module.fullName} - Reload module`, runCmd: () => this.reloadModule(module.name) })
+
+      if (module.shortcuts) {
+        module.shortcuts.map(short => this.addCommand({ ...short, name: module.fullName + ' - ' + short.name }))
+      }
+    })
+
+    this.props.bots.map(bot =>
+      this.addCommand({
+        name: `Switch to bot ${bot.name} (${bot.id})`,
+        action: 'externalLink',
+        arg: window.location.origin + '/studio/' + bot.id
+      })
+    )
+
+    this.setState({ commands: this.commands })
+  }
+
+  reloadModule(moduleName) {
+    alert('RELOADING ' + moduleName)
+  }
+
+  addCommand({ name, action, arg }) {
+    this.commands.push({
+      name,
+      command: () => {
+        if (action === 'link') {
+          this.props.history.push(arg)
+        } else if (action === 'externalLink') {
+          window.location = arg
+        } else if (action === 'openPopup') {
+          window.open(arg)
+        } else if (action === 'runCmd' && _.isFunction(arg)) {
+          arg()
+        } else {
+          console.log('not supported')
+        }
+      }
+    })
+  }
+
+  addCommand22({ name, link, externalLink, openPopup, runCmd }) {
+    this.commands.push({
+      name,
+      command: () => {
+        if (link) {
+          this.props.history.push(link)
+        } else if (externalLink) {
+          window.location = externalLink
+        } else if (openPopup) {
+          window.open(openPopup)
+        } else if (runCmd && _.isFunction(runCmd)) {
+          runCmd()
+        } else {
+          console.log('not supported')
+        }
+      }
+    })
+  }
+
+  render() {
+    if (!this.state.commands) {
+      return null
+    }
+
+    const options = {
+      key: 'name',
+      keys: ['name'],
+      threshold: -2000,
+      limit: 7,
+      allowTypo: true
+    }
+
+    return (
+      <CommandPalette
+        hotKeys={'ctrl+shift+p'}
+        maxDisplayed={15}
+        commands={this.state.commands}
+        trigger={<span />}
+        closeOnSelect={true}
+        options={options}
+      />
+    )
+  }
+}
+const mapStateToProps = state => ({
+  modules: state.modules,
+  bots: state.bots.bots,
+  contentTypes: state.content.categories
+})
+
+const mapDispatchToProps = dispatch => bindActionCreators({ fetchContentCategories }, dispatch)
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Commander)

--- a/src/bp/ui-studio/src/web/components/Shared/Commander.jsx
+++ b/src/bp/ui-studio/src/web/components/Shared/Commander.jsx
@@ -104,25 +104,6 @@ class Commander extends React.Component {
     })
   }
 
-  addCommand22({ name, link, externalLink, openPopup, runCmd }) {
-    this.commands.push({
-      name,
-      command: () => {
-        if (link) {
-          this.props.history.push(link)
-        } else if (externalLink) {
-          window.location = externalLink
-        } else if (openPopup) {
-          window.open(openPopup)
-        } else if (runCmd && _.isFunction(runCmd)) {
-          runCmd()
-        } else {
-          console.log('not supported')
-        }
-      }
-    })
-  }
-
   render() {
     if (!this.state.commands) {
       return null
@@ -131,7 +112,7 @@ class Commander extends React.Component {
     const options = {
       key: 'name',
       keys: ['name'],
-      threshold: -2000,
+      threshold: -2000, // because why not ? fuzzy thing, ajustment required
       limit: 7,
       allowTypo: true
     }

--- a/src/bp/ui-studio/src/web/views/Content/index.jsx
+++ b/src/bp/ui-studio/src/web/views/Content/index.jsx
@@ -49,6 +49,12 @@ class ContentView extends Component {
 
   componentDidUpdate() {
     this.init()
+
+    if (window.location.hash.length) {
+      const selectedId = window.location.hash.substr(1)
+      window.location.hash = ''
+      this.setState({ showModal: true, selectedId })
+    }
   }
 
   fetchCategoryItems(id) {

--- a/src/bp/ui-studio/yarn.lock
+++ b/src/bp/ui-studio/yarn.lock
@@ -578,6 +578,13 @@ autoprefixer@^6.3.1, autoprefixer@^6.5.3:
     postcss "^5.2.16"
     postcss-value-parser "^3.2.3"
 
+autosuggest-highlight@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/autosuggest-highlight/-/autosuggest-highlight-3.1.1.tgz#70bb4f9125fe8a849e85f825f7bb2a1a4806743d"
+  integrity sha512-MQ6GNIGMMZbeA5FlBLXXgkZEthysCdYNkMV4MahB2/qB/9cwBnVsePUPnIqkMuzjzclTtDa67xln7cgLDu2f/g==
+  dependencies:
+    diacritic "0.0.2"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -2472,6 +2479,11 @@ detect-libc@^1.0.2:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
+diacritic@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/diacritic/-/diacritic-0.0.2.tgz#fc2a887b5a5bc0a0a854fb614c7c2f209061ee04"
+  integrity sha1-/CqIe1pbwKCoVPthTHwvIJBh7gQ=
+
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -2783,7 +2795,7 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
-exenv@^1.2.1:
+exenv@^1.2.0, exenv@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
   integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
@@ -3105,6 +3117,16 @@ function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
+fuse.js@^3.4.4:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.4.4.tgz#f98f55fcb3b595cf6a3e629c5ffaf10982103e95"
+  integrity sha512-pyLQo/1oR5Ywf+a/tY8z4JygnIglmRxVUOiyFAbd11o9keUDpUJSMGRWJngcnkURj30kDHPmhoKY8ChJiz3EpQ==
+
+fuzzysort@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/fuzzysort/-/fuzzysort-1.1.4.tgz#a0510206ed44532cbb52cf797bf5a3cb12acd4ba"
+  integrity sha512-JzK/lHjVZ6joAg3OnCjylwYXYVjRiwTY6Yb25LvfpJHK8bjisfnZJ5bY8aVWwTwCXgxPNgLAtmHL+Hs5q1ddLQ==
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -4258,10 +4280,20 @@ lodash.mergewith@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
   integrity sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==
 
+lodash.once@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
+
 lodash.tail@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"
   integrity sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=
+
+lodash.take@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.take/-/lodash.take-4.1.1.tgz#0b4146dcb7a70c6153495187fc10b12b71fefadf"
+  integrity sha1-C0FG3LenDGFTSVGH/BCxK3H++t8=
 
 lodash.tonumber@^4.0.3:
   version "4.0.3"
@@ -4580,7 +4612,7 @@ moment@^2.24.0:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
-mousetrap@^1.5.2:
+mousetrap@^1.5.2, mousetrap@^1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/mousetrap/-/mousetrap-1.6.3.tgz#80fee49665fd478bccf072c9d46bdf1bfed3558a"
   integrity sha512-bd+nzwhhs9ifsUrC2tWaSgm24/oo2c83zaRyZQF06hYA6sANfsXHtnZ19AbbbDXCDzeH5nZBSQ4NvCjgD62tJA==
@@ -4879,6 +4911,11 @@ object-assign@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-2.1.1.tgz#43c36e5d569ff8e4816c4efa8be02d26967c18aa"
   integrity sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=
+
+object-assign@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
+  integrity sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=
 
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
@@ -5783,6 +5820,24 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-autosuggest@^9.4.3:
+  version "9.4.3"
+  resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-9.4.3.tgz#eb46852422a48144ab9f39fb5470319222f26c7c"
+  integrity sha512-wFbp5QpgFQRfw9cwKvcgLR8theikOUkv8PFsuLYqI2PUgVlx186Cz8MYt5bLxculi+jxGGUUVt+h0esaBZZouw==
+  dependencies:
+    prop-types "^15.5.10"
+    react-autowhatever "^10.1.2"
+    shallow-equal "^1.0.0"
+
+react-autowhatever@^10.1.2:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/react-autowhatever/-/react-autowhatever-10.2.0.tgz#bdd07bf19ddf78acdb8ce7ae162ac13b646874ab"
+  integrity sha512-dqHH4uqiJldPMbL8hl/i2HV4E8FMTDEdVlOIbRqYnJi0kTpWseF9fJslk/KS9pGDnm80JkYzVI+nzFjnOG/u+g==
+  dependencies:
+    prop-types "^15.5.8"
+    react-themeable "^1.1.0"
+    section-iterator "^2.0.0"
+
 react-base16-styling@^0.5.1:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/react-base16-styling/-/react-base16-styling-0.5.3.tgz#3858f24e9c4dd8cbd3f702f3f74d581ca2917269"
@@ -5810,6 +5865,21 @@ react-bootstrap@^0.32.1:
     react-transition-group "^2.0.0"
     uncontrollable "^5.0.0"
     warning "^3.0.0"
+
+react-command-palette@^0.0.6-0:
+  version "0.0.6-0"
+  resolved "https://registry.yarnpkg.com/react-command-palette/-/react-command-palette-0.0.6-0.tgz#061224048602f4439e4eda4f68d19ce3407789e3"
+  integrity sha512-a3LucypLp82VxeNhevUR18MgXf4D0rPtTN+N0YPeV0seNB3AXGeHCmsVQf/SYS6v9uNKWsoW1m+z7/kuExdNRg==
+  dependencies:
+    autosuggest-highlight "^3.1.1"
+    fast-deep-equal "^2.0.1"
+    fuse.js "^3.4.4"
+    fuzzysort "^1.1.4"
+    lodash.once "^4.1.1"
+    lodash.take "^4.1.1"
+    mousetrap "^1.6.3"
+    react-autosuggest "^9.4.3"
+    react-modal "^3.8.1"
 
 react-dock@^0.2.4:
   version "0.2.4"
@@ -5926,6 +5996,16 @@ react-markdown@^4.0.4:
     unist-util-visit "^1.3.0"
     xtend "^4.0.1"
 
+react-modal@^3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.8.1.tgz#7300f94a6f92a2e17994de0be6ccb61734464c9e"
+  integrity sha512-aLKeZM9pgXpIKVwopRHMuvqKWiBajkqisDA8UzocdCF6S4fyKVfLWmZR5G1Q0ODBxxxxf2XIwiCP8G/11GJAuw==
+  dependencies:
+    exenv "^1.2.0"
+    prop-types "^15.5.10"
+    react-lifecycles-compat "^3.0.0"
+    warning "^3.0.0"
+
 react-overlays@^0.8.0:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.8.3.tgz#fad65eea5b24301cca192a169f5dddb0b20d3ac5"
@@ -6026,6 +6106,13 @@ react-table@^6.8.6:
   integrity sha512-sTbNHU8Um0xRtmCd1js873HXnXaMWeBwZoiljuj0l1d44eaqjKyYPK/3HCBbJg1yeE2O5pQJ3Km0tlm9niNL9w==
   dependencies:
     classnames "^2.2.5"
+
+react-themeable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
+  integrity sha1-fURm3ZsrX6dQWHJ4JenxUro3mg4=
+  dependencies:
+    object-assign "^3.0.0"
 
 react-toastify@^3.3.3:
   version "3.4.3"
@@ -6521,6 +6608,11 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
+section-iterator@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/section-iterator/-/section-iterator-2.0.0.tgz#bf444d7afeeb94ad43c39ad2fb26151627ccba2a"
+  integrity sha1-v0RNev7rlK1Dw5rS+yYVFifMuio=
+
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0, semver@^5.6.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
@@ -6582,6 +6674,11 @@ shallow-clone@^1.0.0:
     is-extendable "^0.1.1"
     kind-of "^5.0.0"
     mixin-object "^2.0.1"
+
+shallow-equal@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.1.0.tgz#cc022f030dcba0d1c198abf658a3c6c744e171ca"
+  integrity sha512-0SW1nWo1hnabO62SEeHsl8nmTVVEzguVWZCj5gaQrgWAxz/BaCja4OWdJBWLVPDxdtE/WU7c98uUCCXyPHSCvw==
 
 shallowequal@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
This change would add a Command Palette, similar to VSCode and other dev tools. They would allow a quick access to most commands and make using the admin/studio a lot easier. 

Modules could also register custom commands.

![image](https://user-images.githubusercontent.com/42552874/56231628-f2468680-604c-11e9-962e-22a14f7306bf.png)


### Example of Built-in Shortcuts

- Open bot (one entry for each bot)
- Open Flow Editor
- Navigate to module (one per module)
- Reload module (one per module, if super admin)
- Back to admin
- Content Editor
- Create (Text|Carousel|etc) Element
- Insert Skill (Choice|slot|etc)
- Open documentation for (X)

### Example of Module Shortcuts

- Create new QNA
- Create new intent
- Create new entity
- Open Webchat (open /s/bot_name in new window)

### Implementation for modules

The modification involves adding a `shortcuts` definition to the ModuleEntryPoint. The name of the module would be automatically prepended to the command name.

There would be different types of actions:
- goto: Use the history.push method to redirect without reloading
- redirect: Use window.location to force a refresh while navigating
- popup: Opens the URL in a new tab 
- execute: Execute the specified method

We can leverage the window.location.hash property to trigger actions on various pages.

```js
const shortcuts = [
  { name: 'Create New Question', action: 'goto', arg: '/modules/qna#create' },
  { name: 'Import CSV', action: 'goto', arg: '/modules/qna#importcsv' },
  { name: 'Export CSV', action: 'goto', arg: '/modules/qna#exportcsv' }
]
```
