### PR TITLE
chore(migrations): add missing migrations

### DIFF
--- a/modules/hitl/src/migrations/v12_1_0-1564677070-add_source_column_to_hitl_messages.ts
+++ b/modules/hitl/src/migrations/v12_1_0-1564677070-add_source_column_to_hitl_messages.ts
@@ -1,0 +1,15 @@
+import * as sdk from 'botpress/sdk'
+import { MigrationOpts } from 'core/services/migration'
+
+const migration: sdk.ModuleMigration = {
+  info: {
+    description: 'Add source column to hitl_messages',
+    type: 'database'
+  },
+  up: async ({ bp, database, inversify }: MigrationOpts): Promise<sdk.MigrationResult> => {
+    await bp.database.schema.alterTable('hitl_messages', table => table.string('source'))
+    return { success: true, message: 'Source column created.' }
+  }
+}
+
+export default migration

--- a/modules/hitl/src/migrations/v12_1_0-1564677070-add_source_column_to_hitl_messages.ts
+++ b/modules/hitl/src/migrations/v12_1_0-1564677070-add_source_column_to_hitl_messages.ts
@@ -10,7 +10,6 @@ const migration: sdk.ModuleMigration = {
       const tableName = 'hitl_messages'
       const column = 'source'
       const exists = await bp.database.schema.hasColumn(tableName, column)
-      console.log(exists)
 
       if (!exists) {
         await bp.database.schema.alterTable(tableName, table => table.string(column))

--- a/modules/hitl/src/migrations/v12_1_0-1564677070-add_source_column_to_hitl_messages.ts
+++ b/modules/hitl/src/migrations/v12_1_0-1564677070-add_source_column_to_hitl_messages.ts
@@ -1,12 +1,11 @@
 import * as sdk from 'botpress/sdk'
-import { MigrationOpts } from 'core/services/migration'
 
 const migration: sdk.ModuleMigration = {
   info: {
     description: 'Add source column to hitl_messages',
     type: 'database'
   },
-  up: async ({ bp }: MigrationOpts): Promise<sdk.MigrationResult> => {
+  up: async ({ bp }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
     try {
       await bp.database.schema.alterTable('hitl_messages', table => table.string('source'))
     } catch (err) {

--- a/modules/hitl/src/migrations/v12_1_0-1564677070-add_source_column_to_hitl_messages.ts
+++ b/modules/hitl/src/migrations/v12_1_0-1564677070-add_source_column_to_hitl_messages.ts
@@ -7,7 +7,14 @@ const migration: sdk.ModuleMigration = {
   },
   up: async ({ bp }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
     try {
-      await bp.database.schema.alterTable('hitl_messages', table => table.string('source'))
+      const tableName = 'hitl_messages'
+      const column = 'source'
+      const exists = await bp.database.schema.hasColumn(tableName, column)
+      console.log(exists)
+
+      if (!exists) {
+        await bp.database.schema.alterTable(tableName, table => table.string(column))
+      }
     } catch (err) {
       return { success: false, message: err.message }
     }

--- a/modules/hitl/src/migrations/v12_1_0-1564677070-add_source_column_to_hitl_messages.ts
+++ b/modules/hitl/src/migrations/v12_1_0-1564677070-add_source_column_to_hitl_messages.ts
@@ -7,9 +7,12 @@ const migration: sdk.ModuleMigration = {
     type: 'database'
   },
   up: async ({ bp }: MigrationOpts): Promise<sdk.MigrationResult> => {
-    await bp.database.schema
-      .alterTable('hitl_messages', table => table.string('source'))
-      .catch(err => ({ success: false, message: err.message }))
+    try {
+      await bp.database.schema.alterTable('hitl_messages', table => table.string('source'))
+    } catch (err) {
+      return { success: false, message: err.message }
+    }
+
     return { success: true, message: 'Source column created.' }
   }
 }

--- a/modules/hitl/src/migrations/v12_1_0-1564677070-add_source_column_to_hitl_messages.ts
+++ b/modules/hitl/src/migrations/v12_1_0-1564677070-add_source_column_to_hitl_messages.ts
@@ -6,8 +6,10 @@ const migration: sdk.ModuleMigration = {
     description: 'Add source column to hitl_messages',
     type: 'database'
   },
-  up: async ({ bp, database, inversify }: MigrationOpts): Promise<sdk.MigrationResult> => {
-    await bp.database.schema.alterTable('hitl_messages', table => table.string('source'))
+  up: async ({ bp }: MigrationOpts): Promise<sdk.MigrationResult> => {
+    await bp.database.schema
+      .alterTable('hitl_messages', table => table.string('source'))
+      .catch(err => ({ success: false, message: err.message }))
     return { success: true, message: 'Source column created.' }
   }
 }

--- a/src/bp/migrations/v12_1_0-1564683507-remove_migrations_tables.ts
+++ b/src/bp/migrations/v12_1_0-1564683507-remove_migrations_tables.ts
@@ -8,8 +8,13 @@ const migration: Migration = {
   },
   up: async ({ bp }: MigrationOpts): Promise<sdk.MigrationResult> => {
     try {
-      await bp.database.schema.dropTable('knex_core_migrations')
-      await bp.database.schema.dropTable('knex_core_migrations_lock')
+      if (await bp.database.schema.hasTable('knex_core_migrations')) {
+        await bp.database.schema.dropTable('knex_core_migrations')
+      }
+
+      if (await bp.database.schema.hasTable('knex_core_migrations_lock')) {
+        await bp.database.schema.dropTable('knex_core_migrations_lock')
+      }
     } catch (err) {
       return { success: false, message: err.message }
     }

--- a/src/bp/migrations/v12_1_0-1564683507-remove_migrations_tables.ts
+++ b/src/bp/migrations/v12_1_0-1564683507-remove_migrations_tables.ts
@@ -6,13 +6,7 @@ const migration: Migration = {
     description: 'Remove migrations tables',
     type: 'database'
   },
-  up: async ({
-    bp,
-    configProvider,
-    database,
-    inversify,
-    metadata
-  }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
+  up: async ({ bp }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
     try {
       await bp.database.schema.dropTable('knex_core_migrations')
       await bp.database.schema.dropTable('knex_core_migrations_lock')

--- a/src/bp/migrations/v12_1_0-1564683507-remove_migrations_tables.ts
+++ b/src/bp/migrations/v12_1_0-1564683507-remove_migrations_tables.ts
@@ -1,0 +1,27 @@
+import * as sdk from 'botpress/sdk'
+import { Migration } from 'core/services/migration'
+
+const migration: Migration = {
+  info: {
+    description: 'Remove migrations tables',
+    type: 'database'
+  },
+  up: async ({
+    bp,
+    configProvider,
+    database,
+    inversify,
+    metadata
+  }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
+    try {
+      await bp.database.schema.dropTable('knex_core_migrations')
+      await bp.database.schema.dropTable('knex_core_migrations_lock')
+    } catch (err) {
+      return { success: false, message: err.message }
+    }
+
+    return { success: true, message: 'Configuration updated successfully' }
+  }
+}
+
+export default migration

--- a/src/bp/migrations/v12_1_0-1564683507-remove_migrations_tables.ts
+++ b/src/bp/migrations/v12_1_0-1564683507-remove_migrations_tables.ts
@@ -1,12 +1,12 @@
 import * as sdk from 'botpress/sdk'
-import { Migration } from 'core/services/migration'
+import { Migration, MigrationOpts } from 'core/services/migration'
 
 const migration: Migration = {
   info: {
     description: 'Remove migrations tables',
     type: 'database'
   },
-  up: async ({ bp }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
+  up: async ({ bp }: MigrationOpts): Promise<sdk.MigrationResult> => {
     try {
       await bp.database.schema.dropTable('knex_core_migrations')
       await bp.database.schema.dropTable('knex_core_migrations_lock')


### PR DESCRIPTION
* Source column was missing in hitl_messages
* The migrations tables in the DB are unnecessary since we're keeping the migrations status in `data/migrations`