### PR TITLE
fix(ghost): pushing local to remote directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "date-fns": "^1.30.1",
     "debug": "^4.1.1",
     "deep-diff": "^1.0.2",
+    "diff": "^4.0.1",
     "doctrine": "^2.1.0",
     "dotenv": "^7.0.0",
     "errorhandler": "^1.5.0",

--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -279,10 +279,9 @@ export class Botpress {
     if (process.CLUSTER_ENABLED && _.isEmpty(global)) {
       this.logger.info('Syncing data/global/ to database')
       await this.ghostService.global().sync()
-      const botsRef = await this.workspaceService.getBotRefs()
 
       this.logger.info('Syncing data/bots/ to database')
-      await Promise.map(botsRef, botId => this.ghostService.forBot(botId).sync())
+      await this.ghostService.bots().sync()
     }
   }
 

--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -273,10 +273,11 @@ export class Botpress {
 
   @WrapErrorsWith('Error initializing Ghost Service')
   async initializeGhost(): Promise<void> {
-    this.ghostService.initialize(process.CLUSTER_ENABLED)
+    const useDbDriver = process.BPFS_STORAGE === 'database'
+    this.ghostService.initialize(useDbDriver)
     const global = await this.ghostService.global().directoryListing('/')
 
-    if (process.CLUSTER_ENABLED && _.isEmpty(global)) {
+    if (useDbDriver && _.isEmpty(global)) {
       this.logger.info('Syncing data/global/ to database')
       await this.ghostService.global().sync()
 

--- a/src/bp/core/routers/admin/versioning.ts
+++ b/src/bp/core/routers/admin/versioning.ts
@@ -63,7 +63,7 @@ export class VersioningRouter extends CustomRouter {
       })
     )
 
-    // Force update of the production files by the local files
+    // Force update of the remote files by the local files
     this.router.post(
       '/update',
       this.asyncMiddleware(async (req, res) => {

--- a/src/bp/core/services/cms.ts
+++ b/src/bp/core/services/cms.ts
@@ -31,6 +31,7 @@ export class CMSService implements IDisposeOnExit {
   broadcastAddElement: Function = this.local__addElementToCache
   broadcastUpdateElement: Function = this.local__updateElementFromCache
   broadcastRemoveElements: Function = this.local__removeElementsFromCache
+  broadcastInvalidateForBot: Function = this.local__invalidateForBot
 
   private readonly contentTable = 'content_elements'
   private readonly typesDir = 'content-types'
@@ -62,6 +63,7 @@ export class CMSService implements IDisposeOnExit {
     this.broadcastUpdateElement = await this.jobService.broadcast<ContentElement>(
       this.local__updateElementFromCache.bind(this)
     )
+    this.broadcastInvalidateForBot = await this.jobService.broadcast<string>(this.local__invalidateForBot.bind(this))
 
     await this.prepareDb()
     await this._loadContentTypesFromFiles()
@@ -619,5 +621,13 @@ export class CMSService implements IDisposeOnExit {
       id: elementId,
       contentType: contentTypeId
     })
+  }
+
+  /**
+   * Important! Do not use directly. Needs to be broadcasted.
+   */
+  private async local__invalidateForBot(botId: string): Promise<void> {
+    await this.clearElementsFromCache(botId)
+    await this.loadElementsForBot(botId)
   }
 }

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -21,7 +21,7 @@ import { FileRevision, PendingRevisions, ReplaceContent, ServerWidePendingRevisi
 import DBStorageDriver from './db-driver'
 import DiskStorageDriver from './disk-driver'
 
-//TODO better typings
+// TODO better typings
 export type FileChanges = {
   scope: string
   changes: {
@@ -91,7 +91,6 @@ export class GhostService {
         await invalidateFile(file.path)
       })
     }
-    console.log('done')
   }
 
   // TODO refactor this

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -95,11 +95,15 @@ export class GhostService {
 
   // TODO refactor this
   async listFileChanges(tmpFolder: string): Promise<FileChanges> {
-    const botsIds = (await this.bots().directoryListing('/', 'bot.config.json')).map(path.dirname)
-    const uniqueFile = file => `${file.path} | ${file.revision}`
-
     const tmpDiskGlobal = this.custom(path.resolve(tmpFolder, 'data/global'))
-    const tmpDiskBot = botId => this.custom(path.resolve(tmpFolder, 'data/bots', botId))
+    const tmpDiskBot = (botId?: string) => this.custom(path.resolve(tmpFolder, 'data/bots', botId || ''))
+
+    // We need local and remote bot ids to correctly display changes
+    const localBotIds = (await this.bots().directoryListing('/', 'bot.config.json')).map(path.dirname)
+    const remoteBotIds = (await tmpDiskBot().directoryListing('/', 'bot.config.json')).map(path.dirname)
+    const botsIds = _.uniq([...remoteBotIds, ...localBotIds])
+
+    const uniqueFile = file => `${file.path} | ${file.revision}`
 
     const getFileDiff = async file => {
       try {

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -21,7 +21,7 @@ import { FileRevision, PendingRevisions, ReplaceContent, ServerWidePendingRevisi
 import DBStorageDriver from './db-driver'
 import DiskStorageDriver from './disk-driver'
 
-// TODO better typings
+// TODO: better typings
 export type FileChanges = {
   scope: string
   changes: {
@@ -69,7 +69,7 @@ export class GhostService {
     return new ScopedGhostService(baseDir, this.diskDriver, this.dbDriver, false, this.cache, this.logger)
   }
 
-  // TODO refactor this
+  // TODO: refactor this
   async forceUpdate(tmpFolder: string) {
     const invalidateFile = async (fileName: string) => {
       await this.cache.invalidate(`object::${fileName}`)
@@ -93,7 +93,7 @@ export class GhostService {
     }
   }
 
-  // TODO refactor this
+  // TODO: refactor this
   async listFileChanges(tmpFolder: string): Promise<FileChanges> {
     const tmpDiskGlobal = this.custom(path.resolve(tmpFolder, 'data/global'))
     const tmpDiskBot = (botId?: string) => this.custom(path.resolve(tmpFolder, 'data/bots', botId || ''))
@@ -146,7 +146,9 @@ export class GhostService {
       const added = _.difference(localFiles, prodFiles).map(x => ({ path: x, action: 'add' }))
 
       const filterDeleted = file => !_.map([...deleted, ...added], 'path').includes(file)
-      const edited = await Promise.map(unsyncedFiles.filter(filterDeleted), getFileDiff)
+      const edited = (await Promise.map(unsyncedFiles.filter(filterDeleted), getFileDiff)).filter(
+        x => x.add !== 0 || x.del !== 0
+      )
 
       return {
         scope,

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -134,16 +134,16 @@ export class GhostService {
       return files.map(file => forceForwardSlashes(getPath(file)))
     }
 
-    const getFileChanges = async (scope: string, localGhost: ScopedGhostService, prodGhost: ScopedGhostService) => {
+    const getFileChanges = async (scope: string, localGhost: ScopedGhostService, remoteGhost: ScopedGhostService) => {
       const localRevs = await localGhost.listDiskRevisions()
-      const prodRevs = await prodGhost.listDbRevisions()
-      const syncedRevs = _.intersectionBy(localRevs, prodRevs, uniqueFile)
-      const unsyncedFiles = _.uniq(_.differenceBy(prodRevs, syncedRevs, uniqueFile).map(x => x.path))
+      const remoteRevs = await remoteGhost.listDbRevisions()
+      const syncedRevs = _.intersectionBy(localRevs, remoteRevs, uniqueFile)
+      const unsyncedFiles = _.uniq(_.differenceBy(remoteRevs, syncedRevs, uniqueFile).map(x => x.path))
 
       const localFiles: string[] = await getDirectoryFullPaths(scope, localGhost)
-      const prodFiles: string[] = await getDirectoryFullPaths(scope, prodGhost)
-      const deleted = _.difference(prodFiles, localFiles).map(x => ({ path: x, action: 'del' }))
-      const added = _.difference(localFiles, prodFiles).map(x => ({ path: x, action: 'add' }))
+      const remoteFiles: string[] = await getDirectoryFullPaths(scope, remoteGhost)
+      const deleted = _.difference(remoteFiles, localFiles).map(x => ({ path: x, action: 'del' }))
+      const added = _.difference(localFiles, remoteFiles).map(x => ({ path: x, action: 'add' }))
 
       const filterDeleted = file => !_.map([...deleted, ...added], 'path').includes(file)
       const edited = (await Promise.map(unsyncedFiles.filter(filterDeleted), getFileDiff)).filter(

--- a/src/bp/index.ts
+++ b/src/bp/index.ts
@@ -125,7 +125,7 @@ try {
     )
     .command(
       'pull',
-      'Sync pending changes from an external server running botpress to local files',
+      'Pull data from a remote server to your local file system',
       {
         url: {
           description: 'Base URL of the botpress server from which you want to pull changes',
@@ -134,14 +134,14 @@ try {
         },
         authToken: {
           alias: 'token',
-          description: 'your authorization token on the remote botpress server',
+          description: 'Authorization token on the remote botpress server',
           // tslint:disable-next-line:no-null-keyword
           default: null,
           type: 'string'
         },
         targetDir: {
           alias: 'dir',
-          description: 'target directory in which you want sync the changes. will be created if doesnt exist',
+          description: 'Target directory where the remote data will be stored',
           default: path.join(__dirname, 'data'),
           type: 'string'
         }
@@ -153,20 +153,20 @@ try {
       'Push local files to a remote botpress server',
       {
         url: {
-          description: 'url of the botpress server to which to push changes',
+          description: 'URL of the botpress server to which to push changes',
           default: 'http://localhost:3000',
           type: 'string'
         },
         authToken: {
           alias: 'token',
-          description: 'your authorization token on the remote botpress server',
+          description: 'Authorization token on the remote botpress server',
           // tslint:disable-next-line:no-null-keyword
           default: null,
           type: 'string'
         },
         targetDir: {
           alias: 'dir',
-          description: 'The directory of the data you wish to send to production',
+          description: 'The local directory containing the data you want to push on the remote server',
           default: path.join(__dirname, 'data'),
           type: 'string'
         }

--- a/src/bp/index.ts
+++ b/src/bp/index.ts
@@ -86,6 +86,7 @@ try {
       },
       argv => {
         process.IS_PRODUCTION = argv.production || yn(process.env.BP_PRODUCTION) || yn(process.env.CLUSTER_ENABLED)
+        process.BPFS_STORAGE = process.core_env.BPFS_STORAGE || 'disk'
 
         let defaultVerbosity = process.IS_PRODUCTION ? 0 : 2
         if (!isNaN(Number(process.env.VERBOSITY_LEVEL))) {

--- a/src/bp/index.ts
+++ b/src/bp/index.ts
@@ -162,6 +162,12 @@ try {
           // tslint:disable-next-line:no-null-keyword
           default: null,
           type: 'string'
+        },
+        targetDir: {
+          alias: 'dir',
+          description: 'The directory of the data you wish to send to production',
+          default: path.join(__dirname, 'data'),
+          type: 'string'
         }
       },
       argv => require('./push').default(argv)

--- a/src/bp/push.ts
+++ b/src/bp/push.ts
@@ -1,10 +1,11 @@
 import axios from 'axios'
 import chalk from 'chalk'
-import { createArchiveFromFolder } from 'core/misc/archive'
-import { FileChanges } from 'core/services'
 import fse from 'fs-extra'
 import _ from 'lodash'
 import path from 'path'
+
+import { createArchiveFromFolder } from './core/misc/archive'
+import { FileChanges } from './core/services'
 
 // If the push will cause one of these actions, then a force will be required
 const blockingActions = ['del', 'edit']

--- a/src/bp/push.ts
+++ b/src/bp/push.ts
@@ -43,8 +43,8 @@ async function _push(serverUrl: string, authToken: string, targetDir: string): P
 
     const { data } = await axios.post(`${serverUrl}/api/v1/admin/versioning/changes`, archive, options)
 
-    const prodChanges = _.flatten((data.changes as FileChanges).map(x => x.changes))
-    const blockingChanges = prodChanges.filter(x => blockingActions.includes(x.action))
+    const allChanges = _.flatten((data.changes as FileChanges).map(x => x.changes))
+    const blockingChanges = allChanges.filter(x => blockingActions.includes(x.action))
 
     const useForce = process.argv.includes('--force')
 
@@ -57,7 +57,7 @@ async function _push(serverUrl: string, authToken: string, targetDir: string): P
       console.log(chalk.green('🎉 Successfully pushed your local changes to remote'))
     } else {
       console.log(formatHeader(serverUrl))
-      console.log(formatProdChanges(prodChanges))
+      console.log(formatRemoteChanges(allChanges))
     }
   } catch (err) {
     const error = err.response ? err.response.statusText : err.message
@@ -68,10 +68,10 @@ async function _push(serverUrl: string, authToken: string, targetDir: string): P
 function formatHeader(host) {
   return `
 🚨 Out of sync!
-  You have changes on your file system that aren't synchronized on your production environment.
+  You have changes on your file system that aren't synchronized to the remote environment.
 
   (Visit ${chalk.bold(`${host}/admin/server/version`)} to pull changes on your file system)
-  (Use ${chalk.yellow('--force')} to overwrite the production changes by the local changes)
+  (Use ${chalk.yellow('--force')} to overwrite the remote files by your local files)
 `
 }
 
@@ -85,12 +85,12 @@ const printLine = ({ action, path, add, del }) => {
   }
 }
 
-function formatProdChanges(changes) {
+function formatRemoteChanges(changes) {
   const lines = _.orderBy(changes, 'action')
     .map(printLine)
     .join('\n')
 
-  return `Differences between your local changes (green) vs production (red):
+  return `Differences between your local changes (green) vs remote changes (red):
 
 ${lines}
 `

--- a/src/bp/push.ts
+++ b/src/bp/push.ts
@@ -1,11 +1,16 @@
 import axios from 'axios'
 import chalk from 'chalk'
+import followRedirects from 'follow-redirects'
 import fse from 'fs-extra'
 import _ from 'lodash'
 import path from 'path'
 
 import { createArchiveFromFolder } from './core/misc/archive'
+import { asBytes } from './core/misc/utils'
 import { FileChanges } from './core/services'
+
+// This is a dependency of axios, and sets the default body limit to 10mb. Need it to be higher
+followRedirects.maxBodyLength = asBytes('100mb')
 
 // If the push will cause one of these actions, then a force will be required
 const blockingActions = ['del', 'edit']

--- a/src/bp/push.ts
+++ b/src/bp/push.ts
@@ -10,7 +10,7 @@ import { asBytes } from './core/misc/utils'
 import { FileChanges } from './core/services'
 
 // This is a dependency of axios, and sets the default body limit to 10mb. Need it to be higher
-followRedirects.maxBodyLength = asBytes('100mb')
+followRedirects.maxBodyLength = asBytes('500mb')
 
 // If the push will cause one of these actions, then a force will be required
 const blockingActions = ['del', 'edit']
@@ -30,7 +30,7 @@ export default ({ url, authToken, targetDir }) => {
 
 async function _push(serverUrl: string, authToken: string, targetDir: string): Promise<void> {
   try {
-    const archive = await createArchiveFromFolder(targetDir, ['assets/**/*'])
+    const archive = await createArchiveFromFolder(targetDir, ['assets/**/*', 'bots/*/models/**'])
 
     const options = {
       headers: {
@@ -54,7 +54,7 @@ async function _push(serverUrl: string, authToken: string, targetDir: string): P
 
       await axios.post(`${serverUrl}/api/v1/admin/versioning/update`, archive, options)
 
-      console.log(chalk.green('🎉 Successfully pushed your local changes to the production environment!'))
+      console.log(chalk.green('🎉 Successfully pushed your local changes to remote'))
     } else {
       console.log(formatHeader(serverUrl))
       console.log(formatProdChanges(prodChanges))

--- a/src/bp/ui-admin/src/Pages/Server/Versioning.jsx
+++ b/src/bp/ui-admin/src/Pages/Server/Versioning.jsx
@@ -10,7 +10,8 @@ import { pullToken } from '../../Auth'
 
 class Versioning extends Component {
   state = {
-    command: '',
+    pullCommand: '',
+    pushCommand: '',
     copied: false
   }
 
@@ -24,8 +25,11 @@ class Versioning extends Component {
 
     const { token } = pullToken()
     const host = window.location.origin
-    const command = `${bpcli} pull --url ${host}${window.ROOT_PATH} --authToken ${token} --targetDir data`
-    this.setState({ command })
+
+    this.setState({
+      pullCommand: `${bpcli} pull --url ${host}${window.ROOT_PATH} --authToken ${token} --targetDir data`,
+      pushCommand: `${bpcli} push --url ${host}${window.ROOT_PATH} --authToken ${token} --targetDir data`
+    })
   }
 
   setCopied = () => {
@@ -51,14 +55,12 @@ class Versioning extends Component {
   renderMainContent = () => (
     <div>
       {this.props.loading && <div>loading</div>}
-      {!this.props.loading && _.isEmpty(this.props.pendingChanges) && this.renderNoPendingChanges()}
-      {!this.props.loading && !_.isEmpty(this.props.pendingChanges) && (
+
+      {!this.props.loading && (
         <div>
-          <p>
-            Some changes has been made since this server was deployed. Run the botpress pull command to sync server data
-            locally
-          </p>
-          <code>{this.state.command}</code>
+          <h4>Pull remote to file system</h4>
+          <p>Use this command to copy the remote data on your local file system.</p>
+          <code>{this.state.pullCommand}</code>
           <CopyToClipboard text={this.state.command} onCopy={this.setCopied}>
             <Button color="link" size="sm" className="license-infos__icon">
               <svg href="#" id="TooltipCopy" height="15" viewBox="0 0 16 20" xmlns="http://www.w3.org/2000/svg">
@@ -71,6 +73,13 @@ class Versioning extends Component {
             </Button>
           </CopyToClipboard>
           {this.state.copied && <span>&nbsp;copied</span>}
+          <hr />
+          <h4>Push local to this server</h4>
+          <p>
+            If you are using the database storage for BPFS, you can also push your local changes to the database using
+            this command:
+          </p>
+          <code>{this.state.pushCommand}</code>
         </div>
       )}
     </div>

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -15,7 +15,8 @@ declare namespace NodeJS {
 
   export interface Process {
     VERBOSITY_LEVEL: number
-    IS_PRODUCTION: boolean
+    IS_PRODUCTION: boolean // TODO: look to remove this
+    BPFS_STORAGE: 'database' | 'disk'
     APP_SECRET: string
     /**
      * Path to the global APP DATA folder, shared across all installations of Botpress Server
@@ -55,6 +56,9 @@ declare type PRO_FEATURES = 'seats'
 declare type BotpressEnvironementVariables = {
   /** Replace the path of the NodeJS Native Extensions for external OS-specific libraries such as fastText and CRFSuite */
   readonly NATIVE_EXTENSIONS_DIR?: string
+
+  /** Change the BPFS storage mechanism ("database" or "disk"). Defaults to "disk" */
+  readonly BPFS_STORAGE?: 'database' | 'disk'
 
   /**
    * Set this to true if you're exposing Botpress through a reverse proxy such as Nginx

--- a/yarn.lock
+++ b/yarn.lock
@@ -2580,6 +2580,11 @@ diff@^3.2.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
+diff@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
+  integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
+
 dir-glob@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"


### PR DESCRIPTION
Still much refactor to do, but it does work. When you pull, the database is stored on the disk. When pushing, the data folder is compressed, sent to a node, and that node unpack it to compare changes with the database and returns a list of changes.

Invalidation is correctly propagated to other nodes (tested flows, hooks, actions & cms)