### PR TITLE
feat(sdk): added distributed methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "@types/passport": "^1.0.0",
     "@types/puppeteer": "^1.19.1",
     "@types/redis": "^2.8.10",
+    "@types/redlock": "^4.0.0",
     "@types/socket.io": "^2.1.2",
     "@types/tmp": "^0.0.33",
     "@types/universal-analytics": "^0.4.2",

--- a/src/bp/core/api.ts
+++ b/src/bp/core/api.ts
@@ -23,6 +23,7 @@ import { CMSService } from './services/cms'
 import { DialogEngine } from './services/dialog/dialog-engine'
 import { SessionIdFactory } from './services/dialog/session/id-factory'
 import { HookService } from './services/hook/hook-service'
+import { JobService } from './services/job-service'
 import { KeyValueStore } from './services/kvs'
 import MediaService from './services/media'
 import { EventEngine } from './services/middleware/event-engine'
@@ -221,6 +222,14 @@ const workspaces = (workspaceService: WorkspaceService): typeof sdk.workspaces =
   }
 }
 
+const distributed = (jobService: JobService): typeof sdk.distributed => {
+  return {
+    broadcast: jobService.broadcast.bind(jobService),
+    acquireLock: jobService.acquireLock.bind(jobService),
+    clearLock: jobService.clearLock.bind(jobService)
+  }
+}
+
 const experimental = (hookService: HookService): typeof sdk.experimental => {
   return {
     disableHook: hookService.disableHook.bind(hookService),
@@ -257,6 +266,7 @@ export class BotpressAPIProvider {
   experimental: typeof sdk.experimental
   security: typeof sdk.security
   workspaces: typeof sdk.workspaces
+  distributed: typeof sdk.distributed
 
   constructor(
     @inject(TYPES.DialogEngine) dialogEngine: DialogEngine,
@@ -277,7 +287,8 @@ export class BotpressAPIProvider {
     @inject(TYPES.MediaService) mediaService: MediaService,
     @inject(TYPES.HookService) hookService: HookService,
     @inject(TYPES.EventRepository) eventRepo: EventRepository,
-    @inject(TYPES.WorkspaceService) workspaceService: WorkspaceService
+    @inject(TYPES.WorkspaceService) workspaceService: WorkspaceService,
+    @inject(TYPES.JobService) jobService: JobService
   ) {
     this.http = http(httpServer)
     this.events = event(eventEngine, eventRepo)
@@ -295,6 +306,7 @@ export class BotpressAPIProvider {
     this.experimental = experimental(hookService)
     this.security = security()
     this.workspaces = workspaces(workspaceService)
+    this.distributed = distributed(jobService)
   }
 
   @Memoize()
@@ -325,7 +337,8 @@ export class BotpressAPIProvider {
       cms: this.cms,
       security: this.security,
       experimental: this.experimental,
-      workspaces: this.workspaces
+      workspaces: this.workspaces,
+      distributed: this.distributed
     }
   }
 }

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -333,6 +333,17 @@ export class ScopedGhostService {
     this.primaryDriver = useDbDriver ? dbDriver : diskDriver
   }
 
+  public onFileInvalidation(callback: (key: string) => void) {
+    const bufferKey = this.bufferCacheKey(this.baseDir.replace('./', ''))
+    const objectKey = this.objectCacheKey(this.baseDir.replace('./', ''))
+
+    this.cache.events.on('invalidation', key => {
+      if (key.startsWith(bufferKey) || key.startsWith(objectKey)) {
+        callback(key)
+      }
+    })
+  }
+
   /**
    * TODO: Refactor this on v12.1.4
    * This is a temporary workaround to lock bots marked as "locked" until modules are correctly updated.

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -333,17 +333,6 @@ export class ScopedGhostService {
     this.primaryDriver = useDbDriver ? dbDriver : diskDriver
   }
 
-  public onFileInvalidation(callback: (key: string) => void) {
-    const bufferKey = this.bufferCacheKey(this.baseDir.replace('./', ''))
-    const objectKey = this.objectCacheKey(this.baseDir.replace('./', ''))
-
-    this.cache.events.on('invalidation', key => {
-      if (key.startsWith(bufferKey) || key.startsWith(objectKey)) {
-        callback(key)
-      }
-    })
-  }
-
   /**
    * TODO: Refactor this on v12.1.4
    * This is a temporary workaround to lock bots marked as "locked" until modules are correctly updated.

--- a/src/bp/core/services/job-service.ts
+++ b/src/bp/core/services/job-service.ts
@@ -1,3 +1,4 @@
+import { RedisLock } from 'botpress/sdk'
 import { injectable } from 'inversify'
 
 export interface JobService {
@@ -11,11 +12,26 @@ export interface JobService {
    * @param T The return type of the returned function
    */
   broadcast<T>(fn: Function): Promise<Function>
+
+  acquireLock(resource: string, duration: number): Promise<RedisLock | undefined>
+
+  clearLock(resource: string): Promise<boolean>
 }
 
 @injectable()
 export class CEJobService implements JobService {
   async broadcast<T>(fn: Function): Promise<Function> {
     return fn
+  }
+
+  async acquireLock(resource: string, duration: number): Promise<RedisLock | undefined> {
+    return {
+      unlock: async () => {},
+      extend: async (duration: number) => {}
+    }
+  }
+
+  async clearLock(resource: string): Promise<boolean> {
+    return true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -870,6 +870,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/redlock@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/redlock/-/redlock-4.0.0.tgz#d101855b090de5aeb4d0f75c4f5767a4a50efa08"
+  integrity sha512-kF8buBZkNgt9nIwTticRt6a1OR/lVUZ7uwnllW5DJN/i271Yj7BZ/eOP9MnOLV+UA+NhmP+jEgt2FNrfNcUU1A==
+  dependencies:
+    "@types/bluebird" "*"
+
 "@types/serve-static@*":
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.2.tgz#f5ac4d7a6420a99a6a45af4719f4dcd8cd907a48"


### PR DESCRIPTION
This PR adds some methods to the SDK to handle multiple nodes.

Ex:

```js
const lock = await bp.distributed.acquireLock('resourcename', 10000)
if (!lock) {
   console.log('cant acquire lock - another node is processing')
   return
}
// extend it longer
lock.extend(10000)
// when done
lock.unlock()
```

clearLock can be used to forcefully clear the lock on the redis store. It could, for example, be used after broadcasting a "cancel token" to kill a running job, then start another one.

Exposed the broadcast method so modules can broadcast jobs to be executed on all nodes (eg: load models once training is completed)