### PR TITLE
fix(gulp): sending outputs to console when watching

### DIFF
--- a/build/gulp.core.js
+++ b/build/gulp.core.js
@@ -46,7 +46,7 @@ const compileTypescript = () => {
 }
 
 const watch = () => {
-  return gulp.watch('./src/**/*.ts', compileTypescript)
+  return gulp.watch(['./src/**/*.ts', '!./src/bp/ui-*/**/*.ts'], compileTypescript)
 }
 
 const createOutputDirs = () => {

--- a/build/gulp.ui.js
+++ b/build/gulp.ui.js
@@ -16,27 +16,19 @@ const build = () => {
 }
 
 const buildStudio = cb => {
-  const src = 'src/bp/ui-studio'
   const cmd = process.argv.includes('--prod') ? 'yarn && yarn build:prod --nomap' : 'yarn && yarn build'
-  exec(cmd, { cwd: src }, (err, stdout, stderr) => {
-    if (err) {
-      console.error(stderr)
-      return cb(err)
-    }
-    cb()
-  })
+
+  const studio = exec(cmd, { cwd: 'src/bp/ui-studio' }, err => cb(err))
+  studio.stdout.pipe(process.stdout)
+  studio.stderr.pipe(process.stderr)
 }
 
 const buildAdmin = cb => {
   const prod = process.argv.includes('--prod') ? '--nomap' : ''
-  const src = 'src/bp/ui-admin'
-  exec(`yarn && yarn build ${prod}`, { cwd: src }, (err, stdout, stderr) => {
-    if (err) {
-      console.error(stderr)
-      return cb(err)
-    }
-    cb()
-  })
+
+  const admin = exec(`yarn && yarn build ${prod}`, { cwd: 'src/bp/ui-admin' }, err => cb(err))
+  admin.stdout.pipe(process.stdout)
+  admin.stderr.pipe(process.stderr)
 }
 
 const copyAdmin = () => {
@@ -48,7 +40,7 @@ const cleanStudio = () => {
 }
 
 const cleanStudioAssets = () => {
-  return gulp.src('./out/bp/data/assets/ui-studio/public', { allowEmpty: true }).pipe(rimraf())
+  return gulp.src('./out/bp/data/assets/ui-studio', { allowEmpty: true }).pipe(rimraf())
 }
 
 const copyStudio = () => {
@@ -60,23 +52,15 @@ const createStudioSymlink = () => {
 }
 
 const watchAdmin = cb => {
-  exec('yarn && yarn start:dev', { cwd: 'src/bp/ui-admin' }, (err, stdout, stderr) => {
-    if (err) {
-      console.error(stderr)
-      return cb(err)
-    }
-    cb()
-  })
+  const admin = exec('yarn && yarn start:dev', { cwd: 'src/bp/ui-admin' }, err => cb(err))
+  admin.stdout.pipe(process.stdout)
+  admin.stderr.pipe(process.stderr)
 }
 
 const watchStudio = cb => {
-  exec('yarn && yarn watch', { cwd: 'src/bp/ui-studio' }, (err, stdout, stderr) => {
-    if (err) {
-      console.error(stderr)
-      return cb(err)
-    }
-    cb()
-  })
+  const studio = exec('yarn && yarn watch', { cwd: 'src/bp/ui-studio' }, err => cb(err))
+  studio.stdout.pipe(process.stdout)
+  studio.stderr.pipe(process.stderr)
 }
 
 const watchAll = () => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,6 @@ const docs = require('./build/gulp.docs')
 const rimraf = require('rimraf')
 const changelog = require('gulp-conventional-changelog')
 const yn = require('yn')
-const fs = require('fs')
 
 process.on('uncaughtException', err => {
   console.error('An error occurred in your gulpfile: ', err)
@@ -19,6 +18,19 @@ if (yn(process.env.GULP_PARALLEL)) {
 } else {
   gulp.task('build', gulp.series([core.build(), modules.build(), ui.build()]))
 }
+
+gulp.task('default', cb => {
+  console.log(`
+    Development Cheat Sheet
+    ==================================
+    yarn cmd dev:modules  Creates a symlink to modules bundles (restart server to apply backend changes - refresh for UI)
+                          After this command, type "yarn watch" in each module folder you want to watch for changes
+    yarn cmd watch:core   Recompiles the server on file modification (restart server to apply)
+    yarn cmd watch:studio Recompiles the bundle on file modification (no restart required - refresh page manually)
+    yarn cmd watch:admin  Recompiles the bundle on file modification (no restart required - page refresh automatically)
+  `)
+  cb()
+})
 
 gulp.task('build:ui', ui.build())
 gulp.task('build:core', core.build())
@@ -71,17 +83,4 @@ gulp.task('changelog', () => {
     .src('CHANGELOG.md')
     .pipe(changelog(changelogOts, context, gitRawCommitsOpts, commitsParserOpts, changelogWriterOpts))
     .pipe(gulp.dest('./'))
-})
-
-gulp.task('migrate:make', () => {
-  const index = process.argv.findIndex(x => x.toLowerCase() === '--name')
-  if (index === -1) {
-    return Promise.reject('Please use the --name argument and provide a meaningful migration name')
-  }
-
-  const name = Date.now() + '_' + process.argv[index + 1]
-  const template = fs.readFileSync('src/bp/core/database/migrations/template.ts')
-  fs.writeFileSync(`src/bp/core/database/migrations/${name}.ts`, template)
-
-  return Promise.resolve()
 })


### PR DESCRIPTION
Some minor changes:
- Type 'yarn cmd' for a quick recap of the watch commands and how to setup them
- Typing yarn cmd watch:studio or watch:admin will actually display its output (so you know when it's done compiling files)
