### PR TITLE
fix(cms): fix overflow issue with multilang

### DIFF
--- a/src/bp/ui-studio/src/web/components/SmartInput/index.tsx
+++ b/src/bp/ui-studio/src/web/components/SmartInput/index.tsx
@@ -6,7 +6,6 @@ import createSingleLinePlugin from 'draft-js-single-line-plugin'
 import * as React from 'react'
 import { Component } from 'react'
 import { connect } from 'react-redux'
-
 import { refreshHints } from '~/actions'
 import store from '~/store'
 
@@ -92,6 +91,11 @@ class SmartInput extends Component<ConnectedProps, State> {
     }, 100)
   }
 
+  get placeholder() {
+    const placeholder = (this.props.placeholder || '').split('\n').join(' ')
+    return placeholder.length > 50 ? placeholder.substring(0, 50) + '...' : placeholder
+  }
+
   render() {
     const { MentionSuggestions } = this.mentionPlugin
     const plugins = [this.mentionPlugin]
@@ -104,7 +108,7 @@ class SmartInput extends Component<ConnectedProps, State> {
       <div className={cx(style.editor, this.props.className)} onClick={this.focus}>
         <Editor
           stripPastedStyles={true}
-          placeholder={this.props.placeholder.substring(0, 50) + '...'}
+          placeholder={this.placeholder}
           editorState={this.state.editorState}
           onChange={this.onChange}
           plugins={plugins}


### PR DESCRIPTION
Fixed some overflow issue when placeholder spans multiple lines
![image](https://user-images.githubusercontent.com/42552874/60475247-6bb14680-9c44-11e9-838e-bd9cbe615ebd.png)
![image](https://user-images.githubusercontent.com/42552874/60475255-766bdb80-9c44-11e9-95c0-b611ecb8c09e.png)
