### PR TITLE
fix(nlu): original case in entity exact score

### DIFF
--- a/modules/nlu/src/backend/engine2/entity-extractor.ts
+++ b/modules/nlu/src/backend/engine2/entity-extractor.ts
@@ -100,26 +100,26 @@ export const extractListEntities = (
     const candidates = []
     let longestCandidate = 0
 
-    for (const [canonical, occurances] of _.toPairs(list.mappingsTokens)) {
-      for (const occurance of occurances) {
+    for (const [canonical, occurences] of _.toPairs(list.mappingsTokens)) {
+      for (const occurence of occurences) {
         for (let i = 0; i < utterance.tokens.length; i++) {
           if (utterance.tokens[i].isSpace) {
             continue
           }
-          const workset = takeUntil(utterance.tokens, i, _.sumBy(occurance, 'length'))
+          const workset = takeUntil(utterance.tokens, i, _.sumBy(occurence, 'length'))
           const worksetStrLow = workset.map(x => x.toString({ lowerCase: true, realSpaces: true, trim: false }))
           const worksetStrWCase = workset.map(x => x.toString({ lowerCase: false, realSpaces: true, trim: false }))
-          const candidateAsString = occurance.join('')
+          const candidateAsString = occurence.join('')
 
           if (candidateAsString.length > longestCandidate) {
             longestCandidate = candidateAsString.length
           }
 
-          const exact_score = exactScore(worksetStrWCase, occurance) === 1 ? 1 : 0
+          const exact_score = exactScore(worksetStrWCase, occurence) === 1 ? 1 : 0
           const fuzzy = list.fuzzyTolerance < 1 && worksetStrLow.join('').length >= 4
-          const fuzzy_score = fuzzyScore(worksetStrLow, occurance)
+          const fuzzy_score = fuzzyScore(worksetStrLow, occurence)
           const fuzzy_factor = fuzzy_score >= list.fuzzyTolerance ? fuzzy_score : 0
-          const structural_score = structuralScore(worksetStrWCase, occurance)
+          const structural_score = structuralScore(worksetStrWCase, occurence)
           const finalScore = fuzzy ? fuzzy_factor * structural_score : exact_score * structural_score
 
           candidates.push({
@@ -128,7 +128,7 @@ export const extractListEntities = (
             start: i,
             end: i + workset.length - 1,
             source: workset.map(t => t.toString({ lowerCase: false, realSpaces: true })).join(''),
-            occurance: occurance.join(''),
+            occurence: occurence.join(''),
             eliminated: false
           })
         }
@@ -159,7 +159,7 @@ export const extractListEntities = (
           value: match.canonical,
           metadata: {
             source: match.source,
-            occurance: match.occurance,
+            occurence: match.occurence,
             entityId: list.id
           },
           type: list.entityName

--- a/modules/nlu/src/backend/engine2/entity-extractor.ts
+++ b/modules/nlu/src/backend/engine2/entity-extractor.ts
@@ -107,21 +107,19 @@ export const extractListEntities = (
             continue
           }
           const workset = takeUntil(utterance.tokens, i, _.sumBy(occurance, 'length'))
-          const worksetAsStrings = workset.map(x => x.toString({ lowerCase: true, realSpaces: true, trim: false }))
+          const worksetStrLow = workset.map(x => x.toString({ lowerCase: true, realSpaces: true, trim: false }))
+          const worksetStrWCase = workset.map(x => x.toString({ lowerCase: false, realSpaces: true, trim: false }))
           const candidateAsString = occurance.join('')
 
           if (candidateAsString.length > longestCandidate) {
             longestCandidate = candidateAsString.length
           }
 
-          const fuzzy = list.fuzzyTolerance < 1 && worksetAsStrings.join('').length >= 4
-          const exact_score = exactScore(worksetAsStrings, occurance) === 1 ? 1 : 0
-          const fuzzy_score = fuzzyScore(worksetAsStrings, occurance)
+          const exact_score = exactScore(worksetStrWCase, occurance) === 1 ? 1 : 0
+          const fuzzy = list.fuzzyTolerance < 1 && worksetStrLow.join('').length >= 4
+          const fuzzy_score = fuzzyScore(worksetStrLow, occurance)
           const fuzzy_factor = fuzzy_score >= list.fuzzyTolerance ? fuzzy_score : 0
-          const structural_score = structuralScore(
-            workset.map(x => x.toString({ lowerCase: false, realSpaces: true, trim: false })),
-            occurance
-          )
+          const structural_score = structuralScore(worksetStrWCase, occurance)
           const finalScore = fuzzy ? fuzzy_factor * structural_score : exact_score * structural_score
 
           candidates.push({

--- a/modules/nlu/src/backend/engine2/entity-extractor.ts
+++ b/modules/nlu/src/backend/engine2/entity-extractor.ts
@@ -117,7 +117,7 @@ export const extractListEntities = (
 
           const exact_score = exactScore(worksetStrWCase, occurence) === 1 ? 1 : 0
           const fuzzy = list.fuzzyTolerance < 1 && worksetStrLow.join('').length >= 4
-          const fuzzy_score = fuzzyScore(worksetStrLow, occurence)
+          const fuzzy_score = fuzzyScore(worksetStrLow, occurence.map(t => t.toLowerCase()))
           const fuzzy_factor = fuzzy_score >= list.fuzzyTolerance ? fuzzy_score : 0
           const structural_score = structuralScore(worksetStrWCase, occurence)
           const finalScore = fuzzy ? fuzzy_factor * structural_score : exact_score * structural_score

--- a/modules/nlu/src/backend/engine2/list-extractor.test.ts
+++ b/modules/nlu/src/backend/engine2/list-extractor.test.ts
@@ -44,7 +44,7 @@ const list_entities: ListEntityModel[] = [
     mappingsTokens: {
       JFK: ['JFK', 'New-York', 'NYC'].map(T),
       SFO: ['SFO', 'SF', 'San-Francisco'].map(T),
-      YQB: ['YQB', 'Quebec', 'Quebec city'].map(T)
+      YQB: ['YQB', 'Quebec', 'Quebec city', 'QUEB'].map(T)
     },
     sensitive: false,
     type: 'custom.list'
@@ -81,7 +81,9 @@ describe('list entity extractor', () => {
     assertEntity('the [red](qty:1) apple [corporation](qty:1)')
     assertEntity('[apple](qty:2)')
     assertEntity('[apple inc](qty:2)')
-    assertEntity('[SF](qty:1 type:airport) is where I was born, I now live in [Quebec](qty:1 type:airport) the city')
+    assertEntity(
+      '[SF](qty:1 type:airport) is where I was born, I now live in [Quebec](qty:1 type:airport) [the city](qty:0)'
+    )
   })
 
   describe('fuzzy match', () => {
@@ -99,7 +101,6 @@ describe('list entity extractor', () => {
       assertEntity('[Bluberies](qty:1 value:Blueberry) are berries that are blue')
       assertEntity('that is a [poisonous bleberry](qty:1 value:Blueberry confidence:0.9)') // the longer the word, the more we tolerate mistakes
       assertEntity('that is a [poisonus bleberry](qty:1 value:Blueberry confidence:0.8)') // prefer 'poisonous blueberry' to 'blueberry'
-      assertEntity('[aple](qty:1)') // Apple the company has a capital 'A'
     })
 
     describe('added chars', () => {
@@ -118,6 +119,20 @@ describe('list entity extractor', () => {
       assertEntity('that is a [poison](qty:0) [blueberry](qty:1 value:Blueberry confidence:0.9)') // prefer 'blueberry' to 'poisonous blueberry'
       assertEntity('[blberries](qty:1) are berries that are blue')
       assertEntity('[bberries are berries that are blue](qty:0)')
+    })
+
+    describe('casing issues', () => {
+      assertEntity('[queb](qty:1 value:YQB confidence:0.7) is the place')
+      assertEntity('[Queb](qty:1 value:YQB confidence:0.75) is the place')
+      assertEntity('[QUeb](qty:1 value:YQB confidence:0.8) is the place')
+      assertEntity('[QUEb](qty:1 value:YQB confidence:0.85) is the place')
+      assertEntity('[QUEB](qty:1 value:YQB confidence:0.9) is the place')
+      assertEntity('[yqb](qty:0) is the place') // less than 4 chars
+
+      // casing + typos
+      // this will need better structural scoring
+      // assertEntity('[AppLe](qty:1 type:company) is a company, not a fruit')
+      // assertEntity('[aple](qty:1)') // Apple the company has a capital 'A'
     })
 
     describe('bad keystrokes', () => {

--- a/modules/nlu/src/backend/engine2/list-extractor.test.ts
+++ b/modules/nlu/src/backend/engine2/list-extractor.test.ts
@@ -81,12 +81,12 @@ describe('list entity extractor', () => {
     assertEntity('the [red](qty:1) apple [corporation](qty:1)')
     assertEntity('[apple](qty:2)')
     assertEntity('[apple inc](qty:2)')
+    assertEntity('[SF](qty:1 type:airport) is where I was born, I now live in [Quebec](qty:1 type:airport) the city')
   })
 
   describe('fuzzy match', () => {
     describe('loose fuzzy', () => {
-      assertEntity('[Qebec citty](qty:1 value:YQB) is a city within QC, a provice.')
-      assertEntity('A quaterback is also called a [QB](qty:0) and [sn francisco](qty:1 value:SFO) used to have one')
+      assertEntity('[Qebec citty](qty:1 value:YQB) is a city within [QC](qty:0), a provice.')
       assertEntity('A quaterback is also called a [QB](qty:0) and [sn francisco](qty:1 value:SFO) used to have one')
       assertEntity('[sn frncisco](qty:0) is nice but for [New-Yorkers](qty:0) [new-yrk](qty:1 value:JFK) is better')
       assertEntity("I never been to [kbec city](qty:0) but I've been to [kebec city](qty:1 value:YQB)")

--- a/modules/nlu/src/backend/engine2/list-extractor.test.ts
+++ b/modules/nlu/src/backend/engine2/list-extractor.test.ts
@@ -62,7 +62,7 @@ describe('list entity extractor', () => {
     expect(results[0].type).toBe('fruit')
     expect(results[0].confidence).toBeGreaterThan(0.9)
     expect(results[0].metadata.source).toBe('Blueberries')
-    expect(results[0].metadata.occurance).toBe('blueberries')
+    expect(results[0].metadata.occurence).toBe('blueberries')
   })
 
   describe('exact match', () => {

--- a/modules/nlu/src/views/full/entities/ListEntity.tsx
+++ b/modules/nlu/src/views/full/entities/ListEntity.tsx
@@ -1,4 +1,16 @@
-import { Button, Colors, FormGroup, Icon, InputGroup, Position, Radio, RadioGroup, Tooltip } from '@blueprintjs/core'
+import {
+  Button,
+  Classes,
+  Colors,
+  FormGroup,
+  Icon,
+  InputGroup,
+  Position,
+  Radio,
+  RadioGroup,
+  Text,
+  Tooltip
+} from '@blueprintjs/core'
 import { NLU } from 'botpress/sdk'
 import _ from 'lodash'
 import React, { useEffect, useState } from 'react'
@@ -99,7 +111,7 @@ export const ListEntityEditor: React.FC<Props> = props => {
         <FormGroup
           label={
             <Tooltip
-              content="Fuzziness will tolerate slight errors in extraction, typos for instance. Strict means no errors allowed."
+              content="Fuzziness will tolerate slight errors (e.g: typos) in words of 4 characters or more. Strict means no errors allowed."
               position={Position.LEFT}
               popoverClassName={style.configPopover}
             >


### PR DESCRIPTION
This fixes the case where the entity is shorter than 4 chars (exact match only).

2 fixes were possible 
* lowercase the candidate entity occurence and compare with lowercase workset (tokens)
* keep original casing in the workset (tokens) and compare with case

I chose the latter since this is only for short entities