### PR TITLE
fix(core): locked bots are blocked from editing from anywhere

### DIFF
--- a/src/bp/core/routers/bots/index.ts
+++ b/src/bp/core/routers/bots/index.ts
@@ -214,6 +214,7 @@ export class BotsRouter extends CustomRouter {
               window.BOTPRESS_VERSION = "${data.botpress.version}";
               window.APP_NAME = "${data.botpress.name}";
               window.SHOW_POWERED_BY = ${!!config.showPoweredBy};
+              window.BOT_LOCKED = ${!!bot.locked};
               ${app === 'studio' ? studioEnv : ''}
               ${app === 'lite' ? liteEnv : ''}
               // End

--- a/src/bp/core/services/ghost/service.test.ts
+++ b/src/bp/core/services/ghost/service.test.ts
@@ -99,6 +99,9 @@ describe('Ghost Service', () => {
 
     it('Never has any pending revisions', async () => {
       dbDriver.listRevisions.mockReturnValue([{ file_path: 'abc', revision: 'rev' }]) // Even if DB driver says there are some revisions
+      diskDriver.readFile.mockImplementation(fileName => {
+        return fileName === `data/bots/${BOT_ID}/bot.config.json` && '{}'
+      })
       await ghost.forBot(BOT_ID).upsertFile('test', 'a.json', 'Hello') // And that we modify a file
 
       const revisions = await ghost.global().getPendingChanges()
@@ -124,7 +127,7 @@ describe('Ghost Service', () => {
 
         expect(diskDriver.readFile).not.toHaveBeenCalled()
         expect(dbDriver.readFile).toHaveBeenCalled()
-        expect(content).toContain(`test${path.sep}my${path.sep}test.json`)
+        expect(content).toContain(`test/my/test.json`)
       })
       it('write uses DB', async () => {
         await ghost.global().upsertFile('test', 'test.json', 'my content')

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -1,6 +1,7 @@
 import { ListenHandle, Logger } from 'botpress/sdk'
 import { ObjectCache } from 'common/object-cache'
 import { isValidBotId } from 'common/validation'
+import { BotConfig } from 'core/config/bot.config'
 import { asBytes, filterByGlobs, forceForwardSlashes } from 'core/misc/utils'
 import { diffLines } from 'diff'
 import { EventEmitter2 } from 'eventemitter2'
@@ -326,6 +327,21 @@ export class ScopedGhostService {
     this.primaryDriver = useDbDriver ? dbDriver : diskDriver
   }
 
+  /**
+   * TODO: Refactor this on v12.1.4
+   * This is a temporary workaround to lock bots marked as "locked" until modules are correctly updated.
+   */
+  private async _assertBotUnlocked(directory: string, file?: string) {
+    if (!this.botId || directory.startsWith('./models')) {
+      return
+    }
+
+    const config = await this.readFileAsObject<BotConfig>('/', 'bot.config.json')
+    if (config.locked) {
+      throw new Error(`Bot locked`)
+    }
+  }
+
   private _normalizeFolderName(rootFolder: string) {
     return forceForwardSlashes(path.join(this.baseDir, rootFolder))
   }
@@ -360,6 +376,7 @@ export class ScopedGhostService {
     recordRevision = true,
     syncDbToDisk = false
   ): Promise<void> {
+    await this._assertBotUnlocked(rootFolder, file)
     if (this.isDirectoryGlob) {
       throw new Error(`Ghost can't read or write under this scope`)
     }
@@ -380,6 +397,7 @@ export class ScopedGhostService {
   }
 
   async upsertFiles(rootFolder: string, content: FileContent[]): Promise<void> {
+    await this._assertBotUnlocked(rootFolder)
     await Promise.all(content.map(c => this.upsertFile(rootFolder, c.name, c.content)))
   }
 
@@ -524,6 +542,7 @@ export class ScopedGhostService {
   }
 
   async deleteFile(rootFolder: string, file: string): Promise<void> {
+    await this._assertBotUnlocked(rootFolder, file)
     if (this.isDirectoryGlob) {
       throw new Error(`Ghost can't read or write under this scope`)
     }
@@ -535,6 +554,7 @@ export class ScopedGhostService {
   }
 
   async renameFile(rootFolder: string, fromName: string, toName: string): Promise<void> {
+    await this._assertBotUnlocked(rootFolder, fromName)
     const fromPath = this._normalizeFileName(rootFolder, fromName)
     const toPath = this._normalizeFileName(rootFolder, toName)
 
@@ -555,6 +575,7 @@ export class ScopedGhostService {
   }
 
   async deleteFolder(folder: string): Promise<void> {
+    await this._assertBotUnlocked(folder)
     if (this.isDirectoryGlob) {
       throw new Error(`Ghost can't read or write under this scope`)
     }

--- a/src/bp/ui-studio/src/web/components/Layout/PermissionsChecker.js
+++ b/src/bp/ui-studio/src/web/components/Layout/PermissionsChecker.js
@@ -1,6 +1,11 @@
 import { checkRule } from 'common/auth'
 
 export const operationAllowed = ({ user, res, op }) => {
+  // TODO: Refactor this on v12.1.4
+  if (window.BOT_LOCKED && op === 'write' && res.startsWith('bot')) {
+    return false
+  }
+
   if (!user) {
     return false
   }


### PR DESCRIPTION
Temporary fix to make sure locked bots are locked.   Also need the other PR for the flow read only fix.

There is more work to be done in modules before it's fully implemented. Right now, users need write access to module to be able to read content, so if we simply strip all write access, almost nothing can be looked at. 

Full implementation of the lock in a future release. 