### PR TITLE
remove unused property

### DIFF
--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -56,7 +56,6 @@ export class Botpress {
   botpressPath: string
   configLocation: string
   modulesConfig: any
-  version: string
   config!: BotpressConfig | undefined
   api!: typeof sdk
   _heartbeatTimer?: NodeJS.Timeout
@@ -95,7 +94,6 @@ export class Botpress {
     @inject(TYPES.AuthService) private authService: AuthService,
     @inject(TYPES.MigrationService) private migrationService: MigrationService
   ) {
-    this.version = '12.0.1'
     this.botpressPath = path.join(process.cwd(), 'dist')
     this.configLocation = path.join(this.botpressPath, '/config')
   }


### PR DESCRIPTION
I don't know why this would be hardcoded. I incremented the version for 12.0.1 in the last release but didn't check if it was used.

Now after some digging, I don't think its used at all. But if its the case, why would we hardcode this?