### PR TITLE
fix(core): clearing state from redis when reset session

### DIFF
--- a/src/bp/core/services/middleware/state-manager.ts
+++ b/src/bp/core/services/middleware/state-manager.ts
@@ -41,8 +41,8 @@ export class StateManager {
     @inject(TYPES.Database) private database: Database,
     @inject(TYPES.JobService) private jobService: JobService
   ) {
-    // Disabling temporarily
-    this.useRedis = false // process.CLUSTER_ENABLED && !process.core_env.BP_NO_REDIS_STATE
+    // Temporarily opt-in until thoroughly tested
+    this.useRedis = process.CLUSTER_ENABLED && process.env.USE_REDIS_STATE
   }
 
   public initialize() {

--- a/src/bp/core/services/middleware/state-manager.ts
+++ b/src/bp/core/services/middleware/state-manager.ts
@@ -41,7 +41,8 @@ export class StateManager {
     @inject(TYPES.Database) private database: Database,
     @inject(TYPES.JobService) private jobService: JobService
   ) {
-    this.useRedis = process.CLUSTER_ENABLED && !process.core_env.BP_NO_REDIS_STATE
+    // Disabling temporarily
+    this.useRedis = false // process.CLUSTER_ENABLED && !process.core_env.BP_NO_REDIS_STATE
   }
 
   public initialize() {

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -1437,7 +1437,12 @@ declare module 'botpress/sdk' {
      * @param nodeName The name of the optionnal node to jump to.
      * The node will default to the starting node of the flow if this value is omitted.
      */
-    export function jumpTo(sessionId: string, event: IO.Event, flowName: string, nodeName?: string): Promise<void>
+    export function jumpTo(
+      sessionId: string,
+      event: IO.IncomingEvent,
+      flowName: string,
+      nodeName?: string
+    ): Promise<void>
   }
 
   export namespace config {


### PR DESCRIPTION
Clearing state from redis (so reset works correctly) and avoid storing temporary data (stacktrace/error) to redis.