### PR TITLE
fix: validate entry.messaging exists

### DIFF
--- a/modules/channel-messenger/src/backend/messenger.ts
+++ b/modules/channel-messenger/src/backend/messenger.ts
@@ -161,6 +161,7 @@ export class MessengerService {
         continue
       }
       if (!messages) {
+         debugMessages('incoming event without messaging entry')
          return
        }
       for (const webhookEvent of messages) {

--- a/modules/channel-messenger/src/backend/messenger.ts
+++ b/modules/channel-messenger/src/backend/messenger.ts
@@ -162,11 +162,11 @@ export class MessengerService {
       }
       if (!messages) {
          debugMessages('incoming event without messaging entry')
-         return
+         continue
        }
       for (const webhookEvent of messages) {
         if (!webhookEvent.sender) {
-          return
+          continue
         }
 
         debugMessages('incoming', webhookEvent)

--- a/modules/channel-messenger/src/backend/messenger.ts
+++ b/modules/channel-messenger/src/backend/messenger.ts
@@ -160,7 +160,9 @@ export class MessengerService {
         debugMessages('could not find a bot for page id =', pageId)
         continue
       }
-
+      if (!messages) {
+         return
+       }
       for (const webhookEvent of messages) {
         if (!webhookEvent.sender) {
           return


### PR DESCRIPTION
This validation is required for standby events. Any bot that has more than 1 app in FB (primary-secondary) receiver will get standby events.

In my last patch, the validation was not correct and @rndlaine  fixed that but also took away the `entry.messaging` validation, so I am returning the validation in this little PR