### PR TITLE
fix(NLU): loosen language election with short inputs

### DIFF
--- a/modules/nlu/src/backend/engine.ts
+++ b/modules/nlu/src/backend/engine.ts
@@ -565,7 +565,7 @@ export default class ScopedEngine implements Engine {
     }
 
     ds.detectedLanguage = _.get(elected, 'label', 'n/a')
-    ds.language = _.isEmpty(elected) || elected.value < 0.5 ? this.defaultLanguage : ds.detectedLanguage
+    ds.language = _.isEmpty(elected) || elected.value < 0.3 ? this.defaultLanguage : ds.detectedLanguage
 
     return ds
   }

--- a/modules/nlu/src/backend/engine.ts
+++ b/modules/nlu/src/backend/engine.ts
@@ -564,8 +564,10 @@ export default class ScopedEngine implements Engine {
       debugLang.forBot(this.botId, `Detected language is not supported, fallback to ${this.defaultLanguage}`)
     }
 
+    const threshold = ds.tokens.length > 1 ? 0.5 : 0.3
+
     ds.detectedLanguage = _.get(elected, 'label', 'n/a')
-    ds.language = _.isEmpty(elected) || elected.value < 0.3 ? this.defaultLanguage : ds.detectedLanguage
+    ds.language = _.isEmpty(elected) || elected.value > threshold ? ds.detectedLanguage : this.defaultLanguage
 
     return ds
   }


### PR DESCRIPTION
As of today if you have a multi-lang (en and de) bot with a default language set to en, a user input of "danke" will be identified as "de" with a confidence of around .4 which is lower than our hard threshold of .5. it'll fallback to defaultLanguage (en).

This is due to to the length of the input, language identifier is much more confident longer sentences are provided. This PR proposes a quick fix that will work for most of use cases. We could also use an outlier method do find if the highest is language detection confidence is far enough from the other results instead of using a hard threshold.