### PR TITLE
fix slot modal not loading when editing

### DIFF
--- a/src/bp/ui-studio/src/web/views/FlowBuilder/skills/index.jsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/skills/index.jsx
@@ -140,8 +140,16 @@ class SkillsBuilder extends React.Component {
       .then(({ data }) => data)
   }
 
+  findInstalledSkill() {
+    const skillId = this.props.skillId
+    if (skillId) {
+      return find(this.props.installedSkills, x => x.id.toLowerCase() === skillId.toLowerCase())
+    }
+    return undefined
+  }
+
   render() {
-    const skill = find(this.props.installedSkills, { id: this.props.skillId })
+    const skill = this.findInstalledSkill()
     const modalClassName = style['size-' + this.state.windowSize]
     const submitName = this.props.action === 'new' ? 'Insert' : 'Save'
 

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/skills/index.jsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/skills/index.jsx
@@ -142,10 +142,11 @@ class SkillsBuilder extends React.Component {
 
   findInstalledSkill() {
     const skillId = this.props.skillId
-    if (skillId) {
-      return find(this.props.installedSkills, x => x.id.toLowerCase() === skillId.toLowerCase())
+    if (!skillId) {
+      return
     }
-    return undefined
+
+    return find(this.props.installedSkills, x => x.id.toLowerCase() === skillId.toLowerCase())
   }
 
   render() {


### PR DESCRIPTION
Previously the slot skill ids where lowercase and now starts with an uppercase.
So the slot skills of the previous version were not found in the installed skills list.