### PR TITLE
fix(getNumberOfConversationsAction): take property name from global a…

### DIFF
--- a/modules/builtin/src/actions/getNumberOfConversations.js
+++ b/modules/builtin/src/actions/getNumberOfConversations.js
@@ -5,13 +5,13 @@
  * @author Botpress, Inc.
  * @param {string} output - The state variable to output the count to
  */
-const getNumberOfConversations = async output => {
+const getNumberOfConversations = async () => {
   const userId = event.target
   const botId = event.botId
   const key = bp.kvs.getUserStorageKey(userId, 'numberOfConversations')
   const value = await bp.kvs.getStorageWithExpiry(botId, key)
 
-  temp[output] = value
+  temp[args.output] = value
 }
 
 return getNumberOfConversations()


### PR DESCRIPTION
**Description of problem**
The **builtin/getNumberOfConversations** doesn't work, since the output property is taken from a parameter which is not passed in. 

**Description of solution**
The global args object, i.e. the args.output value has to be used instead.

**Additionally**
I don't have written any tests since there is no actions test existing. Moreover, I was not able to get the test-suite running on the master branch.

````
  ● DB[Postgres] KVS › Set › Deep overwrite

    error: role "postgres" does not exist

      at Connection.Object.<anonymous>.Connection.parseE (node_modules/pg/lib/connection.js:555:11)
      at Connection.Object.<anonymous>.Connection.parseMessage (node_modules/pg/lib/connection.js:380:19)
      at Socket.<anonymous> (node_modules/pg/lib/connection.js:120:22)
````

**Steps missing for the PR to be ready**
- running test suite
