### PR TITLE
fix(core): avoid new debug instance creation

### DIFF
--- a/src/bp/core/services/hook/hook-service.ts
+++ b/src/bp/core/services/hook/hook-service.ts
@@ -23,12 +23,18 @@ interface HookOptions {
   timeout: number
 }
 
+const debugInstances: { [hookType: string]: IDebugInstance } = {}
+
 export namespace Hooks {
   export class BaseHook {
     debug: IDebugInstance
 
     constructor(public folder: string, public args: any, public options: HookOptions = { timeout: 1000 }) {
-      this.debug = debug.sub(folder)
+      if (debugInstances[folder]) {
+        this.debug = debugInstances[folder]
+      } else {
+        this.debug = debugInstances[folder] = debug.sub(folder)
+      }
     }
   }
 


### PR DESCRIPTION
Everytime a hook was being executed, it was creating a new debug instance, which does some processing on construct to determine if the terminal is TTY and if it can use colors... 

Believe it or not, it's the highest scorer after my 4 other performance PR.