### PR TITLE
fix(flow): minor improvements

### DIFF
--- a/modules/code-editor/src/views/full/utils/templates.ts
+++ b/modules/code-editor/src/views/full/utils/templates.ts
@@ -2,7 +2,7 @@ const baseAction = `
   /**
    * Small description of your action
    * @title The title displayed in the flow editor
-   * @category Category
+   * @category Custom
    * @author Your_Name
    * @param {string} name - An example string variable
    * @param {any} value - Another Example value

--- a/src/bp/ui-studio/src/web/actions/index.ts
+++ b/src/bp/ui-studio/src/web/actions/index.ts
@@ -356,3 +356,19 @@ export const refreshHints = () => dispatch => {
     dispatch(hintsReceived(res.data))
   })
 }
+
+export const actionsReceived = createAction('ACTIONS/RECEIVED')
+export const refreshActions = () => dispatch => {
+  // tslint:disable-next-line: no-floating-promises
+  axios.get(`${window.BOT_API_PATH}/actions`).then(({ data }) => {
+    dispatch(actionsReceived(_.sortBy(data.filter(action => !action.metadata.hidden), ['metadata.category', 'name'])))
+  })
+}
+
+export const intentsReceived = createAction('INTENTS/RECEIVED')
+export const refreshIntents = () => dispatch => {
+  // tslint:disable-next-line: no-floating-promises
+  axios.get(`${window.BOT_API_PATH}/mod/nlu/intents`).then(({ data }) => {
+    dispatch(intentsReceived(data))
+  })
+}

--- a/src/bp/ui-studio/src/web/reducers/skills.ts
+++ b/src/bp/ui-studio/src/web/reducers/skills.ts
@@ -1,8 +1,10 @@
 import { handleActions } from 'redux-actions'
 import {
+  actionsReceived,
   buildNewSkill,
   cancelNewSkill,
   editSkill,
+  intentsReceived,
   requestInsertNewSkill,
   requestUpdateSkill,
   skillsReceived,
@@ -77,6 +79,16 @@ const reducer = handleActions(
         ...state.builder,
         opened: false
       }
+    }),
+
+    [intentsReceived]: (state, { payload }) => ({
+      ...state,
+      intents: payload
+    }),
+
+    [actionsReceived]: (state, { payload }) => ({
+      ...state,
+      actions: payload
     })
   },
   defaultState

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/index.tsx
@@ -8,6 +8,8 @@ import {
   closeFlowNodeProps,
   flowEditorRedo,
   flowEditorUndo,
+  refreshActions,
+  refreshIntents,
   setDiagramAction,
   switchFlow
 } from '~/actions'
@@ -39,6 +41,8 @@ type Props = {
   clearErrorSaveFlows: () => void
   clearFlowsModification: () => void
   closeFlowNodeProps: () => void
+  refreshActions: () => void
+  refreshIntents: () => void
   flowsByName: _.Dictionary<FlowView>
 } & RouteComponentProps
 
@@ -90,6 +94,8 @@ class FlowBuilder extends Component<Props, State> {
 
   componentDidMount() {
     this.init()
+    this.props.refreshActions()
+    this.props.refreshIntents()
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -260,7 +266,9 @@ const mapDispatchToProps = {
   flowEditorUndo,
   flowEditorRedo,
   clearErrorSaveFlows,
-  closeFlowNodeProps
+  closeFlowNodeProps,
+  refreshActions,
+  refreshIntents
 }
 
 export default connect(

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/ActionModalForm.jsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/ActionModalForm.jsx
@@ -5,14 +5,14 @@ import axios from 'axios'
 import _ from 'lodash'
 
 import { LinkDocumentationProvider } from '~/components/Util/DocumentationProvider'
-
+import { connect } from 'react-redux'
 import SelectActionDropdown from './SelectActionDropdown'
 import ParametersTable from './ParametersTable'
 import ContentPickerWidget from '~/components/Content/Select/Widget'
 
 const style = require('./style.scss')
 
-export default class ActionModalForm extends Component {
+class ActionModalForm extends Component {
   state = {
     actionType: 'message',
     avActions: [],
@@ -49,17 +49,10 @@ export default class ActionModalForm extends Component {
     if (this.props.layoutv2) {
       this.setState({ actionType: 'code' })
     }
-    this.fetchAvailableFunctions()
-  }
 
-  fetchAvailableFunctions() {
-    return axios.get(`${window.BOT_API_PATH}/actions`).then(({ data }) => {
-      this.setState({
-        avActions: data
-          .filter(action => !action.metadata.hidden)
-          .map(x => {
-            return { label: x.name, value: x.name, metadata: x.metadata }
-          })
+    this.setState({
+      avActions: this.props.actions.map(x => {
+        return { label: x.name, value: x.name, metadata: x.metadata }
       })
     })
   }
@@ -241,3 +234,12 @@ export default class ActionModalForm extends Component {
     )
   }
 }
+
+const mapStateToProps = state => ({
+  actions: state.skills.actions
+})
+
+export default connect(
+  mapStateToProps,
+  undefined
+)(ActionModalForm)

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/ConditionModalForm.jsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/ConditionModalForm.jsx
@@ -4,7 +4,7 @@ import Select from 'react-select'
 import _ from 'lodash'
 import axios from 'axios'
 import style from './style.scss'
-
+import { connect } from 'react-redux'
 import SmartInput from '~/components/SmartInput'
 
 const availableProps = [
@@ -13,7 +13,7 @@ const availableProps = [
   { label: 'Temporary Dialog Context', value: 'temp' }
 ]
 
-export default class ConditionModalForm extends Component {
+class ConditionModalForm extends Component {
   state = {
     typeOfTransition: 'end',
     flowToSubflow: null,
@@ -27,8 +27,6 @@ export default class ConditionModalForm extends Component {
   }
 
   componentDidMount() {
-    this.fetchIntents()
-
     const subflowOptions = this.props.subflows
       .filter(flow => !flow.startsWith('skills/'))
       .map(flow => ({
@@ -116,12 +114,6 @@ export default class ConditionModalForm extends Component {
         matchPropsExpression: props[3]
       })
     }
-  }
-
-  fetchIntents() {
-    return axios.get(`${window.BOT_API_PATH}/mod/nlu/intents`).then(({ data }) => {
-      this.setState({ intents: data })
-    })
   }
 
   changeTransitionType(type) {
@@ -289,11 +281,11 @@ export default class ConditionModalForm extends Component {
   }
 
   renderIntentPicker() {
-    if (!this.state.intents) {
+    if (!this.props.intents) {
       return null
     }
 
-    const intents = this.state.intents
+    const intents = this.props.intents
       .filter(i => !i.name.startsWith('__qna__'))
       .map(({ name }) => ({ label: name, value: name }))
       .concat([{ label: 'none', value: 'none' }])
@@ -420,3 +412,12 @@ export default class ConditionModalForm extends Component {
     )
   }
 }
+
+const mapStateToProps = state => ({
+  intents: state.skills.intents
+})
+
+export default connect(
+  mapStateToProps,
+  undefined
+)(ConditionModalForm)


### PR DESCRIPTION
Every time you selected a node on the flow editor, it was fetching actions 2x and intents 1x, so a lot of unneeded calls. Also fixes a react warning.

Actions will be sorted by category, so custom user actions will be on the top of the dropdown menu.