### PR TITLE
fix(logs): follow-logs not working consistently when zoomed

### DIFF
--- a/src/bp/ui-studio/src/web/components/Layout/StatusBar/BottomPanel.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/StatusBar/BottomPanel.tsx
@@ -134,7 +134,8 @@ class BottomPanel extends React.Component<Props, State> {
   }
 
   handleLogsScrolled = e => {
-    const isAtBottom = e.target.scrollHeight - e.target.scrollTop === e.target.clientHeight
+    // When zoomed, scrollTop may have decimals and must be rounded
+    const isAtBottom = e.target.scrollHeight - Math.round(e.target.scrollTop) === e.target.clientHeight
 
     if (isAtBottom && !this.state.followLogs) {
       this.setState({ followLogs: true })


### PR DESCRIPTION
When zoomed in, scrollTop has multiple decimals and the calculation is off by a very small margin. Zoom doesn't impact scrollHeight and neither the client height.