### PR TITLE
fix(confusion): issue with disabled bots & bit of ux

### DIFF
--- a/src/bp/ui-admin/src/Pages/Confusion/details.jsx
+++ b/src/bp/ui-admin/src/Pages/Confusion/details.jsx
@@ -61,43 +61,40 @@ const MatrixComponent = props => {
     const noneConfusions = v.confusions.none || 0
 
     const toolTipContent = (
-      <div>
-        <h3>{key}</h3>
-        <ul>
-          <li>
-            <strong>F1: </strong>
-            {v.f1.toFixed(2)}
-          </li>
-          <li>
-            <strong>Precision: </strong>
-            {v.precision.toFixed(2)}
-          </li>
-          <li>
-            <strong>Recall: </strong>
-            {v.recall.toFixed(2)}
-          </li>
-        </ul>
-        <ul>
-          <li>
-            <strong>False Positives: </strong>
-            {v.fp}
-          </li>
-          <li>
-            <strong>False Negatives: </strong>
-            {v.fn - noneConfusions}
-          </li>
-          {noneConfusions ? (
-            <li>
-              <strong>Not found (none):</strong> {noneConfusions}
-            </li>
-          ) : null}
-        </ul>
+      <div className="smallTooltip">
+        <div>
+          <label>F1: </label>
+          <strong>{v.f1.toFixed(2)}</strong>
+        </div>
+        <div>
+          <label>Precision: </label>
+          <strong>{v.precision.toFixed(2)}</strong>
+        </div>
+        <div>
+          <label>Recall: </label>
+          <strong>{v.recall.toFixed(2)}</strong>
+        </div>
+        <br />
+        <div>
+          <label>False Positives:</label>
+          <strong>{v.fp}</strong>
+        </div>
+        <div>
+          <label>False Negatives:</label>
+          <strong>{v.fn - noneConfusions}</strong>
+        </div>
+        {noneConfusions && (
+          <div>
+            <label>Not found (none):</label>
+            <strong>{noneConfusions}</strong>
+          </div>
+        )}
       </div>
     )
 
     cols[idxByName[key]] = (
       <Cell className="identity" scoreInPercent={v.f1 || 0}>
-        <Tooltip content={toolTipContent} position={Position.RIGHT}>
+        <Tooltip content={toolTipContent} position={Position.TOP}>
           <a data-tip data-for={'cls-' + key}>
             {v.f1.toFixed(1)}
           </a>
@@ -114,17 +111,14 @@ const MatrixComponent = props => {
       const nConfusions = (v.confusions || [])[cls] + ((matrix[cls].confusions || {})[key] || 0)
 
       const content = (
-        <div>
-          <h3>{key}</h3>
-          <p>
-            The model got confused <strong>{nConfusions}</strong> times with the <strong>{cls}</strong> intent.
-          </p>
+        <div className="smallTooltip">
+          The model got confused <strong>{nConfusions}</strong> times with the <strong>{cls}</strong> intent.
         </div>
       )
 
       cols[idxByName[cls]] = (
         <Cell scoreInAbsolute={nConfusions}>
-          <Tooltip content={content}>
+          <Tooltip content={content} position={Position.TOP}>
             <a data-tip data-for={tipKey}>
               {nConfusions}
             </a>

--- a/src/bp/ui-admin/src/Pages/Confusion/styles.css
+++ b/src/bp/ui-admin/src/Pages/Confusion/styles.css
@@ -68,3 +68,12 @@ td.identity {
 table.matrix {
   border-spacing: 0px;
 }
+
+.bp3-tooltip .bp3-popover-content .smallTooltip {
+  font-size: 80%;
+}
+
+.smallTooltip div label {
+  width: 130px;
+  margin: 0px;
+}

--- a/src/bp/ui-admin/src/index.scss
+++ b/src/bp/ui-admin/src/index.scss
@@ -212,3 +212,7 @@ pre.code {
 .form-range {
   padding-right: 25px;
 }
+
+:global(.bp3-tooltip .bp3-popover-content) {
+  padding: 5px 8px !important;
+}


### PR DESCRIPTION
I was getting a bunch of errors with disabled bots, so i've changed it a bit to use the store and filter those. Made some changes to the UX also (not sure if I did them right, usage was a bit cryptic.)

Some changes:
- Fixed the size of content inside the tooltip
- Auto fills the textfield when the version is changed
- Auto-select the version after computing


![image](https://user-images.githubusercontent.com/42552874/60147761-b2aec000-979c-11e9-889b-4269d9462ef2.png)
