### PR TITLE
fix(studio) Skills: allow selection of transition node

### DIFF
--- a/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/SkillCallNode.jsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/SkillCallNode.jsx
@@ -52,6 +52,7 @@ export default class SkillCallNodePropertiesPanel extends Component {
             <TransitionSection
               readOnly={readOnly}
               items={node.next}
+              currentFlow={this.props.flow}
               header="Transitions"
               subflows={this.props.subflows}
               onItemsUpdated={items => this.props.updateNode({ next: items })}


### PR DESCRIPTION
Fixes an issue where selecting the transition node was impossible in from a Skill node's properties.

See https://help.botpress.io/t/cannot-use-the-transition-to-node-transition-for-a-slot-skill/2534 for bug description