### PR TITLE
fix(channel-web): group messages based on full_name

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
@@ -101,7 +101,7 @@ class MessageList extends React.Component<MessageListProps, State> {
     let currentGroup = undefined
 
     messages.forEach(m => {
-      const speaker = !!m.userId ? m.userId : 'bot'
+      const speaker = m.full_name
       const date = m.sent_on
 
       // Create a new group if messages are separated by more than X minutes or if different speaker


### PR DESCRIPTION
This is required to make it possible to emulate presence of another user in the chat - his message should be in a separate group.