### PR TITLE
feat(studio): implement image preview

### DIFF
--- a/modules/builtin/src/content-types/image.js
+++ b/modules/builtin/src/content-types/image.js
@@ -1,5 +1,7 @@
 const base = require('./_base')
+const path = require('path')
 const url = require('url')
+const { tail } = _
 
 function render(data) {
   const events = []
@@ -162,7 +164,13 @@ module.exports = {
       return
     }
 
-    return `[![${formData.title}](${formData.image})](${formData.image})`
+    let fileName = path.basename(formData.image)
+    if (fileName.includes('-')) {
+      fileName = tail(fileName.split('-')).join('-')
+    }
+    const title = formData.title ? ' | ' + formData.title : ''
+
+    return `Image [![${formData.title || ''}](${formData.image})](${formData.image}) - (${fileName}) ${title}`
   },
 
   renderElement: renderElement

--- a/modules/builtin/src/content-types/image.js
+++ b/modules/builtin/src/content-types/image.js
@@ -1,7 +1,5 @@
 const base = require('./_base')
-const path = require('path')
 const url = require('url')
-const { tail } = _
 
 function render(data) {
   const events = []
@@ -164,13 +162,7 @@ module.exports = {
       return
     }
 
-    let fileName = path.basename(formData.image)
-    if (fileName.includes('-')) {
-      fileName = tail(fileName.split('-')).join('-')
-    }
-
-    const title = formData.title ? ' | ' + formData.title : ''
-    return `Image (${fileName}) ${title}`
+    return `[![${formData.title}](${formData.image})](${formData.image})`
   },
 
   renderElement: renderElement

--- a/src/bp/ui-studio/src/web/components/Layout/DocumentationModal.jsx
+++ b/src/bp/ui-studio/src/web/components/Layout/DocumentationModal.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import _ from 'lodash'
 import { Modal, Button } from 'react-bootstrap'
-import ReactMarkdown from 'react-markdown'
+import Markdown from 'react-markdown'
 import classnames from 'classnames'
 
 import { updateDocumentationModal } from '~/actions'
@@ -25,7 +25,7 @@ class DocumentationModal extends React.Component {
     const transformImg = url => 'assets/ui-studio/public/external/docs/' + url.replace(/^assets\//i, '')
 
     return (
-      <ReactMarkdown
+      <Markdown
         source={this.removeFileHeader(src)}
         linkTarget="_blank"
         disallowedTypes={['link', 'linkReference']}

--- a/src/bp/ui-studio/src/web/views/Content/List.tsx
+++ b/src/bp/ui-studio/src/web/views/Content/List.tsx
@@ -3,14 +3,14 @@ import classnames from 'classnames'
 import _ from 'lodash'
 import moment from 'moment'
 import React, { Component } from 'react'
+import Markdown from 'react-markdown'
 import ReactTable from 'react-table'
 import 'react-table/react-table.css'
-import { LeftToolbarButtons, RightToolbarButtons, Toolbar } from '~/components/Shared/Interface'
+import { LeftToolbarButtons, Toolbar } from '~/components/Shared/Interface'
 import { Downloader } from '~/components/Shared/Utils'
 import withLanguage from '~/components/Util/withLanguage'
 
 import style from './style.scss'
-import { ImportModal } from './ImportModal'
 
 class ListView extends Component<Props, State> {
   private debouncedHandleSearch
@@ -213,7 +213,19 @@ class ListView extends Component<Props, State> {
           const className = classnames({ [style.missingTranslation]: preview.startsWith('(missing translation) ') })
           return (
             <React.Fragment>
-              <span className={className}>{preview}</span>
+              <span className={className}>
+                <Markdown
+                  source={preview}
+                  renderers={{
+                    image: props => <img {...props} className={style.imagePreview} />,
+                    link: props => (
+                      <a href={props.href} target="_blank">
+                        {props.children}
+                      </a>
+                    )
+                  }}
+                />
+              </span>
             </React.Fragment>
           )
         }

--- a/src/bp/ui-studio/src/web/views/Content/style.scss
+++ b/src/bp/ui-studio/src/web/views/Content/style.scss
@@ -28,3 +28,7 @@
     }
   }
 }
+
+.imagePreview {
+  height: 16px;
+}

--- a/src/bp/ui-studio/src/web/views/Content/style.scss.d.ts
+++ b/src/bp/ui-studio/src/web/views/Content/style.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'cancel': string;
   'content': string;
+  'imagePreview': string;
   'missingTranslation': string;
   'modal': string;
 }

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/common/action.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/common/action.tsx
@@ -3,6 +3,7 @@ import _ from 'lodash'
 import Mustache from 'mustache'
 import React, { Component } from 'react'
 import { OverlayTrigger, Popover } from 'react-bootstrap'
+import Markdown from 'react-markdown'
 import { connect } from 'react-redux'
 import { fetchContentItem, refreshFlowsLinks } from '~/actions'
 
@@ -87,6 +88,49 @@ class ActionItem extends Component<Props> {
     const item = this.props.items[this.state.itemId]
 
     const preview = item && item.previews && item.previews[this.props.contentLang]
+    const className = classnames(style.name, {
+      [style.missingTranslation]: preview && preview.startsWith('(missing translation) ')
+    })
+
+    if (preview && item && item.schema && item.schema.title === 'Image') {
+      if (this.props.layoutv2) {
+        return (
+          <div className={classnames(this.props.className, style['action-item'])}>
+            <Markdown
+              source={preview}
+              renderers={{
+                image: props => <img {...props} className={style.imagePreview} />,
+                link: props => (
+                  <a href={props.href} target="_blank">
+                    {props.children}
+                  </a>
+                )
+              }}
+            />
+            {this.props.children}
+          </div>
+        )
+      }
+
+      return (
+        <div className={classnames(this.props.className, style['action-item'], style.msg)}>
+          <span className={style.icon}>💬</span>
+          <Markdown
+            source={preview}
+            renderers={{
+              image: props => <img {...props} className={style.imagePreview} />,
+              link: props => (
+                <a href={props.href} target="_blank">
+                  {props.children}
+                </a>
+              )
+            }}
+          />
+          {this.props.children}
+        </div>
+      )
+    }
+
     const textContent = (item && `${item.schema && item.schema.title} | ${preview}`) || ''
     const vars = {}
 
@@ -97,10 +141,6 @@ class ActionItem extends Component<Props> {
       const name = stripDots(x.replace(/{|}/g, ''))
       vars[name] = '<span class="var">' + x + '</span>'
       return '{' + stripDots(x) + '}'
-    })
-
-    const className = classnames(style.name, {
-      [style.missingTranslation]: preview && preview.startsWith('(missing translation) ')
     })
 
     const mustached = restoreDots(Mustache.render(htmlTpl, vars))

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/common/style.scss
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/common/style.scss
@@ -69,3 +69,7 @@
     border: 1px solid #2d74f3;
   }
 }
+
+.imagePreview {
+  width: 160px;
+}

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/common/style.scss.d.ts
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/common/style.scss.d.ts
@@ -7,6 +7,7 @@ interface CssExports {
   'editableInput': string;
   'fn': string;
   'icon': string;
+  'imagePreview': string;
   'missingTranslation': string;
   'msg': string;
   'name': string;

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/ActionModalForm.jsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/ActionModalForm.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import { Modal, Button, Radio, OverlayTrigger, Tooltip } from 'react-bootstrap'
 import Markdown from 'react-markdown'
-import axios from 'axios'
 import _ from 'lodash'
 
 import { LinkDocumentationProvider } from '~/components/Util/DocumentationProvider'


### PR DESCRIPTION
This PR allows the image preview to be viewed as an image, not as text.

- The returned value of `computePreviewText()` is rendered as Markdown, not simple text
- The preview image is clickable, and links to `_blank` target
- This is done in "Content" and "Flows" tabs