### PR TITLE
Extend 'generic template' renderer for FB messenger

### DIFF
--- a/modules/builtin/src/content-types/action_button.js
+++ b/modules/builtin/src/content-types/action_button.js
@@ -47,6 +47,16 @@ module.exports = {
               url: {
                 type: 'string',
                 title: 'Enter a valid URL'
+              },
+              webview_height_ratio: {
+                type: 'string',
+                enum: ['compact', 'tall', 'full'],
+                title: 'Enter the Webview height ratio',
+                default: 'full'
+              },
+              messenger_extensions: {
+                type: 'boolean',
+                default: true
               }
             },
             required: ['url']

--- a/modules/builtin/src/content-types/carousel.js
+++ b/modules/builtin/src/content-types/carousel.js
@@ -62,7 +62,9 @@ function renderMessenger(data) {
           return {
             type: 'web_url',
             url: a.url,
-            title: a.title
+            title: a.title,
+            webview_height_ratio: a.webview_height_ratio,
+            messenger_extensions: a.messenger_extensions
           }
         } else if (a.action === 'Postback') {
           return {


### PR DESCRIPTION
Add webview option as described here:
https://developers.facebook.com/docs/messenger-platform/webview