### PR TITLE
fix(channel-web): flickering issue on internet explorer

### DIFF
--- a/modules/channel-web/assets/inject.js
+++ b/modules/channel-web/assets/inject.js
@@ -9,6 +9,23 @@ function injectDOMElement(tagName, targetSelector, options) {
   return element
 }
 
+function fixPositionIe() {
+  const widget = document.querySelector('#bp-web-widget > #bp-widget')
+
+  if (!widget.classList.contains('bp-widget-side')) {
+    widget.style.position = 'fixed'
+    widget.style.top = 'auto'
+  } else {
+    widget.style.position = 'absolute'
+    widget.style.top = document.documentElement.scrollTop
+  }
+}
+
+const isIe = /MSIE|Trident/.test(window.navigator.userAgent)
+if (isIe) {
+  window.addEventListener('scroll', fixPositionIe)
+}
+
 window.addEventListener('message', function(payload) {
   const data = payload.data
   if (!data || !data.type) {
@@ -17,6 +34,9 @@ window.addEventListener('message', function(payload) {
 
   if (data.type === 'setClass') {
     document.querySelector('#bp-widget').setAttribute('class', data.value)
+    if (isIe) {
+      fixPositionIe()
+    }
   } else if (data.type === 'setWidth') {
     document.querySelector('#bp-widget').style.width = data.value
   }


### PR DESCRIPTION
On internet explorer, when the parent of the webchat has a scrollbar, there's a flickering issue because of the position: fixed. 

This changes the position to absolute when the chat is opened, only on internet explorer. It has no impact on other browsers.