### PR TITLE
fix(channel-web): hiding widget when hiding webchat

### DIFF
--- a/modules/channel-web/assets/inject.css
+++ b/modules/channel-web/assets/inject.css
@@ -24,6 +24,10 @@
   height: 76px !important;
 }
 
+.bp-widget-hidden {
+  display: none;
+}
+
 .bp-widget-convo {
   top: auto;
   left: auto;

--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -194,7 +194,10 @@ class Web extends React.Component<MainProps> {
       return null
     }
 
-    const parentClass = `bp-widget-web bp-widget-${this.props.activeView}`
+    const parentClass = classnames(`bp-widget-web bp-widget-${this.props.activeView}`, {
+      'bp-widget-hidden': !this.props.showWidgetButton
+    })
+
     if (this.parentClass !== parentClass) {
       window.parent && window.parent.postMessage({ type: 'setClass', value: parentClass }, '*')
       this.parentClass = parentClass


### PR DESCRIPTION
Fixing that famous bug from Botpress Dark Ages

![image](https://user-images.githubusercontent.com/42552874/59897986-101dc800-93bd-11e9-885a-9c8c043e898f.png)