### PR TITLE
fix(cms): rendering default payload for unknown channels

### DIFF
--- a/modules/builtin/src/content-types/carousel.js
+++ b/modules/builtin/src/content-types/carousel.js
@@ -162,15 +162,13 @@ function renderSlack(data) {
 }
 
 function renderElement(data, channel) {
-  if (channel === 'web' || channel === 'api' || channel === 'telegram' || channel === 'teams') {
-    return render(data)
-  } else if (channel === 'messenger') {
+  if (channel === 'messenger') {
     return renderMessenger(data)
   } else if (channel === 'slack') {
     return renderSlack(data)
+  } else {
+    return render(data)
   }
-
-  return [] // TODO Handle channel not supported
 }
 
 module.exports = {

--- a/modules/builtin/src/content-types/image.js
+++ b/modules/builtin/src/content-types/image.js
@@ -115,9 +115,7 @@ function renderTeams(data) {
 }
 
 function renderElement(data, channel) {
-  if (channel === 'web' || channel === 'api') {
-    return render(data)
-  } else if (channel === 'messenger') {
+  if (channel === 'messenger') {
     return renderMessenger(data)
   } else if (channel === 'telegram') {
     return renderTelegram(data)
@@ -125,9 +123,9 @@ function renderElement(data, channel) {
     return renderSlack(data)
   } else if (channel === 'teams') {
     return renderTeams(data)
+  } else {
+    return render(data)
   }
-
-  return [] // TODO Handle channel not supported
 }
 
 module.exports = {

--- a/modules/builtin/src/content-types/single_choice.js
+++ b/modules/builtin/src/content-types/single_choice.js
@@ -77,15 +77,13 @@ function renderSlack(data) {
 }
 
 function renderElement(data, channel) {
-  if (channel === 'web' || channel === 'api' || channel === 'telegram' || channel === 'teams') {
-    return render(data)
-  } else if (channel === 'messenger') {
+  if (channel === 'messenger') {
     return renderMessenger(data)
   } else if (channel === 'slack') {
     return renderSlack(data)
+  } else {
+    return render(data)
   }
-
-  return [] // TODO Handle channel not supported
 }
 
 module.exports = {

--- a/modules/builtin/src/content-types/text.js
+++ b/modules/builtin/src/content-types/text.js
@@ -57,15 +57,13 @@ function renderTeams(data) {
 }
 
 function renderElement(data, channel) {
-  if (channel === 'web' || channel === 'api' || channel === 'telegram' || channel === 'slack') {
-    return render(data)
-  } else if (channel === 'messenger') {
+  if (channel === 'messenger') {
     return renderMessenger(data)
   } else if (channel === 'teams') {
     return renderTeams(data)
+  } else {
+    return render(data)
   }
-
-  return [] // TODO
 }
 
 module.exports = {


### PR DESCRIPTION
Instead of returning an empty payload for channels unknown, it will send the default one. 