### PR TITLE
fix(docs) Title alignment

### DIFF
--- a/docs/guide/website/static/css/custom.css
+++ b/docs/guide/website/static/css/custom.css
@@ -46,6 +46,7 @@
 
 .fixedHeaderContainer header .headerTitleWithLogo {
   font-size: 16px;
+  white-space: nowrap;
 }
 
 .error {


### PR DESCRIPTION
Fixes that visual bug in the docs:

![2019-12-05 at 10 53 AM](https://user-images.githubusercontent.com/892367/70251409-71f4a300-174d-11ea-8aa3-783934344186.png)

The bug was visible in Chrome, not Firefox.
