### PR TITLE
fix(config): clear hash on first start & ignore dynamic props

### DIFF
--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -150,7 +150,7 @@ export class Botpress {
     let appSecret = this.config.appSecret || this.config.jwtSecret
     if (!appSecret) {
       appSecret = nanoid(40)
-      await this.configProvider.mergeBotpressConfig({ appSecret })
+      await this.configProvider.mergeBotpressConfig({ appSecret }, true)
       this.logger.debug(`JWT Secret isn't defined. Generating a random key...`)
     }
 


### PR DESCRIPTION
Small change to avoid displaying "pending changes" after the first server start. Some properties are dynamic (eg: super admins) and doesn't require a restart.