### PR TITLE
fix(ux): prevent click close dialog

### DIFF
--- a/modules/qna/src/views/full/FormModal.tsx
+++ b/modules/qna/src/views/full/FormModal.tsx
@@ -248,12 +248,12 @@ export default class FormModal extends Component<Props> {
 
     return (
       <Dialog
-        isOpen={showQnAModal}
-        onClose={this.closeAndClear}
-        canOutsideClickClose={false}
-        transitionDuration={0}
         title={isEdit ? 'Edit Q&A' : 'Create a new Q&A'}
         icon={isEdit ? 'edit' : 'add'}
+        isOpen={showQnAModal}
+        onClose={this.closeAndClear}
+        transitionDuration={0}
+        canOutsideClickClose={false}
         style={{ width: 700 }}
       >
         <div className={Classes.DIALOG_BODY}>

--- a/modules/qna/src/views/full/ImportModal.tsx
+++ b/modules/qna/src/views/full/ImportModal.tsx
@@ -239,11 +239,12 @@ Either the file is empty, or it doesn't match any known format.`)
       </AccessControl>
 
       <Dialog
+        title={analysis ? 'Analysis' : 'Upload File'}
+        icon="import"
         isOpen={isDialogOpen}
         onClose={closeDialog}
         transitionDuration={0}
-        title={analysis ? 'Analysis' : 'Upload File'}
-        icon="import"
+        canOutsideClickClose={false}
       >
         {showStatus && renderStatus()}
         {!showStatus && (analysis ? renderAnalysis() : renderUpload())}

--- a/src/bp/ui-admin/src/Pages/Server/Versioning/UploadArchive.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/Versioning/UploadArchive.tsx
@@ -168,12 +168,13 @@ const UploadArchive = () => {
       <Button icon="upload" id="btn-uploadArchive" text="Upload archive" onClick={() => setDialogOpen(true)} />
 
       <Dialog
+        title="Upload Archive"
+        icon="import"
         isOpen={isDialogOpen}
         onClose={closeDialog}
         transitionDuration={0}
+        canOutsideClickClose={false}
         style={{ width: changes ? 800 : 500 }}
-        title="Upload Archive"
-        icon="import"
       >
         {!changes ? renderUpload() : renderConflict()}
       </Dialog>

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/CreateBotModal.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/CreateBotModal.tsx
@@ -147,11 +147,12 @@ class CreateBotModal extends Component<Props, State> {
   render() {
     return (
       <Dialog
-        isOpen={this.props.isOpen}
+        title="Create a new bot"
         icon="add"
+        isOpen={this.props.isOpen}
         onClose={this.toggleDialog}
         transitionDuration={0}
-        title="Create a new bot"
+        canOutsideClickClose={false}
       >
         <form ref={form => (this._form = form)}>
           <div className={Classes.DIALOG_BODY}>

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/ImportBotModal.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/ImportBotModal.tsx
@@ -105,11 +105,12 @@ class ImportBotModal extends Component<Props, State> {
   render() {
     return (
       <Dialog
-        isOpen={this.props.isOpen}
+        title="Import bot from archive"
         icon="import"
+        isOpen={this.props.isOpen}
         onClose={this.toggleDialog}
         transitionDuration={0}
-        title="Import bot from archive"
+        canOutsideClickClose={false}
       >
         <form
           ref={form => (this._form = form)}

--- a/src/bp/ui-admin/src/Pages/Workspace/Users/ChangeUserRoleModal.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Users/ChangeUserRoleModal.tsx
@@ -45,10 +45,11 @@ const ChangeUserRoleModal: FC<Props> = props => {
 
   return (
     <Dialog
+      title={<span>Editing role of {props.user.email}</span>}
       isOpen={props.isOpen}
       onClose={props.toggle}
       transitionDuration={0}
-      title={<span>Editing role of {props.user.email}</span>}
+      canOutsideClickClose={false}
     >
       <div className={Classes.DIALOG_BODY}>
         <Select

--- a/src/bp/ui-admin/src/Pages/Workspace/Users/CreateUserModal.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Users/CreateUserModal.tsx
@@ -128,11 +128,12 @@ class CreateUserModal extends Component<Props, State> {
   render() {
     return (
       <Dialog
-        isOpen={this.props.isOpen}
+        title="Add Collaborator"
         icon="add"
+        isOpen={this.props.isOpen}
         onClose={this.props.toggleOpen}
         transitionDuration={0}
-        title={'Add Collaborator'}
+        canOutsideClickClose={false}
       >
         <form ref={form => (this.formEl = form)}>
           <div className={Classes.DIALOG_BODY}>

--- a/src/bp/ui-admin/src/Pages/Workspace/Users/ShowInfoModal.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Users/ShowInfoModal.tsx
@@ -12,7 +12,14 @@ interface Props {
 
 const ShowInfoModal: FC<Props> = props => {
   return (
-    <Dialog isOpen={props.isOpen} icon="info-sign" onClose={props.toggle} transitionDuration={0} title={props.title}>
+    <Dialog
+      title={props.title}
+      icon="info-sign"
+      isOpen={props.isOpen}
+      onClose={props.toggle}
+      transitionDuration={0}
+      canOutsideClickClose={false}
+    >
       <div className={Classes.DIALOG_BODY}>
         <Pre>{props.message}</Pre>
       </div>

--- a/src/bp/ui-studio/src/web/components/Layout/StatusBar/ConfigStatus.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/StatusBar/ConfigStatus.tsx
@@ -70,7 +70,13 @@ const ConfigStatus = () => {
         {isDifferent && <Icon icon="cog" style={{ color: Colors.RED5 }} />}
       </ActionItem>
 
-      <Dialog isOpen={isOpen} onClose={() => setOpen(false)} transitionDuration={0} title={'Configuration Outdated'}>
+      <Dialog
+        title="Configuration Outdated"
+        isOpen={isOpen}
+        onClose={() => setOpen(false)}
+        transitionDuration={0}
+        canOutsideClickClose={false}
+      >
         <div className={Classes.DIALOG_BODY}>
           {!isRestarting ? (
             <div>


### PR DESCRIPTION
Added a property to prevent closing a dialog by clicking outside it (either click on the X or use ESC). 

Also reordered properties 