### PR TITLE
fix(ghost): add exclude support for db driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "fs-extra": "^7.0.1",
     "getos": "^3.1.1",
     "glob": "^7.1.3",
+    "globrex": "^0.1.2",
     "https-proxy-agent": "^2.2.1",
     "inversify": "^4.13.0",
     "joi": "^13.6.0",

--- a/src/bp/core/services/ghost/db-driver.ts
+++ b/src/bp/core/services/ghost/db-driver.ts
@@ -1,6 +1,8 @@
 import { forceForwardSlashes } from 'core/misc/utils'
 import { WrapErrorsWith } from 'errors'
+import globrex from 'globrex'
 import { inject, injectable } from 'inversify'
+import _ from 'lodash'
 import nanoid from 'nanoid'
 import path from 'path'
 import { VError } from 'verror'
@@ -127,7 +129,10 @@ export default class DBStorageDriver implements StorageDriver {
     }
   }
 
-  async directoryListing(folder: string): Promise<string[]> {
+  async directoryListing(
+    folder: string,
+    options: { excludes?: string | string[] } = { excludes: [] }
+  ): Promise<string[]> {
     try {
       let query = this.database
         .knex('srv_ghost_files')
@@ -140,9 +145,18 @@ export default class DBStorageDriver implements StorageDriver {
         query = query.andWhere('file_path', 'like', folder + '%')
       }
 
-      return query.then<Iterable<any>>().map((x: any) => {
-        return forceForwardSlashes(path.relative(folder, x.file_path))
-      })
+      const paths = await query
+        .then<Iterable<any>>()
+        .map((x: any) => forceForwardSlashes(path.relative(folder, x.file_path)))
+
+      if (!options.excludes || !options.excludes.length) {
+        return paths
+      }
+
+      const ignoredGlobs = Array.isArray(options.excludes) ? options.excludes : [options.excludes]
+      const rules: { regex: RegExp }[] = ignoredGlobs.map(g => globrex(g, { globstar: true }))
+
+      return paths.filter(path => _.every(rules, rule => !rule.regex.test(path)))
     } catch (e) {
       throw new VError(e, `[DB Storage] Error listing directory content for folder "${folder}"`)
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3781,6 +3781,11 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+globrex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
+  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
+
 glogg@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/glogg/-/glogg-1.0.2.tgz#2d7dd702beda22eb3bffadf880696da6d846313f"


### PR DESCRIPTION
The directoryListing method never supported the excludes parameter (which disk driver supports), which makes it more complicated to implement pull/push correctly and filter unwanted files.