### PR TITLE
fix(dialog) User, temp data to Timeout Flow event

### DIFF
--- a/src/bp/core/services/dialog/janitor.ts
+++ b/src/bp/core/services/dialog/janitor.ts
@@ -1,6 +1,6 @@
 import { BotConfig, IO, Logger } from 'botpress/sdk'
 import { createExpiry } from 'core/misc/expiry'
-import { SessionRepository } from 'core/repositories'
+import { SessionRepository, UserRepository } from 'core/repositories'
 import { Event } from 'core/sdk/impl'
 import { inject, injectable, tagged } from 'inversify'
 import _ from 'lodash'
@@ -28,7 +28,8 @@ export class DialogJanitor extends Janitor {
     @inject(TYPES.ConfigProvider) private configProvider: ConfigProvider,
     @inject(TYPES.DialogEngine) private dialogEngine: DialogEngine,
     @inject(TYPES.BotService) private botService: BotService,
-    @inject(TYPES.SessionRepository) private sessionRepo: SessionRepository
+    @inject(TYPES.SessionRepository) private sessionRepo: SessionRepository,
+    @inject(TYPES.UserRepository) private userRepo: UserRepository
   ) {
     super(logger)
   }
@@ -93,8 +94,12 @@ export class DialogJanitor extends Janitor {
         botId: botId
       }) as IO.IncomingEvent
 
+      const { result: user } = await this.userRepo.getOrCreate(channel, target)
+
       fakeEvent.state.context = session.context as IO.DialogContext
       fakeEvent.state.session = session.session_data as IO.CurrentSession
+      fakeEvent.state.user = user.attributes
+      fakeEvent.state.temp = session.temp_data
 
       const after = await this.dialogEngine.processTimeout(botId, sessionId, fakeEvent)
       if (_.get(after, 'state.context.queue.instructions.length', 0) > 0) {


### PR DESCRIPTION
Fixes a bug described here: https://help.botpress.io/t/accessing-temp-and-event-state-user-from-the-timeout-flow/2444

The `event.state.user` and `event.state.temp` fields were not set on the `FakeEvent` that is sent to the Dialog Engine.