### PR TITLE
fix(bots): added migration for bot imports

### DIFF
--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -27,6 +27,7 @@ import { CMSService } from './cms'
 import { FileContent, GhostService } from './ghost/service'
 import { Hooks, HookService } from './hook/hook-service'
 import { JobService } from './job-service'
+import { MigrationService } from './migration'
 import { ModuleResourceLoader } from './module/resources-loader'
 import RealtimeService from './realtime'
 import { WorkspaceService } from './workspace-service'
@@ -64,7 +65,8 @@ export class BotService {
     @inject(TYPES.JobService) private jobService: JobService,
     @inject(TYPES.Statistics) private stats: Statistics,
     @inject(TYPES.WorkspaceService) private workspaceService: WorkspaceService,
-    @inject(TYPES.RealtimeService) private realtimeService: RealtimeService
+    @inject(TYPES.RealtimeService) private realtimeService: RealtimeService,
+    @inject(TYPES.MigrationService) private migrationService: MigrationService
   ) {
     this._botIds = undefined
   }
@@ -244,7 +246,10 @@ export class BotService {
         }
         await this.configProvider.mergeBotConfig(botId, newConfigs)
         await this.workspaceService.addBotRef(botId, workspaceId)
+
+        await this._migrateBotContent(botId)
         await this.mountBot(botId)
+
         this.logger.forBot(botId).info(`Import of bot ${botId} successful`)
       } else {
         this.logger.forBot(botId).info(`Import of bot ${botId} was denied by hook validation`)
@@ -252,6 +257,11 @@ export class BotService {
     } finally {
       tmpDir.removeCallback()
     }
+  }
+
+  private async _migrateBotContent(botId: string): Promise<void> {
+    const config = await this.configProvider.getBotConfig(botId)
+    return this.migrationService.executeMissingBotMigrations(botId, config.version)
   }
 
   async requestStageChange(botId: string, requested_by: string) {

--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -430,7 +430,8 @@ export class BotService {
         const mergedConfigs = {
           ...DEFAULT_BOT_CONFIGS,
           ...templateConfig,
-          ...botConfig
+          ...botConfig,
+          version: process.BOTPRESS_VERSION
         }
 
         if (!mergedConfigs.imports.contentTypes) {

--- a/src/bp/core/services/migration/template_core.ts
+++ b/src/bp/core/services/migration/template_core.ts
@@ -1,20 +1,19 @@
 import * as sdk from 'botpress/sdk'
-import { ConfigProvider } from 'core/config/config-loader'
-import Database from 'core/database'
 import { Migration } from 'core/services/migration'
-import { Container } from 'inversify'
 
 const migration: Migration = {
   info: {
     description: '',
+    target: 'core',
     type: 'config'
   },
-  up: async (
-    bp: typeof sdk,
-    configProvider: ConfigProvider,
-    database: Database,
-    inversify: Container
-  ): Promise<sdk.MigrationResult> => {
+  up: async ({
+    bp,
+    configProvider,
+    database,
+    inversify,
+    metadata
+  }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
     return { success: true, message: 'Configuration updated successfully' }
   }
 }

--- a/src/bp/core/services/migration/template_module.ts
+++ b/src/bp/core/services/migration/template_module.ts
@@ -3,9 +3,10 @@ import * as sdk from 'botpress/sdk'
 const migration: sdk.ModuleMigration = {
   info: {
     description: '',
+    target: 'core',
     type: 'config'
   },
-  up: async (bp: typeof sdk): Promise<sdk.MigrationResult> => {
+  up: async ({ bp, metadata }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
     return { success: true, message: 'Configuration updated successfully' }
   }
 }

--- a/src/bp/migrations/v11_9_3-1560862171-bot_language.ts
+++ b/src/bp/migrations/v11_9_3-1560862171-bot_language.ts
@@ -1,20 +1,16 @@
-import * as sdk from 'botpress/sdk'
-import { ConfigProvider } from 'core/config/config-loader'
-import Database from 'core/database'
 import { BotService } from 'core/services/bot-service'
-import { Migration } from 'core/services/migration'
+import { Migration, MigrationOpts } from 'core/services/migration'
 import { WorkspaceService } from 'core/services/workspace-service'
 import { TYPES } from 'core/types'
-import { Container } from 'inversify'
 
 const migration: Migration = {
   info: {
     description: 'Bots requires a default language',
     type: 'config'
   },
-  up: async (bp: typeof sdk, configProvider: ConfigProvider, database: Database, container: Container) => {
-    const botService = container.get<BotService>(TYPES.BotService)
-    const workspaceService = container.get<WorkspaceService>(TYPES.WorkspaceService)
+  up: async ({ bp, configProvider, inversify }: MigrationOpts) => {
+    const botService = inversify.get<BotService>(TYPES.BotService)
+    const workspaceService = inversify.get<WorkspaceService>(TYPES.WorkspaceService)
 
     const bots = await botService.getBots()
 

--- a/src/bp/migrations/v12_0_0-1560863171-event_collector.ts
+++ b/src/bp/migrations/v12_0_0-1560863171-event_collector.ts
@@ -1,13 +1,12 @@
 import * as sdk from 'botpress/sdk'
-import { ConfigProvider } from 'core/config/config-loader'
-import { Migration } from 'core/services/migration'
+import { Migration, MigrationOpts } from 'core/services/migration'
 
 const migration: Migration = {
   info: {
     description: 'Adding eventCollector configuration to Botpress Config',
     type: 'config'
   },
-  up: async (bp: typeof sdk, configProvider: ConfigProvider): Promise<sdk.MigrationResult> => {
+  up: async ({ configProvider }: MigrationOpts): Promise<sdk.MigrationResult> => {
     const config = await configProvider.getBotpressConfig()
     if (config.eventCollector) {
       return { success: true, message: `Event Collector configuration already exists, skipping...` }

--- a/src/bp/migrations/v12_0_0-1560882898-move_users_to_db.ts
+++ b/src/bp/migrations/v12_0_0-1560882898-move_users_to_db.ts
@@ -5,7 +5,7 @@ import { StrategyUserTable } from 'core/database/tables/server-wide/strategy_use
 import { StrategyUsersRepository } from 'core/repositories/strategy_users'
 import { WorkspaceUsersRepository } from 'core/repositories/workspace_users'
 import { GhostService } from 'core/services'
-import { Migration } from 'core/services/migration'
+import { Migration, MigrationOpts } from 'core/services/migration'
 import { TYPES } from 'core/types'
 import { Container } from 'inversify'
 import _ from 'lodash'
@@ -15,12 +15,7 @@ const migration: Migration = {
     description: 'Copy existing users from workspaces file to database',
     type: 'database'
   },
-  up: async (
-    bp: typeof sdk,
-    configProvider: ConfigProvider,
-    database: Database,
-    inversify: Container
-  ): Promise<sdk.MigrationResult> => {
+  up: async ({ bp, database, inversify }: MigrationOpts): Promise<sdk.MigrationResult> => {
     const userRepo = inversify.get<StrategyUsersRepository>(TYPES.StrategyUsersRepository)
     const workspaceRepo = inversify.get<WorkspaceUsersRepository>(TYPES.WorkspaceUsersRepository)
 

--- a/src/bp/migrations/v12_0_0-1560882959-auth_strategies_config.ts
+++ b/src/bp/migrations/v12_0_0-1560882959-auth_strategies_config.ts
@@ -1,13 +1,12 @@
 import * as sdk from 'botpress/sdk'
-import { ConfigProvider } from 'core/config/config-loader'
-import { Migration } from 'core/services/migration'
+import { Migration, MigrationOpts } from 'core/services/migration'
 
 const migration: Migration = {
   info: {
     description: 'Adds default strategy to Botpress config & updates super admins',
     type: 'config'
   },
-  up: async (bp: typeof sdk, configProvider: ConfigProvider): Promise<sdk.MigrationResult> => {
+  up: async ({ configProvider }: MigrationOpts): Promise<sdk.MigrationResult> => {
     const config = await configProvider.getBotpressConfig()
 
     const hasAuthStrategy = config.authStrategies && Object.keys(config.authStrategies).length

--- a/src/bp/migrations/v12_0_0-1560888466-update_workspaces_content.ts
+++ b/src/bp/migrations/v12_0_0-1560888466-update_workspaces_content.ts
@@ -1,10 +1,7 @@
 import * as sdk from 'botpress/sdk'
-import { ConfigProvider } from 'core/config/config-loader'
-import Database from 'core/database'
 import { GhostService } from 'core/services'
-import { Migration } from 'core/services/migration'
+import { Migration, MigrationOpts } from 'core/services/migration'
 import { TYPES } from 'core/types'
-import { Container } from 'inversify'
 import _ from 'lodash'
 
 const migration: Migration = {
@@ -12,12 +9,7 @@ const migration: Migration = {
     description: 'Cleanup of workspaces.json to remove unused fields',
     type: 'content'
   },
-  up: async (
-    bp: typeof sdk,
-    configProvider: ConfigProvider,
-    database: Database,
-    inversify: Container
-  ): Promise<sdk.MigrationResult> => {
+  up: async ({ inversify }: MigrationOpts): Promise<sdk.MigrationResult> => {
     const ghost = inversify.get<GhostService>(TYPES.GhostService)
     const workspaces: any = await ghost.global().readFileAsObject('/', `workspaces.json`)
     if (workspaces.length > 1) {

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -985,10 +985,24 @@ declare module 'botpress/sdk' {
   export interface ModuleMigration {
     info: {
       description: string
+      target?: 'core' | 'bot'
       type: 'database' | 'config' | 'content'
     }
-    up: (bp: typeof import('botpress/sdk')) => Promise<MigrationResult>
-    down?: (bp: typeof import('botpress/sdk')) => Promise<MigrationResult>
+    up: (opts: ModuleMigrationOpts) => Promise<MigrationResult>
+    down?: (opts: ModuleMigrationOpts) => Promise<MigrationResult>
+  }
+
+  export interface ModuleMigrationOpts {
+    bp: typeof import('botpress/sdk')
+    metadata: MigrationMetadata
+    configProvider: any
+    database: any
+    inversify: any
+  }
+
+  /** These are additional informations that Botpress may pass down to migrations (for ex: running bot-specific migration) */
+  export interface MigrationMetadata {
+    botId?: string
   }
 
   /**


### PR DESCRIPTION
I had to rewrite part of the migration system to add support for individual bot migrations. When you run Botpress on a new version for the first time, it will run all migrations (provided by core/modules) and apply them to the core and to the bots.

Then, it updates all their versions so they are up to date. The field version was never used in the bot config. From now on, it will be set to the current version of botpress when it's created.

If you import a bot coming from an older version, it will run the bot migrations scripts on that specific bot, and update its version.

### Migration refactor
Previously, fields were passed as individual arguments, but clearly that was not scalable and was a pain in the ass to make any kind of modification. So before it becomes a monster, I converted it to an object so it's much more manageable..

### How to set the bot migrations
- Create a migration like any previous one. In the info part, set `target: 'bot'`
- In your `up` logic, the field `metadata.botId` will be defined if your migration should run on a single bot. In the other case, it should run them on all bots

There is a sample with an existing migration
![image](https://user-images.githubusercontent.com/42552874/61424577-fc914e80-a8e1-11e9-841d-35d3c13a6fe0.png)
