### PR TITLE
Adding PaperGo to the Botpress Partners

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,6 @@ Botpress Partners is a list of agencies who can help you build your next convers
 | [ZeroBulb](https://www.zerobulb.com) | Kerala, India |
 | [Tasqat](https://www.tasqat.com)| Dubai, United Arab Emirates |
 | [Creative Melon](https://creativemelon.co.za) | Johannesburg, South Africa |
+| [PaperGo](https://www.papergo.io) | Patras, Greece |
 
 _If you are an agency and would like to be on this list, please clone the repository & add your agency to the list in the README.md. Then, you can create a pull request on the repository and we'll make sure to review and merge your PR swiftly._


### PR DESCRIPTION
This PR adds PaperGo website and location to the Botpress Partners.