### PR TITLE
fix(lang): streamline lang checks & fix response when erroring

### DIFF
--- a/src/bp/lang-server/service/index.ts
+++ b/src/bp/lang-server/service/index.ts
@@ -64,12 +64,16 @@ export default class LanguageService {
     await this._loadModels(lang)
   }
 
-  @WrapErrorsWith(args => `Couldn't load language model "${args[0]}"`)
   private async _loadModels(lang: string) {
     console.log('Loading Embeddings for', lang.toUpperCase())
-    const fastTextModel = await this._loadFastTextModel(lang)
-    const bpeModel = await this._loadBPEModel(lang)
-    this._models[lang] = { fastTextModel, bpeModel }
+
+    try {
+      const fastTextModel = await this._loadFastTextModel(lang)
+      const bpeModel = await this._loadBPEModel(lang)
+      this._models[lang] = { fastTextModel, bpeModel }
+    } catch (err) {
+      console.error(`[${lang.toUpperCase()}] Error loading language. It will be unavailable.`, err)
+    }
   }
 
   private _getFileInfo = (regexMatch: RegExpMatchArray, isFastText, file): ModelFileInfo => {

--- a/src/bp/lang-server/util.ts
+++ b/src/bp/lang-server/util.ts
@@ -1,4 +1,5 @@
 import { BadRequestError, NotReadyError, UnauthorizedError } from 'core/routers/errors'
+import { Request } from 'express'
 import _ from 'lodash'
 
 import LanguageService from './service'
@@ -39,21 +40,22 @@ export const serviceLoadingMiddleware = (service: LanguageService) => (_req, _re
 }
 
 export const assertValidLanguage = (service: LanguageService) => (req, _res, next) => {
-  const language = req.body.lang
+  const language = req.body.lang || req.params.lang
 
   if (!language) {
-    throw new BadRequestError(`Param 'lang' is mandatory`)
+    return next(new BadRequestError(`Param 'lang' is mandatory`))
   }
 
   if (!_.isString(language)) {
-    throw new BadRequestError(`Param 'lang': ${language} must be a string`)
+    return next(new BadRequestError(`Param 'lang': ${language} must be a string`))
   }
 
   const availableLanguages = service.getModels().map(x => x.lang)
   if (!availableLanguages.includes(language)) {
-    throw new BadRequestError(`Param 'lang': ${language} is not element of the available languages`)
+    return next(new BadRequestError(`Param 'lang': ${language} is not element of the available languages`))
   }
 
+  req.language = language
   next()
 }
 
@@ -84,4 +86,8 @@ export const handleErrorLogging = (err, req, res, next) => {
   }
 
   next(err)
+}
+
+export type RequestWithLang = Request & {
+  language?: string
 }


### PR DESCRIPTION
Using the same language check everywhere. Since we don't use the async middleware, throwing was giving stack traces in the console and no response to the user. 