### PR TITLE
fix(ui-studio) Backspace should not always delete node

### DIFF
--- a/src/bp/ui-studio/src/web/views/FlowBuilder/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/index.tsx
@@ -201,9 +201,8 @@ class FlowBuilder extends Component<Props, State> {
       delete: e => {
         if (!isInputFocused()) {
           e.preventDefault()
+          this.diagram.deleteSelectedElements()
         }
-
-        this.diagram.deleteSelectedElements()
       },
       cancel: e => {
         e.preventDefault()


### PR DESCRIPTION
Fixes a bug where hitting backspace when a `input` field was focused always deleted the selected node.