### PR TITLE
Lang Server ajustments

### DIFF
--- a/src/bp/index.ts
+++ b/src/bp/index.ts
@@ -194,43 +194,42 @@ try {
       'Launch a local language server',
       {
         port: {
-          description: 'the port to listen to',
+          description: 'The port to listen to',
           default: 3100
         },
         host: {
-          description: 'only allow connections from this host',
+          description: 'Binds the language server to a specific hostname',
           default: 'localhost'
         },
         langDir: {
-          description: 'the directory where the language models reside in'
+          description: 'Directory where language embeddings will be saved'
         },
         authToken: {
-          description: 'require API requests to use this Bearer token'
+          description: 'When defined clients must provide this Bearer token'
         },
         limit: {
-          description: 'the maximum number of requests per IP per "limitWindow" interval (0 means unlimited)',
+          description: 'Maximum number of requests per IP per "limitWindow" interval (0 means unlimited)',
           default: 0
         },
         limitWindow: {
-          description: 'the time window on which the limit is applied',
+          description: 'Time window on which the limit is applied (use standard notation, ex: 25m or 1h)',
           default: '1h'
         },
         readOnly: {
-          description: 'disables adding and removing embeddings at run-time',
+          description: 'Read-only prevents adding and removing language embeddings at run-time',
           default: false,
           type: 'boolean'
         },
         metadataLocation: {
-          description: 'location of the available models to download',
+          description: 'URL of metadata file which lists available languages',
           default: 'http://botpress-public.nyc3.digitaloceanspaces.com/embeddings/index.json'
         },
         dim: {
           default: 100,
-          description: '(filter=dim) the dimentions of language to provide. files are named "domain.lang.dim.bin"'
+          description: 'Number of language dimensions provided (25, 100 or 300 at the moment)'
         },
         domain: {
-          description:
-            '(filter=domain) the domain the embeddings were trained on. files are named "domain.lang.dim.bin"',
+          description: 'Name of the domain where those embeddings were trained on.',
           default: 'bp'
         }
       },

--- a/src/bp/lang-server/api.ts
+++ b/src/bp/lang-server/api.ts
@@ -245,8 +245,9 @@ export default async function(options: APIOptions, languageService: LanguageServ
   const httpServer = createServer(app)
 
   await Promise.fromCallback(callback => {
-    httpServer.listen(options.port, options.host, undefined, callback)
+    const hostname = options.host === 'localhost' ? undefined : options.host
+    httpServer.listen(options.port, hostname, undefined, callback)
   })
 
-  console.log(`Language server ready on '${options.host}' port ${options.port}`)
+  console.log(`Language Server is ready at http://${options.host}:${options.port}/`)
 }

--- a/src/bp/lang-server/index.ts
+++ b/src/bp/lang-server/index.ts
@@ -10,6 +10,8 @@ import API from './api'
 import LanguageService from './service'
 import DownloadManager from './service/download-manager'
 
+const debug = DEBUG('api')
+
 export interface ArgV {
   port: number
   host: string
@@ -26,7 +28,7 @@ export interface ArgV {
 export default async function(options: ArgV) {
   options.langDir = options.langDir || path.join(process.APP_DATA_PATH, 'embeddings')
 
-  console.log('Language Server', options)
+  debug('Language Server Options ', options)
 
   const langService = new LanguageService(options.dim, options.domain, options.langDir)
   const downloadManager = new DownloadManager(options.dim, options.domain, options.langDir, options.metadataLocation)

--- a/src/bp/lang-server/monitoring.ts
+++ b/src/bp/lang-server/monitoring.ts
@@ -1,0 +1,46 @@
+import ms from 'ms'
+import onHeaders from 'on-headers'
+
+const debugMonitor = DEBUG('api:monitoring')
+
+let metricCollectionEnabled = false
+let metricsContainer = {}
+
+export const startMonitoring = () => {
+  console.log('Metrics collection enabled. Interval: ', process.env.MONITORING_INTERVAL)
+
+  setInterval(() => {
+    debugMonitor('Stats %o', metricsContainer)
+    metricsContainer = {}
+  }, ms(process.env.MONITORING_INTERVAL!))
+
+  metricCollectionEnabled = true
+}
+
+export const incrementMetric = (language: string, metricName: string, value?: number | undefined) => {
+  if (!metricCollectionEnabled) {
+    return
+  }
+
+  const key = `${language || 'none'}_${metricName}`
+  const realValue = value !== undefined ? value : 1
+
+  if (!metricsContainer[key]) {
+    metricsContainer[key] = realValue
+  } else {
+    metricsContainer[key] += realValue
+  }
+}
+
+export const monitoringMiddleware = (req, res, next) => {
+  const startAt = Date.now()
+
+  onHeaders(res, () => {
+    const timeInMs = Date.now() - startAt
+    incrementMetric(req.body.lang, 'requestCount')
+    incrementMetric(req.body.lang, 'latencySum', timeInMs)
+    res.setHeader('X-Response-Time', `${timeInMs}ms`)
+  })
+
+  next()
+}

--- a/src/bp/lang-server/util.ts
+++ b/src/bp/lang-server/util.ts
@@ -1,0 +1,76 @@
+import { BadRequestError, NotReadyError, UnauthorizedError } from 'core/routers/errors'
+import _ from 'lodash'
+
+import LanguageService from './service'
+
+const debugAuth = DEBUG('api:auth')
+
+export const authMiddleware = (secureToken: string) => (req, _res, next) => {
+  if (!req.headers.authorization) {
+    return next(new UnauthorizedError('Authorization header is missing'))
+  }
+
+  const [scheme, token] = req.headers.authorization.split(' ')
+  if (scheme.toLowerCase() !== 'bearer') {
+    return next(new UnauthorizedError(`Unknown scheme "${scheme}" - expected 'bearer <token>'`))
+  }
+
+  if (!token) {
+    return next(new UnauthorizedError('Authentication token is missing'))
+  }
+
+  if (secureToken !== token) {
+    debugAuth('Invalid token', { ip: req.ip })
+    return next(new UnauthorizedError('Invalid Bearer token'))
+  }
+
+  next()
+}
+
+export const serviceLoadingMiddleware = (service: LanguageService) => (_req, _res, next) => {
+  if (!service.isReady) {
+    return next(new NotReadyError('Language Server is still loading'))
+  }
+
+  next()
+}
+
+export const assertValidLanguage = (service: LanguageService) => (req, _res, next) => {
+  const language = req.body.lang
+
+  if (!language) {
+    throw new BadRequestError(`Param 'lang' is mandatory`)
+  }
+
+  if (!_.isString(language)) {
+    throw new BadRequestError(`Param 'lang': ${language} must be a string`)
+  }
+
+  const availableLanguages = service.getModels().map(x => x.lang)
+  if (!availableLanguages.includes(language)) {
+    throw new BadRequestError(`Param 'lang': ${language} is not element of the available languages`)
+  }
+
+  next()
+}
+
+export const disabledReadonlyMiddleware = (readonly: boolean) => (_req, _res, next) => {
+  if (readonly) {
+    return next(new UnauthorizedError('API server is running in read-only mode'))
+  }
+
+  next()
+}
+
+export const errorHandler = (err, req, res, next) => {
+  const statusCode = err.statusCode || 500
+  const errorCode = err.errorCode || 'BP_000'
+  const message = (err.errorCode && err.message) || 'Unexpected error'
+
+  res.status(statusCode).json({
+    statusCode,
+    errorCode,
+    type: err.type || Object.getPrototypeOf(err).name || 'Exception',
+    message
+  })
+}

--- a/src/bp/lang-server/util.ts
+++ b/src/bp/lang-server/util.ts
@@ -79,7 +79,7 @@ export const handleUnexpectedError = (err, req, res, next) => {
 }
 
 export const handleErrorLogging = (err, req, res, next) => {
-  if ((err && err.skipLogging) || process.env.SKIP_LOGGING) {
+  if (err && (err.skipLogging || process.env.SKIP_LOGGING)) {
     return res.status(err.statusCode).send(err.message)
   }
 


### PR DESCRIPTION
Some ajustments to Lang server:

- There was a bug with the hostname. When it's localhost, it must be undefined, otherwise it only listens to localhost (took me some time to debug that on docker...) 
- Added basic monitoring so we can see usage of languages, their response time (+ returning response time to calling client - could be nice to add to redis eventually for better tracking)
- Enforcing the "skipLogging" of errors to prevent logging every stack trace (ex, when the server is getting ready, it is getting spammed badly by waiting clients) 	
- General cleanup (moved middleware to separate file so we see what matters)

![image](https://user-images.githubusercontent.com/42552874/59803515-ae286a00-92b9-11e9-8724-253723282416.png)
