### PR TITLE
fix(webchat): fix for some messages which crashed the whole chat

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/Message.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/Message.tsx
@@ -11,6 +11,14 @@ import * as Keyboard from '../Keyboard'
 import { Carousel, FileMessage, LoginPrompt, Text } from './renderer'
 
 class Message extends Component<MessageProps> {
+  state = {
+    hasError: false
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true }
+  }
+
   render_text(textMessage?: string) {
     const { text, markdown } = this.props.payload
 
@@ -110,6 +118,10 @@ class Message extends Component<MessageProps> {
   }
 
   render() {
+    if (this.state.hasError) {
+      return '* Cannot display message *'
+    }
+
     const type = this.props.type || (this.props.payload && this.props.payload.type)
     const wrappedType = this.props.payload && this.props.payload.wrapped && this.props.payload.wrapped.type
     const renderer = (this['render_' + type] || this.render_unsupported).bind(this)
@@ -117,7 +129,7 @@ class Message extends Component<MessageProps> {
 
     const rendered = renderer()
     if (rendered === null) {
-      return undefined
+      return null
     }
 
     const additionalStyle = (this.props.payload && this.props.payload['web-style']) || {}

--- a/modules/channel-web/src/views/lite/components/messages/MessageGroup.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/MessageGroup.tsx
@@ -7,69 +7,85 @@ import { Message as MessageDetails } from '../../typings'
 
 import Message from './Message'
 
-const MessageGroup = (props: MessageGroupProps) => {
-  return (
-    <div
-      className={classnames('bpw-message-big-container', {
-        'bpw-from-user': !props.isBot,
-        'bpw-from-bot': props.isBot
-      })}
-    >
-      {props.avatar}
-      <div className={'bpw-message-container'}>
-        {props.showUserName && <div className={'bpw-message-username'}>{props.userName}</div>}
-        <div className={'bpw-message-group'}>
-          {props.messages.map((data, i) => {
-            /**
-             * @deprecated 12.0
-             * Here, we convert old format to the new format Botpress uses internally.
-             * - payload: all the data (raw, whatever) that is necessary to display the element
-             * - type: extracted from payload for easy sorting
-             */
-            let payload = data.payload || data.message_data || data.message_raw || { text: data.message_text }
-            if (!payload.type) {
-              payload.type = data.message_type || (data.message_data && data.message_data.type) || 'text'
-            }
+class MessageGroup extends React.Component<Props> {
+  state = {
+    hasError: false
+  }
 
-            // Keeping compatibility with old schema for the quick reply
-            if (data.message_type === 'quick_reply' && !payload.text) {
-              payload.text = data.message_text
-            }
+  static getDerivedStateFromError(error) {
+    return { hasError: true }
+  }
 
-            if (data.message_type === 'file' && !payload.url) {
-              payload.url = (data.message_data && data.message_data.url) || (data.message_raw && data.message_raw.url)
-            }
+  render() {
+    if (this.state.hasError) {
+      return '* Cannot display message *'
+    }
 
-            if (props.messageWrapper && payload.type !== 'session_reset') {
-              payload = {
-                type: 'custom',
-                module: props.messageWrapper.module,
-                component: props.messageWrapper.component,
-                wrapped: payload
+    return (
+      <div
+        className={classnames('bpw-message-big-container', {
+          'bpw-from-user': !this.props.isBot,
+          'bpw-from-bot': this.props.isBot
+        })}
+      >
+        {this.props.avatar}
+        <div className={'bpw-message-container'}>
+          {this.props.showUserName && <div className={'bpw-message-username'}>{this.props.userName}</div>}
+          <div className={'bpw-message-group'}>
+            {this.props.messages.map((data, i) => {
+              /**
+               * @deprecated 12.0
+               * Here, we convert old format to the new format Botpress uses internally.
+               * - payload: all the data (raw, whatever) that is necessary to display the element
+               * - type: extracted from payload for easy sorting
+               */
+              let payload = data.payload || data.message_data || data.message_raw || { text: data.message_text }
+              if (!payload.type) {
+                payload.type = data.message_type || (data.message_data && data.message_data.type) || 'text'
               }
-            }
 
-            return (
-              <Message
-                key={`msg-${i}`}
-                isHighlighted={props.highlightedMessages && props.highlightedMessages.includes(data.incomingEventId)}
-                isLastOfGroup={i >= props.messages.length - 1}
-                isLastGroup={props.isLastGroup}
-                isBotMessage={!data.userId}
-                incomingEventId={data.incomingEventId}
-                payload={payload}
-                sentOn={data.sent_on}
-                onSendData={props.onSendData}
-                onFileUpload={props.onFileUpload}
-                bp={props.bp}
-                store={props.store}
-              />
-            )
-          })}
+              // Keeping compatibility with old schema for the quick reply
+              if (data.message_type === 'quick_reply' && !payload.text) {
+                payload.text = data.message_text
+              }
+
+              if (data.message_type === 'file' && !payload.url) {
+                payload.url = (data.message_data && data.message_data.url) || (data.message_raw && data.message_raw.url)
+              }
+
+              if (this.props.messageWrapper && payload.type !== 'session_reset') {
+                payload = {
+                  type: 'custom',
+                  module: this.props.messageWrapper.module,
+                  component: this.props.messageWrapper.component,
+                  wrapped: payload
+                }
+              }
+
+              return (
+                <Message
+                  key={`msg-${i}`}
+                  isHighlighted={
+                    this.props.highlightedMessages && this.props.highlightedMessages.includes(data.incomingEventId)
+                  }
+                  isLastOfGroup={i >= this.props.messages.length - 1}
+                  isLastGroup={this.props.isLastGroup}
+                  isBotMessage={!data.userId}
+                  incomingEventId={data.incomingEventId}
+                  payload={payload}
+                  sentOn={data.sent_on}
+                  onSendData={this.props.onSendData}
+                  onFileUpload={this.props.onFileUpload}
+                  bp={this.props.bp}
+                  store={this.props.store}
+                />
+              )
+            })}
+          </div>
         </div>
       </div>
-    </div>
-  )
+    )
+  }
 }
 
 export default inject(({ store }: { store: RootStore }) => ({
@@ -82,7 +98,7 @@ export default inject(({ store }: { store: RootStore }) => ({
   highlightedMessages: store.view.highlightedMessages
 }))(MessageGroup)
 
-type MessageGroupProps = {
+type Props = {
   isBot: boolean
   avatar: JSX.Element
   userName: string


### PR DESCRIPTION
When rendering postback messages, the renderer was returning null since there is no text to display. The logic in the renderer then returned undefined instead of null... which is bad.

Also added a safeguard in Message.tsx (for child components), and converted MessageGroup to a class so it could handle exceptions comding from Message (a component can't handle its own exceptions, must be a parent)