### PR TITLE
fix(build) yarn watch will create studio symlink

### DIFF
--- a/build/gulp.ui.js
+++ b/build/gulp.ui.js
@@ -59,21 +59,21 @@ const watchAdmin = cb => {
   admin.stderr.pipe(process.stderr)
 }
 
-const watchStudio = cb => {
-  const studio = exec('yarn && yarn watch', { cwd: 'src/bp/ui-studio' }, err => cb(err))
-  studio.stdout.pipe(process.stdout)
-  studio.stderr.pipe(process.stderr)
-}
+const watchStudio = gulp.series([
+  cleanStudioAssets,
+  createStudioSymlink,
+  cb => {
+    const studio = exec('yarn && yarn watch', { cwd: 'src/bp/ui-studio' }, err => cb(err))
+    studio.stdout.pipe(process.stdout)
+    studio.stderr.pipe(process.stderr)
+  }
+])
 
-const watchAll = () => {
-  return gulp.parallel([watchStudio, watchAdmin])
-}
+const watchAll = gulp.parallel([watchStudio, watchAdmin])
 
 module.exports = {
   build,
   watchAll,
   watchStudio,
-  watchAdmin,
-  createStudioSymlink,
-  cleanStudioAssets
+  watchAdmin
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,15 +44,11 @@ gulp.task('build:reference', docs.buildReference())
 gulp.task('package:core', package.packageCore())
 gulp.task('package', gulp.series([package.packageApp, modules.packageModules(), package.copyNativeExtensions]))
 
-gulp.task('watch', gulp.parallel([core.watch, ui.watchAll()]))
+gulp.task('watch', gulp.parallel([core.watch, ui.watchAll]))
 gulp.task('watch:core', core.watch)
-gulp.task('watch:studio', gulp.series([ui.cleanStudioAssets, ui.createStudioSymlink, ui.watchStudio]))
+gulp.task('watch:studio', ui.watchStudio)
 gulp.task('watch:admin', ui.watchAdmin)
-
-gulp.task(
-  'watch:ui',
-  gulp.parallel([ui.watchAdmin, gulp.series([ui.cleanStudioAssets, ui.createStudioSymlink, ui.watchStudio])])
-)
+gulp.task('watch:ui', ui.watchAll)
 
 gulp.task('clean:node', cb => rimraf('**/node_modules/**', cb))
 gulp.task('clean:out', cb => rimraf('out', cb))


### PR DESCRIPTION
Running `yarn watch` without having previously ran `yarn cmd watch:studio` resulted in the `createStudioSymlink` to never be run. 

Simply running `yarn watch` should make sure that `createStudioSymlink` is always ran.