### PR TITLE
fix(examples) custom-module: Compilation error

### DIFF
--- a/examples/module-templates/basic-module/src/views/full/index.tsx
+++ b/examples/module-templates/basic-module/src/views/full/index.tsx
@@ -66,7 +66,7 @@ export default class MyMainView extends React.Component {
     return (
       <Container>
         <SidePanel>
-          <SearchBar onChange={this.handleSearchChanged} onClick={this.handleSearchClicked} />
+          <SearchBar onChange={this.handleSearchChanged} onButtonClick={this.handleSearchClicked} />
           <SidePanelSection label={'My Files'} actions={actions}>
             <ItemList items={items} onElementClicked={this.handleItemSelected} />
             Some other stuff here <InfoTooltip text="Hello! Some info" />


### PR DESCRIPTION
This fixes a compilation error when running `yarn build` on the `basic-module` example:

```shell
➜ yarn build
yarn run v1.17.3
$ ./node_modules/.bin/module-builder build
[module-builder] Generated backend (1607 ms)
[module-builder] Build completed
[module-builder] Child
       4 modules

    ERROR in /Users/spg/botpress/modules/basic-module/src/views/full/index.tsx
    ./src/views/full/index.tsx
    [tsl] ERROR in /Users/spg/botpress/modules/basic-module/src/views/full/index.tsx(69,12)
          TS2322: Type '{ onChange: (value: any) => void; onClick: () => void; }' is not assignable to type 'IntrinsicAttributes & SearchBarProps'.
      Property 'onClick' does not exist on type 'IntrinsicAttributes & SearchBarProps'.
Child
       3 modules
error Command failed with exit code 1.
```