### PR TITLE
fix(docs) Quickstart: correct emulator position

### DIFF
--- a/docs/guide/docs/quickstart.md
+++ b/docs/guide/docs/quickstart.md
@@ -40,7 +40,7 @@ You will notice on the left there are a couple of sections available. Some of th
 
 ### Test your bot
 
-To test your bot, there are two different kind of emulators. You can use the built-in chat emulator located in the top right corner, which is exactly what your visitors will face when they speak with your bot. You can also start a new conversation with your bot by clicking the reset button.
+To test your bot, there are two different kind of emulators. You can use the built-in chat emulator located in the bottom right corner, which is exactly what your visitors will face when they speak with your bot. You can also start a new conversation with your bot by clicking the reset button.
 
 ![Toolbar Chat](assets/studio-toolbar.jpg)
 


### PR DESCRIPTION
The emulator is located in the bottom right corner:

![Screen Shot 2019-09-04 at 10 26 17 AM](https://user-images.githubusercontent.com/892367/64263897-72875e80-cefe-11e9-9595-0c2499cc1789.png)


Not sure if I should change the docs for the older versions (pre-V12) of Botpress:
![Screen Shot 2019-09-04 at 10 25 02 AM](https://user-images.githubusercontent.com/892367/64263837-58e61700-cefe-11e9-8289-2af722eaf047.png)
