### PR TITLE
fix(skill-email): fix element rendering & config documentation

### DIFF
--- a/modules/basic-skills/package.json
+++ b/modules/basic-skills/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@babel/helpers": "^7.4.3",
     "@types/node": "^10.11.0",
+    "@types/nodemailer": "^6.2.1",
     "module-builder": "../../build/module-builder"
   },
   "dependencies": {

--- a/modules/basic-skills/src/config.ts
+++ b/modules/basic-skills/src/config.ts
@@ -1,3 +1,5 @@
+import SMTPConnection from 'nodemailer/lib/smtp-connection'
+
 export interface Config {
   /**
    * @default builtin_single-choice
@@ -24,10 +26,14 @@ export interface Config {
    */
   matchNLU: boolean
   /**
-   * Nodemailer2 transport connection string
+   * Nodemailer2 transport connection string.
    * @see https://www.npmjs.com/package/nodemailer2
+   *
+   * Alternatively, you can pass an object with any required parameters
+   * @see https://nodemailer.com/smtp/#examples
+   *
    * @example smtps://user%40gmail.com:pass@smtp.gmail.com
    * @default <<change me>>
    */
-  transportConnectionString: string
+  transportConnectionString: string | SMTPConnection
 }

--- a/modules/basic-skills/yarn.lock
+++ b/modules/basic-skills/yarn.lock
@@ -805,6 +805,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.141.tgz#d81f4d0c562abe28713406b571ffb27692a82ae6"
   integrity sha512-v5NYIi9qEbFEUpCyikmnOYe4YlP8BMUdTcNCAquAKzu+FA7rZ1onj9x80mbnDdOW/K5bFf3Tv5kJplP33+gAbQ==
 
+"@types/node@*":
+  version "12.7.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.11.tgz#be879b52031cfb5d295b047f5462d8ef1a716446"
+  integrity sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==
+
 "@types/node@^10.11.0":
   version "10.14.19"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.19.tgz#f52742c7834a815dedf66edfc8a51547e2a67342"
@@ -814,6 +819,13 @@
   version "8.10.54"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.54.tgz#1c88eb253ac1210f1a5876953fb70f7cc4928402"
   integrity sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg==
+
+"@types/nodemailer@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.2.1.tgz#8f089bf0ef826f04b9d8dd8750233b04978cb675"
+  integrity sha512-6f46rxxaFwyOW39psPoQiM7jHjL7apDRNT5WPHIuv+TZFv+7sBGSI9J7blIC3/NWff4O9/VSzgoQtO6aPLUdvQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/prop-types@*":
   version "15.7.3"
@@ -4310,13 +4322,6 @@ react-dnd@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-5.0.0.tgz#c4a17c70109e456dad8906be838e6ee8f32b06b5"
   integrity sha1-xKF8cBCeRW2tiQa+g45u6PMrBrU=
-  dependencies:
-    dnd-core "^4.0.5"
-    hoist-non-react-statics "^2.5.0"
-    invariant "^2.1.0"
-    lodash "^4.17.10"
-    recompose "^0.27.1"
-    shallowequal "^1.0.2"
 
 react-dnd@^7.4.5:
   version "7.7.0"

--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -32,7 +32,7 @@ class Web extends React.Component<MainProps> {
   componentDidMount() {
     this.props.store.setIntlProvider(this.props.intl)
     window.store = this.props.store
-    window.parent['webchat'] = this.props.store
+    window.parent['webchat_store'] = this.props.store
 
     window.addEventListener('message', this.handleIframeApi)
     window.addEventListener('keydown', e => {

--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -32,6 +32,7 @@ class Web extends React.Component<MainProps> {
   componentDidMount() {
     this.props.store.setIntlProvider(this.props.intl)
     window.store = this.props.store
+    window.parent['webchat'] = this.props.store
 
     window.addEventListener('message', this.handleIframeApi)
     window.addEventListener('keydown', e => {


### PR DESCRIPTION
It was not possible to send content elements with variables  {{session.subject}} because they were not parsed. 