### PR TITLE
chore: add v12 migration guide

### DIFF
--- a/docs/guide/docs/releases/migrate.md
+++ b/docs/guide/docs/releases/migrate.md
@@ -17,7 +17,7 @@ Botpress 12 comes with an "auto-migration" feature that runs migrations for the 
 
 ### How to upgrade
 
-Replace `bp`, `modules/` and `bindings/` of your Botpress 11 installation by the ones from Botpress 12 of the target plateform.
+Replace `bp`, `modules/` and `bindings/` of your Botpress 11 installation by the ones from Botpress 12 of the target platform.
 
 ## Migration from 11.7 to 11.8
 

--- a/docs/guide/docs/releases/migrate.md
+++ b/docs/guide/docs/releases/migrate.md
@@ -3,6 +3,22 @@ id: migrate
 title: Migrations
 ---
 
+## Migration from 11.9 to 12.0
+
+### Auto-migrate
+
+Botpress 12 comes with an "auto-migration" feature that runs migrations for the database and Botpress config files. No more database or file manipulation is required when upgrading from now on.
+
+### Database changes
+
+- Users from `workspaces.json` are now in the `workspace_user` table
+- User credentials are stored in the database alongside their auth strategy
+- Events are stored in the `events` table
+
+### How to upgrade
+
+Replace `bp`, `modules/` and `bindings/` of your Botpress 11 installation by the ones from Botpress 12 of the target plateform.
+
 ## Migration from 11.7 to 11.8
 
 ### Channel-Web Refactor


### PR DESCRIPTION
Run with env var `MIGRATION_TEST_VERSION=12.0.0` for dev and bin versions until v12 is shipped.