### PR TITLE
fix(channel-web): adding config to change default css

### DIFF
--- a/modules/channel-web/src/views/lite/main.jsx
+++ b/modules/channel-web/src/views/lite/main.jsx
@@ -27,13 +27,9 @@ const HISTORY_MAX_MESSAGES = 10
 const HISTORY_UP = 'ArrowUp'
 
 const defaultOptions = {
-  locale: 'en-US',
   botName: 'Bot',
-  backgroundColor: '#ffffff',
-  textColorOnBackground: '#666666',
-  foregroundColor: '#000000',
-  textColorOnForeground: '#ffffff',
   enableReset: true,
+  stylesheet: '/assets/modules/channel-web/default.css',
   extraStylesheet: '',
   showConversationsButton: true,
   showUserName: false,
@@ -608,13 +604,14 @@ export default class Web extends React.Component {
       this.parentClass = parentClass
     }
 
-    const stylesheet = this.state.config.extraStylesheet
+    const { stylesheet, extraStylesheet } = this.state.config
+
     const view = this.state.view !== 'side' && !this.props.fullscreen ? this.renderWidget() : this.renderSide()
 
     return (
       <div onFocus={this.handleResetUnreadCount}>
-        <link rel="stylesheet" type="text/css" href={'/assets/modules/channel-web/default.css'} />
         {stylesheet && stylesheet.length && <link rel="stylesheet" type="text/css" href={stylesheet} />}
+        {extraStylesheet && extraStylesheet.length && <link rel="stylesheet" type="text/css" href={extraStylesheet} />}
         {view}
       </div>
     )


### PR DESCRIPTION
Since default.css is overwritten on server restarts, i've added a config to change the default stylesheet path. So, the user can copy "default.css" to something else, then refer to that file.

There are two different properties that the user can set: stylesheet and extraStylesheet (the latter is the same property as before). 