### PR TITLE
feat(cms): warn modules of content element changes

### DIFF
--- a/src/bp/core/module-loader.ts
+++ b/src/bp/core/module-loader.ts
@@ -1,4 +1,13 @@
-import { BotTemplate, Flow, Logger, ModuleDefinition, ModuleEntryPoint, Skill } from 'botpress/sdk'
+import {
+  BotTemplate,
+  Flow,
+  Logger,
+  ModuleDefinition,
+  ModuleEntryPoint,
+  Skill,
+  ContentElement,
+  ElementChangedAction
+} from 'botpress/sdk'
 import { ValidationError } from 'errors'
 
 import { inject, injectable, tagged } from 'inversify'
@@ -19,6 +28,7 @@ const MODULE_SCHEMA = joi.object().keys({
   onBotMount: joi.func().optional(),
   onBotUnmount: joi.func().optional(),
   onFlowChanged: joi.func().optional(),
+  onElementChanged: joi.func().optional(),
   skills: joi.array().optional(),
   botTemplates: joi.array().optional(),
   definition: joi.object().keys({
@@ -133,6 +143,20 @@ export class ModuleLoader {
       const entryPoint = this.getModule(module.name)
       const api = await createForModule(module.name)
       await (entryPoint.onFlowChanged && entryPoint.onFlowChanged(api, botId, flow))
+    }
+  }
+
+  public async onElementChanged(
+    botId: string,
+    action: ElementChangedAction,
+    element: ContentElement,
+    oldElement?: ContentElement
+  ) {
+    const modules = this.getLoadedModules()
+    for (const module of modules) {
+      const entryPoint = this.getModule(module.name)
+      const api = await createForModule(module.name)
+      await (entryPoint.onElementChanged && entryPoint.onElementChanged(api, botId, action, element, oldElement))
     }
   }
 

--- a/src/bp/core/services/cms.ts
+++ b/src/bp/core/services/cms.ts
@@ -235,10 +235,13 @@ export class CMSService implements IDisposeOnExit {
     const elements = await this.getContentElements(botId, ids)
     await Promise.map(elements, el => this.moduleLoader.onElementChanged(botId, 'delete', el))
 
-    return this.memDb(this.contentTable)
+    await this.memDb(this.contentTable)
       .where({ botId })
       .whereIn('id', ids)
       .del()
+
+    const contentTypes = _.uniq(_.map(elements, 'contentType'))
+    await Promise.mapSeries(contentTypes, contentTypeId => this.dumpDataToFile(botId, contentTypeId))
   }
 
   async getAllContentTypes(botId?: string): Promise<ContentType[]> {

--- a/src/bp/core/services/cms.ts
+++ b/src/bp/core/services/cms.ts
@@ -323,8 +323,8 @@ export class CMSService implements IDisposeOnExit {
       .where({ id: contentElementId, botId })
       .then()
 
-    const inserted = await this.getContentElement(botId, contentElementId)
-    await this.moduleLoader.onElementChanged(botId, 'update', inserted, original)
+    const updated = await this.getContentElement(botId, contentElementId)
+    await this.moduleLoader.onElementChanged(botId, 'update', updated, original)
   }
 
   private async _createContentElement(botId: string, body: object, contentTypeId: string) {
@@ -340,8 +340,8 @@ export class CMSService implements IDisposeOnExit {
       })
       .then()
 
-    const inserted = await this.getContentElement(botId, newElementId)
-    await this.moduleLoader.onElementChanged(botId, 'insert', inserted)
+    const created = await this.getContentElement(botId, newElementId)
+    await this.moduleLoader.onElementChanged(botId, 'create', created)
 
     return newElementId
   }

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -67,7 +67,7 @@ declare module 'botpress/sdk' {
     error(message: string, metadata?: any): void
   }
 
-  export type ElementChangedAction = 'insert' | 'update' | 'delete'
+  export type ElementChangedAction = 'create' | 'update' | 'delete'
 
   /**
    * The Module Entry Point is used by the module loader to bootstrap the module. It must be present in the index.js file

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -67,6 +67,8 @@ declare module 'botpress/sdk' {
     error(message: string, metadata?: any): void
   }
 
+  export type ElementChangedAction = 'insert' | 'update' | 'delete'
+
   /**
    * The Module Entry Point is used by the module loader to bootstrap the module. It must be present in the index.js file
    * of the module. The path to the module must also be specified in the global botpress config.
@@ -85,6 +87,17 @@ declare module 'botpress/sdk' {
     /** An array of available bot templates when creating a new bot */
     botTemplates?: BotTemplate[]
     onFlowChanged?: ((bp: typeof import('botpress/sdk'), botId: string, flow: Flow) => void)
+    /**
+     * This method is called whenever a content element is created, updated or deleted.
+     * Modules can act on these events if they need to update references, for example.
+     */
+    onElementChanged: ((
+      bp: typeof import('botpress/sdk'),
+      botId: string,
+      action: ElementChangedAction,
+      element: ContentElement,
+      oldElement?: ContentElement
+    ) => void)
   }
 
   /**


### PR DESCRIPTION
This modification would allow modules to register a handler to know when an element is created, updated and deleted. It will receive the complete content element, and can call the CMS for further processing. 

Since the delete would require the complete content element, I've done the same for create or update, but if there's too much overhead, we can send only the element id. 

I've used onElementChanged instead of onContentElementChanged since it's unnecessarily long... 

Also, i extracted some code from the original method, it was beginning to get big... 