### PR TITLE
fix(core): small changes to botpress fatal errors

### DIFF
--- a/modules/nlu/src/backend/index.ts
+++ b/modules/nlu/src/backend/index.ts
@@ -25,7 +25,9 @@ export const initializeLangServer = async (bp: typeof sdk) => {
   } catch (e) {
     if (e.failure && e.failure.code === 'ECONNREFUSED') {
       bp.logger.error(`Language server can't be reached at adress ${e.failure.address}:${e.failure.port}`)
-      process.exit()
+      if (!process.IS_FAILSAFE) {
+        process.exit()
+      }
     }
     throw e
   }

--- a/src/bp/bootstrap.ts
+++ b/src/bp/bootstrap.ts
@@ -86,7 +86,10 @@ async function start() {
 Please make sure that Botpress has the right to access this folder or change the folder path by providing the 'APP_DATA_PATH' env variable.
 This is a fatal error, process will exit.`
       )
-      process.exit(1)
+
+      if (!process.IS_FAILSAFE) {
+        process.exit(1)
+      }
     }
   }
 
@@ -123,16 +126,15 @@ This is a fatal error, process will exit.`
   logger.info(`Using ${chalk.bold(modules.length.toString())} modules` + modulesLog)
 
   for (const err of loadingErrors) {
-    logger.attachError(err).error('Error starting Botpress')
-  }
-
-  if (loadingErrors.length) {
-    process.exit(1)
+    logger.attachError(err).error('Error while loading some modules, they will be disabled')
   }
 
   await Botpress.start({ modules }).catch(err => {
     logger.attachError(err).error('Error starting Botpress')
-    process.exit(1)
+
+    if (!process.IS_FAILSAFE) {
+      process.exit(1)
+    }
   })
 
   logger.info(`Botpress is listening at: ${process.LOCAL_URL}`)

--- a/src/bp/core/services/migration/index.ts
+++ b/src/bp/core/services/migration/index.ts
@@ -69,7 +69,13 @@ export class MigrationService {
       await this.logger.error(
         `Botpress needs to migrate your data. Please make a copy of your data, then start it with "./bp --auto-migrate"`
       )
-      process.exit(0)
+
+      // When failsafe is enabled, simply stop executing migrations
+      if (!process.IS_FAILSAFE) {
+        process.exit(0)
+      } else {
+        return
+      }
     }
 
     await this.executeMigrations(missingMigrations)
@@ -154,7 +160,10 @@ export class MigrationService {
       await this.logger.error(
         `Some steps failed to complete. Please fix errors manually, then restart Botpress so the update process may finish.`
       )
-      process.exit(0)
+
+      if (!process.IS_FAILSAFE) {
+        process.exit(0)
+      }
     }
 
     await this.updateAllVersions()

--- a/src/bp/index.ts
+++ b/src/bp/index.ts
@@ -43,6 +43,7 @@ if (process.env.APP_DATA_PATH) {
   process.APP_DATA_PATH = getAppDataPath()
 }
 
+process.IS_FAILSAFE = yn(process.env.BP_FAILSAFE)
 process.BOTPRESS_EVENTS = new EventEmitter()
 process.BOTPRESS_EVENTS.setMaxListeners(1000)
 
@@ -59,7 +60,9 @@ process.on('unhandledRejection', err => {
 
 process.on('uncaughtException', err => {
   global.printErrorDefault(err)
-  process.exit(1)
+  if (!process.IS_FAILSAFE) {
+    process.exit(1)
+  }
 })
 
 try {

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -44,6 +44,7 @@ declare namespace NodeJS {
     distro: OSDistribution
     BOTPRESS_EVENTS: EventEmitter
     AUTO_MIGRATE: boolean
+    IS_FAILSAFE: boolean
   }
 }
 
@@ -141,6 +142,12 @@ declare type BotpressEnvironementVariables = {
    * @default false
    */
   readonly BP_DISABLE_SERVER_CONFIG?: boolean
+
+  /**
+   * Prevents Botpress from closing cleanly when an error is encountered.
+   * This only affects fatal errors, it will not affect business rules checks (eg: licensing)
+   */
+  readonly BP_FAILSAFE?: boolean
 }
 
 interface IDebug {


### PR DESCRIPTION
Missing modules will no longer crash on startup (will just print a warning and be disabled)

Added a flag "BP_FAILSAFE" which will keep Botpress from auto-closing cleanly when an error is encountered. This is handy when an error prevents BP from starting and configuration files are stored on the BPFS. 

This only affects fatal errors, it doesn't affect business rules (if it doesn't respect licensing, for example). 