### PR TITLE
fix(channel-web): allows different user id for different purposes

### DIFF
--- a/modules/channel-web/src/views/full/index.tsx
+++ b/modules/channel-web/src/views/full/index.tsx
@@ -23,6 +23,7 @@ export class WebBotpressUIInjection extends React.Component {
         enableReset: true,
         enableTranscriptDownload: true,
         botId: window.BOT_ID,
+        userIdScope: 'studio',
         sendUsageStats: window.SEND_USAGE_STATS,
         disableAnimations: true,
         showPoweredBy: false,

--- a/modules/channel-web/src/views/lite/core/socket.tsx
+++ b/modules/channel-web/src/views/lite/core/socket.tsx
@@ -1,13 +1,17 @@
+import { Config } from '../typings'
+
 export default class BpSocket {
   private events: any
   private userId: string
+  private userIdScope: string
 
   public onMessage: (event: any) => void
   public onTyping: (event: any) => void
   public onUserIdChanged: (userId: string) => void
 
-  constructor(bp) {
+  constructor(bp, config: Config) {
     this.events = bp && bp.events
+    this.userIdScope = config.userIdScope
   }
 
   public setup() {
@@ -16,7 +20,7 @@ export default class BpSocket {
     }
 
     // Connect the Botpress Web Socket to the server
-    this.events.setup()
+    this.events.setup(this.userIdScope)
 
     this.events.on('guest.webchat.message', this.onMessage)
     this.events.on('guest.webchat.typing', this.onTyping)
@@ -31,7 +35,7 @@ export default class BpSocket {
   }
 
   public changeUserId(newId: string): Promise<void> {
-    this.events.updateVisitorId(newId)
+    this.events.updateVisitorId(newId, this.userIdScope)
     return this.waitForUserId()
   }
 

--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -50,13 +50,14 @@ class Web extends React.Component<MainProps> {
   }
 
   async initialize() {
-    this.socket = new BpSocket(this.props.bp)
+    const config = this.extractConfig()
+
+    this.socket = new BpSocket(this.props.bp, config)
     this.socket.onMessage = this.handleNewMessage
     this.socket.onTyping = this.props.updateTyping
     this.socket.onUserIdChanged = this.props.setUserId
     this.socket.setup()
 
-    const config = this.extractConfig()
     config.overrides && this.loadOverrides(config.overrides)
     config.userId && this.socket.changeUserId(config.userId)
 

--- a/modules/channel-web/src/views/lite/typings.d.ts
+++ b/modules/channel-web/src/views/lite/typings.d.ts
@@ -124,6 +124,8 @@ export type Config = {
   botId?: string
   externalAuthToken?: string
   userId?: string
+  /** Allows to set a different user id for different windows (eg: studio, specific bot, etc) */
+  userIdScope?: string
   enableReset: boolean
   stylesheet: string
   extraStylesheet: string

--- a/src/bp/ui-studio/src/web/util/Auth.ts
+++ b/src/bp/ui-studio/src/web/util/Auth.ts
@@ -1,5 +1,5 @@
-import EventEmitter2 from 'eventemitter2'
 import axios from 'axios'
+import { EventEmitter2 } from 'eventemitter2'
 import nanoid from 'nanoid'
 
 import storage from './storage'
@@ -49,16 +49,18 @@ export const login = (email, password) => {
   })
 }
 
-export const setVisitorId = userId => {
-  storage.set('bp/socket/user', userId)
+export const setVisitorId = (userId: string, userIdScope?: string) => {
+  storage.set(userIdScope ? `bp/socket/${userIdScope}/user` : 'bp/socket/user', userId)
   window.__BP_VISITOR_ID = userId
 }
 
-export const getUniqueVisitorId = () => {
-  let userId = storage.get('bp/socket/user')
+export const getUniqueVisitorId = (userIdScope?: string): string => {
+  const key = userIdScope ? `bp/socket/${userIdScope}/user` : 'bp/socket/user'
+
+  let userId = storage.get(key)
   if (!userId) {
     userId = nanoid()
-    storage.set('bp/socket/user', userId)
+    storage.set(key, userId)
   }
 
   window.__BP_VISITOR_ID = userId


### PR DESCRIPTION
This allows to set a different scope for the user ID on channel web. For example, there can be a separate user ID on the studio, versus opening the embedded webchat. Mostly for dev