### PR TITLE
fix(channel-web): fix for intermittent issue with emulator

### DIFF
--- a/src/bp/ui-studio/src/web/lite.jsx
+++ b/src/bp/ui-studio/src/web/lite.jsx
@@ -30,6 +30,10 @@ class LiteView extends React.Component {
   }
 
   render() {
+    if (!this.props.modules || !this.props.modules.length) {
+      return null
+    }
+
     const modules = moduleViewNames(this.props.modules, 'plugin')
     const onNotFound = () => (
       <h1>


### PR DESCRIPTION
Fixes an intermittent issue (observed only on firefox, but may affect others).

The view was rendered twice (at first mount + when modules were received), which forced channel-web to load twice. The mobx store can only be initialized once.