### PR TITLE
chore(bench): use a seed file to randomize messages

### DIFF
--- a/src/bp/index.ts
+++ b/src/bp/index.ts
@@ -183,6 +183,10 @@ try {
         text: {
           description: 'Configure the text message that will be send by the fake users',
           default: 'Hey'
+        },
+        messageFile: {
+          alias: 'file',
+          description: 'Path to a text file with one message on each line (randomize sent messages)'
         }
       },
       argv => {


### PR DESCRIPTION
Added a parameter to specify a text file when running benchmarks. Right now it just sends the same message over and over, and doesn't simulate real-life situation. 

Simply create a text file with one different message per line, and it will select one randomly each time.