### PR TITLE
fix(core): added warning when home folder not defined

### DIFF
--- a/src/bp/core/misc/app_data.ts
+++ b/src/bp/core/misc/app_data.ts
@@ -1,12 +1,19 @@
+import chalk from 'chalk'
 import path from 'path'
 
 export function getAppDataPath() {
-  if (process.platform === 'win32') {
-    return path.join(process.env.APPDATA!, 'botpress')
-  } else if (process.platform === 'darwin') {
-    return path.join(process.env.HOME!, 'Library', 'Application Support', 'botpress')
+  const homeDir = process.env.HOME || process.env.APPDATA
+  if (homeDir) {
+    if (process.platform === 'darwin') {
+      return path.join(homeDir, 'Library', 'Application Support', 'botpress')
+    }
+
+    return path.join(homeDir, 'botpress')
   }
 
-  // unix
-  return path.join(process.env.HOME!, 'botpress')
+  console.error(
+    chalk.red(`Could not determine your HOME directory.
+Please set the environment variable "APP_DATA_PATH", then start Botpress`)
+  )
+  process.exit()
 }


### PR DESCRIPTION
Making it clearer when the HOME folder is not defined, and displaying the env variable to use to fix the issue. Fix for https://help.botpress.io/t/botpress-12-1-not-starting-as-ubuntu-service/2133