### PR TITLE
fix(checklist): add sticky session verification

### DIFF
--- a/src/bp/core/routers/auth.ts
+++ b/src/bp/core/routers/auth.ts
@@ -61,7 +61,13 @@ export class AuthRouter extends CustomRouter {
       })
     )
 
-    router.get('/ping', this.checkTokenHeader, this.asyncMiddleware(this.sendSuccess))
+    router.get(
+      '/ping',
+      this.checkTokenHeader,
+      this.asyncMiddleware(async (req, res) => {
+        sendSuccess(res, 'Pong', { serverId: process.SERVER_ID })
+      })
+    )
 
     router.get(
       '/me/profile',

--- a/src/bp/index.ts
+++ b/src/bp/index.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events'
-import { boolean } from 'joi'
+import nanoid from 'nanoid/generate'
 
 const yn = require('yn')
 const path = require('path')
@@ -103,6 +103,7 @@ try {
         process.IS_LICENSED = true
         process.ASSERT_LICENSED = () => {}
         process.BOTPRESS_VERSION = metadataContent.version
+        process.SERVER_ID = nanoid('1234567890abcdefghijklmnopqrstuvwxyz', 10)
 
         process.IS_PRO_AVAILABLE = fs.existsSync(path.resolve(process.PROJECT_LOCATION, 'pro')) || !!process.pkg
         const configPath = path.join(process.PROJECT_LOCATION, '/data/global/botpress.config.json')

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -45,6 +45,8 @@ declare namespace NodeJS {
     BOTPRESS_EVENTS: EventEmitter
     AUTO_MIGRATE: boolean
     IS_FAILSAFE: boolean
+    /** A random ID generated on server start to identify each server in a cluster */
+    SERVER_ID: string
   }
 }
 


### PR DESCRIPTION
The checklist will ping 3 times the server, if a different server answers, it means sticky is not enabled, which prevent websocket connections