### PR TITLE
fix(core): sync is done correctly when enabling bpfs first time

### DIFF
--- a/src/bp/bootstrap.ts
+++ b/src/bp/bootstrap.ts
@@ -18,10 +18,10 @@ import { setupMasterNode } from './cluster'
 import { FatalError } from './errors'
 
 async function setupEnv() {
-  const useDbDriver = process.BPFS_STORAGE === 'database'
-  Ghost.initialize(useDbDriver)
-
   await Db.initialize()
+
+  const useDbDriver = process.BPFS_STORAGE === 'database'
+  await Ghost.initialize(useDbDriver)
 }
 
 async function getLogger(loggerName: string) {

--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -273,21 +273,6 @@ export class Botpress {
     await Promise.map(botsToMount, botId => this.botService.mountBot(botId))
   }
 
-  @WrapErrorsWith('Error initializing Ghost Service')
-  async initializeGhost(): Promise<void> {
-    const useDbDriver = process.BPFS_STORAGE === 'database'
-    this.ghostService.initialize(useDbDriver)
-    const global = await this.ghostService.global().directoryListing('/')
-
-    if (useDbDriver && _.isEmpty(global)) {
-      this.logger.info('Syncing data/global/ to database')
-      await this.ghostService.global().sync()
-
-      this.logger.info('Syncing data/bots/ to database')
-      await this.ghostService.bots().sync()
-    }
-  }
-
   private async initializeServices() {
     await this.loggerDbPersister.initialize(this.database, await this.loggerProvider('LogDbPersister'))
     this.loggerDbPersister.start()

--- a/src/bp/core/services/ghost/service.test.ts
+++ b/src/bp/core/services/ghost/service.test.ts
@@ -30,8 +30,8 @@ describe('Ghost Service', () => {
   })
 
   describe(`Using Disk Driver`, () => {
-    beforeEach(() => {
-      ghost.initialize(false)
+    beforeEach(async () => {
+      await ghost.initialize(false, true)
     })
 
     it('DB Driver is never ever called', async () => {
@@ -116,8 +116,8 @@ describe('Ghost Service', () => {
         revision: n
       }
 
-    beforeEach(() => {
-      ghost.initialize(true)
+    beforeEach(async () => {
+      await ghost.initialize(true, true)
     })
 
     describe('read/write/delete', () => {

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -61,9 +61,19 @@ export class GhostService {
     this.cache.events.on && this.cache.events.on('syncDbFilesToDisk', this._onSyncReceived)
   }
 
-  initialize(enabled: boolean) {
-    this.enabled = enabled
+  async initialize(useDbDriver: boolean) {
+    this.enabled = useDbDriver
     this._scopedGhosts.clear()
+
+    const global = await this.global().directoryListing('/')
+
+    if (useDbDriver && _.isEmpty(global)) {
+      this.logger.info('Syncing data/global/ to database')
+      await this.global().sync()
+
+      this.logger.info('Syncing data/bots/ to database')
+      await this.bots().sync()
+    }
   }
 
   // Not caching this scope since it's rarely used

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -61,13 +61,13 @@ export class GhostService {
     this.cache.events.on && this.cache.events.on('syncDbFilesToDisk', this._onSyncReceived)
   }
 
-  async initialize(useDbDriver: boolean) {
+  async initialize(useDbDriver: boolean, ignoreSync?: boolean) {
     this.useDbDriver = useDbDriver
     this._scopedGhosts.clear()
 
     const global = await this.global().directoryListing('/')
 
-    if (useDbDriver && _.isEmpty(global)) {
+    if (useDbDriver && !ignoreSync && _.isEmpty(global)) {
       this.logger.info('Syncing data/global/ to database')
       await this.global().sync()
 

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -48,7 +48,7 @@ const BOTS_GHOST_KEY = '__bots__'
 @injectable()
 export class GhostService {
   private _scopedGhosts: Map<string, ScopedGhostService> = new Map()
-  public enabled: boolean = false
+  public useDbDriver: boolean = false
 
   constructor(
     @inject(TYPES.DiskStorageDriver) private diskDriver: DiskStorageDriver,
@@ -62,7 +62,7 @@ export class GhostService {
   }
 
   async initialize(useDbDriver: boolean) {
-    this.enabled = useDbDriver
+    this.useDbDriver = useDbDriver
     this._scopedGhosts.clear()
 
     const global = await this.global().directoryListing('/')
@@ -78,7 +78,7 @@ export class GhostService {
 
   // Not caching this scope since it's rarely used
   root(): ScopedGhostService {
-    return new ScopedGhostService(`./data`, this.diskDriver, this.dbDriver, this.enabled, this.cache, this.logger)
+    return new ScopedGhostService(`./data`, this.diskDriver, this.dbDriver, this.useDbDriver, this.cache, this.logger)
   }
 
   global(): ScopedGhostService {
@@ -90,7 +90,7 @@ export class GhostService {
       `./data/global`,
       this.diskDriver,
       this.dbDriver,
-      this.enabled,
+      this.useDbDriver,
       this.cache,
       this.logger
     )
@@ -221,7 +221,7 @@ export class GhostService {
       `./data/bots`,
       this.diskDriver,
       this.dbDriver,
-      this.enabled,
+      this.useDbDriver,
       this.cache,
       this.logger
     )
@@ -243,7 +243,7 @@ export class GhostService {
       `./data/bots/${botId}`,
       this.diskDriver,
       this.dbDriver,
-      this.enabled,
+      this.useDbDriver,
       this.cache,
       this.logger,
       botId
@@ -290,7 +290,7 @@ export class GhostService {
   }
 
   public async getPending(botIds: string[]): Promise<ServerWidePendingRevisions | {}> {
-    if (!this.enabled) {
+    if (!this.useDbDriver) {
       return {}
     }
 


### PR DESCRIPTION
Fix first sync when enabling bpfs on a server which has local files

1. Init DB
2. Init Ghost. If BPFS = database and no file are stored, sync local to database.