### PR TITLE
fix(webchat): history behaviour & convo resilience

### DIFF
--- a/modules/channel-web/src/views/lite/store/composer.ts
+++ b/modules/channel-web/src/views/lite/store/composer.ts
@@ -1,5 +1,5 @@
 import last from 'lodash/last'
-import take from 'lodash/take'
+import takeRight from 'lodash/takeRight'
 import { action, observable } from 'mobx'
 
 import constants from '../core/constants'
@@ -41,7 +41,10 @@ class ComposerStore {
       this._sentHistoryIndex = 0
 
       if (window.BP_STORAGE && this.rootStore.config.enablePersistHistory) {
-        window.BP_STORAGE.set(SENT_HISTORY_KEY, JSON.stringify(take(this._sentHistory, constants.SENT_HISTORY_SIZE)))
+        window.BP_STORAGE.set(
+          SENT_HISTORY_KEY,
+          JSON.stringify(takeRight(this._sentHistory, constants.SENT_HISTORY_SIZE))
+        )
       }
     }
   }
@@ -52,7 +55,7 @@ class ComposerStore {
       return
     }
 
-    let newIndex = direction === HISTORY_UP ? this._sentHistoryIndex + 1 : this._sentHistoryIndex - 1
+    let newIndex = direction === HISTORY_UP ? this._sentHistoryIndex - 1 : this._sentHistoryIndex + 1
 
     if (newIndex < 0) {
       newIndex = this._sentHistory.length - 1

--- a/modules/channel-web/src/views/lite/store/index.ts
+++ b/modules/channel-web/src/views/lite/store/index.ts
@@ -165,6 +165,11 @@ class RootStore {
   /** Fetch the specified conversation ID, or try to fetch a valid one from the list */
   @action.bound
   async fetchConversation(convoId?: number): Promise<void> {
+    const conversationId = convoId || this._getCurrentConvoId()
+    if (!conversationId) {
+      return this.createConversation()
+    }
+
     const conversation = await this.api.fetchConversation(convoId || this._getCurrentConvoId())
     runInAction('-> setConversation', () => {
       this.currentConversation = conversation


### PR DESCRIPTION
- History behaviour was off (arrows weren't working as expected & history wasn't kept correctly)
- In some cases convo id was undefined, so when it happens it creates a new convo gracefully (seems to happen when moving between databases & keeping browser history... don't think much user would encounter it, but so.)