### PR TITLE
fix(admin): Enable overwrite destination on copy

### DIFF
--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -347,7 +347,7 @@ export class BotService {
     delete newBot.pipeline_status.stage_request
 
     try {
-      await this.duplicateBot(initialBot.id, newBot.id)
+      await this.duplicateBot(initialBot.id, newBot.id, true)
       await this.configProvider.setBotConfig(newBot.id, newBot)
 
       delete initialBot.pipeline_status.stage_request


### PR DESCRIPTION
This need to be enabled in order to this kind of pipeline to work

![image](https://user-images.githubusercontent.com/13484138/57851180-4cef1180-77b6-11e9-9b66-7f4d926ffd07.png)

with this on_stage_request hook
`if (!bot.id.endsWith('_dev')) {
   hookResult.actions = [];
   return;
 }`
 `bot.id = bot.id.replace('_dev', '')`