### PR TITLE
quick access to common requests

### DIFF
--- a/api.rest
+++ b/api.rest
@@ -1,0 +1,57 @@
+// Details on how to use at the bottom of the file
+
+### Login on the Admin UI
+# @name login
+POST {{baseUrl}}/api/v1/auth/login/basic/default
+Content-Type: application/x-www-form-urlencoded
+
+email={{email}}&password={{password}}
+
+@authToken = {{login.response.body.payload.token}}
+
+### List All Bots (need to login first)
+GET {{baseUrl}}/api/v1/admin/bots
+Authorization: Bearer {{authToken}}
+X-BP-Workspace: default
+
+### Send a request using Converse
+POST {{baseUrl}}/api/v1/bots/welcome-bot/converse/benchmarkUser
+Content-Type: application/json
+
+{
+  "type": "text",
+  "text": "hey"
+}
+
+### Test Duckling
+POST https://duckling.botpress.io/parse
+Content-Type: application/x-www-form-urlencoded
+
+text=hello how are you today
+&lang=en
+&reftime={{$datetime "xx"}}
+&tz=America/Toronto
+
+### Test Lang Server
+GET https://lang-01.botpress.io/info
+
+### SETUP 
+
+#  Use with https://marketplace.visualstudio.com/items?itemName=humao.rest-client
+
+#  1) Configure environment variable in VS Code
+#    - Open settings.json and add that snippet (replace vars as wanted for different environments)
+# 
+# "rest-client.environmentVariables": {
+#     "$shared": {
+#       "baseUrl": "http://localhost:3000",
+#       "email": "admin",
+#       "password": "123456"
+#     },
+#     "local": {
+#       "baseUrl": "http://localhost:3000"
+#     },
+#     "production": {
+#       "baseUrl": "https://botpress.io",
+#     }
+#   }


### PR DESCRIPTION
I'd like to add a file I use often to make requests instead of CURL. We could use it and add common calls so it's easier to test/debug.

All you need to do is add your specific parameters as environment variables in settings.json, then you can log on the admin UI, make authorized requests, test duckling, etc.

![image](https://user-images.githubusercontent.com/42552874/60215714-3a94d880-9836-11e9-905e-212e179bb209.png)
