### PR TITLE
fix(studio): rename only when flow name is changed

### DIFF
--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowNameModal.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowNameModal.tsx
@@ -84,7 +84,13 @@ const FlowNameModal: FC<Props> = props => {
 
         <div className={Classes.DIALOG_FOOTER}>
           <div className={Classes.DIALOG_FOOTER_ACTIONS}>
-            <Button type="submit" id="btn-submit" text="Submit" onClick={submit} disabled={!name || alreadyExists} />
+            <Button
+              type="submit"
+              id="btn-submit"
+              text="Submit"
+              onClick={submit}
+              disabled={!name || isIdentical || alreadyExists}
+            />
           </div>
         </div>
       </form>

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowsList.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/FlowsList.tsx
@@ -82,18 +82,18 @@ export default class FlowsList extends Component<Props, State> {
           onClick={() => this.props.renameFlow(node.nodeData.name)}
         />
         <MenuItem
-          id="btn-delete"
-          disabled={lockedFlows.includes(node.nodeData.name) || !this.props.canDelete || this.props.readOnly}
-          icon="delete"
-          text="Delete"
-          onClick={() => this.handleDelete(node.nodeData)}
-        />
-        <MenuItem
           id="btn-duplicate"
           disabled={this.props.readOnly}
           icon="duplicate"
           text="Duplicate"
           onClick={() => this.props.duplicateFlow(node.nodeData.name)}
+        />
+        <MenuItem
+          id="btn-delete"
+          disabled={lockedFlows.includes(node.nodeData.name) || !this.props.canDelete || this.props.readOnly}
+          icon="delete"
+          text="Delete"
+          onClick={() => this.handleDelete(node.nodeData)}
         />
       </Menu>,
       { left: e.clientX, top: e.clientY }


### PR DESCRIPTION
Currently, on renaming a flow, the submit button is enabled, even if the value didn't change.

This PR allows submission only when the name has changed, credit to `EFF` for detecting that during review of #2716.

Also, this PR changes the order of the context menu, so instead of "Rename/Delete/Duplicate", it makes sense to change it to "Rename/Duplicate/Delete", since delete is usually be the end of selections.