### PR TITLE
fix(debugger): minor ajustment

### DIFF
--- a/modules/extensions/src/views/lite/components/debugger/views/Entities.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/views/Entities.tsx
@@ -23,6 +23,7 @@ export const Entities: SFC<{ entities: sdk.NLU.Entity[] }> = props => (
               <span>{entity.meta.source}</span>
             </td>
             <td>
+              {/** TODO: remove the unit in the backend when not required  */}
               {entity.data.value}&nbsp;{entity.data.unit !== 'string' && entity.data.unit}
             </td>
           </tr>

--- a/modules/extensions/src/views/lite/components/debugger/views/Entities.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/views/Entities.tsx
@@ -23,7 +23,7 @@ export const Entities: SFC<{ entities: sdk.NLU.Entity[] }> = props => (
               <span>{entity.meta.source}</span>
             </td>
             <td>
-              {entity.data.value}&nbsp;{entity.data.unit}
+              {entity.data.value}&nbsp;{entity.data.unit !== 'string' && entity.data.unit}
             </td>
           </tr>
         ))}

--- a/modules/extensions/src/views/lite/components/debugger/views/NLU.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/views/NLU.tsx
@@ -20,7 +20,7 @@ const NLU: SFC<{ nluData: sdk.IO.EventUnderstanding; session: any }> = ({ nluDat
             position={Position.TOP}
             content={
               <span>
-                Predicted intents are very close. You can account for it checking the{' '}
+                Predicted intents are very close.<br />You can account for it checking the{' '}
                 <strong>event.nlu.ambiguous</strong> variable.
               </span>
             }


### PR DESCRIPTION
Hiding the text "string" when a list or a pattern. Also adds new line for ambiguous message (wasn't completely visible)