### PR TITLE
fix(core): using redis for better io with user state

### DIFF
--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -360,6 +360,7 @@ export class Botpress {
       this.realtimeService.sendToSocket(payload)
     }
 
+    await this.stateManager.initialize()
     await this.logJanitor.start()
     await this.dialogJanitor.start()
     await this.monitoringService.start()

--- a/src/bp/core/services/job-service.ts
+++ b/src/bp/core/services/job-service.ts
@@ -1,5 +1,6 @@
 import { RedisLock } from 'botpress/sdk'
 import { injectable } from 'inversify'
+import { Redis } from 'ioredis'
 
 export interface JobService {
   /**
@@ -16,6 +17,8 @@ export interface JobService {
   acquireLock(resource: string, duration: number): Promise<RedisLock | undefined>
 
   clearLock(resource: string): Promise<boolean>
+
+  getRedisClient(): Redis | undefined
 }
 
 @injectable()
@@ -34,5 +37,9 @@ export class CEJobService implements JobService {
 
   async clearLock(resource: string): Promise<boolean> {
     return true
+  }
+
+  getRedisClient(): undefined {
+    return
   }
 }

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -552,7 +552,7 @@ declare module 'botpress/sdk' {
       /** Array of possible suggestions that the Decision Engine can take  */
       readonly suggestions?: Suggestion[]
       /** Contains data related to the state of the event */
-      readonly state: EventState
+      state: EventState
       /** Holds NLU extraction results (when the event is natural language) */
       readonly nlu?: EventUnderstanding
       /** The final decision that the Decision Engine took */

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -150,6 +150,12 @@ declare type BotpressEnvironementVariables = {
    * This only affects fatal errors, it will not affect business rules checks (eg: licensing)
    */
   readonly BP_FAILSAFE?: boolean
+
+  /**
+   * When true, it will not store/load the state from redis to speed up event processing
+   * Adding temporarily until the feature is battle-tested
+   */
+  readonly BP_NO_REDIS_STATE?: boolean
 }
 
 interface IDebug {


### PR DESCRIPTION
When cluster mode is enabled, the user's state is stored on Redis, and events are batched to be saved ot the database. It avoids costly calls to the database under load when the user is actively chatting with the bot.

