### PR TITLE
fix(studio): config status not visible & bp-ui changes

### DIFF
--- a/src/bp/ui-studio/src/web/components/Layout/StatusBar/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/StatusBar/index.tsx
@@ -1,29 +1,45 @@
 import { Icon } from '@blueprintjs/core'
-import style from './StatusBar.styl'
-import React from 'react'
-import _ from 'lodash'
+import axios from 'axios'
 import classNames from 'classnames'
-import { Glyphicon } from 'react-bootstrap'
+import _ from 'lodash'
 import { Line } from 'progressbar.js'
-import EventBus from '~/util/EventBus'
-import { keyMap } from '~/keyboardShortcuts'
+import React from 'react'
+import { Glyphicon } from 'react-bootstrap'
+import { GoMortarBoard } from 'react-icons/go'
 import { connect } from 'react-redux'
 import { updateDocumentationModal } from '~/actions'
-import LangSwitcher from './LangSwitcher'
-import BotSwitcher from './BotSwitcher'
-import ActionItem from './ActionItem'
 import NotificationHub from '~/components/Notifications/Hub'
-import { GoMortarBoard } from 'react-icons/go'
-import NluPerformanceStatus from './NluPerformanceStatus'
-
-import axios from 'axios'
 import { AccessControl } from '~/components/Shared/Utils'
+import { keyMap } from '~/keyboardShortcuts'
+import EventBus from '~/util/EventBus'
+
+import ActionItem from './ActionItem'
+import BotSwitcher from './BotSwitcher'
 import ConfigStatus from './ConfigStatus'
+import LangSwitcher from './LangSwitcher'
+import NluPerformanceStatus from './NluPerformanceStatus'
+import style from './StatusBar.styl'
 
 const COMPLETED_DURATION = 2000
 
-class StatusBar extends React.Component {
-  clearCompletedStyleTimer = undefined
+interface Props {
+  isEmulatorOpen: boolean
+  langSwitcherOpen: boolean
+  contentLang: string
+  docHints: any
+  updateDocumentationModal: any
+  botpressVersion: string
+  user: any
+  onToggleGuidedTour: () => void
+  toggleBottomPanel: () => void
+  onToggleEmulator: () => void
+  toggleLangSwitcher: () => void
+}
+
+class StatusBar extends React.Component<Props> {
+  private progressContainerRef
+  private progressBar: Line
+  private clearCompletedStyleTimer?: number = undefined
 
   state = {
     progress: 0,
@@ -202,6 +218,7 @@ class StatusBar extends React.Component {
 }
 
 const mapStateToProps = state => ({
+  user: state.user,
   botInfo: state.bot,
   docHints: state.ui.docHints,
   contentLang: state.language.contentLang

--- a/src/bp/ui-studio/src/web/components/Shared/Interface/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Shared/Interface/index.tsx
@@ -15,7 +15,6 @@ import classnames from 'classnames'
 import _ from 'lodash'
 import React, { useState } from 'react'
 import { HotKeys } from 'react-hotkeys'
-import { MdHelpOutline, MdInfoOutline } from 'react-icons/md'
 import SplitPane from 'react-split-pane'
 
 import style from './style.scss'
@@ -230,11 +229,7 @@ export const RightToolbarButtons = (props: ToolbarButtonsProps) => {
 }
 
 export const InfoTooltip = (props: InfoTooltipProps) => (
-  <Tooltip content={props.text} position={props.position || Position.RIGHT}>
-    {props.icon === 'help' ? (
-      <MdHelpOutline className={style.infoTooltip} />
-    ) : (
-      <MdInfoOutline className={style.infoTooltip} />
-    )}
+  <Tooltip content={props.text} position={props.position || Position.RIGHT} usePortal={false}>
+    <Icon icon={props.icon || 'info-sign'} iconSize={13} className={style.infoTooltip} />
   </Tooltip>
 )

--- a/src/bp/ui-studio/src/web/components/Shared/Interface/style.scss
+++ b/src/bp/ui-studio/src/web/components/Shared/Interface/style.scss
@@ -1,12 +1,12 @@
-$status-bar-height: 24px;
+$status-bar-height: 30px;
 
 .container {
   position: relative;
-  height: 100%;
+  height: calc(100vh - #{$status-bar-height});
 }
 
 .fullsize {
-  height: 100%;
+  height: calc(100vh - #{$status-bar-height});
 }
 
 .container :global(.Resizer.vertical) {
@@ -107,10 +107,9 @@ $status-bar-height: 24px;
 }
 
 .infoTooltip {
-  font-size: 14px;
-  vertical-align: middle;
   opacity: 0.5;
-  cursor: pointer;
+  cursor: auto;
+
   &:hover {
     opacity: 1;
   }

--- a/src/bp/ui-studio/src/web/components/Shared/Interface/typings.d.ts
+++ b/src/bp/ui-studio/src/web/components/Shared/Interface/typings.d.ts
@@ -70,8 +70,8 @@ export interface SplashScreenProps {
 export interface InfoTooltipProps {
   /** The text displayed when the cursor is over the icon */
   text: string
-  /** The icon to display. By default it will use info */
-  icon?: 'info' | 'help'
+  /** The icon to display. By default it will use 'info-sign' */
+  icon?: IconName | MaybeElement
   /** Where the tooltip will be directed. By default, it's right */
   position?: Position
 }


### PR DESCRIPTION
Removed the user property by mistake, now the config status never displays when botpress config is changed. Converted to TS to avoid in future.

Also made minor changes to botpress-ui 