### PR TITLE
fix messenger require of undefined

### DIFF
--- a/docs/guide/docs/channels/messenger.md
+++ b/docs/guide/docs/channels/messenger.md
@@ -56,6 +56,8 @@ Restart Botpress Server to reload the configuration.
 
 Read the [config definition file](https://github.com/botpress/botpress/blob/master/modules/channel-messenger/src/config.ts) to learn more about configurations.
 
+> All changes to the configuration will take effect on `onBotMount`. To refresh the configuration at runtime, you can disable and enable the bot again without having to restart the server.
+
 ### Greeting Text
 
 ```json
@@ -76,11 +78,14 @@ Read more about [get started](https://developers.facebook.com/docs/messenger-pla
 
 The raw persistent menu object. Read more about persistent menu [here](https://developers.facebook.com/docs/messenger-platform/send-messages/persistent-menu).
 
+> The persistent menu is cached locally on the user's client, but updates are fetched periodically. If you change the persistent menu, it can take some time for the menu to update. You can force refresh by deleting the conversation and starting a new one.
+
+**Configuration example**:
+
 ```json
  "persistentMenu": [
     {
       "locale": "default",
-      "composer_input_disabled": true,
       "call_to_actions": [
         {
           "title": "My Account",

--- a/modules/channel-messenger/src/backend/messenger.ts
+++ b/modules/channel-messenger/src/backend/messenger.ts
@@ -1,8 +1,7 @@
 import axios, { AxiosInstance } from 'axios'
-import bodyParser from 'body-parser'
 import * as sdk from 'botpress/sdk'
 import crypto from 'crypto'
-import { Router } from 'express'
+import { json as expressJson, Router } from 'express'
 import _ from 'lodash'
 
 import { Config } from '../config'
@@ -30,11 +29,13 @@ export class MessengerService {
     const config = (await this.bp.config.getModuleConfig('channel-messenger')) as Config
 
     if (!config.verifyToken || config.verifyToken.length < 1) {
-      throw new Error('You need to set a non-empty value for "verifyToken" in the *global* messenger config')
+      throw new Error(
+        'You need to set a non-empty value for "verifyToken" in data/global/config/channel-messenger.json'
+      )
     }
 
     if (!config.appSecret || config.appSecret.length < 1) {
-      throw new Error(`You need to provide your app's App Secret in the *global* messenger config`)
+      throw new Error(`You need to provide your app's App Secret in data/global/config/channel-messenger.json`)
     }
 
     this.appSecret = config.appSecret
@@ -53,7 +54,7 @@ export class MessengerService {
     })
 
     this.router.use(
-      bodyParser.json({
+      expressJson({
         verify: this._verifySignature.bind(this)
       })
     )
@@ -256,36 +257,34 @@ export class MessengerClient {
       return
     }
 
-    const body = {
+    await this.sendProfile({
       get_started: {
         payload: config.getStarted
       }
-    }
-
-    await this.sendProfile(body)
+    })
   }
 
   async setupGreeting(): Promise<void> {
     const config = await this.getConfig()
     if (!config.greeting) {
+      await this.deleteProfileFields(['greeting'])
       return
     }
 
-    const payload = {
+    await this.sendProfile({
       greeting: [
         {
           locale: 'default',
           text: config.greeting
         }
       ]
-    }
-
-    await this.sendProfile(payload)
+    })
   }
 
   async setupPersistentMenu(): Promise<void> {
     const config = await this.getConfig()
     if (!config.persistentMenu || !config.persistentMenu.length) {
+      await this.deleteProfileFields(['persistent_menu'])
       return
     }
 
@@ -313,6 +312,13 @@ export class MessengerClient {
 
     debugMessages('outgoing text message', { senderId, message, body })
     await this._callEndpoint('/messages', body)
+  }
+
+  async deleteProfileFields(fields: string[]) {
+    const endpoint = '/messenger_profile'
+    const config = await this.getConfig()
+    debugHttpOut(endpoint, fields)
+    await this.http.delete(endpoint, { params: { access_token: config.accessToken }, data: { fields } })
   }
 
   async sendProfile(message) {

--- a/modules/channel-messenger/src/backend/messenger.ts
+++ b/modules/channel-messenger/src/backend/messenger.ts
@@ -28,14 +28,14 @@ export class MessengerService {
   async initialize() {
     const config = (await this.bp.config.getModuleConfig('channel-messenger')) as Config
 
-    if (!config.verifyToken || config.verifyToken.length < 1) {
+    if (!config.verifyToken || !config.verifyToken.length) {
       throw new Error(
         'You need to set a non-empty value for "verifyToken" in data/global/config/channel-messenger.json'
       )
     }
 
-    if (!config.appSecret || config.appSecret.length < 1) {
-      throw new Error(`You need to provide your app's App Secret in data/global/config/channel-messenger.json`)
+    if (!config.appSecret || !config.appSecret.length) {
+      throw new Error(`You need to set a non-empty value for "appSecret" in data/global/config/channel-messenger.json`)
     }
 
     this.appSecret = config.appSecret


### PR DESCRIPTION
Fix an issue with the use of body-parser in channel-messenger. I replaced `bodyParser.json()` with `express.json()` which is a builtin body-parser since express 4.16.