### PR TITLE
fix(lang-server): provide embeddings metadata by default

### DIFF
--- a/build/gulp.core.js
+++ b/build/gulp.core.js
@@ -3,6 +3,7 @@ const gulp = require('gulp')
 const ts = require('gulp-typescript')
 const sourcemaps = require('gulp-sourcemaps')
 const gulpif = require('gulp-if')
+const rename = require('gulp-rename')
 const run = require('gulp-run')
 const file = require('gulp-file')
 const buildJsonSchemas = require('./jsonschemas')
@@ -54,6 +55,7 @@ const createOutputDirs = () => {
     .src('*.*', { read: false })
     .pipe(gulp.dest('./out/bp/data'))
     .pipe(gulp.dest('./out/bp/data/storage'))
+    .pipe(gulp.dest('./out/bp/data/embeddings'))
 }
 
 const createMigration = cb => {
@@ -91,13 +93,15 @@ const buildSchemas = cb => {
   cb()
 }
 
-const copyBinaries = () => {
-  return gulp.src('src/bp/ml/bin/*.*').pipe(gulp.dest('./out/bp/ml/bin'))
-}
+const copyBinaries = () => gulp.src('src/bp/ml/bin/*.*').pipe(gulp.dest('./out/bp/ml/bin'))
 
-const copyJs = () => {
-  return gulp.src('src/bp/ml/svm-js/**/*.*').pipe(gulp.dest('./out/bp/ml/svm-js'))
-}
+const copyJs = () => gulp.src('src/bp/ml/svm-js/**/*.*').pipe(gulp.dest('./out/bp/ml/svm-js'))
+
+const copyEmbeddings = () =>
+  gulp
+    .src('src/embeddings.json')
+    .pipe(rename('index.json'))
+    .pipe(gulp.dest('./out/bp/data/embeddings/'))
 
 const build = () => {
   return gulp.series([
@@ -107,7 +111,8 @@ const build = () => {
     buildSchemas,
     createOutputDirs,
     copyJs,
-    copyBinaries
+    copyBinaries,
+    copyEmbeddings
   ])
 }
 

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "gulp-if": "^2.0.2",
     "gulp-ignore": "^2.0.2",
     "gulp-print": "^5.0.0",
+    "gulp-rename": "^1.4.0",
     "gulp-rimraf": "^0.2.2",
     "gulp-run": "^1.7.1",
     "gulp-sourcemaps": "^2.6.4",

--- a/src/embeddings.json
+++ b/src/embeddings.json
@@ -1,0 +1,35 @@
+{
+  "generated_on": "2019-07-22T13:24:09.634Z",
+  "languages": {
+    "ar": {
+      "code": "ar",
+      "name": "Arabic",
+      "flag": "https://upload.wikimedia.org/wikipedia/commons/7/77/Flag_of_Algeria.svg"
+    },
+    "en": {
+      "code": "en",
+      "name": "English",
+      "flag": "https://upload.wikimedia.org/wikipedia/commons/4/43/Flag_of_Britain.svg"
+    },
+    "fr": {
+      "code": "fr",
+      "name": "French",
+      "flag": "https://upload.wikimedia.org/wikipedia/commons/c/c3/Flag_of_France.svg"
+    },
+    "ja": {
+      "code": "ja",
+      "name": "Japanese",
+      "flag": "https://upload.wikimedia.org/wikipedia/commons/9/9e/Flag_of_Japan.svg"
+    },
+    "pt": {
+      "code": "pt",
+      "name": "Portuguese",
+      "flag": "https://upload.wikimedia.org/wikipedia/commons/5/5c/Flag_of_Portugal.svg"
+    },
+    "ru": {
+      "code": "ru",
+      "name": "Russian",
+      "flag": "https://upload.wikimedia.org/wikipedia/commons/f/f3/Flag_of_Russia.svg"
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -561,16 +561,7 @@
     "@types/node" "*"
     "@types/range-parser" "*"
 
-"@types/express@*":
-  version "4.16.1"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.16.1.tgz#d756bd1a85c34d87eaf44c888bad27ba8a4b7cf0"
-  integrity sha512-V0clmJow23WeyblmACoxbHBu2JKlE5TiIme6Lem14FnPW9gsttyHtk6wq7njcdIWH1njAaFgR8gW09lgY98gQg==
-  dependencies:
-    "@types/body-parser" "*"
-    "@types/express-serve-static-core" "*"
-    "@types/serve-static" "*"
-
-"@types/express@^4.16.0":
+"@types/express@*", "@types/express@^4.16.0":
   version "4.16.1"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.16.1.tgz#d756bd1a85c34d87eaf44c888bad27ba8a4b7cf0"
   integrity sha512-V0clmJow23WeyblmACoxbHBu2JKlE5TiIme6Lem14FnPW9gsttyHtk6wq7njcdIWH1njAaFgR8gW09lgY98gQg==
@@ -3879,6 +3870,11 @@ gulp-print@^5.0.0:
     fancy-log "^1.3.3"
     map-stream "0.0.7"
     vinyl "^2.2.0"
+
+gulp-rename@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-1.4.0.tgz#de1c718e7c4095ae861f7296ef4f3248648240bd"
+  integrity sha512-swzbIGb/arEoFK89tPY58vg3Ok1bw+d35PfUNwWqdo7KM4jkmuGA78JiDNqR+JeZFaeeHnRg9N7aihX3YPmsyg==
 
 gulp-rimraf@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
* When you host the lang server, you need the embeddings metadata file so the models gets recognized
* By providing this metadata by default, we make the process of hosting its lang server easier
* We just have to update `embeddings.json` with the new metadata every time we update the languages