### PR TITLE
fix(core): requiring actions directly from bpfs

### DIFF
--- a/src/bp/core/services/action/utils.ts
+++ b/src/bp/core/services/action/utils.ts
@@ -1,0 +1,50 @@
+import { requireAtPaths } from 'core/modules/require'
+import path from 'path'
+
+export const getBaseLookupPaths = (fullPath: string) => {
+  const actionLocation = path.dirname(fullPath)
+
+  let parts = path.relative(process.PROJECT_LOCATION, actionLocation).split(path.sep)
+  parts = parts.slice(parts.indexOf('actions') + 1) // We only keep the parts after /actions/...
+
+  const lookups: string[] = [actionLocation]
+
+  if (parts[0] in process.LOADED_MODULES) {
+    // the action is in a directory by the same name as a module
+    lookups.unshift(process.LOADED_MODULES[parts[0]])
+  }
+
+  return lookups
+}
+
+export const prepareRequire = (fullPath: string, lookups: string[]) => {
+  return module => requireAtPaths(module, lookups, fullPath)
+}
+
+export const prepareRequireTester = (parentScript: string, lookups: string[]) => {
+  const _require = module => requireAtPaths(module, lookups, parentScript)
+
+  return (file: string) => {
+    try {
+      _require(file)
+      return true
+    } catch (err) {
+      return false
+    }
+  }
+}
+
+export const extractRequiredFiles = (code: string) => {
+  const commentRegex = /\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm
+  const requireRegex = /require\([\\'"]?(.*?)[\\'"]?\)/gm
+
+  const withoutComments = code.replace(commentRegex, '')
+  const files: string[] = []
+
+  let match
+  while ((match = requireRegex.exec(withoutComments))) {
+    files.push(match[1])
+  }
+
+  return files
+}

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -161,6 +161,11 @@ declare type BotpressEnvironementVariables = {
    * Adding temporarily until the feature is battle-tested
    */
   readonly BP_NO_REDIS_STATE?: boolean
+
+  /**
+   * Experimental feature which will try to load actions locally, then from the ghost
+   */
+  readonly BP_EXPERIMENTAL_REQUIRE_BPFS?: boolean
 }
 
 interface IDebug {


### PR DESCRIPTION
Experimental feature which tries to load actions from the bpfs when it fails from the file system. There seems to be an issue in certain situations when using the BPFS_STORAGE = database.

The first time an action is executed, the file is parsed to fetch all its require()'d files, then all other scripts are tested like this. Since require() cannot be async, we need a little workaround to load them in memory.

To enable, set the flag BP_EXPERIMENTAL_REQUIRE_BPFS=true