### PR TITLE
fix(stats) Cast chat users count as int

### DIFF
--- a/src/bp/core/repositories/users.ts
+++ b/src/bp/core/repositories/users.ts
@@ -143,6 +143,7 @@ export class KnexUserRepository implements UserRepository {
       .first()
       .then(result => result!.qty)) as string
 
+    // depending on the DB type (sqlite, postgres), the returned type can be string or int. We force int.
     return parseInt(result)
   }
 }

--- a/src/bp/core/repositories/users.ts
+++ b/src/bp/core/repositories/users.ts
@@ -137,13 +137,14 @@ export class KnexUserRepository implements UserRepository {
   }
 
   async getUserCount() {
-    const result = (await this.database
+    const result = await this.database
       .knex<User>(this.tableName)
       .count<Record<string, number>>('user_id as qty')
       .first()
-      .then(result => result!.qty)) as string
+      .then(result => result!.qty)
 
     // depending on the DB type (sqlite, postgres), the returned type can be string or int. We force int.
+    // @ts-ignore
     return parseInt(result)
   }
 }

--- a/src/bp/core/repositories/users.ts
+++ b/src/bp/core/repositories/users.ts
@@ -137,10 +137,12 @@ export class KnexUserRepository implements UserRepository {
   }
 
   async getUserCount() {
-    return await this.database
+    const result = (await this.database
       .knex<User>(this.tableName)
       .count<Record<string, number>>('user_id as qty')
       .first()
-      .then(result => result!.qty)
+      .then(result => result!.qty)) as string
+
+    return parseInt(result)
   }
 }

--- a/src/bp/core/services/stats-service.ts
+++ b/src/bp/core/services/stats-service.ts
@@ -136,7 +136,7 @@ export class StatsService {
           count: await this.getCollaboratorsCount()
         },
         chat: {
-          count: parseInt(await this.userRepository.getUserCount())
+          count: await this.userRepository.getUserCount()
         }
       },
       auth: {

--- a/src/bp/core/services/stats-service.ts
+++ b/src/bp/core/services/stats-service.ts
@@ -136,7 +136,7 @@ export class StatsService {
           count: await this.getCollaboratorsCount()
         },
         chat: {
-          count: await this.userRepository.getUserCount()
+          count: parseInt(await this.userRepository.getUserCount())
         }
       },
       auth: {


### PR DESCRIPTION
Sometimes the database returns a string instead of a int:

```
{'superAdmins': {'count': 0}, 'collaborators': {'count': 0}, 'chat': {'count': 0}}
{'superAdmins': {'count': 1}, 'collaborators': {'count': 2}, 'chat': {'count': '43'}}
{'superAdmins': {'count': 1}, 'collaborators': {'count': 1}, 'chat': {'count': 1}}
{'superAdmins': {'count': 1}, 'collaborators': {'count': 1}, 'chat': {'count': 1}}
```