### PR TITLE
fix(bpfs): various fixes due to legacy logic

### DIFF
--- a/src/bp/bootstrap.ts
+++ b/src/bp/bootstrap.ts
@@ -31,10 +31,10 @@ async function start() {
 
   const logger = await Logger('Launcher')
   logger.info(chalk`========================================
-  {bold ${center(`Botpress Server`, 40)}}
-  {dim ${center(`Version ${sdk.version}`, 40)}}
-  {dim ${center(`OS ${process.distro.toString()}`, 40)}}
-  ========================================`)
+{bold ${center(`Botpress Server`, 40)}}
+{dim ${center(`Version ${sdk.version}`, 40)}}
+{dim ${center(`OS ${process.distro.toString()}`, 40)}}
+========================================`)
 
   global.printErrorDefault = err => {
     logger.attachError(err).error('Unhandled Rejection')
@@ -57,8 +57,8 @@ async function start() {
     } catch (err) {
       logger.attachError(err).error(
         `Could not find/create APP_DATA folder "${process.APP_DATA_PATH}".
-  Please make sure that Botpress has the right to access this folder or change the folder path by providing the 'APP_DATA_PATH' env variable.
-  This is a fatal error, process will exit.`
+Please make sure that Botpress has the right to access this folder or change the folder path by providing the 'APP_DATA_PATH' env variable.
+This is a fatal error, process will exit.`
       )
       process.exit(1)
     }

--- a/src/bp/core/app.ts
+++ b/src/bp/core/app.ts
@@ -6,17 +6,23 @@ import 'reflect-metadata'
 import { container } from './app.inversify'
 import { Botpress as Core } from './botpress'
 import { ConfigProvider } from './config/config-loader'
+import Database from './database'
 import { LoggerProvider } from './logger/logger'
+import { GhostService } from './services'
 import { TYPES } from './types'
 
 let botpress
 let logger: LoggerProvider | undefined
 let config: ConfigProvider | undefined
+let ghost: GhostService | undefined
+let database: Database | undefined
 
 try {
   botpress = container.get<Core>(TYPES.Botpress)
   logger = container.get<LoggerProvider>(TYPES.LoggerProvider)
   config = container.get<ConfigProvider>(TYPES.ConfigProvider)
+  ghost = container.get<GhostService>(TYPES.GhostService)
+  database = container.get<Database>(TYPES.Database)
 
   const licensing = container.get<LicensingService>(TYPES.LicensingService)
   licensing.installProtection()
@@ -27,3 +33,5 @@ try {
 export const Botpress = botpress
 export const Logger = logger!
 export const Config = config
+export const Ghost = ghost
+export const Db = database

--- a/src/bp/core/config/config-loader.ts
+++ b/src/bp/core/config/config-loader.ts
@@ -5,7 +5,6 @@ import { GhostService } from 'core/services'
 import { TYPES } from 'core/types'
 import { FatalError } from 'errors'
 import fs from 'fs'
-import fse from 'fs-extra'
 import { inject, injectable } from 'inversify'
 import defaultJsonBuilder from 'json-schema-defaults'
 import _, { PartialDeep } from 'lodash'
@@ -51,11 +50,6 @@ export class ConfigProvider {
     await this.ghostService.global().upsertFile('/', 'botpress.config.json', stringify(config))
   }
 
-  async invalidateBotpressConfig(): Promise<void> {
-    this._botpressConfigCache = undefined
-    await this.ghostService.global().invalidateFile('/', 'botpress.config.json')
-  }
-
   async getBotConfig(botId: string): Promise<BotConfig> {
     return this.getConfig<BotConfig>('bot.config.json', botId)
   }
@@ -72,13 +66,13 @@ export class ConfigProvider {
   }
 
   public async createDefaultConfigIfMissing() {
-    const botpressConfig = path.resolve(process.PROJECT_LOCATION, 'data', 'global', 'botpress.config.json')
+    if (!(await this.ghostService.global().fileExists('/', 'botpress.config.json'))) {
+      await this._copyConfigSchemas()
 
-    if (!fse.existsSync(botpressConfig)) {
-      await this.ensureDataFolderStructure()
-
-      const botpressConfigSchema = path.resolve(process.PROJECT_LOCATION, 'data', 'botpress.config.schema.json')
-      const defaultConfig = defaultJsonBuilder(JSON.parse(fse.readFileSync(botpressConfigSchema, 'utf-8')))
+      const botpressConfigSchema = await this.ghostService
+        .root()
+        .readFileAsObject<any>('/', 'botpress.config.schema.json')
+      const defaultConfig = defaultJsonBuilder(botpressConfigSchema)
 
       const config = {
         $schema: `../botpress.config.schema.json`,
@@ -87,22 +81,16 @@ export class ConfigProvider {
         version: process.BOTPRESS_VERSION
       }
 
-      await fse.writeFileSync(botpressConfig, stringify(config))
+      await this.ghostService.global().upsertFile('/', 'botpress.config.json', stringify(config))
     }
   }
 
-  private async ensureDataFolderStructure() {
-    const requiredFolders = ['bots', 'global', 'storage']
+  private async _copyConfigSchemas() {
     const schemasToCopy = ['botpress.config.schema.json', 'bot.config.schema.json']
-    const dataFolder = path.resolve(process.PROJECT_LOCATION, 'data')
-
-    for (const folder of requiredFolders) {
-      await fse.ensureDir(path.resolve(dataFolder, folder))
-    }
 
     for (const schema of schemasToCopy) {
       const schemaContent = fs.readFileSync(path.join(__dirname, 'schemas', schema))
-      fs.writeFileSync(path.resolve(dataFolder, schema), schemaContent)
+      await this.ghostService.root().upsertFile('/', schema, schemaContent)
     }
   }
 

--- a/src/bp/core/database/index.ts
+++ b/src/bp/core/database/index.ts
@@ -1,7 +1,7 @@
 import { Logger } from 'botpress/sdk'
 import { KnexExtension } from 'common/knex'
 import { TYPES } from 'core/types'
-import fs from 'fs'
+import { mkdirpSync } from 'fs-extra'
 import { inject, injectable, tagged } from 'inversify'
 import Knex from 'knex'
 import _ from 'lodash'
@@ -65,6 +65,7 @@ export default class Database {
       })
     } else {
       const dbLocation = databaseUrl ? databaseUrl : `${process.PROJECT_LOCATION}/data/storage/core.sqlite`
+      mkdirpSync(path.dirname(dbLocation))
 
       Object.assign(config, {
         client: 'sqlite3',

--- a/src/bp/core/server.ts
+++ b/src/bp/core/server.ts
@@ -183,6 +183,7 @@ export default class HTTPServer {
 
   @postConstruct()
   async initialize() {
+    await AppLifecycle.waitFor(AppLifecycleEvents.CONFIGURATION_LOADED)
     await this.setupRootPath()
 
     const app = express()

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -331,10 +331,6 @@ export class ScopedGhostService {
 
     this.isDirectoryGlob = this.baseDir.endsWith('*')
     this.primaryDriver = useDbDriver ? dbDriver : diskDriver
-
-    if (process.BPFS_STORAGE === 'database' && !useDbDriver) {
-      this.logger.warn(`Accessing a file before ghost is initialized. Use AppLifeCycle when using postConstruct`)
-    }
   }
 
   /**

--- a/src/bp/core/services/migration/index.ts
+++ b/src/bp/core/services/migration/index.ts
@@ -23,6 +23,12 @@ const types = {
   config: 'Config File Changes',
   content: 'Changes to Content Files (*.json)'
 }
+/**
+ * Use a combination of these environment variables to easily test migrations.
+ * TESTMIG_BP_VERSION: Change the target version of your migration
+ * TESTMIG_CONFIG_VERSION: Override the current version of the server
+ * TESTMIG_IGNORE_COMPLETED: Ignore completed migrations (so they can be run again and again)
+ */
 
 @injectable()
 export class MigrationService {
@@ -201,7 +207,11 @@ export class MigrationService {
     return [...coreMigrations, ...moduleMigrations]
   }
 
-  private _getCompletedMigrations(): Promise<string[]> {
+  private async _getCompletedMigrations(): Promise<string[]> {
+    if (process.env.TESTMIG_IGNORE_COMPLETED) {
+      return []
+    }
+
     return this.ghostService.root().directoryListing('migrations')
   }
 

--- a/src/bp/core/stats.ts
+++ b/src/bp/core/stats.ts
@@ -1,5 +1,6 @@
 import { gaId, machineUUID } from 'common/stats'
 import { inject, injectable, postConstruct } from 'inversify'
+import { AppLifecycle, AppLifecycleEvents } from 'lifecycle'
 import ua, { Visitor } from 'universal-analytics'
 
 import { ConfigProvider } from './config/config-loader'
@@ -15,6 +16,7 @@ export class Statistics {
 
   @postConstruct()
   public async init() {
+    await AppLifecycle.waitFor(AppLifecycleEvents.CONFIGURATION_LOADED)
     const botpressConfig = await this.configProvider.getBotpressConfig()
     this._sendUsageStats = botpressConfig.sendUsageStats
 


### PR DESCRIPTION
- Changed initialization order so the BPFS and Database are initialized during bootstraping instead of when initializing services

- Modules, Base path and License key are now fetched from the correct config file (ghosted one)

- On first run, files are created on the ghost directly instead of locally (then pushing them) (that was actually the issue we had with sync)

- Clearing cache when ghost is initialized (in case config was accessed before being initialized correctly)
 
- Migration status is kept on the ghost instead of locally

- Added one flag and changed the migration test flag, so we can test migrations more easily :
TESTMIG_CONFIG_VERSION
TESTMIG_BP_VERSION
 