### PR TITLE
fix(bots): checking bot status & fix export

### DIFF
--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -188,7 +188,7 @@ export class BotService {
   }
 
   async exportBot(botId: string): Promise<Buffer> {
-    return this.ghostService.forBot(botId).exportToArchiveBuffer('models/*')
+    return this.ghostService.forBot(botId).exportToArchiveBuffer('models/**/*')
   }
 
   async importBot(botId: string, archive: Buffer, allowOverwrite?: boolean): Promise<void> {
@@ -518,7 +518,7 @@ export class BotService {
 
     const botGhost = this.ghostService.forBot(botId)
     const globalGhost = this.ghostService.global()
-    await globalGhost.upsertFile(REVISIONS_DIR, `${revName}.tgz`, await botGhost.exportToArchiveBuffer('models/*'))
+    await globalGhost.upsertFile(REVISIONS_DIR, `${revName}.tgz`, await botGhost.exportToArchiveBuffer('models/**/*'))
     return this._cleanupRevisions(botId)
   }
 

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemCompact.jsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemCompact.jsx
@@ -21,18 +21,22 @@ export default ({ bot, deleteBot, exportBot, permissions, history, createRevisio
           <FaCog /> Configs
         </Button>
       </AccessControl>
-      <Button size="sm" color="link" target="_blank" href={`${window.location.origin}/s/${bot.id}`}>
-        <IoIosChatbubbles /> Open chat
-      </Button>
+      {!bot.disabled && (
+        <Button size="sm" color="link" target="_blank" href={`${window.location.origin}/s/${bot.id}`}>
+          <IoIosChatbubbles /> Open chat
+        </Button>
+      )}
       <UncontrolledButtonDropdown>
         <DropdownToggle tag="span" className="more">
           <MdMoreVert />
         </DropdownToggle>
         <DropdownMenu>
-          <DropdownItem disabled={bot.locked} tag="a" href={`/studio/${bot.id}`}>
-            <MdModeEdit />
-            &nbsp;Edit in studio
-          </DropdownItem>
+          {!bot.disabled && (
+            <DropdownItem disabled={bot.locked} tag="a" href={`/studio/${bot.id}`}>
+              <MdModeEdit />
+              &nbsp;Edit in studio
+            </DropdownItem>
+          )}
           <AccessControl permissions={permissions} resource="admin.bots.*" operation="write">
             <DropdownItem onClick={createRevision}>
               <MdBackup />

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemPipeline.jsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemPipeline.jsx
@@ -40,13 +40,17 @@ export default ({
           <MdMoreVert />
         </DropdownToggle>
         <DropdownMenu>
-          <DropdownItem tag="a" target="_blank" href={`${window.location.origin}/s/${bot.id}`}>
-            <IoIosChatbubbles /> &nbsp;Open chat
-          </DropdownItem>
-          <DropdownItem disabled={bot.locked} tag="a" href={`/studio/${bot.id}`}>
-            <MdModeEdit />
-            &nbsp;Edit in studio
-          </DropdownItem>
+          {!bot.disabled && (
+            <React.Fragment>
+              <DropdownItem tag="a" target="_blank" href={`${window.location.origin}/s/${bot.id}`}>
+                <IoIosChatbubbles /> &nbsp;Open chat
+              </DropdownItem>
+              <DropdownItem disabled={bot.locked} tag="a" href={`/studio/${bot.id}`}>
+                <MdModeEdit />
+                &nbsp;Edit in studio
+              </DropdownItem>
+            </React.Fragment>
+          )}
           {allowStageChange && (
             <DropdownItem onClick={requestStageChange}>
               <MdSkipNext />


### PR DESCRIPTION
Some quick fixes:
- Open Chat & Edit Studio are hidden when bot is disabled
- Excluding models from export & revision
- When bot is disabled, disabling all routes for it (previously some info was available - was generating a lot of garbage in logs)