### PR TITLE
feat(core): added support for a custom url 

### DIFF
--- a/modules/channel-web/assets/examples/embedded-webchat.html
+++ b/modules/channel-web/assets/examples/embedded-webchat.html
@@ -1,7 +1,10 @@
 <html>
   <head>
     <title>Embedded Webchat</title>
-    <script src="/assets/modules/channel-web/inject.js"></script>
+    <!-- Set the base URL to access this page, for example: /botpress/
+    It must match the path configured as an externalUrl in Botpress config, and in the init method -->
+    <base href="/" />
+    <script src="assets/modules/channel-web/inject.js"></script>
   </head>
 
   <body>
@@ -10,13 +13,13 @@
 
   <script>
     window.botpressWebChat.init({
-      host: 'http://localhost:3000',
+      host: 'http://localhost:3000/',
       botId: 'welcome-bot'
       /*
         To change the styling of the webchat, you can either edit directly default.css, or use the extraStylesheet property.
         This allows you to customize the chat on a per-bot basis.
       */
-      //extraStylesheet: '/assets/modules/channel-web/examples/my-theme.css'
+      //extraStylesheet: 'assets/modules/channel-web/examples/my-theme.css'
     })
   </script>
 </html>

--- a/modules/channel-web/assets/inject.js
+++ b/modules/channel-web/assets/inject.js
@@ -23,12 +23,12 @@ window.addEventListener('message', function(payload) {
 })
 
 function init(config) {
-  const host = config.host || ''
+  const host = config.host || window.ROOT_PATH || ''
   const botId = config.botId || ''
-  const cssHref = host + '/assets/modules/channel-web/inject.css'
+  const cssHref = host + 'assets/modules/channel-web/inject.css'
   injectDOMElement('link', 'head', { rel: 'stylesheet', href: cssHref })
   const options = encodeURIComponent(JSON.stringify({ config: config }))
-  let iframeSrc = host + '/lite/' + botId + '/?m=channel-web&v=Embedded&options=' + options
+  let iframeSrc = host + 'lite/' + botId + '/?m=channel-web&v=Embedded&options=' + options
   if (config.ref) {
     iframeSrc += '&ref=' + encodeURIComponent(config.ref)
   }

--- a/modules/channel-web/src/views/full/index.tsx
+++ b/modules/channel-web/src/views/full/index.tsx
@@ -4,7 +4,7 @@ import Message from '../lite/components/messages/Message'
 import * as Keyboard from '../lite/components/Keyboard'
 
 const INJECTION_ID = 'bp-channel-web-injection'
-const INJECTION_URL = `/assets/modules/channel-web/inject.js`
+const INJECTION_URL = `assets/modules/channel-web/inject.js`
 
 export class WebBotpressUIInjection extends React.Component {
   componentDidMount() {

--- a/modules/channel-web/src/views/lite/core/api.tsx
+++ b/modules/channel-web/src/views/lite/core/api.tsx
@@ -30,7 +30,7 @@ export default class WebchatApi {
   updateAxiosConfig({ botId = undefined, externalAuthToken = undefined } = {}) {
     this.botId = botId
     this.axiosConfig = botId
-      ? { baseURL: `${window.location.origin}/api/v1/bots/${botId}/mod/channel-web` }
+      ? { baseURL: `${window.location.origin}${window.BOT_API_PATH}/mod/channel-web` }
       : { baseURL: `${window.BOT_API_PATH}/mod/channel-web` }
 
     if (externalAuthToken) {

--- a/modules/channel-web/src/views/lite/core/constants.tsx
+++ b/modules/channel-web/src/views/lite/core/constants.tsx
@@ -14,7 +14,7 @@ export default {
   /** The default configuration when starting the chat */
   DEFAULT_CONFIG: {
     userId: undefined,
-    stylesheet: '/assets/modules/channel-web/default.css',
+    stylesheet: 'assets/modules/channel-web/default.css',
     extraStylesheet: '',
     botName: undefined,
     botConvoDescription: undefined,

--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -158,7 +158,7 @@ class Web extends React.Component<MainProps> {
       return
     }
 
-    const audio = new Audio('/assets/modules/channel-web/notification.mp3')
+    const audio = new Audio(`${window.ROOT_PATH}assets/modules/channel-web/notification.mp3`)
     await audio.play()
 
     this.setState({ played: true })

--- a/modules/channel-web/src/views/lite/typings.d.ts
+++ b/modules/channel-web/src/views/lite/typings.d.ts
@@ -9,6 +9,7 @@ declare global {
     API_PATH: string
     BOTPRESS_VERSION: string
     BOT_NAME: string
+    ROOT_PATH: string
     BOT_ID: string
     BP_BASE_PATH: string
     SEND_USAGE_STATS: boolean

--- a/modules/code-editor/webpack.frontend.js
+++ b/modules/code-editor/webpack.frontend.js
@@ -5,7 +5,7 @@ module.exports = ({ full, lite }) => {
     ...full,
     output: {
       ...full.output,
-      publicPath: '/assets/modules/code-editor/web/'
+      publicPath: 'assets/modules/code-editor/web/'
     },
     plugins: [
       ...full.plugins,

--- a/src/bp/bootstrap.ts
+++ b/src/bp/bootstrap.ts
@@ -96,7 +96,7 @@ This is a fatal error, process will exit.`
     process.exit(1)
   })
 
-  logger.info(`Botpress is ready at http://${process.HOST}:${process.PORT}/`)
+  logger.info(`Botpress is ready at http://${process.HOST}:${process.PORT}${process.ROOT_PATH}`)
 }
 
 start().catch(global.printErrorDefault)

--- a/src/bp/core/routers/bots/index.ts
+++ b/src/bp/core/routers/bots/index.ts
@@ -202,11 +202,11 @@ export class BotsRouter extends CustomRouter {
               // Common
               window.UUID = "${data.uuid}"
               window.ANALYTICS_ID = "${data.gaId}";
-              window.API_PATH = "/api/v1";
-              window.BOT_API_PATH = "/api/v1/bots/${botId}";
+              window.API_PATH = "${process.ROOT_PATH}api/v1";
+              window.BOT_API_PATH = "${process.ROOT_PATH}api/v1/bots/${botId}";
               window.BOT_ID = "${botId}";
               window.BOT_NAME = "${bot.name}";
-              window.BP_BASE_PATH = "/${app}/${botId}";
+              window.BP_BASE_PATH = "${process.ROOT_PATH}${app}/${botId}";
               window.BOTPRESS_VERSION = "${data.botpress.version}";
               window.APP_NAME = "${data.botpress.name}";
               window.SHOW_POWERED_BY = ${!!config.showPoweredBy};

--- a/src/bp/ui-admin/package.json
+++ b/src/bp/ui-admin/package.json
@@ -41,10 +41,10 @@
     "build-css": "node-sass-chokidar src/ -o src/",
     "watch-css": "npm run build-css && node-sass-chokidar src/ -o src/ --watch --recursive",
     "start-js": "cross-env BROWSER=none react-app-rewired start",
-    "start": "cross-env PUBLIC_URL=/admin npm-run-all -p watch-css start-js",
-    "start:dev": "cross-env PUBLIC_URL=/admin cross-env REACT_APP_API_URL=http://localhost:3000 cross-env PORT=3001 npm-run-all -p watch-css start-js",
+    "start": "cross-env PUBLIC_URL=admin npm-run-all -p watch-css start-js",
+    "start:dev": "cross-env PUBLIC_URL=admin cross-env REACT_APP_API_URL=http://localhost:3000 cross-env PORT=3001 npm-run-all -p watch-css start-js",
     "build-js": "react-app-rewired build",
-    "build": "yarn build-css && cross-env PUBLIC_URL=/admin yarn build-js",
+    "build": "yarn build-css && cross-env PUBLIC_URL=admin yarn build-js",
     "test": "react-app-rewired test --env=jsdom",
     "eject": "react-scripts eject"
   },

--- a/src/bp/ui-admin/public/index.html
+++ b/src/bp/ui-admin/public/index.html
@@ -8,9 +8,10 @@
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
+    <base href="/" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <link href="/assets/custom-theme.css" rel="stylesheet" />
+    <link href="assets/custom-theme.css" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600" rel="stylesheet" />
 
     <!--

--- a/src/bp/ui-admin/src/App/Layout.jsx
+++ b/src/bp/ui-admin/src/App/Layout.jsx
@@ -22,7 +22,7 @@ class App extends Component {
       <Fragment>
         <header className="bp-header">
           <Navbar expand="md">
-            <NavbarBrand href="/admin">
+            <NavbarBrand href="admin/">
               <img src={logo} alt="logo" className="bp-header__logo" />
             </NavbarBrand>
             <NavbarToggler onClick={this.toggleMenu} />

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemCompact.jsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemCompact.jsx
@@ -22,7 +22,7 @@ export default ({ bot, deleteBot, exportBot, permissions, history, createRevisio
         </Button>
       </AccessControl>
       {!bot.disabled && (
-        <Button size="sm" color="link" target="_blank" href={`${window.location.origin}/s/${bot.id}`}>
+        <Button size="sm" color="link" target="_blank" href={`s/${bot.id}`}>
           <IoIosChatbubbles /> Open chat
         </Button>
       )}
@@ -32,7 +32,7 @@ export default ({ bot, deleteBot, exportBot, permissions, history, createRevisio
         </DropdownToggle>
         <DropdownMenu>
           {!bot.disabled && (
-            <DropdownItem disabled={bot.locked} tag="a" href={`/studio/${bot.id}`}>
+            <DropdownItem disabled={bot.locked} tag="a" href={`studio/${bot.id}`}>
               <MdModeEdit />
               &nbsp;Edit in studio
             </DropdownItem>
@@ -66,7 +66,7 @@ export default ({ bot, deleteBot, exportBot, permissions, history, createRevisio
           &nbsp;
         </span>
       )}
-      {bot.disabled ? <span>{bot.name || bot.id}</span> : <a href={`/studio/${bot.id}`}>{bot.name || bot.id}</a>}
+      {bot.disabled ? <span>{bot.name || bot.id}</span> : <a href={`studio/${bot.id}`}>{bot.name || bot.id}</a>}
 
       {!bot.defaultLanguage && (
         <React.Fragment>

--- a/src/bp/ui-admin/src/api.js
+++ b/src/bp/ui-admin/src/api.js
@@ -59,7 +59,7 @@ const showToast = message => {
 
 const overrideApiUrl = process.env.REACT_APP_API_URL
   ? { baseURL: `${process.env.REACT_APP_API_URL}/api/v1` }
-  : { baseURL: `/api/v1` }
+  : { baseURL: `${window.ROOT_PATH}api/v1` }
 
 const overrideLicensingServer = process.env.REACT_APP_LICENSING_SERVER
   ? { baseURL: `${process.env.REACT_APP_LICENSING_SERVER}` }

--- a/src/bp/ui-admin/src/history.js
+++ b/src/bp/ui-admin/src/history.js
@@ -7,7 +7,7 @@ const addLocationQuery = history => {
   })
 }
 
-const history = createHistory({ basename: '/admin' })
+const history = createHistory({ basename: `${window.ROOT_PATH}admin` })
 
 addLocationQuery(history)
 history.listen(() => addLocationQuery(history))

--- a/src/bp/ui-studio/src/web/components/Authentication/index.jsx
+++ b/src/bp/ui-studio/src/web/components/Authentication/index.jsx
@@ -47,7 +47,7 @@ const ensureAuthenticated = WrappedComponent => {
       if (pathname !== '/login' && !urlToken) {
         this.context.router.history.push('/login?returnTo=' + pathname)
       }
-      window.location.href = '/admin'
+      window.location.href = window.ROOT_PATH + 'admin'
       window.botpressWebChat && window.botpressWebChat.sendEvent({ type: 'hide' })
     }
 

--- a/src/bp/ui-studio/src/web/components/Layout/DocumentationModal.jsx
+++ b/src/bp/ui-studio/src/web/components/Layout/DocumentationModal.jsx
@@ -22,8 +22,7 @@ class DocumentationModal extends React.Component {
   handleClose = () => this.props.updateDocumentationModal(null)
 
   renderPage = src => {
-    const transformImg = url =>
-      window.origin + '/assets/ui-studio/public/external/docs/' + url.replace(/^assets\//i, '')
+    const transformImg = url => 'assets/ui-studio/public/external/docs/' + url.replace(/^assets\//i, '')
 
     return (
       <ReactMarkdown

--- a/src/bp/ui-studio/src/web/components/Layout/Sidebar.jsx
+++ b/src/bp/ui-studio/src/web/components/Layout/Sidebar.jsx
@@ -106,7 +106,7 @@ class Sidebar extends React.Component {
       <aside style={{ zIndex: '1000' }}>
         <div className={classnames(style.sidebar, 'bp-sidebar')}>
           <div style={{ padding: '8px 13px', overflowX: 'hidden' }}>
-            <a href="/" className={classnames(style.logo, 'bp-logo')}>
+            <a href="admin/" className={classnames(style.logo, 'bp-logo')}>
               <img width="125" src="assets/ui-studio/public/img/logo_white.png" alt="Botpress Logo" />
             </a>
           </div>

--- a/src/bp/ui-studio/src/web/components/Layout/Sidebar.jsx
+++ b/src/bp/ui-studio/src/web/components/Layout/Sidebar.jsx
@@ -49,7 +49,7 @@ class Sidebar extends React.Component {
   renderModuleItem = module => {
     const rule = { res: `module.${module.name}`, op: 'write' }
     const path = `/modules/${module.name}`
-    const iconPath = `/assets/modules/${module.name}/icon.png`
+    const iconPath = `assets/modules/${module.name}/icon.png`
     const moduleIcon =
       module.menuIcon === 'custom' ? (
         <img className={classnames(style.customIcon, 'bp-custom-icon')} src={iconPath} />
@@ -107,7 +107,7 @@ class Sidebar extends React.Component {
         <div className={classnames(style.sidebar, 'bp-sidebar')}>
           <div style={{ padding: '8px 13px', overflowX: 'hidden' }}>
             <a href="/" className={classnames(style.logo, 'bp-logo')}>
-              <img width="125" src="/assets/ui-studio/public/img/logo_white.png" alt="Botpress Logo" />
+              <img width="125" src="assets/ui-studio/public/img/logo_white.png" alt="Botpress Logo" />
             </a>
           </div>
           <ul className={classnames('nav', style.mainMenu)}>

--- a/src/bp/ui-studio/src/web/components/Layout/StatusBar/BotSwitcher.jsx
+++ b/src/bp/ui-studio/src/web/components/Layout/StatusBar/BotSwitcher.jsx
@@ -38,14 +38,14 @@ export default class BotSwitcher extends React.Component {
               .filter(id => this.props.currentBotId != id)
               .map(id => (
                 <li className={style.langItem}>
-                  <a key={id} href={`/studio/${id}`}>
+                  <a key={id} href={`studio/${id}`}>
                     {id}
                   </a>
                 </li>
               ))}
             <MenuItem divider />
             <li className={style.langItem}>
-              <a key="admin" href={`/admin`}>
+              <a key="admin" href="admin">
                 Back to admin
               </a>
             </li>

--- a/src/bp/ui-studio/src/web/components/Layout/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/index.tsx
@@ -121,7 +121,7 @@ class Layout extends React.Component<ILayoutProps> {
 
   goHome = () => {
     if (!isInputFocused()) {
-      window.location.href = '/admin'
+      window.location.href = `${window.ROOT_PATH}admin`
     }
   }
 

--- a/src/bp/ui-studio/src/web/components/PluginInjectionSite/module.tsx
+++ b/src/bp/ui-studio/src/web/components/PluginInjectionSite/module.tsx
@@ -56,7 +56,7 @@ export default class InjectedModuleView extends React.Component<Props, State> {
         })
       }
 
-      script.src = `/assets/modules/${moduleName}/web/${this.props.lite ? 'lite.bundle.js' : 'full.bundle.js'}`
+      script.src = `assets/modules/${moduleName}/web/${this.props.lite ? 'lite.bundle.js' : 'full.bundle.js'}`
       document.getElementsByTagName('head')[0].appendChild(script)
     } else {
       this.setState({ moduleComponent: null })
@@ -70,7 +70,7 @@ export default class InjectedModuleView extends React.Component<Props, State> {
     if (!window.botpress || !window.botpress[moduleName]) {
       const script = document.createElement('script')
       script.type = 'text/javascript'
-      script.src = `/assets/modules/${moduleName}/web/${isLite ? 'lite.bundle.js' : 'full.bundle.js'}`
+      script.src = `assets/modules/${moduleName}/web/${isLite ? 'lite.bundle.js' : 'full.bundle.js'}`
       document.getElementsByTagName('head')[0].appendChild(script)
     }
   }

--- a/src/bp/ui-studio/src/web/index.html
+++ b/src/bp/ui-studio/src/web/index.html
@@ -5,17 +5,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
     <meta name="description" content="" />
     <meta name="keywords" content="" />
-    <link rel="icon" type="image/png" href="/assets/ui-studio/public/img/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="/assets/ui-studio/public/img/favicon-16x16.png" sizes="16x16" />
-    <link href="/assets/ui-studio/public/external/material-icons.css" rel="stylesheet" />
-    <link href="/assets/ui-studio/public/external/font-lato.css" rel="stylesheet" />
-    <link href="/assets/ui-studio/public/external/bootstrap.min.css" rel="stylesheet" />
-    <link href="/assets/custom-theme.css" rel="stylesheet" />
-    <link href="/assets/modules/channel-web/default.css" rel="stylesheet" />
+    <script src="env.js"></script>
+    <base href="/" />
+    <link rel="icon" type="image/png" href="assets/ui-studio/public/img/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="assets/ui-studio/public/img/favicon-16x16.png" sizes="16x16" />
+    <link href="assets/ui-studio/public/external/material-icons.css" rel="stylesheet" />
+    <link href="assets/ui-studio/public/external/font-lato.css" rel="stylesheet" />
+    <link href="assets/ui-studio/public/external/bootstrap.min.css" rel="stylesheet" />
+    <link href="assets/custom-theme.css" rel="stylesheet" />
+    <link href="assets/modules/channel-web/default.css" rel="stylesheet" />
   </head>
 
   <body>
     <div id="app"></div>
-    <script src="env.js"></script>
   </body>
 </html>

--- a/src/bp/ui-studio/src/web/lite.html
+++ b/src/bp/ui-studio/src/web/lite.html
@@ -5,12 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
     <meta name="description" content="" />
     <meta name="keywords" content="" />
-    <link rel="icon" type="image/png" href="/assets/ui-studio/public/img/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="/assets/ui-studio/public/img/favicon-16x16.png" sizes="16x16" />
+    <script src="env.js"></script>
+    <base href="/" />
+    <link rel="icon" type="image/png" href="assets/ui-studio/public/img/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="assets/ui-studio/public/img/favicon-16x16.png" sizes="16x16" />
   </head>
 
   <body>
     <div id="app"></div>
-    <script src="env.js"></script>
   </body>
 </html>

--- a/src/bp/ui-studio/src/web/reducers/notifications.js
+++ b/src/bp/ui-studio/src/web/reducers/notifications.js
@@ -5,7 +5,7 @@ import _ from 'lodash'
 import { allNotificationsReceived, newNotificationsReceived } from '~/actions'
 
 const defaultState = []
-const sound = new Howl({ src: ['/assets/ui-studio/public/audio/notification.mp3'] })
+const sound = new Howl({ src: [window.ROOT_PATH + 'assets/ui-studio/public/audio/notification.mp3'] })
 
 const reducer = handleActions(
   {

--- a/src/bp/ui-studio/src/web/typings.d.ts
+++ b/src/bp/ui-studio/src/web/typings.d.ts
@@ -11,6 +11,7 @@ declare global {
     BOT_API_PATH: string
     API_PATH: string
     BOTPRESS_VERSION: string
+    ROOT_PATH: string
     BOT_NAME: string
     BOT_ID: string
     BP_BASE_PATH: string

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/style.scss
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/style.scss
@@ -7,7 +7,7 @@ $toolbar-height: 36px;
 
 .diagram :global(.storm-diagrams-canvas) {
   height: calc(100%);
-  background: url('/assets/ui-studio/public/img/grid.png') repeat;
+  background: url('assets/ui-studio/public/img/grid.png') repeat;
 }
 
 .wrapper {

--- a/src/bp/ui-studio/webpack.web.js
+++ b/src/bp/ui-studio/webpack.web.js
@@ -20,7 +20,7 @@ const webConfig = {
   },
   output: {
     path: path.resolve(__dirname, './public/js'),
-    publicPath: '/assets/ui-studio/public/js/',
+    publicPath: 'assets/ui-studio/public/js/',
     filename: '[name].[chunkhash].js'
   },
   resolve: {
@@ -152,6 +152,7 @@ const webConfig = {
             loader: 'css-loader',
             options: {
               modules: true,
+              url: false,
               importLoaders: 1,
               localIdentName: '[name]__[local]___[hash:base64:5]'
             }

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -27,6 +27,8 @@ declare namespace NodeJS {
     PROXY?: string
     EXTERNAL_URL: string
     LOCAL_URL: string
+    /** This is the subfolder where Botpress is located (ex: /botpress/). It is extracted from the external URL */
+    ROOT_PATH: string
     PROJECT_LOCATION: string
     LOADED_MODULES: { [module: string]: string }
     pkg: any


### PR DESCRIPTION
These changes allows Botpress to be served from a different url than the root one /.
For example, you could have it at http://localhost:3000/botpress/

The path is extracted from the external URL, so setting it is mandatory. Afterwards, you can access it either with process.ROOT_PATH in the backend, or with window.ROOT_PATH in the frontend (studio, admin, modules, etc).

These changes relies heavily on the `<base href>` html5 tag, so all future URL must be **relative**, not absolute. For ex, use `assets/mod` instead of `/assets/mod`

Completed: 
- Test without externalUrl set
- Test with externalUrl set with or without final slash
- Test with the binary

To be done:
- Test docker
- Test on a website with a real address
- Test with nginx
- Update all related documentation
- Examples, etc.... 