### PR TITLE
feat(nlu) intent name dialog

### DIFF
--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -167,13 +167,6 @@ export default async (bp: typeof sdk, state: NLUState) => {
     res.sendStatus(200)
   })
 
-  router.post('/intents/:intentName/duplicate', async (req, res) => {
-    const botEngine = state.nluByBot[req.params.botId].engine1 as ScopedEngine
-    await botEngine.storage.duplicateIntent(req.params.intentName, req.body.name)
-    scheduleSyncNLU(req.params.botId)
-
-    res.sendStatus(200)
-  })
   router.get('/contexts', async (req, res) => {
     const botId = req.params.botId
     const intents = await (state.nluByBot[botId].engine1 as ScopedEngine).storage.getIntents()

--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -158,10 +158,7 @@ export default async (bp: typeof sdk, state: NLUState) => {
 
   router.post('/intents/:intentName', async (req, res) => {
     const botEngine = state.nluByBot[req.params.botId].engine1 as ScopedEngine
-    const targetName = req.params.intentName
-    const intent = await botEngine.storage.getIntent(targetName)
-    intent.name = req.body.name
-    await botEngine.storage.updateIntent(targetName, intent)
+    await botEngine.storage.updateIntent(req.params.intentName, req.body)
     scheduleSyncNLU(req.params.botId)
 
     res.sendStatus(200)

--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -156,6 +156,22 @@ export default async (bp: typeof sdk, state: NLUState) => {
     }
   })
 
+  router.post('/intents/:intentName', async (req, res) => {
+    try {
+      const botEngine = state.nluByBot[req.params.botId].engine1 as ScopedEngine
+      const targetName = req.params.intentName
+      const intent = await botEngine.storage.getIntent(targetName)
+      intent.name = req.body.name
+      await botEngine.storage.updateIntent(targetName, intent)
+      scheduleSyncNLU(req.params.botId)
+
+      res.sendStatus(200)
+    } catch (err) {
+      bp.logger.attachError(err).warn('Cannot update intent, invalid schema')
+      res.status(400).send('Invalid schema')
+    }
+  })
+
   router.get('/contexts', async (req, res) => {
     const botId = req.params.botId
     const intents = await (state.nluByBot[botId].engine1 as ScopedEngine).storage.getIntents()

--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -157,21 +157,23 @@ export default async (bp: typeof sdk, state: NLUState) => {
   })
 
   router.post('/intents/:intentName', async (req, res) => {
-    try {
-      const botEngine = state.nluByBot[req.params.botId].engine1 as ScopedEngine
-      const targetName = req.params.intentName
-      const intent = await botEngine.storage.getIntent(targetName)
-      intent.name = req.body.name
-      await botEngine.storage.updateIntent(targetName, intent)
-      scheduleSyncNLU(req.params.botId)
+    const botEngine = state.nluByBot[req.params.botId].engine1 as ScopedEngine
+    const targetName = req.params.intentName
+    const intent = await botEngine.storage.getIntent(targetName)
+    intent.name = req.body.name
+    await botEngine.storage.updateIntent(targetName, intent)
+    scheduleSyncNLU(req.params.botId)
 
-      res.sendStatus(200)
-    } catch (err) {
-      bp.logger.attachError(err).warn('Cannot update intent, invalid schema')
-      res.status(400).send('Invalid schema')
-    }
+    res.sendStatus(200)
   })
 
+  router.post('/intents/:intentName/duplicate', async (req, res) => {
+    const botEngine = state.nluByBot[req.params.botId].engine1 as ScopedEngine
+    await botEngine.storage.duplicateIntent(req.params.intentName, req.body.name)
+    scheduleSyncNLU(req.params.botId)
+
+    res.sendStatus(200)
+  })
   router.get('/contexts', async (req, res) => {
     const botId = req.params.botId
     const intents = await (state.nluByBot[botId].engine1 as ScopedEngine).storage.getIntents()

--- a/modules/nlu/src/backend/storage.ts
+++ b/modules/nlu/src/backend/storage.ts
@@ -11,7 +11,7 @@ const N_KEEP_MODELS = 25
 
 export const ID_REGEX = /[\t\s]/gi
 
-export const sanitizeFilenameNoExt = name =>
+export const sanitizeFilenameNoExt = (name: string) =>
   name
     .toLowerCase()
     .replace('.json', '')
@@ -69,7 +69,10 @@ export default class Storage {
   async updateIntent(intentName: string, content: Partial<sdk.NLU.IntentDefinition>) {
     const intentDef = await this.getIntent(intentName)
     const merged = _.merge(intentDef, content)
-
+    if (content.name && content.name !== intentName) {
+      this.botGhost.deleteFile(this.intentsDir, `${intentName}.json`)
+      intentName = content.name
+    }
     return this.saveIntent(intentName, merged)
   }
 

--- a/modules/nlu/src/backend/storage.ts
+++ b/modules/nlu/src/backend/storage.ts
@@ -76,12 +76,6 @@ export default class Storage {
     return this.saveIntent(intentName, merged)
   }
 
-  async duplicateIntent(intentName: string, name: string) {
-    const intent = await this.getIntent(intentName)
-    intent.name = name
-    this.saveIntent(name, intent)
-  }
-
   async saveConfusionMatrix({
     modelHash,
     lang,

--- a/modules/nlu/src/backend/storage.ts
+++ b/modules/nlu/src/backend/storage.ts
@@ -76,6 +76,12 @@ export default class Storage {
     return this.saveIntent(intentName, merged)
   }
 
+  async duplicateIntent(intentName: string, name: string) {
+    const intent = await this.getIntent(intentName)
+    intent.name = name
+    this.saveIntent(name, intent)
+  }
+
   async saveConfusionMatrix({
     modelHash,
     lang,

--- a/modules/nlu/src/views/api.ts
+++ b/modules/nlu/src/views/api.ts
@@ -7,7 +7,6 @@ export interface NLUApi {
   fetchIntent: (x: string) => Promise<NLU.IntentDefinition>
   createIntent: (x: Partial<NLU.IntentDefinition>) => Promise<any>
   renameIntent: (targetIntent: string, name: string) => Promise<any>
-  duplicateIntent: (targetIntent: string, name: string) => Promise<any>
   deleteIntent: (x: string) => Promise<any>
   fetchEntities: () => Promise<NLU.EntityDefinition[]>
   createEntity: (x: NLU.EntityDefinition) => Promise<any>
@@ -25,8 +24,6 @@ export const makeApi = (bp: { axios: AxiosInstance }): NLUApi => ({
   createIntent: (intent: Partial<NLU.IntentDefinition>) => bp.axios.post(`/mod/nlu/intents`, intent),
   renameIntent: (targetIntent: string, name: string) =>
     bp.axios.post(`/mod/nlu/intents/${targetIntent}`, { name: name }),
-  duplicateIntent: (targetIntent: string, name: string) =>
-    bp.axios.post(`/mod/nlu/intents/${targetIntent}/duplicate`, { name: name }),
   deleteIntent: (name: string) => bp.axios.post(`/mod/nlu/intents/${name}/delete`),
   fetchEntities: () => bp.axios.get('/mod/nlu/entities').then(res => res.data),
   createEntity: (entity: NLU.EntityDefinition) => bp.axios.post(`/mod/nlu/entities/`, entity),

--- a/modules/nlu/src/views/api.ts
+++ b/modules/nlu/src/views/api.ts
@@ -6,6 +6,7 @@ export interface NLUApi {
   fetchIntents: () => Promise<NLU.IntentDefinition[]>
   fetchIntent: (x: string) => Promise<NLU.IntentDefinition>
   createIntent: (x: Partial<NLU.IntentDefinition>) => Promise<any>
+  renameIntent: (targetIntent: string, name: string) => Promise<any>
   deleteIntent: (x: string) => Promise<any>
   fetchEntities: () => Promise<NLU.EntityDefinition[]>
   createEntity: (x: NLU.EntityDefinition) => Promise<any>
@@ -21,6 +22,8 @@ export const makeApi = (bp: { axios: AxiosInstance }): NLUApi => ({
   },
   fetchIntent: (intentName: string) => bp.axios.get(`/mod/nlu/intents/${intentName}`).then(res => res.data),
   createIntent: (intent: Partial<NLU.IntentDefinition>) => bp.axios.post(`/mod/nlu/intents`, intent),
+  renameIntent: (targetIntent: string, name: string) =>
+    bp.axios.post(`/mod/nlu/intents/${targetIntent}`, { name: name }),
   deleteIntent: (name: string) => bp.axios.post(`/mod/nlu/intents/${name}/delete`),
   fetchEntities: () => bp.axios.get('/mod/nlu/entities').then(res => res.data),
   createEntity: (entity: NLU.EntityDefinition) => bp.axios.post(`/mod/nlu/entities/`, entity),

--- a/modules/nlu/src/views/api.ts
+++ b/modules/nlu/src/views/api.ts
@@ -6,7 +6,7 @@ export interface NLUApi {
   fetchIntents: () => Promise<NLU.IntentDefinition[]>
   fetchIntent: (x: string) => Promise<NLU.IntentDefinition>
   createIntent: (x: Partial<NLU.IntentDefinition>) => Promise<any>
-  renameIntent: (targetIntent: string, name: string) => Promise<any>
+  updateIntent: (targetIntent: string, intent: Partial<NLU.IntentDefinition>) => Promise<any>
   deleteIntent: (x: string) => Promise<any>
   fetchEntities: () => Promise<NLU.EntityDefinition[]>
   createEntity: (x: NLU.EntityDefinition) => Promise<any>
@@ -22,8 +22,8 @@ export const makeApi = (bp: { axios: AxiosInstance }): NLUApi => ({
   },
   fetchIntent: (intentName: string) => bp.axios.get(`/mod/nlu/intents/${intentName}`).then(res => res.data),
   createIntent: (intent: Partial<NLU.IntentDefinition>) => bp.axios.post(`/mod/nlu/intents`, intent),
-  renameIntent: (targetIntent: string, name: string) =>
-    bp.axios.post(`/mod/nlu/intents/${targetIntent}`, { name: name }),
+  updateIntent: (targetIntent: string, intent: Partial<NLU.IntentDefinition>) =>
+    bp.axios.post(`/mod/nlu/intents/${targetIntent}`, intent),
   deleteIntent: (name: string) => bp.axios.post(`/mod/nlu/intents/${name}/delete`),
   fetchEntities: () => bp.axios.get('/mod/nlu/entities').then(res => res.data),
   createEntity: (entity: NLU.EntityDefinition) => bp.axios.post(`/mod/nlu/entities/`, entity),

--- a/modules/nlu/src/views/api.ts
+++ b/modules/nlu/src/views/api.ts
@@ -7,6 +7,7 @@ export interface NLUApi {
   fetchIntent: (x: string) => Promise<NLU.IntentDefinition>
   createIntent: (x: Partial<NLU.IntentDefinition>) => Promise<any>
   renameIntent: (targetIntent: string, name: string) => Promise<any>
+  duplicateIntent: (targetIntent: string, name: string) => Promise<any>
   deleteIntent: (x: string) => Promise<any>
   fetchEntities: () => Promise<NLU.EntityDefinition[]>
   createEntity: (x: NLU.EntityDefinition) => Promise<any>
@@ -24,6 +25,8 @@ export const makeApi = (bp: { axios: AxiosInstance }): NLUApi => ({
   createIntent: (intent: Partial<NLU.IntentDefinition>) => bp.axios.post(`/mod/nlu/intents`, intent),
   renameIntent: (targetIntent: string, name: string) =>
     bp.axios.post(`/mod/nlu/intents/${targetIntent}`, { name: name }),
+  duplicateIntent: (targetIntent: string, name: string) =>
+    bp.axios.post(`/mod/nlu/intents/${targetIntent}/duplicate`, { name: name }),
   deleteIntent: (name: string) => bp.axios.post(`/mod/nlu/intents/${name}/delete`),
   fetchEntities: () => bp.axios.get('/mod/nlu/entities').then(res => res.data),
   createEntity: (entity: NLU.EntityDefinition) => bp.axios.post(`/mod/nlu/entities/`, entity),

--- a/modules/nlu/src/views/full/intents/IntentNameModal.tsx
+++ b/modules/nlu/src/views/full/intents/IntentNameModal.tsx
@@ -65,10 +65,10 @@ const IntentNameModal: FC<Props> = props => {
               id="input-intent-name"
               tabIndex={1}
               placeholder="Choose a name for your intent"
-              required={true}
+              required
               value={name}
               onChange={e => setName(sanitizeName(e.currentTarget.value))}
-              autoFocus={true}
+              autoFocus
             />
           </FormGroup>
 

--- a/modules/nlu/src/views/full/intents/IntentNameModal.tsx
+++ b/modules/nlu/src/views/full/intents/IntentNameModal.tsx
@@ -81,7 +81,13 @@ const IntentNameModal: FC<Props> = props => {
 
         <div className={Classes.DIALOG_FOOTER}>
           <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-            <Button type="submit" id="btn-submit" text="Submit" onClick={submit} disabled={!name || alreadyExists} />
+            <Button
+              type="submit"
+              id="btn-submit"
+              text="Submit"
+              onClick={submit}
+              disabled={!name || isIdentical || alreadyExists}
+            />
           </div>
         </div>
       </form>

--- a/modules/nlu/src/views/full/intents/IntentNameModal.tsx
+++ b/modules/nlu/src/views/full/intents/IntentNameModal.tsx
@@ -1,0 +1,92 @@
+import { Button, Callout, Classes, Dialog, FormGroup, InputGroup, Intent } from '@blueprintjs/core'
+import _ from 'lodash'
+import React, { FC, useEffect, useState } from 'react'
+
+interface Props {
+  // Used for actions rename and duplicate
+  originalName?: string
+  action: 'create' | 'rename' | 'duplicate'
+  intentNames: string[]
+  isOpen: boolean
+  toggle: () => void
+  onCreateIntent: (name: string) => void
+  onDuplicateIntent: (intent: { intentNameToDuplicate: string; name: string }) => void
+  onRenameIntent: (intent: { targetIntent: string; name: string }) => void
+}
+
+export const sanitizeName = (text: string) =>
+  text
+    .toLowerCase()
+    .replace(/\s|\t|\n/g, '-')
+    .replace(/[^a-z0-9-_.]/g, '')
+
+const IntentNameModal: FC<Props> = props => {
+  const [name, setName] = useState()
+
+  useEffect(() => {
+    props.action === 'rename' ? setName(props.originalName) : setName('')
+  }, [props.isOpen])
+
+  const submit = async e => {
+    e.preventDefault()
+
+    if (props.action === 'create') {
+      props.onCreateIntent(name)
+    } else if (props.action === 'duplicate') {
+      props.onDuplicateIntent({ intentNameToDuplicate: props.originalName, name: name })
+    } else if (props.action === 'rename') {
+      props.onRenameIntent({ targetIntent: props.originalName, name: name })
+    }
+
+    closeModal()
+  }
+
+  const closeModal = () => {
+    setName('')
+    props.toggle()
+  }
+
+  const isIdentical = props.action === 'rename' && props.originalName === name
+  const alreadyExists = !isIdentical && _.some(props.intentNames, n => n.toLowerCase() === name.toLowerCase())
+
+  let dialog: { icon: any; title: string } = { icon: 'add', title: 'Create Intent' }
+  if (props.action === 'duplicate') {
+    dialog = { icon: 'duplicate', title: 'Duplicate Intent' }
+  } else if (props.action === 'rename') {
+    dialog = { icon: 'edit', title: 'Rename Intent' }
+  }
+
+  return (
+    <Dialog isOpen={props.isOpen} onClose={closeModal} transitionDuration={0} {...dialog}>
+      <form onSubmit={submit}>
+        <div className={Classes.DIALOG_BODY}>
+          <FormGroup label="Intent Name" helperText={`It can only contain letters, numbers, underscores and hyphens.`}>
+            <InputGroup
+              id="input-intent-name"
+              tabIndex={1}
+              placeholder="Choose a name for your intent"
+              required={true}
+              value={name}
+              onChange={e => setName(sanitizeName(e.currentTarget.value))}
+              autoFocus={true}
+            />
+          </FormGroup>
+
+          {alreadyExists && (
+            <Callout title="Name already in use" intent={Intent.DANGER}>
+              An intent with that name already exists. Please choose another one.
+            </Callout>
+          )}
+        </div>
+
+        <div className={Classes.DIALOG_FOOTER}>
+          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+            <Button type="submit" id="btn-submit" text="Submit" onClick={submit} disabled={!name || alreadyExists} />
+          </div>
+        </div>
+      </form>
+    </Dialog>
+  )
+}
+
+export default IntentNameModal

--- a/modules/nlu/src/views/full/intents/IntentNameModal.tsx
+++ b/modules/nlu/src/views/full/intents/IntentNameModal.tsx
@@ -10,8 +10,8 @@ interface Props {
   isOpen: boolean
   toggle: () => void
   onCreateIntent: (name: string) => void
-  onDuplicateIntent: (intent: { intentNameToDuplicate: string; name: string }) => void
-  onRenameIntent: (intent: { targetIntent: string; name: string }) => void
+  onRenameIntent: (targetIntent: string, name: string) => void
+  onDuplicateIntent: (intentNameToDuplicate: string, name: string) => void
 }
 
 export const sanitizeName = (text: string) =>
@@ -33,9 +33,9 @@ const IntentNameModal: FC<Props> = props => {
     if (props.action === 'create') {
       props.onCreateIntent(name)
     } else if (props.action === 'duplicate') {
-      props.onDuplicateIntent({ intentNameToDuplicate: props.originalName, name: name })
+      props.onDuplicateIntent(props.originalName, name)
     } else if (props.action === 'rename') {
-      props.onRenameIntent({ targetIntent: props.originalName, name: name })
+      props.onRenameIntent(props.originalName, name)
     }
 
     closeModal()

--- a/modules/nlu/src/views/full/intents/SidePanelSection.tsx
+++ b/modules/nlu/src/views/full/intents/SidePanelSection.tsx
@@ -33,6 +33,12 @@ export const IntentSidePanelSection: FC<Props> = props => {
     setModalOpen(true)
   }
 
+  const duplicateIntent = (intentName: string) => {
+    setIntentName(intentName)
+    setIntentAction('duplicate')
+    setModalOpen(true)
+  }
+
   const deleteIntent = (intentName: string) => {
     const confirmDelete = window.confirm(`Are you sure you want to delete the intent "${intentName}" ?`)
     if (confirmDelete) {
@@ -61,13 +67,8 @@ export const IntentSidePanelSection: FC<Props> = props => {
     props.setCurrentItem({ name: name, type: 'intent' })
   }
 
-  const onDuplicateIntent = async (intent: { intentNameToDuplicate: string; name: string }) => {
-    const intentDef = {
-      name: name,
-      utterances: { [props.contentLang]: [name] }
-    }
-
-    await props.api.createIntent(intentDef)
+  const onDuplicateIntent = async (targetIntent: string, name: string) => {
+    await props.api.duplicateIntent(targetIntent, name)
     await props.reloadIntents()
     props.setCurrentItem({ name: name, type: 'intent' })
   }
@@ -83,7 +84,7 @@ export const IntentSidePanelSection: FC<Props> = props => {
           selected: props.currentItem && props.currentItem.name === intent.name,
           contextMenu: [
             { label: 'Rename', icon: 'edit', onClick: () => renameIntent(intent.name) },
-            { label: 'Duplicate', icon: 'duplicate', onClick: () => {} },
+            { label: 'Duplicate', icon: 'duplicate', onClick: () => duplicateIntent(intent.name) },
             { label: 'Delete', icon: 'delete', onClick: () => deleteIntent(intent.name) }
           ]
         } as Item)
@@ -106,7 +107,7 @@ export const IntentSidePanelSection: FC<Props> = props => {
         toggle={() => setModalOpen(!modalOpen)}
         onCreateIntent={onCreateIntent}
         onRenameIntent={onRenameIntent}
-        onDuplicateIntent={() => {}}
+        onDuplicateIntent={onDuplicateIntent}
       />
     </div>
   )

--- a/modules/nlu/src/views/full/intents/SidePanelSection.tsx
+++ b/modules/nlu/src/views/full/intents/SidePanelSection.tsx
@@ -3,6 +3,7 @@ import { NLUApi } from 'api'
 import { NLU } from 'botpress/sdk'
 import { Item, ItemList, SearchBar, SectionAction, SidePanelSection } from 'botpress/ui'
 import { NluItem } from 'full'
+import _ from 'lodash'
 import React, { FC, useState } from 'react'
 
 import IntentNameModal from './IntentNameModal'
@@ -68,7 +69,10 @@ export const IntentSidePanelSection: FC<Props> = props => {
   }
 
   const onDuplicateIntent = async (targetIntent: string, name: string) => {
-    await props.api.duplicateIntent(targetIntent, name)
+    const intent = await props.api.fetchIntent(targetIntent)
+    const clone = _.cloneDeep(intent)
+    clone.name = name
+    await props.api.createIntent(clone)
     await props.reloadIntents()
     props.setCurrentItem({ name: name, type: 'intent' })
   }

--- a/modules/nlu/src/views/full/intents/SidePanelSection.tsx
+++ b/modules/nlu/src/views/full/intents/SidePanelSection.tsx
@@ -63,7 +63,9 @@ export const IntentSidePanelSection: FC<Props> = props => {
   }
 
   const onRenameIntent = async (targetIntent: string, name: string) => {
-    await props.api.renameIntent(targetIntent, name)
+    const intent = await props.api.fetchIntent(targetIntent)
+    intent.name = name
+    await props.api.updateIntent(targetIntent, intent)
     await props.reloadIntents()
     props.setCurrentItem({ name: name, type: 'intent' })
   }

--- a/modules/nlu/src/views/full/intents/SidePanelSection.tsx
+++ b/modules/nlu/src/views/full/intents/SidePanelSection.tsx
@@ -5,6 +5,8 @@ import { Item, ItemList, SearchBar, SectionAction, SidePanelSection } from 'botp
 import { NluItem } from 'full'
 import React, { FC, useState } from 'react'
 
+import IntentNameModal from './IntentNameModal'
+
 interface Props {
   api: NLUApi
   intents: NLU.IntentDefinition[]
@@ -15,6 +17,9 @@ interface Props {
 }
 
 export const IntentSidePanelSection: FC<Props> = props => {
+  const [modalOpen, setModalOpen] = useState(false)
+  const [intentName, setIntentName] = useState()
+  const [intentAction, setIntentAction] = useState<any>('create')
   const [intentsFilter, setIntentsFilter] = useState('')
 
   const deleteIntent = (intentName: string) => {
@@ -28,26 +33,15 @@ export const IntentSidePanelSection: FC<Props> = props => {
     }
   }
 
-  const createIntent = async () => {
-    const name = prompt('Enter the name of the new intent')
-
-    if (!name || !name.length) {
-      return
-    }
-
-    const sanitizedName = name
-      .toLowerCase()
-      .replace(/\s|\t|\n/g, '-')
-      .replace(/[^a-z0-9-_.]/g, '')
-
+  const onCreateIntent = async (name: string) => {
     const intentDef = {
-      name: sanitizedName,
+      name: name,
       utterances: { [props.contentLang]: [name] }
     }
 
     await props.api.createIntent(intentDef)
     await props.reloadIntents()
-    props.setCurrentItem({ name: sanitizedName, type: 'intent' })
+    props.setCurrentItem({ name: name, type: 'intent' })
   }
 
   const intentItems = props.intents
@@ -73,11 +67,21 @@ export const IntentSidePanelSection: FC<Props> = props => {
 
   return (
     <div>
-      <Button className={Classes.MINIMAL} icon="new-object" text="New intent" onClick={createIntent} />
+      <Button className={Classes.MINIMAL} icon="new-object" text="New intent" onClick={() => setModalOpen(true)} />
       <SearchBar icon="filter" placeholder="filter intents" onChange={setIntentsFilter} showButton={false} />
       <ItemList
         items={intentItems}
         onElementClicked={({ value: name }) => props.setCurrentItem({ type: 'intent', name })}
+      />
+      <IntentNameModal
+        action={intentAction}
+        originalName={intentName}
+        intentNames={props.intents.map(i => i.name)}
+        isOpen={modalOpen}
+        toggle={() => setModalOpen(!modalOpen)}
+        onCreateIntent={onCreateIntent}
+        onRenameIntent={() => {}}
+        onDuplicateIntent={() => {}}
       />
     </div>
   )

--- a/modules/nlu/src/views/full/intents/SidePanelSection.tsx
+++ b/modules/nlu/src/views/full/intents/SidePanelSection.tsx
@@ -92,7 +92,13 @@ export const IntentSidePanelSection: FC<Props> = props => {
 
   return (
     <div>
-      <Button className={Classes.MINIMAL} icon="new-object" text="New intent" onClick={createIntent} />
+      <Button
+        id="btn-add-intent"
+        className={Classes.MINIMAL}
+        icon="new-object"
+        text="New intent"
+        onClick={createIntent}
+      />
       <SearchBar icon="filter" placeholder="filter intents" onChange={setIntentsFilter} showButton={false} />
       <ItemList
         items={intentItems}

--- a/src/e2e/modules/nlu.test.ts
+++ b/src/e2e/modules/nlu.test.ts
@@ -14,9 +14,9 @@ describe('Module - NLU', () => {
   })
 
   it('Create new intent', async () => {
-    autoAnswerDialog('hello_there')
-    await clickOn('button', { text: 'New intent' })
-    await expectBotApiCallSuccess('mod/nlu/intents', 'POST')
+    await clickOn('#btn-add-intent')
+    await fillField('#input-intent-name', 'hello_there')
+    await Promise.all([expectBotApiCallSuccess('mod/nlu/intents', 'POST'), clickOn('#btn-submit')])
   })
 
   it('Create new entity', async () => {


### PR DESCRIPTION
This PR adds the functionality to NLU intents, where user can `add`, `rename` and `duplicate` the intents.

The feature is almost identical to the one in `flow` add/remove/duplicate.

Comments/questions:

1. Delete intent has been moved from item action to context menu
1. Utterances are copied as is from old to new intent, on `rename` and `duplicate`, should we change that?
1. In the context menu, the order is "rename/duplicate/delete", but in flow it is "rename/delete/duplicate", I am inclined to change the order of the flow, since "delete" should be the last one I guess
1. On creating the file the first time, there is no `filename` property, but this is added on retrieving the intent (through the method [_migrate_intentDef_11_12](https://github.com/botpress/botpress/blob/master/modules/nlu/src/backend/storage.ts#L171)), which is deprecated. I am a little confused, shouldn't this property saved on first creation? Currently it is copied as is on "rename/duplicate" from old to new intent.