### PR TITLE
fix(core): handling studio index file missing

### DIFF
--- a/src/bp/core/server.ts
+++ b/src/bp/core/server.ts
@@ -344,12 +344,16 @@ export default class HTTPServer {
       }
 
       fs.readFile(this.resolveAsset(page), (err, data) => {
-        this.indexCache[page] = data
-          .toString()
-          .replace(/\<base href=\"\/\" ?\/\>/, `<base href="${process.ROOT_PATH}/" />`)
-          .replace(/ROOT_PATH=""|ROOT_PATH = ''/, `window.ROOT_PATH="${process.ROOT_PATH}"`)
+        if (data) {
+          this.indexCache[page] = data
+            .toString()
+            .replace(/\<base href=\"\/\" ?\/\>/, `<base href="${process.ROOT_PATH}/" />`)
+            .replace(/ROOT_PATH=""|ROOT_PATH = ''/, `window.ROOT_PATH="${process.ROOT_PATH}"`)
 
-        res.send(this.indexCache[page])
+          res.send(this.indexCache[page])
+        } else {
+          res.sendStatus(404)
+        }
       })
     }
 


### PR DESCRIPTION
Happens often when developing locally and rebuilding studio... If the asset is not created on time, it crashes BP.