### PR TITLE
fix(nlu): various performance fixes wrt lang server

### DIFF
--- a/modules/nlu/src/backend/pipelines/entities/pattern_extractor.test.ts
+++ b/modules/nlu/src/backend/pipelines/entities/pattern_extractor.test.ts
@@ -17,7 +17,7 @@ const languageProvider: LanguageProvider = {
     const res = text.split(' ').filter(_.identity)
     return Promise.resolve(res)
   },
-  generateSimilarJunkWords: (tokens: string[]) => Promise.resolve([]), // Not implemented
+  generateSimilarJunkWords: (tokens: string[], lang: string) => Promise.resolve([]), // Not implemented
   getHealth: (): Partial<NLUHealth> => {
     return {}
   }

--- a/modules/nlu/src/backend/pipelines/slots/pre-processor.test.ts
+++ b/modules/nlu/src/backend/pipelines/slots/pre-processor.test.ts
@@ -19,7 +19,7 @@ const languageProvider: LanguageProvider = {
     return Promise.resolve(res)
   },
 
-  generateSimilarJunkWords: (tokens: string[]) => Promise.resolve([]), // Not implemented
+  generateSimilarJunkWords: (tokens: string[], lang: string) => Promise.resolve([]), // Not implemented
 
   getHealth: (): Partial<NLUHealth> => {
     return {}

--- a/modules/nlu/src/backend/typings.ts
+++ b/modules/nlu/src/backend/typings.ts
@@ -99,14 +99,22 @@ export interface NLUStructure {
 
 export type Token2Vec = { [token: string]: number[] }
 
+export interface Gateway {
+  source: LanguageSource
+  client: AxiosInstance
+  errors: number
+  disabledUntil?: Date
+}
+[]
+
 export interface LangsGateway {
-  [lang: string]: { source: LanguageSource; client: AxiosInstance; errors: number; disabledUntil?: Date }[]
+  [lang: string]: Gateway[]
 }
 
 export interface LanguageProvider {
   vectorize(tokens: string[], lang: string): Promise<Float32Array[]>
   tokenize(text: string, lang: string): Promise<string[]>
-  generateSimilarJunkWords(subsetVocab: string[]): Promise<string[]>
+  generateSimilarJunkWords(subsetVocab: string[], lang: string): Promise<string[]>
   getHealth(): Partial<NLUHealth>
 }
 


### PR DESCRIPTION
- We batch calls to `/vectorize` with entire vocabulary and junk words (used to hit the API for every word)
- Prevent sending payloads that are too large, we batch by groups of 100
- We don't disable lang provider when there's only one healthy
- None utterances ever only contained one word and the length was wrong