### PR TITLE
fix(cluster): broadcasting reboot to all nodes

### DIFF
--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -105,6 +105,11 @@ export class Botpress {
     this.logger.info(`Started in ${bootTime}ms`)
   }
 
+  private _killServer(message: string) {
+    this.logger.error(message)
+    process.exit()
+  }
+
   private async initialize(options: StartOptions) {
     this.config = await this.configProvider.getBotpressConfig()
 
@@ -162,7 +167,7 @@ export class Botpress {
     const dbType = DATABASE_URL && DATABASE_URL.toLowerCase().startsWith('postgres') ? 'postgres' : 'sqlite'
 
     if (!process.IS_PRO_ENABLED && process.CLUSTER_ENABLED) {
-      this.logger.warn(
+      this._killServer(
         'Redis is enabled in your Botpress configuration. To use Botpress in a cluster, please upgrade to Botpress Pro.'
       )
     }
@@ -170,7 +175,7 @@ export class Botpress {
     if (!process.IS_PRO_ENABLED) {
       const workspaces = await this.workspaceService.getWorkspaces()
       if (workspaces.length > 1) {
-        throw new Error(
+        this._killServer(
           'You have more than one workspace. To create unlimited workspaces, please upgrade to Botpress Pro.'
         )
       }
@@ -179,7 +184,7 @@ export class Botpress {
         for (const workspace of workspaces) {
           const pipeline = await this.workspaceService.getPipeline(workspace.id)
           if (pipeline && pipeline.length > 1) {
-            throw new Error(
+            this._killServer(
               'Your pipeline has more than a single stage. To enable the pipeline feature, please upgrade to Botpress Pro.'
             )
           }
@@ -190,7 +195,7 @@ export class Botpress {
     const bots = await this.botService.getBots()
     bots.forEach(bot => {
       if (!process.IS_PRO_ENABLED && bot.languages && bot.languages.length > 1) {
-        throw new Error(
+        this._killServer(
           'A bot has more than a single language. To enable the multilangual feature, please upgrade to Botpress Pro.'
         )
       }
@@ -201,12 +206,12 @@ export class Botpress {
       )
     }
     if (process.IS_PRO_ENABLED && dbType !== 'postgres' && process.CLUSTER_ENABLED) {
-      throw new Error(
+      this._killServer(
         'Postgres is required to use Botpress in a cluster. Please migrate your database to Postgres and enable it in your Botpress configuration file.'
       )
     }
     if (process.CLUSTER_ENABLED && !process.env.REDIS_URL) {
-      throw new Error('The environment variable REDIS_URL is required when cluster is enabled')
+      this._killServer('The environment variable REDIS_URL is required when cluster is enabled')
     }
   }
 

--- a/src/bp/core/routers/admin/index.ts
+++ b/src/bp/core/routers/admin/index.ts
@@ -7,6 +7,7 @@ import { GhostService } from 'core/services'
 import { AlertingService } from 'core/services/alerting-service'
 import AuthService, { TOKEN_AUDIENCE } from 'core/services/auth/auth-service'
 import { BotService } from 'core/services/bot-service'
+import { JobService } from 'core/services/job-service'
 import { MonitoringService } from 'core/services/monitoring'
 import { WorkspaceService } from 'core/services/workspace-service'
 import { RequestHandler, Router } from 'express'
@@ -44,7 +45,8 @@ export class AdminRouter extends CustomRouter {
     configProvider: ConfigProvider,
     monitoringService: MonitoringService,
     alertingService: AlertingService,
-    moduleLoader: ModuleLoader
+    moduleLoader: ModuleLoader,
+    jobService: JobService
   ) {
     super('Admin', logger, Router({ mergeParams: true }))
     this.checkTokenHeader = checkTokenHeader(this.authService, TOKEN_AUDIENCE)
@@ -53,7 +55,14 @@ export class AdminRouter extends CustomRouter {
     this.licenseRouter = new LicenseRouter(logger, this.licenseService, configProvider)
     this.versioningRouter = new VersioningRouter(logger, this.ghostService, this.botService)
     this.rolesRouter = new RolesRouter(logger, this.workspaceService)
-    this.serverRouter = new ServerRouter(logger, monitoringService, alertingService, configProvider, ghostService)
+    this.serverRouter = new ServerRouter(
+      logger,
+      monitoringService,
+      alertingService,
+      configProvider,
+      ghostService,
+      jobService
+    )
     this.languagesRouter = new LanguagesRouter(logger, moduleLoader, this.workspaceService)
     this.loadUser = loadUser(this.authService)
 

--- a/src/bp/core/routers/admin/server.ts
+++ b/src/bp/core/routers/admin/server.ts
@@ -1,8 +1,8 @@
 import { Logger } from 'botpress/sdk'
-import { spawn } from 'child_process'
 import { ConfigProvider } from 'core/config/config-loader'
 import { GhostService } from 'core/services'
 import { AlertingService } from 'core/services/alerting-service'
+import { JobService } from 'core/services/job-service'
 import { MonitoringService } from 'core/services/monitoring'
 import { Router } from 'express'
 import _ from 'lodash'
@@ -11,18 +11,22 @@ import { getDebugScopes, setDebugScopes } from '../../../debug'
 import { CustomRouter } from '../customRouter'
 
 export class ServerRouter extends CustomRouter {
+  private _rebootServer!: Function
+
   constructor(
     private logger: Logger,
     private monitoringService: MonitoringService,
     private alertingService: AlertingService,
     private configProvider: ConfigProvider,
-    private ghostService: GhostService
+    private ghostService: GhostService,
+    private jobService: JobService
   ) {
     super('Server', logger, Router({ mergeParams: true }))
+    // tslint:disable-next-line: no-floating-promises
     this.setupRoutes()
   }
 
-  setupRoutes() {
+  async setupRoutes() {
     const router = this.router
 
     router.post(
@@ -84,9 +88,8 @@ export class ServerRouter extends CustomRouter {
 
         this.logger.info(`User ${user} requested a server reboot`)
 
+        await this._rebootServer()
         res.sendStatus(200)
-
-        process.send && process.send({ type: 'reboot_server' })
       })
     )
 
@@ -122,5 +125,11 @@ export class ServerRouter extends CustomRouter {
         res.sendStatus(200)
       })
     )
+
+    this._rebootServer = await this.jobService.broadcast<void>(this.__local_rebootServer.bind(this))
+  }
+
+  private __local_rebootServer() {
+    process.send && process.send({ type: 'reboot_server' })
   }
 }

--- a/src/bp/core/server.ts
+++ b/src/bp/core/server.ts
@@ -44,6 +44,7 @@ import { ConverseService } from './services/converse'
 import { FlowService } from './services/dialog/flow/service'
 import { SkillService } from './services/dialog/skill/service'
 import { HintsService } from './services/hints'
+import { JobService } from './services/job-service'
 import { LogsService } from './services/logs/service'
 import MediaService from './services/media'
 import { MonitoringService } from './services/monitoring'
@@ -110,7 +111,8 @@ export default class HTTPServer {
     @inject(TYPES.BotService) private botService: BotService,
     @inject(TYPES.AuthStrategies) private authStrategies: AuthStrategies,
     @inject(TYPES.MonitoringService) private monitoringService: MonitoringService,
-    @inject(TYPES.AlertingService) private alertingService: AlertingService
+    @inject(TYPES.AlertingService) private alertingService: AlertingService,
+    @inject(TYPES.JobService) private jobService: JobService
   ) {
     this.app = express()
 
@@ -149,7 +151,8 @@ export default class HTTPServer {
       this.configProvider,
       this.monitoringService,
       this.alertingService,
-      moduleLoader
+      moduleLoader,
+      this.jobService
     )
     this.shortlinksRouter = new ShortLinksRouter(this.logger)
     this.botsRouter = new BotsRouter({

--- a/src/bp/ui-studio/src/web/components/Layout/StatusBar/ConfigStatus.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/StatusBar/ConfigStatus.tsx
@@ -7,7 +7,7 @@ import EventBus from '~/util/EventBus'
 import ActionItem from './ActionItem'
 import style from './StatusBar.styl'
 
-const adminUrl = `${window['ROOT_PATH']}${window['API_PATH']}/admin/server/`
+const adminUrl = `${window['ROOT_PATH']}${window['API_PATH']}/admin/server`
 
 const ConfigStatus = () => {
   const [isDifferent, setDifferent] = useState(false)

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -101,6 +101,12 @@ declare type BotpressEnvironementVariables = {
    * @default false
    */
   readonly BP_DISABLE_AUTO_RESTART?: boolean
+
+  /**
+   * Define the maximum number of time the server will be automatically restarted.
+   * @default 5
+   */
+  readonly BP_MAX_SERVER_REBOOT?: number
 }
 
 interface IDebug {


### PR DESCRIPTION
Forgot to broadcast the server reboot to all connected nodes. 

This isn't the best behavior, actually we should reboot servers one at a time, but that logic is not there right now