### PR TITLE
fix sync issue

### DIFF
--- a/modules/code-editor/src/backend/editor.ts
+++ b/modules/code-editor/src/backend/editor.ts
@@ -101,9 +101,9 @@ export default class Editor {
     const ghost = this._getGhost(file)
 
     if (type === 'action') {
-      return ghost.upsertFile('/actions', location, content)
+      return ghost.upsertFile('/actions', location, content, true, true)
     } else if (type === 'hook') {
-      return ghost.upsertFile(`/hooks/${hookType}`, location.replace(hookType, ''), content)
+      return ghost.upsertFile(`/hooks/${hookType}`, location.replace(hookType, ''), content, true, true)
     } else if (type === 'bot_config') {
       return ghost.upsertFile('/', 'bot.config.json', content)
     }

--- a/modules/code-editor/src/views/full/utils/wrapper.ts
+++ b/modules/code-editor/src/views/full/utils/wrapper.ts
@@ -23,10 +23,14 @@ const wrapper = {
       return content.replace('bp://types/bot.config.schema.json', '../../bot.config.schema.json')
     }
 
-    const contentStart = content.indexOf(START_COMMENT) + START_COMMENT.length
-    const contentEnd = content.indexOf(END_COMMENT)
+    const startIndex = content.indexOf(START_COMMENT)
+    const endIndex = content.indexOf(END_COMMENT)
 
-    return content.substring(contentStart, contentEnd).trim()
+    if (startIndex === -1 || endIndex === -1) {
+      return content
+    }
+
+    return content.substring(startIndex + START_COMMENT.length, endIndex).trim()
   }
 }
 

--- a/src/bp/common/object-cache.ts
+++ b/src/bp/common/object-cache.ts
@@ -7,4 +7,5 @@ export interface ObjectCache {
   has(key: string): Promise<boolean>
   invalidate(key: string): Promise<void>
   invalidateStartingWith(prefix: string): Promise<void>
+  sync(message: string): Promise<void>
 }

--- a/src/bp/core/services/ghost/memory-cache.ts
+++ b/src/bp/core/services/ghost/memory-cache.ts
@@ -57,4 +57,8 @@ export default class MemoryObjectCache implements ObjectCache {
     keys.forEach(x => this.cache.del(x))
     this.events.emit('invalidation', prefix)
   }
+
+  async sync(message: string): Promise<void> {
+    this.events.emit('syncDbFilesToDisk', message)
+  }
 }

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -37,7 +37,7 @@ export class GhostService {
     @tagged('name', 'GhostService')
     private logger: Logger
   ) {
-    this.cache.events.on('syncDbFilesToDisk', this._onSyncReceived)
+    this.cache.events.on && this.cache.events.on('syncDbFilesToDisk', this._onSyncReceived)
   }
 
   initialize(enabled: boolean) {

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -702,8 +702,15 @@ declare module 'botpress/sdk' {
      * @param file - The name of the file
      * @param content - The content of the file
      * @param recordRevision - Whether or not to record a revision @default true
+     * @param syncDbToDisk - When enabled, files changed on the database are synced locally so they can be used locally (eg: require in actions) @default false
      */
-    upsertFile(rootFolder: string, file: string, content: string | Buffer, recordRevision?: boolean): Promise<void>
+    upsertFile(
+      rootFolder: string,
+      file: string,
+      content: string | Buffer,
+      recordRevision?: boolean,
+      syncDbToDisk?: boolean
+    ): Promise<void>
     readFileAsBuffer(rootFolder: string, file: string): Promise<Buffer>
     readFileAsString(rootFolder: string, file: string): Promise<string>
     readFileAsObject<T>(rootFolder: string, file: string): Promise<T>


### PR DESCRIPTION
When actions are edited using the code-editor and a database, we need to sync them back to the file system so they can be required() by actions and hooks. VM2 can't load them from the ghost.

This PR fixes an issue where there was way too many invalidate triggered for nothing. It is triggered once when a file is inserted, then it is propagated to other nodes via redis