### PR TITLE
fix(channel-web): using native includes instead

### DIFF
--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -122,8 +122,7 @@ export default async (bp: typeof sdk, db: Database) => {
       conversationId = conversationId && parseInt(conversationId)
 
       if (
-        !_.includes(
-          ['text', 'quick_reply', 'form', 'login_prompt', 'visit', 'request_start_conversation', 'postback'],
+        !['text', 'quick_reply', 'form', 'login_prompt', 'visit', 'request_start_conversation', 'postback'].includes(
           payload.type
         )
       ) {


### PR DESCRIPTION
Fixes botpress/v12#747 , lodash isn't required for that