### PR TITLE
channel-web: add event when open chat button is clicked

### DIFF
--- a/modules/channel-web/src/views/lite/main.jsx
+++ b/modules/channel-web/src/views/lite/main.jsx
@@ -345,6 +345,7 @@ export default class Web extends React.Component {
 
   handleButtonClicked = () => {
     this.state.view === 'convo' ? this.handleSwitchView('widget') : this.handleSwitchView('side')
+    parent.postMessage({ name: 'handleButtonClicked' }, '*')
   }
 
   handleApiError = error => {


### PR DESCRIPTION
As we can read [in the doc](https://botpress.io/docs/tutorials/proactive/#send-message-on-chat-widget-click), we can send a custom event when the open chat button is clicked. If we put an event listener in the `before_incoming_middleware` hook, we allow the bot to send the first message when the button is clicked.
The problem is that it works only if the HTML file which integrate the Botpress initialization snippet is hosted on the same server that Botpress Server, so we need to have the same domain origin. This is the proper logic of iframe cross-domain communication.
I tested with the [proactive module example](https://github.com/botpress/botpress/tree/master/examples/proactive) and in fact, it works because the examples html files are served by the local server when you run the bot.
Try to put the HTML file which integrate the Botpress init snippet in the `data/assets/modules/channel-web/` folder (to get the same address with Botpress server) and you'll see that it works too.

So I think it could be useful to have an event that we can listen from anywhere when we click the open chatbot button.
We can listen this event by using :
```js
window.addEventListener('message', function(event) {
  if (event.data.name === 'handleButtonClicked') {
    window.botpressWebChat.sendEvent({ type: 'proactive-trigger' })
  }
})
```
and that's all. No need to be on the same domain origin.

Tell me if you're okay with me (and the way it's done) so I can update the documentation :)