### PR TITLE
feat(debugger): added actionerrors to debugger view

### DIFF
--- a/modules/extensions/src/views/lite/components/debugger/index.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/index.tsx
@@ -1,4 +1,4 @@
-import { Tab, Tabs } from '@blueprintjs/core'
+import { Icon, Tab, Tabs } from '@blueprintjs/core'
 import '@blueprintjs/core/lib/css/blueprint.css'
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
@@ -11,6 +11,7 @@ import Settings from './settings'
 import style from './style.scss'
 import { loadSettings } from './utils'
 import Dialog from './views/Dialog'
+import { Error } from './views/Error'
 import { Inspector } from './views/Inspector'
 import NLU from './views/NLU'
 import EventNotFound from './EventNotFound'
@@ -202,6 +203,30 @@ export class Debugger extends React.Component<Props, State> {
     return <SplashScreen />
   }
 
+  renderEvent() {
+    const eventError = this.state.event.state['__error']
+
+    return (
+      <div className={style.content}>
+        <Tabs id="tabs" onChange={this.handleTabChange} selectedTabId={this.state.selectedTabId}>
+          <Tab id="basic" title="Summary" panel={this.renderSummary()} />
+          <Tab id="advanced" title="Raw JSON" panel={<Inspector data={this.state.event} />} />
+          {eventError && (
+            <Tab
+              id="errors"
+              title={
+                <span>
+                  <Icon icon="error" color="red" /> Error
+                </span>
+              }
+              panel={<Error error={eventError} />}
+            />
+          )}
+        </Tabs>
+      </div>
+    )
+  }
+
   render() {
     if (!this.state.visible) {
       return null
@@ -212,14 +237,7 @@ export class Debugger extends React.Component<Props, State> {
         <Settings store={this.props.store} isOpen={this.state.showSettings} toggle={this.toggleSettings} />
         <Header newSession={this.handleNewSession} toggleSettings={this.toggleSettings} />
         {!this.state.event && this.renderWhenNoEvent()}
-        {this.state.event && (
-          <div className={style.content}>
-            <Tabs id="tabs" onChange={this.handleTabChange} selectedTabId={this.state.selectedTabId}>
-              <Tab id="basic" title="Summary" panel={this.renderSummary()} />
-              <Tab id="advanced" title="Raw JSON" panel={<Inspector data={this.state.event} />} />
-            </Tabs>
-          </div>
-        )}
+        {this.state.event && this.renderEvent()}
       </div>
     )
   }

--- a/modules/extensions/src/views/lite/components/debugger/style.scss
+++ b/modules/extensions/src/views/lite/components/debugger/style.scss
@@ -117,3 +117,9 @@
 :global(.bp3-tooltip .bp3-popover-content) {
   padding: 5px 8px !important;
 }
+
+.stacktrace {
+  height: 100%;
+  width: 100%;
+  overflow: auto;
+}

--- a/modules/extensions/src/views/lite/components/debugger/style.scss.d.ts
+++ b/modules/extensions/src/views/lite/components/debugger/style.scss.d.ts
@@ -10,6 +10,7 @@ interface CssExports {
   'inspectorContainer': string;
   'notFound': string;
   'splash': string;
+  'stacktrace': string;
   'subSection': string;
   'summaryTable': string;
   'title': string;

--- a/modules/extensions/src/views/lite/components/debugger/views/Error.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/views/Error.tsx
@@ -1,17 +1,22 @@
-import { Colors, H5, Pre } from '@blueprintjs/core'
+import { Button, Collapse, Colors, H5, H6, Pre } from '@blueprintjs/core'
 import * as sdk from 'botpress/sdk'
-import React, { FC } from 'react'
+import _ from 'lodash'
+import React, { FC, useState } from 'react'
 import JSONTree from 'react-json-tree'
 
 import inspectorTheme from '../inspectorTheme'
 import style from '../style.scss'
 
 export const Error: FC<{ error: sdk.IO.EventError }> = ({ error }) => {
+  const [showStack, setShowStack] = useState(false)
+  const message = _.first(error.stacktrace && error.stacktrace.split('\n'))
+
   return (
     <div>
       {error.type === 'action-execution' && (
         <div className={style.subSection}>
           <H5 color={Colors.DARK_GRAY5}>Error executing action "{error.actionName}"</H5>
+          <p style={{ margin: 15 }}>{message}</p>
           <H5 color={Colors.DARK_GRAY5}>Arguments</H5>
           <Pre className={style.inspectorContainer}>
             <div className={style.inspector}>
@@ -29,8 +34,17 @@ export const Error: FC<{ error: sdk.IO.EventError }> = ({ error }) => {
       <br />
       {error.stacktrace && (
         <div>
-          <H5 color={Colors.DARK_GRAY5}>Stack trace</H5>
-          <Pre className={style.stacktrace}>{error.stacktrace}</Pre>
+          <H5 color={Colors.DARK_GRAY5}>
+            <Button
+              onClick={() => setShowStack(!showStack)}
+              text="Stack trace"
+              rightIcon={showStack ? 'chevron-down' : 'chevron-up'}
+              minimal={true}
+            />
+          </H5>
+          <Collapse isOpen={showStack}>
+            <Pre className={style.stacktrace}>{error.stacktrace}</Pre>
+          </Collapse>
         </div>
       )}
     </div>

--- a/modules/extensions/src/views/lite/components/debugger/views/Error.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/views/Error.tsx
@@ -1,0 +1,38 @@
+import { Colors, H5, Pre } from '@blueprintjs/core'
+import * as sdk from 'botpress/sdk'
+import React, { FC } from 'react'
+import JSONTree from 'react-json-tree'
+
+import inspectorTheme from '../inspectorTheme'
+import style from '../style.scss'
+
+export const Error: FC<{ error: sdk.IO.EventError }> = ({ error }) => {
+  return (
+    <div>
+      {error.type === 'action-execution' && (
+        <div className={style.subSection}>
+          <H5 color={Colors.DARK_GRAY5}>Error executing action "{error.actionName}"</H5>
+          <H5 color={Colors.DARK_GRAY5}>Arguments</H5>
+          <Pre className={style.inspectorContainer}>
+            <div className={style.inspector}>
+              <JSONTree
+                data={error.actionArgs || {}}
+                theme={inspectorTheme}
+                invertTheme={true}
+                hideRoot={true}
+                shouldExpandNode={() => true}
+              />
+            </div>
+          </Pre>
+        </div>
+      )}
+      <br />
+      {error.stacktrace && (
+        <div>
+          <H5 color={Colors.DARK_GRAY5}>Stack trace</H5>
+          <Pre className={style.stacktrace}>{error.stacktrace}</Pre>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/bp/core/services/dialog/instruction/strategy.ts
+++ b/src/bp/core/services/dialog/instruction/strategy.ts
@@ -105,7 +105,7 @@ export class ActionStrategy implements InstructionStrategy {
     return ProcessingResult.none()
   }
 
-  private async invokeAction(botId, instruction, event): Promise<ProcessingResult> {
+  private async invokeAction(botId, instruction, event: IO.IncomingEvent): Promise<ProcessingResult> {
     const chunks: string[] = instruction.fn.split(' ')
     const argsStr = _.tail(chunks).join(' ')
     const actionName = _.first(chunks)!
@@ -138,28 +138,19 @@ export class ActionStrategy implements InstructionStrategy {
     try {
       await this.actionService.forBot(botId).runAction(actionName, event, args)
     } catch (err) {
-      const payloads = [
-        {
-          type: 'error',
-          errorType: 'action-execution',
-          message: `Error executing action "${actionName}": ${err.message}`,
-          stacktrace: err.stacktrace,
-          actionName: actionName,
-          actionArgs: actionArgs
-        }
-      ]
-
-      // TODO: This is a proposal, so that we can show an error in the emulator
-      // For this to work properly we need 3 things:
-      // 1) A way of knowing if target == emulator user
-      // 2) A way of cancelling an event from being sent (event.setFlag(cancel)) if not
-      // 3) A custom error component in webchat extensions (emulator only)
-      // await this.eventEngine.replyToEvent(event, payloads, event.id)
+      event.state.__error = {
+        type: 'action-execution',
+        stacktrace: err.stacktrace,
+        actionName: actionName,
+        actionArgs: _.omit(args, ['event'])
+      }
 
       const { onErrorFlowTo } = event.state.temp
       if (typeof onErrorFlowTo === 'string' && onErrorFlowTo.length) {
         return ProcessingResult.transition(event.state.temp.onErrorFlowTo)
       }
+
+      await this.eventEngine.replyToEvent(event, [{ text: 'An error has occurred' }], event.id)
     }
 
     return ProcessingResult.none()

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -564,6 +564,15 @@ declare module 'botpress/sdk' {
        * This includes all the flow/nodes which were traversed for the current event
        */
       __stacktrace: JumpPoint[]
+      /** Contains details about an error that occurred while processing the event */
+      __error?: EventError
+    }
+
+    export interface EventError {
+      type: string
+      stacktrace?: string
+      actionName?: string
+      actionArgs?: any
     }
 
     export interface JumpPoint {


### PR DESCRIPTION
When there is an error while processing an action, the bot simply doesn't reply back. This adds the error details to the event object, and returns a simple message back to the user (which will be customizable shortly)

![image](https://user-images.githubusercontent.com/42552874/63874305-4a907c00-c98f-11e9-8fb8-8f4a52306739.png)
