### PR TITLE
fix(channel-web): target self for links that start by javascript:

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/renderer/Carousel.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/renderer/Carousel.tsx
@@ -75,9 +75,14 @@ export const Card = props => {
           {buttons.map((btn: Renderer.CardButton) => {
             if (btn.url) {
               return (
-                <a href={btn.url} key={`1-${btn.title}`} target={'_blank'} className={'bpw-card-action'}>
+                <a
+                  href={btn.url}
+                  key={`1-${btn.title}`}
+                  target={/^javascript:/.test(btn.url) ? '_self' : '_blank'}
+                  className={'bpw-card-action'}
+                >
                   {btn.title || btn}
-                  <i className={'bpw-card-external-icon'} />
+                  {/^javascript:/.test(btn.url) ? null : <i className={'bpw-card-external-icon'} />}
                 </a>
               )
             } else if (btn.type == 'postback' || btn.payload) {


### PR DESCRIPTION
I use Carousel in my bot to display one card. This card has an action that execute javascript on the page by setting `javascript:alert('example')` in the URL field.

The `target="_blank"` disabled this behavior.