### PR TITLE
fix(channel-web):  verify if its a channel-web msg

### DIFF
--- a/modules/channel-web/src/hooks/before_outgoing_middleware/quick_replies.js
+++ b/modules/channel-web/src/hooks/before_outgoing_middleware/quick_replies.js
@@ -1,6 +1,6 @@
 const _ = require('lodash')
 
-if (event.payload.quick_replies) {
+if (event.payload.quick_replies && event.channel == 'channel-web') {
   event.payload = {
     type: 'custom',
     module: 'channel-web',


### PR DESCRIPTION
even if message is for a different channel this hook will change the default quick_reply structure and affecting other channels (messenger)