### PR TITLE
fix(studio) preventDefault on backspace

### DIFF
--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
@@ -405,6 +405,7 @@ class Diagram extends Component<Props> {
     } else if ((event.ctrlKey || event.metaKey) && event.key === 'v') {
       this.pasteElementFromBuffer()
     } else if (event.code === 'Backspace' || event.code === 'Delete') {
+      event.preventDefault()
       this.deleteSelectedElements()
     }
   }


### PR DESCRIPTION
Fixes an issue in Firefox where hitting backspace in the Studio deletes the selected node AND goes backward one page in the browser. Hitting backspace should not go back one page.