### PR TITLE
fix(debugger): better handling of unauthorized users

### DIFF
--- a/modules/extensions/src/views/lite/components/debugger/Unauthorized.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/Unauthorized.tsx
@@ -1,0 +1,18 @@
+import classnames from 'classnames'
+import React from 'react'
+import { MdBugReport } from 'react-icons/md'
+
+import style from './style.scss'
+
+export default () => (
+  <div className={classnames(style.splash, style.notFound)}>
+    <div>
+      <MdBugReport />
+      <h2>Unauthorized</h2>
+      <p>
+        You lack sufficient permissions to inspect events. <br />Permission required: write access on
+        "module.extensions"
+      </p>
+    </div>
+  </div>
+)


### PR DESCRIPTION
Content editor lack permissions to module.extensions by default (so they can't inspect events). Previous message of "Event not found" was not clear enough

![image](https://user-images.githubusercontent.com/42552874/66344470-01333500-e91c-11e9-9bb6-c5f267ef2047.png)
