### PR TITLE
fix: Expose getAttributes from UserRepository

### DIFF
--- a/src/bp/core/api.ts
+++ b/src/bp/core/api.ts
@@ -121,6 +121,7 @@ const users = (userRepo: UserRepository): typeof sdk.users => {
   return {
     getOrCreateUser: userRepo.getOrCreate.bind(userRepo),
     updateAttributes: userRepo.updateAttributes.bind(userRepo),
+    getAttributes: userRepo.getAttributes.bind(userRepo),
     setAttributes: userRepo.setAttributes.bind(userRepo),
     getAllUsers: userRepo.getAllUsers.bind(userRepo),
     getUserCount: userRepo.getUserCount.bind(userRepo)

--- a/src/bp/core/repositories/users.ts
+++ b/src/bp/core/repositories/users.ts
@@ -9,6 +9,7 @@ export interface UserRepository {
   getOrCreate(channel: string, id: string): Knex.GetOrCreateResult<User>
   updateAttributes(channel: string, id: string, attributes: any): Promise<void>
   setAttributes(channel: string, id: string, attributes: any): Promise<void>
+  getAttributes(channel: string, id: string): Promise<any>
   getAllUsers(paging?: Paging): Promise<any>
   getUserCount(): Promise<any>
 }


### PR DESCRIPTION
getAttributes is a not private method that could be used to retrieve user info in the channel main module.

In my scenario, I am trying to identify if the user had some basic info provided by the channel stored as attributes before processing the event.