### PR TITLE
fix(core): debug logs are not saved to file output

### DIFF
--- a/src/bp/bootstrap.ts
+++ b/src/bp/bootstrap.ts
@@ -35,7 +35,7 @@ async function getLogger(loggerName: string) {
 }
 
 async function setupDebugLogger() {
-  const logger = await Logger('Debug')
+  const logger = await Logger('')
 
   global.printBotLog = (botId, args) => {
     const message = args[0]

--- a/src/bp/bootstrap.ts
+++ b/src/bp/bootstrap.ts
@@ -31,6 +31,12 @@ async function getLogger(loggerName: string) {
     logger.attachError(err).error('Unhandled Rejection')
   }
 
+  return logger
+}
+
+async function setupDebugLogger() {
+  const logger = await Logger('Debug')
+
   global.printBotLog = (botId, args) => {
     const message = args[0]
     const rest = args.slice(1)
@@ -42,10 +48,21 @@ async function getLogger(loggerName: string) {
       .debug(message.trim(), rest)
   }
 
-  return logger
+  global.printLog = args => {
+    const message = args[0]
+    const rest = args.slice(1)
+
+    logger
+      .level(sdk.LogLevel.DEBUG)
+      .persist(false)
+      .noEmit() // We don't want to emit global debugs to the studio (ex: audit, configurations)
+      .debug(message.trim(), rest)
+  }
 }
 
 async function start() {
+  await setupDebugLogger()
+
   if (cluster.isMaster) {
     // The master process only needs getos and rewire
     return setupMasterNode(await getLogger('Cluster'))

--- a/src/bp/core/app.inversify.ts
+++ b/src/bp/core/app.inversify.ts
@@ -39,7 +39,7 @@ container.bind<string>(TYPES.Logger_Name).toDynamicValue(ctx => {
     }
   }
 
-  return loggerName || 'Unknown'
+  return loggerName || ''
 })
 
 container.bind<Logger>(TYPES.Logger).to(PersistedConsoleLogger)

--- a/src/bp/debug.ts
+++ b/src/bp/debug.ts
@@ -33,6 +33,6 @@ debug.log = function(...args) {
   if (botId) {
     global.printBotLog(botId, args)
   } else {
-    console.log.call(console, ...args)
+    global.printLog(args)
   }
 }

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -54,6 +54,7 @@ declare module 'botpress/sdk' {
     attachError(error: Error): this
     persist(shouldPersist: boolean): this
     level(level: LogLevel): this
+    noEmit(): this
 
     /**
      * Sets the level that will be required at runtime to

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -11,6 +11,7 @@ declare namespace NodeJS {
     require: ExtraRequire
     rewire: (name: string) => string
     printBotLog(botId: string, args: any[]): void
+    printLog(args: any[]): void
   }
 
   export interface Process {


### PR DESCRIPTION
Global debug logs were only displayed in the console, so there were no traces of them in logs when file persister was being used. (which means, audit trail was not being persisted)

Logs will now go through the logger, and i've added a flag to avoid emitting those events to the studio (we don't want users to see audit or configs in the studio)_