### PR TITLE
feat(core): add .ghostignore to exclude files from tracking

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,7 @@
         "${workspaceFolder}/private-modules/*/dist",
         "!${workspaceFolder}/**/node_modules"
       ],
+      "args": ["-p"],
       "console": "integratedTerminal",
       "sourceMaps": true,
       "autoAttachChildProcesses": true

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,6 @@
         "${workspaceFolder}/private-modules/*/dist",
         "!${workspaceFolder}/**/node_modules"
       ],
-      "args": ["-p"],
       "console": "integratedTerminal",
       "sourceMaps": true,
       "autoAttachChildProcesses": true

--- a/src/bp/core/services/ghost/disk-driver.ts
+++ b/src/bp/core/services/ghost/disk-driver.ts
@@ -84,10 +84,10 @@ export default class DiskStorageDriver implements StorageDriver {
       dot: options.includeDotFiles
     }
 
-    // options.excludes can either be a string or an array of strings
+    // options.excludes can either be a string or an array of strings or undefined
     if (Array.isArray(options.excludes)) {
       globOptions['ignore'] = [...options.excludes, ...ghostIgnorePatterns]
-    } else {
+    } else if (options.excludes) {
       globOptions['ignore'] = [options.excludes, ...ghostIgnorePatterns]
     }
 

--- a/src/bp/core/services/ghost/disk-driver.ts
+++ b/src/bp/core/services/ghost/disk-driver.ts
@@ -89,6 +89,8 @@ export default class DiskStorageDriver implements StorageDriver {
       globOptions['ignore'] = [...options.excludes, ...ghostIgnorePatterns]
     } else if (options.excludes) {
       globOptions['ignore'] = [options.excludes, ...ghostIgnorePatterns]
+    } else {
+      globOptions['ignore'] = ghostIgnorePatterns
     }
 
     try {
@@ -133,7 +135,7 @@ export default class DiskStorageDriver implements StorageDriver {
   private async _getGhostIgnorePatterns(ghostIgnorePath: string): Promise<string[]> {
     if (await fse.pathExists(ghostIgnorePath)) {
       const ghostIgnoreFile = await fse.readFile(ghostIgnorePath)
-      return ghostIgnoreFile.toString().split(os.EOL)
+      return ghostIgnoreFile.toString().split(/\r?\n/gi)
     }
     return []
   }

--- a/src/bp/core/services/ghost/index.ts
+++ b/src/bp/core/services/ghost/index.ts
@@ -3,7 +3,10 @@ export interface StorageDriver {
   readFile(filePath: string): Promise<Buffer>
   deleteFile(filePath: string, recordRevision: boolean): Promise<void>
   deleteDir(dirPath: string): Promise<void>
-  directoryListing(folder: string, exclude?: string | string[], includeDotFiles?: boolean): Promise<string[]>
+  directoryListing(
+    folder: string,
+    options: { excludes?: string | string[]; includeDotFiles?: boolean }
+  ): Promise<string[]>
   listRevisions(pathPrefix: string): Promise<FileRevision[]>
   deleteRevision(filePath: string, revision: string): Promise<void>
   moveFile(fromPath: string, toPath: string): Promise<void>

--- a/src/bp/core/services/ghost/service.test.ts
+++ b/src/bp/core/services/ghost/service.test.ts
@@ -172,7 +172,6 @@ describe('Ghost Service', () => {
       it('if disk is not up to date, mark as dirty and dont sync disk files', async () => {
         dbDriver.listRevisions.mockReturnValue(['1', '2', '3'].map(buildRev))
         diskDriver.listRevisions.mockReturnValue(['1', '2'].map(buildRev)) // missing revision "3"
-        diskDriver.discoverTrackableFolders.mockReturnValue(['test', '.'])
 
         await ghost.global().sync()
 
@@ -181,12 +180,10 @@ describe('Ghost Service', () => {
 
         // Make sure we haven't synced anything
         expect(diskDriver.readFile).not.toHaveBeenCalled()
-        expect(diskDriver.directoryListing).not.toHaveBeenCalled()
         expect(dbDriver.upsertFile).not.toHaveBeenCalled()
       })
       it('if disk is up to date, sync disk files', async () => {
         dbDriver.listRevisions.mockReturnValue(['1', '2', '3'].map(buildRev))
-        diskDriver.discoverTrackableFolders.mockReturnValue(['.'])
         diskDriver.listRevisions.mockReturnValue(['1', '2', '3'].map(buildRev)) // All synced!
         diskDriver.readFile.mockReturnValueOnce('FILE A CONTENT')
         diskDriver.readFile.mockReturnValueOnce('FILE D CONTENT')

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -195,7 +195,8 @@ export class ScopedGhostService {
   }
 
   /**
-   * Synchronize all tracked files to BP Ghost.
+   * All tracked files will be synced.
+   * All files are tracked by default, unless `.ghostignore` is used to exclude them.
    */
   async sync() {
     if (!this.useDbDriver) {

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -147,12 +147,12 @@ export class ScopedGhostService {
     this.primaryDriver = useDbDriver ? dbDriver : diskDriver
   }
 
-  private normalizeFolderName(rootFolder: string) {
+  private _normalizeFolderName(rootFolder: string) {
     return forceForwardSlashes(path.join(this.baseDir, rootFolder))
   }
 
-  private normalizeFileName(rootFolder: string, file: string) {
-    return forceForwardSlashes(path.join(this.normalizeFolderName(rootFolder), file))
+  private _normalizeFileName(rootFolder: string, file: string) {
+    return forceForwardSlashes(path.join(this._normalizeFolderName(rootFolder), file))
   }
 
   objectCacheKey = str => `string::${str}`
@@ -164,13 +164,13 @@ export class ScopedGhostService {
   }
 
   async invalidateFile(rootFolder: string, fileName: string): Promise<void> {
-    const filePath = this.normalizeFileName(rootFolder, fileName)
+    const filePath = this._normalizeFileName(rootFolder, fileName)
     await this._invalidateFile(filePath)
   }
 
   async ensureDirs(rootFolder: string, directories: string[]): Promise<void> {
     if (!this.useDbDriver) {
-      await Promise.mapSeries(directories, d => this.diskDriver.createDir(this.normalizeFileName(rootFolder, d)))
+      await Promise.mapSeries(directories, d => this.diskDriver.createDir(this._normalizeFileName(rootFolder, d)))
     }
   }
 
@@ -179,7 +179,7 @@ export class ScopedGhostService {
       throw new Error(`Ghost can't read or write under this scope`)
     }
 
-    const fileName = this.normalizeFileName(rootFolder, file)
+    const fileName = this._normalizeFileName(rootFolder, file)
 
     if (content.length > MAX_GHOST_FILE_SIZE) {
       throw new Error(`The size of the file ${fileName} is over the 20mb limit`)
@@ -194,8 +194,8 @@ export class ScopedGhostService {
     await Promise.all(content.map(c => this.upsertFile(rootFolder, c.name, c.content)))
   }
 
-  /** All tracked directories will be synced
-   * Directories are tracked by default, unless a `.noghost` file is present in the directory
+  /**
+   * Synchronize all tracked files to BP Ghost.
    */
   async sync() {
     if (!this.useDbDriver) {
@@ -203,7 +203,8 @@ export class ScopedGhostService {
       return
     }
 
-    const paths = await this.diskDriver.discoverTrackableFolders(this.normalizeFolderName('./'))
+    // Get files from disk that should be ghosted
+    const trackedFiles = await this.diskDriver.directoryListing(this.baseDir, { includeDotFiles: true })
 
     const diskRevs = await this.diskDriver.listRevisions(this.baseDir)
     const dbRevs = await this.dbDriver.listRevisions(this.baseDir)
@@ -219,36 +220,26 @@ export class ScopedGhostService {
       return
     }
 
-    for (const path of paths) {
-      const normalizedPath = this.normalizeFolderName(path)
-      let currentFiles = await this.dbDriver.directoryListing(normalizedPath)
-      let newFiles = await this.diskDriver.directoryListing(normalizedPath, undefined, true)
+    // Delete the ghosted files that has been deleted from disk
+    const ghostedFiles = await this.dbDriver.directoryListing(this._normalizeFolderName('./'))
+    const filesToDelete = _.difference(ghostedFiles, trackedFiles)
+    await Promise.map(filesToDelete, filePath =>
+      this.dbDriver.deleteFile(this._normalizeFileName('./', filePath), false)
+    )
 
-      if (path === './') {
-        currentFiles = currentFiles.filter(x => !x.includes('/'))
-        newFiles = newFiles.filter(x => !x.includes('/'))
-      }
-
-      // We delete files that have been deleted from disk
-      for (const file of _.difference(currentFiles, newFiles)) {
-        const filePath = this.normalizeFileName(path, file)
-        await this.dbDriver.deleteFile(filePath, false)
-      }
-
-      // We now update files in DB by those on the disk
-      for (const file of newFiles) {
-        const filePath = this.normalizeFileName(path, file)
-        const content = await this.diskDriver.readFile(filePath)
-        await this.dbDriver.upsertFile(filePath, content, false)
-      }
-    }
+    // Overwrite all of the ghosted files with the tracked files
+    await Promise.each(trackedFiles, async file => {
+      const filePath = this._normalizeFileName('./', file)
+      const content = await this.diskDriver.readFile(filePath)
+      await this.dbDriver.upsertFile(filePath, content, false)
+    })
   }
 
   public async exportToDirectory(directory: string, exludes?: string | string[]): Promise<string[]> {
     const allFiles = await this.directoryListing('./', '*.*', exludes, true)
 
     for (const file of allFiles.filter(x => x !== 'revisions.json')) {
-      const content = await this.primaryDriver.readFile(this.normalizeFileName('./', file))
+      const content = await this.primaryDriver.readFile(this._normalizeFileName('./', file))
       const outPath = path.join(directory, file)
       mkdirp.sync(path.dirname(outPath))
       await fse.writeFile(outPath, content)
@@ -307,7 +298,7 @@ export class ScopedGhostService {
       throw new Error(`Ghost can't read or write under this scope`)
     }
 
-    const fileName = this.normalizeFileName(rootFolder, file)
+    const fileName = this._normalizeFileName(rootFolder, file)
     const cacheKey = this.bufferCacheKey(fileName)
 
     if (!(await this.cache.has(cacheKey))) {
@@ -324,7 +315,7 @@ export class ScopedGhostService {
   }
 
   async readFileAsObject<T>(rootFolder: string, file: string): Promise<T> {
-    const fileName = this.normalizeFileName(rootFolder, file)
+    const fileName = this._normalizeFileName(rootFolder, file)
     const cacheKey = this.objectCacheKey(fileName)
 
     if (!(await this.cache.has(cacheKey))) {
@@ -338,7 +329,7 @@ export class ScopedGhostService {
   }
 
   async fileExists(rootFolder: string, file: string): Promise<boolean> {
-    const fileName = this.normalizeFileName(rootFolder, file)
+    const fileName = this._normalizeFileName(rootFolder, file)
     try {
       await this.primaryDriver.readFile(fileName)
       return true
@@ -352,15 +343,15 @@ export class ScopedGhostService {
       throw new Error(`Ghost can't read or write under this scope`)
     }
 
-    const fileName = this.normalizeFileName(rootFolder, file)
+    const fileName = this._normalizeFileName(rootFolder, file)
     await this.primaryDriver.deleteFile(fileName, true)
     this.events.emit('changed', fileName)
     await this._invalidateFile(fileName)
   }
 
   async renameFile(rootFolder: string, fromName: string, toName: string): Promise<void> {
-    const fromPath = this.normalizeFileName(rootFolder, fromName)
-    const toPath = this.normalizeFileName(rootFolder, toName)
+    const fromPath = this._normalizeFileName(rootFolder, fromName)
+    const toPath = this._normalizeFileName(rootFolder, toName)
 
     await this.primaryDriver.moveFile(fromPath, toPath)
   }
@@ -370,7 +361,7 @@ export class ScopedGhostService {
       throw new Error(`Ghost can't read or write under this scope`)
     }
 
-    const folderName = this.normalizeFolderName(folder)
+    const folderName = this._normalizeFolderName(folder)
     await this.primaryDriver.deleteDir(folderName)
   }
 
@@ -381,11 +372,10 @@ export class ScopedGhostService {
     includeDotFiles?: boolean
   ): Promise<string[]> {
     try {
-      const files = await this.primaryDriver.directoryListing(
-        this.normalizeFolderName(rootFolder),
+      const files = await this.primaryDriver.directoryListing(this._normalizeFolderName(rootFolder), {
         excludes,
         includeDotFiles
-      )
+      })
 
       return (files || []).filter(
         minimatch.filter(fileEndingPattern, { matchBase: true, nocase: true, noglobstar: false, dot: includeDotFiles })


### PR DESCRIPTION
`.ghostignore` works just like `.gitignore`

1. Create a `.ghostignore` file in your `data/` directory (**mandatory**)
1. List the patterns of the files / folders that you don't want to be tracked by the ghost
1. Restart the server

File content example:
```
**/.git/**
**/.gitignore
**/*.lol
**/*.lul
```
