### PR TITLE
fix(config): missing typings and added external url

### DIFF
--- a/modules/code-editor/src/typings/bot.config.schema.json
+++ b/modules/code-editor/src/typings/bot.config.schema.json
@@ -46,6 +46,19 @@
         "contentTypes"
       ]
     },
+    "converse": {
+      "type": "object",
+      "properties": {
+        "timeout": {
+          "description": "The timeout of the converse API requests",
+          "default": "5s",
+          "type": "string"
+        }
+      },
+      "required": [
+        "timeout"
+      ]
+    },
     "dialog": {
       "$ref": "#/definitions/DialogConfig"
     },
@@ -104,14 +117,16 @@
       "type": "object",
       "properties": {
         "timeoutInterval": {
+          "description": "The interval until the context of the session expires.\nThis clears the position of the user in the flow and triggers the before_session_timeout hook",
+          "default": "5m",
           "type": "string"
         },
         "sessionTimeoutInterval": {
+          "description": "The interval until the session timeout. The default value is 30m. This deletes the session from the database.",
           "type": "string"
         }
       },
       "required": [
-        "sessionTimeoutInterval",
         "timeoutInterval"
       ]
     },

--- a/modules/code-editor/src/typings/botpress.config.schema.json
+++ b/modules/code-editor/src/typings/botpress.config.schema.json
@@ -47,6 +47,7 @@
         },
         "externalUrl": {
           "description": "Represents the complete base URL exposed externally by your bot. This is useful if you configure the bot\nlocally and use NGINX as a reverse proxy to handle HTTPS. It should include the protocol and no trailing slash.\nIf unset, it will be constructed from the real host/port",
+          "default": "",
           "type": "string"
         },
         "session": {
@@ -72,6 +73,7 @@
         "backlog",
         "bodyLimit",
         "cors",
+        "externalUrl",
         "host",
         "port",
         "session"

--- a/src/bp/core/config/bot.config.ts
+++ b/src/bp/core/config/bot.config.ts
@@ -15,6 +15,7 @@ export type BotConfig = {
     /** Defines the list of content types supported by the bot */
     contentTypes: string[]
   }
+  converse?: ConverseConfig
   dialog?: DialogConfig
   logs?: LogsConfig
   defaultLanguage: string
@@ -50,6 +51,22 @@ export interface LogsConfig {
 }
 
 export interface DialogConfig {
+  /**
+   * The interval until the context of the session expires.
+   * This clears the position of the user in the flow and triggers the before_session_timeout hook
+   * @default 5m
+   */
   timeoutInterval: string
-  sessionTimeoutInterval: string
+  /**
+   * The interval until the session timeout. The default value is 30m. This deletes the session from the database.
+   */
+  sessionTimeoutInterval?: string
+}
+
+export type ConverseConfig = {
+  /**
+   * The timeout of the converse API requests
+   * @default 5s
+   */
+  timeout: string
 }

--- a/src/bp/core/config/botpress.config.ts
+++ b/src/bp/core/config/botpress.config.ts
@@ -123,8 +123,9 @@ export type BotpressConfig = {
      * locally and use NGINX as a reverse proxy to handle HTTPS. It should include the protocol and no trailing slash.
      * If unset, it will be constructed from the real host/port
      * @example https://botpress.io
+     * @default
      */
-    externalUrl?: string
+    externalUrl: string
     session: {
       /**
        * @default false


### PR DESCRIPTION
Added the converse typings which was missing in the bot config, and also set externalUrl to an empty string. This way, users will simply have to fill it instead of going through the doc or schema to find it.