### PR TITLE
fix(flow): give higher importance to main flow

### DIFF
--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowsList.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowsList.tsx
@@ -7,8 +7,8 @@ import { buildFlowsTree } from './util'
 export const FOLDER_ICON = 'folder-close'
 export const DIRTY_ICON = 'clean'
 export const FLOW_ICON = 'document'
-export const MAIN_FLOW_ICON = 'selection'
-export const ERROR_FLOW_ICON = 'error'
+export const MAIN_FLOW_ICON = 'flow-end'
+export const ERROR_FLOW_ICON = 'pivot'
 
 export default class FlowsList extends Component<Props, State> {
   state = {
@@ -29,15 +29,6 @@ export default class FlowsList extends Component<Props, State> {
       this.traverseTree(this.state.nodes, (n: ITreeNode<NodeData>) => {
         return (n.isSelected = n.nodeData && n.nodeData.name === this.props.currentFlow['name'])
       })
-    }
-
-    if (this.props.dirtyFlows && prevProps.dirtyFlows !== this.props.dirtyFlows) {
-      this.traverseTree(this.state.nodes, (node: ITreeNode<NodeData>) => {
-        if (node.nodeData) {
-          node.icon = this.props.dirtyFlows.includes(node.nodeData.name) ? DIRTY_ICON : node['defaultIcon']
-        }
-      })
-      this.forceUpdate()
     }
   }
 

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowsList.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowsList.tsx
@@ -7,6 +7,8 @@ import { buildFlowsTree } from './util'
 export const FOLDER_ICON = 'folder-close'
 export const DIRTY_ICON = 'clean'
 export const FLOW_ICON = 'document'
+export const MAIN_FLOW_ICON = 'selection'
+export const ERROR_FLOW_ICON = 'error'
 
 export default class FlowsList extends Component<Props, State> {
   state = {
@@ -32,7 +34,7 @@ export default class FlowsList extends Component<Props, State> {
     if (this.props.dirtyFlows && prevProps.dirtyFlows !== this.props.dirtyFlows) {
       this.traverseTree(this.state.nodes, (node: ITreeNode<NodeData>) => {
         if (node.nodeData) {
-          node.icon = this.props.dirtyFlows.includes(node.nodeData.name) ? DIRTY_ICON : FLOW_ICON
+          node.icon = this.props.dirtyFlows.includes(node.nodeData.name) ? DIRTY_ICON : node['defaultIcon']
         }
       })
       this.forceUpdate()

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/util.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/util.tsx
@@ -93,7 +93,5 @@ export const buildFlowsTree = flows => {
 
   sortChildren(tree)
 
-  console.log(tree)
-
   return tree.childNodes
 }

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/util.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/util.tsx
@@ -1,6 +1,25 @@
 import find from 'lodash/find'
+import React from 'react'
 
-import { FLOW_ICON, FOLDER_ICON } from './FlowsList'
+import { ERROR_FLOW_ICON, FLOW_ICON, FOLDER_ICON, MAIN_FLOW_ICON } from './FlowsList'
+
+const getNodeIcon = (flowId: string) => {
+  if (flowId === 'main') {
+    return MAIN_FLOW_ICON
+  } else if (flowId === 'error') {
+    return ERROR_FLOW_ICON
+  }
+  return FLOW_ICON
+}
+
+const getNodeLabel = (flowId: string, flowName: string) => {
+  if (flowId === 'main') {
+    return <strong>Main entry point</strong>
+  } else if (flowId === 'error') {
+    return <strong>Error handling</strong>
+  }
+  return flowName
+}
 
 const addNode = (tree, folders, flowDesc, data) => {
   for (const folderDesc of folders) {
@@ -15,6 +34,11 @@ const addNode = (tree, folders, flowDesc, data) => {
 }
 
 const compareNodes = (a, b) => {
+  // Always display the main flow and error flow as the top node
+  if (a.id === 'main' || a.id === 'error') {
+    return -1
+  }
+
   if (a.type === b.type) {
     return a.name < b.name ? -1 : 1
   }
@@ -48,13 +72,14 @@ export const splitFlowPath = flow => {
   }
 
   currentPath.push(flowName)
+  const id = currentPath.join('/')
   return {
     folders,
     flow: {
-      id: currentPath.join('/'),
-      icon: FLOW_ICON,
-      label: flowName,
-      fullPath: currentPath.join('/')
+      id,
+      defaultIcon: getNodeIcon(id),
+      label: getNodeLabel(id, flowName),
+      fullPath: id
     }
   }
 }
@@ -67,6 +92,8 @@ export const buildFlowsTree = flows => {
   })
 
   sortChildren(tree)
+
+  console.log(tree)
 
   return tree.childNodes
 }


### PR DESCRIPTION
Up for discussion. The main flow should always be displayed on top and should stand out of other flows. Since an image is worth a thousand words...

![image](https://user-images.githubusercontent.com/42552874/63905091-18a80580-c9e1-11e9-9d11-5ab32bf7b643.png)

(also took the occasion to add the logic for the error flow, which is gonna be in an upcoming pr)

What do you think of removing the dirty flows icon ? It's not very relevant since auto-save, and it just always blink through the two states...