### PR TITLE
fix(gulp): added shortcut to symlink all modules

### DIFF
--- a/build/gulp.modules.js
+++ b/build/gulp.modules.js
@@ -163,6 +163,31 @@ const createModuleSymlink = () => {
     .pipe(symlink(`./out/bp/data/assets/modules/${moduleName}/`, { type: 'dir' }))
 }
 
+const createAllModulesSymlink = () => {
+  const moduleFolder = process.argv.includes('--internal') ? 'internal-modules' : 'modules'
+  const modules = getAllModulesRoot()
+
+  const tasks = modules.map(m => {
+    const moduleName = path.basename(m)
+    const taskName = `dev-modules ${moduleName}`
+
+    gulp.task(
+      taskName,
+      gulp.series(
+        () => gulp.src(`./out/bp/data/assets/modules/${moduleName}`, { allowEmpty: true }).pipe(rimraf()),
+        () =>
+          gulp
+            .src(`./${moduleFolder}/${moduleName}/assets/`)
+            .pipe(symlink(`./out/bp/data/assets/modules/${moduleName}/`, { type: 'dir' }))
+      )
+    )
+
+    return taskName
+  })
+
+  return gulp.series(tasks)
+}
+
 module.exports = {
   build,
   buildSdk,
@@ -170,5 +195,6 @@ module.exports = {
   packageModules,
   buildModuleBuilder,
   cleanModuleAssets,
-  createModuleSymlink
+  createModuleSymlink,
+  createAllModulesSymlink
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,6 +43,7 @@ gulp.task('clean:db', cb => rimraf('out/bp/data/storage/core.sqlite', cb))
 
 // Example: yarn cmd dev:module --public nlu or yarn cmd dev:module --private bank
 gulp.task('dev:module', gulp.series([modules.cleanModuleAssets, modules.createModuleSymlink]))
+gulp.task('dev:modules', modules.createAllModulesSymlink())
 
 /**
  * Example: yarn cmd migration:create --target core --ver 13.0.0 --title "some config update"


### PR DESCRIPTION
Instead of typing the command for each modules, all you need to do is type yarn cmd dev:modules to create a symlink to all of them. I'm leaving the single module commands for now