### PR TITLE
status-bar: interchanged docs & language

### DIFF
--- a/src/bp/ui-studio/src/web/components/Layout/StatusBar/LangSwitcher.jsx
+++ b/src/bp/ui-studio/src/web/components/Layout/StatusBar/LangSwitcher.jsx
@@ -44,7 +44,6 @@ class LangSwitcher extends React.Component {
       <Fragment>
         <ActionItem
           shortcut={keyMap['lang-switcher']}
-          className={style.right}
           title="Content Language"
           description={`Change the bot content language. Currently editing: ${this.props.contentLang.toUpperCase()}`}
           onClick={this.props.toggleLangSwitcher}
@@ -56,7 +55,6 @@ class LangSwitcher extends React.Component {
           </span>
         </ActionItem>
         <Dropdown
-          className={style.right}
           pullRight
           dropup={true}
           open={this.props.langSwitcherOpen}

--- a/src/bp/ui-studio/src/web/components/Layout/StatusBar/index.jsx
+++ b/src/bp/ui-studio/src/web/components/Layout/StatusBar/index.jsx
@@ -18,6 +18,7 @@ import { GoMortarBoard } from 'react-icons/go'
 import NluPerformanceStatus from './NluPerformanceStatus'
 
 import axios from 'axios'
+import { Icon } from '@blueprintjs/core'
 
 const COMPLETED_DURATION = 2000
 
@@ -135,9 +136,9 @@ class StatusBar extends React.Component {
         shortcut={keyMap['docs-toggle']}
         description="This screen has documentation available."
         onClick={onClick}
+        className={style.right}
       >
-        <Glyphicon glyph="question-sign" style={{ marginRight: '5px' }} />
-        Documentation
+        <Icon icon="help" />
       </ActionItem>
     )
   }


### PR DESCRIPTION
Simply switched the location of two elements in the status bar. I haven't migrated to blueprint since it will require more work with all other icons so they are similar.

![image](https://user-images.githubusercontent.com/42552874/60141530-dd404f00-9783-11e9-8408-8c32559a6a40.png)
