### PR TITLE
fix(module): enforces bot-scoped config when global is not wanted

### DIFF
--- a/modules/channel-slack/src/backend/index.ts
+++ b/modules/channel-slack/src/backend/index.ts
@@ -21,7 +21,7 @@ const onServerReady = async (bp: typeof sdk) => {
 }
 
 const onBotMount = async (bp: typeof sdk, botId: string) => {
-  const config = (await bp.config.getModuleConfigForBot('channel-slack', botId)) as Config
+  const config = (await bp.config.getModuleConfigForBot('channel-slack', botId, true)) as Config
 
   if (config.enabled) {
     const bot = new SlackClient(bp, botId, config, router)

--- a/modules/channel-teams/src/backend/index.ts
+++ b/modules/channel-teams/src/backend/index.ts
@@ -27,7 +27,7 @@ const onServerReady = async (bp: typeof sdk) => {
 }
 
 const onBotMount = async (bp: typeof sdk, botId: string) => {
-  const config = (await bp.config.getModuleConfigForBot('channel-teams', botId)) as Config
+  const config = (await bp.config.getModuleConfigForBot('channel-teams', botId, true)) as Config
 
   if (config.enabled) {
     const bot = new TeamsClient(bp, botId, config, publicPath)

--- a/modules/channel-telegram/src/backend/index.ts
+++ b/modules/channel-telegram/src/backend/index.ts
@@ -40,7 +40,7 @@ const onServerStarted = async (bp: typeof sdk) => {
 }
 
 const onBotMount = async (bp: typeof sdk, botId: string) => {
-  const config = (await bp.config.getModuleConfigForBot('channel-telegram', botId)) as Config
+  const config = (await bp.config.getModuleConfigForBot('channel-telegram', botId, true)) as Config
 
   if (config.enabled) {
     const bot = new Telegraf(config.botToken)

--- a/src/bp/core/api.ts
+++ b/src/bp/core/api.ts
@@ -93,12 +93,8 @@ const dialog = (dialogEngine: DialogEngine, sessionRepo: SessionRepository): typ
 
 const config = (moduleLoader: ModuleLoader, configProvider: ConfigProvider): typeof sdk.config => {
   return {
-    getModuleConfig(moduleId: string): Promise<any> {
-      return moduleLoader.configReader.getGlobal(moduleId)
-    },
-    getModuleConfigForBot(moduleId: string, botId: string): Promise<any> {
-      return moduleLoader.configReader.getForBot(moduleId, botId)
-    },
+    getModuleConfig: moduleLoader.configReader.getGlobal.bind(moduleLoader.configReader),
+    getModuleConfigForBot: moduleLoader.configReader.getForBot.bind(moduleLoader.configReader),
     getBotpressConfig: configProvider.getBotpressConfig.bind(configProvider),
     mergeBotConfig: configProvider.mergeBotConfig.bind(configProvider)
   }

--- a/src/bp/core/services/module/config-reader.ts
+++ b/src/bp/core/services/module/config-reader.ts
@@ -168,9 +168,13 @@ export default class ConfigReader {
     }
   }
 
-  private async getMerged(moduleId: string, botId?: string): Promise<Config> {
+  private async getMerged(moduleId: string, botId?: string, ignoreGlobal?: boolean): Promise<Config> {
     let config = await this.loadFromDefaultValues(moduleId)
-    config = { ...config, ...(await this.loadFromGlobalConfigFile(moduleId)) }
+
+    if (!ignoreGlobal) {
+      config = { ...config, ...(await this.loadFromGlobalConfigFile(moduleId)) }
+    }
+
     config = { ...config, ...(await this.loadFromEnvVariables(moduleId)) }
     if (botId) {
       config = { ...config, ...(await this.loadFromBotConfigFile(moduleId, botId)) }
@@ -186,7 +190,7 @@ export default class ConfigReader {
 
   // Don't @Memoize() this fn. It only memoizes on the first argument
   // https://github.com/steelsojka/lodash-decorators/blob/master/src/memoize.ts#L15
-  public getForBot(moduleId: string, botId: string): Promise<Config> {
-    return this.getMerged(moduleId, botId)
+  public getForBot(moduleId: string, botId: string, ignoreGlobal?: boolean): Promise<Config> {
+    return this.getMerged(moduleId, botId, ignoreGlobal)
   }
 }

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -1400,8 +1400,9 @@ declare module 'botpress/sdk' {
      * Returns the configuation values for the specified module and bot.
      * @param moduleId
      * @param botId
+     * @param ignoreGlobal Enable this when you want only bot-specific configuration to be possible
      */
-    export function getModuleConfigForBot(moduleId: string, botId: string): Promise<any>
+    export function getModuleConfigForBot(moduleId: string, botId: string, ignoreGlobal?: boolean): Promise<any>
 
     /**
      * Returns the configuration options of Botpress


### PR DESCRIPTION
For channels, we ask users to configure channels at the bot level. This change ignores the global configuration to avoid weird issues (eg: multiple bots registered to a single bot)