### PR TITLE
fix(env): allow json in env var (for complex configs)

### DIFF
--- a/src/bp/core/services/module/config-reader.ts
+++ b/src/bp/core/services/module/config-reader.ts
@@ -101,12 +101,20 @@ export default class ConfigReader {
       return [path]
     }
 
+    const getValue = (key: string) => {
+      try {
+        return JSON.parse(process.env[key]!)
+      } catch (err) {
+        return process.env[key]
+      }
+    }
+
     for (const option of getPropertiesRecursive(schema)) {
       const envOption = `${moduleId}_${option}`.replace(/[^A-Z0-9_]+/gi, '_')
       const envKey = `BP_MODULE_${envOption}`.toUpperCase()
       if (envKey in process.env) {
         // Using .set because it supports set on a path with dots
-        const value = process.env[envKey]
+        const value = getValue(envKey)
         _.set(config, option, value)
         debugConfig('ENV SET', { variable: option, env: envKey, value })
       } else {


### PR DESCRIPTION
There's no way to set the language source by env variable since it's an array of object. I think using a JSON is the easiest and most robust method:

BP_MODULE_NLU_LANGUAGESOURCE=[{"endpoint": "http://url.com", "authToken":"token"}]

The other option would be require more processing, and building the final object with correct camel-casing.. ex:
BP_MODULE_NLU_LANGUAGESOURCES_0_ENDPOINT=http://localhost:3000
BP_MODULE_NLU_LANGUAGESOURCES_0_AUTHTOKEN=abc123   