### PR TITLE
fix(dialog-engine): ending flow when no nodes configured

### DIFF
--- a/src/bp/core/services/dialog/dialog-engine.ts
+++ b/src/bp/core/services/dialog/dialog-engine.ts
@@ -75,10 +75,15 @@ export class DialogEngine {
         this._debug(event.botId, event.target, 'waiting until next event')
         context.queue = queue
       } else if (result.followUpAction === 'transition') {
+        const destination = result.options!.transitionTo!
+        if (!destination || !destination.length) {
+          this._debug(event.botId, event.target, 'no node configured, ending flow')
+          return event
+        }
         // We reset the queue when we transition to another node.
         // This way the queue will be rebuilt from the next node.
         context.queue = undefined
-        return this._transition(sessionId, event, result.options!.transitionTo!)
+        return this._transition(sessionId, event, destination)
       }
     } catch (err) {
       this._reportProcessingError(botId, err, event, instruction)


### PR DESCRIPTION
With this change, when the user encounters a node/transition which doesn't have any destination, the flow ends instead of throwing an error and locking him for the duration of his session (unless he resets the conversation).

![image](https://user-images.githubusercontent.com/42552874/62322823-ef449a00-b473-11e9-95dd-5c9b84b22082.png)

With the autosave, my guess is that more people will get stuck in that kind of situation. 

What do you think of that ? Should we keep throwing an error, or should we gracefully handle it ? 