### PR TITLE
fix(event): added some checks for parameters

### DIFF
--- a/modules/extensions/src/views/lite/components/debugger/index.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/index.tsx
@@ -10,10 +10,9 @@ import { MdBugReport } from 'react-icons/md'
 import Settings from './settings'
 import style from './style.scss'
 import { loadSettings } from './utils'
-import Dialog from './views/Dialog'
 import { Error } from './views/Error'
 import { Inspector } from './views/Inspector'
-import NLU from './views/NLU'
+import Summary from './views/Summary'
 import EventNotFound from './EventNotFound'
 import FetchingEvent from './FetchingEvent'
 import Header from './Header'
@@ -178,19 +177,6 @@ export class Debugger extends React.Component<Props, State> {
   toggleSettings = e => this.setState({ showSettings: !this.state.showSettings })
   handleTabChange = selectedTabId => this.setState({ selectedTabId })
 
-  renderSummary() {
-    return (
-      <div>
-        <Dialog
-          suggestions={this.state.event.suggestions}
-          decision={this.state.event.decision}
-          stacktrace={this.state.event.state.__stacktrace}
-        />
-        <NLU session={this.state.event.state.session} nluData={this.state.event.nlu} />
-      </div>
-    )
-  }
-
   // check rendering
 
   renderWhenNoEvent() {
@@ -204,12 +190,12 @@ export class Debugger extends React.Component<Props, State> {
   }
 
   renderEvent() {
-    const eventError = this.state.event.state['__error']
+    const eventError = _.get(this.state, 'event.state.__error')
 
     return (
       <div className={style.content}>
         <Tabs id="tabs" onChange={this.handleTabChange} selectedTabId={this.state.selectedTabId}>
-          <Tab id="basic" title="Summary" panel={this.renderSummary()} />
+          <Tab id="basic" title="Summary" panel={<Summary event={this.state.event} />} />
           <Tab id="advanced" title="Raw JSON" panel={<Inspector data={this.state.event} />} />
           {eventError && (
             <Tab

--- a/modules/extensions/src/views/lite/components/debugger/views/NLU.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/views/NLU.tsx
@@ -11,6 +11,10 @@ import { Language } from './Language'
 import { Slots } from './Slots'
 
 const NLU: SFC<{ nluData: sdk.IO.EventUnderstanding; session: any }> = ({ nluData, session }) => {
+  if (!nluData) {
+    return null
+  }
+
   return (
     <div className={style.block}>
       <div className={style.title}>

--- a/modules/extensions/src/views/lite/components/debugger/views/Summary.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/views/Summary.tsx
@@ -1,0 +1,42 @@
+import sdk from 'botpress/sdk'
+import React from 'react'
+
+import Dialog from './Dialog'
+import NLU from './NLU'
+
+interface Props {
+  event: sdk.IO.IncomingEvent
+}
+
+export default class Summary extends React.Component<Props> {
+  state = {
+    hasError: false
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.event !== this.props.event) {
+      this.setState({ hasError: false })
+    }
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div>Cannot display event summary</div>
+    }
+
+    return (
+      <div>
+        <Dialog
+          suggestions={this.props.event.suggestions}
+          decision={this.props.event.decision}
+          stacktrace={this.props.event.state.__stacktrace}
+        />
+        <NLU session={this.props.event.state.session} nluData={this.props.event.nlu} />
+      </div>
+    )
+  }
+}

--- a/src/bp/core/services/middleware/event-collector.ts
+++ b/src/bp/core/services/middleware/event-collector.ts
@@ -54,6 +54,10 @@ export class EventCollector {
       return
     }
 
+    if (!event.botId || !event.channel || !event.direction) {
+      throw new Error(`Can't store event missing required fields (botId, channel, direction)`)
+    }
+
     const { id, botId, channel, threadId, target, direction } = event
 
     const incomingEventId = (event as sdk.IO.OutgoingEvent).incomingEventId


### PR DESCRIPTION
I was playing around with events, setting various properties undefined using actions. Managed to bug the event collector, and break the debugger when it tried to load some event with missing properties.

![image](https://user-images.githubusercontent.com/42552874/65377625-c3c47b80-dc7c-11e9-8f3c-30e7aea1f2ee.png)

The debugger will show this instead of crashing completely: 
![image](https://user-images.githubusercontent.com/42552874/65377917-63830900-dc7f-11e9-9c46-d8d749402ed3.png)
