### PR TITLE
fix(core): added config to choose socket transport order

### DIFF
--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -407,8 +407,8 @@ export class Botpress {
     AppLifecycle.setDone(AppLifecycleEvents.HTTP_SERVER_READY)
   }
 
-  private startRealtime() {
-    this.realtimeService.installOnHttpServer(this.httpServer.httpServer)
+  private async startRealtime() {
+    await this.realtimeService.installOnHttpServer(this.httpServer.httpServer)
   }
 
   private formatProcessingError(err: ProcessingError) {

--- a/src/bp/core/config/botpress.config.ts
+++ b/src/bp/core/config/botpress.config.ts
@@ -138,6 +138,13 @@ export type BotpressConfig = {
        */
       maxAge: string
     }
+    /**
+     * Configure the priority for establishing socket connections for webchat and studio users.
+     * If the first method is not supported, it will fallback on the second.
+     * If the first is supported but it fails with an error, it will not fallback.
+     * @default ["websocket","polling"]
+     */
+    socketTransports: string[]
   }
   converse: ConverseConfig
   dialog: DialogConfig

--- a/src/bp/core/routers/bots/index.ts
+++ b/src/bp/core/routers/bots/index.ts
@@ -18,6 +18,7 @@ import { FlowService, MutexError } from 'core/services/dialog/flow/service'
 import { LogsService } from 'core/services/logs/service'
 import MediaService from 'core/services/media'
 import { NotificationsService } from 'core/services/notification/service'
+import { getSocketTransports } from 'core/services/realtime'
 import { WorkspaceService } from 'core/services/workspace-service'
 import { Express, RequestHandler, Router } from 'express'
 import { AppLifecycle, AppLifecycleEvents } from 'lifecycle'
@@ -215,6 +216,7 @@ export class BotsRouter extends CustomRouter {
               window.APP_NAME = "${data.botpress.name}";
               window.SHOW_POWERED_BY = ${!!config.showPoweredBy};
               window.BOT_LOCKED = ${!!bot.locked};
+              window.SOCKET_TRANSPORTS = ["${getSocketTransports(config).join('","')}"];
               ${app === 'studio' ? studioEnv : ''}
               ${app === 'lite' ? liteEnv : ''}
               // End

--- a/src/bp/core/services/realtime/index.ts
+++ b/src/bp/core/services/realtime/index.ts
@@ -15,7 +15,8 @@ import { MonitoringService } from '../monitoring'
 const debug = DEBUG('realtime')
 
 export const getSocketTransports = (config: BotpressConfig): string[] => {
-  const transports = config.httpServer.socketTransports
+  // Just to be sure there is at least one valid transport configured
+  const transports = _.filter(config.httpServer.socketTransports, t => ['websocket', 'polling'].includes(t))
   return transports && transports.length ? transports : ['websocket', 'polling']
 }
 

--- a/src/bp/ui-studio/src/web/typings.d.ts
+++ b/src/bp/ui-studio/src/web/typings.d.ts
@@ -18,6 +18,7 @@ declare global {
     BP_BASE_PATH: string
     SEND_USAGE_STATS: boolean
     BOTPRESS_FLOW_EDITOR_DISABLED: boolean
+    SOCKET_TRANSPORTS: string[]
     ANALYTICS_ID: string
     UUID: string
     BP_STORAGE: BPStorage

--- a/src/bp/ui-studio/src/web/util/EventBus.ts
+++ b/src/bp/ui-studio/src/web/util/EventBus.ts
@@ -58,7 +58,7 @@ class EventBus extends EventEmitter2 {
     }
 
     const socketUrl = window['BP_SOCKET_URL'] || window.location.origin
-    const transports = ['websocket', 'polling']
+    const transports = window.SOCKET_TRANSPORTS
 
     this.adminSocket = io(socketUrl + '/admin', { query, transports, path: `${window['ROOT_PATH']}/socket.io` })
     this.adminSocket.on('event', this.dispatchSocketEvent)


### PR DESCRIPTION
By default, we use websocket, then fallback on polling if not supported. Some place have issues when polling is first (multi node without sticky), others with websocket (firewall issue).

Everybody will be happy, just pick and choose your transport.