### PR TITLE
fix(bot): normalized bot name and id

### DIFF
--- a/modules/channel-web/src/views/lite/components/Container.jsx
+++ b/modules/channel-web/src/views/lite/components/Container.jsx
@@ -57,6 +57,7 @@ export default class Container extends React.Component {
         showConvos={this.state.showConvos}
         showBotInfo={this.state.showBotInfo}
         botInfo={this.props.botInfo}
+        botName={this.props.botName}
         config={this.props.config}
         currentConversation={this.props.currentConversation}
         unreadCount={this.props.unreadCount}
@@ -73,17 +74,16 @@ export default class Container extends React.Component {
 
   renderComposer() {
     const focused = this.state.currentFocus === 'input' && !this.state.showConvos && !this.state.showBotInfo
-    const name = this.props.config.botName || 'Bot'
     const Component = getOverridedComponent(this.props.config.overrides, 'composer')
 
     if (Component) {
-      return <Component original={{ Composer }} name={name} {...this.props} />
+      return <Component original={{ Composer }} name={this.props.botName} {...this.props} />
     }
 
     return (
       <Keyboard.Default>
         <Composer
-          placeholder={'Reply to ' + name}
+          placeholder={'Reply to ' + this.props.botName}
           send={this.props.onTextSend}
           change={this.props.onTextChanged}
           text={this.props.text}
@@ -105,7 +105,7 @@ export default class Container extends React.Component {
       bp: this.props.bp,
       typingUntil: this.props.currentConversation && this.props.currentConversation.typingUntil,
       messages: this.props.currentConversation && this.props.currentConversation.messages,
-      botName: this.props.botInfo.name || this.props.config.botName,
+      botName: this.props.botName,
       botAvatarUrl: (this.props.botInfo.details && this.props.botInfo.details.avatarUrl) || this.props.config.avatarUrl,
       showUserName: this.props.config && this.props.config.showUserName,
       showUserAvatar: this.props.config && this.props.config.showUserAvatar,

--- a/modules/channel-web/src/views/lite/components/Header.jsx
+++ b/modules/channel-web/src/views/lite/components/Header.jsx
@@ -50,14 +50,13 @@ export default class Header extends React.Component {
   }
 
   renderAvatar = () => {
-    const name = this.props.config.botName || this.props.botInfo.name
     const avatarUrl =
       (this.props.botInfo.details && this.props.botInfo.details.avatarUrl) || this.props.config.avatarUrl
-    return <Avatar name={name} avatarUrl={avatarUrl} height={40} width={40} />
+    return <Avatar name={this.props.botName} avatarUrl={avatarUrl} height={40} width={40} />
   }
 
   renderTitle = () => {
-    const title = this.props.showConvos ? 'Conversations' : this.props.config.botName || this.props.botInfo.name
+    const title = this.props.showConvos ? 'Conversations' : this.props.botName
     const description = this.props.config.botConvoDescription
     const hasDescription = description && description.length > 0
 

--- a/modules/channel-web/src/views/lite/main.jsx
+++ b/modules/channel-web/src/views/lite/main.jsx
@@ -28,7 +28,6 @@ const HISTORY_UP = 'ArrowUp'
 
 const defaultOptions = {
   locale: 'en-US',
-  botName: 'Bot',
   backgroundColor: '#ffffff',
   textColorOnBackground: '#666666',
   foregroundColor: '#000000',
@@ -593,6 +592,7 @@ export default class Web extends React.Component {
         downloadConversation={this.downloadConversation}
         createConversation={this.createConversation}
         botInfo={this.state.botInfo}
+        botName={this.state.botInfo.name || this.state.config.botName || 'Bot'}
       />
     )
   }

--- a/src/bp/common/validation.ts
+++ b/src/bp/common/validation.ts
@@ -10,9 +10,9 @@ export const BotCreationSchema = Joi.object().keys({
     .regex(BOTID_REGEX)
     .required(),
   name: Joi.string()
-    .min(3)
     .max(50)
-    .required(),
+    .allow('')
+    .optional(),
   // tslint:disable-next-line:no-null-keyword
   category: Joi.string().allow(null),
   description: Joi.string()
@@ -30,9 +30,8 @@ export const BotCreationSchema = Joi.object().keys({
 
 export const BotEditSchema = Joi.object().keys({
   name: Joi.string()
-    .min(3)
-    .max(50)
-    .required(),
+    .allow('')
+    .max(50),
   // tslint:disable-next-line:no-null-keyword
   category: Joi.string().allow(null),
   description: Joi.string()

--- a/src/bp/ui-admin/src/Pages/Bot/Details.jsx
+++ b/src/bp/ui-admin/src/Pages/Bot/Details.jsx
@@ -483,7 +483,7 @@ class Bots extends Component {
   render() {
     return (
       <SectionLayout
-        title={this.state.name}
+        title={this.state.name || this.state.botId}
         helpText="This page shows the details you can configure for a desired bot."
         activePage="bots"
         currentTeam={this.props.team}

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemCompact.jsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemCompact.jsx
@@ -52,7 +52,7 @@ export default ({ bot, deleteBot, exportBot, permissions, history }) => (
           &nbsp;
         </span>
       )}
-      {bot.disabled ? <span>{bot.name}</span> : <a href={`/studio/${bot.id}`}>{bot.name}</a>}
+      {bot.disabled ? <span>{bot.name || bot.id}</span> : <a href={`/studio/${bot.id}`}>{bot.name || bot.id}</a>}
 
       {!bot.defaultLanguage && (
         <React.Fragment>

--- a/src/bp/ui-admin/src/Pages/Workspace/CreateBotModal.jsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/CreateBotModal.jsx
@@ -9,7 +9,9 @@ import api from '../../api'
 import { fetchBotTemplates, fetchBotCategories } from '../../reducers/bots'
 
 const defaultState = {
+  botId: '',
   name: '',
+  generateId: true,
   template: null,
   category: null,
   error: null
@@ -36,22 +38,16 @@ class CreateBotModal extends Component {
   }
 
   handleNameChanged = e => {
-    this.setState({ name: e.target.value })
+    const name = e.target.value
+    this.setState({ name, botId: this.state.generateId ? this.sanitizeName(name) : this.state.botId })
   }
 
-  handleTemplateChanged = template => {
-    this.setState({ template })
-  }
+  handleBotIdChanged = e => this.setState({ botId: this.sanitizeName(e.target.value), generateId: false })
+  handleTemplateChanged = template => this.setState({ template })
+  handleCategoryChanged = category => this.setState({ category })
 
-  handleCategoryChanged = category => {
-    this.setState({ category })
-  }
-  handleLangChanged = ({ value }) => {
-    this.setState({ defaultLanguage: value })
-  }
-
-  stanitizeName = () => {
-    return this.state.name
+  sanitizeName = name => {
+    return name
       .toLowerCase()
       .replace(/\s/g, '-')
       .replace(/[$&+,:;=?@#|'<>.^*()%!]/g, '')
@@ -64,15 +60,13 @@ class CreateBotModal extends Component {
       return
     }
 
-    const id = this.stanitizeName()
-    const name = this.state.name
+    const { botId, name } = this.state
+
     const template = _.pick(this.state.template, ['id', 'moduleId'])
     const category = this.state.category ? this.state.category.value : null
 
     try {
-      await api
-        .getSecured()
-        .post(`/admin/bots`, { id, name, template, category, defaultLanguage: this.state.defaultLanguage })
+      await api.getSecured().post(`/admin/bots`, { id: botId, name, template, category })
       this.setState({ ...defaultState })
       this.props.onCreateBotSuccess && this.props.onCreateBotSuccess()
       this.props.toggle()
@@ -108,12 +102,16 @@ class CreateBotModal extends Component {
           <form onSubmit={this.createBot} ref={form => (this.formEl = form)}>
             <FormGroup>
               <Label for="name">
-                <strong>Name</strong>
+                <strong>Name of your bot</strong>
+                <br />
+                <small>
+                  It will be displayed to your visitors. You can change it anytime. If you put nothing, it will be named
+                  "Bot" by default.
+                </small>
               </Label>
               <Input
                 tabIndex="1"
                 innerRef={el => (this.nameInput = el)}
-                required
                 type="text"
                 id="name"
                 value={this.state.name}
@@ -121,10 +119,30 @@ class CreateBotModal extends Component {
               />
               <FormFeedback>The bot name should have at least 4 characters.</FormFeedback>
             </FormGroup>
+
+            <FormGroup>
+              <Label for="id">
+                <strong>Your bot ID *</strong>
+                <br />
+                <small>
+                  This ID cannot be changed, so choose wisely. It will be displayed in the URL and your visitors can see
+                  it. Special characters are not allowed. Minimum length: 3
+                </small>
+              </Label>
+              <Input
+                tabIndex="2"
+                required
+                type="text"
+                minLength={3}
+                value={this.state.botId}
+                onChange={this.handleBotIdChanged}
+              />
+              <FormFeedback>The bot id should have at least 4 characters.</FormFeedback>
+            </FormGroup>
             {this.props.botTemplates.length > 0 && (
               <FormGroup>
                 <Label for="template">
-                  <strong>Bot Template</strong>
+                  <strong>Bot Template *</strong>
                 </Label>
                 {this.renderTemplateGroupSelect()}
               </FormGroup>

--- a/src/bp/ui-studio/src/web/components/Layout/index.jsx
+++ b/src/bp/ui-studio/src/web/components/Layout/index.jsx
@@ -36,6 +36,7 @@ class Layout extends React.Component {
   componentDidMount() {
     this.botpressVersion = window.BOTPRESS_VERSION
     this.botName = window.BOT_NAME
+    this.botId = window.BOT_ID
 
     const viewMode = this.props.location.query && this.props.location.query.viewMode
 
@@ -105,7 +106,7 @@ class Layout extends React.Component {
           <SelectContentManager />
           <Dock isOpen={this.state.emulatorOpen} onToggle={this.toggleEmulator} />
           <StatusBar
-            botName={this.botName}
+            botName={this.botName || this.botId}
             onToggleEmulator={this.toggleEmulator}
             isEmulatorOpen={this.state.emulatorOpen}
             botpressVersion={this.botpressVersion}


### PR DESCRIPTION
Just clarifying a bit the purpose of the bot ID and its Name. 

- Name serves only as a "display name" on the UI and the bot interface (when unset, the bot id is displayed)
- By default, the bot name is displayed in the chat. If no name is taken, it will display 'Bot'
- Removed the multiple logic for the bot name in channel web and simplified it 