### PR TITLE
fix(core): clearing cache of required actions and sync when remote

### DIFF
--- a/src/bp/core/services/action/action-service.ts
+++ b/src/bp/core/services/action/action-service.ts
@@ -63,6 +63,11 @@ export class ScopedActionService {
       if (key.toLowerCase().indexOf(`/actions`) > -1) {
         this._scriptsCache.clear()
         this._actionsCache = undefined
+
+        // Clearing cache for files required in actions
+        Object.keys(require.cache)
+          .filter(r => r.match(/(\\|\/)actions(\\|\/)/g))
+          .map(file => delete require.cache[file])
       }
     })
   }

--- a/src/bp/core/services/action/action-service.ts
+++ b/src/bp/core/services/action/action-service.ts
@@ -63,7 +63,7 @@ export class ScopedActionService {
   }
 
   private _listenForCacheInvalidation() {
-    this.cache.events.on('invalidation', async key => {
+    this.cache.events.on('invalidation', key => {
       if (key.toLowerCase().indexOf(`/actions`) > -1) {
         this._scriptsCache.clear()
         this._actionsCache = undefined

--- a/src/bp/core/services/action/action-service.ts
+++ b/src/bp/core/services/action/action-service.ts
@@ -53,7 +53,11 @@ export default class ActionService {
       .filter(r => r.match(/(\\|\/)actions(\\|\/)/g))
       .map(file => delete require.cache[file])
 
-    await this.ghost.forBot(botId).syncRemoteFiles('actions')
+    if (botId === 'global') {
+      await this.ghost.global().syncDatabaseFilesToDisk('actions')
+    } else {
+      await this.ghost.forBot(botId).syncDatabaseFilesToDisk('actions')
+    }
   }
 
   forBot(botId: string): ScopedActionService {

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -365,6 +365,19 @@ export class ScopedGhostService {
     await this.primaryDriver.moveFile(fromPath, toPath)
   }
 
+  async syncRemoteFiles(rootFolder: string): Promise<void> {
+    if (this.primaryDriver instanceof DiskStorageDriver) {
+      return
+    }
+
+    const remoteFiles = await this.dbDriver.directoryListing(this._normalizeFolderName(rootFolder))
+    const filePath = filename => this._normalizeFileName(rootFolder, filename)
+
+    await Promise.mapSeries(remoteFiles, async file =>
+      this.diskDriver.upsertFile(filePath(file), await this.dbDriver.readFile(filePath(file)))
+    )
+  }
+
   async deleteFolder(folder: string): Promise<void> {
     if (this.isDirectoryGlob) {
       throw new Error(`Ghost can't read or write under this scope`)

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -365,7 +365,7 @@ export class ScopedGhostService {
     await this.primaryDriver.moveFile(fromPath, toPath)
   }
 
-  async syncRemoteFiles(rootFolder: string): Promise<void> {
+  async syncDatabaseFilesToDisk(rootFolder: string): Promise<void> {
     if (this.primaryDriver instanceof DiskStorageDriver) {
       return
     }

--- a/src/bp/core/services/hook/hook-service.ts
+++ b/src/bp/core/services/hook/hook-service.ts
@@ -159,7 +159,7 @@ export class HookService {
       .filter(r => r.match(/(\\|\/)hooks(\\|\/)/g))
       .map(file => delete require.cache[file])
 
-    await this.ghost.global().syncRemoteFiles('hooks')
+    await this.ghost.global().syncDatabaseFilesToDisk('hooks')
   }
 
   async executeHook(hook: Hooks.BaseHook): Promise<void> {

--- a/src/bp/core/services/hook/hook-service.ts
+++ b/src/bp/core/services/hook/hook-service.ts
@@ -144,7 +144,7 @@ export class HookService {
   }
 
   private _listenForCacheInvalidation() {
-    this.cache.events.on('invalidation', async key => {
+    this.cache.events.on('invalidation', key => {
       if (key.toLowerCase().indexOf(`/hooks/`) > -1) {
         // clear the cache if there's any file that has changed in the `hooks` folder
         this._scriptsCache.clear()

--- a/src/bp/core/services/hook/hook-service.ts
+++ b/src/bp/core/services/hook/hook-service.ts
@@ -3,6 +3,7 @@ import { IO } from 'botpress/sdk'
 import { ObjectCache } from 'common/object-cache'
 import { UntrustedSandbox } from 'core/misc/code-sandbox'
 import { printObject } from 'core/misc/print'
+import { WorkspaceUserAttributes } from 'core/repositories/workspace_users'
 import { inject, injectable, tagged } from 'inversify'
 import _ from 'lodash'
 import path from 'path'
@@ -13,7 +14,6 @@ import { requireAtPaths } from '../../modules/require'
 import { TYPES } from '../../types'
 import { VmRunner } from '../action/vm'
 import { Incident } from '../alerting-service'
-import { WorkspaceUserAttributes } from 'core/repositories/workspace_users'
 
 const debug = DEBUG('hooks')
 
@@ -144,6 +144,11 @@ export class HookService {
       if (key.toLowerCase().indexOf(`/hooks/`) > -1) {
         // clear the cache if there's any file that has changed in the `hooks` folder
         this._scriptsCache.clear()
+
+        // Clearing cache for files required in hooks
+        Object.keys(require.cache)
+          .filter(r => r.match(/(\\|\/)hooks(\\|\/)/g))
+          .map(file => delete require.cache[file])
       }
     })
   }


### PR DESCRIPTION
When actions are edited, we also clear the require cache of those actions. They must be present in the actions folder (could also be a subfolder)

When using Botpress remotely (with a database), actions and other files are saved on the ghost. However, the VM needs to require those files locally on the file system. So, whenever a file is changed (hooks or actions), they are copied locally so they can be used.