### PR TITLE
fix(core): minor adjustments

### DIFF
--- a/src/bp/bootstrap.ts
+++ b/src/bp/bootstrap.ts
@@ -68,6 +68,9 @@ async function start() {
     return setupMasterNode(await getLogger('Cluster'))
   }
 
+  // Server ID is provided by the master node
+  process.SERVER_ID = process.env.SERVER_ID!
+
   await setupEnv()
 
   const logger = await getLogger('Launcher')

--- a/src/bp/cluster.ts
+++ b/src/bp/cluster.ts
@@ -1,5 +1,6 @@
 import sdk from 'botpress/sdk'
 import cluster from 'cluster'
+import nanoid from 'nanoid/generate'
 import yn from 'yn'
 
 const debug = DEBUG('cluster')
@@ -21,6 +22,8 @@ export const registerMsgHandler = (messageType: string, handler: (message: any, 
 }
 
 export const setupMasterNode = (logger: sdk.Logger) => {
+  process.SERVER_ID = process.env.SERVER_ID || nanoid('1234567890abcdefghijklmnopqrstuvwxyz', 10)
+
   registerMsgHandler('reboot_server', (_message, worker) => {
     logger.warn(`Restarting server...`)
     worker.disconnect()
@@ -47,7 +50,7 @@ export const setupMasterNode = (logger: sdk.Logger) => {
         process.exit(0)
       }
 
-      cluster.fork()
+      cluster.fork({ SERVER_ID: process.SERVER_ID })
       rebootCount++
     }
   })
@@ -65,5 +68,5 @@ export const setupMasterNode = (logger: sdk.Logger) => {
     }
   })
 
-  cluster.fork()
+  cluster.fork({ SERVER_ID: process.SERVER_ID })
 }

--- a/src/bp/index.ts
+++ b/src/bp/index.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'events'
-import nanoid from 'nanoid/generate'
 
 const yn = require('yn')
 const path = require('path')
@@ -104,7 +103,6 @@ try {
         process.IS_LICENSED = true
         process.ASSERT_LICENSED = () => {}
         process.BOTPRESS_VERSION = metadataContent.version
-        process.SERVER_ID = nanoid('1234567890abcdefghijklmnopqrstuvwxyz', 10)
 
         process.IS_PRO_AVAILABLE = fs.existsSync(path.resolve(process.PROJECT_LOCATION, 'pro')) || !!process.pkg
         const configPath = path.join(process.PROJECT_LOCATION, '/data/global/botpress.config.json')


### PR DESCRIPTION
- Pro: Removing the max listeners warning (we added broadcasted jobs which brought us over the limit)
- Minor change to keep the server id sticky when restarting its child process (will be used in a future pr)
- Added a check for redis which caused an error when querying status while booting