### PR TITLE
fix(nlu): entity matching is bit tighter and robust

### DIFF
--- a/modules/nlu/src/backend/pipelines/entities/pattern_extractor.test.ts
+++ b/modules/nlu/src/backend/pipelines/entities/pattern_extractor.test.ts
@@ -127,7 +127,57 @@ I'm riding my mercedes-benz to the dealership then I will take my BM to buy an o
       expect(entities[3].meta.end).toEqual(139)
       expect(entities[3].meta.source).toEqual('BMW!')
       expect(entities[3].data.value).toEqual('BMW')
-    })
+    }),
+      test('Extract fuzzier list entities', async () => {
+        const entityDef = {
+          id: '_',
+          name: 'Oeufs',
+          type: 'list',
+          fuzzy: true,
+          occurences: [
+            {
+              name: 'mirroirs',
+              synonyms: []
+            },
+            {
+              name: 'brouillés',
+              synonyms: []
+            },
+            {
+              name: "dans l'trou",
+              synonyms: []
+            },
+            {
+              name: 'omelette',
+              synonyms: []
+            },
+            {
+              name: 'au fromage',
+              synonyms: []
+            }
+          ]
+        } as sdk.NLU.EntityDefinition
+
+        const userInput =
+          "J'aime les oeufs bourille, les oeufs au miroirr, les oeufs dan ltrou, les omelets et les oeufs au fomage"
+
+        const extractor = new PatternExtractor(Toolkit, languageProvider)
+
+        const sanitized = userInput.replace('\n', '')
+        // TODO: Extract & expose DS-building logic as helper method
+        const ds = initNLUStruct(sanitized, [], ['global'])
+        ds.sanitizedText = sanitized
+        ds.sanitizedLowerText = sanitized.toLowerCase()
+        const [stringTokens] = await languageProvider.tokenize([sanitized], 'en')
+        ds.tokens = makeTokens(stringTokens, sanitized)
+
+        const entities = await extractor.extractLists(ds, [entityDef])
+
+        console.log(entities)
+
+        expect(entities.length).toEqual(5)
+        expect(_.uniq(entities.map(e => e.data.value)).length).toEqual(5)
+      })
 
     test('Extract exact list entities', async () => {
       const entityDef = {

--- a/modules/nlu/src/backend/pipelines/entities/pattern_extractor.test.ts
+++ b/modules/nlu/src/backend/pipelines/entities/pattern_extractor.test.ts
@@ -353,14 +353,11 @@ I'm riding my mercedes-benz to the dealership then I will take my BM to buy an o
         fuzzy: true,
         occurences: [
           {
-            name: 'aescp',
+            name: 'aecsp',
             synonyms: ['acspe', 'essacc', 'eascsc']
           }
         ]
       } as sdk.NLU.EntityDefinition
-
-      // Add this to break the test
-      // entityDef.occurences[0].synonyms.push('acczse')
 
       const userInput = `Can I have access to this ressource`
 

--- a/modules/nlu/src/backend/pipelines/entities/pattern_extractor.ts
+++ b/modules/nlu/src/backend/pipelines/entities/pattern_extractor.ts
@@ -8,6 +8,7 @@ import { extractPattern } from '../../tools/patterns-utils'
 import { LanguageProvider, Token } from '../../typings'
 import { NLUStructure } from '../../typings'
 import { sanitize } from '../language/sanitizer'
+import { SPACE } from '../../tools/token-utils'
 
 const debug = DEBUG('nlu').sub('entities')
 const debugLists = debug.sub('lists')
@@ -136,7 +137,7 @@ export default class PatternExtractor {
   }
 
   private extractPartOfPhrase(remainingTokens: Token[], searched: string[]): PartOfPhrase[] {
-    const occ = searched.join('')
+    let occ = searched.join('')
     let firstToken = remainingTokens.shift()
     let lastToken = firstToken
 
@@ -145,6 +146,10 @@ export default class PatternExtractor {
     }
 
     let partOfPhrase: string = firstToken.value
+    if (occ.startsWith(SPACE) && firstToken.value.startsWith(SPACE)) {
+      occ = occ.substr(1)
+      partOfPhrase = partOfPhrase.substr(1)
+    }
 
     if (searched.length > 1) {
       let previous: string

--- a/modules/nlu/src/backend/pipelines/entities/pattern_extractor.ts
+++ b/modules/nlu/src/backend/pipelines/entities/pattern_extractor.ts
@@ -198,10 +198,13 @@ export default class PatternExtractor {
     const d1 = this.toolkit.Strings.computeLevenshteinDistance(a, b)
     const d2 = this.toolkit.Strings.computeJaroWinklerDistance(a, b, { caseSensitive: true })
 
+    // TODO: find a more robust logic. Their might be a case where Levenshtein is more accurate than Jaro-Winkler
     distance = Math.min(d1, d2)
+
     const diffLen = Math.abs(a.length - b.length)
     if (diffLen <= 3) {
-      distance = Math.min(1, distance * (0.1 * (4 - diffLen) + 1)) // gives a chance to small differences in length: "apple" vs "apples,". Both distances functions are already normalized in domain [0, 1]
+      // gives a chance to small differences in length: "apple" vs "apples,". Both distances functions are already normalized in domain [0, 1]
+      distance = Math.min(1, distance * (0.1 * (4 - diffLen) + 1))
     }
 
     return distance

--- a/modules/nlu/src/backend/pipelines/entities/pattern_extractor.ts
+++ b/modules/nlu/src/backend/pipelines/entities/pattern_extractor.ts
@@ -5,7 +5,7 @@ import _ from 'lodash'
 
 import { allInRange } from '../../tools/math'
 import { extractPattern } from '../../tools/patterns-utils'
-import { LanguageProvider } from '../../typings'
+import { LanguageProvider, Token } from '../../typings'
 import { NLUStructure } from '../../typings'
 import { sanitize } from '../language/sanitizer'
 
@@ -14,6 +14,14 @@ const debugLists = debug.sub('lists')
 
 const MIN_LENGTH_FUZZY_MATCH = 5
 const MIN_CONFIDENCE = 0.65
+
+interface PartOfPhrase {
+  firstToken: Token
+  lastToken: Token
+  value: string
+  occ: string
+  distance?: number
+}
 
 export default class PatternExtractor {
   constructor(private toolkit: typeof sdk.MLToolkit, private languageProvider: LanguageProvider) {}
@@ -45,62 +53,38 @@ export default class PatternExtractor {
     const findings: sdk.NLU.Entity[] = []
 
     for (const { tok, tokenIndex } of ds.tokens.map((tok, tokenIndex) => ({ tok, tokenIndex }))) {
-      const rawToken = tok.value
-
       let highest = 0
       let extracted = ''
       let source = ''
-      let lastToken = tok
+      let currentFirstToken = tok
+      let currentLastToken = tok
 
       for (const val of values) {
-        let partOfPhrase: string = rawToken
-        const occ = val.join('+')
-        let currentLastToken = tok
+        const remainingTokens = ds.tokens.slice(tokenIndex)
+        const results = this.extractPartOfPhrase(remainingTokens, val)
 
-        if (val.length > 1) {
-          const remainingTokens = ds.tokens.slice(tokenIndex + 1)
+        const partOfPhrase = _.chain(results)
+          .map(pop => ({
+            ...pop,
+            distance: this.calculateDistance(pop.value, pop.occ, entityDef)
+          }))
+          .maxBy('distance')
+          .value()
 
-          // TODO: try with one token less and one token more if no perfect match in length
-          while (!_.isEmpty(remainingTokens) && partOfPhrase.length < occ.length) {
-            const nextToken = remainingTokens.shift()
-            if (!nextToken) {
-              break
-            }
-            partOfPhrase += '+' + nextToken.value
-            currentLastToken = nextToken
-          }
-        }
-
-        let distance = 0.0
-
-        const strippedPop = sanitize(partOfPhrase.toLowerCase())
-
-        if (entityDef.fuzzy && strippedPop.length > MIN_LENGTH_FUZZY_MATCH) {
-          const d1 = this.toolkit.Strings.computeLevenshteinDistance(partOfPhrase, occ)
-          const d2 = this.toolkit.Strings.computeJaroWinklerDistance(partOfPhrase, occ, { caseSensitive: true })
-          distance = Math.min(d1, d2)
-          const diffLen = Math.abs(partOfPhrase.length - occ.length)
-          if (diffLen <= 3) {
-            distance = Math.min(1, distance * (0.1 * (4 - diffLen) + 1))
-          }
-        } else {
-          const strippedOcc = sanitize(occ.toLowerCase())
-          if (strippedPop.length && strippedOcc.length) {
-            distance = strippedPop === strippedOcc ? 1 : 0
-          }
-        }
+        const { distance, lastToken, firstToken, occ } = partOfPhrase
 
         // if is closer OR if the match found is longer
         if (distance > highest || (distance === highest && extracted.length < occ.length)) {
           extracted = occ
           highest = distance
-          lastToken = currentLastToken
-          source = ds.sanitizedText.substring(tok.start, lastToken.end)
+          currentFirstToken = firstToken
+          currentLastToken = lastToken
+          source = ds.sanitizedText.substring(firstToken.start, lastToken.end)
         }
       }
 
-      const start = tok.start
-      const end = lastToken.end
+      const start = currentFirstToken.start
+      const end = currentLastToken.end
 
       // prevent adding substrings of an already matched, longer entity
       // prioretize longer matches with confidence * its length higher
@@ -149,6 +133,78 @@ export default class PatternExtractor {
     }
 
     return findings
+  }
+
+  private extractPartOfPhrase(remainingTokens: Token[], searched: string[]): PartOfPhrase[] {
+    const occ = searched.join('')
+    let firstToken = remainingTokens.shift()
+    let lastToken = firstToken
+
+    if (!firstToken) {
+      return []
+    }
+
+    let partOfPhrase: string = firstToken.value
+
+    if (searched.length > 1) {
+      let previous: string
+      while (!_.isEmpty(remainingTokens)) {
+        const nextToken = remainingTokens.shift()
+        if (!nextToken) {
+          return [{ firstToken, lastToken, value: partOfPhrase, occ }]
+        }
+        previous = partOfPhrase
+        partOfPhrase += nextToken.value
+
+        if (partOfPhrase.length === occ.length) {
+          return [{ firstToken, lastToken: nextToken, value: partOfPhrase, occ }]
+        }
+
+        if (partOfPhrase.length > occ.length) {
+          const oneTokenLess = previous
+          const oneTokenMore = partOfPhrase
+
+          return [
+            { firstToken, lastToken, value: oneTokenLess, occ },
+            { firstToken, lastToken: nextToken, value: oneTokenMore, occ }
+          ]
+        }
+
+        lastToken = nextToken
+      }
+    }
+
+    return [{ firstToken, lastToken, value: partOfPhrase, occ }]
+  }
+
+  private calculateDistance(a: string, b: string, { fuzzy }: sdk.NLU.EntityDefinition): number {
+    return fuzzy && sanitize(a.toLowerCase()).length > MIN_LENGTH_FUZZY_MATCH
+      ? this.calculateFuzzyDistance(a, b)
+      : this.calculateExactDistance(a, b)
+  }
+
+  private calculateExactDistance(a: string, b: string): number {
+    const strippedPop = sanitize(a.toLowerCase())
+    const strippedOcc = sanitize(b.toLowerCase())
+    if (strippedPop.length && strippedOcc.length) {
+      return strippedPop === strippedOcc ? 1 : 0
+    }
+    return 0
+  }
+
+  private calculateFuzzyDistance(a: string, b: string): number {
+    let distance = 0.0
+
+    const d1 = this.toolkit.Strings.computeLevenshteinDistance(a, b)
+    const d2 = this.toolkit.Strings.computeJaroWinklerDistance(a, b, { caseSensitive: true })
+
+    distance = Math.min(d1, d2)
+    const diffLen = Math.abs(a.length - b.length)
+    if (diffLen <= 3) {
+      distance = Math.min(1, distance * (0.1 * (4 - diffLen) + 1)) // gives a chance to small differences in length: "apple" vs "apples,". Both distances functions are already normalized in domain [0, 1]
+    }
+
+    return distance
   }
 
   async extractPatterns(input: string, entityDefs: sdk.NLU.EntityDefinition[]): Promise<sdk.NLU.Entity[]> {

--- a/src/bp/ml/homebrew/jaro-winkler.ts
+++ b/src/bp/ml/homebrew/jaro-winkler.ts
@@ -1,12 +1,12 @@
 const defaults = { caseSensitive: true }
 
 /**
- * Returns the jaro-winkler distance between two strings
+ * Returns the jaro-winkler similarity between two strings
  * @param s1 String A
  * @param s2 String B
  * @returns A number between 0 and 1, where 1 means very similar
  */
-export default function distance(s1, s2, options: { caseSensitive: boolean } = defaults): number {
+export default function similarity(s1, s2, options: { caseSensitive: boolean } = defaults): number {
   let m = 0
 
   let i

--- a/src/bp/ml/homebrew/levenshtein.ts
+++ b/src/bp/ml/homebrew/levenshtein.ts
@@ -1,15 +1,12 @@
 /**
- * Returns the levenshtein distance between two strings
+ * Returns the levenshtein similitude between two strings
  * @returns the proximity between 0 and 1, where 1 is very close
  */
 export default (a: string, b: string): number => {
   let tmp
 
-  if (a.length === 0) {
-    return b.length
-  }
-  if (b.length === 0) {
-    return a.length
+  if (a.length === 0 || b.length === 0) {
+    return 0
   }
   if (a.length > b.length) {
     tmp = a
@@ -23,21 +20,16 @@ export default (a: string, b: string): number => {
 
   const alen = a.length,
     blen = b.length,
-    row = Array(alen)
-
-  for (i = 0; i <= alen; i++) {
-    row[i] = i
-  }
+    row = [...Array(alen + 1).keys()]
 
   for (i = 1; i <= blen; i++) {
     res = i
     for (j = 1; j <= alen; j++) {
       tmp = row[j - 1]
       row[j - 1] = res
-      res = b[i - 1] === a[j - 1] ? tmp : Math.min(tmp + 1, Math.min(res + 1, row[j] + 1))
+      res = b[i - 1] === a[j - 1] ? tmp : Math.min(tmp + 1, res + 1, row[j] + 1)
     }
   }
 
-  const smallest = Math.min(a.length, b.length)
-  return (smallest - res) / smallest
+  return (alen - res) / alen
 }

--- a/src/bp/ml/homebrew/levenshtein.ts
+++ b/src/bp/ml/homebrew/levenshtein.ts
@@ -1,5 +1,5 @@
 /**
- * Returns the levenshtein similitude between two strings
+ * Returns the levenshtein similarity between two strings
  * @returns the proximity between 0 and 1, where 1 is very close
  */
 export default (a: string, b: string): number => {

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -279,13 +279,16 @@ declare module 'botpress/sdk' {
 
     export namespace Strings {
       /**
-       * Returns the levenshtein distance between two strings
+       * Returns the levenshtein similarity between two strings
+       * sim(a, b) = (|a| - dist(a, b)) / |a| where |a| < |b|
+       * sim(a, b) ∈ [0, 1]
        * @returns the proximity between 0 and 1, where 1 is very close
        */
       export const computeLevenshteinDistance: (a: string, b: string) => number
 
       /**
-       * Returns the jaro-winkler distance between two strings
+       * Returns the jaro-winkler similarity between two strings
+       * sim(a, b) = 1 - dist(a, b)
        * @returns the proximity between 0 and 1, where 1 is very close
        */
       export const computeJaroWinklerDistance: (a: string, b: string, options: { caseSensitive: boolean }) => number


### PR DESCRIPTION
## What was done
### change 1:

var synonym = 'au fromage'
var userInput = 'au mirroir'

used to match because

```
levenshtein_sim('_au+_fromage', '_au+_mirroir') // is high
```
By removing the "+" character for white space (wich was usefull when using white-space tokenization), we get:

```
levenshtein_sim('_au_fromage', '_au_mirroir') // a bit less high
```

### change 2:

var synonym = "dans l'trou"
var userInput = "dan ltrou"

we used to append tokens util the partOfPhrase had a bigger length than the entityDef synonym. This would have resulted in :

```
var partOfPhrase = 'dan ltrou, les'
```

which would not have matched.

Now with try with one more token and one less.


### change 3:

The methods we expose in the sdk 

``` "computeLevenshteinDistance" ```

and 

```"computeJaroWinklerDistance"```

are actually similarity metrics instead of distances:

```
sim_levenshtein(a, b) = (|a| - dist_levenshtein(a, b)) / |a| where |a| < |b|
sim_levenshtein(a, b) ∈ [0, 1]

sim_jarowinkler(a, b) = 1 - dist_jarowinkler(a, b)
sim_jarowinkler(a, b)  ∈ [0, 1]
```

Now few variable and functions occurences have been renamed, but not the sdk methods as this is a breaking change. They should eventually be deprecated in another PR so they can be renamed.

### change 4:

The first space character is removed.

The Levenstein similarity between "apple" and "banana" is 0.
The same similartity for "_apple" and "_banana" is 0.16.

The first space char should not count in the similarity metrics calculation.

## To be done (in another PR)
### change 1

The kept similarity is the min between levenshtein and jaro-winkler. Then for small words (with a length of magic number 4), we give a chance to added or removed characters by multiplying the similarity by a factor between 1.1 and 1.4.

This seems like a dummy logic. The test are passing, but I feel like theirs work to be done around there. 

This [stack overflow thread](https://stackoverflow.com/questions/25540581/difference-between-jaro-winkler-and-levenshtein-distance) suggests that jaro-winkler metric is more suited for small string as levenstein is better for long strings. 

This looks like a good track to make entity matching more robust. 

### change 2

currently, those two will match as the sample string is super long

```
var synonym = "I really really like apples"
var userInput = "I really really like bananas"
```

I know, list entities are not likely to be that long but still.

We might want to calculate the fuzzy similarity for each pair of tokens and keep the lowest one. So the similarity will only be calculated beetween "apples" and "bananas".

Theses are only some rough ideas... Let me know what you guys think!

