### PR TITLE
feat(config): prompt server reboot when configuration is updated

### DIFF
--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -289,6 +289,10 @@ export class Botpress {
 
     await this.loggerFilePersister.initialize(this.config!, await this.loggerProvider('LogFilePersister'))
 
+    this.configProvider.onBotpressConfigChanged = async (initialHash: string, newHash: string) => {
+      this.realtimeService.sendToSocket({ eventName: 'config.updated', payload: { initialHash, newHash } })
+    }
+
     await this.authService.initialize()
     await this.workspaceService.initialize()
     await this.cmsService.initialize()

--- a/src/bp/core/misc/utils.ts
+++ b/src/bp/core/misc/utils.ts
@@ -1,4 +1,5 @@
 import { Logger } from 'botpress/sdk'
+import crypto from 'crypto'
 import globrex from 'globrex'
 import _ from 'lodash'
 
@@ -101,3 +102,9 @@ export function filterByGlobs<T>(array: T[], iteratee: (value: T) => string, glo
 
   return array.filter(x => _.every(rules, rule => !rule.regex.test(iteratee(x))))
 }
+
+export const calculateHash = (content: string) =>
+  crypto
+    .createHash('sha256')
+    .update(content)
+    .digest('hex')

--- a/src/bp/core/routers/admin/server.ts
+++ b/src/bp/core/routers/admin/server.ts
@@ -91,6 +91,16 @@ export class ServerRouter extends CustomRouter {
     )
 
     router.get(
+      '/configHash',
+      this.asyncMiddleware(async (req, res) => {
+        res.send({
+          initialHash: this.configProvider.initialConfigHash,
+          currentHash: this.configProvider.currentConfigHash
+        })
+      })
+    )
+
+    router.get(
       '/debug',
       this.asyncMiddleware(async (req, res) => {
         res.send(getDebugScopes())

--- a/src/bp/ui-studio/src/web/components/Layout/StatusBar/ConfigStatus.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/StatusBar/ConfigStatus.tsx
@@ -1,0 +1,103 @@
+import { Button, Classes, Dialog, Icon, Intent } from '@blueprintjs/core'
+import axios from 'axios'
+import React, { Fragment, useEffect, useState } from 'react'
+import { toastFailure } from '~/components/Shared/Utils'
+import EventBus from '~/util/EventBus'
+
+import ActionItem from './ActionItem'
+import style from './StatusBar.styl'
+
+const adminUrl = `${window['ROOT_PATH']}${window['API_PATH']}/admin/server/`
+
+const ConfigStatus = () => {
+  const [isDifferent, setDifferent] = useState(false)
+  const [isRestarting, setRestart] = useState(false)
+  const [isOpen, setOpen] = useState(false)
+
+  useEffect(() => {
+    // tslint:disable-next-line: no-floating-promises
+    fetchHash()
+
+    const configUpdated = event => setDifferent(event.initialHash !== event.newHash)
+
+    EventBus.default.on('config.updated', configUpdated)
+    return () => EventBus.default.off('config.updated', configUpdated)
+  }, [])
+
+  useEffect(() => {
+    if (!isRestarting) {
+      return
+    }
+
+    const interval = setInterval(async () => {
+      try {
+        await axios.get('/status', { timeout: 500 })
+        window.location.reload()
+      } catch (err) {} // silent catch intended
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [isRestarting])
+
+  const fetchHash = async () => {
+    try {
+      const { data } = await axios.get(`${adminUrl}/configHash`)
+      if (data.initialHash && data.currentHash && data.initialHash !== data.currentHash) {
+        setDifferent(true)
+      }
+    } catch (err) {
+      toastFailure(err.message)
+    }
+  }
+
+  const restartServer = async () => {
+    try {
+      await axios.post(`${adminUrl}/rebootServer`)
+      setRestart(true)
+    } catch (err) {
+      toastFailure(err.message)
+    }
+  }
+
+  return (
+    <Fragment>
+      <ActionItem
+        id="statusbar_configstatus"
+        title="Config Status"
+        description="Pending changes"
+        className={style.right}
+        onClick={() => setOpen(true)}
+      >
+        {isDifferent && <Icon icon="cog" intent={Intent.WARNING} />}
+      </ActionItem>
+
+      <Dialog isOpen={isOpen} onClose={() => setOpen(false)} transitionDuration={0} title={'Configuration Status'}>
+        <div className={Classes.DIALOG_BODY}>
+          {!isRestarting ? (
+            <div>
+              Changes were made to the main Botpress configuration file. <br />
+              The server must be restarted for all changes to take effect.
+            </div>
+          ) : (
+            <div>
+              Server restart in progress... <br />
+              Page will reload automatically.
+            </div>
+          )}
+        </div>
+        <div className={Classes.DIALOG_FOOTER}>
+          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+            <Button
+              id="btn-restart"
+              text={isRestarting ? 'Please wait...' : 'Restart server now'}
+              disabled={isRestarting}
+              onClick={restartServer}
+              intent={Intent.PRIMARY}
+            />
+          </div>
+        </div>
+      </Dialog>
+    </Fragment>
+  )
+}
+
+export default ConfigStatus

--- a/src/bp/ui-studio/src/web/components/Layout/StatusBar/ConfigStatus.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/StatusBar/ConfigStatus.tsx
@@ -30,10 +30,7 @@ const ConfigStatus = () => {
     }
 
     const interval = setInterval(async () => {
-      try {
-        await axios.get('/status', { timeout: 500 })
-        window.location.reload()
-      } catch (err) {} // silent catch intended
+      await axios.get('/status', { timeout: 500 }).then(window.location.reload)
     }, 1000)
     return () => clearInterval(interval)
   }, [isRestarting])

--- a/src/bp/ui-studio/src/web/components/Layout/StatusBar/ConfigStatus.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/StatusBar/ConfigStatus.tsx
@@ -1,4 +1,4 @@
-import { Button, Classes, Dialog, Icon, Intent } from '@blueprintjs/core'
+import { Button, Classes, Colors, Dialog, Icon, Intent } from '@blueprintjs/core'
 import axios from 'axios'
 import React, { Fragment, useEffect, useState } from 'react'
 import { toastFailure } from '~/components/Shared/Utils'
@@ -67,7 +67,7 @@ const ConfigStatus = () => {
         className={style.right}
         onClick={() => setOpen(true)}
       >
-        {isDifferent && <Icon icon="cog" intent={Intent.WARNING} />}
+        {isDifferent && <Icon icon="cog" style={{ color: Colors.RED5 }} />}
       </ActionItem>
 
       <Dialog isOpen={isOpen} onClose={() => setOpen(false)} transitionDuration={0} title={'Configuration Outdated'}>

--- a/src/bp/ui-studio/src/web/components/Layout/StatusBar/ConfigStatus.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/StatusBar/ConfigStatus.tsx
@@ -70,18 +70,15 @@ const ConfigStatus = () => {
         {isDifferent && <Icon icon="cog" intent={Intent.WARNING} />}
       </ActionItem>
 
-      <Dialog isOpen={isOpen} onClose={() => setOpen(false)} transitionDuration={0} title={'Configuration Status'}>
+      <Dialog isOpen={isOpen} onClose={() => setOpen(false)} transitionDuration={0} title={'Configuration Outdated'}>
         <div className={Classes.DIALOG_BODY}>
           {!isRestarting ? (
             <div>
               Changes were made to the main Botpress configuration file. <br />
-              The server must be restarted for all changes to take effect.
+              It is recommended to restart the server so they can take effect.
             </div>
           ) : (
-            <div>
-              Server restart in progress... <br />
-              Page will reload automatically.
-            </div>
+            <div>Server restart in progress, please wait...</div>
           )}
         </div>
         <div className={Classes.DIALOG_FOOTER}>

--- a/src/bp/ui-studio/src/web/components/Layout/StatusBar/index.jsx
+++ b/src/bp/ui-studio/src/web/components/Layout/StatusBar/index.jsx
@@ -18,6 +18,7 @@ import { GoMortarBoard } from 'react-icons/go'
 import NluPerformanceStatus from './NluPerformanceStatus'
 
 import axios from 'axios'
+import ConfigStatus from './ConfigStatus'
 
 const COMPLETED_DURATION = 2000
 
@@ -187,6 +188,7 @@ class StatusBar extends React.Component {
             <strong>v{this.props.botpressVersion}</strong>
           </div>
           <BotSwitcher />
+          {this.props.user && this.props.user.isSuperAdmin && <ConfigStatus />}
           {this.renderDocHints()}
           {this.renderTaskProgress()}
           <LangSwitcher

--- a/src/bp/ui-studio/src/web/components/Shared/Utils/Toaster.tsx
+++ b/src/bp/ui-studio/src/web/components/Shared/Utils/Toaster.tsx
@@ -1,0 +1,24 @@
+import { Intent, Position, Toaster } from '@blueprintjs/core'
+import _ from 'lodash'
+import React from 'react'
+
+export const toastSuccess = message =>
+  Toaster.create({ className: 'recipe-toaster', position: Position.TOP_RIGHT }).show({
+    message,
+    intent: Intent.SUCCESS,
+    timeout: 1000
+  })
+
+export const toastFailure = message =>
+  Toaster.create({ className: 'recipe-toaster', position: Position.TOP_RIGHT }).show({
+    message,
+    intent: Intent.DANGER,
+    timeout: 3000
+  })
+
+export const toastInfo = message =>
+  Toaster.create({ className: 'recipe-toaster', position: Position.TOP_RIGHT }).show({
+    message,
+    intent: Intent.PRIMARY,
+    timeout: 1000
+  })

--- a/src/bp/ui-studio/src/web/components/Shared/Utils/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Shared/Utils/index.tsx
@@ -1,2 +1,3 @@
 export { default as ElementPreview } from './ElementPreview'
+export { toastSuccess, toastFailure, toastInfo } from './Toaster'
 export { Downloader } from './Downloader'

--- a/src/bp/ui-studio/src/web/components/Shared/Utils/typings.d.ts
+++ b/src/bp/ui-studio/src/web/components/Shared/Utils/typings.d.ts
@@ -4,6 +4,9 @@ import React from 'react'
 declare module 'botpress/utils' {
   export function ElementPreview(props: ElementPreviewProps): JSX.Element
   export function Downloader(props: DownloaderProps): JSX.Element
+  export function toastFailure(message: string): void
+  export function toastSuccess(message: string): void
+  export function toastInfo(message: string): void
 }
 
 export interface DownloaderProps {


### PR DESCRIPTION
With the new cluster mode, we can reboot the server easily without breaking console outputs. When changes are made to the main configuration file, an icon is displayed in the studio, and clicking it allows to restart the serverà quickly. 

Not all changes requires a reboot to take effect, but this should be enough for a first draft.

![image](https://user-images.githubusercontent.com/42552874/64652149-21d99f00-d3f1-11e9-896b-8786ac5d5936.png)
