### PR TITLE
fix(logs): added color for studio viewer

### DIFF
--- a/src/bp/core/logger/logger.ts
+++ b/src/bp/core/logger/logger.ts
@@ -155,7 +155,12 @@ export class PersistedConsoleLogger implements Logger {
       timestamp: moment().toISOString()
     }
 
-    PersistedConsoleLogger.LogStreamEmitter.emit(`logs::${this.botId || '*'}`, level, entry.message, entry.metadata) // Args => level, message, args
+    PersistedConsoleLogger.LogStreamEmitter.emit(
+      `logs::${this.botId || '*'}`,
+      level,
+      indentedMessage,
+      serializedMetadata
+    ) // Args => level, message, args
 
     if (this.willPersistMessage && level !== LoggerLevel.Debug) {
       this.loggerDbPersister.appendLog(entry)

--- a/src/bp/ui-studio/package.json
+++ b/src/bp/ui-studio/package.json
@@ -4,6 +4,7 @@
   "author": "Botpress",
   "dependencies": {
     "@blueprintjs/core": "^3.15.1",
+    "anser": "^1.4.8",
     "axios": "^0.18.1",
     "babel-polyfill": "^6.26.0",
     "bluebird": "^3.5.5",

--- a/src/bp/ui-studio/src/web/components/Layout/StatusBar/BottomPanel.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/StatusBar/BottomPanel.tsx
@@ -1,4 +1,5 @@
 import { Button, ButtonGroup, Divider, Tab, Tabs, Tooltip } from '@blueprintjs/core'
+import anser from 'anser'
 import axios from 'axios'
 import cn from 'classnames'
 import _ from 'lodash'
@@ -57,8 +58,8 @@ class BottomPanel extends React.Component<Props, State> {
         ts: new Date(),
         id: nanoid(10),
         level,
-        message,
-        args
+        message: anser.ansiToHtml(message),
+        args: anser.ansiToHtml(args)
       })
 
       if (this.logs.length > MAX_LOGS_LIMIT) {
@@ -97,8 +98,9 @@ class BottomPanel extends React.Component<Props, State> {
     return (
       <li className={cn(style.entry, style[`level-${log.level}`])} key={'log-entry-' + log.id}>
         <span className={style.time}>{time}</span>
-        <span className={style.level}>{log.level}</span> <span className={style.message}>{log.message}</span>
-        <span className={style.message}>{log.args || ''}</span>
+        <span className={style.level}>{log.level}</span>
+        <span className={style.message} dangerouslySetInnerHTML={{ __html: log.message }} />
+        <span className={style.message} dangerouslySetInnerHTML={{ __html: log.args || '' }} />
       </li>
     )
   }

--- a/src/bp/ui-studio/yarn.lock
+++ b/src/bp/ui-studio/yarn.lock
@@ -496,6 +496,11 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
+anser@^1.4.8:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.8.tgz#19a3bfc5f0e31c49efaea38f58fd0d136597f2a3"
+  integrity sha512-tVHucTCKIt9VRrpQKzPtOlwm/3AmyQ7J+QE29ixFnvuE2hm83utEVrN7jJapYkHV6hI0HOHkEX9TOMCzHtwvuA==
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"


### PR DESCRIPTION
Passing ansi colors from the backend to the frontend. I'm using dangerouslySetInnerHtml so the ansi library can directly convert ansi codes to html color codes when logs are received, and not when they are rendered.

The other option would be to convert the ansi structure to JSON, then create a react component to parse that JSON and create dynamically the elements. Not sure it would be good performance-wise if there's a lot of incoming logs