### PR TITLE
fix(flow): identifying timeout flow & bigger archive timeout

### DIFF
--- a/src/bp/ui-admin/src/Pages/Components/Downloader.tsx
+++ b/src/bp/ui-admin/src/Pages/Components/Downloader.tsx
@@ -14,7 +14,7 @@ export const Downloader: FC<DownloadProps> = props => {
   const [filename, setFilename] = useState('')
 
   const startDownload = async (url: string, filename: string, method: string = 'get') => {
-    const { data } = await api.getSecured({ timeout: ms('2m') })({
+    const { data } = await api.getSecured({ timeout: ms('10m') })({
       method,
       url,
       responseType: 'blob'

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowsList.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowsList.tsx
@@ -9,6 +9,7 @@ export const DIRTY_ICON = 'clean'
 export const FLOW_ICON = 'document'
 export const MAIN_FLOW_ICON = 'flow-end'
 export const ERROR_FLOW_ICON = 'pivot'
+export const TIMEOUT_ICON = 'time'
 
 const lockedFlows = ['main.flow.json', 'error.flow.json']
 

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/util.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/util.tsx
@@ -69,7 +69,7 @@ const reorderFlows = flows => {
     flows.find(x => x.id === 'main'),
     flows.find(x => x.id === 'error'),
     flows.find(x => x.id === 'timeout'),
-    ...flows.filter(x => x.id !== 'main' && x.id !== 'error' && x.id !== 'timeout')
+    ...flows.filter(x => !['main', 'error', 'timeout'].contains(x.id))
   ].filter(x => Boolean(x))
 }
 

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/util.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/util.tsx
@@ -3,7 +3,7 @@ import _ from 'lodash'
 import find from 'lodash/find'
 import React from 'react'
 
-import { ERROR_FLOW_ICON, FLOW_ICON, FOLDER_ICON, MAIN_FLOW_ICON } from './FlowsList'
+import { ERROR_FLOW_ICON, FLOW_ICON, FOLDER_ICON, MAIN_FLOW_ICON, TIMEOUT_ICON } from './FlowsList'
 
 /**
  *  Returns a different display for special flows.
@@ -38,6 +38,24 @@ const getFlowInfo = (flowId: string, flowName: string) => {
         </Tooltip>
       )
     }
+  } else if (flowId === 'timeout') {
+    return {
+      icon: TIMEOUT_ICON,
+      label: (
+        <Tooltip
+          content={
+            <span>
+              When a discussion timeouts (user doesn't answer in the configured timeframe)
+              <br /> he will be redirected here.
+            </span>
+          }
+          hoverOpenDelay={500}
+          position={Position.BOTTOM}
+        >
+          <strong>Timeout</strong>
+        </Tooltip>
+      )
+    }
   }
   return {
     icon: FLOW_ICON,
@@ -49,7 +67,8 @@ const reorderFlows = flows => {
   return [
     flows.find(x => x.id === 'main'),
     flows.find(x => x.id === 'error'),
-    ...flows.filter(x => x.id !== 'main' && x.id !== 'error')
+    flows.find(x => x.id === 'timeout'),
+    ...flows.filter(x => x.id !== 'main' && x.id !== 'error' && x.id !== 'timeout')
   ].filter(x => Boolean(x))
 }
 

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/util.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/util.tsx
@@ -45,8 +45,9 @@ const getFlowInfo = (flowId: string, flowName: string) => {
         <Tooltip
           content={
             <span>
-              When a discussion timeouts (user doesn't answer in the configured timeframe)
-              <br /> he will be redirected here.
+              When a discussion timeouts (user doesn't answer in
+              <br />
+              the configured timeframe) he will be redirected here.
             </span>
           }
           hoverOpenDelay={500}


### PR DESCRIPTION
- Bigger delay for archive download (when there's a lot of medias)
- Added an official label for the timeout node (will be added by default in a future version with a migration)

![image](https://user-images.githubusercontent.com/42552874/67832516-44666b00-fab8-11e9-97a4-6e6d7d5be296.png)
