### PR TITLE
fix(core): global actions/hooks executed outside nodevm

### DIFF
--- a/src/bp/core/services/action/action-service.ts
+++ b/src/bp/core/services/action/action-service.ts
@@ -195,7 +195,7 @@ export class ScopedActionService {
 
     try {
       let result
-      if (action.location === 'global' && !process.FORCE_CODE_SANDBOX) {
+      if (action.location === 'global' && process.DISABLE_GLOBAL_SANDBOX) {
         result = await this.runWithoutVm(code, args, _require)
       } else {
         result = await this.runInVm(code, dirPath, args, _require)

--- a/src/bp/core/services/dialog/instruction/strategy.ts
+++ b/src/bp/core/services/dialog/instruction/strategy.ts
@@ -184,7 +184,14 @@ export class TransitionStrategy implements InstructionStrategy {
     }
   }
 
-  private async runCode(instruction, sandbox): Promise<any> {
+  private async runCode(instruction: Instruction, sandbox): Promise<any> {
+    if (instruction.fn === 'true') {
+      return true
+    } else if (instruction.fn && instruction.fn.match(/intent\.name === '([a-zA-Z0-9_-]+)'/)) {
+      const fn = new Function(...Object.keys(sandbox), instruction.fn)
+      return fn(...Object.values(sandbox))
+    }
+
     const vm = new NodeVM({
       wrapper: 'none',
       sandbox: sandbox,

--- a/src/bp/core/services/dialog/instruction/strategy.ts
+++ b/src/bp/core/services/dialog/instruction/strategy.ts
@@ -187,7 +187,7 @@ export class TransitionStrategy implements InstructionStrategy {
   private async runCode(instruction: Instruction, sandbox): Promise<any> {
     if (instruction.fn === 'true') {
       return true
-    } else if (instruction.fn && instruction.fn.match(/intent\.name === '([a-zA-Z0-9_-]+)'/)) {
+    } else if (instruction.fn && instruction.fn.match(/^event\.nlu\.intent\.name === '([a-zA-Z0-9_-]+)'$/)) {
       const fn = new Function(...Object.keys(sandbox), instruction.fn)
       return fn(...Object.values(sandbox))
     }

--- a/src/bp/core/services/hook/hook-service.ts
+++ b/src/bp/core/services/hook/hook-service.ts
@@ -238,7 +238,7 @@ export class HookService {
     hook.debug.forBot(botId, 'before execute %o', { path: hookScript.path, botId, args: _.omit(hook.args, ['bp']) })
     process.BOTPRESS_EVENTS.emit(hook.folder, hook.args)
 
-    if (!process.FORCE_CODE_SANDBOX) {
+    if (process.DISABLE_GLOBAL_SANDBOX) {
       await this.runWithoutVm(hookScript, hook, botId, _require)
     } else {
       await this.runInVm(hookScript, hook, botId, _require)

--- a/src/bp/index.ts
+++ b/src/bp/index.ts
@@ -100,7 +100,7 @@ try {
           process.env.AUTO_MIGRATE === undefined ? yn(argv.autoMigrate) : yn(process.env.AUTO_MIGRATE)
 
         process.VERBOSITY_LEVEL = argv.verbose ? Number(argv.verbose) : defaultVerbosity
-        process.FORCE_CODE_SANDBOX = yn(process.env.FORCE_CODE_SANDBOX)
+        process.DISABLE_GLOBAL_SANDBOX = yn(process.env.DISABLE_GLOBAL_SANDBOX)
         process.IS_LICENSED = true
         process.ASSERT_LICENSED = () => {}
         process.BOTPRESS_VERSION = metadataContent.version

--- a/src/bp/index.ts
+++ b/src/bp/index.ts
@@ -100,6 +100,7 @@ try {
           process.env.AUTO_MIGRATE === undefined ? yn(argv.autoMigrate) : yn(process.env.AUTO_MIGRATE)
 
         process.VERBOSITY_LEVEL = argv.verbose ? Number(argv.verbose) : defaultVerbosity
+        process.FORCE_CODE_SANDBOX = yn(process.env.FORCE_CODE_SANDBOX)
         process.IS_LICENSED = true
         process.ASSERT_LICENSED = () => {}
         process.BOTPRESS_VERSION = metadataContent.version

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -47,8 +47,11 @@ declare namespace NodeJS {
     IS_FAILSAFE: boolean
     /** A random ID generated on server start to identify each server in a cluster */
     SERVER_ID: string
-    /** When enabled, global hooks and actions will always be executed in the sandbox */
-    FORCE_CODE_SANDBOX: boolean
+    /**
+     * When true, global hooks and actions will be executed outside of the sandbox.
+     * This gives a boost in performances for code deemed "safe", while bot-specific content is executed in the sandbox
+     */
+    DISABLE_GLOBAL_SANDBOX: boolean
   }
 }
 

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -47,6 +47,8 @@ declare namespace NodeJS {
     IS_FAILSAFE: boolean
     /** A random ID generated on server start to identify each server in a cluster */
     SERVER_ID: string
+    /** When enabled, global hooks and actions will always be executed in the sandbox */
+    FORCE_CODE_SANDBOX: boolean
   }
 }
 


### PR DESCRIPTION
Added a new environment variable which would cause global actions and hooks to be executed outside of the VM, giving a notable performance boost. 

Also optimized transitions, so the most common ones ("always" and "intent is") are no longer being parsed in a new VM