### PR TITLE
fix(webchat): scroll to the very bottom of the chat on open

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/MessageList.jsx
+++ b/modules/channel-web/src/views/lite/components/messages/MessageList.jsx
@@ -31,7 +31,7 @@ class MessageList extends Component {
       } catch (err) {
         // Discard the error
       }
-    }, 0)
+    }, 50)
   }
 
   handleKeyDown = e => {


### PR DESCRIPTION
This fixes an issue with webchat not scrolling to the very bottom when opened. It was leaving some space below to scroll (like ~100px).
I know `setTimeout` isn't the best option, but it was used here anyways. :blush: 