### PR TITLE
change stale bot time trigger

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,6 +1,6 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
-daysUntilStale: 60
+daysUntilStale: 180
 daysUntilClose: 30
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable


### PR DESCRIPTION
Stale Bot is starting to close recent issues. I've pushed the daysUntilClose to 6 months for now until we figure out how to handle old issues.