### PR TITLE
feat(studio): various improvements to flow builder

### DIFF
--- a/src/bp/ui-studio/src/web/keyboardShortcuts.ts
+++ b/src/bp/ui-studio/src/web/keyboardShortcuts.ts
@@ -5,6 +5,7 @@ export const keyMap = {
   add: `${controlKey}+a`,
   save: `${controlKey}+s`,
   undo: `${controlKey}+z`,
+  find: `${controlKey}+f`,
   redo: `${controlKey}+shift+z`,
   'emulator-focus': ['e', `${controlKey}+e`],
   'docs-toggle': `${controlKey}+h`,

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
@@ -355,12 +355,17 @@ class Diagram extends Component<Props> {
 
   renderCatchAllInfo() {
     const nbNext = _.get(this.props.currentFlow, 'catchAll.next.length', 0)
+    const nbReceive = _.get(this.props.currentFlow, 'catchAll.onReceive.length', 0)
 
     return (
       <div style={{ display: 'flex', marginTop: 5 }}>
         <Button onClick={this.handleFlowWideClicked} minimal={true}>
           <Tag intent={nbNext > 0 ? Intent.PRIMARY : Intent.NONE}>{nbNext}</Tag> flow-wide
           {nbNext === 1 ? ' transition' : ' transitions'}
+        </Button>
+        <Button onClick={this.handleFlowWideClicked} minimal={true}>
+          <Tag intent={nbReceive > 0 ? Intent.PRIMARY : Intent.NONE}>{nbReceive}</Tag> flow-wide
+          {nbReceive === 1 ? ' on receive' : ' on receives'}
         </Button>
         {this.props.showSearch && (
           <ControlGroup>

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/manager.ts
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/manager.ts
@@ -44,7 +44,7 @@ export class DiagramManager {
   private diagramEngine: DiagramEngine
   private activeModel: ExtendedDiagramModel
   private diagramWidget: DiagramWidget
-  private highlightedNodeName?: string
+  private highlightedNodeNames?: string[]
   private currentFlow: FlowView
   private isReadOnly: boolean
   private diagramContainerSize: DiagramContainerSize
@@ -70,7 +70,7 @@ export class DiagramManager {
       return createNodeModel(node, {
         ...node,
         isStartNode: currentFlow.startNode === node.name,
-        isHighlighted: this.highlightedNodeName === node.name
+        isHighlighted: this.shouldHighlightNode(node.name)
       })
     })
 
@@ -82,6 +82,10 @@ export class DiagramManager {
 
     // Setting the initial links hash when changing flow
     this.getLinksRequiringUpdate()
+  }
+
+  shouldHighlightNode(nodeName): boolean {
+    return this.highlightedNodeNames && !!this.highlightedNodeNames.find(x => nodeName.includes(x))
   }
 
   // Syncs model with the store (only update changes instead of complete initialization)
@@ -114,7 +118,7 @@ export class DiagramManager {
           model.setData({
             ..._.pick(node, passThroughNodeProps),
             isStartNode: this.currentFlow.startNode === node.name,
-            isHighlighted: this.highlightedNodeName === node.name
+            isHighlighted: this.shouldHighlightNode(node.name)
           })
         }
       })
@@ -243,8 +247,8 @@ export class DiagramManager {
     this.currentFlow = currentFlow
   }
 
-  setHighlightedNodeName(nodeName: string) {
-    this.highlightedNodeName = nodeName
+  setHighlightedNodes(nodeName: string | string[]) {
+    this.highlightedNodeNames = _.isArray(nodeName) ? nodeName : [nodeName]
   }
 
   setReadOnly(readOnly: boolean) {
@@ -289,7 +293,7 @@ export class DiagramManager {
     const model = createNodeModel(node, {
       ...node,
       isStartNode: this.currentFlow.startNode === node.name,
-      isHighlighted: this.highlightedNodeName === node.name
+      isHighlighted: this.shouldHighlightNode(node.name)
     })
 
     this.activeModel.addNode(model)
@@ -308,7 +312,7 @@ export class DiagramManager {
     model.setData({
       ..._.pick(node, passThroughNodeProps),
       isStartNode: this.currentFlow.startNode === node.name,
-      isHighlighted: this.highlightedNodeName === node.name
+      isHighlighted: this.shouldHighlightNode(node.name)
     })
 
     model.setPosition(node.x, node.y)

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/index.tsx
@@ -20,10 +20,35 @@ import { UserReducer } from '~/reducers/user'
 
 import Diagram from './diagram'
 import SidePanel from './sidePanel'
-import { PannelPermissions } from './sidePanel'
+import { PanelPermissions } from './sidePanel'
 import { MutexInfo } from './sidePanel/Toolbar'
 import SkillsBuilder from './skills'
 import style from './style.scss'
+
+type Props = {
+  currentFlow: string
+  showFlowNodeProps: boolean
+  dirtyFlows: string[]
+  user: UserReducer
+  setDiagramAction: (action: string) => void
+  switchFlow: (flowName: string) => void
+  flowEditorUndo: () => void
+  flowEditorRedo: () => void
+  errorSavingFlows: any
+  clearErrorSaveFlows: () => void
+  clearFlowsModification: () => void
+  closeFlowNodeProps: () => void
+  flowsByName: _.Dictionary<FlowView>
+} & RouteComponentProps
+
+interface State {
+  initialized: any
+  readOnly: boolean
+  pannelPermissions: PanelPermissions[]
+  flowPreview: boolean
+  mutexInfo: MutexInfo
+  showSearch: boolean
+}
 
 class FlowBuilder extends Component<Props, State> {
   private diagram
@@ -34,10 +59,11 @@ class FlowBuilder extends Component<Props, State> {
     readOnly: false,
     pannelPermissions: this.allPermissions,
     flowPreview: false,
-    mutexInfo: undefined
+    mutexInfo: undefined,
+    showSearch: false
   }
 
-  get allPermissions(): PannelPermissions[] {
+  get allPermissions(): PanelPermissions[] {
     return ['create', 'rename', 'delete']
   }
 
@@ -137,6 +163,8 @@ class FlowBuilder extends Component<Props, State> {
     this.props.history.push(`/flows/${flow.replace(/\.flow\.json/, '')}`)
   }
 
+  hideSearch = () => this.setState({ showSearch: false })
+
   render() {
     if (!this.state.initialized) {
       return null
@@ -157,6 +185,10 @@ class FlowBuilder extends Component<Props, State> {
         e.preventDefault()
         this.props.flowEditorRedo()
       },
+      find: e => {
+        e.preventDefault()
+        this.setState({ showSearch: !this.state.showSearch })
+      },
       'preview-flow': e => {
         e.preventDefault()
         this.setState({ flowPreview: true })
@@ -168,6 +200,7 @@ class FlowBuilder extends Component<Props, State> {
       cancel: e => {
         e.preventDefault()
         this.props.closeFlowNodeProps()
+        this.hideSearch()
       }
     }
 
@@ -187,6 +220,8 @@ class FlowBuilder extends Component<Props, State> {
           <Diagram
             readOnly={readOnly}
             flowPreview={this.state.flowPreview}
+            showSearch={this.state.showSearch}
+            hideSearch={this.hideSearch}
             ref={el => {
               if (!!el) {
                 // @ts-ignore
@@ -225,27 +260,3 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps
 )(withRouter(FlowBuilder))
-
-type Props = {
-  currentFlow: string
-  showFlowNodeProps: boolean
-  dirtyFlows: string[]
-  user: UserReducer
-  setDiagramAction: any
-  switchFlow: any
-  flowEditorUndo: any
-  flowEditorRedo: any
-  errorSavingFlows: any
-  clearErrorSaveFlows: () => void
-  clearFlowsModification: () => void
-  closeFlowNodeProps: () => void
-  flowsByName: _.Dictionary<FlowView>
-} & RouteComponentProps
-
-interface State {
-  initialized: any
-  readOnly: boolean
-  pannelPermissions: PannelPermissions[]
-  flowPreview: boolean
-  mutexInfo: MutexInfo
-}

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/index.tsx
@@ -205,7 +205,7 @@ class FlowBuilder extends Component<Props, State> {
     }
 
     return (
-      <Container keyHandlers={keyHandlers}>
+      <Container keyHandlers={keyHandlers} sidePanelWidth={320}>
         <SidePanel
           readOnly={this.state.readOnly}
           mutexInfo={this.state.mutexInfo}

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/inspector/style.scss
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/inspector/style.scss
@@ -1,5 +1,6 @@
 .inspector {
   background-color: #fcfcfc;
+  padding: 5px;
 
   h4 {
     padding-top: 10px;

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/SkillCallNode.jsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/SkillCallNode.jsx
@@ -22,13 +22,6 @@ export default class SkillCallNodePropertiesPanel extends Component {
   render() {
     const { node, readOnly } = this.props
 
-    const onNameMounted = input => {
-      if (input.value.startsWith('node-')) {
-        input.focus()
-        input.setSelectionRange(0, 1000)
-      }
-    }
-
     const editSkill = () => this.props.requestEditSkill(node.id)
 
     return (
@@ -36,7 +29,6 @@ export default class SkillCallNodePropertiesPanel extends Component {
         <Panel>
           <EditableInput
             readOnly={readOnly}
-            onMount={onNameMounted}
             value={node.name}
             className={style.name}
             onChanged={this.renameNode}

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/StandardNode.jsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/StandardNode.jsx
@@ -23,19 +23,11 @@ export default class StandardNodePropertiesPanel extends Component {
   render() {
     const { node, readOnly } = this.props
 
-    const onNameMounted = input => {
-      if (input.value.startsWith('node-')) {
-        input.focus()
-        input.setSelectionRange(0, 1000)
-      }
-    }
-
     return (
       <div className={style.node}>
         <Panel>
           <EditableInput
             readOnly={readOnly}
-            onMount={onNameMounted}
             value={node.name}
             className={style.name}
             onChanged={this.renameNode}

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowNameModal.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowNameModal.tsx
@@ -1,0 +1,95 @@
+import { Button, Callout, Classes, Dialog, FormGroup, InputGroup, Intent } from '@blueprintjs/core'
+import _ from 'lodash'
+import React, { FC, useEffect, useState } from 'react'
+
+interface Props {
+  // Used for actions rename and duplicate
+  originalName?: string
+  action: 'create' | 'rename' | 'duplicate'
+  flowsNames: any
+  isOpen: boolean
+  toggle: () => void
+  onCreateFlow: (flowName: string) => void
+  onDuplicateFlow: (flow: { flowNameToDuplicate: string; name: string }) => void
+  onRenameFlow: (flow: { targetFlow: string; name: string }) => void
+}
+
+export const sanitizeName = (text: string) =>
+  text
+    .replace(/\s/g, '-')
+    .replace(/[^a-zA-Z0-9\/_-]/g, '')
+    .replace(/\/\//, '/')
+
+const FlowNameModal: FC<Props> = props => {
+  const [name, setName] = useState()
+
+  useEffect(() => {
+    props.action === 'rename' ? setName(props.originalName.replace(/\.flow\.json$/i, '')) : setName('')
+  }, [props.isOpen])
+
+  const submit = async e => {
+    e.preventDefault()
+
+    if (props.action === 'create') {
+      props.onCreateFlow(name)
+    } else if (props.action === 'duplicate') {
+      props.onDuplicateFlow({ flowNameToDuplicate: props.originalName, name: `${name}.flow.json` })
+    } else if (props.action === 'rename') {
+      props.onRenameFlow({ targetFlow: props.originalName, name: `${name}.flow.json` })
+    }
+
+    closeModal()
+  }
+
+  const closeModal = () => {
+    setName('')
+    props.toggle()
+  }
+
+  const isIdentical = props.action === 'rename' && props.originalName === `${name}.flow.json`
+  const alreadyExists = !isIdentical && _.includes(props.flowsNames, `${name}.flow.json`)
+
+  let dialog: { icon: any; title: string } = { icon: 'add', title: 'Create Flow' }
+  if (props.action === 'duplicate') {
+    dialog = { icon: 'duplicate', title: 'Duplicate Flow' }
+  } else if (props.action === 'rename') {
+    dialog = { icon: 'edit', title: 'Rename Flow' }
+  }
+
+  return (
+    <Dialog isOpen={props.isOpen} onClose={closeModal} transitionDuration={0} {...dialog}>
+      <form onSubmit={submit}>
+        <div className={Classes.DIALOG_BODY}>
+          <FormGroup
+            label="Flow Name"
+            helperText={`It can only contain letters, numbers, underscores and hyphens. You can also use slashes to create folders (ex: myfolder/mynewflow)`}
+          >
+            <InputGroup
+              id="input-flow-name"
+              tabIndex={1}
+              placeholder="Choose a name for your flow"
+              required={true}
+              value={name}
+              onChange={e => setName(sanitizeName(e.currentTarget.value))}
+              autoFocus={true}
+            />
+          </FormGroup>
+
+          {alreadyExists && (
+            <Callout title="Name already in use" intent={Intent.DANGER}>
+              A flow with that name already exists. Please choose another one.
+            </Callout>
+          )}
+        </div>
+
+        <div className={Classes.DIALOG_FOOTER}>
+          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+            <Button type="submit" id="btn-submit" text="Submit" onClick={submit} disabled={!name || alreadyExists} />
+          </div>
+        </div>
+      </form>
+    </Dialog>
+  )
+}
+
+export default FlowNameModal

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/index.tsx
@@ -2,19 +2,21 @@ import { Icon } from '@blueprintjs/core'
 import _ from 'lodash'
 import reject from 'lodash/reject'
 import values from 'lodash/values'
-import React, { Component } from 'react'
+import React, { FC, useState } from 'react'
 import { connect } from 'react-redux'
 import { RouteComponentProps } from 'react-router'
 import { deleteFlow, duplicateFlow, renameFlow } from '~/actions'
-import { SidePanel, SidePanelSection } from '~/components/Shared/Interface'
+import { history } from '~/components/Routes'
+import { SearchBar, SidePanel, SidePanelSection } from '~/components/Shared/Interface'
 import { getCurrentFlow, getDirtyFlows } from '~/reducers'
 
 import Inspector from '../inspector'
 
 import FlowsList from './FlowsList'
+import FlowNameModal from './FlowNameModal'
 import FlowTools from './FlowTools'
 import Toolbar from './Toolbar'
-export type PannelPermissions = 'create' | 'rename' | 'delete'
+export type PanelPermissions = 'create' | 'rename' | 'delete'
 
 type Props = {
   flowsNames: string[]
@@ -23,7 +25,7 @@ type Props = {
   deleteFlow: (flowName: string) => void
   renameFlow: any
   history: any
-  permissions: PannelPermissions[]
+  permissions: PanelPermissions[]
   dirtyFlows: any
   duplicateFlow: any
   currentFlow: any
@@ -31,74 +33,88 @@ type Props = {
   mutexInfo: string
   readOnly: boolean
   showFlowNodeProps: boolean
-} & RouteComponentProps
+}
 
-class PanelContent extends Component<Props> {
-  createFlow = () => {
-    let name = prompt('Enter the name of the new flow')
+const SidePanelContent: FC<Props> = props => {
+  const [modalOpen, setModalOpen] = useState(false)
+  const [flowName, setFlowName] = useState()
+  const [flowAction, setFlowAction] = useState<any>('create')
+  const [filter, setFilter] = useState()
 
-    if (!name) {
-      return
+  const goToFlow = flow => history.push(`/flows/${flow.replace(/\.flow\.json/, '')}`)
+
+  const normalFlows = reject(props.flows, x => x.name.startsWith('skills/'))
+  const flowsName = normalFlows.map(x => {
+    return { name: x.name }
+  })
+
+  const createFlowAction = {
+    id: 'btn-add-flow',
+    icon: <Icon icon="add" />,
+    key: 'create',
+    tooltip: 'Create new flow',
+    onClick: () => {
+      setFlowAction('create')
+      setModalOpen(true)
     }
-
-    name = name.replace(/\.flow\.json$/i, '')
-
-    if (/[^A-Z0-9-_\/]/i.test(name)) {
-      return alert('ERROR: The flow name can only contain letters, numbers, underscores and hyphens.')
-    }
-
-    if (_.includes(this.props.flowsNames, name + '.flow.json')) {
-      return alert('ERROR: This flow already exists')
-    }
-
-    this.props.onCreateFlow(name)
   }
 
-  goToFlow = flow => this.props.history.push(`/flows/${flow.replace(/\.flow\.json/, '')}`)
-
-  render() {
-    const normalFlows = reject(this.props.flows, x => x.name.startsWith('skills/'))
-    const flowsName = normalFlows.map(x => {
-      return { name: x.name }
-    })
-    const createFlowAction = {
-      id: 'btn-add-flow',
-      icon: <Icon icon="add" />,
-      key: 'create',
-      tooltip: 'Create new flow',
-      onClick: this.createFlow
-    }
-
-    return (
-      <SidePanel>
-        <Toolbar mutexInfo={this.props.mutexInfo} />
-        {this.props.showFlowNodeProps ? (
-          <Inspector />
-        ) : (
-          <React.Fragment>
-            <SidePanelSection label={'Flows'} actions={this.props.permissions.includes('create') && [createFlowAction]}>
-              <FlowsList
-                readOnly={this.props.readOnly}
-                canDelete={this.props.permissions.includes('delete')}
-                canRename={this.props.permissions.includes('rename')}
-                flows={flowsName}
-                dirtyFlows={this.props.dirtyFlows}
-                goToFlow={this.goToFlow}
-                deleteFlow={this.props.deleteFlow}
-                duplicateFlow={this.props.duplicateFlow}
-                renameFlow={this.props.renameFlow}
-                currentFlow={this.props.currentFlow}
-              />
-            </SidePanelSection>
-
-            <SidePanelSection label="Tools">
-              <FlowTools flowPreview={this.props.flowPreview} />
-            </SidePanelSection>
-          </React.Fragment>
-        )}
-      </SidePanel>
-    )
+  const renameFlow = (flowName: string) => {
+    setFlowName(flowName)
+    setFlowAction('rename')
+    setModalOpen(true)
   }
+
+  const duplicateFlow = (flowName: string) => {
+    setFlowName(flowName)
+    setFlowAction('duplicate')
+    setModalOpen(true)
+  }
+
+  return (
+    <SidePanel>
+      <Toolbar mutexInfo={props.mutexInfo} />
+
+      {props.showFlowNodeProps ? (
+        <Inspector />
+      ) : (
+        <React.Fragment>
+          <SearchBar icon="filter" placeholder="Filter flows" onChange={setFilter} />
+
+          <SidePanelSection label={'Flows'} actions={props.permissions.includes('create') && [createFlowAction]}>
+            <FlowsList
+              readOnly={props.readOnly}
+              canDelete={props.permissions.includes('delete')}
+              canRename={props.permissions.includes('rename')}
+              flows={flowsName}
+              dirtyFlows={props.dirtyFlows}
+              goToFlow={goToFlow}
+              deleteFlow={props.deleteFlow}
+              duplicateFlow={duplicateFlow}
+              renameFlow={renameFlow}
+              currentFlow={props.currentFlow}
+              filter={filter}
+            />
+          </SidePanelSection>
+
+          <SidePanelSection label="Tools">
+            <FlowTools flowPreview={props.flowPreview} />
+          </SidePanelSection>
+        </React.Fragment>
+      )}
+
+      <FlowNameModal
+        action={flowAction}
+        originalName={flowName}
+        flowsNames={props.flowsNames}
+        isOpen={modalOpen}
+        toggle={() => setModalOpen(!modalOpen)}
+        onCreateFlow={props.onCreateFlow}
+        onRenameFlow={props.renameFlow}
+        onDuplicateFlow={props.duplicateFlow}
+      />
+    </SidePanel>
+  )
 }
 
 const mapStateToProps = state => ({
@@ -119,4 +135,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(PanelContent)
+)(SidePanelContent)

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/util.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/util.tsx
@@ -113,11 +113,13 @@ export const splitFlowPath = flow => {
   }
 }
 
-export const buildFlowsTree = flows => {
+export const buildFlowsTree = (flows, filterName) => {
   const tree = { icon: 'root', fullPath: '', label: '<root>', childNodes: [] }
   flows.forEach(flowData => {
     const { folders, flow } = splitFlowPath(flowData.name)
-    addNode(tree, folders, flow, { nodeData: flowData })
+    if (!filterName || flow.id.includes(filterName)) {
+      addNode(tree, folders, flow, { nodeData: flowData })
+    }
   })
 
   sortChildren(tree)

--- a/src/e2e/studio/flows.test.ts
+++ b/src/e2e/studio/flows.test.ts
@@ -1,4 +1,4 @@
-import { clickOn } from '../expectPuppeteer'
+import { clickOn, fillField } from '../expectPuppeteer'
 import { autoAnswerDialog, clickOnTreeNode, expectBotApiCallSuccess, gotoStudio } from '../utils'
 
 describe('Studio - Flows', () => {
@@ -13,16 +13,18 @@ describe('Studio - Flows', () => {
   })
 
   it('Create new flow', async () => {
-    autoAnswerDialog('test_flow')
     await clickOn('#btn-add-flow')
-    await expectBotApiCallSuccess('flow')
+    await fillField('#input-flow-name', 'test_flow')
+
+    await Promise.all([expectBotApiCallSuccess('flow'), clickOn('#btn-submit')])
   })
 
   it('Rename flow', async () => {
-    autoAnswerDialog('test_flow_renamed')
     await clickOnTreeNode('test_flow', 'right')
+    await clickOn('#btn-rename')
+    await fillField('#input-flow-name', 'test_flow_renamed')
 
-    await Promise.all([expectBotApiCallSuccess('flow/test_flow_renamed.flow.json', 'POST'), clickOn('#btn-rename')])
+    await Promise.all([expectBotApiCallSuccess('flow/test_flow_renamed.flow.json', 'POST'), clickOn('#btn-submit')])
   })
 
   it('Delete flow', async () => {
@@ -36,10 +38,11 @@ describe('Studio - Flows', () => {
   })
 
   it('Duplicate flow', async () => {
-    autoAnswerDialog('new_duplicated_flow')
     await clickOnTreeNode('memory', 'right')
+    await clickOn('#btn-duplicate')
+    await fillField('#input-flow-name', 'new_duplicated_flow')
 
-    await Promise.all([expectBotApiCallSuccess('flow', 'POST'), clickOn('#btn-duplicate')])
+    await Promise.all([expectBotApiCallSuccess('flow', 'POST'), clickOn('#btn-submit')])
     await page.waitFor(3000)
   })
 


### PR DESCRIPTION
- Improved UX with create flow / duplicate / rename. Using a proper dialog and only allowed characters can be used. Also gave a hint for folders

![image](https://user-images.githubusercontent.com/42552874/66594816-d806e480-eb67-11e9-90b9-1e73fbf2ab4c.png)


- Ability to filter flows by name
![image](https://user-images.githubusercontent.com/42552874/66594745-b9a0e900-eb67-11e9-8bf5-d3b9fc978664.png)

- Using CTRL+F allows you to highlight nodes by name
![image](https://user-images.githubusercontent.com/42552874/66594773-c58cab00-eb67-11e9-9309-653c59f5a5de.png)

- Disabled auto-focus of node name on focus since it provided a bad UX when deleting

- Slightly enlarged side panel so tools stay 3 on the same line when the scrollbar is displayed

- Added flow-wide on receive
![image](https://user-images.githubusercontent.com/42552874/66596051-2917d800-eb6a-11e9-938d-a966409a5a4b.png)
