### PR TITLE
fix(migrations): execute migrations after modules are loaded

### DIFF
--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -120,9 +120,9 @@ export class Botpress {
     this.config = await this.loadConfiguration(true)
 
     await AppLifecycle.setDone(AppLifecycleEvents.CONFIGURATION_LOADED)
-    await this.migrationService.initialize()
     await this.checkJwtSecret()
     await this.loadModules(options.modules)
+    await this.migrationService.initialize()
     await this.cleanDisabledModules()
     await this.initializeServices()
     await this.checkEditionRequirements()


### PR DESCRIPTION
There was an issue with modules migrations where the migration was applied before the table is created. I just changed the order of execution to load modules before migrations are executed.