### PR TITLE
fix(nlu): removing useless confusion matrix error

### DIFF
--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -87,9 +87,7 @@ export default async (bp: typeof sdk, nlus: EngineByBot) => {
       const matrix = await engine.storage.getConfusionMatrix(req.params.modelHash, req.params.version, lang)
       res.send({ matrix, confusionComputing })
     } catch (err) {
-      if (err.code !== 'ENOENT') {
-        bp.logger.attachError(err).warn(`Could not get confusion matrix for ${req.params.modelHash}.`)
-      }
+      bp.logger.attachError(err).warn(`Could not get confusion matrix for ${req.params.modelHash}.`)
       res.send({ confusionComputing })
     }
   })

--- a/modules/nlu/src/backend/storage.ts
+++ b/modules/nlu/src/backend/storage.ts
@@ -100,11 +100,13 @@ export default class Storage {
       })
     )
 
-  async getConfusionMatrix(modelHash: string, buildVersion: string, lang: string): Promise<Result> {
-    return await this.botGhost.readFileAsObject<Result>(
-      `${this.modelsDir}/${lang}`,
-      `confusion__${modelHash}__${buildVersion}.json`
-    )
+  async getConfusionMatrix(modelHash: string, buildVersion: string, lang: string): Promise<Result | undefined> {
+    const rootFolder = `${this.modelsDir}/${lang}`
+    const filename = `confusion__${modelHash}__${buildVersion}.json`
+
+    if (await this.botGhost.fileExists(rootFolder, filename)) {
+      return this.botGhost.readFileAsObject<Result>(rootFolder, filename)
+    }
   }
 
   async deleteIntent(intent) {


### PR DESCRIPTION
Just checking if the file exists instead of relying on ENOENT (which is only emitted by the disk driver)