### PR TITLE
add variable to override migration version

### DIFF
--- a/src/bp/core/services/migration/index.ts
+++ b/src/bp/core/services/migration/index.ts
@@ -39,7 +39,7 @@ export class MigrationService {
     @inject(TYPES.Database) private database: Database,
     @inject(TYPES.ConfigProvider) private configProvider: ConfigProvider
   ) {
-    this.currentVersion = process.BOTPRESS_VERSION
+    this.currentVersion = process.env.MIGRATION_TEST_VERSION || process.BOTPRESS_VERSION
     this.completedMigrationsDir = path.resolve(process.PROJECT_LOCATION, `data/migrations`)
     mkdirp.sync(this.completedMigrationsDir)
   }


### PR DESCRIPTION
This is mostly to test more easily migrations, & be able to test them before the version is officially bumped. It doesn't overrides anything else outside the migration service