### PR TITLE
fix(nlu): prevent training on not supported languages

### DIFF
--- a/modules/nlu/src/backend/language-provider.ts
+++ b/modules/nlu/src/backend/language-provider.ts
@@ -40,6 +40,10 @@ export class RemoteLanguageProvider implements LanguageProvider {
 
   private langs: LangsGateway = {}
 
+  get languages(): string[] {
+    return Object.keys(this.langs)
+  }
+
   private addProvider(lang: string, source: LanguageSource, client: AxiosInstance) {
     this.langs[lang] = [...(this.langs[lang] || []), { source, client, errors: 0, disabledUntil: undefined }]
     debug(`[${lang.toUpperCase()}] Language Provider added %o`, source)

--- a/modules/nlu/src/backend/typings.ts
+++ b/modules/nlu/src/backend/typings.ts
@@ -100,6 +100,7 @@ export interface NLUStructure {
   intents: sdk.NLU.Intent[]
   intent: sdk.NLU.Intent
   tokens: Token[]
+  errored: boolean
 }
 
 export type Token2Vec = { [token: string]: number[] }
@@ -116,6 +117,7 @@ export interface LangsGateway {
 }
 
 export interface LanguageProvider {
+  languages: string[]
   vectorize(tokens: string[], lang: string): Promise<Float32Array[]>
   tokenize(utterances: string[], lang: string): Promise<string[][]>
   generateSimilarJunkWords(subsetVocab: string[], lang: string): Promise<string[]>

--- a/src/bp/core/routers/admin/languages.ts
+++ b/src/bp/core/routers/admin/languages.ts
@@ -150,12 +150,12 @@ export class LanguagesRouter extends CustomRouter {
           const { data } = await client.get('/languages')
 
           const languages = [
-            ...(await this.getExtraLangs()),
             ...data.installed
               .filter(x => x.loaded)
               .map(x => ({
                 ...data.available.find(l => l.code === x.lang)
-              }))
+              })),
+            ...(await this.getExtraLangs())
           ]
 
           res.send({ languages })

--- a/src/bp/core/routers/admin/users.ts
+++ b/src/bp/core/routers/admin/users.ts
@@ -17,7 +17,7 @@ import {
 } from '../util'
 
 export class UsersRouter extends CustomRouter {
-  private readonly resource = 'admin.users'
+  private readonly resource = 'admin.collaborators'
   private needPermissions: (operation: string, resource: string) => RequestHandler
   private assertBotpressPro: RequestHandler
 


### PR DESCRIPTION
I also took the time to fix the predict retry logic i.e return partially populated nlu data structure if extraction fails in any of the predict pipeline steps.