### PR TITLE
fix(modules): fixed module entry points

### DIFF
--- a/modules/basic-skills/src/backend/index.ts
+++ b/modules/basic-skills/src/backend/index.ts
@@ -7,8 +7,6 @@ import choice from './choice'
 import email from './email'
 import slot from './slot'
 
-const onServerStarted = async (bp: typeof sdk) => {}
-
 const onServerReady = async (bp: typeof sdk) => {
   await choice.setup(bp)
 }
@@ -45,7 +43,6 @@ const skillsToRegister: sdk.Skill[] = [
 ]
 
 const entryPoint: sdk.ModuleEntryPoint = {
-  onServerStarted,
   onServerReady,
   onModuleUnmount,
   definition: {

--- a/modules/builtin/src/backend/index.ts
+++ b/modules/builtin/src/backend/index.ts
@@ -1,8 +1,5 @@
 import * as sdk from 'botpress/sdk'
 
-const onServerStarted = async (bp: typeof sdk) => {}
-const onServerReady = async (bp: typeof sdk) => {}
-
 const botTemplates: sdk.BotTemplate[] = [
   { id: 'welcome-bot', name: 'Welcome Bot', desc: `Basic bot that showcases some of the bot's functionality` },
   { id: 'small-talk', name: 'Small Talk', desc: `Includes basic smalltalk examples` },
@@ -10,8 +7,6 @@ const botTemplates: sdk.BotTemplate[] = [
 ]
 
 const entryPoint: sdk.ModuleEntryPoint = {
-  onServerStarted,
-  onServerReady,
   botTemplates,
   definition: {
     name: 'builtin',

--- a/modules/channel-messenger/src/backend/index.ts
+++ b/modules/channel-messenger/src/backend/index.ts
@@ -14,8 +14,6 @@ const onServerStarted = async (bp: typeof sdk) => {
   }
 }
 
-const onServerReady = (bp: typeof sdk) => {}
-
 const onBotMount = async (bp: typeof sdk, botId: string) => {
   await service.mountBot(botId)
 }
@@ -30,7 +28,6 @@ const onModuleUnmount = async (bp: typeof sdk) => {
 }
 
 const entryPoint: sdk.ModuleEntryPoint = {
-  onServerReady,
   onServerStarted,
   onBotMount,
   onBotUnmount,

--- a/modules/channel-web/src/backend/index.ts
+++ b/modules/channel-web/src/backend/index.ts
@@ -13,8 +13,6 @@ const onServerStarted = async (bp: typeof sdk) => {
   await socket(bp, db)
 }
 
-const onServerReady = async (bp: typeof sdk) => {}
-
 const onModuleUnmount = async (bp: typeof sdk) => {
   bp.events.removeMiddleware('web.sendMessages')
   bp.http.deleteRouterForBot('channel-web')
@@ -22,7 +20,6 @@ const onModuleUnmount = async (bp: typeof sdk) => {
 
 const entryPoint: sdk.ModuleEntryPoint = {
   onServerStarted,
-  onServerReady,
   onModuleUnmount,
   definition: {
     name: 'channel-web',

--- a/modules/code-editor/src/backend/index.ts
+++ b/modules/code-editor/src/backend/index.ts
@@ -8,7 +8,6 @@ import { EditorByBot } from './typings'
 
 const editorByBot: EditorByBot = {}
 
-const onServerStarted = async (bp: typeof sdk) => {}
 const onServerReady = async (bp: typeof sdk) => {
   await api(bp, editorByBot)
 }
@@ -23,7 +22,6 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
 }
 
 const entryPoint: sdk.ModuleEntryPoint = {
-  onServerStarted,
   onServerReady,
   onBotMount,
   onBotUnmount,

--- a/modules/extensions/src/backend/index.ts
+++ b/modules/extensions/src/backend/index.ts
@@ -1,6 +1,5 @@
 import * as sdk from 'botpress/sdk'
 
-const onServerStarted = async (bp: typeof sdk) => {}
 const onServerReady = async (bp: typeof sdk) => {
   const router = bp.http.createRouterForBot('extensions')
   const config = (await bp.config.getBotpressConfig()).eventCollector
@@ -24,7 +23,6 @@ const onServerReady = async (bp: typeof sdk) => {
 }
 
 const entryPoint: sdk.ModuleEntryPoint = {
-  onServerStarted,
   onServerReady,
   definition: {
     name: 'extensions',

--- a/modules/testing/src/backend/index.ts
+++ b/modules/testing/src/backend/index.ts
@@ -2,13 +2,11 @@ import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 
 import api from './api'
-
 import { Testing } from './testing'
 import { TestByBot } from './typings'
 
 const testByBot: TestByBot = {}
 
-const onServerStarted = async (bp: typeof sdk) => {}
 const onServerReady = async (bp: typeof sdk) => {
   await api(bp, testByBot)
 }
@@ -26,7 +24,6 @@ const onModuleUnmount = async (bp: typeof sdk) => {
 }
 
 const entryPoint: sdk.ModuleEntryPoint = {
-  onServerStarted,
   onServerReady,
   onModuleUnmount,
   onBotMount,

--- a/src/bp/core/module-loader.ts
+++ b/src/bp/core/module-loader.ts
@@ -23,8 +23,8 @@ import { ModuleResourceLoader } from './services/module/resources-loader'
 import { TYPES } from './types'
 
 const MODULE_SCHEMA = joi.object().keys({
-  onServerStarted: joi.func().required(),
-  onServerReady: joi.func().required(),
+  onServerStarted: joi.func().optional(),
+  onServerReady: joi.func().optional(),
   onBotMount: joi.func().optional(),
   onBotUnmount: joi.func().optional(),
   onModuleUnmount: joi.func().optional(),

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -86,9 +86,9 @@ declare module 'botpress/sdk' {
     /** An array of available bot templates when creating a new bot */
     botTemplates?: BotTemplate[]
     /** Called once the core is initialized. Usually for middlewares / database init */
-    onServerStarted: (bp: typeof import('botpress/sdk')) => void
+    onServerStarted?: (bp: typeof import('botpress/sdk')) => void
     /** This is called once all modules are initialized, usually for routing and logic */
-    onServerReady: (bp: typeof import('botpress/sdk')) => void
+    onServerReady?: (bp: typeof import('botpress/sdk')) => void
     onBotMount?: (bp: typeof import('botpress/sdk'), botId: string) => void
     onBotUnmount?: (bp: typeof import('botpress/sdk'), botId: string) => void
     /**


### PR DESCRIPTION
The legend says that onServerStarted and onServerReady were required from the beginning of time... For no reason at all.

So, made them officially optional (they were already being null-checked before being called, thus not really being required)