### PR TITLE
chore(core): changed assets path to ./data/assets

### DIFF
--- a/build/gulp.modules.js
+++ b/build/gulp.modules.js
@@ -144,7 +144,7 @@ const buildSdk = () => {
 
 const cleanModuleAssets = () => {
   const moduleName = _.last(process.argv)
-  return gulp.src(`./out/bp/assets/modules/${moduleName}`, { allowEmpty: true }).pipe(rimraf())
+  return gulp.src(`./out/bp/data/assets/modules/${moduleName}`, { allowEmpty: true }).pipe(rimraf())
 }
 
 const createModuleSymlink = () => {
@@ -152,7 +152,7 @@ const createModuleSymlink = () => {
   const moduleName = _.last(process.argv)
   return gulp
     .src(`./${moduleFolder}/${moduleName}/assets/`)
-    .pipe(symlink(`./out/bp/assets/modules/${moduleName}/`, { type: 'dir' }))
+    .pipe(symlink(`./out/bp/data/assets/modules/${moduleName}/`, { type: 'dir' }))
 }
 
 module.exports = {

--- a/build/gulp.ui.js
+++ b/build/gulp.ui.js
@@ -48,7 +48,7 @@ const cleanStudio = () => {
 }
 
 const cleanStudioAssets = () => {
-  return gulp.src('./out/bp/assets/ui-studio/public', { allowEmpty: true }).pipe(rimraf())
+  return gulp.src('./out/bp/data/assets/ui-studio/public', { allowEmpty: true }).pipe(rimraf())
 }
 
 const copyStudio = () => {
@@ -56,7 +56,7 @@ const copyStudio = () => {
 }
 
 const createStudioSymlink = () => {
-  return gulp.src('./src/bp/ui-studio/public').pipe(symlink('./out/bp/assets/ui-studio/', { type: 'dir' }))
+  return gulp.src('./src/bp/ui-studio/public').pipe(symlink('./out/bp/data/assets/ui-studio/', { type: 'dir' }))
 }
 
 const watchAdmin = cb => {

--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -178,7 +178,7 @@ export class Botpress {
 
   async deployAssets() {
     try {
-      const assets = path.resolve(process.PROJECT_LOCATION, 'assets')
+      const assets = path.resolve(process.PROJECT_LOCATION, 'data/assets')
       await copyDir(path.join(__dirname, '../ui-admin'), `${assets}/ui-admin`)
 
       // Avoids overwriting the folder when developping locally on the studio

--- a/src/bp/core/server.ts
+++ b/src/bp/core/server.ts
@@ -163,7 +163,7 @@ export default class HTTPServer {
     this.botsRouter.router.use('/converse', this.converseRouter.router)
   }
 
-  resolveAsset = file => path.resolve(process.PROJECT_LOCATION, 'assets', file)
+  resolveAsset = file => path.resolve(process.PROJECT_LOCATION, 'data/assets', file)
 
   async start() {
     const botpressConfig = await this.configProvider.getBotpressConfig()
@@ -283,7 +283,6 @@ export default class HTTPServer {
       res.sendFile(this.resolveAsset('ui-admin/public/index.html'))
     })
 
-    app.get('/api/community/hero', (req, res) => res.send({ hidden: true }))
     app.get('/', (req, res) => res.redirect('/admin'))
   }
 

--- a/src/bp/core/services/module/config-reader.ts
+++ b/src/bp/core/services/module/config-reader.ts
@@ -91,7 +91,7 @@ export default class ConfigReader {
   private async getModuleDefaultConfigFile(moduleId): Promise<any | undefined> {
     try {
       const defaultConfig = {
-        $schema: `../../../assets/modules/${moduleId}/config.schema.json`,
+        $schema: `../../assets/modules/${moduleId}/config.schema.json`,
         ...defaultJsonBuilder(await this.getModuleConfigSchema(moduleId))
       }
 

--- a/src/bp/core/services/module/resources-loader.ts
+++ b/src/bp/core/services/module/resources-loader.ts
@@ -64,7 +64,7 @@ export class ModuleResourceLoader {
       },
       {
         src: `${this.modulePath}/assets`,
-        dest: `/assets/modules/${this.moduleName}`,
+        dest: `/data/assets/modules/${this.moduleName}`,
         ignoreChecksum: true
       },
       {


### PR DESCRIPTION
The goal is to have all the data required by Botpress inside the `data` directory, this will make it easier for volume-based deployments not to have to map multiple directories.

Next step is to also store modules in data (and the `cache` / `temp` directory should be overridable).