### PR TITLE
feat(bpfs): workaround to fix bpfs issues

### DIFF
--- a/src/bp/bootstrap.ts
+++ b/src/bp/bootstrap.ts
@@ -13,17 +13,13 @@ import ModuleResolver from 'core/modules/resolver'
 import fs from 'fs'
 import os from 'os'
 
-import { DatabaseType } from 'core/database'
 import { FatalError } from './errors'
 
 async function setupEnv() {
-  const { DATABASE_URL } = process.env
-
   const useDbDriver = process.BPFS_STORAGE === 'database'
   Ghost.initialize(useDbDriver)
 
-  const dbType = DATABASE_URL && DATABASE_URL.toLowerCase().startsWith('postgres') ? 'postgres' : 'sqlite'
-  await Db.initialize(<DatabaseType>dbType, DATABASE_URL)
+  await Db.initialize()
 }
 
 async function start() {

--- a/src/bp/bpfs_recovery.ts
+++ b/src/bp/bpfs_recovery.ts
@@ -23,13 +23,10 @@ export default async (argv, action) => {
     ghost = container.get<GhostService>(TYPES.GhostService)
     database = container.get<Database>(TYPES.Database)
 
-    const { DATABASE_URL } = process.env
-
     const useDbDriver = process.env.BPFS_STORAGE === 'database'
     ghost.initialize(useDbDriver)
 
-    const dbType = DATABASE_URL && DATABASE_URL.toLowerCase().startsWith('postgres') ? 'postgres' : 'sqlite'
-    await database.initialize(dbType, DATABASE_URL)
+    await database.initialize()
   } catch (err) {
     console.error(chalk.red(`Error during initialization`), err)
     return process.exit()
@@ -42,7 +39,7 @@ export default async (argv, action) => {
 =========================================`)
 
     const files = await ghost.root().directoryListing(argv.list)
-    files.map(file => console.log(chalk.green(` - ${file}`)))
+    files.forEach(file => console.log(chalk.green(` - ${file}`)))
     process.exit()
   }
 
@@ -51,7 +48,7 @@ export default async (argv, action) => {
     process.exit()
   }
 
-  if (action === 'pulldb') {
+  if (action === 'pullfile') {
     const rootFolder = path.dirname(file)
     const filename = path.basename(file)
 
@@ -62,13 +59,13 @@ export default async (argv, action) => {
 
     const fileBuffer = await ghost.root().readFileAsBuffer(rootFolder, filename)
 
-    mkdirpSync(dest ? path.dirname(dest) : path.dirname(file))
+    mkdirpSync(path.dirname(dest || file))
     fs.writeFileSync(dest || file, fileBuffer)
 
     console.log(chalk.green(`File "${filename}" saved at ${path.resolve(dest || file)}`))
   }
 
-  if (action === 'pushdb') {
+  if (action === 'pushfile') {
     if (!fs.existsSync(path.resolve(file))) {
       console.error(`File ${file} doesn't exist locally.`)
       process.exit()

--- a/src/bp/bpfs_recovery.ts
+++ b/src/bp/bpfs_recovery.ts
@@ -1,0 +1,85 @@
+import 'bluebird-global'
+// tslint:disable-next-line:ordered-imports
+import './sdk/rewire'
+// tslint:disable-next-line:ordered-imports
+import './common/polyfills'
+
+import chalk from 'chalk'
+import { FatalError } from 'errors'
+import fs from 'fs'
+import { mkdirpSync } from 'fs-extra'
+import path from 'path'
+import 'reflect-metadata'
+import { container } from './core/app.inversify'
+import Database from './core/database'
+import { GhostService } from './core/services'
+import { TYPES } from './core/types'
+
+export default async (argv, action) => {
+  let ghost: GhostService | undefined
+  let database: Database | undefined
+
+  try {
+    ghost = container.get<GhostService>(TYPES.GhostService)
+    database = container.get<Database>(TYPES.Database)
+
+    const { DATABASE_URL } = process.env
+
+    const useDbDriver = process.env.BPFS_STORAGE === 'database'
+    ghost.initialize(useDbDriver)
+
+    const dbType = DATABASE_URL && DATABASE_URL.toLowerCase().startsWith('postgres') ? 'postgres' : 'sqlite'
+    await database.initialize(dbType, DATABASE_URL)
+  } catch (err) {
+    console.error(chalk.red(`Error during initialization`), err)
+    return process.exit()
+  }
+
+  const { file, dest } = argv
+
+  if (argv.list) {
+    console.log(`Directory listing of ${path.join('data', argv.list)}
+=========================================`)
+
+    const files = await ghost.root().directoryListing(argv.list)
+    files.map(file => console.log(chalk.green(` - ${file}`)))
+    process.exit()
+  }
+
+  if (!file) {
+    console.error(chalk.red(`The --file parameter is required`))
+    process.exit()
+  }
+
+  if (action === 'pulldb') {
+    const rootFolder = path.dirname(file)
+    const filename = path.basename(file)
+
+    if (!(await ghost.root().fileExists(rootFolder, filename))) {
+      console.error(chalk.red(`File "${file}" not found in the database.`))
+      process.exit()
+    }
+
+    const fileBuffer = await ghost.root().readFileAsBuffer(rootFolder, filename)
+
+    mkdirpSync(dest ? path.dirname(dest) : path.dirname(file))
+    fs.writeFileSync(dest || file, fileBuffer)
+
+    console.log(chalk.green(`File "${filename}" saved at ${path.resolve(dest || file)}`))
+  }
+
+  if (action === 'pushdb') {
+    if (!fs.existsSync(path.resolve(file))) {
+      console.error(`File ${file} doesn't exist locally.`)
+      process.exit()
+    }
+
+    const destFolder = path.dirname(dest || file)
+    const destFile = path.basename(dest || file)
+
+    await ghost.root().upsertFile(destFolder, destFile, fs.readFileSync(path.resolve(file), 'UTF-8'))
+    console.log(chalk.green(`File "${file}" saved at ${path.join(destFolder, destFile)}`))
+  }
+
+  process.exit()
+}

--- a/src/bp/core/database/index.ts
+++ b/src/bp/core/database/index.ts
@@ -53,7 +53,18 @@ export default class Database {
     })
   }
 
-  async initialize(databaseType: DatabaseType, databaseUrl?: string) {
+  async initialize(databaseType?: DatabaseType, databaseUrl?: string) {
+    const { DATABASE_URL } = process.env
+
+    if (DATABASE_URL) {
+      if (!databaseType) {
+        databaseType = DATABASE_URL.toLowerCase().startsWith('postgres') ? 'postgres' : 'sqlite'
+      }
+      if (!databaseUrl) {
+        databaseUrl = DATABASE_URL
+      }
+    }
+
     const config: Knex.Config = {
       useNullAsDefault: true
     }

--- a/src/bp/index.ts
+++ b/src/bp/index.ts
@@ -168,7 +168,7 @@ try {
       argv => require('./bpfs').default(argv, 'push')
     )
     .command(
-      'pulldb',
+      'pullfile',
       'Pull a single file from the database',
       {
         file: {
@@ -183,13 +183,13 @@ try {
       argv => {
         getos.default().then(distro => {
           process.distro = distro
-          require('./bpfs_recovery').default(argv, 'pulldb')
+          require('./bpfs_recovery').default(argv, 'pullfile')
         })
       }
     )
     .command(
-      'pushdb',
-      'Push local files to a remote database directly',
+      'pushfile',
+      'Push a local file to a remote database directly',
       {
         file: {
           description: 'Path of the local file (eg: botpress.config.json)',
@@ -203,7 +203,7 @@ try {
       argv => {
         getos.default().then(distro => {
           process.distro = distro
-          require('./bpfs_recovery').default(argv, 'pushdb')
+          require('./bpfs_recovery').default(argv, 'pushfile')
         })
       }
     )

--- a/src/bp/index.ts
+++ b/src/bp/index.ts
@@ -168,6 +168,46 @@ try {
       argv => require('./bpfs').default(argv, 'push')
     )
     .command(
+      'pulldb',
+      'Pull a single file from the database',
+      {
+        file: {
+          description: 'Complete path of the remote file (ex: global/botpress.config.json)',
+          type: 'string'
+        },
+        dest: {
+          description: 'Path where the file will be copied locally (if not set, it uses the same path as "file")',
+          type: 'string'
+        }
+      },
+      argv => {
+        getos.default().then(distro => {
+          process.distro = distro
+          require('./bpfs_recovery').default(argv, 'pulldb')
+        })
+      }
+    )
+    .command(
+      'pushdb',
+      'Push local files to a remote database directly',
+      {
+        file: {
+          description: 'Path of the local file (eg: botpress.config.json)',
+          type: 'string'
+        },
+        dest: {
+          description: 'Complete path of the destination file (ex: global/botpress.config.json)',
+          type: 'string'
+        }
+      },
+      argv => {
+        getos.default().then(distro => {
+          process.distro = distro
+          require('./bpfs_recovery').default(argv, 'pushdb')
+        })
+      }
+    )
+    .command(
       'bench',
       'Run a benchmark on your bot',
       {


### PR DESCRIPTION
When you have an error in your botpress config or in any file preventing the normal start of Botpress, you need to edit that file manually to fix it.

If you use the ghost, that implies connecting on  the database, download the file, edit it, then push it again. There's no simple way to do that.

This PR adds two new commands to the CLI utility to pull or push a single file directly to the database. 

- bp pulldb --file global/botpress.config.json
- bp pushdb --file global/botpress.config.json

As a bonus, use --list some/folder to list the remote files.

I wanted to keep it lightweight, so it's not pulling the whole database, but maybe we can add it in a future one ? 