### PR TITLE
fix(docs) Broken links

### DIFF
--- a/docs/guide/docs/main/module.md
+++ b/docs/guide/docs/main/module.md
@@ -34,4 +34,4 @@ Modules are already bundled with the server binary for the moment. They are bund
 
 ## Custom Modules
 
-Learn how to create custom modules [here](../../../advanced/custom-module).
+Learn how to create custom modules [here](../../advanced/custom-module).

--- a/docs/guide/website/versioned_docs/version-12.1.4/main/module.md
+++ b/docs/guide/website/versioned_docs/version-12.1.4/main/module.md
@@ -35,4 +35,4 @@ Modules are already bundled with the server binary for the moment. They are bund
 
 ## Custom Modules
 
-Learn how to create custom modules [here](../../../advanced/custom-module).
+Learn how to create custom modules [here](../../advanced/custom-module).


### PR DESCRIPTION
Same fix as https://github.com/botpress/botpress/pull/2399 but targeting `master` instead of `patch/12-1-5`

This will fix the failing build in `master`