### PR TITLE
fix(studio): fix issue in flow with skills/redux

### DIFF
--- a/src/bp/ui-studio/src/web/views/FlowBuilder/containers/Diagram.ts
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/containers/Diagram.ts
@@ -25,7 +25,8 @@ const mapStateToProps = state => ({
   currentFlow: getCurrentFlow(state),
   currentFlowNode: getCurrentFlowNode(state),
   currentDiagramAction: state.flows.currentDiagramAction,
-  canPasteNode: Boolean(state.flows.nodeInBuffer)
+  canPasteNode: Boolean(state.flows.nodeInBuffer),
+  skills: state.skills.installed
 })
 
 const mapDispatchToProps = {

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
@@ -5,6 +5,8 @@ import { Button, Label } from 'react-bootstrap'
 import ReactDOM from 'react-dom'
 import { DiagramEngine, DiagramWidget, NodeModel } from 'storm-react-diagrams'
 
+import { SkillDefinition } from '../sidePanel/FlowTools'
+
 import { defaultTransition, DIAGRAM_PADDING, DiagramManager, nodeTypes } from './manager'
 import { DeletableLinkFactory } from './nodes/LinkWidget'
 import { SkillCallNodeModel, SkillCallWidgetFactory } from './nodes/SkillCallNode'
@@ -26,7 +28,7 @@ export default class FlowBuilder extends Component<Props> {
 
     this.diagramEngine = new DiagramEngine()
     this.diagramEngine.registerNodeFactory(new StandardWidgetFactory())
-    this.diagramEngine.registerNodeFactory(new SkillCallWidgetFactory())
+    this.diagramEngine.registerNodeFactory(new SkillCallWidgetFactory(this.props.skills))
     this.diagramEngine.registerNodeFactory(new SaySomethingWidgetFactory())
     this.diagramEngine.registerNodeFactory(new ExecuteWidgetFactory())
     this.diagramEngine.registerNodeFactory(new ListenWidgetFactory())
@@ -372,6 +374,7 @@ interface Props {
   readOnly: boolean
   canPasteNode: boolean
   flowPreview: boolean
+  skills: SkillDefinition[]
 }
 
 interface NodeProblem {

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/SkillCallNode.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/SkillCallNode.tsx
@@ -69,13 +69,6 @@ class SkillCallNodeWidget extends React.Component<{ node: SkillCallNodeModel; sk
   }
 }
 
-const mapStateToProps = state => ({ skills: state.skills.installed })
-export const ConnectedSkillCallNodeWidget = connect(
-  mapStateToProps,
-  undefined,
-  null
-)(SkillCallNodeWidget)
-
 export class SkillCallNodeModel extends BaseNodeModel {
   public skill?
 
@@ -129,12 +122,15 @@ export class SkillCallNodeModel extends BaseNodeModel {
 }
 
 export class SkillCallWidgetFactory extends AbstractNodeFactory {
-  constructor() {
+  private skillsDefinitions: SkillDefinition[]
+
+  constructor(skills) {
     super('skill-call')
+    this.skillsDefinitions = skills
   }
 
   generateReactWidget(diagramEngine, node) {
-    return <ConnectedSkillCallNodeWidget node={node} />
+    return <SkillCallNodeWidget node={node} skills={this.skillsDefinitions} />
   }
 
   getNewInstance() {


### PR DESCRIPTION
Storm diagram doesn't like having a store connected to widgets... They are never rendered, so ports stays disconnected on the UI. It's a bit of hackish workaround, but it works.
