### PR TITLE
Fix the documentation about the location of the env file

### DIFF
--- a/docs/guide/docs/channels/faq.md
+++ b/docs/guide/docs/channels/faq.md
@@ -11,9 +11,9 @@ Some channels (e.g. Messenger) require to have a public secure url. When testing
 
 Assets are exposed using a configurable base path. Make sure the `EXTERNAL_URL` environment variable is set so that your assets are accessible from the outside.
 
-You can set the environment variable in a `.env` file located under `/data`.
+You can set the environment variable in a `.env` file located in the same folder as the Botpress executable.
 
-If you don't know anything about `.env` files, just create a new file named `.env` in your `/data` folder. Then add the following line to it:
+If you don't know anything about `.env` files, just create a new file named `.env` at the base of your project. Then add the following line to it:
 
 ```bash
 EXTERNAL_URL=<public_url>

--- a/docs/guide/docs/main/channels.md
+++ b/docs/guide/docs/main/channels.md
@@ -166,9 +166,9 @@ Some channels (e.g. Messenger) require to have a public secure url. When testing
 
 Assets are exposed using a configurable base path. Make sure the `EXTERNAL_URL` environment variable is set so that your assets are accessible from the outside.
 
-You can set the environment variable in a `.env` file located under `/data`.
+You can set the environment variable in a `.env` file located in the same folder as the Botpress executable.
 
-If you don't know anything about `.env` files, just create a new file named `.env` in your `/data` folder. Then add the following line to it:
+If you don't know anything about `.env` files, just create a new file named `.env` at the base of your project. Then add the following line to it:
 
 ```bash
 EXTERNAL_URL=<public_url>


### PR DESCRIPTION
Fixing the location of the `.env` file in the documentation.