### PR TITLE
added new hook after event is fully processed

### DIFF
--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -251,7 +251,11 @@ export class Botpress {
       const updatedConfig: any = {}
 
       if (!bot.defaultLanguage) {
-        this.logger.warn(`Bot "${bot.id}" doesn't have a default language, which is now required, go to your admin console to fix this issue.`)
+        this.logger.warn(
+          `Bot "${
+            bot.id
+          }" doesn't have a default language, which is now required, go to your admin console to fix this issue.`
+        )
         updatedConfig.disabled = true
       }
 
@@ -310,6 +314,10 @@ export class Botpress {
       suggestions: sdk.IO.Suggestion[]
     ) => {
       await this.hookService.executeHook(new Hooks.BeforeSuggestionsElection(this.api, sessionId, event, suggestions))
+    }
+
+    this.decisionEngine.onAfterEventProcessed = async (event: sdk.IO.IncomingEvent) => {
+      await this.hookService.executeHook(new Hooks.AfterEventProcessed(this.api, event))
     }
 
     this.dataRetentionService.initialize()

--- a/src/bp/core/services/dialog/decision-engine.ts
+++ b/src/bp/core/services/dialog/decision-engine.ts
@@ -20,6 +20,7 @@ export class DecisionEngine {
   public onBeforeSuggestionsElection:
     | ((sessionId: string, event: IO.IncomingEvent, suggestions: IO.Suggestion[]) => Promise<void>)
     | undefined
+  public onAfterEventProcessed: ((event) => Promise<void>) | undefined
 
   constructor(
     @inject(TYPES.Logger)
@@ -79,6 +80,8 @@ export class DecisionEngine {
           }
         })
         const processedEvent = await this.dialogEngine.processEvent(sessionId, event)
+        this.onAfterEventProcessed && (await this.onAfterEventProcessed(processedEvent))
+
         await this.stateManager.persist(processedEvent, false)
         return
       } catch (err) {

--- a/src/bp/core/services/hook/hook-service.ts
+++ b/src/bp/core/services/hook/hook-service.ts
@@ -65,6 +65,12 @@ export namespace Hooks {
     }
   }
 
+  export class AfterEventProcessed extends BaseHook {
+    constructor(bp: typeof sdk, event: IO.Event) {
+      super('after_event_processed', { bp, event })
+    }
+  }
+
   export class BeforeSessionTimeout extends BaseHook {
     constructor(bp: typeof sdk, event: IO.Event) {
       super('before_session_timeout', { bp, event })


### PR DESCRIPTION
Added one hook which is called after the event is completely processed, just before being persisted. 

You have access to the definitive elected suggestion + the last messages, which includes the user preview and what the bot is sending to the user. Data can still be edited before being saved. 

![image](https://user-images.githubusercontent.com/42552874/56617524-19bdc600-65ee-11e9-9725-e609f926ab6e.png)
