### PR TITLE
fix(perms): modules were always displayed

### DIFF
--- a/src/bp/core/routers/bots/index.ts
+++ b/src/bp/core/routers/bots/index.ts
@@ -190,6 +190,7 @@ export class BotsRouter extends CustomRouter {
         }
 
         const config = await this.configProvider.getBotpressConfig()
+        const workspaceId = await this.workspaceService.getBotWorkspaceId(botId)
 
         const data = this.studioParams(botId)
         const liteEnv = `
@@ -217,6 +218,7 @@ export class BotsRouter extends CustomRouter {
               window.APP_NAME = "${data.botpress.name}";
               window.SHOW_POWERED_BY = ${!!config.showPoweredBy};
               window.BOT_LOCKED = ${!!bot.locked};
+              window.WORKSPACE_ID = "${workspaceId}";
               window.SOCKET_TRANSPORTS = ["${getSocketTransports(config).join('","')}"];
               ${app === 'studio' ? studioEnv : ''}
               ${app === 'lite' ? liteEnv : ''}

--- a/src/bp/ui-studio/src/web/index.jsx
+++ b/src/bp/ui-studio/src/web/index.jsx
@@ -34,6 +34,7 @@ require('./theme.scss')
 const token = getToken()
 if (token) {
   axios.defaults.headers.common['Authorization'] = `Bearer ${token.token}`
+  axios.defaults.headers.common['X-BP-Workspace'] = window.WORKSPACE_ID
 }
 
 // Do not use "import App from ..." as hoisting will screw up styling

--- a/src/bp/ui-studio/src/web/typings.d.ts
+++ b/src/bp/ui-studio/src/web/typings.d.ts
@@ -17,6 +17,8 @@ declare global {
     BOT_ID: string
     BP_BASE_PATH: string
     SEND_USAGE_STATS: boolean
+    BOT_LOCKED: boolean
+    WORKSPACE_ID: string
     BOTPRESS_FLOW_EDITOR_DISABLED: boolean
     SOCKET_TRANSPORTS: string[]
     ANALYTICS_ID: string


### PR DESCRIPTION
Front-end issue, modules were always displayed even if they had no access. Workspace id was missing in the studio, so it could not fetch permissions.