### PR TITLE
feat(channel-web): bot can have different avatars for different messages

### DIFF
--- a/docs/guide/docs/channels/web.md
+++ b/docs/guide/docs/channels/web.md
@@ -131,6 +131,18 @@ const payload = {
 // This is the information that will be persisted: { type: 'login_prompt', username: 'someuser' }
 ```
 
+### Changing avatar for messages
+
+If you need to display different bot's avatar for some of the messages (like imitating changing author) you can achieve that by setting `botAvatarUrl` like this:
+
+```js
+const payload = {
+  type: 'text',
+  botAvatarUrl: 'http://some.url'
+  text: 'Lorem ipsum'
+}
+```
+
 ## Creating a Custom Component
 
 We already have an [example module](https://github.com/botpress/botpress/tree/master/examples/custom-component) showing how to create them, so we will just make a quick recap here. The Debugger is also implemented entirely as a custom component in the [extensions module](https://github.com/botpress/botpress/tree/master/modules/extensions/src/views/lite/components/debugger), so don't hesitate to take a look on how it was implemented.

--- a/modules/channel-web/src/backend/socket.ts
+++ b/modules/channel-web/src/backend/socket.ts
@@ -51,8 +51,8 @@ export default async (bp: typeof sdk, db: Database) => {
       bp.realtime.sendPayload(payload)
     } else if (standardTypes.includes(messageType)) {
       const message = await db.appendBotMessage(
-        botName,
-        botAvatarUrl,
+        (event.payload || {}).botName || botName,
+        (event.payload || {}).botAvatarUrl || botAvatarUrl,
         conversationId,
         event.payload,
         event.incomingEventId

--- a/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
@@ -146,7 +146,7 @@ class MessageList extends React.Component<MessageListProps, State> {
 
           const avatar = userId
             ? this.props.showUserAvatar && this.renderAvatar(userName, avatarUrl)
-            : this.renderAvatar(this.props.botName, this.props.botAvatarUrl)
+            : this.renderAvatar(this.props.botName, avatarUrl || this.props.botAvatarUrl)
 
           return (
             <div key={i}>


### PR DESCRIPTION
This allows applying different avatars to different bot's messages.