### PR TITLE
fix(nlu): exact match also matches if one entity type differs

### DIFF
--- a/modules/nlu/src/backend/engine.ts
+++ b/modules/nlu/src/backend/engine.ts
@@ -410,7 +410,8 @@ export default class ScopedEngine implements Engine {
   }
 
   private _extractIntents = async (ds: NLUStructure): Promise<NLUStructure> => {
-    const exactIntent = this._exactMatch(ds)
+    const exactMatcher = this._exactIntentMatchers[ds.language]
+    const exactIntent = exactMatcher && exactMatcher.exactMatch(ds)
     if (exactIntent) {
       ds.intent = exactIntent
       ds.intents = [exactIntent]
@@ -441,21 +442,6 @@ export default class ScopedEngine implements Engine {
     debugIntents.forBot(this.botId, ds.sanitizedText, { intents })
 
     return ds
-  }
-
-  private _exactMatch = (ds: NLUStructure) => {
-    const exactMatcher = this._exactIntentMatchers[ds.language]
-    let exactIntent = exactMatcher && exactMatcher.exactMatch(ds.sanitizedText, ds.includedContexts)
-    if (exactIntent) {
-      return exactIntent
-    }
-
-    for (const entity of ds.entities) {
-      exactIntent = exactMatcher && exactMatcher.exactMatchIgnoringEntity(ds.sanitizedText, ds.includedContexts, entity)
-      if (exactIntent) {
-        return exactIntent
-      }
-    }
   }
 
   private _setTextWithoutEntities = async (ds: NLUStructure): Promise<NLUStructure> => {

--- a/modules/nlu/src/backend/pipelines/intents/exact_matcher.test.ts
+++ b/modules/nlu/src/backend/pipelines/intents/exact_matcher.test.ts
@@ -1,0 +1,185 @@
+import { TrainingSequence, KnownSlot } from '../../typings'
+import * as sdk from 'botpress/sdk'
+import { makeTokens } from '../../tools/make-tokens'
+import ExactMatcher from './exact_matcher'
+
+const I_LIKE_ANIMALS_INTENT = 'I_LIKE_ANIMALS_INTENT'
+const ANIMAL_I_LIKE_SLOT = 'ANIMAL_I_LIKE_SLOT'
+
+const ANIMAL_ENTITY = 'ANIMAL_ENTITY'
+const FOOD_ENTITY = 'FOOD_ENTITY'
+const NUMBER_ENTITY = 'NUMBER_ENTITY'
+
+const SPACE = '\u2581'
+
+function makeSequence(text: string, intent: string, knownSlots?: KnownSlot[], contexts?: string[]): TrainingSequence {
+  const tokens = makeTokens(text.split(' ').map(t => SPACE + t), text)
+
+  contexts = contexts || []
+  knownSlots = knownSlots || []
+  return {
+    cannonical: text,
+    contexts,
+    intent,
+    knownSlots,
+    tokens
+  }
+}
+
+const I_like_animals = makeSequence('I like animals', I_LIKE_ANIMALS_INTENT)
+
+const I_like_dogs = makeSequence('I like dogs', I_LIKE_ANIMALS_INTENT, [
+  {
+    name: ANIMAL_I_LIKE_SLOT,
+    entities: [ANIMAL_ENTITY],
+    start: 7,
+    end: 11,
+    source: 'dogs'
+  }
+])
+
+const I_like_69_pretty_dogs = makeSequence('I like 69 pretty dogs', I_LIKE_ANIMALS_INTENT, [
+  {
+    name: 'number_of_animals',
+    entities: [NUMBER_ENTITY],
+    start: 7,
+    end: 9,
+    source: '69'
+  },
+  {
+    name: ANIMAL_I_LIKE_SLOT,
+    entities: [ANIMAL_ENTITY],
+    start: 17,
+    end: 21,
+    source: 'dogs'
+  }
+])
+
+describe('Exact Match', () => {
+  test('exact match with actual exact match should return correct intent', async () => {
+    // Arrange
+    const trainingSet: TrainingSequence[] = []
+    trainingSet.push(I_like_animals)
+
+    const exactMatcher = new ExactMatcher(trainingSet)
+
+    const ds = {
+      sanitizedText: 'I like animals',
+      includedContexts: [],
+      entities: []
+    }
+
+    // Act
+    const intent = exactMatcher.exactMatch(ds) as sdk.NLU.Intent
+
+    // Assert
+    expect(intent).toBeDefined()
+    expect(intent!.name).toBe(I_LIKE_ANIMALS_INTENT)
+    expect(intent.confidence).toEqual(1)
+  })
+
+  test('exact match with match except for one slot of same entity should return correct intent', async () => {
+    // Arrange
+    const trainingSet: TrainingSequence[] = []
+    trainingSet.push(I_like_animals)
+    trainingSet.push(I_like_dogs)
+
+    const exactMatcher = new ExactMatcher(trainingSet)
+
+    const ds = {
+      sanitizedText: 'I like dogs',
+      includedContexts: [],
+      entities: [
+        {
+          name: ANIMAL_ENTITY,
+          data: {},
+          meta: {
+            start: 7,
+            end: 11
+          },
+          type: 'list'
+        } as sdk.NLU.Entity
+      ]
+    }
+
+    // Act
+    const intent = exactMatcher.exactMatch(ds) as sdk.NLU.Intent
+
+    // Assert
+    expect(intent).toBeDefined()
+    expect(intent!.name).toBe(I_LIKE_ANIMALS_INTENT)
+    expect(intent.confidence).toEqual(1)
+  })
+
+  test('exact match with match except for one slot of different entity should not match', async () => {
+    // Arrange
+    const trainingSet: TrainingSequence[] = []
+    trainingSet.push(I_like_animals)
+    trainingSet.push(I_like_dogs)
+
+    const exactMatcher = new ExactMatcher(trainingSet)
+
+    const ds = {
+      sanitizedText: 'I like tomatos',
+      includedContexts: [],
+      entities: [
+        {
+          name: FOOD_ENTITY,
+          data: {},
+          meta: {
+            start: 7,
+            end: 14
+          },
+          type: 'list'
+        } as sdk.NLU.Entity
+      ]
+    }
+
+    // Act
+    const intent = exactMatcher.exactMatch(ds) as sdk.NLU.Intent
+
+    // Assert
+    expect(intent).toBeUndefined()
+  })
+
+  test('exact match with match for more than one slot should not match', async () => {
+    // Arrange
+    const trainingSet: TrainingSequence[] = []
+    trainingSet.push(I_like_animals)
+    trainingSet.push(I_like_dogs)
+    trainingSet.push(I_like_69_pretty_dogs)
+
+    const exactMatcher = new ExactMatcher(trainingSet)
+
+    const ds = {
+      sanitizedText: 'I like 42 stupid dogs',
+      includedContexts: [],
+      entities: [
+        {
+          name: NUMBER_ENTITY,
+          data: {},
+          meta: {
+            start: 7,
+            end: 9
+          },
+          type: 'list'
+        } as sdk.NLU.Entity,
+        {
+          name: ANIMAL_ENTITY,
+          data: {},
+          meta: {
+            start: 17,
+            end: 21
+          },
+          type: 'list'
+        } as sdk.NLU.Entity
+      ]
+    }
+
+    // Act
+    const intent = exactMatcher.exactMatch(ds) as sdk.NLU.Intent
+
+    // Assert
+    expect(intent).toBeUndefined()
+  })
+})

--- a/modules/nlu/src/backend/pipelines/intents/exact_matcher.ts
+++ b/modules/nlu/src/backend/pipelines/intents/exact_matcher.ts
@@ -1,68 +1,69 @@
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 
-import { TrainingSequence, Sequence } from '../../typings'
+import { TrainingSequence, NLUStructure, KnownSlot } from '../../typings'
 import { sanitize } from '../language/sanitizer'
+
+type ExactMatchStructure = {
+  sanitizedText: string
+  includedContexts: string[]
+  entities: sdk.NLU.Entity[]
+}
 
 // TODO if we're going to keep this, replace the training set with an inversed index or tree or at anything faster than O(n) at predict time
 // this might be replaced by a knn with tweaked distance func & proper usage at predict time
 export default class ExactMatcher {
   constructor(private trainingSet: TrainingSequence[]) {}
 
-  exactMatch(text: string, includedContext: string[]): sdk.NLU.Intent | void {
-    return this._exactMatchFromSequence(text, includedContext, this.trainingSet)
-  }
+  exactMatch(ds: ExactMatchStructure): sdk.NLU.Intent | void {
+    const { sanitizedText: text, includedContexts, entities: detectedEntities } = ds
 
-  exactMatchIgnoringEntity(text: string, includedContext: string[], entity: sdk.NLU.Entity) {
-    const replacedText = this._replaceText(text, entity.name, entity.meta.start, entity.meta.end)
-    const replacedCorpus = this._replaceCorpus(this.trainingSet, entity)
+    for (const seq of this.trainingSet) {
+      if (includedContexts.length && !_.intersection(seq.contexts || [], includedContexts).length) {
+        continue
+      }
 
-    return this._exactMatchFromSequence(replacedText, includedContext, replacedCorpus)
-  }
+      let isMatch = this._matchWithoutReplacingSlots(text, seq.cannonical)
 
-  private _replaceText = (text: string, by: string, start: number, end: number) =>
-    text.substring(0, start) + by + text.substring(end)
+      const firstKnownSlot = _.first(seq.knownSlots)
+      isMatch =
+        isMatch ||
+        (seq.knownSlots.length === 1 &&
+          this._matchIgnoringSlot(text, seq.cannonical, firstKnownSlot!, detectedEntities))
 
-  private _replaceCorpus(corpus: TrainingSequence[], entity: sdk.NLU.Entity): Partial<Sequence>[] {
-    const sequences = { ...corpus }
-
-    const newCorpus = [] as Partial<Sequence>[]
-    for (const seq of sequences) {
-      const knownSlots = seq.knownSlots
-
-      let cannonical = seq.cannonical
-      for (const ks of knownSlots) {
-        if (ks.entities.includes(entity.name)) {
-          cannonical = this._replaceText(cannonical, entity.name, ks.start, ks.end)
+      if (isMatch) {
+        return {
+          name: seq.intent,
+          confidence: 1,
+          context: seq.contexts![0] // todo fix this
         }
       }
-      newCorpus.push({
-        cannonical,
-        contexts: seq.contexts,
-        intent: seq.intent
-      })
     }
-
-    return newCorpus
   }
 
-  private _exactMatchFromSequence(
-    text: string,
-    includedContext: string[],
-    sequences: Partial<Sequence>[]
-  ): sdk.NLU.Intent | void {
-    const lowText = sanitize(text.toLowerCase())
+  private _sanitizeText(text: string): string {
+    return sanitize(text.toLowerCase())
+  }
 
-    const seq = sequences
-      .filter(seq => !includedContext.length || _.intersection(seq.contexts || [], includedContext).length)
-      .find(s => sanitize(s.cannonical.toLowerCase()) === lowText)
+  private _matchWithoutReplacingSlots(textInput: string, textTraining: string): boolean {
+    return this._sanitizeText(textTraining) === this._sanitizeText(textInput)
+  }
 
-    if (seq) {
-      return {
-        name: seq.intent,
-        confidence: 1,
-        context: seq.contexts[0] // todo fix this
-      }
-    }
+  private _matchIgnoringSlot(
+    textInput: string,
+    textTraining: string,
+    slot: KnownSlot,
+    detectedEntities: sdk.NLU.Entity[]
+  ): boolean {
+    textInput = this._sanitizeText(textInput)
+    const cannonical = this._sanitizeText(textTraining)
+
+    const seqWithoutSlot = cannonical.substring(0, slot.start) + cannonical.substring(slot.end)
+
+    const match = detectedEntities.find(e => {
+      const textWithoutEntity = textInput.substring(0, e.meta.start) + textInput.substring(e.meta.end)
+      return textWithoutEntity === seqWithoutSlot && slot.entities.includes(e.name)
+    })
+    return !!match
   }
 }

--- a/modules/nlu/src/backend/pipelines/intents/exact_matcher.ts
+++ b/modules/nlu/src/backend/pipelines/intents/exact_matcher.ts
@@ -1,18 +1,59 @@
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 
-import { Sequence } from '../../typings'
+import { TrainingSequence, Sequence } from '../../typings'
 import { sanitize } from '../language/sanitizer'
 
 // TODO if we're going to keep this, replace the training set with an inversed index or tree or at anything faster than O(n) at predict time
 // this might be replaced by a knn with tweaked distance func & proper usage at predict time
 export default class ExactMatcher {
-  constructor(private trainingSet: Sequence[]) {}
+  constructor(private trainingSet: TrainingSequence[]) {}
 
   exactMatch(text: string, includedContext: string[]): sdk.NLU.Intent | void {
+    return this._exactMatchFromSequence(text, includedContext, this.trainingSet)
+  }
+
+  exactMatchIgnoringEntity(text: string, includedContext: string[], entity: sdk.NLU.Entity) {
+    const replacedText = this._replaceText(text, entity.name, entity.meta.start, entity.meta.end)
+    const replacedCorpus = this._replaceCorpus(this.trainingSet, entity)
+
+    return this._exactMatchFromSequence(replacedText, includedContext, replacedCorpus)
+  }
+
+  private _replaceText = (text: string, by: string, start: number, end: number) =>
+    text.substring(0, start) + by + text.substring(end)
+
+  private _replaceCorpus(corpus: TrainingSequence[], entity: sdk.NLU.Entity): Partial<Sequence>[] {
+    const sequences = { ...corpus }
+
+    const newCorpus = [] as Partial<Sequence>[]
+    for (const seq of sequences) {
+      const knownSlots = seq.knownSlots
+
+      let cannonical = seq.cannonical
+      for (const ks of knownSlots) {
+        if (ks.entities.includes(entity.name)) {
+          cannonical = this._replaceText(cannonical, entity.name, ks.start, ks.end)
+        }
+      }
+      newCorpus.push({
+        cannonical,
+        contexts: seq.contexts,
+        intent: seq.intent
+      })
+    }
+
+    return newCorpus
+  }
+
+  private _exactMatchFromSequence(
+    text: string,
+    includedContext: string[],
+    sequences: Partial<Sequence>[]
+  ): sdk.NLU.Intent | void {
     const lowText = sanitize(text.toLowerCase())
 
-    const seq = this.trainingSet
+    const seq = sequences
       .filter(seq => !includedContext.length || _.intersection(seq.contexts || [], includedContext).length)
       .find(s => sanitize(s.cannonical.toLowerCase()) === lowText)
 

--- a/modules/nlu/src/backend/pipelines/slots/pre-processor.ts
+++ b/modules/nlu/src/backend/pipelines/slots/pre-processor.ts
@@ -125,8 +125,10 @@ export const generateTrainingSequence = (langProvider: LanguageProvider) => asyn
 
   const lastSlot = _.maxBy(knownSlots, ks => ks.end)
   if (lastSlot && lastSlot!.end < cannonical.length) {
-    const sup: string = cannonical.substring(lastSlot!.end)
-    tokens = [...tokens, ...(await genToken(sup, lang, _.isEmpty(tokens) ? 0 : _.last(tokens)!.end))]
+    const textLeftAfterLastSlot: string = cannonical.substring(lastSlot!.end)
+    const start = _.isEmpty(tokens) ? 0 : _.last(tokens)!.end
+    const tokensLeft = await genToken(textLeftAfterLastSlot, lang, start)
+    tokens = [...tokens, ...tokensLeft]
   }
 
   return {

--- a/modules/nlu/src/backend/typings.ts
+++ b/modules/nlu/src/backend/typings.ts
@@ -26,6 +26,16 @@ export interface Sequence {
   contexts?: string[]
 }
 
+export interface TrainingSequence extends Sequence {
+  knownSlots: KnownSlot[]
+}
+
+export interface KnownSlot extends sdk.NLU.SlotDefinition {
+  start: number
+  end: number
+  source: string
+}
+
 export type EngineByBot = { [botId: string]: Engine }
 
 export interface Engine {
@@ -101,7 +111,7 @@ export interface Gateway {
   errors: number
   disabledUntil?: Date
 }
-[]
+;[]
 
 export interface LangsGateway {
   [lang: string]: Gateway[]


### PR DESCRIPTION
For now:

suppose we have entity list:

animals = ['dogs', 'cats', 'camels', 'birds']

"I like cats and dogs"
"i like birds and camels"

Are both changed to "I like animals and animals" by the exactMatcher

So they will match.


Howerver this currently only works for one entity at a time. If we have

"I want 3 dogs"
"I want 2 cats"

The exact matcher will try:

"I want 3 animals" !== "I want 2 animals"
"I want number dogs" !== "I want number cats"

And there will be no match.

Todo: match on all possible combination.