### PR TITLE
fix(config): added revision recording for bot and botpress config

### DIFF
--- a/src/bp/core/config/config-loader.ts
+++ b/src/bp/core/config/config-loader.ts
@@ -48,7 +48,7 @@ export class ConfigProvider {
     const content = await this.ghostService.global().readFileAsString('/', 'botpress.config.json')
     const config = _.merge(JSON.parse(content), partialConfig)
 
-    await this.ghostService.global().upsertFile('/', 'botpress.config.json', stringify(config), false)
+    await this.ghostService.global().upsertFile('/', 'botpress.config.json', stringify(config))
   }
 
   async invalidateBotpressConfig(): Promise<void> {
@@ -61,7 +61,7 @@ export class ConfigProvider {
   }
 
   async setBotConfig(botId: string, config: BotConfig) {
-    await this.ghostService.forBot(botId).upsertFile('/', 'bot.config.json', stringify(config), false)
+    await this.ghostService.forBot(botId).upsertFile('/', 'bot.config.json', stringify(config))
   }
 
   async mergeBotConfig(botId: string, partialConfig: PartialDeep<BotConfig>): Promise<BotConfig> {

--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -458,7 +458,7 @@ export class BotService {
         }
 
         await scopedGhost.ensureDirs('/', BOT_DIRECTORIES)
-        await scopedGhost.upsertFile('/', BOT_CONFIG_FILENAME, stringify(mergedConfigs), false)
+        await scopedGhost.upsertFile('/', BOT_CONFIG_FILENAME, stringify(mergedConfigs))
         await scopedGhost.upsertFiles('/', files)
 
         return mergedConfigs


### PR DESCRIPTION
With manual bp push / pull and the simplicity of code editor, it's useful to see latest revisions also.