### PR TITLE
fix(logs): log table migration won't run if not needed

### DIFF
--- a/src/bp/migrations/v12_1_0-1564421788-database_srv_logs_table_has_date_timestamp.ts
+++ b/src/bp/migrations/v12_1_0-1564421788-database_srv_logs_table_has_date_timestamp.ts
@@ -6,9 +6,9 @@ const TABLE_NAME = 'srv_logs'
 const COLUMN_NAME = 'timestamp'
 const CURRENT_DATE_FORMAT = 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
 
-// const PG_VARCHAR_TYPE = 'character varying'
+const PG_VARCHAR_TYPE = 'character varying'
 // const SQLITE_VARCHAR_TYPE = 'varchar'
-const PG_TIMESTAMP_TYPE = 'timestamp without time zone'
+// const PG_TIMESTAMP_TYPE = 'timestamp without time zone'
 const SQLITE_TIMESTAMP_TYPE = 'datetime'
 
 const migration: Migration = {
@@ -30,7 +30,7 @@ const migration: Migration = {
       return migrateSqlite3(database)
     }
 
-    if (columnInfo.type === PG_TIMESTAMP_TYPE) {
+    if (columnInfo.type !== PG_VARCHAR_TYPE) {
       return noMigrationNeeded
     }
     return migratePostgresql(database)

--- a/src/bp/migrations/v12_1_0-1564421788-database_srv_logs_table_has_date_timestamp.ts
+++ b/src/bp/migrations/v12_1_0-1564421788-database_srv_logs_table_has_date_timestamp.ts
@@ -85,7 +85,7 @@ async function migratePostgresql(db: Database): Promise<sdk.MigrationResult> {
     await db.knex.raw(
       `
       ALTER TABLE ${TABLE_NAME}
-      ALTER COLUMN ${COLUMN_NAME} TYPE TIMESTAMP USING TO_TIMESTAMP(${COLUMN_NAME}, '${CURRENT_DATE_FORMAT}');
+      ALTER COLUMN ${COLUMN_NAME} TYPE TIMESTAMP WITH TIME ZONE USING TO_TIMESTAMP(${COLUMN_NAME}, '${CURRENT_DATE_FORMAT}');
       `
     )
   } catch (err) {

--- a/src/bp/migrations/v12_1_0-1564421788-database_srv_logs_table_has_date_timestamp.ts
+++ b/src/bp/migrations/v12_1_0-1564421788-database_srv_logs_table_has_date_timestamp.ts
@@ -7,8 +7,6 @@ const COLUMN_NAME = 'timestamp'
 const CURRENT_DATE_FORMAT = 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
 
 const PG_VARCHAR_TYPE = 'character varying'
-// const SQLITE_VARCHAR_TYPE = 'varchar'
-// const PG_TIMESTAMP_TYPE = 'timestamp without time zone'
 const SQLITE_TIMESTAMP_TYPE = 'datetime'
 
 const migration: Migration = {


### PR DESCRIPTION
When creating a Postgres table with knex, a timestamp actually becomes a "timestamp with time zone".

Unfortunatly when writing my migration, I messed up and used "timestamp without timezone".

So previous users who migrated their data now have "timestamp without timezone" but new users (after 12.1.0) have "timestamp with timezone". 

It's quite a problem as there is two different database configuration out their...

My fix here to prevent the migration from running twice is to run the migration only if the field is still a varchar.

I also updated the migration, but users who have already migrated will have a "timestamp without time zone" always.