### PR TITLE
fix(docs) Search: version facet

### DIFF
--- a/docs/guide/website/siteConfig.js
+++ b/docs/guide/website/siteConfig.js
@@ -20,7 +20,9 @@ const siteConfig = {
   algolia: {
     apiKey: '570227d66d130d069630e7226c740158',
     indexName: 'botpress',
-    facetFilters: ['version:VERSION']
+    algoliaOptions: {
+      facetFilters: ['version:VERSION']
+    }
   },
 
   docsSideNavCollapsible: true,


### PR DESCRIPTION
Fixes a bug in the Search (Algolia) feature of our docs where results were not faceted by version.

Before:
![Screen Shot 2019-11-12 at 14 26 17](https://user-images.githubusercontent.com/892367/68703379-87b0e700-0558-11ea-81ae-6d8bebe07c27.png)

After:
![Screen Shot 2019-11-12 at 14 25 48](https://user-images.githubusercontent.com/892367/68703390-8da6c800-0558-11ea-9f0c-a2702c816627.png)
