### PR TITLE
fix(core): caching required files in actions and hooks

### DIFF
--- a/src/bp/core/modules/require.ts
+++ b/src/bp/core/modules/require.ts
@@ -29,7 +29,7 @@ export const explodePath = (location: string): string[] => {
 export const requireAtPaths = (module: string, locations: string[], scriptPath?: string) => {
   const requireKey = getRequireCacheKey(scriptPath, module)
 
-  if (requireCache[requireKey]) {
+  if (requireCache[requireKey] && scriptPath) {
     return requireCache[requireKey]
   }
 

--- a/src/bp/core/services/hook/hook-service.ts
+++ b/src/bp/core/services/hook/hook-service.ts
@@ -11,7 +11,7 @@ import path from 'path'
 import { NodeVM } from 'vm2'
 
 import { GhostService } from '..'
-import { requireAtPaths } from '../../modules/require'
+import { clearRequireCache, requireAtPaths } from '../../modules/require'
 import { TYPES } from '../../types'
 import { VmRunner } from '../action/vm'
 import { Incident } from '../alerting-service'
@@ -157,6 +157,8 @@ export class HookService {
     Object.keys(require.cache)
       .filter(r => r.match(/(\\|\/)hooks(\\|\/)/g))
       .map(file => delete require.cache[file])
+
+    clearRequireCache()
   }
 
   async executeHook(hook: Hooks.BaseHook): Promise<void> {
@@ -209,7 +211,9 @@ export class HookService {
     }
   }
 
-  private _prepareRequire(hookLocation: string, hookType: string) {
+  private _prepareRequire(fullPath: string, hookType: string) {
+    const hookLocation = path.dirname(fullPath)
+
     let parts = path.relative(process.PROJECT_LOCATION, hookLocation).split(path.sep)
     parts = parts.slice(parts.indexOf(hookType) + 1) // We only keep the parts after /hooks/{type}/...
 
@@ -220,14 +224,14 @@ export class HookService {
       lookups.unshift(process.LOADED_MODULES[parts[0]])
     }
 
-    return module => requireAtPaths(module, lookups)
+    return module => requireAtPaths(module, lookups, fullPath)
   }
 
   private async runScript(hookScript: HookScript, hook: Hooks.BaseHook) {
     const hookPath = `/data/global/hooks/${hook.folder}/${hookScript.path}.js`
     const dirPath = path.resolve(path.join(process.PROJECT_LOCATION, hookPath))
 
-    const _require = this._prepareRequire(path.dirname(dirPath), hook.folder)
+    const _require = this._prepareRequire(dirPath, hook.folder)
 
     const modRequire = new Proxy(
       {},


### PR DESCRIPTION
Everytime a lib was required by an action or a hook, it was doing multiple existsSync to find the correct path in a list of lookup paths. This caused every require to take around 20ms of time to load the file.

This PR keeps the required file in memory for subsequent calls. We had a cache for hooks and actions themselves, but we did not for the libraries they required. 

They are also invalidated when changes are made via the code editor.