### PR TITLE
fix(admin): cleanup of permissions

### DIFF
--- a/src/bp/ui-admin/src/App/AccessControl.tsx
+++ b/src/bp/ui-admin/src/App/AccessControl.tsx
@@ -2,8 +2,6 @@ import { checkRule } from 'common/auth'
 import { connect } from 'react-redux'
 import store from '~/store'
 
-import { fetchPermissions } from '../reducers/user'
-
 export interface PermissionAllowedProps {
   /** The resource to check permissions. Ex: module.qna */
   resource: string
@@ -51,9 +49,9 @@ const PermissionsChecker = (props: AccessControlProps) => {
   return isOperationAllowed({ resource, operation, superAdmin }) ? children : (fallback as any)
 }
 
-const mapStateToProps = state => ({ permissions: state.user.permissions, test: state.user })
+const mapStateToProps = state => ({ permissions: state.user.permissions })
 
 export default connect(
   mapStateToProps,
-  { fetchPermissions }
+  undefined
 )(PermissionsChecker)

--- a/src/bp/ui-admin/src/App/Layout.tsx
+++ b/src/bp/ui-admin/src/App/Layout.tsx
@@ -1,23 +1,21 @@
 import { Alignment, Icon, Navbar } from '@blueprintjs/core'
 import axios from 'axios'
-import { AuthRule } from 'common/typings'
+import { UserProfile } from 'common/typings'
 import React, { FC, Fragment, useEffect, useState } from 'react'
 import { connect } from 'react-redux'
 import { NavLink } from 'reactstrap'
 
 import logo from '../media/logo_white.png'
 import { fetchLicensing } from '../reducers/license'
-import { fetchPermissions, fetchProfile } from '../reducers/user'
+import { fetchProfile } from '../reducers/user'
 
 import Menu from './Menu'
 import UserDropdownMenu from './UserDropdownMenu'
 
 interface Props {
-  permissions?: AuthRule[]
-  profile: any
+  profile: UserProfile
   licensing: any
   fetchLicensing: () => void
-  fetchPermissions: () => void
   fetchProfile: () => void
 }
 
@@ -26,7 +24,6 @@ const App: FC<Props> = props => {
 
   useEffect(() => {
     props.fetchLicensing()
-    props.fetchPermissions()
     props.fetchProfile()
 
     // tslint:disable-next-line: no-floating-promises
@@ -38,7 +35,7 @@ const App: FC<Props> = props => {
     setVersion(data)
   }
 
-  if (!props.permissions || !props.profile) {
+  if (!props.profile) {
     return null
   }
 
@@ -109,13 +106,11 @@ const Unlicensed = () => (
 
 const mapStateToProps = state => ({
   profile: state.user.profile,
-  licensing: state.license.licensing,
-  permissions: state.user.permissions
+  licensing: state.license.licensing
 })
 
 const mapDispatchToProps = {
   fetchLicensing,
-  fetchPermissions,
   fetchProfile
 }
 

--- a/src/bp/ui-admin/src/Pages/Layouts/Tabs.tsx
+++ b/src/bp/ui-admin/src/Pages/Layouts/Tabs.tsx
@@ -7,7 +7,6 @@ import { matchPath, Route, Switch } from 'react-router-dom'
 import { Col, Container, Nav, NavItem, NavLink, Row } from 'reactstrap'
 
 import { fetchLicensing } from '../../reducers/license'
-import { fetchPermissions } from '../../reducers/user'
 import AccessControl from '../../App/AccessControl'
 
 export interface AdminTab {
@@ -30,9 +29,7 @@ export interface AdminTab {
 }
 
 type Props = {
-  permissions: any
   licensing: any
-  fetchPermissions: () => void
   fetchLicensing: () => void
   tabs: AdminTab[]
   showHome: boolean
@@ -45,7 +42,6 @@ class TabLayout extends Component<Props> {
   }
 
   componentDidMount() {
-    !this.props.permissions && this.props.fetchPermissions()
     !this.props.licensing && this.props.fetchLicensing()
     this.setState({ activeTab: this.props.tabs[0].name })
   }
@@ -128,12 +124,10 @@ class TabLayout extends Component<Props> {
 }
 
 const mapStateToProps = state => ({
-  permissions: state.user.permissions,
   licensing: state.license.licensing
 })
 
 const mapDispatchToProps = {
-  fetchPermissions,
   fetchLicensing
 }
 

--- a/src/bp/ui-admin/src/reducers/user.ts
+++ b/src/bp/ui-admin/src/reducers/user.ts
@@ -7,8 +7,6 @@ import { fetchLicensing } from './license'
 
 export const MY_PROFILE_REQUESTED = 'user/MY_PROFILE_REQUESTED'
 export const MY_PROFILE_RECEIVED = 'user/MY_PROFILE_RECEIVED'
-export const MY_PERMISSIONS_REQUESTED = 'user/MY_PERMISSIONS_REQUESTED'
-export const MY_PERMISSIONS_RECEIVED = 'user/MY_PERMISSIONS_RECEIVED'
 export const FETCH_USERS_REQUESTED = 'user/FETCH_USERS_REQUESTED'
 export const FETCH_USERS_RECEIVED = 'user/FETCH_USERS_RECEIVED'
 export const MY_WORKSPACES_RECEIVED = 'user/MY_WORKSPACES_RECEIVED'
@@ -40,7 +38,6 @@ const initialState: UserState = {
 export default (state = initialState, action) => {
   switch (action.type) {
     case MY_PROFILE_REQUESTED:
-    case MY_PERMISSIONS_REQUESTED:
       return {
         ...state,
         loading: true
@@ -56,14 +53,8 @@ export default (state = initialState, action) => {
       return {
         ...state,
         loading: false,
-        profile: action.profile
-      }
-
-    case MY_PERMISSIONS_RECEIVED:
-      return {
-        ...state,
-        loading: false,
-        permissions: action.permissions
+        profile: action.profile,
+        permissions: action.profile.permissions
       }
 
     case FETCH_USERS_RECEIVED:
@@ -123,14 +114,6 @@ export const fetchProfile = () => {
   }
 }
 
-export const fetchPermissions = () => {
-  return async dispatch => {
-    dispatch({ type: MY_PERMISSIONS_REQUESTED })
-    const { data } = await api.getSecured().get(`/auth/me/permissions`)
-    dispatch({ type: MY_PERMISSIONS_RECEIVED, permissions: data.payload })
-  }
-}
-
 export const fetchMyWorkspaces = () => {
   return async dispatch => {
     const { data } = await api.getSecured().get('/auth/me/workspaces')
@@ -149,7 +132,6 @@ export const switchWorkspace = (workspaceId: string) => {
   return async dispatch => {
     setActiveWorkspace(workspaceId)
     await dispatch(fetchProfile())
-    await dispatch(fetchPermissions())
     await dispatch(fetchLicensing())
 
     dispatch({ type: CURRENT_WORKSPACE_CHANGED, currentWorkspace: workspaceId })


### PR DESCRIPTION
In the studio, we use the profile to get the user's informations and permissions. 
We also call the profile in admin, but we also have another call to specifically fetch permissions.

To save one unnecessary call, we're keeping only the /me/profile route, which also returns permissions.