### PR TITLE
fix(flow): fix subflows not working & bit of ux

### DIFF
--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowsList.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowsList.tsx
@@ -122,7 +122,9 @@ export default class FlowsList extends Component<Props, State> {
     node.isSelected = originallySelected !== null
 
     if (node.nodeData) {
-      this.props.goToFlow(node.label)
+      this.props.goToFlow(node.nodeData.name)
+    } else {
+      node.isExpanded ? this.handleNodeCollapse(node) : this.handleNodeExpand(node)
     }
 
     this.forceUpdate()


### PR DESCRIPTION
Using correct value for flow selection, and clicking the folder name toggles it (not just the caret)