### PR TITLE
fix: various spelling mistakes

### DIFF
--- a/docs/guide/docs/advanced/authentication.md
+++ b/docs/guide/docs/advanced/authentication.md
@@ -68,7 +68,7 @@ You can clear the list of users by emptying (or deleting) the table `strategy_de
 
 ### OAuth2
 
-Some OAuth2 implementations returns a JWT token containing all the user's informations, while some other returns a special token, which must then be used to query the user's informations.
+Some OAuth2 implementations returns a JWT token containing all the user's information, while some other returns a special token, which must then be used to query the user's information.
 
 ```js
 {
@@ -85,7 +85,7 @@ Some OAuth2 implementations returns a JWT token containing all the user's inform
         "clientSecret": "your-client-secret",
         "callbackURL": "http://localhost:3000/api/v1/auth/login-callback/oauth2/botpress",
         /**
-         * If the token doesn't contain user informations, set the userInfoURL
+         * If the token doesn't contain user information, set the userInfoURL
          */
         "userInfoURL": "https://example.auth0.com/userinfo",
         /**
@@ -155,7 +155,7 @@ Here is a complete example
 #### Prerequisite
 
 - Botpress Pro enabled with a valid license key
-- Informations to access the LDAP server
+- Information to access the LDAP server
 
 #### Quick Start
 
@@ -188,7 +188,7 @@ Here's a summary of the process:
 
 1. User authenticate on your platform
 2. Your platform returns a JWT token to the user and configure the webchat
-3. The token is sent to Botpress everytime a message is sent
+3. The token is sent to Botpress every time a message is sent
 4. Botpress validates the token, decrypt the content and makes it available through `event.credentials`
 
 ### Prerequisite

--- a/docs/guide/docs/advanced/configuration.md
+++ b/docs/guide/docs/advanced/configuration.md
@@ -11,7 +11,7 @@ On this page, you will learn about the Botpress global configuration, individual
 
 This is the main file used to configure the Botpress server. It will be created automatically when it is missing. Default values should be good when discovering Botpress, but in this page you will learn about the most common configuration you may need to change.
 
-To get more informations about each individual options, check out the [comments on the configuration schema](https://github.com/botpress/botpress/blob/master/src/bp/core/config/botpress.config.ts)
+To get more information about each individual options, check out the [comments on the configuration schema](https://github.com/botpress/botpress/blob/master/src/bp/core/config/botpress.config.ts)
 
 ## HTTP Server Configuration
 
@@ -39,7 +39,7 @@ When you start Botpress from the binary (or using the Docker image), the bot is 
 
 There are 4 different levels of logs:
 
-- Debug: display very detailed informations about the bot operations
+- Debug: display very detailed information about the bot operations
 - Info: gives general information or "good to know" stuff
 - Warn: means that something didn't go as expected, but the bot was able to recover
 - Error: there was an error that should be addressed
@@ -115,7 +115,7 @@ Each module has a different set of possible configuration, so we won't go throug
 
 Most of these variables can be set in the configuration file `data/global/botpress.config.json`. Infrastructure configuration (like the database, cluster mode, etc) aren't available in the configuration file, since they are required before the config is loaded.
 
-Botpress supports `.env` files, so you don't have to set them everytime you start the app. Just add the file in the same folder as the executable.
+Botpress supports `.env` files, so you don't have to set them every time you start the app. Just add the file in the same folder as the executable.
 
 ### Common
 
@@ -142,9 +142,9 @@ Botpress supports `.env` files, so you don't have to set them everytime you star
 | FAST_TEXT_CLEANUP_MS      | The model will be kept in memory until it receives no messages to process for that duration | 60000   |
 | REVERSE_PROXY             | When enabled, it uses "x-forwarded-for" to fetch the user IP instead of remoteAddress       | false   |
 
-It is also possible to use environment variables to override module configuration. The pattern is `BP_%MODULE_NAME%_%OPTION_PATH%`, all in upper cases. For example, to define the `confidenceTreshold` option of the module `nlu`, you would use `BP_NLU_CONFIDENCETRESHOLD`. You can list the available environment variales for each modules by enabling the `DEBUG=bp:configuration:modules:*` flag.
+It is also possible to use environment variables to override module configuration. The pattern is `BP_%MODULE_NAME%_%OPTION_PATH%`, all in upper cases. For example, to define the `confidenceTreshold` option of the module `nlu`, you would use `BP_NLU_CONFIDENCETRESHOLD`. You can list the available environment variables for each modules by enabling the `DEBUG=bp:configuration:modules:*` flag.
 
-## More Informations
+## More Information
 
 - Check out the [database](../tutorials/database) page for details about `DATABASE_URL`
 - Check out the [cluster](cluster) page for details about `CLUSTER_ENABLED` and `REDIS_URL`

--- a/docs/guide/docs/advanced/custom-module.md
+++ b/docs/guide/docs/advanced/custom-module.md
@@ -140,7 +140,7 @@ const onServerReady = async (bp: SDK) => {
 
 ### onBotMount && onBotUnmount
 
-These methods are called everytime a bot is started or stopped (either when starting Botpress or when creating or deleting a bot).
+These methods are called every time a bot is started or stopped (either when starting Botpress or when creating or deleting a bot).
 
 Example:
 
@@ -202,7 +202,7 @@ const botTemplates: sdk.BotTemplate[] = [
 
 The definition is used by Botpress to setup your module.
 
-Please refer to the [API Reference](https://botpress.io/reference/) for informations on the possible options
+Please refer to the [API Reference](https://botpress.io/reference/) for information on the possible options
 
 The only way to communicate with modules (or between them) is by using the API endpoint.
 All modules are isolated and receives their own instance of `bp`
@@ -485,7 +485,7 @@ const entryPoint: sdk.ModuleEntryPoint = {
 
 ## Register Actions
 
-Modules can register new actions that will be available on the flow editor. Please check out the [Custom Code](../main/code) section for more informations about Actions.
+Modules can register new actions that will be available on the flow editor. Please check out the [Custom Code](../main/code) section for more information about Actions.
 Those actions must be deployed to the `data/global/actions` folder to be recognized by Botpress. Here is how to do that:
 
 1. Create a folder named `actions` in `src`

--- a/docs/guide/docs/advanced/monitoring.md
+++ b/docs/guide/docs/advanced/monitoring.md
@@ -122,7 +122,7 @@ When an incident is resolved, no other incident of the same nature (same name / 
 
 ### Incident & Hook
 
-Now that you have some incident rules, how do you get alerted when something happens? This is where hooks comes in handy. Everytime an incident is opened or resolved, Botpress will call the hook `on_incident_status_changed` with the incident as an object. When the property `endTime` is not defined, it means that the incident was opened. When it is set, the incident is resolved.
+Now that you have some incident rules, how do you get alerted when something happens? This is where hooks comes in handy. Every time an incident is opened or resolved, Botpress will call the hook `on_incident_status_changed` with the incident as an object. When the property `endTime` is not defined, it means that the incident was opened. When it is set, the incident is resolved.
 
 Here's an example of `data/global/hooks/on_incident_status_changed/alert.js`
 

--- a/docs/guide/docs/channels/teams.md
+++ b/docs/guide/docs/channels/teams.md
@@ -36,7 +36,7 @@ These instructions will guide you through any steps required to be up and runnin
 
 ### 2. Create your bot
 
-1. Navigate to the [Bot Framework Registration Page](https://dev.botframework.com/bots/new) and fill the required informations:
+1. Navigate to the [Bot Framework Registration Page](https://dev.botframework.com/bots/new) and fill the required information:
 
 - Display name
 - Bot handle

--- a/docs/guide/docs/channels/web.md
+++ b/docs/guide/docs/channels/web.md
@@ -33,14 +33,14 @@ There is an example included in the default botpress installation at `http://loc
 
 ## Bot Information page
 
-The information page displays informations like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
+The information page displays information like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
 
 ![Bot Info Page](assets/webchat-bot-info.png)
 
 How to set up the information page:
 
 1. On the Admin UI, click on the link `Config` next to the name of the bot you want to change.
-2. Edit your bot informations in the `More details` and `Pictures` sections.
+2. Edit your bot information in the `More details` and `Pictures` sections.
 3. Edit the file `data/global/config/channel-web.json` and set `showBotInfoPage` to `true` **\*\***
 4. Refresh your browser.
 
@@ -105,7 +105,7 @@ The method `window.botpressWebChat.configure` allows you to change the configura
 
 ## Advanced Customization
 
-Every message sent by the bot to a user consist of a `payload`. That payload has a `type` property, that tells the webchat how the other informations included on that payload should be rendered on screen.
+Every message sent by the bot to a user consist of a `payload`. That payload has a `type` property, that tells the webchat how the other information included on that payload should be rendered on screen.
 
 There are different ways to send that payload to the user:
 
@@ -114,11 +114,11 @@ There are different ways to send that payload to the user:
 
 There are multiple types already built in Botpress (they are listed at the bottom of this page), but if you require more advanced components, you can create them easily.
 
-### Prevent storing sensitive informations
+### Prevent storing sensitive information
 
 By default, the complete payload is stored in the database, so the information is not lost when the user refreshes the page. On some occasion, however, we may want to hide some properties deemed "sensitive" (ex: password, credit card, etc..).
 
-To remove those informations, there is a special property that you need to set: `sensitive`. Here's an example:
+To remove this information, there is a special property that you need to set: `sensitive`. Here's an example:
 
 ```js
 const payload = {
@@ -155,7 +155,7 @@ payload: {
 
 ### What can I do in my component ?
 
-There are a couple of properties that are passed down to your custom component. These can be used to customize the displayed informations, and/or to pursue interactions.
+There are a couple of properties that are passed down to your custom component. These can be used to customize the displayed information, and/or to pursue interactions.
 
 | Property        | Description                                                                    |
 | --------------- | ------------------------------------------------------------------------------ |

--- a/docs/guide/docs/main/code.md
+++ b/docs/guide/docs/main/code.md
@@ -92,7 +92,7 @@ session.store = [{ id: 1, id: 2, id: 3 }]
 
 The only way to register new actions is to add your javascript code in a `.js` file and put them in the folder `data/global/actions`. There is no way to programmatically add new ones during runtime.
 
-There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful informations (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
+There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful information (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
 
 ## Hooks
 
@@ -114,7 +114,7 @@ Parameters: `bp`
 
 ### After Bot Mount
 
-This event is called everytime a bot is mounted, be it when the server is starting up or when new bots are added at runtime.
+This event is called every time a bot is mounted, be it when the server is starting up or when new bots are added at runtime.
 
 Location: `data/global/hooks/after_bot_mount`
 
@@ -122,7 +122,7 @@ Parameters: `bp`, `botId`
 
 ### After Bot Unmount
 
-This event is called everytime a bot is unmounted. This is usually to do cleanup when a bot is deleted.
+This event is called every time a bot is unmounted. This is usually to do cleanup when a bot is deleted.
 
 Location: `data/global/hooks/after_bot_unmount`
 

--- a/docs/guide/docs/main/memory.md
+++ b/docs/guide/docs/main/memory.md
@@ -102,13 +102,13 @@ You can consume a memory action just like any other action from the Botpress Flo
 
 Variables set using the `user` namespace will be saved as attributes for the user. This means that those attributes will always follow the user, not notwithstanding conversations or time period.
 
-When a user sends a message to the bot, the first middleware is tasked with loading that user's informations. After everything is processed, any changes to the `user` object will be persisted to the database.
+When a user sends a message to the bot, the first middleware is tasked with loading that user's information. After everything is processed, any changes to the `user` object will be persisted to the database.
 
 This means that you can alter the `user` object using middlwares and actions, and it will be saved at the end.
 
 #### User Memory - Data Retention
 
-Since privacy is an important matter, there is a built-in system that makes it dead-easy to set retention periods for different type of informations. You could have, for example a policy that says `email expires after 2 months` or `remember user's mood for 1 day`. Whenever the user's attribute is changed, the expiration policy is updated.
+Since privacy is an important matter, there is a built-in system that makes it dead-easy to set retention periods for different type of information. You could have, for example a policy that says `email expires after 2 months` or `remember user's mood for 1 day`. Whenever the user's attribute is changed, the expiration policy is updated.
 
 Here's how it could be configured:
 

--- a/docs/guide/docs/main/nlu.md
+++ b/docs/guide/docs/main/nlu.md
@@ -58,7 +58,7 @@ Here's an example of the structure of an incoming event processed by Botpress Na
   "flags": {},
   "nlu": { // <<<<------
     "language": "en", // language identified
-    "intent": { // most likely intent, assuming confidence is within config treshold
+    "intent": { // most likely intent, assuming confidence is within config threshold
       "name": "hello",
       "confidence": 1
     },
@@ -205,19 +205,19 @@ An example of placeholder entity would be : Please tell **Sarah** that **she's l
 
 ### Custom Entities
 
-As of today we provide 2 types of custom entites: [pattern](#pattern-extraction) and [list](#list-extraction) entitites. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
+As of today we provide 2 types of custom entities: [pattern](#pattern-extraction) and [list](#list-extraction) entities. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
 
 <img src="/docs/assets/nlu-create-entity.png">
 
-### Sensitive Informations
+### Sensitive Information
 
-Communication between users and bots are stored in the database, which means that sometimes personal informations (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
+Communication between users and bots are stored in the database, which means that sometimes personal information (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
 
 When checked, the information will still be displayed in the chat window, but the sensitive information will be replaced by `*****` before being stored. The original value is still available from `event.nlu.entities`
 
 #### Pattern extraction
 
-Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incomming message and add it to `event.nlu.entities`.
+Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incoming message and add it to `event.nlu.entities`.
 
 ##### Example :
 
@@ -345,7 +345,7 @@ Slot filling is the process of gathering information required by an intent. This
 
 ## Language Server
 
-The language server provides additional informations about words, which allows your bot to understand words with a similar meaning even if you didn't specifically taught it about it. By default, your Botpress server will query one of our language server for that purpose. You can also choose to host your own server if you would like to keep everything on your premise. Head over to the [Hosting](../advanced/hosting#running-your-own-language-server) page for more details.
+The language server provides additional information about words, which allows your bot to understand words with a similar meaning even if you didn't specifically taught it about it. By default, your Botpress server will query one of our language server for that purpose. You can also choose to host your own server if you would like to keep everything on your premise. Head over to the [Hosting](../advanced/hosting#running-your-own-language-server) page for more details.
 
 ## External NLU Providers
 

--- a/docs/guide/docs/main/nlu.md
+++ b/docs/guide/docs/main/nlu.md
@@ -251,7 +251,7 @@ Extraction will go like:
 
 #### List extraction
 
-List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurences** of your entity with corresponding synonyms.
+List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurrences** of your entity with corresponding synonyms.
 
 Let's take **Airport Codes** as an example:
 

--- a/docs/guide/docs/releases/migrate.md
+++ b/docs/guide/docs/releases/migrate.md
@@ -75,7 +75,7 @@ my-module/views/lite/index.jsx
 
 This change implied modifications on how modules are packaged. Please clear the `node_modules` folder of every module, then run `yarn build`
 
-For more informations see: [Module Views](../advanced/custom-module#views)
+For more information see: [Module Views](../advanced/custom-module#views)
 
 ## Migration from 11.3 to 11.4
 

--- a/docs/guide/docs/tutorials/database.md
+++ b/docs/guide/docs/tutorials/database.md
@@ -31,4 +31,4 @@ While using Postgres, you can configure the Connection Pools by using the `DATAB
 
 Please make sure you are using Postgres 9.5 or higher.
 
-If you don't want to type those variables each time you start Botpress, we also supports `.env` files. Check out our [configuration section](../advanced/configuration) for more informations about that
+If you don't want to type those variables each time you start Botpress, we also supports `.env` files. Check out our [configuration section](../advanced/configuration) for more information about that

--- a/docs/guide/docs/tutorials/existing-backend.md
+++ b/docs/guide/docs/tutorials/existing-backend.md
@@ -18,7 +18,7 @@ You can either define the token when the chat is initialized: `window.botpressWe
 
 ## Persisting the user's profile
 
-Once the user is authenticated, you may want to extract some informations out of the credentials to save them in the `user` state, like the First name, Last name, etc. All you need to do is set up a hook listening for a certain type of event, for example `update_profile`. Then, just select the required fields
+Once the user is authenticated, you may want to extract some information out of the credentials to save them in the `user` state, like the First name, Last name, etc. All you need to do is set up a hook listening for a certain type of event, for example `update_profile`. Then, just select the required fields
 
 Example:
 

--- a/docs/guide/docs/tutorials/proactive.md
+++ b/docs/guide/docs/tutorials/proactive.md
@@ -11,7 +11,7 @@ You may wish to make your bot act proactively on your website in response to som
 
 ### Send an event from the webpage
 
-First you need to open the webchat (either manually or programatically) and then send an event from the webpage.
+First you need to open the webchat (either manually or programmatically) and then send an event from the webpage.
 
 > 📖 How do I open the webchat? Please refer to the [channel-web](../channels/web#embedding) section.
 
@@ -58,7 +58,7 @@ Here are some examples of how can you use webchat events in your page.
 
 ### Send message on page load
 
-This will send an event everytime the page is loaded.
+This will send an event every time the page is loaded.
 
 Use this code in your `index.html`:
 
@@ -208,7 +208,7 @@ When you want to respond only to new users, you have to check if their session i
 ```js
 if (event.type === 'proactive-trigger') {
   // We only want to trigger a proactive message when the session is new,
-  // otherwise the conversation will progress everytime the page is refreshed.
+  // otherwise the conversation will progress every time the page is refreshed.
   if (event.state.session.lastMessages.length) {
     // This will tell the dialog engine to skip the processing of this event.
     event.setFlag(bp.IO.WellKnownFlags.SKIP_DIALOG_ENGINE, true)

--- a/docs/guide/website/versioned_docs/version-11.0.1/build/code.md
+++ b/docs/guide/website/versioned_docs/version-11.0.1/build/code.md
@@ -68,7 +68,7 @@ The action itself must return a new state object.
 
 The only way to register new actions is to add your javascript code in a `.js` file and put them in the folder `data/global/actions`. There is no way to programmatically add new ones during runtime.
 
-There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful informations (name, description, arguments, default values) on the dialog flow editor.
+There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful information (name, description, arguments, default values) on the dialog flow editor.
 
 ## Hooks
 

--- a/docs/guide/website/versioned_docs/version-11.0.1/build/nlu.md
+++ b/docs/guide/website/versioned_docs/version-11.0.1/build/nlu.md
@@ -59,7 +59,7 @@ Here's an example of the structure of an incoming event processed by Botpress Na
   "flags": {},
   "nlu": { // <<<<------
     "language": "en", // language identified
-    "intent": { // most likely intent, assuming confidence is within config treshold
+    "intent": { // most likely intent, assuming confidence is within config threshold
       "name": "hello",
       "confidence": 1
     },
@@ -90,7 +90,7 @@ You can use that metadata in your flows to create transitions when a specific in
 
 To enable debugging of the NLU module, make sure that `debugModeEnabled` is set to `true` in your `data/global/config/nlu.json` file.
 
-> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environement variable instead of modifying the configuration directly.
+> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environment variable instead of modifying the configuration directly.
 
 ##### Example of debugging message
 

--- a/docs/guide/website/versioned_docs/version-11.0.1/create-module.md
+++ b/docs/guide/website/versioned_docs/version-11.0.1/create-module.md
@@ -471,7 +471,7 @@ const entryPoint: sdk.ModuleEntryPoint = {
 
 ## Register Actions
 
-Modules can register new actions that will be available on the flow editor. Please check out the [Custom Code](build/code) section for more informations about Actions.
+Modules can register new actions that will be available on the flow editor. Please check out the [Custom Code](build/code) section for more information about Actions.
 Those actions must be deployed to the `data/global/actions` folder to be recognized by Botpress. Here is how to do that:
 
 1. Create a folder named `actions` in `src`

--- a/docs/guide/website/versioned_docs/version-11.0.1/create-module.md
+++ b/docs/guide/website/versioned_docs/version-11.0.1/create-module.md
@@ -181,7 +181,7 @@ const skillsToRegister: sdk.Skill[] = [
 
 The definition is used by Botpress to setup your module.
 
-Please refer to the [API Reference](https://botpress.io/reference/) for informations on the possible options
+Please refer to the [API Reference](https://botpress.io/reference/) for information on the possible options
 
 The only way to communicate with modules (or between them) is by using the API endpoint.
 All modules are isolated and receives their own instance of `bp`

--- a/docs/guide/website/versioned_docs/version-11.0.1/deploy/hosting.md
+++ b/docs/guide/website/versioned_docs/version-11.0.1/deploy/hosting.md
@@ -4,7 +4,7 @@ title: Hosting & Environment
 original_id: hosting
 ---
 
-When you are ready to open your bot to the world, you should deploy it in production mode. When the bot is started in production, the ghost is enabled ([click here for more details](/docs/manage/sync-changes)) and debug logs are no longer displayed. We also highly recomment using a Postgres database instead of the embedded SQLite.
+When you are ready to open your bot to the world, you should deploy it in production mode. When the bot is started in production, the ghost is enabled ([click here for more details](/docs/manage/sync-changes)) and debug logs are no longer displayed. We also highly recommend using a Postgres database instead of the embedded SQLite.
 
 All you need to do is start Botpress with the `-p` flag, like this: `./bp -p`
 
@@ -20,7 +20,7 @@ Below are multiple possible ways of deploying Botpress in the cloud.
 
 ### Preparing the Docker image
 
-To create a new bot from scratch, simply create a file named `Dockerfile` in any directory. Write this snippet in the file (and replace $VERSION with the latest one in [hub.docker.com](https://hub.docker.com/r/botpress/server/tags/))
+To create a new bot from scratch, simply create a file named `Dockerfile` in any directory. Write this snippet in the file (and replace \$VERSION with the latest one in [hub.docker.com](https://hub.docker.com/r/botpress/server/tags/))
 
 ```docker
 FROM botpress/server:$VERSION
@@ -99,7 +99,7 @@ Dokku is like a mini heroku on-prem. Once setup on your host, it's very easy to 
 
 ### Install and configure Dokku
 
-We have summarised the required steps, but you can [follow the official guide](http://dokku.viewdocs.io/dokku~v0.12.13/getting-started/installation/) if you prefer.
+We have summarized the required steps, but you can [follow the official guide](http://dokku.viewdocs.io/dokku~v0.12.13/getting-started/installation/) if you prefer.
 
 ```bash
 wget https://raw.githubusercontent.com/dokku/dokku/v0.12.13/bootstrap.sh

--- a/docs/guide/website/versioned_docs/version-11.2.0/build/code.md
+++ b/docs/guide/website/versioned_docs/version-11.2.0/build/code.md
@@ -88,7 +88,7 @@ session.store = [{ id: 1, id: 2, id: 3 }]
 
 The only way to register new actions is to add your javascript code in a `.js` file and put them in the folder `data/global/actions`. There is no way to programmatically add new ones during runtime.
 
-There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful informations (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
+There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful information (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
 
 ## Hooks
 
@@ -110,7 +110,7 @@ Parameters: `bp`
 
 ### After Bot Mount
 
-This event is called everytime a bot is mounted, be it when the server is starting up or when new bots are added at runtime.
+This event is called every time a bot is mounted, be it when the server is starting up or when new bots are added at runtime.
 
 Location: `data/global/hooks/after_bot_mount`
 
@@ -118,7 +118,7 @@ Parameters: `bp`, `botId`
 
 ### After Bot Unmount
 
-This event is called everytime a bot is unmounted. This is usually to do cleanup when a bot is deleted.
+This event is called every time a bot is unmounted. This is usually to do cleanup when a bot is deleted.
 
 Location: `data/global/hooks/after_bot_unmount`
 

--- a/docs/guide/website/versioned_docs/version-11.2.0/build/memory.md
+++ b/docs/guide/website/versioned_docs/version-11.2.0/build/memory.md
@@ -16,7 +16,7 @@ You can consume a memory action just like any other action from the Botpress Flo
 
 ### User Memory
 
-Variables stored inside this memory are persisted and remain available for the same user. They survive the different conversations. When a message is received from the user, his informations are automatically loaded and are available to actions and nodes without calling anything,.
+Variables stored inside this memory are persisted and remain available for the same user. They survive the different conversations. When a message is received from the user, his information is automatically loaded and is available to actions and nodes without calling anything.
 
 They never expires unless there is a data retention policy for some variables.
 

--- a/docs/guide/website/versioned_docs/version-11.2.0/build/nlu.md
+++ b/docs/guide/website/versioned_docs/version-11.2.0/build/nlu.md
@@ -59,7 +59,7 @@ Here's an example of the structure of an incoming event processed by Botpress Na
   "flags": {},
   "nlu": { // <<<<------
     "language": "en", // language identified
-    "intent": { // most likely intent, assuming confidence is within config treshold
+    "intent": { // most likely intent, assuming confidence is within config threshold
       "name": "hello",
       "confidence": 1
     },
@@ -90,7 +90,7 @@ You can use that metadata in your flows to create transitions when a specific in
 
 To enable debugging of the NLU module, make sure that `debugModeEnabled` is set to `true` in your `data/global/config/nlu.json` file.
 
-> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environement variable instead of modifying the configuration directly.
+> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environment variable instead of modifying the configuration directly.
 
 ##### Example of debugging message
 

--- a/docs/guide/website/versioned_docs/version-11.2.0/create-module.md
+++ b/docs/guide/website/versioned_docs/version-11.2.0/create-module.md
@@ -147,7 +147,7 @@ const onServerReady = async (bp: SDK) => {
 
 ### onBotMount && onBotUnmount
 
-These methods are called everytime a bot is started or stopped (either when starting Botpress or when creating or deleting a bot).
+These methods are called every time a bot is started or stopped (either when starting Botpress or when creating or deleting a bot).
 
 Example:
 
@@ -487,7 +487,7 @@ const entryPoint: sdk.ModuleEntryPoint = {
 
 ## Register Actions
 
-Modules can register new actions that will be available on the flow editor. Please check out the [Custom Code](build/code) section for more informations about Actions.
+Modules can register new actions that will be available on the flow editor. Please check out the [Custom Code](build/code) section for more information about Actions.
 Those actions must be deployed to the `data/global/actions` folder to be recognized by Botpress. Here is how to do that:
 
 1. Create a folder named `actions` in `src`

--- a/docs/guide/website/versioned_docs/version-11.2.0/create-module.md
+++ b/docs/guide/website/versioned_docs/version-11.2.0/create-module.md
@@ -197,7 +197,7 @@ const botTemplates: sdk.BotTemplate[] = [
 
 The definition is used by Botpress to setup your module.
 
-Please refer to the [API Reference](https://botpress.io/reference/) for informations on the possible options
+Please refer to the [API Reference](https://botpress.io/reference/) for information on the possible options
 
 The only way to communicate with modules (or between them) is by using the API endpoint.
 All modules are isolated and receives their own instance of `bp`

--- a/docs/guide/website/versioned_docs/version-11.3.0/build/code.md
+++ b/docs/guide/website/versioned_docs/version-11.3.0/build/code.md
@@ -92,7 +92,7 @@ session.store = [{ id: 1, id: 2, id: 3 }]
 
 The only way to register new actions is to add your javascript code in a `.js` file and put them in the folder `data/global/actions`. There is no way to programmatically add new ones during runtime.
 
-There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful informations (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
+There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful information (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
 
 ## Hooks
 

--- a/docs/guide/website/versioned_docs/version-11.3.0/build/nlu.md
+++ b/docs/guide/website/versioned_docs/version-11.3.0/build/nlu.md
@@ -59,7 +59,7 @@ Here's an example of the structure of an incoming event processed by Botpress Na
   "flags": {},
   "nlu": { // <<<<------
     "language": "en", // language identified
-    "intent": { // most likely intent, assuming confidence is within config treshold
+    "intent": { // most likely intent, assuming confidence is within config threshold
       "name": "hello",
       "confidence": 1
     },
@@ -91,11 +91,12 @@ You can use that metadata in your flows to create transitions when a specific in
 
 To enable debugging of the NLU module, make sure that `debugModeEnabled` is set to `true` in your `data/global/config/nlu.json` file.
 
-> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environement variable instead of modifying the configuration directly.
+> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environment variable instead of modifying the configuration directly.
 
 ##### Example of debugging message
 
-NLU Extraction 
+NLU Extraction
+
 ```js
 { text: 'they there bud',
   intent: 'hello',
@@ -115,6 +116,7 @@ Entity Extraction helps you extract and normalize known entities from phrases.
 Attached to NLU extraction, you will find an entities property which is an array of [System](#system-entities) and [Custom](#custom-entities) entities.
 
 #### Using entities
+
 You may access and use data by looking up the `event.nlu.entities` variable in your hooks, flow transitions or actions.
 
 ##### Example of extracted entity:
@@ -172,8 +174,8 @@ At the moment, Duckling is hosted on our remote servers. If you don't want your 
 
 ##### Example
 
-|             User said             |    Type    | Value |   Unit   |
-| :-------------------------------: | :--------: | :---: | :------: |
+|             User said             |    Type    | Value |  Unit   |
+| :-------------------------------: | :--------: | :---: | :-----: |
 | _"Add 5 lbs of sugar to my cart"_ | "quantity" |   5   | "pound" |
 
 ```js
@@ -204,13 +206,13 @@ An example of placeholder entity would be : Please tell **Sarah** that **she's l
 
 ### Custom Entities
 
-As of today we provide 2 types of custom entites: [pattern](#pattern-extraction) and [list](#list-extraction) entitites. To define a custom entity, head to the __Entity section__ of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on __create new entity__
+As of today we provide 2 types of custom entities: [pattern](#pattern-extraction) and [list](#list-extraction) entities. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
 
 <img src="/docs/assets/nlu-create-entity.png">
 
 #### Pattern extraction
 
-Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incomming message and add it to `event.nlu.entities`.
+Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incoming message and add it to `event.nlu.entities`.
 
 ##### Example :
 
@@ -220,9 +222,9 @@ Given a Pattern Entity definition with `[A-Z]{3}-[0-9]{4}-[A-Z]{3}` as pattern:
 
 Extraction will go like:
 
-|             User said             |Type|Value|
-| :-------------------------------: | :---: | :-----------: |
-| _"Find product BHZ-1234-UYT"_ | "SKU" |"BHZ-1234-UYT"|
+|           User said           | Type  |     Value      |
+| :---------------------------: | :---: | :------------: |
+| _"Find product BHZ-1234-UYT"_ | "SKU" | "BHZ-1234-UYT" |
 
 ```js
 { name: 'SKU',
@@ -244,44 +246,34 @@ Extraction will go like:
 
 #### List extraction
 
-List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurences** of your entity with corresponding synonyms.
+List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurrences** of your entity with corresponding synonyms.
 
-Let's take __Airport Codes__ as an example:
+Let's take **Airport Codes** as an example:
 
 ![create slot](assets/nlu-list-entity.png)
 
 Extraction will go like:
 
-|             User said             |Type|Value|
-| :-------------------------------: | :---: | :-----------: |
-| _"Find a flight from SFO to Mumbai"_ | "Airport Codes" |["SFO", "BOM"]|
+|              User said               |      Type       |     Value      |
+| :----------------------------------: | :-------------: | :------------: |
+| _"Find a flight from SFO to Mumbai"_ | "Airport Codes" | ["SFO", "BOM"] |
 
 ```js
-[
-  { name: 'Airport Codes',
+;[
+  {
+    name: 'Airport Codes',
     type: 'list',
-    meta:
-    { confidence: 1,
-      provider: 'native',
-      source: 'SFO',
-      start: 19,
-      end: 22,
-      raw: {} },
+    meta: { confidence: 1, provider: 'native', source: 'SFO', start: 19, end: 22, raw: {} },
     data: {
       extras: {},
       value: 'SFO',
       unit: 'string'
     }
   },
-  { name: 'Airport Codes',
+  {
+    name: 'Airport Codes',
     type: 'list',
-    meta:
-    { confidence: 1,
-      provider: 'native',
-      source: 'Mumbai',
-      start: 26,
-      end: 32,
-      raw: {} },
+    meta: { confidence: 1, provider: 'native', source: 'Mumbai', start: 26, end: 32, raw: {} },
     data: {
       extras: {},
       value: 'BOM',
@@ -291,15 +283,15 @@ Extraction will go like:
 ]
 ```
 
-## Slots 
+## Slots
 
-Slots are another major concept in Botpress NLU. You can think of them as necessary __parameters__ to complete the action associated to an intent.
+Slots are another major concept in Botpress NLU. You can think of them as necessary **parameters** to complete the action associated to an intent.
 
 ### Slot Tagging
 
 Botpress Native NLU will tag each _words_ (tokens) of user input. If it's correctly identified as an intent slot it will be attached to NLU extraction event. Each identified slot will be accessible in the `event.nlu.slots` map using its name as key.
 
-To define a slot for a particular intent, head to the __Intent section__ of the Understanding Module in your Botpress Studio side bar. From there select the intent you want to add slots to, then you'll be able to define your slots. Go ahead and click on __create a slot__
+To define a slot for a particular intent, head to the **Intent section** of the Understanding Module in your Botpress Studio side bar. From there select the intent you want to add slots to, then you'll be able to define your slots. Go ahead and click on **create a slot**
 
 ![create slot](assets/nlu-create-slot.png)
 
@@ -312,6 +304,7 @@ Let's use a `find_flight` intent. In order to book a flight, we'll define 2 slot
 User said : `I would like to go to SFO from Mumbai`
 
 `event.nlu.slots` will look like
+
 ```js
 slots : {
   airport_to: {
@@ -329,10 +322,9 @@ slots : {
 
 ### Slot Filling
 
- As of now when you define an intent slot, it is considered as optional. If it's mandatory for a desired task, you'll have to handle slot filling yourself in your conversational flow design using [Botpress Flow Builder](/docs/build/dialogs). We plan to add suppport for __required slots__ with automatic slot filling.
+As of now when you define an intent slot, it is considered as optional. If it's mandatory for a desired task, you'll have to handle slot filling yourself in your conversational flow design using [Botpress Flow Builder](/docs/build/dialogs). We plan to add support for **required slots** with automatic slot filling.
 
- **TODO provide example**
-
+**TODO provide example**
 
 ## External NLU Providers
 
@@ -344,16 +336,16 @@ If for some reason you want to use an external provider, you can do so by using 
 
 ### Example
 
-You can enable **Recast AI** by removing the `.` prefix to the `hooks/before_incoming_middleware/.05_recast_nlu.js` file. 
+You can enable **Recast AI** by removing the `.` prefix to the `hooks/before_incoming_middleware/.05_recast_nlu.js` file.
 
 > Feel free to contribute to Botpress to add new external NLU providers
 
 ##### Features by Providers
 
 |  Provider  | Intent | Entity | Slot tagging | Lang | Context | Sentiment |
-| :--------: | :----: | :----: | :--: | :--: | :-----: | :--:   |
-|   Native   |   X    |   X    |  X   |  X   |         |    |
-| DialogFlow |   X    |   X    |  X   |      |    X    |    |
-|    Luis    |   X    |   X    |      |      |         |  X  |
-|   Recast   |   X    |   X    |      |  X   |         |  X |
-|   Rasa     |   X    |   X    |      |      |         |    |
+| :--------: | :----: | :----: | :----------: | :--: | :-----: | :-------: |
+|   Native   |   X    |   X    |      X       |  X   |         |           |
+| DialogFlow |   X    |   X    |      X       |      |    X    |           |
+|    Luis    |   X    |   X    |              |      |         |     X     |
+|   Recast   |   X    |   X    |              |  X   |         |     X     |
+|    Rasa    |   X    |   X    |              |      |         |           |

--- a/docs/guide/website/versioned_docs/version-11.4.0/build/code.md
+++ b/docs/guide/website/versioned_docs/version-11.4.0/build/code.md
@@ -92,7 +92,7 @@ session.store = [{ id: 1, id: 2, id: 3 }]
 
 The only way to register new actions is to add your javascript code in a `.js` file and put them in the folder `data/global/actions`. There is no way to programmatically add new ones during runtime.
 
-There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful informations (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
+There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful information (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
 
 ## Hooks
 

--- a/docs/guide/website/versioned_docs/version-11.5.0/build/code.md
+++ b/docs/guide/website/versioned_docs/version-11.5.0/build/code.md
@@ -92,7 +92,7 @@ session.store = [{ id: 1, id: 2, id: 3 }]
 
 The only way to register new actions is to add your javascript code in a `.js` file and put them in the folder `data/global/actions`. There is no way to programmatically add new ones during runtime.
 
-There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful informations (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
+There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful information (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
 
 ## Hooks
 

--- a/docs/guide/website/versioned_docs/version-11.5.0/deploy/hosting.md
+++ b/docs/guide/website/versioned_docs/version-11.5.0/deploy/hosting.md
@@ -4,7 +4,7 @@ title: Hosting & Environment
 original_id: hosting
 ---
 
-When you are ready to open your bot to the world, you should deploy it in production mode. When the bot is started in production, the botpress file system (BPFS) is enabled ([click here for more details](/docs/manage/sync-changes)) and debug logs are no longer displayed. We also strongly recomment using a Postgres database instead of the embedded SQLite.
+When you are ready to open your bot to the world, you should deploy it in production mode. When the bot is started in production, the botpress file system (BPFS) is enabled ([click here for more details](/docs/manage/sync-changes)) and debug logs are no longer displayed. We also strongly recommend using a Postgres database instead of the embedded SQLite.
 
 All you need to do is start Botpress with the `-p` flag, like this: `./bp -p`
 
@@ -20,7 +20,7 @@ Below are multiple possible ways of deploying Botpress in the cloud.
 
 ### Preparing the Docker image
 
-To create a new bot from scratch, simply create a file named `Dockerfile` in any directory. Write this snippet in the file (and replace $VERSION with the latest one in [hub.docker.com](https://hub.docker.com/r/botpress/server/tags/))
+To create a new bot from scratch, simply create a file named `Dockerfile` in any directory. Write this snippet in the file (and replace \$VERSION with the latest one in [hub.docker.com](https://hub.docker.com/r/botpress/server/tags/))
 
 ```docker
 FROM botpress/server:$VERSION

--- a/docs/guide/website/versioned_docs/version-11.5.1/developers/create-module.md
+++ b/docs/guide/website/versioned_docs/version-11.5.1/developers/create-module.md
@@ -210,7 +210,7 @@ const botTemplates: sdk.BotTemplate[] = [
 
 The definition is used by Botpress to setup your module.
 
-Please refer to the [API Reference](https://botpress.io/reference/) for informations on the possible options
+Please refer to the [API Reference](https://botpress.io/reference/) for information on the possible options
 
 The only way to communicate with modules (or between them) is by using the API endpoint.
 All modules are isolated and receives their own instance of `bp`
@@ -502,7 +502,7 @@ const entryPoint: sdk.ModuleEntryPoint = {
 
 ## Register Actions
 
-Modules can register new actions that will be available on the flow editor. Please check out the [Custom Code](../build/code) section for more informations about Actions.
+Modules can register new actions that will be available on the flow editor. Please check out the [Custom Code](../build/code) section for more information about Actions.
 Those actions must be deployed to the `data/global/actions` folder to be recognized by Botpress. Here is how to do that:
 
 1. Create a folder named `actions` in `src`

--- a/docs/guide/website/versioned_docs/version-11.5.1/quickstart.md
+++ b/docs/guide/website/versioned_docs/version-11.5.1/quickstart.md
@@ -64,7 +64,7 @@ Open the chat window and say "_Hello_". The bot should greet you with something 
 
 ![Hello from the bot](assets/flow_page.png)
 
-There is another emulator, which is specifically designed for you (the bot owner) to understand quickly why the bot gives you a specific answer. That emulator is only available for authenticated users. It includes all sort of useful informations: list of suggested answers by module, nlu intents, and the elected suggestion.
+There is another emulator, which is specifically designed for you (the bot owner) to understand quickly why the bot gives you a specific answer. That emulator is only available for authenticated users. It includes all sort of useful information: list of suggested answers by module, nlu intents, and the elected suggestion.
 
 ![Emulator Hello](assets/emulator_ng.png)
 

--- a/docs/guide/website/versioned_docs/version-11.6.0/build/memory.md
+++ b/docs/guide/website/versioned_docs/version-11.6.0/build/memory.md
@@ -31,13 +31,13 @@ You can consume a memory action just like any other action from the Botpress Flo
 
 Variables set using the `user` namespace will be saved as attributes for the user. This means that those attributes will always follow the user, not notwithstanding conversations or time period.
 
-When a user sends a message to the bot, the first middleware is tasked with loading that user's informations. After everything is processed, any changes to the `user` object will be persisted to the database.
+When a user sends a message to the bot, the first middleware is tasked with loading that user's information. After everything is processed, any changes to the `user` object will be persisted to the database.
 
 This means that you can alter the `user` object using middlwares and actions, and it will be saved at the end.
 
 #### User Memory - Data Retention
 
-Since privacy is an important matter, there is a built-in system that makes it dead-easy to set retention periods for different type of informations. You could have, for example a policy that says `email expires after 2 months` or `remember user's mood for 1 day`. Whenever the user's attribute is changed, the expiration policy is updated.
+Since privacy is an important matter, there is a built-in system that makes it dead-easy to set retention periods for different type of information. You could have, for example a policy that says `email expires after 2 months` or `remember user's mood for 1 day`. Whenever the user's attribute is changed, the expiration policy is updated.
 
 Here's how it could be configured:
 

--- a/docs/guide/website/versioned_docs/version-11.6.0/build/nlu.md
+++ b/docs/guide/website/versioned_docs/version-11.6.0/build/nlu.md
@@ -59,7 +59,7 @@ Here's an example of the structure of an incoming event processed by Botpress Na
   "flags": {},
   "nlu": { // <<<<------
     "language": "en", // language identified
-    "intent": { // most likely intent, assuming confidence is within config treshold
+    "intent": { // most likely intent, assuming confidence is within config threshold
       "name": "hello",
       "confidence": 1
     },
@@ -91,7 +91,7 @@ You can use that metadata in your flows to create transitions when a specific in
 
 To enable debugging of the NLU module, make sure that `debugModeEnabled` is set to `true` in your `data/global/config/nlu.json` file.
 
-> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environement variable instead of modifying the configuration directly.
+> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environment variable instead of modifying the configuration directly.
 
 ##### Example of debugging message
 
@@ -206,19 +206,19 @@ An example of placeholder entity would be : Please tell **Sarah** that **she's l
 
 ### Custom Entities
 
-As of today we provide 2 types of custom entites: [pattern](#pattern-extraction) and [list](#list-extraction) entitites. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
+As of today we provide 2 types of custom entities: [pattern](#pattern-extraction) and [list](#list-extraction) entities. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
 
 <img src="/docs/assets/nlu-create-entity.png">
 
-### Sensitive Informations
+### Sensitive Information
 
-Communication between users and bots are stored in the database, which means that sometimes personal informations (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
+Communication between users and bots are stored in the database, which means that sometimes personal information (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
 
 When checked, the information will still be displayed in the chat window, but the sensitive information will be replaced by `*****` before being stored. The original value is still available from `event.nlu.entities`
 
 #### Pattern extraction
 
-Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incomming message and add it to `event.nlu.entities`.
+Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incoming message and add it to `event.nlu.entities`.
 
 ##### Example :
 
@@ -252,7 +252,7 @@ Extraction will go like:
 
 #### List extraction
 
-List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurences** of your entity with corresponding synonyms.
+List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurrences** of your entity with corresponding synonyms.
 
 Let's take **Airport Codes** as an example:
 
@@ -342,7 +342,7 @@ slots : {
 
 ### Slot Filling
 
-As of now when you define an intent slot, it is considered as optional. If it's mandatory for a desired task, you'll have to handle slot filling yourself in your conversational flow design using [Botpress Flow Builder](/docs/build/dialogs). We plan to add suppport for **required slots** with automatic slot filling.
+As of now when you define an intent slot, it is considered as optional. If it's mandatory for a desired task, you'll have to handle slot filling yourself in your conversational flow design using [Botpress Flow Builder](/docs/build/dialogs). We plan to add support for **required slots** with automatic slot filling.
 
 **TODO provide example**
 

--- a/docs/guide/website/versioned_docs/version-11.6.0/deploy/hosting.md
+++ b/docs/guide/website/versioned_docs/version-11.6.0/deploy/hosting.md
@@ -4,7 +4,7 @@ title: Hosting & Environment
 original_id: hosting
 ---
 
-When you are ready to open your bot to the world, you should deploy it in production mode. When the bot is started in production, the botpress file system (BPFS) is enabled ([click here for more details](/docs/manage/sync-changes)) and debug logs are no longer displayed. We also strongly recomment using a Postgres database instead of the embedded SQLite.
+When you are ready to open your bot to the world, you should deploy it in production mode. When the bot is started in production, the botpress file system (BPFS) is enabled ([click here for more details](/docs/manage/sync-changes)) and debug logs are no longer displayed. We also strongly recommend using a Postgres database instead of the embedded SQLite.
 
 All you need to do is start Botpress with the `-p` flag, like this: `./bp -p`
 
@@ -20,7 +20,7 @@ Below are multiple possible ways of deploying Botpress in the cloud.
 
 ### Preparing the Docker image
 
-To create a new bot from scratch, simply create a file named `Dockerfile` in any directory. Write this snippet in the file (and replace $VERSION with the latest one in [hub.docker.com](https://hub.docker.com/r/botpress/server/tags/))
+To create a new bot from scratch, simply create a file named `Dockerfile` in any directory. Write this snippet in the file (and replace \$VERSION with the latest one in [hub.docker.com](https://hub.docker.com/r/botpress/server/tags/))
 
 ```docker
 FROM botpress/server:$VERSION

--- a/docs/guide/website/versioned_docs/version-11.6.0/developers/create-module.md
+++ b/docs/guide/website/versioned_docs/version-11.6.0/developers/create-module.md
@@ -210,7 +210,7 @@ const botTemplates: sdk.BotTemplate[] = [
 
 The definition is used by Botpress to setup your module.
 
-Please refer to the [API Reference](https://botpress.io/reference/) for informations on the possible options
+Please refer to the [API Reference](https://botpress.io/reference/) for information on the possible options
 
 The only way to communicate with modules (or between them) is by using the API endpoint.
 All modules are isolated and receives their own instance of `bp`
@@ -493,7 +493,7 @@ const entryPoint: sdk.ModuleEntryPoint = {
 
 ## Register Actions
 
-Modules can register new actions that will be available on the flow editor. Please check out the [Custom Code](../build/code) section for more informations about Actions.
+Modules can register new actions that will be available on the flow editor. Please check out the [Custom Code](../build/code) section for more information about Actions.
 Those actions must be deployed to the `data/global/actions` folder to be recognized by Botpress. Here is how to do that:
 
 1. Create a folder named `actions` in `src`

--- a/docs/guide/website/versioned_docs/version-11.6.0/developers/migrate.md
+++ b/docs/guide/website/versioned_docs/version-11.6.0/developers/migrate.md
@@ -22,7 +22,7 @@ my-module/views/full/index.jsx
 my-module/views/lite/index.jsx
 ```
 
-More informations: http://localhost:3001/docs/next/developers/create-module#views
+More information: http://localhost:3001/docs/next/developers/create-module#views
 
 ## Migration from 11.3 to 11.4
 

--- a/docs/guide/website/versioned_docs/version-11.6.0/manage/authentication.md
+++ b/docs/guide/website/versioned_docs/version-11.6.0/manage/authentication.md
@@ -90,7 +90,7 @@ Here is a complete example
 #### Prerequisite
 
 - Botpress Pro enabled with a valid license key
-- Informations to access the LDAP server
+- Information to access the LDAP server
 
 #### Quick Start
 

--- a/docs/guide/website/versioned_docs/version-11.6.0/manage/configuration.md
+++ b/docs/guide/website/versioned_docs/version-11.6.0/manage/configuration.md
@@ -14,7 +14,7 @@ On this page, you will learn about the Botpress global configuration, individual
 
 This is the main file used to configure the Botpress server. It will be created automatically when it is missing. Default values should be good when discovering Botpress, but in this page you will learn about the most common configuration you may need to change.
 
-To get more informations about each individual options, check out the [comments on the configuration schema](https://github.com/botpress/botpress/blob/master/src/bp/core/config/botpress.config.ts)
+To get more information about each individual options, check out the [comments on the configuration schema](https://github.com/botpress/botpress/blob/master/src/bp/core/config/botpress.config.ts)
 
 ## HTTP Server Configuration
 
@@ -36,7 +36,7 @@ When you start Botpress from the binary (or using the Docker image), the bot is 
 
 There are 4 different levels of logs:
 
-- Debug: display very detailed informations about the bot operations
+- Debug: display very detailed information about the bot operations
 - Info: gives general information or "good to know" stuff
 - Warn: means that something didn't go as expected, but the bot was able to recover
 - Error: there was an error that should be addressed
@@ -110,7 +110,7 @@ Here there are:
 | CLUSTER_ENABLED      | Enables multi-node support using Redis                                                                    | false   |
 | REDIS_URL            | The connection string to connect to your Redis instance                                                   |         |
 
-## More Informations
+## More Information
 
 - Check out the [database](../tutorials/database) page for details about `DATABASE` and `DATABASE_URL`
 - Check out the [cluster](../developers/cluster) page for details about `CLUSTER_ENABLED` and `REDIS_URL`

--- a/docs/guide/website/versioned_docs/version-11.6.0/tutorials/database.md
+++ b/docs/guide/website/versioned_docs/version-11.6.0/tutorials/database.md
@@ -27,4 +27,4 @@ Here are the two variables you need to change:
 
 Please make sure you are using Postgres 9.5 or higher.
 
-If you don't want to type those variables each time you start Botpress, we also supports `.env` files. Check out our [configuration section](../../manage/configuration) for more informations about that
+If you don't want to type those variables each time you start Botpress, we also supports `.env` files. Check out our [configuration section](../../manage/configuration) for more information about that

--- a/docs/guide/website/versioned_docs/version-11.6.0/tutorials/existing-backend.md
+++ b/docs/guide/website/versioned_docs/version-11.6.0/tutorials/existing-backend.md
@@ -19,7 +19,7 @@ You can either define the token when the chat is initialized: `window.botpressWe
 
 ## Persisting the user's profile
 
-Once the user is authenticated, you may want to extract some informations out of the credentials to save them in the `user` state, like the First name, Last name, etc. All you need to do is set up a hook listening for a certain type of event, for example `update_profile`. Then, just select the required fields
+Once the user is authenticated, you may want to extract some information out of the credentials to save them in the `user` state, like the First name, Last name, etc. All you need to do is set up a hook listening for a certain type of event, for example `update_profile`. Then, just select the required fields
 
 Example:
 

--- a/docs/guide/website/versioned_docs/version-11.6.1/build/nlu.md
+++ b/docs/guide/website/versioned_docs/version-11.6.1/build/nlu.md
@@ -59,7 +59,7 @@ Here's an example of the structure of an incoming event processed by Botpress Na
   "flags": {},
   "nlu": { // <<<<------
     "language": "en", // language identified
-    "intent": { // most likely intent, assuming confidence is within config treshold
+    "intent": { // most likely intent, assuming confidence is within config threshold
       "name": "hello",
       "confidence": 1
     },
@@ -91,7 +91,7 @@ You can use that metadata in your flows to create transitions when a specific in
 
 To enable debugging of the NLU module, make sure that `debugModeEnabled` is set to `true` in your `data/global/config/nlu.json` file.
 
-> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environement variable instead of modifying the configuration directly.
+> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environment variable instead of modifying the configuration directly.
 
 ##### Example of debugging message
 
@@ -206,19 +206,19 @@ An example of placeholder entity would be : Please tell **Sarah** that **she's l
 
 ### Custom Entities
 
-As of today we provide 2 types of custom entites: [pattern](#pattern-extraction) and [list](#list-extraction) entitites. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
+As of today we provide 2 types of custom entities: [pattern](#pattern-extraction) and [list](#list-extraction) entities. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
 
 <img src="/docs/assets/nlu-create-entity.png">
 
-### Sensitive Informations
+### Sensitive Information
 
-Communication between users and bots are stored in the database, which means that sometimes personal informations (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
+Communication between users and bots are stored in the database, which means that sometimes personal information (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
 
 When checked, the information will still be displayed in the chat window, but the sensitive information will be replaced by `*****` before being stored. The original value is still available from `event.nlu.entities`
 
 #### Pattern extraction
 
-Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incomming message and add it to `event.nlu.entities`.
+Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incoming message and add it to `event.nlu.entities`.
 
 ##### Example :
 
@@ -252,7 +252,7 @@ Extraction will go like:
 
 #### List extraction
 
-List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurences** of your entity with corresponding synonyms.
+List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurrences** of your entity with corresponding synonyms.
 
 Let's take **Airport Codes** as an example:
 
@@ -342,7 +342,7 @@ slots : {
 
 ### Slot Filling
 
-As of now when you define an intent slot, it is considered as optional. If it's mandatory for a desired task, you'll have to handle slot filling yourself in your conversational flow design using [Botpress Flow Builder](/docs/build/dialogs). We plan to add suppport for **required slots** with automatic slot filling.
+As of now when you define an intent slot, it is considered as optional. If it's mandatory for a desired task, you'll have to handle slot filling yourself in your conversational flow design using [Botpress Flow Builder](/docs/build/dialogs). We plan to add support for **required slots** with automatic slot filling.
 
 **TODO provide example**
 

--- a/docs/guide/website/versioned_docs/version-11.6.1/developers/migrate.md
+++ b/docs/guide/website/versioned_docs/version-11.6.1/developers/migrate.md
@@ -24,7 +24,7 @@ my-module/views/lite/index.jsx
 
 This change implied modifications on how modules are packaged. Please clear the `node_modules` folder of every module, then run `yarn build`
 
-More informations: http://localhost:3001/docs/next/developers/create-module#views
+More information: http://localhost:3001/docs/next/developers/create-module#views
 
 ## Migration from 11.3 to 11.4
 

--- a/docs/guide/website/versioned_docs/version-11.6.1/tutorials/webchat-embedding.md
+++ b/docs/guide/website/versioned_docs/version-11.6.1/tutorials/webchat-embedding.md
@@ -26,12 +26,12 @@ There is an example included in the default botpress installation at `http://loc
 
 ## How to display a Bot Information page
 
-The information page displays informations like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
+The information page displays information like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
 
 How to set up the information page:
 
 1. On the Admin UI, click on the link `Config` next to the name of the bot you want to change.
-2. Edit your bot informations in the `More details` and `Pictures` sections.
+2. Edit your bot information in the `More details` and `Pictures` sections.
 3. Edit the file `data/global/config/channel-web.json` and set `showBotInfoPage` to `true` \*\*
 4. Refresh your browser.
 

--- a/docs/guide/website/versioned_docs/version-11.7.0/build/nlu.md
+++ b/docs/guide/website/versioned_docs/version-11.7.0/build/nlu.md
@@ -59,7 +59,7 @@ Here's an example of the structure of an incoming event processed by Botpress Na
   "flags": {},
   "nlu": { // <<<<------
     "language": "en", // language identified
-    "intent": { // most likely intent, assuming confidence is within config treshold
+    "intent": { // most likely intent, assuming confidence is within config threshold
       "name": "hello",
       "confidence": 1
     },
@@ -91,7 +91,7 @@ You can use that metadata in your flows to create transitions when a specific in
 
 To enable debugging of the NLU module, make sure that `debugModeEnabled` is set to `true` in your `data/global/config/nlu.json` file.
 
-> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environement variable instead of modifying the configuration directly.
+> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environment variable instead of modifying the configuration directly.
 
 ##### Example of debugging message
 
@@ -206,19 +206,19 @@ An example of placeholder entity would be : Please tell **Sarah** that **she's l
 
 ### Custom Entities
 
-As of today we provide 2 types of custom entites: [pattern](#pattern-extraction) and [list](#list-extraction) entitites. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
+As of today we provide 2 types of custom entities: [pattern](#pattern-extraction) and [list](#list-extraction) entities. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
 
 <img src="/docs/assets/nlu-create-entity.png">
 
-### Sensitive Informations
+### Sensitive Information
 
-Communication between users and bots are stored in the database, which means that sometimes personal informations (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
+Communication between users and bots are stored in the database, which means that sometimes personal information (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
 
 When checked, the information will still be displayed in the chat window, but the sensitive information will be replaced by `*****` before being stored. The original value is still available from `event.nlu.entities`
 
 #### Pattern extraction
 
-Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incomming message and add it to `event.nlu.entities`.
+Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incoming message and add it to `event.nlu.entities`.
 
 ##### Example :
 
@@ -252,7 +252,7 @@ Extraction will go like:
 
 #### List extraction
 
-List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurences** of your entity with corresponding synonyms.
+List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurrences** of your entity with corresponding synonyms.
 
 Let's take **Airport Codes** as an example:
 
@@ -342,7 +342,7 @@ slots : {
 
 ### Slot Filling
 
-As of now when you define an intent slot, it is considered as optional. If it's mandatory for a desired task, you'll have to handle slot filling yourself in your conversational flow design using [Botpress Flow Builder](/docs/build/dialogs). We plan to add suppport for **required slots** with automatic slot filling.
+As of now when you define an intent slot, it is considered as optional. If it's mandatory for a desired task, you'll have to handle slot filling yourself in your conversational flow design using [Botpress Flow Builder](/docs/build/dialogs). We plan to add support for **required slots** with automatic slot filling.
 
 **TODO provide example**
 

--- a/docs/guide/website/versioned_docs/version-11.7.0/deploy/hosting.md
+++ b/docs/guide/website/versioned_docs/version-11.7.0/deploy/hosting.md
@@ -4,7 +4,7 @@ title: Hosting & Environment
 original_id: hosting
 ---
 
-When you are ready to open your bot to the world, you should deploy it in production mode. When the bot is started in production, the botpress file system (BPFS) is enabled ([click here for more details](/docs/manage/sync-changes)) and debug logs are no longer displayed. We also strongly recomment using a Postgres database instead of the embedded SQLite.
+When you are ready to open your bot to the world, you should deploy it in production mode. When the bot is started in production, the botpress file system (BPFS) is enabled ([click here for more details](/docs/manage/sync-changes)) and debug logs are no longer displayed. We also strongly recommend using a Postgres database instead of the embedded SQLite.
 
 All you need to do is start Botpress with the `-p` flag, like this: `./bp -p`
 
@@ -20,7 +20,7 @@ Below are multiple possible ways of deploying Botpress in the cloud.
 
 ### Preparing the Docker image
 
-To create a new bot from scratch, simply create a file named `Dockerfile` in any directory. Write this snippet in the file (and replace $VERSION with the latest one in [hub.docker.com](https://hub.docker.com/r/botpress/server/tags/))
+To create a new bot from scratch, simply create a file named `Dockerfile` in any directory. Write this snippet in the file (and replace \$VERSION with the latest one in [hub.docker.com](https://hub.docker.com/r/botpress/server/tags/))
 
 ```docker
 FROM botpress/server:$VERSION

--- a/docs/guide/website/versioned_docs/version-11.7.0/manage/configuration.md
+++ b/docs/guide/website/versioned_docs/version-11.7.0/manage/configuration.md
@@ -14,7 +14,7 @@ On this page, you will learn about the Botpress global configuration, individual
 
 This is the main file used to configure the Botpress server. It will be created automatically when it is missing. Default values should be good when discovering Botpress, but in this page you will learn about the most common configuration you may need to change.
 
-To get more informations about each individual options, check out the [comments on the configuration schema](https://github.com/botpress/botpress/blob/master/src/bp/core/config/botpress.config.ts)
+To get more information about each individual options, check out the [comments on the configuration schema](https://github.com/botpress/botpress/blob/master/src/bp/core/config/botpress.config.ts)
 
 ## HTTP Server Configuration
 
@@ -36,7 +36,7 @@ When you start Botpress from the binary (or using the Docker image), the bot is 
 
 There are 4 different levels of logs:
 
-- Debug: display very detailed informations about the bot operations
+- Debug: display very detailed information about the bot operations
 - Info: gives general information or "good to know" stuff
 - Warn: means that something didn't go as expected, but the bot was able to recover
 - Error: there was an error that should be addressed
@@ -122,7 +122,7 @@ Here there are:
 | CLUSTER_ENABLED      | Enables multi-node support using Redis                                                                    | false   |
 | REDIS_URL            | The connection string to connect to your Redis instance                                                   |         |
 
-## More Informations
+## More Information
 
 - Check out the [database](../tutorials/database) page for details about `DATABASE` and `DATABASE_URL`
 - Check out the [cluster](../developers/cluster) page for details about `CLUSTER_ENABLED` and `REDIS_URL`

--- a/docs/guide/website/versioned_docs/version-11.7.1/build/code.md
+++ b/docs/guide/website/versioned_docs/version-11.7.1/build/code.md
@@ -93,7 +93,7 @@ session.store = [{ id: 1, id: 2, id: 3 }]
 
 The only way to register new actions is to add your javascript code in a `.js` file and put them in the folder `data/global/actions`. There is no way to programmatically add new ones during runtime.
 
-There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful informations (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
+There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful information (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
 
 ## Hooks
 

--- a/docs/guide/website/versioned_docs/version-11.7.1/deploy/hosting.md
+++ b/docs/guide/website/versioned_docs/version-11.7.1/deploy/hosting.md
@@ -4,7 +4,7 @@ title: Hosting & Environment
 original_id: hosting
 ---
 
-When you are ready to open your bot to the world, you should deploy it in production mode. When the bot is started in production, the botpress file system (BPFS) is enabled ([click here for more details](/docs/manage/sync-changes)) and debug logs are no longer displayed. We also strongly recomment using a Postgres database instead of the embedded SQLite.
+When you are ready to open your bot to the world, you should deploy it in production mode. When the bot is started in production, the botpress file system (BPFS) is enabled ([click here for more details](/docs/manage/sync-changes)) and debug logs are no longer displayed. We also strongly recommend using a Postgres database instead of the embedded SQLite.
 
 All you need to do is start Botpress with the `-p` flag, like this: `./bp -p`
 
@@ -20,7 +20,7 @@ Below are multiple possible ways of deploying Botpress in the cloud.
 
 ### Preparing the Docker image
 
-To create a new bot from scratch, simply create a file named `Dockerfile` in any directory. Write this snippet in the file (and replace $VERSION with the latest one in [hub.docker.com](https://hub.docker.com/r/botpress/server/tags/))
+To create a new bot from scratch, simply create a file named `Dockerfile` in any directory. Write this snippet in the file (and replace \$VERSION with the latest one in [hub.docker.com](https://hub.docker.com/r/botpress/server/tags/))
 
 ```docker
 FROM botpress/server:$VERSION

--- a/docs/guide/website/versioned_docs/version-11.7.1/manage/configuration.md
+++ b/docs/guide/website/versioned_docs/version-11.7.1/manage/configuration.md
@@ -14,7 +14,7 @@ On this page, you will learn about the Botpress global configuration, individual
 
 This is the main file used to configure the Botpress server. It will be created automatically when it is missing. Default values should be good when discovering Botpress, but in this page you will learn about the most common configuration you may need to change.
 
-To get more informations about each individual options, check out the [comments on the configuration schema](https://github.com/botpress/botpress/blob/master/src/bp/core/config/botpress.config.ts)
+To get more information about each individual options, check out the [comments on the configuration schema](https://github.com/botpress/botpress/blob/master/src/bp/core/config/botpress.config.ts)
 
 ## HTTP Server Configuration
 
@@ -36,7 +36,7 @@ When you start Botpress from the binary (or using the Docker image), the bot is 
 
 There are 4 different levels of logs:
 
-- Debug: display very detailed informations about the bot operations
+- Debug: display very detailed information about the bot operations
 - Info: gives general information or "good to know" stuff
 - Warn: means that something didn't go as expected, but the bot was able to recover
 - Error: there was an error that should be addressed
@@ -121,9 +121,9 @@ Here there are:
 | CLUSTER_ENABLED      | Enables multi-node support using Redis                                                                    | false         |
 | REDIS_URL            | The connection string to connect to your Redis instance                                                   |               |
 
-About `DATABASE_URL` : This variable will determine the type of database you're running (i.e postgres | sqlite). Anything else than a valid postgress url it will be used as a path to sqlite file. If you want to use the default postgres connection, simply use `postgres` as value. Leave this empty if you want to use the default sqlite location.
+About `DATABASE_URL` : This variable will determine the type of database you're running (i.e postgres | sqlite). Anything else than a valid postgres url it will be used as a path to sqlite file. If you want to use the default postgres connection, simply use `postgres` as value. Leave this empty if you want to use the default sqlite location.
 
-## More Informations
+## More Information
 
 - Check out the [database](../tutorials/database) page for details about `DATABASE_URL`
 - Check out the [cluster](../developers/cluster) page for details about `CLUSTER_ENABLED` and `REDIS_URL`

--- a/docs/guide/website/versioned_docs/version-11.7.1/tutorials/database.md
+++ b/docs/guide/website/versioned_docs/version-11.7.1/tutorials/database.md
@@ -28,4 +28,4 @@ If you want to use default postgres connection string simply set it as follow
 
 Please make sure you are using Postgres 9.5 or higher.
 
-If you don't want to type those variables each time you start Botpress, we also supports `.env` files. Check out our [configuration section](../../manage/configuration) for more informations about that
+If you don't want to type those variables each time you start Botpress, we also supports `.env` files. Check out our [configuration section](../../manage/configuration) for more information about that

--- a/docs/guide/website/versioned_docs/version-11.7.1/tutorials/webchat-embedding.md
+++ b/docs/guide/website/versioned_docs/version-11.7.1/tutorials/webchat-embedding.md
@@ -26,12 +26,12 @@ There is an example included in the default botpress installation at `http://loc
 
 ## How to display a Bot Information page
 
-The information page displays informations like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
+The information page displays information like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
 
 How to set up the information page:
 
 1. On the Admin UI, click on the link `Config` next to the name of the bot you want to change.
-2. Edit your bot informations in the `More details` and `Pictures` sections.
+2. Edit your bot information in the `More details` and `Pictures` sections.
 3. Edit the file `data/global/config/channel-web.json` and set `showBotInfoPage` to `true` \*\*
 4. Refresh your browser.
 

--- a/docs/guide/website/versioned_docs/version-11.7.3/build/nlu.md
+++ b/docs/guide/website/versioned_docs/version-11.7.3/build/nlu.md
@@ -59,7 +59,7 @@ Here's an example of the structure of an incoming event processed by Botpress Na
   "flags": {},
   "nlu": { // <<<<------
     "language": "en", // language identified
-    "intent": { // most likely intent, assuming confidence is within config treshold
+    "intent": { // most likely intent, assuming confidence is within config threshold
       "name": "hello",
       "confidence": 1
     },
@@ -91,7 +91,7 @@ You can use that metadata in your flows to create transitions when a specific in
 
 To enable debugging of the NLU module, make sure that `debugModeEnabled` is set to `true` in your `data/global/config/nlu.json` file.
 
-> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environement variable instead of modifying the configuration directly.
+> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` enviroement variable instead of modifying the configuration directly.
 
 ##### Example of debugging message
 
@@ -206,19 +206,19 @@ An example of placeholder entity would be : Please tell **Sarah** that **she's l
 
 ### Custom Entities
 
-As of today we provide 2 types of custom entites: [pattern](#pattern-extraction) and [list](#list-extraction) entitites. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
+As of today we provide 2 types of custom entities: [pattern](#pattern-extraction) and [list](#list-extraction) entities. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
 
 <img src="/docs/assets/nlu-create-entity.png">
 
-### Sensitive Informations
+### Sensitive Information
 
-Communication between users and bots are stored in the database, which means that sometimes personal informations (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
+Communication between users and bots are stored in the database, which means that sometimes personal information (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
 
 When checked, the information will still be displayed in the chat window, but the sensitive information will be replaced by `*****` before being stored. The original value is still available from `event.nlu.entities`
 
 #### Pattern extraction
 
-Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incomming message and add it to `event.nlu.entities`.
+Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incoming message and add it to `event.nlu.entities`.
 
 ##### Example :
 
@@ -252,7 +252,7 @@ Extraction will go like:
 
 #### List extraction
 
-List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurences** of your entity with corresponding synonyms.
+List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurrences** of your entity with corresponding synonyms.
 
 Let's take **Airport Codes** as an example:
 
@@ -342,7 +342,7 @@ slots : {
 
 ### Slot Filling
 
-As of now when you define an intent slot, it is considered as optional. If it's mandatory for a desired task, you'll have to handle slot filling yourself in your conversational flow design using [Botpress Flow Builder](/docs/build/dialogs). We plan to add suppport for **required slots** with automatic slot filling.
+As of now when you define an intent slot, it is considered as optional. If it's mandatory for a desired task, you'll have to handle slot filling yourself in your conversational flow design using [Botpress Flow Builder](/docs/build/dialogs). We plan to add support for **required slots** with automatic slot filling.
 
 **TODO provide example**
 

--- a/docs/guide/website/versioned_docs/version-11.7.3/build/nlu.md
+++ b/docs/guide/website/versioned_docs/version-11.7.3/build/nlu.md
@@ -91,7 +91,7 @@ You can use that metadata in your flows to create transitions when a specific in
 
 To enable debugging of the NLU module, make sure that `debugModeEnabled` is set to `true` in your `data/global/config/nlu.json` file.
 
-> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` enviroement variable instead of modifying the configuration directly.
+> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environment variable instead of modifying the configuration directly.
 
 ##### Example of debugging message
 

--- a/docs/guide/website/versioned_docs/version-11.8.0/developers/migrate.md
+++ b/docs/guide/website/versioned_docs/version-11.8.0/developers/migrate.md
@@ -60,7 +60,7 @@ my-module/views/lite/index.jsx
 
 This change implied modifications on how modules are packaged. Please clear the `node_modules` folder of every module, then run `yarn build`
 
-More informations: http://localhost:3001/docs/next/developers/create-module#views
+More information: http://localhost:3001/docs/next/developers/create-module#views
 
 ## Migration from 11.3 to 11.4
 

--- a/docs/guide/website/versioned_docs/version-11.8.0/developers/webchat-extending.md
+++ b/docs/guide/website/versioned_docs/version-11.8.0/developers/webchat-extending.md
@@ -15,11 +15,11 @@ There are different ways to send that payload to the user:
 
 There are multiple types already built in Botpress (they are listed at the bottom of this page), but if you require more advanced components, you can create them easily.
 
-### Prevent storing sensitive informations
+### Prevent storing sensitive information
 
 By default, the complete payload is stored in the database, so the information is not lost when the user refreshes the page. On some occasion, however, we may want to hide some properties deemed "sensitive" (ex: password, credit card, etc..).
 
-To remove those informations, there is a special property that you need to set: `sensitive`. Here's an example:
+To remove this information, there is a special property that you need to set: `sensitive`. Here's an example:
 
 ```js
 const payload = {

--- a/docs/guide/website/versioned_docs/version-11.8.0/developers/webchat-extending.md
+++ b/docs/guide/website/versioned_docs/version-11.8.0/developers/webchat-extending.md
@@ -6,7 +6,7 @@ original_id: webchat-extending
 
 ## The Basics
 
-Every message sent by the bot to a user consist of a `payload`. That payload has a `type` property, that tells the webchat how the other informations included on that payload should be rendered on screen.
+Every message sent by the bot to a user consist of a `payload`. That payload has a `type` property, that tells the webchat how the other information included on that payload should be rendered on screen.
 
 There are different ways to send that payload to the user:
 
@@ -56,7 +56,7 @@ payload: {
 
 ### What can I do in my component ?
 
-There are a couple of properties that are passed down to your custom component. These can be used to customize the displayed informations, and/or to pursue interactions.
+There are a couple of properties that are passed down to your custom component. These can be used to customize the displayed information, and/or to pursue interactions.
 
 | Property      | Description                                                                    |
 | ------------- | ------------------------------------------------------------------------------ |

--- a/docs/guide/website/versioned_docs/version-11.8.0/tutorials/webchat-embedding.md
+++ b/docs/guide/website/versioned_docs/version-11.8.0/tutorials/webchat-embedding.md
@@ -26,12 +26,12 @@ There is an example included in the default botpress installation at `http://loc
 
 ## How to display a Bot Information page
 
-The information page displays informations like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
+The information page displays information like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
 
 How to set up the information page:
 
 1. On the Admin UI, click on the link `Config` next to the name of the bot you want to change.
-2. Edit your bot informations in the `More details` and `Pictures` sections.
+2. Edit your bot information in the `More details` and `Pictures` sections.
 3. Edit the file `data/global/config/channel-web.json` and set `showBotInfoPage` to `true` \*\*
 4. Refresh your browser.
 

--- a/docs/guide/website/versioned_docs/version-11.8.1/advanced/authentication.md
+++ b/docs/guide/website/versioned_docs/version-11.8.1/advanced/authentication.md
@@ -90,7 +90,7 @@ Here is a complete example
 #### Prerequisite
 
 - Botpress Pro enabled with a valid license key
-- Informations to access the LDAP server
+- Information to access the LDAP server
 
 #### Quick Start
 

--- a/docs/guide/website/versioned_docs/version-11.8.1/advanced/configuration.md
+++ b/docs/guide/website/versioned_docs/version-11.8.1/advanced/configuration.md
@@ -14,7 +14,7 @@ On this page, you will learn about the Botpress global configuration, individual
 
 This is the main file used to configure the Botpress server. It will be created automatically when it is missing. Default values should be good when discovering Botpress, but in this page you will learn about the most common configuration you may need to change.
 
-To get more informations about each individual options, check out the [comments on the configuration schema](https://github.com/botpress/botpress/blob/master/src/bp/core/config/botpress.config.ts)
+To get more information about each individual options, check out the [comments on the configuration schema](https://github.com/botpress/botpress/blob/master/src/bp/core/config/botpress.config.ts)
 
 ## HTTP Server Configuration
 
@@ -36,7 +36,7 @@ When you start Botpress from the binary (or using the Docker image), the bot is 
 
 There are 4 different levels of logs:
 
-- Debug: display very detailed informations about the bot operations
+- Debug: display very detailed information about the bot operations
 - Info: gives general information or "good to know" stuff
 - Warn: means that something didn't go as expected, but the bot was able to recover
 - Error: there was an error that should be addressed
@@ -121,9 +121,9 @@ Here there are:
 | CLUSTER_ENABLED      | Enables multi-node support using Redis                                                                    | false         |
 | REDIS_URL            | The connection string to connect to your Redis instance                                                   |               |
 
-About `DATABASE_URL` : This variable will determine the type of database you're running (i.e postgres | sqlite). Anything else than a valid postgress url it will be used as a path to sqlite file. If you want to use the default postgres connection, simply use `postgres` as value. Leave this empty if you want to use the default sqlite location.
+About `DATABASE_URL` : This variable will determine the type of database you're running (i.e postgres | sqlite). Anything else than a valid postgres url it will be used as a path to sqlite file. If you want to use the default postgres connection, simply use `postgres` as value. Leave this empty if you want to use the default sqlite location.
 
-## More Informations
+## More Information
 
 - Check out the [database](../tutorials/database) page for details about `DATABASE_URL`
 - Check out the [cluster](cluster) page for details about `CLUSTER_ENABLED` and `REDIS_URL`

--- a/docs/guide/website/versioned_docs/version-11.8.1/advanced/custom-module.md
+++ b/docs/guide/website/versioned_docs/version-11.8.1/advanced/custom-module.md
@@ -203,7 +203,7 @@ const botTemplates: sdk.BotTemplate[] = [
 
 The definition is used by Botpress to setup your module.
 
-Please refer to the [API Reference](https://botpress.io/reference/) for informations on the possible options
+Please refer to the [API Reference](https://botpress.io/reference/) for information on the possible options
 
 The only way to communicate with modules (or between them) is by using the API endpoint.
 All modules are isolated and receives their own instance of `bp`
@@ -486,7 +486,7 @@ const entryPoint: sdk.ModuleEntryPoint = {
 
 ## Register Actions
 
-Modules can register new actions that will be available on the flow editor. Please check out the [Custom Code](../main/code) section for more informations about Actions.
+Modules can register new actions that will be available on the flow editor. Please check out the [Custom Code](../main/code) section for more information about Actions.
 Those actions must be deployed to the `data/global/actions` folder to be recognized by Botpress. Here is how to do that:
 
 1. Create a folder named `actions` in `src`

--- a/docs/guide/website/versioned_docs/version-11.8.1/advanced/hosting.md
+++ b/docs/guide/website/versioned_docs/version-11.8.1/advanced/hosting.md
@@ -4,7 +4,7 @@ title: Hosting & Environment
 original_id: hosting
 ---
 
-When you are ready to open your bot to the world, you should deploy it in production mode. When the bot is started in production, the botpress file system (BPFS) is enabled ([click here for more details](../../advanced/sync-changes)) and debug logs are no longer displayed. We also strongly recomment using a Postgres database instead of the embedded SQLite.
+When you are ready to open your bot to the world, you should deploy it in production mode. When the bot is started in production, the botpress file system (BPFS) is enabled ([click here for more details](../../advanced/sync-changes)) and debug logs are no longer displayed. We also strongly recommend using a Postgres database instead of the embedded SQLite.
 
 All you need to do is start Botpress with the `-p` flag, like this: `./bp -p`
 

--- a/docs/guide/website/versioned_docs/version-11.8.1/channels/web.md
+++ b/docs/guide/website/versioned_docs/version-11.8.1/channels/web.md
@@ -26,12 +26,12 @@ There is an example included in the default botpress installation at `http://loc
 
 ## How to display a Bot Information page
 
-The information page displays informations like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
+The information page displays information like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
 
 How to set up the information page:
 
 1. On the Admin UI, click on the link `Config` next to the name of the bot you want to change.
-2. Edit your bot informations in the `More details` and `Pictures` sections.
+2. Edit your bot information in the `More details` and `Pictures` sections.
 3. Edit the file `data/global/config/channel-web.json` and set `showBotInfoPage` to `true` \*\*
 4. Refresh your browser.
 

--- a/docs/guide/website/versioned_docs/version-11.8.1/main/code.md
+++ b/docs/guide/website/versioned_docs/version-11.8.1/main/code.md
@@ -93,7 +93,7 @@ session.store = [{ id: 1, id: 2, id: 3 }]
 
 The only way to register new actions is to add your javascript code in a `.js` file and put them in the folder `data/global/actions`. There is no way to programmatically add new ones during runtime.
 
-There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful informations (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
+There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful information (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
 
 ## Hooks
 

--- a/docs/guide/website/versioned_docs/version-11.8.1/main/memory.md
+++ b/docs/guide/website/versioned_docs/version-11.8.1/main/memory.md
@@ -29,13 +29,13 @@ You can consume a memory action just like any other action from the Botpress Flo
 
 Variables set using the `user` namespace will be saved as attributes for the user. This means that those attributes will always follow the user, not notwithstanding conversations or time period.
 
-When a user sends a message to the bot, the first middleware is tasked with loading that user's informations. After everything is processed, any changes to the `user` object will be persisted to the database.
+When a user sends a message to the bot, the first middleware is tasked with loading that user's information. After everything is processed, any changes to the `user` object will be persisted to the database.
 
 This means that you can alter the `user` object using middlwares and actions, and it will be saved at the end.
 
 #### User Memory - Data Retention
 
-Since privacy is an important matter, there is a built-in system that makes it dead-easy to set retention periods for different type of informations. You could have, for example a policy that says `email expires after 2 months` or `remember user's mood for 1 day`. Whenever the user's attribute is changed, the expiration policy is updated.
+Since privacy is an important matter, there is a built-in system that makes it dead-easy to set retention periods for different type of information. You could have, for example a policy that says `email expires after 2 months` or `remember user's mood for 1 day`. Whenever the user's attribute is changed, the expiration policy is updated.
 
 Here's how it could be configured:
 

--- a/docs/guide/website/versioned_docs/version-11.8.1/main/nlu.md
+++ b/docs/guide/website/versioned_docs/version-11.8.1/main/nlu.md
@@ -59,7 +59,7 @@ Here's an example of the structure of an incoming event processed by Botpress Na
   "flags": {},
   "nlu": { // <<<<------
     "language": "en", // language identified
-    "intent": { // most likely intent, assuming confidence is within config treshold
+    "intent": { // most likely intent, assuming confidence is within config threshold
       "name": "hello",
       "confidence": 1
     },
@@ -91,7 +91,7 @@ You can use that metadata in your flows to create transitions when a specific in
 
 To enable debugging of the NLU module, make sure that `debugModeEnabled` is set to `true` in your `data/global/config/nlu.json` file.
 
-> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environement variable instead of modifying the configuration directly.
+> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environment variable instead of modifying the configuration directly.
 
 ##### Example of debugging message
 
@@ -206,19 +206,19 @@ An example of placeholder entity would be : Please tell **Sarah** that **she's l
 
 ### Custom Entities
 
-As of today we provide 2 types of custom entites: [pattern](#pattern-extraction) and [list](#list-extraction) entitites. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
+As of today we provide 2 types of custom entities: [pattern](#pattern-extraction) and [list](#list-extraction) entities. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
 
 <img src="/docs/assets/nlu-create-entity.png">
 
-### Sensitive Informations
+### Sensitive Information
 
-Communication between users and bots are stored in the database, which means that sometimes personal informations (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
+Communication between users and bots are stored in the database, which means that sometimes personal information (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
 
 When checked, the information will still be displayed in the chat window, but the sensitive information will be replaced by `*****` before being stored. The original value is still available from `event.nlu.entities`
 
 #### Pattern extraction
 
-Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incomming message and add it to `event.nlu.entities`.
+Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incoming message and add it to `event.nlu.entities`.
 
 ##### Example :
 
@@ -252,7 +252,7 @@ Extraction will go like:
 
 #### List extraction
 
-List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurences** of your entity with corresponding synonyms.
+List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurrences** of your entity with corresponding synonyms.
 
 Let's take **Airport Codes** as an example:
 
@@ -342,7 +342,7 @@ slots : {
 
 ### Slot Filling
 
-As of now when you define an intent slot, it is considered as optional. If it's mandatory for a desired task, you'll have to handle slot filling yourself in your conversational flow design using [Botpress Flow Builder](dialog). We plan to add suppport for **required slots** with automatic slot filling.
+As of now when you define an intent slot, it is considered as optional. If it's mandatory for a desired task, you'll have to handle slot filling yourself in your conversational flow design using [Botpress Flow Builder](dialog). We plan to add support for **required slots** with automatic slot filling.
 
 **TODO provide example**
 

--- a/docs/guide/website/versioned_docs/version-11.8.1/quickstart.md
+++ b/docs/guide/website/versioned_docs/version-11.8.1/quickstart.md
@@ -49,7 +49,7 @@ Open the chat window and say "_Hello_". The bot should greet you with something 
 
 ![Hello from the bot](assets/flow_page.png)
 
-There is another emulator, which is specifically designed for you (the bot owner) to understand quickly why the bot gives you a specific answer. That emulator is only available for authenticated users. It includes all sort of useful informations: list of suggested answers by module, nlu intents, and the elected suggestion.
+There is another emulator, which is specifically designed for you (the bot owner) to understand quickly why the bot gives you a specific answer. That emulator is only available for authenticated users. It includes all sort of useful information: list of suggested answers by module, nlu intents, and the elected suggestion.
 
 ![Emulator Hello](assets/emulator_ng.png)
 

--- a/docs/guide/website/versioned_docs/version-11.8.1/releases/migrate.md
+++ b/docs/guide/website/versioned_docs/version-11.8.1/releases/migrate.md
@@ -60,7 +60,7 @@ my-module/views/lite/index.jsx
 
 This change implied modifications on how modules are packaged. Please clear the `node_modules` folder of every module, then run `yarn build`
 
-For more informations see: [Module Views](../advanced/custom-module#views)
+For more information see: [Module Views](../advanced/custom-module#views)
 
 ## Migration from 11.3 to 11.4
 

--- a/docs/guide/website/versioned_docs/version-11.8.1/tutorials/database.md
+++ b/docs/guide/website/versioned_docs/version-11.8.1/tutorials/database.md
@@ -28,4 +28,4 @@ If you want to use default postgres connection string simply set it as follow
 
 Please make sure you are using Postgres 9.5 or higher.
 
-If you don't want to type those variables each time you start Botpress, we also supports `.env` files. Check out our [configuration section](../advanced/configuration) for more informations about that
+If you don't want to type those variables each time you start Botpress, we also supports `.env` files. Check out our [configuration section](../advanced/configuration) for more information about that

--- a/docs/guide/website/versioned_docs/version-11.8.1/tutorials/existing-backend.md
+++ b/docs/guide/website/versioned_docs/version-11.8.1/tutorials/existing-backend.md
@@ -19,7 +19,7 @@ You can either define the token when the chat is initialized: `window.botpressWe
 
 ## Persisting the user's profile
 
-Once the user is authenticated, you may want to extract some informations out of the credentials to save them in the `user` state, like the First name, Last name, etc. All you need to do is set up a hook listening for a certain type of event, for example `update_profile`. Then, just select the required fields
+Once the user is authenticated, you may want to extract some information out of the credentials to save them in the `user` state, like the First name, Last name, etc. All you need to do is set up a hook listening for a certain type of event, for example `update_profile`. Then, just select the required fields
 
 Example:
 

--- a/docs/guide/website/versioned_docs/version-11.8.3/channels/web.md
+++ b/docs/guide/website/versioned_docs/version-11.8.3/channels/web.md
@@ -28,14 +28,14 @@ There is an example included in the default botpress installation at `http://loc
 
 ## Bot Information page
 
-The information page displays informations like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
+The information page displays information like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
 
 ![Bot Info Page](assets/webchat-bot-info.png)
 
 How to set up the information page:
 
 1. On the Admin UI, click on the link `Config` next to the name of the bot you want to change.
-2. Edit your bot informations in the `More details` and `Pictures` sections.
+2. Edit your bot information in the `More details` and `Pictures` sections.
 3. Edit the file `data/global/config/channel-web.json` and set `showBotInfoPage` to `true` **\*\***
 4. Refresh your browser.
 
@@ -96,7 +96,7 @@ The method `window.botpressWebChat.configure` allows you to change the configura
 
 ## Advanced Customization
 
-Every message sent by the bot to a user consist of a `payload`. That payload has a `type` property, that tells the webchat how the other informations included on that payload should be rendered on screen.
+Every message sent by the bot to a user consist of a `payload`. That payload has a `type` property, that tells the webchat how the other information included on that payload should be rendered on screen.
 
 There are different ways to send that payload to the user:
 
@@ -105,7 +105,7 @@ There are different ways to send that payload to the user:
 
 There are multiple types already built in Botpress (they are listed at the bottom of this page), but if you require more advanced components, you can create them easily.
 
-### Prevent storing sensitive informations
+### Prevent storing sensitive information
 
 By default, the complete payload is stored in the database, so the information is not lost when the user refreshes the page. On some occasion, however, we may want to hide some properties deemed "sensitive" (ex: password, credit card, etc..).
 
@@ -146,7 +146,7 @@ payload: {
 
 ### What can I do in my component ?
 
-There are a couple of properties that are passed down to your custom component. These can be used to customize the displayed informations, and/or to pursue interactions.
+There are a couple of properties that are passed down to your custom component. These can be used to customize the displayed information, and/or to pursue interactions.
 
 | Property      | Description                                                                    |
 | ------------- | ------------------------------------------------------------------------------ |

--- a/docs/guide/website/versioned_docs/version-11.8.3/channels/web.md
+++ b/docs/guide/website/versioned_docs/version-11.8.3/channels/web.md
@@ -109,7 +109,7 @@ There are multiple types already built in Botpress (they are listed at the botto
 
 By default, the complete payload is stored in the database, so the information is not lost when the user refreshes the page. On some occasion, however, we may want to hide some properties deemed "sensitive" (ex: password, credit card, etc..).
 
-To remove those informations, there is a special property that you need to set: `sensitive`. Here's an example:
+To remove this information, there is a special property that you need to set: `sensitive`. Here's an example:
 
 ```js
 const payload = {

--- a/docs/guide/website/versioned_docs/version-11.9.0/main/memory.md
+++ b/docs/guide/website/versioned_docs/version-11.9.0/main/memory.md
@@ -29,13 +29,13 @@ You can consume a memory action just like any other action from the Botpress Flo
 
 Variables set using the `user` namespace will be saved as attributes for the user. This means that those attributes will always follow the user, not notwithstanding conversations or time period.
 
-When a user sends a message to the bot, the first middleware is tasked with loading that user's informations. After everything is processed, any changes to the `user` object will be persisted to the database.
+When a user sends a message to the bot, the first middleware is tasked with loading that user's information. After everything is processed, any changes to the `user` object will be persisted to the database.
 
 This means that you can alter the `user` object using middlwares and actions, and it will be saved at the end.
 
 #### User Memory - Data Retention
 
-Since privacy is an important matter, there is a built-in system that makes it dead-easy to set retention periods for different type of informations. You could have, for example a policy that says `email expires after 2 months` or `remember user's mood for 1 day`. Whenever the user's attribute is changed, the expiration policy is updated.
+Since privacy is an important matter, there is a built-in system that makes it dead-easy to set retention periods for different type of information. You could have, for example a policy that says `email expires after 2 months` or `remember user's mood for 1 day`. Whenever the user's attribute is changed, the expiration policy is updated.
 
 Here's how it could be configured:
 

--- a/docs/guide/website/versioned_docs/version-11.9.0/main/nlu.md
+++ b/docs/guide/website/versioned_docs/version-11.9.0/main/nlu.md
@@ -59,7 +59,7 @@ Here's an example of the structure of an incoming event processed by Botpress Na
   "flags": {},
   "nlu": { // <<<<------
     "language": "en", // language identified
-    "intent": { // most likely intent, assuming confidence is within config treshold
+    "intent": { // most likely intent, assuming confidence is within config threshold
       "name": "hello",
       "confidence": 1
     },
@@ -91,7 +91,7 @@ You can use that metadata in your flows to create transitions when a specific in
 
 To enable debugging of the NLU module, make sure that `debugModeEnabled` is set to `true` in your `data/global/config/nlu.json` file.
 
-> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environement variable instead of modifying the configuration directly.
+> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environment variable instead of modifying the configuration directly.
 
 ##### Example of debugging message
 
@@ -206,19 +206,19 @@ An example of placeholder entity would be : Please tell **Sarah** that **she's l
 
 ### Custom Entities
 
-As of today we provide 2 types of custom entites: [pattern](#pattern-extraction) and [list](#list-extraction) entitites. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
+As of today we provide 2 types of custom entities: [pattern](#pattern-extraction) and [list](#list-extraction) entities. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
 
 <img src="/docs/assets/nlu-create-entity.png">
 
-### Sensitive Informations
+### Sensitive Information
 
-Communication between users and bots are stored in the database, which means that sometimes personal informations (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
+Communication between users and bots are stored in the database, which means that sometimes personal information (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
 
 When checked, the information will still be displayed in the chat window, but the sensitive information will be replaced by `*****` before being stored. The original value is still available from `event.nlu.entities`
 
 #### Pattern extraction
 
-Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incomming message and add it to `event.nlu.entities`.
+Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incoming message and add it to `event.nlu.entities`.
 
 ##### Example :
 
@@ -252,7 +252,7 @@ Extraction will go like:
 
 #### List extraction
 
-List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurences** of your entity with corresponding synonyms.
+List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurrences** of your entity with corresponding synonyms.
 
 Let's take **Airport Codes** as an example:
 

--- a/docs/guide/website/versioned_docs/version-11.9.2/advanced/authentication.md
+++ b/docs/guide/website/versioned_docs/version-11.9.2/advanced/authentication.md
@@ -90,7 +90,7 @@ Here is a complete example
 #### Prerequisite
 
 - Botpress Pro enabled with a valid license key
-- Informations to access the LDAP server
+- Information to access the LDAP server
 
 #### Quick Start
 

--- a/docs/guide/website/versioned_docs/version-11.9.2/main/memory.md
+++ b/docs/guide/website/versioned_docs/version-11.9.2/main/memory.md
@@ -103,13 +103,13 @@ You can consume a memory action just like any other action from the Botpress Flo
 
 Variables set using the `user` namespace will be saved as attributes for the user. This means that those attributes will always follow the user, not notwithstanding conversations or time period.
 
-When a user sends a message to the bot, the first middleware is tasked with loading that user's informations. After everything is processed, any changes to the `user` object will be persisted to the database.
+When a user sends a message to the bot, the first middleware is tasked with loading that user's information. After everything is processed, any changes to the `user` object will be persisted to the database.
 
 This means that you can alter the `user` object using middlwares and actions, and it will be saved at the end.
 
 #### User Memory - Data Retention
 
-Since privacy is an important matter, there is a built-in system that makes it dead-easy to set retention periods for different type of informations. You could have, for example a policy that says `email expires after 2 months` or `remember user's mood for 1 day`. Whenever the user's attribute is changed, the expiration policy is updated.
+Since privacy is an important matter, there is a built-in system that makes it dead-easy to set retention periods for different type of information. You could have, for example a policy that says `email expires after 2 months` or `remember user's mood for 1 day`. Whenever the user's attribute is changed, the expiration policy is updated.
 
 Here's how it could be configured:
 

--- a/docs/guide/website/versioned_docs/version-11.9.4/channels/web.md
+++ b/docs/guide/website/versioned_docs/version-11.9.4/channels/web.md
@@ -111,11 +111,11 @@ There are different ways to send that payload to the user:
 
 There are multiple types already built in Botpress (they are listed at the bottom of this page), but if you require more advanced components, you can create them easily.
 
-### Prevent storing sensitive informations
+### Prevent storing sensitive information
 
 By default, the complete payload is stored in the database, so the information is not lost when the user refreshes the page. On some occasion, however, we may want to hide some properties deemed "sensitive" (ex: password, credit card, etc..).
 
-To remove those informations, there is a special property that you need to set: `sensitive`. Here's an example:
+To remove this information, there is a special property that you need to set: `sensitive`. Here's an example:
 
 ```js
 const payload = {

--- a/docs/guide/website/versioned_docs/version-11.9.4/channels/web.md
+++ b/docs/guide/website/versioned_docs/version-11.9.4/channels/web.md
@@ -34,14 +34,14 @@ There is an example included in the default botpress installation at `http://loc
 
 ## Bot Information page
 
-The information page displays informations like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
+The information page displays information like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
 
 ![Bot Info Page](assets/webchat-bot-info.png)
 
 How to set up the information page:
 
 1. On the Admin UI, click on the link `Config` next to the name of the bot you want to change.
-2. Edit your bot informations in the `More details` and `Pictures` sections.
+2. Edit your bot information in the `More details` and `Pictures` sections.
 3. Edit the file `data/global/config/channel-web.json` and set `showBotInfoPage` to `true` **\*\***
 4. Refresh your browser.
 
@@ -102,7 +102,7 @@ The method `window.botpressWebChat.configure` allows you to change the configura
 
 ## Advanced Customization
 
-Every message sent by the bot to a user consist of a `payload`. That payload has a `type` property, that tells the webchat how the other informations included on that payload should be rendered on screen.
+Every message sent by the bot to a user consist of a `payload`. That payload has a `type` property, that tells the webchat how the other information included on that payload should be rendered on screen.
 
 There are different ways to send that payload to the user:
 
@@ -152,7 +152,7 @@ payload: {
 
 ### What can I do in my component ?
 
-There are a couple of properties that are passed down to your custom component. These can be used to customize the displayed informations, and/or to pursue interactions.
+There are a couple of properties that are passed down to your custom component. These can be used to customize the displayed information, and/or to pursue interactions.
 
 | Property      | Description                                                                    |
 | ------------- | ------------------------------------------------------------------------------ |

--- a/docs/guide/website/versioned_docs/version-11.9.4/main/code.md
+++ b/docs/guide/website/versioned_docs/version-11.9.4/main/code.md
@@ -93,7 +93,7 @@ session.store = [{ id: 1, id: 2, id: 3 }]
 
 The only way to register new actions is to add your javascript code in a `.js` file and put them in the folder `data/global/actions`. There is no way to programmatically add new ones during runtime.
 
-There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful informations (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
+There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful information (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
 
 ## Hooks
 

--- a/docs/guide/website/versioned_docs/version-11.9.5/advanced/authentication.md
+++ b/docs/guide/website/versioned_docs/version-11.9.5/advanced/authentication.md
@@ -90,7 +90,7 @@ Here is a complete example
 #### Prerequisite
 
 - Botpress Pro enabled with a valid license key
-- Informations to access the LDAP server
+- Information to access the LDAP server
 
 #### Quick Start
 

--- a/docs/guide/website/versioned_docs/version-11.9.5/advanced/configuration.md
+++ b/docs/guide/website/versioned_docs/version-11.9.5/advanced/configuration.md
@@ -12,7 +12,7 @@ On this page, you will learn about the Botpress global configuration, individual
 
 This is the main file used to configure the Botpress server. It will be created automatically when it is missing. Default values should be good when discovering Botpress, but in this page you will learn about the most common configuration you may need to change.
 
-To get more informations about each individual options, check out the [comments on the configuration schema](https://github.com/botpress/botpress/blob/master/src/bp/core/config/botpress.config.ts)
+To get more information about each individual options, check out the [comments on the configuration schema](https://github.com/botpress/botpress/blob/master/src/bp/core/config/botpress.config.ts)
 
 ## HTTP Server Configuration
 
@@ -34,7 +34,7 @@ When you start Botpress from the binary (or using the Docker image), the bot is 
 
 There are 4 different levels of logs:
 
-- Debug: display very detailed informations about the bot operations
+- Debug: display very detailed information about the bot operations
 - Info: gives general information or "good to know" stuff
 - Warn: means that something didn't go as expected, but the bot was able to recover
 - Error: there was an error that should be addressed
@@ -119,9 +119,9 @@ Here there are:
 | CLUSTER_ENABLED      | Enables multi-node support using Redis                                                                    | false         |
 | REDIS_URL            | The connection string to connect to your Redis instance                                                   |               |
 
-About `DATABASE_URL` : This variable will determine the type of database you're running (i.e postgres | sqlite). Anything else than a valid postgress url it will be used as a path to sqlite file. If you want to use the default postgres connection, simply use `postgres` as value. Leave this empty if you want to use the default sqlite location.
+About `DATABASE_URL` : This variable will determine the type of database you're running (i.e postgres | sqlite). Anything else than a valid postgres url it will be used as a path to sqlite file. If you want to use the default postgres connection, simply use `postgres` as value. Leave this empty if you want to use the default sqlite location.
 
-## More Informations
+## More Information
 
 - Check out the [database](../tutorials/database) page for details about `DATABASE_URL`
 - Check out the [cluster](cluster) page for details about `CLUSTER_ENABLED` and `REDIS_URL`

--- a/docs/guide/website/versioned_docs/version-11.9.5/advanced/hosting.md
+++ b/docs/guide/website/versioned_docs/version-11.9.5/advanced/hosting.md
@@ -4,7 +4,7 @@ title: Deployment
 original_id: hosting
 ---
 
-When you are ready to open your bot to the world, you should deploy it in production mode. When the bot is started in production, the botpress file system (BPFS) is enabled [click here for more details](versions) and debug logs are no longer displayed. We also strongly recomment using a Postgres database instead of the embedded SQLite.
+When you are ready to open your bot to the world, you should deploy it in production mode. When the bot is started in production, the botpress file system (BPFS) is enabled [click here for more details](versions) and debug logs are no longer displayed. We also strongly recommend using a Postgres database instead of the embedded SQLite.
 
 All you need to do is start Botpress with the `-p` flag, like this: `./bp -p`
 
@@ -20,7 +20,7 @@ Below are multiple possible ways of deploying Botpress in the cloud.
 
 ### Preparing the Docker image
 
-To create a new bot from scratch, simply create a file named `Dockerfile` in any directory. Write this snippet in the file (and replace $VERSION with the latest one in [hub.docker.com](https://hub.docker.com/r/botpress/server/tags/))
+To create a new bot from scratch, simply create a file named `Dockerfile` in any directory. Write this snippet in the file (and replace \$VERSION with the latest one in [hub.docker.com](https://hub.docker.com/r/botpress/server/tags/))
 
 ```docker
 FROM botpress/server:$VERSION

--- a/docs/guide/website/versioned_docs/version-11.9.5/main/code.md
+++ b/docs/guide/website/versioned_docs/version-11.9.5/main/code.md
@@ -93,7 +93,7 @@ session.store = [{ id: 1, id: 2, id: 3 }]
 
 The only way to register new actions is to add your javascript code in a `.js` file and put them in the folder `data/global/actions`. There is no way to programmatically add new ones during runtime.
 
-There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful informations (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
+There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful information (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
 
 ## Hooks
 

--- a/docs/guide/website/versioned_docs/version-11.9.5/main/nlu.md
+++ b/docs/guide/website/versioned_docs/version-11.9.5/main/nlu.md
@@ -59,7 +59,7 @@ Here's an example of the structure of an incoming event processed by Botpress Na
   "flags": {},
   "nlu": { // <<<<------
     "language": "en", // language identified
-    "intent": { // most likely intent, assuming confidence is within config treshold
+    "intent": { // most likely intent, assuming confidence is within config threshold
       "name": "hello",
       "confidence": 1
     },
@@ -91,7 +91,7 @@ You can use that metadata in your flows to create transitions when a specific in
 
 To enable debugging of the NLU module, make sure that `debugModeEnabled` is set to `true` in your `data/global/config/nlu.json` file.
 
-> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environement variable instead of modifying the configuration directly.
+> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environment variable instead of modifying the configuration directly.
 
 ##### Example of debugging message
 
@@ -206,19 +206,19 @@ An example of placeholder entity would be : Please tell **Sarah** that **she's l
 
 ### Custom Entities
 
-As of today we provide 2 types of custom entites: [pattern](#pattern-extraction) and [list](#list-extraction) entitites. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
+As of today we provide 2 types of custom entities: [pattern](#pattern-extraction) and [list](#list-extraction) entities. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
 
 <img src="/docs/assets/nlu-create-entity.png">
 
-### Sensitive Informations
+### Sensitive Information
 
-Communication between users and bots are stored in the database, which means that sometimes personal informations (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
+Communication between users and bots are stored in the database, which means that sometimes personal information (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
 
 When checked, the information will still be displayed in the chat window, but the sensitive information will be replaced by `*****` before being stored. The original value is still available from `event.nlu.entities`
 
 #### Pattern extraction
 
-Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incomming message and add it to `event.nlu.entities`.
+Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incoming message and add it to `event.nlu.entities`.
 
 ##### Example :
 
@@ -252,7 +252,7 @@ Extraction will go like:
 
 #### List extraction
 
-List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurences** of your entity with corresponding synonyms.
+List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurrences** of your entity with corresponding synonyms.
 
 Let's take **Airport Codes** as an example:
 

--- a/docs/guide/website/versioned_docs/version-11.9.5/releases/migrate.md
+++ b/docs/guide/website/versioned_docs/version-11.9.5/releases/migrate.md
@@ -60,7 +60,7 @@ my-module/views/lite/index.jsx
 
 This change implied modifications on how modules are packaged. Please clear the `node_modules` folder of every module, then run `yarn build`
 
-For more informations see: [Module Views](../advanced/custom-module#views)
+For more information see: [Module Views](../advanced/custom-module#views)
 
 ## Migration from 11.3 to 11.4
 

--- a/docs/guide/website/versioned_docs/version-11.9.5/tutorials/existing-backend.md
+++ b/docs/guide/website/versioned_docs/version-11.9.5/tutorials/existing-backend.md
@@ -19,7 +19,7 @@ You can either define the token when the chat is initialized: `window.botpressWe
 
 ## Persisting the user's profile
 
-Once the user is authenticated, you may want to extract some informations out of the credentials to save them in the `user` state, like the First name, Last name, etc. All you need to do is set up a hook listening for a certain type of event, for example `update_profile`. Then, just select the required fields
+Once the user is authenticated, you may want to extract some information out of the credentials to save them in the `user` state, like the First name, Last name, etc. All you need to do is set up a hook listening for a certain type of event, for example `update_profile`. Then, just select the required fields
 
 Example:
 

--- a/docs/guide/website/versioned_docs/version-12.0.0/advanced/hosting.md
+++ b/docs/guide/website/versioned_docs/version-12.0.0/advanced/hosting.md
@@ -4,7 +4,7 @@ title: Deployment
 original_id: hosting
 ---
 
-When you are ready to open your bot to the world, you should deploy it in production mode. When the bot is started in production, the botpress file system (BPFS) is enabled [click here for more details](versions) and debug logs are no longer displayed. We also strongly recomment using a Postgres database instead of the embedded SQLite.
+When you are ready to open your bot to the world, you should deploy it in production mode. When the bot is started in production, the botpress file system (BPFS) is enabled [click here for more details](versions) and debug logs are no longer displayed. We also strongly recommend using a Postgres database instead of the embedded SQLite.
 
 All you need to do is start Botpress with the `-p` flag, like this: `./bp -p`
 
@@ -382,7 +382,7 @@ Botpress supports `.env` files, so you don't have to set them everytime you star
 | FAST_TEXT_CLEANUP_MS      | The model will be kept in memory until it receives no messages to process for that duration | 60000   |
 | REVERSE_PROXY             | When enabled, it uses "x-forwarded-for" to fetch the user IP instead of remoteAddress       | false   |
 
-It is also possible to use environment variables to override module configuration. The pattern is `BP_%MODULE_NAME%_%OPTION_PATH%`, all in upper cases. For example, to define the `confidenceTreshold` option of the module `nlu`, you would use `BP_NLU_CONFIDENCETRESHOLD`. You can list the available environment variales for each modules by enabling the `DEBUG=bp:configuration:modules:*` flag.
+It is also possible to use environment variables to override module configuration. The pattern is `BP_%MODULE_NAME%_%OPTION_PATH%`, all in upper cases. For example, to define the `confidenceTreshold` option of the module `nlu`, you would use `BP_NLU_CONFIDENCETRESHOLD`. You can list the available environment variables for each modules by enabling the `DEBUG=bp:configuration:modules:*` flag.
 
 ##### Example
 

--- a/docs/guide/website/versioned_docs/version-12.0.0/channels/web.md
+++ b/docs/guide/website/versioned_docs/version-12.0.0/channels/web.md
@@ -34,14 +34,14 @@ There is an example included in the default botpress installation at `http://loc
 
 ## Bot Information page
 
-The information page displays informations like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
+The information page displays information like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
 
 ![Bot Info Page](assets/webchat-bot-info.png)
 
 How to set up the information page:
 
 1. On the Admin UI, click on the link `Config` next to the name of the bot you want to change.
-2. Edit your bot informations in the `More details` and `Pictures` sections.
+2. Edit your bot information in the `More details` and `Pictures` sections.
 3. Edit the file `data/global/config/channel-web.json` and set `showBotInfoPage` to `true` **\*\***
 4. Refresh your browser.
 
@@ -102,7 +102,7 @@ The method `window.botpressWebChat.configure` allows you to change the configura
 
 ## Advanced Customization
 
-Every message sent by the bot to a user consist of a `payload`. That payload has a `type` property, that tells the webchat how the other informations included on that payload should be rendered on screen.
+Every message sent by the bot to a user consist of a `payload`. That payload has a `type` property, that tells the webchat how the other information included on that payload should be rendered on screen.
 
 There are different ways to send that payload to the user:
 
@@ -152,7 +152,7 @@ payload: {
 
 ### What can I do in my component ?
 
-There are a couple of properties that are passed down to your custom component. These can be used to customize the displayed informations, and/or to pursue interactions.
+There are a couple of properties that are passed down to your custom component. These can be used to customize the displayed information, and/or to pursue interactions.
 
 | Property        | Description                                                                    |
 | --------------- | ------------------------------------------------------------------------------ |

--- a/docs/guide/website/versioned_docs/version-12.0.0/channels/web.md
+++ b/docs/guide/website/versioned_docs/version-12.0.0/channels/web.md
@@ -111,11 +111,11 @@ There are different ways to send that payload to the user:
 
 There are multiple types already built in Botpress (they are listed at the bottom of this page), but if you require more advanced components, you can create them easily.
 
-### Prevent storing sensitive informations
+### Prevent storing sensitive information
 
 By default, the complete payload is stored in the database, so the information is not lost when the user refreshes the page. On some occasion, however, we may want to hide some properties deemed "sensitive" (ex: password, credit card, etc..).
 
-To remove those informations, there is a special property that you need to set: `sensitive`. Here's an example:
+To remove this information, there is a special property that you need to set: `sensitive`. Here's an example:
 
 ```js
 const payload = {

--- a/docs/guide/website/versioned_docs/version-12.0.0/main/nlu.md
+++ b/docs/guide/website/versioned_docs/version-12.0.0/main/nlu.md
@@ -59,7 +59,7 @@ Here's an example of the structure of an incoming event processed by Botpress Na
   "flags": {},
   "nlu": { // <<<<------
     "language": "en", // language identified
-    "intent": { // most likely intent, assuming confidence is within config treshold
+    "intent": { // most likely intent, assuming confidence is within config threshold
       "name": "hello",
       "confidence": 1
     },
@@ -91,7 +91,7 @@ You can use that metadata in your flows to create transitions when a specific in
 
 To enable debugging of the NLU module, make sure that `debugModeEnabled` is set to `true` in your `data/global/config/nlu.json` file.
 
-> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environement variable instead of modifying the configuration directly.
+> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environment variable instead of modifying the configuration directly.
 
 ##### Example of debugging message
 
@@ -206,19 +206,19 @@ An example of placeholder entity would be : Please tell **Sarah** that **she's l
 
 ### Custom Entities
 
-As of today we provide 2 types of custom entites: [pattern](#pattern-extraction) and [list](#list-extraction) entitites. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
+As of today we provide 2 types of custom entities: [pattern](#pattern-extraction) and [list](#list-extraction) entities. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
 
 <img src="/docs/assets/nlu-create-entity.png">
 
-### Sensitive Informations
+### Sensitive Information
 
-Communication between users and bots are stored in the database, which means that sometimes personal informations (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
+Communication between users and bots are stored in the database, which means that sometimes personal information (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
 
 When checked, the information will still be displayed in the chat window, but the sensitive information will be replaced by `*****` before being stored. The original value is still available from `event.nlu.entities`
 
 #### Pattern extraction
 
-Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incomming message and add it to `event.nlu.entities`.
+Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incoming message and add it to `event.nlu.entities`.
 
 ##### Example :
 
@@ -252,7 +252,7 @@ Extraction will go like:
 
 #### List extraction
 
-List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurences** of your entity with corresponding synonyms.
+List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurrences** of your entity with corresponding synonyms.
 
 Let's take **Airport Codes** as an example:
 
@@ -346,7 +346,7 @@ Slot filling is the process of gathering information required by an intent. This
 
 ## Language Server
 
-The language server provides additional informations about words, which allows your bot to understand words with a similar meaning even if you didn't specifically taught it about it. By default, your Botpress server will query one of our language server for that purpose. You can also choose to host your own server if you would like to keep everything on your premise. Head over to the [Hosting](../advanced/hosting#running-your-own-language-server) page for more details.
+The language server provides additional information about words, which allows your bot to understand words with a similar meaning even if you didn't specifically taught it about it. By default, your Botpress server will query one of our language server for that purpose. You can also choose to host your own server if you would like to keep everything on your premise. Head over to the [Hosting](../advanced/hosting#running-your-own-language-server) page for more details.
 
 ## External NLU Providers
 

--- a/docs/guide/website/versioned_docs/version-12.0.0/releases/migrate.md
+++ b/docs/guide/website/versioned_docs/version-12.0.0/releases/migrate.md
@@ -76,7 +76,7 @@ my-module/views/lite/index.jsx
 
 This change implied modifications on how modules are packaged. Please clear the `node_modules` folder of every module, then run `yarn build`
 
-For more informations see: [Module Views](../advanced/custom-module#views)
+For more information see: [Module Views](../advanced/custom-module#views)
 
 ## Migration from 11.3 to 11.4
 

--- a/docs/guide/website/versioned_docs/version-12.0.2/channels/web.md
+++ b/docs/guide/website/versioned_docs/version-12.0.2/channels/web.md
@@ -34,14 +34,14 @@ There is an example included in the default botpress installation at `http://loc
 
 ## Bot Information page
 
-The information page displays informations like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
+The information page displays information like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
 
 ![Bot Info Page](assets/webchat-bot-info.png)
 
 How to set up the information page:
 
 1. On the Admin UI, click on the link `Config` next to the name of the bot you want to change.
-2. Edit your bot informations in the `More details` and `Pictures` sections.
+2. Edit your bot information in the `More details` and `Pictures` sections.
 3. Edit the file `data/global/config/channel-web.json` and set `showBotInfoPage` to `true` **\*\***
 4. Refresh your browser.
 
@@ -115,7 +115,7 @@ The method `window.botpressWebChat.configure` allows you to change the configura
 
 ## Advanced Customization
 
-Every message sent by the bot to a user consist of a `payload`. That payload has a `type` property, that tells the webchat how the other informations included on that payload should be rendered on screen.
+Every message sent by the bot to a user consist of a `payload`. That payload has a `type` property, that tells the webchat how the other information included on that payload should be rendered on screen.
 
 There are different ways to send that payload to the user:
 
@@ -165,7 +165,7 @@ payload: {
 
 ### What can I do in my component ?
 
-There are a couple of properties that are passed down to your custom component. These can be used to customize the displayed informations, and/or to pursue interactions.
+There are a couple of properties that are passed down to your custom component. These can be used to customize the displayed information, and/or to pursue interactions.
 
 | Property        | Description                                                                    |
 | --------------- | ------------------------------------------------------------------------------ |

--- a/docs/guide/website/versioned_docs/version-12.0.2/channels/web.md
+++ b/docs/guide/website/versioned_docs/version-12.0.2/channels/web.md
@@ -124,11 +124,11 @@ There are different ways to send that payload to the user:
 
 There are multiple types already built in Botpress (they are listed at the bottom of this page), but if you require more advanced components, you can create them easily.
 
-### Prevent storing sensitive informations
+### Prevent storing sensitive information
 
 By default, the complete payload is stored in the database, so the information is not lost when the user refreshes the page. On some occasion, however, we may want to hide some properties deemed "sensitive" (ex: password, credit card, etc..).
 
-To remove those informations, there is a special property that you need to set: `sensitive`. Here's an example:
+To remove this information, there is a special property that you need to set: `sensitive`. Here's an example:
 
 ```js
 const payload = {

--- a/docs/guide/website/versioned_docs/version-12.0.3/advanced/hosting.md
+++ b/docs/guide/website/versioned_docs/version-12.0.3/advanced/hosting.md
@@ -480,7 +480,7 @@ Botpress supports `.env` files, so you don't have to set them everytime you star
 | FAST_TEXT_CLEANUP_MS      | The model will be kept in memory until it receives no messages to process for that duration | 60000   |
 | REVERSE_PROXY             | When enabled, it uses "x-forwarded-for" to fetch the user IP instead of remoteAddress       | false   |
 
-It is also possible to use environment variables to override module configuration. The pattern is `BP_%MODULE_NAME%_%OPTION_PATH%`, all in upper cases. For example, to define the `confidenceTreshold` option of the module `nlu`, you would use `BP_NLU_CONFIDENCETRESHOLD`. You can list the available environment variales for each modules by enabling the `DEBUG=bp:configuration:modules:*` flag.
+It is also possible to use environment variables to override module configuration. The pattern is `BP_%MODULE_NAME%_%OPTION_PATH%`, all in upper cases. For example, to define the `confidenceTreshold` option of the module `nlu`, you would use `BP_NLU_CONFIDENCETRESHOLD`. You can list the available environment variables for each modules by enabling the `DEBUG=bp:configuration:modules:*` flag.
 
 ### Example
 

--- a/docs/guide/website/versioned_docs/version-12.0.4/advanced/authentication.md
+++ b/docs/guide/website/versioned_docs/version-12.0.4/advanced/authentication.md
@@ -90,7 +90,7 @@ Here is a complete example
 #### Prerequisite
 
 - Botpress Pro enabled with a valid license key
-- Informations to access the LDAP server
+- Information to access the LDAP server
 
 #### Quick Start
 

--- a/docs/guide/website/versioned_docs/version-12.0.4/channels/web.md
+++ b/docs/guide/website/versioned_docs/version-12.0.4/channels/web.md
@@ -34,14 +34,14 @@ There is an example included in the default botpress installation at `http://loc
 
 ## Bot Information page
 
-The information page displays informations like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
+The information page displays information like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
 
 ![Bot Info Page](assets/webchat-bot-info.png)
 
 How to set up the information page:
 
 1. On the Admin UI, click on the link `Config` next to the name of the bot you want to change.
-2. Edit your bot informations in the `More details` and `Pictures` sections.
+2. Edit your bot information in the `More details` and `Pictures` sections.
 3. Edit the file `data/global/config/channel-web.json` and set `showBotInfoPage` to `true` **\*\***
 4. Refresh your browser.
 
@@ -106,7 +106,7 @@ The method `window.botpressWebChat.configure` allows you to change the configura
 
 ## Advanced Customization
 
-Every message sent by the bot to a user consist of a `payload`. That payload has a `type` property, that tells the webchat how the other informations included on that payload should be rendered on screen.
+Every message sent by the bot to a user consist of a `payload`. That payload has a `type` property, that tells the webchat how the other information included on that payload should be rendered on screen.
 
 There are different ways to send that payload to the user:
 
@@ -156,7 +156,7 @@ payload: {
 
 ### What can I do in my component ?
 
-There are a couple of properties that are passed down to your custom component. These can be used to customize the displayed informations, and/or to pursue interactions.
+There are a couple of properties that are passed down to your custom component. These can be used to customize the displayed information, and/or to pursue interactions.
 
 | Property        | Description                                                                    |
 | --------------- | ------------------------------------------------------------------------------ |

--- a/docs/guide/website/versioned_docs/version-12.0.4/channels/web.md
+++ b/docs/guide/website/versioned_docs/version-12.0.4/channels/web.md
@@ -115,11 +115,11 @@ There are different ways to send that payload to the user:
 
 There are multiple types already built in Botpress (they are listed at the bottom of this page), but if you require more advanced components, you can create them easily.
 
-### Prevent storing sensitive informations
+### Prevent storing sensitive information
 
 By default, the complete payload is stored in the database, so the information is not lost when the user refreshes the page. On some occasion, however, we may want to hide some properties deemed "sensitive" (ex: password, credit card, etc..).
 
-To remove those informations, there is a special property that you need to set: `sensitive`. Here's an example:
+To remove this information, there is a special property that you need to set: `sensitive`. Here's an example:
 
 ```js
 const payload = {

--- a/docs/guide/website/versioned_docs/version-12.1.0/advanced/configuration.md
+++ b/docs/guide/website/versioned_docs/version-12.1.0/advanced/configuration.md
@@ -12,7 +12,7 @@ On this page, you will learn about the Botpress global configuration, individual
 
 This is the main file used to configure the Botpress server. It will be created automatically when it is missing. Default values should be good when discovering Botpress, but in this page you will learn about the most common configuration you may need to change.
 
-To get more informations about each individual options, check out the [comments on the configuration schema](https://github.com/botpress/botpress/blob/master/src/bp/core/config/botpress.config.ts)
+To get more information about each individual options, check out the [comments on the configuration schema](https://github.com/botpress/botpress/blob/master/src/bp/core/config/botpress.config.ts)
 
 ## HTTP Server Configuration
 
@@ -40,7 +40,7 @@ When you start Botpress from the binary (or using the Docker image), the bot is 
 
 There are 4 different levels of logs:
 
-- Debug: display very detailed informations about the bot operations
+- Debug: display very detailed information about the bot operations
 - Info: gives general information or "good to know" stuff
 - Warn: means that something didn't go as expected, but the bot was able to recover
 - Error: there was an error that should be addressed
@@ -126,9 +126,9 @@ Here there are:
 | BPFS_STORAGE         | Storage destination used by BPFS to read and write files (global and bots)                                | disk          |
 | REDIS_URL            | The connection string to connect to your Redis instance                                                   |               |
 
-About `DATABASE_URL` : This variable will determine the type of database you're running (i.e postgres | sqlite). Anything else than a valid postgress url it will be used as a path to sqlite file. If you want to use the default postgres connection, simply use `postgres` as value. Leave this empty if you want to use the default sqlite location.
+About `DATABASE_URL` : This variable will determine the type of database you're running (i.e postgres | sqlite). Anything else than a valid postgres url it will be used as a path to sqlite file. If you want to use the default postgres connection, simply use `postgres` as value. Leave this empty if you want to use the default sqlite location.
 
-## More Informations
+## More Information
 
 - Check out the [database](../tutorials/database) page for details about `DATABASE_URL`
 - Check out the [cluster](cluster) page for details about `CLUSTER_ENABLED` and `REDIS_URL`

--- a/docs/guide/website/versioned_docs/version-12.1.0/advanced/hosting.md
+++ b/docs/guide/website/versioned_docs/version-12.1.0/advanced/hosting.md
@@ -482,7 +482,7 @@ Botpress supports `.env` files, so you don't have to set them everytime you star
 | FAST_TEXT_CLEANUP_MS      | The model will be kept in memory until it receives no messages to process for that duration | 60000   |
 | REVERSE_PROXY             | When enabled, it uses "x-forwarded-for" to fetch the user IP instead of remoteAddress       | false   |
 
-It is also possible to use environment variables to override module configuration. The pattern is `BP_%MODULE_NAME%_%OPTION_PATH%`, all in upper cases. For example, to define the `confidenceTreshold` option of the module `nlu`, you would use `BP_NLU_CONFIDENCETRESHOLD`. You can list the available environment variales for each modules by enabling the `DEBUG=bp:configuration:modules:*` flag.
+It is also possible to use environment variables to override module configuration. The pattern is `BP_%MODULE_NAME%_%OPTION_PATH%`, all in upper cases. For example, to define the `confidenceTreshold` option of the module `nlu`, you would use `BP_NLU_CONFIDENCETRESHOLD`. You can list the available environment variables for each modules by enabling the `DEBUG=bp:configuration:modules:*` flag.
 
 ### Example
 

--- a/docs/guide/website/versioned_docs/version-12.1.0/channels/teams.md
+++ b/docs/guide/website/versioned_docs/version-12.1.0/channels/teams.md
@@ -37,7 +37,7 @@ These instructions will guide you through any steps required to be up and runnin
 
 ### 2. Create your bot
 
-1. Navigate to the [Bot Framework Registration Page](https://dev.botframework.com/bots/new) and fill the required informations:
+1. Navigate to the [Bot Framework Registration Page](https://dev.botframework.com/bots/new) and fill the required information:
 
 - Display name
 - Bot handle

--- a/docs/guide/website/versioned_docs/version-12.1.0/main/nlu.md
+++ b/docs/guide/website/versioned_docs/version-12.1.0/main/nlu.md
@@ -59,7 +59,7 @@ Here's an example of the structure of an incoming event processed by Botpress Na
   "flags": {},
   "nlu": { // <<<<------
     "language": "en", // language identified
-    "intent": { // most likely intent, assuming confidence is within config treshold
+    "intent": { // most likely intent, assuming confidence is within config threshold
       "name": "hello",
       "confidence": 1
     },
@@ -91,7 +91,7 @@ You can use that metadata in your flows to create transitions when a specific in
 
 To enable debugging of the NLU module, make sure that `debugModeEnabled` is set to `true` in your `data/global/config/nlu.json` file.
 
-> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environement variable instead of modifying the configuration directly.
+> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environment variable instead of modifying the configuration directly.
 
 ##### Example of debugging message
 
@@ -206,19 +206,19 @@ An example of placeholder entity would be : Please tell **Sarah** that **she's l
 
 ### Custom Entities
 
-As of today we provide 2 types of custom entites: [pattern](#pattern-extraction) and [list](#list-extraction) entitites. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
+As of today we provide 2 types of custom entities: [pattern](#pattern-extraction) and [list](#list-extraction) entities. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
 
 <img src="/docs/assets/nlu-create-entity.png">
 
-### Sensitive Informations
+### Sensitive Information
 
-Communication between users and bots are stored in the database, which means that sometimes personal informations (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
+Communication between users and bots are stored in the database, which means that sometimes personal information (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
 
 When checked, the information will still be displayed in the chat window, but the sensitive information will be replaced by `*****` before being stored. The original value is still available from `event.nlu.entities`
 
 #### Pattern extraction
 
-Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incomming message and add it to `event.nlu.entities`.
+Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incoming message and add it to `event.nlu.entities`.
 
 ##### Example :
 
@@ -252,7 +252,7 @@ Extraction will go like:
 
 #### List extraction
 
-List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurences** of your entity with corresponding synonyms.
+List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurrences** of your entity with corresponding synonyms.
 
 Let's take **Airport Codes** as an example:
 
@@ -346,7 +346,7 @@ Slot filling is the process of gathering information required by an intent. This
 
 ## Language Server
 
-The language server provides additional informations about words, which allows your bot to understand words with a similar meaning even if you didn't specifically taught it about it. By default, your Botpress server will query one of our language server for that purpose. You can also choose to host your own server if you would like to keep everything on your premise. Head over to the [Hosting](../advanced/hosting#running-your-own-language-server) page for more details.
+The language server provides additional information about words, which allows your bot to understand words with a similar meaning even if you didn't specifically taught it about it. By default, your Botpress server will query one of our language server for that purpose. You can also choose to host your own server if you would like to keep everything on your premise. Head over to the [Hosting](../advanced/hosting#running-your-own-language-server) page for more details.
 
 ## External NLU Providers
 

--- a/docs/guide/website/versioned_docs/version-12.1.2/advanced/configuration.md
+++ b/docs/guide/website/versioned_docs/version-12.1.2/advanced/configuration.md
@@ -12,7 +12,7 @@ On this page, you will learn about the Botpress global configuration, individual
 
 This is the main file used to configure the Botpress server. It will be created automatically when it is missing. Default values should be good when discovering Botpress, but in this page you will learn about the most common configuration you may need to change.
 
-To get more informations about each individual options, check out the [comments on the configuration schema](https://github.com/botpress/botpress/blob/master/src/bp/core/config/botpress.config.ts)
+To get more information about each individual options, check out the [comments on the configuration schema](https://github.com/botpress/botpress/blob/master/src/bp/core/config/botpress.config.ts)
 
 ## HTTP Server Configuration
 
@@ -40,7 +40,7 @@ When you start Botpress from the binary (or using the Docker image), the bot is 
 
 There are 4 different levels of logs:
 
-- Debug: display very detailed informations about the bot operations
+- Debug: display very detailed information about the bot operations
 - Info: gives general information or "good to know" stuff
 - Warn: means that something didn't go as expected, but the bot was able to recover
 - Error: there was an error that should be addressed
@@ -145,7 +145,7 @@ Botpress supports `.env` files, so you don't have to set them everytime you star
 
 It is also possible to use environment variables to override module configuration. The pattern is `BP_%MODULE_NAME%_%OPTION_PATH%`, all in upper cases. For example, to define the `confidenceTreshold` option of the module `nlu`, you would use `BP_NLU_CONFIDENCETRESHOLD`. You can list the available environment variables for each modules by enabling the `DEBUG=bp:configuration:modules:*` flag.
 
-## More Informations
+## More Information
 
 - Check out the [database](../tutorials/database) page for details about `DATABASE_URL`
 - Check out the [cluster](cluster) page for details about `CLUSTER_ENABLED` and `REDIS_URL`

--- a/docs/guide/website/versioned_docs/version-12.1.2/advanced/configuration.md
+++ b/docs/guide/website/versioned_docs/version-12.1.2/advanced/configuration.md
@@ -143,7 +143,7 @@ Botpress supports `.env` files, so you don't have to set them everytime you star
 | FAST_TEXT_CLEANUP_MS      | The model will be kept in memory until it receives no messages to process for that duration | 60000   |
 | REVERSE_PROXY             | When enabled, it uses "x-forwarded-for" to fetch the user IP instead of remoteAddress       | false   |
 
-It is also possible to use environment variables to override module configuration. The pattern is `BP_%MODULE_NAME%_%OPTION_PATH%`, all in upper cases. For example, to define the `confidenceTreshold` option of the module `nlu`, you would use `BP_NLU_CONFIDENCETRESHOLD`. You can list the available environment variales for each modules by enabling the `DEBUG=bp:configuration:modules:*` flag.
+It is also possible to use environment variables to override module configuration. The pattern is `BP_%MODULE_NAME%_%OPTION_PATH%`, all in upper cases. For example, to define the `confidenceTreshold` option of the module `nlu`, you would use `BP_NLU_CONFIDENCETRESHOLD`. You can list the available environment variables for each modules by enabling the `DEBUG=bp:configuration:modules:*` flag.
 
 ## More Informations
 

--- a/docs/guide/website/versioned_docs/version-12.1.4/main/code.md
+++ b/docs/guide/website/versioned_docs/version-12.1.4/main/code.md
@@ -93,7 +93,7 @@ session.store = [{ id: 1, id: 2, id: 3 }]
 
 The only way to register new actions is to add your javascript code in a `.js` file and put them in the folder `data/global/actions`. There is no way to programmatically add new ones during runtime.
 
-There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful informations (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
+There are already a [couple of actions](https://github.com/botpress/botpress/tree/master/modules/builtin/src/actions) that you can use to get some inspiration. We use JavaDoc comments to display meaningful information (name, description, arguments, default values) on the dialog flow editor. It is possible to keep an action hidden in the flow editor by adding the flag `@hidden true` in the javadoc.
 
 ## Hooks
 

--- a/docs/guide/website/versioned_docs/version-12.1.4/quickstart.md
+++ b/docs/guide/website/versioned_docs/version-12.1.4/quickstart.md
@@ -49,7 +49,7 @@ Open the chat window and say "_Hello_". The bot should greet you with something 
 
 ![Hello from the bot](assets/flow_page.png)
 
-There is another emulator, which is specifically designed for you (the bot owner) to understand quickly why the bot gives you a specific answer. That emulator is only available for authenticated users. It includes all sort of useful informations: list of suggested answers by module, nlu intents, and the elected suggestion.
+There is another emulator, which is specifically designed for you (the bot owner) to understand quickly why the bot gives you a specific answer. That emulator is only available for authenticated users. It includes all sort of useful information: list of suggested answers by module, nlu intents, and the elected suggestion.
 
 ![Emulator Hello](assets/emulator_ng.png)
 

--- a/docs/guide/website/versioned_docs/version-12.1.6/channels/web.md
+++ b/docs/guide/website/versioned_docs/version-12.1.6/channels/web.md
@@ -34,14 +34,14 @@ There is an example included in the default botpress installation at `http://loc
 
 ## Bot Information page
 
-The information page displays informations like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
+The information page displays information like the website url, a phone number, an e-mail contact address, and links to terms of services and privacy policies. You can also include a cover picture and an avatar for your bot.
 
 ![Bot Info Page](assets/webchat-bot-info.png)
 
 How to set up the information page:
 
 1. On the Admin UI, click on the link `Config` next to the name of the bot you want to change.
-2. Edit your bot informations in the `More details` and `Pictures` sections.
+2. Edit your bot information in the `More details` and `Pictures` sections.
 3. Edit the file `data/global/config/channel-web.json` and set `showBotInfoPage` to `true` **\*\***
 4. Refresh your browser.
 
@@ -106,7 +106,7 @@ The method `window.botpressWebChat.configure` allows you to change the configura
 
 ## Advanced Customization
 
-Every message sent by the bot to a user consist of a `payload`. That payload has a `type` property, that tells the webchat how the other informations included on that payload should be rendered on screen.
+Every message sent by the bot to a user consist of a `payload`. That payload has a `type` property, that tells the webchat how the other information included on that payload should be rendered on screen.
 
 There are different ways to send that payload to the user:
 
@@ -156,7 +156,7 @@ payload: {
 
 ### What can I do in my component ?
 
-There are a couple of properties that are passed down to your custom component. These can be used to customize the displayed informations, and/or to pursue interactions.
+There are a couple of properties that are passed down to your custom component. These can be used to customize the displayed information, and/or to pursue interactions.
 
 | Property        | Description                                                                    |
 | --------------- | ------------------------------------------------------------------------------ |

--- a/docs/guide/website/versioned_docs/version-12.1.6/channels/web.md
+++ b/docs/guide/website/versioned_docs/version-12.1.6/channels/web.md
@@ -115,11 +115,11 @@ There are different ways to send that payload to the user:
 
 There are multiple types already built in Botpress (they are listed at the bottom of this page), but if you require more advanced components, you can create them easily.
 
-### Prevent storing sensitive informations
+### Prevent storing sensitive information
 
 By default, the complete payload is stored in the database, so the information is not lost when the user refreshes the page. On some occasion, however, we may want to hide some properties deemed "sensitive" (ex: password, credit card, etc..).
 
-To remove those informations, there is a special property that you need to set: `sensitive`. Here's an example:
+To remove this information, there is a special property that you need to set: `sensitive`. Here's an example:
 
 ```js
 const payload = {

--- a/docs/guide/website/versioned_docs/version-12.2.0/advanced/authentication.md
+++ b/docs/guide/website/versioned_docs/version-12.2.0/advanced/authentication.md
@@ -68,7 +68,7 @@ You can clear the list of users by emptying (or deleting) the table `strategy_de
 
 ### OAuth2
 
-Some OAuth2 implementations returns a JWT token containing all the user's informations, while some other returns a special token, which must then be used to query the user's informations.
+Some OAuth2 implementations returns a JWT token containing all the user's information, while some other returns a special token, which must then be used to query the user's information.
 
 ```js
 {
@@ -85,7 +85,7 @@ Some OAuth2 implementations returns a JWT token containing all the user's inform
         "clientSecret": "your-client-secret",
         "callbackURL": "http://localhost:3000/api/v1/auth/login-callback/oauth2/botpress",
         /**
-         * If the token doesn't contain user informations, set the userInfoURL
+         * If the token doesn't contain user information, set the userInfoURL
          */
         "userInfoURL": "https://example.auth0.com/userinfo",
         /**
@@ -155,7 +155,7 @@ Here is a complete example
 #### Prerequisite
 
 - Botpress Pro enabled with a valid license key
-- Informations to access the LDAP server
+- Information to access the LDAP server
 
 #### Quick Start
 

--- a/docs/guide/website/versioned_docs/version-12.2.0/main/nlu.md
+++ b/docs/guide/website/versioned_docs/version-12.2.0/main/nlu.md
@@ -59,7 +59,7 @@ Here's an example of the structure of an incoming event processed by Botpress Na
   "flags": {},
   "nlu": { // <<<<------
     "language": "en", // language identified
-    "intent": { // most likely intent, assuming confidence is within config treshold
+    "intent": { // most likely intent, assuming confidence is within config threshold
       "name": "hello",
       "confidence": 1
     },
@@ -91,7 +91,7 @@ You can use that metadata in your flows to create transitions when a specific in
 
 To enable debugging of the NLU module, make sure that `debugModeEnabled` is set to `true` in your `data/global/config/nlu.json` file.
 
-> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environement variable instead of modifying the configuration directly.
+> **Tip**: In production, you can also use the `BP_NLU_DEBUGMODEENABLED` environment variable instead of modifying the configuration directly.
 
 ##### Example of debugging message
 
@@ -206,19 +206,19 @@ An example of placeholder entity would be : Please tell **Sarah** that **she's l
 
 ### Custom Entities
 
-As of today we provide 2 types of custom entites: [pattern](#pattern-extraction) and [list](#list-extraction) entitites. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
+As of today we provide 2 types of custom entities: [pattern](#pattern-extraction) and [list](#list-extraction) entities. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
 
 <img src="/docs/assets/nlu-create-entity.png">
 
-### Sensitive Informations
+### Sensitive Information
 
-Communication between users and bots are stored in the database, which means that sometimes personal informations (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
+Communication between users and bots are stored in the database, which means that sometimes personal information (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
 
 When checked, the information will still be displayed in the chat window, but the sensitive information will be replaced by `*****` before being stored. The original value is still available from `event.nlu.entities`
 
 #### Pattern extraction
 
-Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incomming message and add it to `event.nlu.entities`.
+Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incoming message and add it to `event.nlu.entities`.
 
 ##### Example :
 
@@ -252,7 +252,7 @@ Extraction will go like:
 
 #### List extraction
 
-List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurences** of your entity with corresponding synonyms.
+List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurrences** of your entity with corresponding synonyms.
 
 Let's take **Airport Codes** as an example:
 
@@ -346,7 +346,7 @@ Slot filling is the process of gathering information required by an intent. This
 
 ## Language Server
 
-The language server provides additional informations about words, which allows your bot to understand words with a similar meaning even if you didn't specifically taught it about it. By default, your Botpress server will query one of our language server for that purpose. You can also choose to host your own server if you would like to keep everything on your premise. Head over to the [Hosting](../advanced/hosting#running-your-own-language-server) page for more details.
+The language server provides additional information about words, which allows your bot to understand words with a similar meaning even if you didn't specifically taught it about it. By default, your Botpress server will query one of our language server for that purpose. You can also choose to host your own server if you would like to keep everything on your premise. Head over to the [Hosting](../advanced/hosting#running-your-own-language-server) page for more details.
 
 ## External NLU Providers
 

--- a/docs/guide/website/versioned_docs/version-12.2.0/tutorials/database.md
+++ b/docs/guide/website/versioned_docs/version-12.2.0/tutorials/database.md
@@ -32,4 +32,4 @@ While using Postgres, you can configure the Connection Pools by using the `DATAB
 
 Please make sure you are using Postgres 9.5 or higher.
 
-If you don't want to type those variables each time you start Botpress, we also supports `.env` files. Check out our [configuration section](../advanced/configuration) for more informations about that
+If you don't want to type those variables each time you start Botpress, we also supports `.env` files. Check out our [configuration section](../advanced/configuration) for more information about that

--- a/docs/guide/website/versioned_docs/version-12.2.2/advanced/authentication.md
+++ b/docs/guide/website/versioned_docs/version-12.2.2/advanced/authentication.md
@@ -69,7 +69,7 @@ You can clear the list of users by emptying (or deleting) the table `strategy_de
 
 ### OAuth2
 
-Some OAuth2 implementations returns a JWT token containing all the user's informations, while some other returns a special token, which must then be used to query the user's informations.
+Some OAuth2 implementations returns a JWT token containing all the user's information, while some other returns a special token, which must then be used to query the user's information.
 
 ```js
 {
@@ -86,7 +86,7 @@ Some OAuth2 implementations returns a JWT token containing all the user's inform
         "clientSecret": "your-client-secret",
         "callbackURL": "http://localhost:3000/api/v1/auth/login-callback/oauth2/botpress",
         /**
-         * If the token doesn't contain user informations, set the userInfoURL
+         * If the token doesn't contain user information, set the userInfoURL
          */
         "userInfoURL": "https://example.auth0.com/userinfo",
         /**
@@ -156,7 +156,7 @@ Here is a complete example
 #### Prerequisite
 
 - Botpress Pro enabled with a valid license key
-- Informations to access the LDAP server
+- Information to access the LDAP server
 
 #### Quick Start
 

--- a/docs/guide/website/versioned_docs/version-12.3.0/main/memory.md
+++ b/docs/guide/website/versioned_docs/version-12.3.0/main/memory.md
@@ -103,13 +103,13 @@ You can consume a memory action just like any other action from the Botpress Flo
 
 Variables set using the `user` namespace will be saved as attributes for the user. This means that those attributes will always follow the user, not notwithstanding conversations or time period.
 
-When a user sends a message to the bot, the first middleware is tasked with loading that user's informations. After everything is processed, any changes to the `user` object will be persisted to the database.
+When a user sends a message to the bot, the first middleware is tasked with loading that user's information. After everything is processed, any changes to the `user` object will be persisted to the database.
 
 This means that you can alter the `user` object using middlwares and actions, and it will be saved at the end.
 
 #### User Memory - Data Retention
 
-Since privacy is an important matter, there is a built-in system that makes it dead-easy to set retention periods for different type of informations. You could have, for example a policy that says `email expires after 2 months` or `remember user's mood for 1 day`. Whenever the user's attribute is changed, the expiration policy is updated.
+Since privacy is an important matter, there is a built-in system that makes it dead-easy to set retention periods for different type of information. You could have, for example a policy that says `email expires after 2 months` or `remember user's mood for 1 day`. Whenever the user's attribute is changed, the expiration policy is updated.
 
 Here's how it could be configured:
 

--- a/docs/guide/website/versioned_docs/version-12.3.0/main/nlu.md
+++ b/docs/guide/website/versioned_docs/version-12.3.0/main/nlu.md
@@ -59,7 +59,7 @@ Here's an example of the structure of an incoming event processed by Botpress Na
   "flags": {},
   "nlu": { // <<<<------
     "language": "en", // language identified
-    "intent": { // most likely intent, assuming confidence is within config treshold
+    "intent": { // most likely intent, assuming confidence is within config threshold
       "name": "hello",
       "confidence": 1
     },
@@ -206,19 +206,19 @@ An example of placeholder entity would be : Please tell **Sarah** that **she's l
 
 ### Custom Entities
 
-As of today we provide 2 types of custom entites: [pattern](#pattern-extraction) and [list](#list-extraction) entitites. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
+As of today we provide 2 types of custom entities: [pattern](#pattern-extraction) and [list](#list-extraction) entities. To define a custom entity, head to the **Entity section** of the Understanding Module in your botpress studio side bar. From there you'll be able to define your custom entities that will be available for any input message treated by your chatbot. Go ahead and click on **create new entity**
 
 <img src="/docs/assets/nlu-create-entity.png">
 
-### Sensitive Informations
+### Sensitive Information
 
-Communication between users and bots are stored in the database, which means that sometimes personal informations (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
+Communication between users and bots are stored in the database, which means that sometimes personal information (eg: credit card) may be persisted as well. To avoid that problem, it is possible to tell Botpress that certain entities are not to be persisted. When creating or editing an Entity, there is a small checkbox located in the upper right corner labeled `sensitive`.
 
 When checked, the information will still be displayed in the chat window, but the sensitive information will be replaced by `*****` before being stored. The original value is still available from `event.nlu.entities`
 
 #### Pattern extraction
 
-Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incomming message and add it to `event.nlu.entities`.
+Once you've created a pattern entity, Botpress Native NLU will perform a regex extraction on each incoming message and add it to `event.nlu.entities`.
 
 ##### Example :
 
@@ -252,7 +252,7 @@ Extraction will go like:
 
 #### List extraction
 
-List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurences** of your entity with corresponding synonyms.
+List extraction will behave in a similar way. The major addition is that for your entity definition, you'll be able to add different **occurrences** of your entity with corresponding synonyms.
 
 Let's take **Airport Codes** as an example:
 
@@ -346,7 +346,7 @@ Slot filling is the process of gathering information required by an intent. This
 
 ## Language Server
 
-The language server provides additional informations about words, which allows your bot to understand words with a similar meaning even if you didn't specifically taught it about it. By default, your Botpress server will query one of our language server for that purpose. You can also choose to host your own server if you would like to keep everything on your premise. Head over to the [Hosting](../advanced/hosting#running-your-own-language-server) page for more details.
+The language server provides additional information about words, which allows your bot to understand words with a similar meaning even if you didn't specifically taught it about it. By default, your Botpress server will query one of our language server for that purpose. You can also choose to host your own server if you would like to keep everything on your premise. Head over to the [Hosting](../advanced/hosting#running-your-own-language-server) page for more details.
 
 ## External NLU Providers
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,6 +1,6 @@
 # Botpress SDK
 
-Botpress SDK allows you to create _Botpress Modules_ that extends the functionalities of the plateform. Botpress SDK exposes all the major methods that a Module needs to interact with the core.
+Botpress SDK allows you to create _Botpress Modules_ that extends the functionalities of the platform. Botpress SDK exposes all the major methods that a Module needs to interact with the core.
 
 We made sure that the SDK is always up-to-date with the latest version of Botpress. It will always match the current version of your Botpress installation.
 

--- a/examples/chat-3rd-party-OAuth/src/botpress.d.ts
+++ b/examples/chat-3rd-party-OAuth/src/botpress.d.ts
@@ -73,18 +73,18 @@ declare module 'botpress/sdk' {
    */
   export interface ModuleEntryPoint {
     /** Called once the core is initialized. Usually for middlewares / database init */
-    onServerStarted: ((bp: typeof import('botpress/sdk')) => void)
+    onServerStarted: (bp: typeof import('botpress/sdk')) => void
     /** This is called once all modules are initialized, usually for routing and logic */
-    onServerReady: ((bp: typeof import('botpress/sdk')) => void)
-    onBotMount?: ((bp: typeof import('botpress/sdk'), botId: string) => void)
-    onBotUnmount?: ((bp: typeof import('botpress/sdk'), botId: string) => void)
+    onServerReady: (bp: typeof import('botpress/sdk')) => void
+    onBotMount?: (bp: typeof import('botpress/sdk'), botId: string) => void
+    onBotUnmount?: (bp: typeof import('botpress/sdk'), botId: string) => void
     /** Additional metadata about the module */
     definition: ModuleDefinition
     /** An array of the flow generators used by skills in the module */
     skills?: Skill[]
     /** An array of available bot templates when creating a new bot */
     botTemplates?: BotTemplate[]
-    onFlowChanged?: ((bp: typeof import('botpress/sdk'), botId: string, flow: Flow) => void)
+    onFlowChanged?: (bp: typeof import('botpress/sdk'), botId: string, flow: Flow) => void
   }
 
   /**
@@ -847,7 +847,7 @@ declare module 'botpress/sdk' {
 
     /**
      * Create a new router for a module. Once created, use them to register new endpoints. Routers created
-     * with this method are accessible via the url /mod/{routernName}
+     * with this method are accessible via the url /mod/{routerName}
      *
      * @example const router = bp.http.createRouterForBot('myModule')
      * @example router.get('/list', ...)
@@ -868,13 +868,13 @@ declare module 'botpress/sdk' {
 
   /**
    * Events is the base communication channel of the bot. Messages and payloads are a part of it,
-   * and it is the only way to receive or send informations. Each event goes through the whole middleware chain (incoming or outgoing)
+   * and it is the only way to receive or send information. Each event goes through the whole middleware chain (incoming or outgoing)
    * before being received by either the bot or the user.
    */
   export namespace events {
     /**
      * Register a new middleware globally. They are sorted based on their declared order each time a new one is registered.
-     * @param midddleware - The middleware definition to register
+     * @param middleware - The middleware definition to register
      */
     export function registerMiddleware(middleware: IO.MiddlewareDefinition): void
 
@@ -941,7 +941,7 @@ declare module 'botpress/sdk' {
     export function deleteSession(sessionId: string): Promise<void>
 
     /**
-     * Jumps to a specific flow and optionally a specific node. This is useful when the default flow behaviour needs to be bypassed.
+     * Jumps to a specific flow and optionally a specific node. This is useful when the default flow behavior needs to be bypassed.
      * @param sessionId The Id of the the current Dialog Session. If the session doesn't exists, it will be created with this Id.
      * @param event The event to be processed
      * @param flowName The name of the flow to jump to

--- a/examples/module-templates/complete-module/README.md
+++ b/examples/module-templates/complete-module/README.md
@@ -1,7 +1,7 @@
 ## Overview
 
 This example includes a lot of "boilerplate" to create a module with almost all features you can implement from the documentation
-Please check the [official documentation](https://botpress.io/docs/developers/create-module/) for more informations
+Please check the [official documentation](https://botpress.io/docs/developers/create-module/) for more information
 
 ## Quick Start
 
@@ -28,4 +28,4 @@ Please check the [official documentation](https://botpress.io/docs/developers/cr
 
 When you make changes to any portion of your module, you need to build it and restart Botpress.
 
-You can type `yarn watch` which will save you some time, since everytime you make a change, the source will be compiled immediately. You will only have to restart Botpress.
+You can type `yarn watch` which will save you some time, since every time you make a change, the source will be compiled immediately. You will only have to restart Botpress.

--- a/examples/module-templates/complete-module/assets/README.md
+++ b/examples/module-templates/complete-module/assets/README.md
@@ -1,6 +1,6 @@
 ## Assets
 
-Everytime the server is started, all the content of this folder will be copied in the `assets/modules/complete-module/` folder.
+Every time the server is started, all the content of this folder will be copied in the `assets/modules/complete-module/` folder.
 They will overwrite existing files.
 
 Beware: This is a little different from actions and hooks, since they will be replaced even if you edit them.

--- a/examples/module-templates/complete-module/src/actions/README.md
+++ b/examples/module-templates/complete-module/src/actions/README.md
@@ -1,8 +1,8 @@
 ## Actions
 
-Everytime the server is started, Actions that you put in this folder will be copied in the `data/global/actions/complete-module/` folder.
+Every time the server is started, Actions that you put in this folder will be copied in the `data/global/actions/complete-module/` folder.
 They will overwrite existing files only if they haven't been edited manually.
 
-Actions added this way will be avaialble on the flow editor using `complete-module/your-action-name`
+Actions added this way will be available on the flow editor using `complete-module/your-action-name`
 
-Check the documentation for more informations about [Actions](https://botpress.io/docs/build/code#actions)
+Check the documentation for more information about [Actions](https://botpress.io/docs/build/code#actions)

--- a/examples/module-templates/complete-module/src/backend/index.ts
+++ b/examples/module-templates/complete-module/src/backend/index.ts
@@ -10,10 +10,10 @@ const onServerReady = async (bp: typeof sdk) => {
   await api(bp)
 }
 
-// Everytime a bot is created (or enabled), this method will be called with the bot id
+// Every time a bot is created (or enabled), this method will be called with the bot id
 const onBotMount = async (bp: typeof sdk, botId: string) => {}
 
-// This is called everytime a bot is deleted (or disabled)
+// This is called every time a bot is deleted (or disabled)
 const onBotUnmount = async (botId: string) => {}
 
 // When anything is changed using the flow editor, this is called with the new flow, so you can rename nodes if you reference them
@@ -27,7 +27,7 @@ const botTemplates: sdk.BotTemplate[] = [{ id: 'my_bot_demo', name: 'Bot Demo', 
 
 /**
  * Skills allows you to create custom logic and use them easily on the flow editor
- * Check this link for more informations: https://botpress.io/docs/developers/create-module/#skill-creation
+ * Check this link for more information: https://botpress.io/docs/developers/create-module/#skill-creation
  */
 const skills: sdk.Skill[] = []
 

--- a/examples/module-templates/complete-module/src/content-types/README.md
+++ b/examples/module-templates/complete-module/src/content-types/README.md
@@ -1,8 +1,8 @@
 ## Content-Types
 
-Everytime the server is started, Content-types that you put in this folder will be copied in the `data/global/content-types/complete-module/` folder.
+Every time the server is started, Content-types that you put in this folder will be copied in the `data/global/content-types/complete-module/` folder.
 They will overwrite existing files only if they haven't been edited manually.
 
 The name of your content types must be unique throughout the server
 
-Check the documentation for more informations about [Content Types](http://localhost:3001/docs/next/build/content)
+Check the documentation for more information about [Content Types](http://localhost:3001/docs/next/build/content)

--- a/examples/module-templates/complete-module/src/hooks/README.md
+++ b/examples/module-templates/complete-module/src/hooks/README.md
@@ -1,6 +1,6 @@
 ## Hooks
 
-Everytime the server is started, Hooks that you put in this folder will be copied in the `data/global/hooks/complete-module/HOOK_TYPE/` folder.
+Every time the server is started, Hooks that you put in this folder will be copied in the `data/global/hooks/complete-module/HOOK_TYPE/` folder.
 They will overwrite existing files only if they haven't been edited manually.
 
-Check the documentation for more informations about [Hooks](https://botpress.io/docs/build/code#hooks)
+Check the documentation for more information about [Hooks](https://botpress.io/docs/build/code#hooks)

--- a/examples/proactive/assets/examples/proactive-form.html
+++ b/examples/proactive/assets/examples/proactive-form.html
@@ -24,8 +24,8 @@
       <input id="cryptic-field" type="text" placeholder="Enter something here" />
       <br />
 
-      <label for="plateform">What is your preferred chatbot plateform?</label>
-      <select id="plateform">
+      <label for="platform">What is your preferred chatbot platform?</label>
+      <select id="platform">
         <option selected value="botpress">Botpress</option>
       </select>
       <br />
@@ -45,7 +45,7 @@
         const payload = {
           name: document.getElementById('name').value,
           email: document.getElementById('email').value,
-          plateform: document.getElementById('plateform').value
+          platform: document.getElementById('platform').value
         }
         window.botpressWebChat.sendEvent({ type: 'show' })
         window.botpressWebChat.sendEvent({ type: 'contact-form', payload })

--- a/examples/proactive/src/bot-templates/proactive-bot/content-elements/builtin_text.json
+++ b/examples/proactive/src/bot-templates/proactive-bot/content-elements/builtin_text.json
@@ -12,7 +12,7 @@
   {
     "id": "builtin_text-aJG2tU",
     "formData": {
-      "text$en": "👋 {{session.contactForm.name}}, I'm glad you prefer Botpress over all the other plateforms!",
+      "text$en": "👋 {{session.contactForm.name}}, I'm glad you prefer Botpress over all the other platforms!",
       "typing$en": true
     },
     "createdBy": "admin",
@@ -32,7 +32,7 @@
   {
     "id": "builtin_text-l37HZR",
     "formData": {
-      "text$en": "Ohh really?! \"{{session.contactForm.plateform}}\" ??  Let's add you to the \"special\" users list 😈",
+      "text$en": "Ohh really?! \"{{session.contactForm.platform}}\" ??  Let's add you to the \"special\" users list 😈",
       "typing$en": true
     },
     "createdBy": "admin",

--- a/examples/proactive/src/bot-templates/proactive-bot/flows/main.flow.json
+++ b/examples/proactive/src/bot-templates/proactive-bot/flows/main.flow.json
@@ -15,7 +15,7 @@
           "node": "describe-field"
         },
         {
-          "condition": "session.contactForm && session.contactForm.plateform !== \"botpress\"",
+          "condition": "session.contactForm && session.contactForm.platform !== \"botpress\"",
           "node": "not-botpress"
         },
         {
@@ -34,36 +34,28 @@
       "id": "4820de8851",
       "name": "contact-form",
       "next": [],
-      "onEnter": [
-        "say #!builtin_text-aJG2tU"
-      ],
+      "onEnter": ["say #!builtin_text-aJG2tU"],
       "onReceive": null
     },
     {
       "id": "a174c2286a",
       "name": "welcome",
       "next": [],
-      "onEnter": [
-        "say #!builtin_text-LnsobY"
-      ],
+      "onEnter": ["say #!builtin_text-LnsobY"],
       "onReceive": null
     },
     {
       "id": "789c93ce09",
       "name": "describe-field",
       "next": [],
-      "onEnter": [
-        "say #!builtin_text-c9e7j-"
-      ],
+      "onEnter": ["say #!builtin_text-c9e7j-"],
       "onReceive": null
     },
     {
       "id": "838e3e7bff",
       "name": "not-botpress",
       "next": [],
-      "onEnter": [
-        "say #!builtin_text-l37HZR"
-      ],
+      "onEnter": ["say #!builtin_text-l37HZR"],
       "onReceive": null
     }
   ]

--- a/modules/builtin/src/bot-templates/small-talk/qna/r1kyn11enn_i_love_you.json
+++ b/modules/builtin/src/bot-templates/small-talk/qna/r1kyn11enn_i_love_you.json
@@ -29,12 +29,8 @@
       ]
     },
     "answers": {
-      "en": [
-        "People tell me all the time that i'm a lovable little bot :-)"
-      ],
-      "fr": [
-        "S'il vous plait, continuez à me dire que je un petit robot aimable!"
-      ]
+      "en": ["People tell me all the time that I'm a lovable little bot :-)"],
+      "fr": ["S'il vous plait, continuez à me dire que je un petit robot aimable!"]
     },
     "redirectFlow": "main.flow.json",
     "redirectNode": "node-1fe2",

--- a/modules/code-editor/src/typings/botpress.config.schema.json
+++ b/modules/code-editor/src/typings/botpress.config.schema.json
@@ -19,7 +19,7 @@
           "type": "number"
         },
         "proxy": {
-          "description": "There are two external URL that Botpress calls: https://license.botpress.io and https://duckling.botpress.io\nIf you are behind a corporare proxy, you can configure it below.\nIt is also possible to self-host Duckling, please check the documentation",
+          "description": "There are two external URL that Botpress calls: https://license.botpress.io and https://duckling.botpress.io\nIf you are behind a corporate proxy, you can configure it below.\nIt is also possible to self-host Duckling, please check the documentation",
           "type": "string"
         },
         "backlog": {
@@ -28,10 +28,7 @@
         },
         "bodyLimit": {
           "default": "100kb",
-          "type": [
-            "string",
-            "number"
-          ]
+          "type": ["string", "number"]
         },
         "cors": {
           "type": "object",
@@ -63,17 +60,11 @@
               "type": "string"
             }
           },
-          "required": [
-            "enabled",
-            "maxAge"
-          ]
+          "required": ["enabled", "maxAge"]
         },
         "socketTransports": {
           "description": "Configure the priority for establishing socket connections for webchat and studio users.\nIf the first method is not supported, it will fallback on the second.\nIf the first is supported but it fails with an error, it will not fallback.",
-          "default": [
-            "websocket",
-            "polling"
-          ],
+          "default": ["websocket", "polling"],
           "type": "array",
           "items": {
             "type": "string"
@@ -121,10 +112,7 @@
             "type": "boolean"
           }
         },
-        "required": [
-          "enabled",
-          "location"
-        ]
+        "required": ["enabled", "location"]
       }
     },
     "pro": {
@@ -132,9 +120,7 @@
       "properties": {
         "collaboratorsAuthStrategies": {
           "description": "These strategies are allowed to log on the Admin UI.\nOnce a user is logged on, he still needs individual access to respective workspaces",
-          "default": [
-            "default"
-          ],
+          "default": ["default"],
           "type": "array",
           "items": {
             "type": "string"
@@ -162,13 +148,7 @@
           "description": "External Authentication makes it possible to authenticate end-users (chat users) from an other system\nby using JWT tokens.\n\nIn addition to authenticate the users, the JWT token can also contain arbitrary additional\ndata about the user that you would like to make Botpress aware of.\n\nThe identity of the user will be checked for every incoming message and the additional data in the JWT token\nwill be available in `event.credentials`."
         }
       },
-      "required": [
-        "alerting",
-        "collaboratorsAuthStrategies",
-        "enabled",
-        "licenseKey",
-        "monitoring"
-      ]
+      "required": ["alerting", "collaboratorsAuthStrategies", "enabled", "licenseKey", "monitoring"]
     },
     "superAdmins": {
       "description": "An array of e-mails of users which will have root access to Botpress (manage users, server settings)",
@@ -207,21 +187,14 @@
         },
         "allowedMimeTypes": {
           "description": "The list of allowed extensions for media file uploads",
-          "default": [
-            "image/jpeg",
-            "image/png",
-            "image/gif"
-          ],
+          "default": ["image/jpeg", "image/png", "image/gif"],
           "type": "array",
           "items": {
             "type": "string"
           }
         }
       },
-      "required": [
-        "allowedMimeTypes",
-        "maxFileSize"
-      ]
+      "required": ["allowedMimeTypes", "maxFileSize"]
     },
     "jwtToken": {
       "type": "object",
@@ -237,10 +210,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "allowRefresh",
-        "duration"
-      ]
+      "required": ["allowRefresh", "duration"]
     },
     "autoRevision": {
       "description": "When enabled, a bot revision will be stored in the revisions directory when it change or its about to change stage",
@@ -284,10 +254,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "code",
-          "name"
-        ]
+        "required": ["code", "name"]
       }
     }
   },
@@ -331,11 +298,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "janitorInterval",
-        "sessionTimeoutInterval",
-        "timeoutInterval"
-      ]
+      "required": ["janitorInterval", "sessionTimeoutInterval", "timeoutInterval"]
     },
     "LogsConfig": {
       "type": "object",
@@ -354,10 +317,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "expiration",
-            "janitorInterval"
-          ]
+          "required": ["expiration", "janitorInterval"]
         },
         "fileOutput": {
           "description": "The file output records everything that is displayed in the console logs.",
@@ -379,17 +339,10 @@
               "type": "number"
             }
           },
-          "required": [
-            "enabled",
-            "folder",
-            "maxFileSize"
-          ]
+          "required": ["enabled", "folder", "maxFileSize"]
         }
       },
-      "required": [
-        "dbOutput",
-        "fileOutput"
-      ]
+      "required": ["dbOutput", "fileOutput"]
     },
     "MonitoringConfig": {
       "type": "object",
@@ -415,12 +368,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "collectionInterval",
-        "enabled",
-        "janitorInterval",
-        "retentionPeriod"
-      ]
+      "required": ["collectionInterval", "enabled", "janitorInterval", "retentionPeriod"]
     },
     "AlertingConfig": {
       "type": "object",
@@ -451,19 +399,13 @@
           "items": {}
         }
       },
-      "required": [
-        "enabled",
-        "janitorInterval",
-        "retentionPeriod",
-        "rules",
-        "watcherInterval"
-      ]
+      "required": ["enabled", "janitorInterval", "retentionPeriod", "rules", "watcherInterval"]
     },
     "ExternalAuthConfig": {
       "type": "object",
       "properties": {
         "enabled": {
-          "description": "Set to true to enable external authentification",
+          "description": "Set to true to enable external authentication",
           "default": false,
           "type": "boolean"
         },
@@ -497,9 +439,7 @@
         },
         "algorithms": {
           "description": "The algorithms allowed to validate the JWT tokens.",
-          "default": [
-            "HS256"
-          ],
+          "default": ["HS256"],
           "type": "array",
           "items": {
             "type": "string"
@@ -511,10 +451,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "algorithms",
-        "enabled"
-      ]
+      "required": ["algorithms", "enabled"]
     },
     "DataRetentionConfig": {
       "type": "object",
@@ -532,10 +469,7 @@
           }
         }
       },
-      "required": [
-        "janitorInterval",
-        "policies"
-      ]
+      "required": ["janitorInterval", "policies"]
     },
     "EventCollectorConfig": {
       "type": "object",
@@ -556,11 +490,8 @@
           "type": "string"
         },
         "ignoredEventTypes": {
-          "description": "Specify an array of event types that won't be persisted to the database. For example, typing events and visits\nmay not provide you with useful informations",
-          "default": [
-            "visit",
-            "typing"
-          ],
+          "description": "Specify an array of event types that won't be persisted to the database. For example, typing events and visits\nmay not provide you with useful information",
+          "default": ["visit", "typing"],
           "type": "array",
           "items": {
             "type": "string"
@@ -575,13 +506,7 @@
           }
         }
       },
-      "required": [
-        "collectionInterval",
-        "enabled",
-        "ignoredEventProperties",
-        "ignoredEventTypes",
-        "retentionPeriod"
-      ]
+      "required": ["collectionInterval", "enabled", "ignoredEventProperties", "ignoredEventTypes", "retentionPeriod"]
     },
     "AuthStrategy": {
       "type": "object",
@@ -628,20 +553,10 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "allowSelfSignup",
-        "id",
-        "options",
-        "type"
-      ]
+      "required": ["allowSelfSignup", "id", "options", "type"]
     },
     "AuthStrategyType": {
-      "enum": [
-        "basic",
-        "ldap",
-        "oauth2",
-        "saml"
-      ],
+      "enum": ["basic", "ldap", "oauth2", "saml"],
       "type": "string"
     },
     "AuthStrategyBasic": {
@@ -671,9 +586,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "maxLoginAttempt"
-      ]
+      "required": ["maxLoginAttempt"]
     },
     "AuthStrategySaml": {
       "description": "SAML Options, identical to the \"passeport-saml\" NPM library",
@@ -709,13 +622,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "acceptedClockSkewMs",
-        "callbackUrl",
-        "cert",
-        "entryPoint",
-        "issuer"
-      ]
+      "required": ["acceptedClockSkewMs", "callbackUrl", "cert", "entryPoint", "issuer"]
     },
     "AuthStrategyOauth2": {
       "type": "object",
@@ -789,9 +696,7 @@
             },
             "algorithms": {
               "description": "The algorithms allowed to validate the JWT tokens.",
-              "default": [
-                "HS256"
-              ],
+              "default": ["HS256"],
               "type": "array",
               "items": {
                 "type": "string"
@@ -802,19 +707,10 @@
               "type": "string"
             }
           },
-          "required": [
-            "algorithms"
-          ]
+          "required": ["algorithms"]
         }
       },
-      "required": [
-        "authorizationURL",
-        "callbackURL",
-        "clientID",
-        "clientSecret",
-        "scope",
-        "tokenURL"
-      ]
+      "required": ["authorizationURL", "callbackURL", "clientID", "clientSecret", "scope", "tokenURL"]
     },
     "AuthStrategyLdap": {
       "type": "object",
@@ -862,4 +758,3 @@
   },
   "$schema": "http://json-schema.org/draft-07/schema#"
 }
-

--- a/modules/nlu/src/backend/engine2/exact-matcher.test.ts
+++ b/modules/nlu/src/backend/engine2/exact-matcher.test.ts
@@ -3,7 +3,7 @@ import { buildExactMatchIndex, Intent } from './training-pipeline'
 import Utterance from './utterance'
 
 const u1 = 'Hi my name is Alex W and I try to make NLU for a living'
-const u2 = "Hi I'm Justine and I'am a smart bot with very scoped skills"
+const u2 = "Hi I'm Justine and I'm a smart bot with very scoped skills"
 const u3 = 'Medication makes me high'
 
 const makeTestUtterances = (textUtterances: string[]): Utterance[] => {

--- a/modules/nlu/src/backend/engine2/intent-vocab.test.ts
+++ b/modules/nlu/src/backend/engine2/intent-vocab.test.ts
@@ -63,7 +63,7 @@ describe('Build intent vocab', () => {
       })
   })
 
-  test('With list entitites and Utterance tokens', () => {
+  test('With list entities and Utterance tokens', () => {
     const u1 = new Utterance(u1Toks, genMockVectors(u1Toks), genMockPOS(u1Toks), 'en')
     const u2 = new Utterance(u2Toks, genMockVectors(u2Toks), genMockPOS(u2Toks), 'en')
 

--- a/modules/nlu/src/backend/engine2/labeler2.test.ts
+++ b/modules/nlu/src/backend/engine2/labeler2.test.ts
@@ -56,7 +56,7 @@ describe('makeExtractedSlots', () => {
     tagResults = new Array(u.tokens.filter(t => !t.isSpace).length).fill(out)
   })
 
-  test('consecutives slots token combined properly', () => {
+  test('consecutive slots token combined properly', () => {
     tagResults.splice(
       4,
       2,
@@ -73,7 +73,7 @@ describe('makeExtractedSlots', () => {
     expect(extractedSlots[0].end).toEqual(22)
   })
 
-  test('consecutives different slots are not combined', () => {
+  test('consecutive different slots are not combined', () => {
     tagResults.splice(
       4,
       4,
@@ -96,7 +96,7 @@ describe('makeExtractedSlots', () => {
     expect(extractedSlots[1].end).toEqual(34)
   })
 
-  test('slot with associated entites adds proper value', () => {
+  test('slot with associated entities adds proper value', () => {
     tagResults.splice(
       4,
       2,
@@ -113,7 +113,7 @@ describe('makeExtractedSlots', () => {
     expect(extractedSlots[0].slot.value).toEqual(value)
   })
 
-  test('slot with entites but not set in intent def keeps source as value', () => {
+  test('slot with entities but not set in intent def keeps source as value', () => {
     tagResults.splice(
       6,
       2,

--- a/modules/nlu/src/backend/engine2/labeler2.test.ts
+++ b/modules/nlu/src/backend/engine2/labeler2.test.ts
@@ -6,7 +6,7 @@ import Utterance, { makeTestUtterance } from './utterance'
 
 describe('Slot tagger labels for utterance', () => {
   test('without slots', () => {
-    const u = makeTestUtterance('My mame is Heisenberg and I am the danger')
+    const u = makeTestUtterance('My name is Heisenberg and I am the danger')
     const labels = labelizeUtterance(u)
 
     expect(labels.length).toEqual(u.tokens.filter(t => !t.isSpace).length)

--- a/modules/nlu/src/backend/engine2/predict-pipeline.ts
+++ b/modules/nlu/src/backend/engine2/predict-pipeline.ts
@@ -180,7 +180,7 @@ function predictionsReallyConfused(predictions: sdk.MLToolkit.SVM.Prediction[]):
 }
 
 // TODO implement this algorithm properly / improve it
-// currently taken as is from svm classifier (engine 1) and does't make much sens
+// currently taken as is from svm classifier (engine 1) and doesn't make much sens
 function electIntent(input: PredictStep): PredictStep {
   const totalConfidence = Math.min(1, _.sumBy(input.ctx_predictions, 'confidence'))
   const ctxPreds = input.ctx_predictions.map(x => ({ ...x, confidence: x.confidence / totalConfidence }))

--- a/modules/nlu/src/backend/engine2/utterance.ts
+++ b/modules/nlu/src/backend/engine2/utterance.ts
@@ -159,7 +159,7 @@ export default class Utterance {
         toAdd = tok.value
       }
 
-      // case ignore is handled implicitely
+      // case ignore is handled implicitly
       if (tok.slots.length && options.slots === 'keep-name') {
         toAdd = tok.slots[0].name
       } else if (tok.slots.length && options.slots === 'keep-value') {

--- a/modules/nlu/src/backend/middleware.ts
+++ b/modules/nlu/src/backend/middleware.ts
@@ -68,7 +68,7 @@ export const registerMiddleware = async (bp: typeof sdk, e1ByBot: EngineByBot, e
         event.payload.text = event.payload.text.replace(entity.data.value, stars)
       }
     } catch (err) {
-      bp.logger.warn('Error removing sensitive informations: ' + err.message)
+      bp.logger.warn('Error removing sensitive information: ' + err.message)
     }
   }
 }

--- a/modules/nlu/src/backend/module-lifecycle/on-bot-mount.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-bot-mount.ts
@@ -49,8 +49,8 @@ export function getOnBotMount(state: NLUState) {
     const trainOrLoad = _.debounce(
       async () => {
         const ghost = bp.ghost.forBot(botId)
-        const intentDefs = await (engine1 as ScopedEngine).storage.getIntents() // todo replace this with intent service when implemented
-        const entityDefs = await (engine1 as ScopedEngine).storage.getCustomEntities() // TODO: replace this wit entities service once implemented
+        const intentDefs = await (engine1 as ScopedEngine).storage.getIntents() // TODO replace this with intent service when implemented
+        const entityDefs = await (engine1 as ScopedEngine).storage.getCustomEntities() // TODO: replace this with entities service once implemented
         const hash = ModelService.computeModelHash(intentDefs, entityDefs)
 
         await Promise.mapSeries(languages, async languageCode => {
@@ -81,7 +81,7 @@ export function getOnBotMount(state: NLUState) {
       { leading: true }
     )
     // register trainOrLoad with ghost file watcher
-    // we use local events so training occures on the same node where the request for changes enters
+    // we use local events so training occurs on the same node where the request for changes enters
     const trainWatcher = bp.ghost.forBot(botId).onFileChanged(async f => {
       if (f.includes('intents') || f.includes('entities')) {
         // eventually cancel & restart training only for given language

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -27,7 +27,7 @@ export const initializeLanguageProvider = async (bp: typeof sdk, state: NLUState
     state.health = health
   } catch (e) {
     if (e.failure && e.failure.code === 'ECONNREFUSED') {
-      bp.logger.error(`Language server can't be reached at adress ${e.failure.address}:${e.failure.port}`)
+      bp.logger.error(`Language server can't be reached at address ${e.failure.address}:${e.failure.port}`)
       if (!process.IS_FAILSAFE) {
         process.exit()
       }
@@ -131,7 +131,7 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
         event.payload.text = event.payload.text.replace(entity.data.value, stars)
       }
     } catch (err) {
-      bp.logger.warn('Error removing sensitive informations: ' + err.message)
+      bp.logger.warn('Error removing sensitive information: ' + err.message)
     }
   }
 }

--- a/modules/nlu/src/backend/pipelines/entities/duckling_extractor.ts
+++ b/modules/nlu/src/backend/pipelines/entities/duckling_extractor.ts
@@ -41,7 +41,7 @@ export class DucklingEntityExtractor implements EntityExtractor {
       })
 
       const ducklingDisabledMsg = `, so it will be disabled.
-For more informations (or if you want to self-host it), please check the docs at
+For more information (or if you want to self-host it), please check the docs at
 https://botpress.io/docs/build/nlu/#system-entities
 `
 

--- a/modules/nlu/src/backend/pipelines/entities/pattern_extractor.ts
+++ b/modules/nlu/src/backend/pipelines/entities/pattern_extractor.ts
@@ -88,7 +88,7 @@ export default class PatternExtractor {
       const end = currentLastToken.end
 
       // prevent adding substrings of an already matched, longer entity
-      // prioretize longer matches with confidence * its length higher
+      // prioritize longer matches with confidence * its length higher
 
       const hasBiggerMatch = findings.find(
         x =>
@@ -110,7 +110,7 @@ export default class PatternExtractor {
           name: entityDef.name,
           type: 'list',
           meta: {
-            confidence: highest, // extrated with synonyme as patterns
+            confidence: highest, // extracted with synonym as patterns
             provider: 'native',
             source: source,
             start,

--- a/modules/nlu/src/backend/pipelines/intents/exact_matcher.ts
+++ b/modules/nlu/src/backend/pipelines/intents/exact_matcher.ts
@@ -31,7 +31,7 @@ export default class ExactMatcher {
         return {
           name: seq.intent,
           confidence: 1,
-          context: seq.contexts![0] // todo fix this
+          context: seq.contexts![0] // TODO fix this
         }
       }
     }

--- a/modules/nlu/src/backend/storage.ts
+++ b/modules/nlu/src/backend/storage.ts
@@ -42,7 +42,7 @@ export default class Storage {
 
     if (content.slots) {
       for (const slot of content.slots) {
-        // @deprecated > 11 gracefull migration
+        // @deprecated > 11 graceful migration
         if (!slot.entities && slot.entity) {
           slot.entities = [slot.entity]
         }

--- a/modules/nlu/src/views/lite/intentEditor/IntentHint.tsx
+++ b/modules/nlu/src/views/lite/intentEditor/IntentHint.tsx
@@ -17,7 +17,7 @@ const fetchRecommendations = async (axios: AxiosInstance): Promise<NluMlRecommen
   return axios.get('/mod/nlu/ml-recommendations').then(({ data }) => data)
 }
 
-// At some point, recommendations will be computed in the backend and this component will simply fetch and display intents recommentations
+// At some point, recommendations will be computed in the backend and this component will simply fetch and display intents recommendations
 const IntentHint: FC<Props> = props => {
   const utterances = props.intent.utterances[props.contentLang] || []
   const slotsLength = (props.intent.slots || []).length
@@ -34,9 +34,9 @@ const IntentHint: FC<Props> = props => {
   /*
     The ideal number of utterances should not be computed for the whole intent but rather by slots.
     Meaning, we should recommend a number of utterances for each slot, what we are doing right now is only
-    valid if the're no slots. Also, we should do a density based clustering per slots and for the whole intent
+    valid if there're no slots. Also, we should do a density based clustering per slots and for the whole intent
     to see if the utterances all belong to the same class or if the are considerable different ways of saying
-    the samething. Then, we could also not only recommend number of utterances per intent & slots but by cluster also.
+    the same thing. Then, we could also not only recommend number of utterances per intent & slots but by cluster also.
   */
   const idealNumberOfUtt = Math.max(Math.pow(slotsLength * 2, 2), recommendations.goodUtterancesForML)
   let hint: JSX.Element

--- a/modules/testing/src/views/full/NoScenarios.jsx
+++ b/modules/testing/src/views/full/NoScenarios.jsx
@@ -10,7 +10,7 @@ export default ({ onRecordClicked }) => (
       <p>
         Scenarios are a great way to ensure your bot still behaves the same while your making changes to it. They are
         the conversation design version software unit tests. Instead of going through every possible conversation path
-        everytime you change something in your bot, automate it by recording and running scenarios. Check out{' '}
+        every time you change something in your bot, automate it by recording and running scenarios. Check out{' '}
         <a target="_blank" href="https://github.com/botpress/botpress/tree/master/modules/testing/README.md">
           the docs
         </a>{' '}

--- a/src/bp/common/typings.ts
+++ b/src/bp/common/typings.ts
@@ -161,7 +161,7 @@ export interface ChatUserAuth {
 export interface AuthPayload {
   /** User is considered authenticated until that date (duration is determined per channel) */
   authenticatedUntil?: Date
-  /** An authorized user has an acces (any) to the workspace the bot is part of */
+  /** An authorized user has an access (any) to the workspace the bot is part of */
   isAuthorized?: boolean
   /** User must provide a valid invite code before he's added to the workspace & authorized */
   inviteRequired?: boolean

--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -226,7 +226,7 @@ export class Botpress {
       const assets = path.resolve(process.PROJECT_LOCATION, 'data/assets')
       await copyDir(path.join(__dirname, '../ui-admin'), `${assets}/ui-admin`)
 
-      // Avoids overwriting the folder when developping locally on the studio
+      // Avoids overwriting the folder when developing locally on the studio
       if (fse.pathExistsSync(`${assets}/ui-studio/public`)) {
         const studioPath = await fse.lstatSync(`${assets}/ui-studio/public`)
         if (studioPath.isSymbolicLink()) {

--- a/src/bp/core/config/botpress.config.ts
+++ b/src/bp/core/config/botpress.config.ts
@@ -102,7 +102,7 @@ export type BotpressConfig = {
     port: number
     /**
      * There are two external URL that Botpress calls: https://license.botpress.io and https://duckling.botpress.io
-     * If you are behind a corporare proxy, you can configure it below.
+     * If you are behind a corporate proxy, you can configure it below.
      * It is also possible to self-host Duckling, please check the documentation
      *
      * @example http://username:password@hostname:port
@@ -277,7 +277,7 @@ export type BotpressConfig = {
 }
 
 export interface ExternalAuthConfig {
-  /** Set to true to enable external authentification
+  /** Set to true to enable external authentication
    * @default false
    */
   enabled: boolean
@@ -437,7 +437,7 @@ export interface AuthStrategyOauth2 {
    */
   callbackURL: string
   /*
-   * Set this URL if your access token doesn't include user data. Botpress will query that URL to fetch user informations
+   * Set this URL if your access token doesn't include user data. Botpress will query that URL to fetch user information
    * @example https://botpress.io/userinfo
    */
   userInfoURL?: string
@@ -558,7 +558,7 @@ export interface EventCollectorConfig {
   retentionPeriod: string
   /**
    * Specify an array of event types that won't be persisted to the database. For example, typing events and visits
-   * may not provide you with useful informations
+   * may not provide you with useful information
    * @default ["visit","typing"]
    */
   ignoredEventTypes: string[]

--- a/src/bp/core/config/botpress.config.ts
+++ b/src/bp/core/config/botpress.config.ts
@@ -102,7 +102,7 @@ export type BotpressConfig = {
     port: number
     /**
      * There are three external URLs that Botpress calls: https://license.botpress.io, https://duckling.botpress.io and https://lang-01.botpress.io
-     * If you are behind a corporare proxy, you can configure it below.
+     * If you are behind a corporate proxy, you can configure it below.
      * It is also possible to self-host Duckling, please check the documentation
      *
      * @example http://username:password@hostname:port

--- a/src/bp/core/routers/bots/index.ts
+++ b/src/bp/core/routers/bots/index.ts
@@ -179,7 +179,7 @@ export class BotsRouter extends CustomRouter {
   private setupRoutes() {
     /**
      * UNAUTHENTICATED ROUTES
-     * Do not return sensitive informations there. These must be accessible by unauthenticated users
+     * Do not return sensitive information there. These must be accessible by unauthenticated users
      */
     this.router.get('/studio-params', (req, res) => {
       const info = this.studioParams(req.params.botId)

--- a/src/bp/core/services/dialog/dialog-engine.ts
+++ b/src/bp/core/services/dialog/dialog-engine.ts
@@ -130,7 +130,7 @@ export class DialogEngine {
 
     await this._loadFlows(botId)
 
-    // This is the only place we dont want to catch node or flow not found errors
+    // This is the only place we don't want to catch node or flow not found errors
     const findNodeWithoutError = (flow, nodeName) => {
       try {
         return this._findNode(botId, flow, nodeName)
@@ -301,8 +301,8 @@ export class DialogEngine {
     const subflow = this._findFlow(botId, subflowName)
     const subflowStartNode = this._findNode(botId, subflow, subflow.startNode)
 
-    // We only update previousNodeName and previousFlowName when we transition to a subblow.
-    // When the sublow ends, we will transition back to previousNodeName / previousFlowName.
+    // We only update previousNodeName and previousFlowName when we transition to a subflow.
+    // When the subflow ends, we will transition back to previousNodeName / previousFlowName.
 
     event.state.context = {
       currentFlow: subflow.name,

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -556,10 +556,10 @@ declare module 'botpress/sdk' {
 
     export interface EventUnderstanding {
       readonly intent: NLU.Intent
-      /** Predicted intents needs disambiguiation */
+      /** Predicted intents needs disambiguation */
       readonly ambiguous: boolean
       readonly intents: NLU.Intent[]
-      /** The language used for prediction. Will be equal to detected langauge when its part of supported languages, falls back to default language otherwise */
+      /** The language used for prediction. Will be equal to detected language when its part of supported languages, falls back to default language otherwise */
       readonly language: string
       /** Language detected from users input. */
       readonly detectedLanguage: string
@@ -1132,7 +1132,7 @@ declare module 'botpress/sdk' {
     inversify: any
   }
 
-  /** These are additional informations that Botpress may pass down to migrations (for ex: running bot-specific migration) */
+  /** These are additional information that Botpress may pass down to migrations (for ex: running bot-specific migration) */
   export interface MigrationMetadata {
     botId?: string
   }
@@ -1298,7 +1298,7 @@ declare module 'botpress/sdk' {
 
     /**
      * Create a new router for a module. Once created, use them to register new endpoints. Routers created
-     * with this method are accessible via the url /mod/{routernName}
+     * with this method are accessible via the url /mod/{routerName}
      *
      * @example const router = bp.http.createRouterForBot('myModule')
      * @example router.get('/list', ...)
@@ -1349,13 +1349,13 @@ declare module 'botpress/sdk' {
 
   /**
    * Events is the base communication channel of the bot. Messages and payloads are a part of it,
-   * and it is the only way to receive or send informations. Each event goes through the whole middleware chain (incoming or outgoing)
+   * and it is the only way to receive or send information. Each event goes through the whole middleware chain (incoming or outgoing)
    * before being received by either the bot or the user.
    */
   export namespace events {
     /**
      * Register a new middleware globally. They are sorted based on their declared order each time a new one is registered.
-     * @param midddleware - The middleware definition to register
+     * @param middleware - The middleware definition to register
      */
     export function registerMiddleware(middleware: IO.MiddlewareDefinition): void
 
@@ -1379,7 +1379,7 @@ declare module 'botpress/sdk' {
     export function replyToEvent(eventDestination: IO.EventDestination, payloads: any[], incomingEventId?: string): void
 
     /**
-     * Return the state of the icoming queue. True if there are any events(messages)
+     * Return the state of the incoming queue. True if there are any events(messages)
      * from the user waiting in the queue.
      * @param event - Current event in the action context, used to identify the queue
      */
@@ -1450,7 +1450,7 @@ declare module 'botpress/sdk' {
     export function deleteSession(sessionId: string): Promise<void>
 
     /**
-     * Jumps to a specific flow and optionally a specific node. This is useful when the default flow behaviour needs to be bypassed.
+     * Jumps to a specific flow and optionally a specific node. This is useful when the default flow behavior needs to be bypassed.
      * @param sessionId The Id of the the current Dialog Session. If the session doesn't exists, it will be created with this Id.
      * @param event The event to be processed
      * @param flowName The name of the flow to jump to
@@ -1469,7 +1469,7 @@ declare module 'botpress/sdk' {
     export function getModuleConfig(moduleId: string): Promise<any>
 
     /**
-     * Returns the configuation values for the specified module and bot.
+     * Returns the configuration values for the specified module and bot.
      * @param moduleId
      * @param botId
      * @param ignoreGlobal Enable this when you want only bot-specific configuration to be possible
@@ -1729,7 +1729,7 @@ declare module 'botpress/sdk' {
 
     /**
      * Render a template using Mustache template rendering.
-     * Use recursive template rendering to extract nexted templates.
+     * Use recursive template rendering to extract nested templates.
      *
      * @param item TemplateItem to render
      * @param context Variables to use for the template rendering

--- a/src/bp/ui-admin/src/Pages/Bot/Details.jsx
+++ b/src/bp/ui-admin/src/Pages/Bot/Details.jsx
@@ -456,7 +456,7 @@ class Bots extends Component {
           </Col>
         </Row>
         <small>
-          These informations are displayed on the Bot Information page,{' '}
+          This information is displayed on the Bot Information page,{' '}
           <a href="https://botpress.io/docs/tutorials/webchat-embedding" target="_blank" rel="noopener noreferrer">
             check the documentation for more details
           </a>

--- a/src/bp/ui-admin/src/Pages/Server/Checklist/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/Checklist/index.tsx
@@ -304,7 +304,7 @@ export const Checklist: FC<Props> = props => {
           docs="https://botpress.io/docs/advanced/hosting/#setting-up-nginx"
           status="none"
         >
-          Check the documentation for more informations
+          Check the documentation for more information
         </Item>
       </div>
     </Container>

--- a/src/bp/ui-admin/src/Pages/Server/Versioning/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/Versioning/index.tsx
@@ -62,7 +62,7 @@ const Versioning: FC<{ profile: any }> = props => {
             <a href="https://botpress.io/docs/next/advanced/versions/" target="_blank">
               <b>documentation</b>
             </a>{' '}
-            for more informations.
+            for more information.
           </p>
         </Callout>
       )}

--- a/src/bp/ui-admin/src/api.tsx
+++ b/src/bp/ui-admin/src/api.tsx
@@ -16,7 +16,7 @@ export const toastError = error => {
       {errorCode && <span>[{errorCode}]</span>} {details}{' '}
       {docs && (
         <a href={docs} target="_blank">
-          More informations
+          More information
         </a>
       )}
     </span>

--- a/src/bp/ui-studio/src/web/components/ContentForm/UploadWidget.js
+++ b/src/bp/ui-studio/src/web/components/ContentForm/UploadWidget.js
@@ -67,7 +67,7 @@ class UploadWidget extends Component {
       <AccessControl
         operation="write"
         resource="bot.media"
-        fallback={<em>Youd don&apos;t have permission to upload files for this bot. Talk to your team owner.</em>}
+        fallback={<em>You don&apos;t have permission to upload files for this bot. Talk to your team owner.</em>}
       >
         <FormGroup>
           {!expanded ? (

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/manager.ts
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/manager.ts
@@ -17,7 +17,7 @@ export const DIAGRAM_PADDING: number = 100
 // Must be identified by the deleteSelectedElement logic to know it needs to delete something
 export const nodeTypes = ['standard', 'skill-call', 'say_something', 'execute', 'listen', 'router']
 
-// Using the new node types to prevent displaying start prort
+// Using the new node types to prevent displaying start port
 export const newNodeTypes = ['say_something', 'execute', 'listen', 'router']
 
 // Default transition applied for new nodes 1.5
@@ -181,7 +181,7 @@ export class DiagramManager {
         return this.diagramWidget.forceUpdate()
       }
 
-      // If ports have more than one outbout link
+      // If ports have more than one output link
       const ports = [link.getSourcePort(), link.getTargetPort()]
       ports.forEach(port => {
         if (!port) {


### PR DESCRIPTION
In one case, `plateform` was changed in code, but I guess it is fine since it is in code samples, and all occurrences were corrected.