### PR TITLE
fix(flow): bigger handle to drag and drop nodes

### DIFF
--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowTools.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowTools.tsx
@@ -57,14 +57,15 @@ const FlowTools: FC<{ skills: SkillDefinition[]; user: any; flowPreview: boolean
 
 const ToolItem: FC<ToolItemProps> = ({ label, type, id, icon }) => {
   return (
-    <div className={style.toolItem} key={id}>
-      <div
-        className={style.icon}
-        draggable={true}
-        onDragStart={event => {
-          event.dataTransfer.setData('diagram-node', JSON.stringify({ type, id }))
-        }}
-      >
+    <div
+      className={style.toolItem}
+      key={id}
+      draggable={true}
+      onDragStart={event => {
+        event.dataTransfer.setData('diagram-node', JSON.stringify({ type, id }))
+      }}
+    >
+      <div className={style.icon}>
         <Icon icon={icon || 'add'} iconSize={22} />
       </div>
       <div className={style.title}>{label}</div>

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/style.scss
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/style.scss
@@ -19,6 +19,17 @@
   display: inline-block;
   font-size: 1.2rem;
 
+  cursor: move; /* fallback if grab cursor is unsupported */
+  cursor: grab;
+  cursor: -moz-grab;
+  cursor: -webkit-grab;
+
+  &:active {
+    cursor: grabbing;
+    cursor: -moz-grabbing;
+    cursor: -webkit-grabbing;
+  }
+
   .title {
     width: 100%;
     margin: 2px 0 2px 0;
@@ -30,16 +41,6 @@
     width: 30px;
     height: 30px;
     margin: 1.2rem auto auto auto;
-    cursor: move; /* fallback if grab cursor is unsupported */
-    cursor: grab;
-    cursor: -moz-grab;
-    cursor: -webkit-grab;
-
-    &:active {
-      cursor: grabbing;
-      cursor: -moz-grabbing;
-      cursor: -webkit-grabbing;
-    }
   }
 }
 


### PR DESCRIPTION
Moved the drag logic to the parent div of the icon so the whole square is draggable