### PR TITLE
fix(lock): allowing upsert to bypass locked status

### DIFF
--- a/modules/code-editor/src/backend/editor.ts
+++ b/modules/code-editor/src/backend/editor.ts
@@ -214,11 +214,11 @@ export default class Editor {
 
     const ghost = this._getGhost(file)
     if (type === 'action') {
-      return ghost.upsertFile('/actions', location, content, true, true)
+      return ghost.upsertFile('/actions', location, content, { syncDbToDisk: true })
     }
 
     if (type === 'hook') {
-      return ghost.upsertFile(`/hooks/${hookType}`, location.replace(hookType, ''), content, true, true)
+      return ghost.upsertFile(`/hooks/${hookType}`, location.replace(hookType, ''), content, { syncDbToDisk: true })
     }
 
     if (type === 'bot_config' || type === 'global_config' || type === 'module_config') {

--- a/modules/nlu/src/backend/storage.ts
+++ b/modules/nlu/src/backend/storage.ts
@@ -263,7 +263,7 @@ export default class Storage {
     const modelName = `${model.meta.context}__${model.meta.created_on}__${model.meta.hash}__${model.meta.type}.bin`
     const modelDir = `${this.modelsDir}/${lang}`
 
-    return this.botGhost.upsertFile(modelDir, modelName, model.model)
+    return this.botGhost.upsertFile(modelDir, modelName, model.model, { ignoreLock: true })
   }
 
   private async _cleanupModels(lang: string): Promise<void> {

--- a/src/bp/core/config/config-loader.ts
+++ b/src/bp/core/config/config-loader.ts
@@ -60,14 +60,14 @@ export class ConfigProvider {
     return this.getConfig<BotConfig>('bot.config.json', botId)
   }
 
-  async setBotConfig(botId: string, config: BotConfig) {
-    await this.ghostService.forBot(botId).upsertFile('/', 'bot.config.json', stringify(config))
+  async setBotConfig(botId: string, config: BotConfig, ignoreLock?: boolean) {
+    await this.ghostService.forBot(botId).upsertFile('/', 'bot.config.json', stringify(config), { ignoreLock })
   }
 
-  async mergeBotConfig(botId: string, partialConfig: PartialDeep<BotConfig>): Promise<BotConfig> {
+  async mergeBotConfig(botId: string, partialConfig: PartialDeep<BotConfig>, ignoreLock?: boolean): Promise<BotConfig> {
     const originalConfig = await this.getBotConfig(botId)
     const config = _.merge(originalConfig, partialConfig)
-    await this.setBotConfig(botId, config)
+    await this.setBotConfig(botId, config, ignoreLock)
     return config
   }
 

--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -269,7 +269,9 @@ export class BotService {
         if (await this.botExists(botId)) {
           await this.unmountBot(botId)
         }
-        await this.configProvider.mergeBotConfig(botId, newConfigs)
+
+        await this.configProvider.mergeBotConfig(botId, newConfigs, true)
+
         await this.workspaceService.addBotRef(botId, workspaceId)
 
         await this._migrateBotContent(botId)

--- a/src/bp/core/services/migration/index.ts
+++ b/src/bp/core/services/migration/index.ts
@@ -156,7 +156,7 @@ export class MigrationService {
 
     const botIds = (await this.ghostService.bots().directoryListing('/', 'bot.config.json')).map(path.dirname)
     for (const botId of botIds) {
-      await this.configProvider.mergeBotConfig(botId, { version: this.currentVersion })
+      await this.configProvider.mergeBotConfig(botId, { version: this.currentVersion }, true)
     }
   }
 

--- a/src/bp/core/services/module/resources-loader.ts
+++ b/src/bp/core/services/module/resources-loader.ts
@@ -202,7 +202,7 @@ export class ModuleResourceLoader {
       if (isNewFile || (ressourceHasChanged && !fileHasBeenManuallyUpdated)) {
         debug('adding missing file "%s"', file)
         const contentWithHash = await this._getRessourceContentWithHash(from)
-        await this.ghost.global().upsertFile('/', to, contentWithHash, false)
+        await this.ghost.global().upsertFile('/', to, contentWithHash, { recordRevision: false })
       } else if (fileHasBeenManuallyUpdated) {
         debug('not copying file "%s" because it has been changed manually', file)
       } else {

--- a/src/bp/migrations/v12_1_3-1567534454-bots_error_handling_flow.ts
+++ b/src/bp/migrations/v12_1_3-1567534454-bots_error_handling_flow.ts
@@ -63,16 +63,18 @@ const migration: Migration = {
         )
       }
 
-      await bpfs.upsertFile(FLOW_DIR, ERROR_FLOW, JSON.stringify(errorFlow, undefined, 2))
-      await bpfs.upsertFile(FLOW_DIR, ERROR_UI, JSON.stringify(errorFlowUi, undefined, 2))
-
       const botConfig = await configProvider.getBotConfig(botId)
-      const existingElements = await bpfs.readFileAsObject<any[]>(ELEMENTS_DIR, TEXT_ELEMENTS)
+      const hasTextElements = await bpfs.fileExists(ELEMENTS_DIR, TEXT_ELEMENTS)
+      const existingElements = hasTextElements ? await bpfs.readFileAsObject<any[]>(ELEMENTS_DIR, TEXT_ELEMENTS) : []
+
+      await bpfs.upsertFile(FLOW_DIR, ERROR_FLOW, JSON.stringify(errorFlow, undefined, 2), { ignoreLock: true })
+      await bpfs.upsertFile(FLOW_DIR, ERROR_UI, JSON.stringify(errorFlowUi, undefined, 2), { ignoreLock: true })
 
       await bpfs.upsertFile(
         ELEMENTS_DIR,
         TEXT_ELEMENTS,
-        JSON.stringify([...existingElements, getErrorElement(botConfig.defaultLanguage)], undefined, 2)
+        JSON.stringify([...existingElements, getErrorElement(botConfig.defaultLanguage)], undefined, 2),
+        { ignoreLock: true }
       )
     }
 

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -708,22 +708,23 @@ declare module 'botpress/sdk' {
     redirectUrl?: string
   }
 
+  export interface UpsertOptions {
+    /** Whether or not to record a revision @default true */
+    recordRevision?: boolean
+    /** When enabled, files changed on the database are synced locally so they can be used locally (eg: require in actions) @default false */
+    syncDbToDisk?: boolean
+    /** This is only applicable for bot-scoped ghost. When true, the lock status of the bot is ignored. @default false */
+    ignoreLock?: boolean
+  }
+
   export interface ScopedGhostService {
     /**
      * Insert or Update the file at the specified location
      * @param rootFolder - Folder relative to the scoped parent
      * @param file - The name of the file
      * @param content - The content of the file
-     * @param recordRevision - Whether or not to record a revision @default true
-     * @param syncDbToDisk - When enabled, files changed on the database are synced locally so they can be used locally (eg: require in actions) @default false
      */
-    upsertFile(
-      rootFolder: string,
-      file: string,
-      content: string | Buffer,
-      recordRevision?: boolean,
-      syncDbToDisk?: boolean
-    ): Promise<void>
+    upsertFile(rootFolder: string, file: string, content: string | Buffer, options?: UpsertOptions): Promise<void>
     readFileAsBuffer(rootFolder: string, file: string): Promise<Buffer>
     readFileAsString(rootFolder: string, file: string): Promise<string>
     readFileAsObject<T>(rootFolder: string, file: string): Promise<T>


### PR DESCRIPTION
- Added flag to allow some way to update bots when locked (eg: migration, import)
- Fix small issue with migration when the bot doesn't have any text element