### PR TITLE
fix(channel-web) Do not display postback messages

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/Message.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/Message.tsx
@@ -102,10 +102,6 @@ class Message extends Component<MessageProps> {
     return null
   }
 
-  render_postback() {
-    return this.render_text()
-  }
-
   render_unsupported() {
     return '*Unsupported message type*'
   }

--- a/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
@@ -2,7 +2,7 @@ import differenceInMinutes from 'date-fns/difference_in_minutes'
 import { observe } from 'mobx'
 import { inject, observer } from 'mobx-react'
 import React from 'react'
-
+import { Message } from '../../typings'
 import constants from '../../core/constants'
 import { RootStore, StoreDef } from '../../store'
 import Avatar from '../common/Avatar'
@@ -78,7 +78,7 @@ class MessageList extends React.Component<MessageListProps> {
   }
 
   renderMessageGroups() {
-    const messages = this.props.currentMessages || []
+    const messages = (this.props.currentMessages || []).filter(m => this.shouldDisplayMesage(m))
     const groups = []
 
     let lastSpeaker = undefined
@@ -149,6 +149,10 @@ class MessageList extends React.Component<MessageListProps> {
         })}
       </div>
     )
+  }
+
+  shouldDisplayMesage = (m: Message): boolean => {
+    return m.message_type !== 'postback'
   }
 
   render() {


### PR DESCRIPTION
Fixes an issue where a postback message (e.g. clicking on a Carousel button) will display an empty box in the debugger.

Before:
![large-image](https://user-images.githubusercontent.com/892367/66596163-63817500-eb6a-11e9-823b-9e189f68dcf6.png)

After:
![2019-10-10 at 2 30 PM](https://user-images.githubusercontent.com/892367/66596242-87dd5180-eb6a-11e9-8d18-1a7b0f23441e.png)

