### PR TITLE
fix(admin): fixed bot import using drag&drop

### DIFF
--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -221,7 +221,9 @@ export class BotService {
 
     if (await this.botExists(botId)) {
       if (!allowOverwrite) {
-        return this.logger.error(`Cannot import the bot ${botId}, it already exists, and overwrite is not allowed`)
+        throw new InvalidOperationError(
+          `Cannot import the bot ${botId}, it already exists, and overwrite is not allowed`
+        )
       } else {
         this.logger.warn(`The bot ${botId} already exists, files in the archive will overwrite existing ones`)
       }
@@ -251,9 +253,11 @@ export class BotService {
 
         const folder = await this._validateBotArchive(tmpDir.name)
         await this.ghostService.forBot(botId).importFromDirectory(folder)
+        const originalConfig = await this.configProvider.getBotConfig(botId)
 
         const newConfigs = <Partial<BotConfig>>{
           id: botId,
+          name: `${originalConfig.name} (${botId})`,
           pipeline_status: {
             current_stage: {
               id: pipeline && pipeline[0].id,

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/ImportBotModal.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/ImportBotModal.tsx
@@ -69,13 +69,17 @@ class ImportBotModal extends Component<Props, State> {
 
   handleBotIdChanged = e => this.setState({ botId: sanitizeBotId(e.target.value) }, this.checkIdAvailability)
 
-  handleFileChanged = e => {
+  handleFileChanged = (files: FileList | null) => {
+    if (!files) {
+      return
+    }
+
     const fr = new FileReader()
-    fr.readAsArrayBuffer(e.target.files[0])
+    fr.readAsArrayBuffer(files[0])
     fr.onload = loadedEvent => {
       this.setState({ fileContent: _.get(loadedEvent, 'target.result') })
     }
-    this.setState({ filePath: e.target.value })
+    this.setState({ filePath: files[0].name })
   }
 
   toggleDialog = () => {
@@ -118,18 +122,26 @@ class ImportBotModal extends Component<Props, State> {
               />
             </FormGroup>
 
-            <FormGroup
-              label="Bot Archive"
-              labelInfo="*"
-              labelFor="archive"
-              helperText="File must be a valid .zip or .tgz archive"
+            <div
+              onDragOver={e => e.preventDefault()}
+              onDrop={e => {
+                e.preventDefault()
+                this.handleFileChanged(e.dataTransfer.files)
+              }}
             >
-              <FileInput
-                tabIndex={2}
-                text={this.state.filePath || 'Choose file...'}
-                onChange={this.handleFileChanged}
-              />
-            </FormGroup>
+              <FormGroup
+                label="Bot Archive"
+                labelInfo="*"
+                labelFor="archive"
+                helperText="File must be a valid .zip or .tgz archive"
+              >
+                <FileInput
+                  tabIndex={2}
+                  text={this.state.filePath || 'Choose file...'}
+                  onChange={event => this.handleFileChanged((event.target as HTMLInputElement).files)}
+                />
+              </FormGroup>
+            </div>
           </div>
           <div className={Classes.DIALOG_FOOTER}>
             {!!this.state.error && <p className="text-danger">{this.state.error}</p>}

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/ImportBotModal.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/ImportBotModal.tsx
@@ -89,7 +89,7 @@ class ImportBotModal extends Component<Props, State> {
   generateBotId = (filename: string) => {
     const noExt = filename.substr(0, filename.indexOf('.'))
     const matches = noExt.match(/bot_(.*)_[0-9]+/)
-    this.setState({ botId: sanitizeBotId((matches && matches[1]) || filename) })
+    this.setState({ botId: sanitizeBotId((matches && matches[1]) || noExt) })
   }
 
   toggleDialog = () => {


### PR DESCRIPTION
Curiously blueprint file input doesn't support drag&drop of files, so added a workaround in its parent container

- Whole dialog can serve as a drop zone for the file
- If you drop a file without setting an ID first, it will try to generate the ID from the filename
- When importing a bot, the name of the bot is the original name with its ID in parenthesis (so it's easier to find in the list...)