### PR TITLE
fix(studio) case insensitive flow names

### DIFF
--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowNameModal.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowNameModal.tsx
@@ -47,7 +47,8 @@ const FlowNameModal: FC<Props> = props => {
   }
 
   const isIdentical = props.action === 'rename' && props.originalName === `${name}.flow.json`
-  const alreadyExists = !isIdentical && _.includes(props.flowsNames, `${name}.flow.json`)
+  const alreadyExists =
+    !isIdentical && _.some(props.flowsNames, n => n.toLowerCase() === `${name}.flow.json`.toLowerCase())
 
   let dialog: { icon: any; title: string } = { icon: 'add', title: 'Create Flow' }
   if (props.action === 'duplicate') {


### PR DESCRIPTION
On creating or renaming a flow, the name is compared with other flows with case sensitivity. This doesn't correctly work in case-insensitive Operating Systems (e.g. Windows).

This PR is related to botpress/v12#896, but I couldn't reproduce the 'exporting' of flows, since I use Windows.