### PR TITLE
feat(studio): add Content Usage count in CMS

### DIFF
--- a/modules/qna/src/backend/api.ts
+++ b/modules/qna/src/backend/api.ts
@@ -99,6 +99,15 @@ export default async (bp: typeof sdk, botScopedStorage: Map<string, Storage>) =>
     res.end(data)
   })
 
+  router.get('/contentElementUsage', async (req, res) => {
+    const storage = botScopedStorage.get(req.params.botId)
+    const usage = await storage.getContentElementUsage()
+    const data = JSON.stringify(usage)
+
+    res.setHeader('Content-Type', 'application/json')
+    res.end(data)
+  })
+
   const upload = multer()
   router.post('/analyzeImport', upload.single('file'), async (req, res) => {
     const storage = botScopedStorage.get(req.params.botId)

--- a/modules/qna/src/backend/api.ts
+++ b/modules/qna/src/backend/api.ts
@@ -1,4 +1,5 @@
 import * as sdk from 'botpress/sdk'
+import { Request, Response } from 'express'
 import { validate } from 'joi'
 import _ from 'lodash'
 import moment from 'moment'
@@ -14,7 +15,7 @@ export default async (bp: typeof sdk, botScopedStorage: Map<string, Storage>) =>
   const jsonUploadStatuses = {}
   const router = bp.http.createRouterForBot('qna')
 
-  router.get('/questions', async (req, res) => {
+  router.get('/questions', async (req: Request, res: Response) => {
     try {
       const {
         query: { question = '', categories = [], limit, offset }
@@ -29,7 +30,7 @@ export default async (bp: typeof sdk, botScopedStorage: Map<string, Storage>) =>
     }
   })
 
-  router.post('/questions', async (req, res, next) => {
+  router.post('/questions', async (req: Request, res: Response, next: Function) => {
     try {
       const qnaEntry = (await validate(req.body, QnaDefSchema)) as QnaEntry
       const storage = botScopedStorage.get(req.params.botId)
@@ -40,7 +41,7 @@ export default async (bp: typeof sdk, botScopedStorage: Map<string, Storage>) =>
     }
   })
 
-  router.get('/questions/:id', async (req, res) => {
+  router.get('/questions/:id', async (req: Request, res: Response) => {
     try {
       const storage = botScopedStorage.get(req.params.botId)
       const question = await storage.getQnaItem(req.params.id)
@@ -50,7 +51,7 @@ export default async (bp: typeof sdk, botScopedStorage: Map<string, Storage>) =>
     }
   })
 
-  router.post('/questions/:id', async (req, res, next) => {
+  router.post('/questions/:id', async (req: Request, res: Response, next: Function) => {
     const {
       query: { limit, offset, question, categories }
     } = req
@@ -67,7 +68,7 @@ export default async (bp: typeof sdk, botScopedStorage: Map<string, Storage>) =>
     }
   })
 
-  router.post('/questions/:id/delete', async (req, res) => {
+  router.post('/questions/:id/delete', async (req: Request, res: Response) => {
     const {
       query: { limit, offset, question, categories }
     } = req
@@ -78,19 +79,19 @@ export default async (bp: typeof sdk, botScopedStorage: Map<string, Storage>) =>
       const questionsData = await storage.getQuestions({ question, categories }, { limit, offset })
       res.send(questionsData)
     } catch (e) {
-      bp.logger.attachError(e).error('Could not delete QnA #' + req.params.id)
+      bp.logger.attachError(e).error(`Could not delete QnA #${req.params.id}`)
       res.status(500).send(e.message || 'Error')
       sendToastError('Delete', e.message)
     }
   })
 
-  router.get('/categories', async (req, res) => {
+  router.get('/categories', async (req: Request, res: Response) => {
     const storage = botScopedStorage.get(req.params.botId)
     const categories = await storage.getCategories()
     res.send({ categories })
   })
 
-  router.get('/export', async (req, res) => {
+  router.get('/export', async (req: Request, res: Response) => {
     const storage = botScopedStorage.get(req.params.botId)
     const data: string = await prepareExport(storage, bp)
 
@@ -99,17 +100,14 @@ export default async (bp: typeof sdk, botScopedStorage: Map<string, Storage>) =>
     res.end(data)
   })
 
-  router.get('/contentElementUsage', async (req, res) => {
+  router.get('/contentElementUsage', async (req: Request, res: Response) => {
     const storage = botScopedStorage.get(req.params.botId)
     const usage = await storage.getContentElementUsage()
-    const data = JSON.stringify(usage)
-
-    res.setHeader('Content-Type', 'application/json')
-    res.end(data)
+    res.send(usage)
   })
 
   const upload = multer()
-  router.post('/analyzeImport', upload.single('file'), async (req, res) => {
+  router.post('/analyzeImport', upload.single('file'), async (req: any, res: Response) => {
     const storage = botScopedStorage.get(req.params.botId)
     const cmsIds = await storage.getAllContentElementIds()
     const importData = await prepareImport(JSON.parse(req.file.buffer))
@@ -122,7 +120,7 @@ export default async (bp: typeof sdk, botScopedStorage: Map<string, Storage>) =>
     })
   })
 
-  router.post('/import', upload.single('file'), async (req, res) => {
+  router.post('/import', upload.single('file'), async (req: any, res: Response) => {
     const uploadStatusId = nanoid()
     res.send(uploadStatusId)
 
@@ -147,20 +145,19 @@ export default async (bp: typeof sdk, botScopedStorage: Map<string, Storage>) =>
     }
   })
 
-  router.get('/json-upload-status/:uploadStatusId', async (req, res) => {
+  router.get('/json-upload-status/:uploadStatusId', async (req: Request, res: Response) => {
     res.end(jsonUploadStatuses[req.params.uploadStatusId])
   })
 
-  const sendToastError = (action, error) => {
+  const sendToastError = (action: string, error: string) => {
     bp.realtime.sendPayload(
       bp.RealTimePayload.forAdmins('toast.qna-save', { text: `QnA ${action} Error: ${error}`, type: 'error' })
     )
   }
 
-  const updateUploadStatus = (uploadStatusId, status) => {
-    if (!uploadStatusId) {
-      return
+  const updateUploadStatus = (uploadStatusId: string, status: string) => {
+    if (uploadStatusId) {
+      jsonUploadStatuses[uploadStatusId] = status
     }
-    jsonUploadStatuses[uploadStatusId] = status
   }
 }

--- a/modules/qna/src/backend/storage.ts
+++ b/modules/qna/src/backend/storage.ts
@@ -23,7 +23,7 @@ const makeID = (qna: QnaEntry) => {
     .replace(/_+$/, '')}`
 }
 
-const normalizeQuestions = questions =>
+const normalizeQuestions = (questions: string[]) =>
   questions
     .map(q =>
       q
@@ -102,10 +102,10 @@ export default class Storage {
     const { data: allIntents } = await axios.get(`/mod/nlu/intents`, axiosConfig)
 
     const leftOverQnaIntents = allIntents.filter(
-      intent =>
+      (intent: sdk.NLU.IntentDefinition) =>
         intent.name.startsWith('__qna__') && !_.find(allQuestions, q => getIntentId(q.id).toLowerCase() === intent.name)
     )
-    await Promise.map(leftOverQnaIntents, intent =>
+    await Promise.map(leftOverQnaIntents, (intent: sdk.NLU.IntentDefinition) =>
       axios.post(`/mod/nlu/intents/${intent.name}/delete`, {}, axiosConfig)
     )
 
@@ -280,21 +280,23 @@ export default class Storage {
   async getContentElementUsage(): Promise<any> {
     const qnas = await this.fetchQNAs()
 
-    const obj = {}
-    _.forEach(qnas, qna => {
-      const qnaName = qna.id.substr(qna.id.indexOf('_') + 1)
-      const answers = _.flatMap(Object.values(qna.data.answers))
+    return _.reduce(
+      qnas,
+      (result, qna) => {
+        const answers = _.flatMap(Object.values(qna.data.answers))
 
-      _.forEach(_.filter(answers, x => x.startsWith('#!')), answer => {
-        const values = obj[answer]
-        if (values) {
-          values.count++
-        } else {
-          obj[answer] = { qna: qnaName, count: 1 }
-        }
-      })
-    })
-    return obj
+        _.filter(answers, x => x.startsWith('#!')).forEach(answer => {
+          const values = result[answer]
+          if (values) {
+            values.count++
+          } else {
+            result[answer] = { qna: qna.id.substr(qna.id.indexOf('_') + 1), count: 1 }
+          }
+        })
+        return result
+      },
+      {}
+    )
   }
 
   async count() {
@@ -305,11 +307,11 @@ export default class Storage {
   // TODO remove batch deleter, it's done one by one anyway
   async delete(qnaId) {
     const ids = _.isArray(qnaId) ? qnaId : [qnaId]
-    if (ids.length === 0) {
+    if (!ids.length) {
       return
     }
 
-    const deletePromise = async (id): Promise<void> => {
+    const deletePromise = async (id: string): Promise<void> => {
       await this.deleteMatchingIntent(id)
       return this.bp.ghost.forBot(this.botId).deleteFile(this.config.qnaDir, `${id}.json`)
     }

--- a/modules/qna/src/backend/storage.ts
+++ b/modules/qna/src/backend/storage.ts
@@ -273,8 +273,28 @@ export default class Storage {
 
   async getAllContentElementIds(list?: QnaItem[]): Promise<string[]> {
     const qnas = list || (await this.fetchQNAs())
-    const allAnswers = _.flatMapDeep(qnas, qna => Object.keys(qna.data.answers).map(lang => qna.data.answers[lang]))
+    const allAnswers = _.flatMapDeep(qnas, qna => Object.values(qna.data.answers))
     return _.uniq(_.filter(allAnswers as string[], x => _.isString(x) && x.startsWith('#!')))
+  }
+
+  async getContentElementUsage(): Promise<any> {
+    const qnas = await this.fetchQNAs()
+
+    const obj = {}
+    _.forEach(qnas, qna => {
+      const qnaName = qna.id.substr(qna.id.indexOf('_') + 1)
+      const answers = _.flatMap(Object.values(qna.data.answers))
+
+      _.forEach(_.filter(answers, x => x.startsWith('#!')), answer => {
+        const values = obj[answer]
+        if (values) {
+          values.count++
+        } else {
+          obj[answer] = { qna: qnaName, count: 1 }
+        }
+      })
+    })
+    return obj
   }
 
   async count() {

--- a/src/bp/ui-studio/src/web/actions/index.ts
+++ b/src/bp/ui-studio/src/web/actions/index.ts
@@ -387,3 +387,7 @@ export const refreshIntents = () => dispatch => {
     dispatch(intentsReceived(data))
   })
 }
+
+export const getQnAContentElementUsage = () => {
+  return axios.get(`${window.BOT_API_PATH}/mod/qna/contentElementUsage`)
+}

--- a/src/bp/ui-studio/src/web/actions/index.ts
+++ b/src/bp/ui-studio/src/web/actions/index.ts
@@ -388,6 +388,10 @@ export const refreshIntents = () => dispatch => {
   })
 }
 
-export const getQnAContentElementUsage = () => {
-  return axios.get(`${window.BOT_API_PATH}/mod/qna/contentElementUsage`)
+export const receiveQNAContentElement = createAction('QNA/CONTENT_ELEMENT')
+export const getQNAContentElementUsage = () => dispatch => {
+  // tslint:disable-next-line: no-floating-promises
+  axios.get(`${window.BOT_API_PATH}/mod/qna/contentElementUsage`).then(({ data }) => {
+    dispatch(receiveQNAContentElement(data))
+  })
 }

--- a/src/bp/ui-studio/src/web/reducers/content.ts
+++ b/src/bp/ui-studio/src/web/reducers/content.ts
@@ -1,6 +1,12 @@
 import _ from 'lodash'
 import { handleActions } from 'redux-actions'
-import { receiveContentCategories, receiveContentItem, receiveContentItems, receiveContentItemsCount } from '~/actions'
+import {
+  receiveContentCategories,
+  receiveContentItem,
+  receiveContentItems,
+  receiveContentItemsCount,
+  receiveQNAContentElement
+} from '~/actions'
 
 const defaultState = {
   categories: null,
@@ -32,6 +38,11 @@ export default handleActions(
     [receiveContentItemsCount]: (state, { payload }) => ({
       ...state,
       itemsCount: payload.data.count
+    }),
+
+    [receiveQNAContentElement]: (state, { payload }) => ({
+      ...state,
+      qnaUsage: payload
     })
   },
   defaultState
@@ -40,4 +51,5 @@ export default handleActions(
 export interface ContentReducer {
   categories: any
   currentItems: any
+  qnaUsage: any
 }

--- a/src/bp/ui-studio/src/web/reducers/skills.ts
+++ b/src/bp/ui-studio/src/web/reducers/skills.ts
@@ -7,8 +7,7 @@ import {
   intentsReceived,
   requestInsertNewSkill,
   requestUpdateSkill,
-  skillsReceived,
-  updateSkill
+  skillsReceived
 } from '~/actions'
 
 const defaultState = {

--- a/src/bp/ui-studio/src/web/views/Content/List.tsx
+++ b/src/bp/ui-studio/src/web/views/Content/List.tsx
@@ -132,7 +132,7 @@ class ListView extends Component<Props, State> {
     })
 
     if (sortOrder[0].column == 'usage') {
-      // we save the sorting locally, and we don't ask the database for sorting
+      // we save the sorting locally, because the database doesn't have the 'usage' column
       this.state.sortOrderUsage = sortOrder[0].desc ? 'desc' : 'asc'
       sortOrder = []
     } else {
@@ -169,7 +169,7 @@ class ListView extends Component<Props, State> {
       onClick: (e, handleOriginal) => {
         if (rowInfo) {
           if (column.id === 'usage') {
-            if (rowInfo.original.usage.length > 0) {
+            if (rowInfo.original.usage.length) {
               this.setState({ showUsageModal: true, contentUsage: rowInfo.original.usage })
             }
           } else if (column.id !== 'checkbox' && !this.props.readOnly) {

--- a/src/bp/ui-studio/src/web/views/Content/List.tsx
+++ b/src/bp/ui-studio/src/web/views/Content/List.tsx
@@ -12,7 +12,7 @@ import withLanguage from '~/components/Util/withLanguage'
 
 import { ContentUsage } from '.'
 import style from './style.scss'
-import UsageModal from './UsageModal'
+import { UsageModal } from './UsageModal'
 
 class ListView extends Component<Props, State> {
   private debouncedHandleSearch
@@ -387,9 +387,11 @@ class ListView extends Component<Props, State> {
           </RightToolbarButtons> */}
         </Toolbar>
         <div style={{ padding: 5 }}>{this.renderTable()}</div>
-        {this.state.showUsageModal && (
-          <UsageModal usage={this.state.contentUsage} handleClose={() => this.setState({ showUsageModal: false })} />
-        )}
+        <UsageModal
+          usage={this.state.contentUsage}
+          handleClose={() => this.setState({ showUsageModal: false })}
+          isOpen={this.state.showUsageModal}
+        />
       </div>
     )
   }

--- a/src/bp/ui-studio/src/web/views/Content/List.tsx
+++ b/src/bp/ui-studio/src/web/views/Content/List.tsx
@@ -10,6 +10,7 @@ import { LeftToolbarButtons, Toolbar } from '~/components/Shared/Interface'
 import { Downloader } from '~/components/Shared/Utils'
 import withLanguage from '~/components/Util/withLanguage'
 
+import { ContentUsage } from '.'
 import style from './style.scss'
 
 class ListView extends Component<Props, State> {
@@ -247,6 +248,12 @@ class ListView extends Component<Props, State> {
         Header: 'Created On',
         Cell: x => (x.original.createdOn ? moment(x.original.createdOn).format('MMM Do YYYY, h:mm') : 'Never'),
         accessor: 'createdOn',
+        filterable: false,
+        width: 150
+      },
+      {
+        Header: 'Used',
+        Cell: x => x.original.usage.reduce((acc: number, v: ContentUsage) => (acc += v.count), 0),
         filterable: false,
         width: 150
       },

--- a/src/bp/ui-studio/src/web/views/Content/UsageModal.tsx
+++ b/src/bp/ui-studio/src/web/views/Content/UsageModal.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
-import { Modal } from 'react-bootstrap'
+import { Classes, Dialog } from '@blueprintjs/core'
+import React, { FC, useState } from 'react'
 import ReactTable from 'react-table'
 
 import { ContentUsage } from '.'
@@ -7,83 +7,69 @@ import style from './style.scss'
 
 interface Props {
   usage: ContentUsage[]
-  handleClose: Function
+  isOpen: boolean
+  handleClose: () => void
 }
 
-interface State {
-  page: number
-  pageSize: number
-}
+export const UsageModal: FC<Props> = props => {
+  const [getPage, setPage] = useState(0)
+  const [getPageSize, setPageSize] = useState(5)
 
-export default class UsageModal extends React.Component<Props, State> {
-  state = {
-    page: 0,
-    pageSize: 5
+  const columns = [
+    {
+      Header: 'Type',
+      filterable: false,
+      accessor: 'type'
+    },
+    {
+      Header: 'Name',
+      filterable: false,
+      accessor: 'name'
+    },
+    {
+      Header: 'Node',
+      filterable: false,
+      accessor: 'node'
+    },
+    {
+      Header: 'Count',
+      filterable: false,
+      accessor: 'count'
+    }
+  ]
+
+  const onFetchData = ({ page, pageSize }) => {
+    setPage(page)
+    setPageSize(pageSize)
   }
 
-  getTableColumns() {
-    return [
-      {
-        Header: 'Type',
-        filterable: false,
-        accessor: 'type',
-        width: 150
-      },
-      {
-        Header: 'Name',
-        filterable: false,
-        accessor: 'name',
-        width: 150
-      },
-      {
-        Header: 'Node',
-        filterable: false,
-        accessor: 'node',
-        width: 150
-      },
-      {
-        Header: 'Count',
-        filterable: false,
-        accessor: 'count',
-        width: 50
-      }
-    ]
+  const onPageSizeChange = (pageSize: number, page: number) => {
+    setPage(page)
+    setPageSize(pageSize)
   }
 
-  fetchData = (state: State) => {
-    this.setState({
-      pageSize: state.pageSize,
-      page: state.page
-    })
-  }
-
-  render() {
-    const pageCount = Math.ceil(this.props.usage.length / this.state.pageSize)
-    return (
-      <Modal
-        container={document.getElementById('app')}
-        className={style.modal}
-        onHide={this.props.handleClose}
-        backdrop={'static'}
-        show
-      >
-        <Modal.Header closeButton>
-          <Modal.Title>Content Usage</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <ReactTable
-            columns={this.getTableColumns()}
-            data={this.props.usage}
-            page={this.state.page}
-            onFetchData={this.fetchData}
-            onPageSizeChange={(pageSize, page) => this.setState({ page, pageSize })}
-            onPageChange={page => this.setState({ page })}
-            defaultPageSize={this.state.pageSize}
-            className="-striped -highlight"
-            pages={pageCount}
-          />
-        </Modal.Body>
-      </Modal>
-    )
-  }
+  const pageCount = Math.ceil(props.usage.length / getPageSize)
+  return (
+    <Dialog
+      title="Content Usage"
+      isOpen={props.isOpen}
+      className={style.modal}
+      onClose={props.handleClose}
+      canOutsideClickClose
+    >
+      <div className={Classes.DIALOG_BODY}>
+        <ReactTable
+          columns={columns}
+          data={props.usage}
+          page={getPage}
+          onFetchData={onFetchData}
+          onPageSizeChange={onPageSizeChange}
+          onPageChange={setPage}
+          defaultPageSize={getPageSize}
+          className="-striped -highlight"
+          pages={pageCount}
+        />
+      </div>
+    </Dialog>
+  )
 }

--- a/src/bp/ui-studio/src/web/views/Content/UsageModal.tsx
+++ b/src/bp/ui-studio/src/web/views/Content/UsageModal.tsx
@@ -24,15 +24,21 @@ export default class UsageModal extends React.Component<Props, State> {
   getTableColumns() {
     return [
       {
-        Header: 'Flow',
+        Header: 'Type',
         filterable: false,
-        accessor: 'flowName',
+        accessor: 'type',
+        width: 150
+      },
+      {
+        Header: 'Name',
+        filterable: false,
+        accessor: 'name',
         width: 150
       },
       {
         Header: 'Node',
         filterable: false,
-        accessor: 'nodeName',
+        accessor: 'node',
         width: 150
       },
       {

--- a/src/bp/ui-studio/src/web/views/Content/UsageModal.tsx
+++ b/src/bp/ui-studio/src/web/views/Content/UsageModal.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react'
+import { Modal } from 'react-bootstrap'
+import ReactTable from 'react-table'
+
+import { ContentUsage } from '.'
+import style from './style.scss'
+
+interface Props {
+  usage: ContentUsage[]
+  handleClose: Function
+}
+
+interface State {
+  page: number
+  pageSize: number
+}
+
+export default class UsageModal extends React.Component<Props, State> {
+  state = {
+    page: 0,
+    pageSize: 5
+  }
+
+  getTableColumns() {
+    return [
+      {
+        Header: 'Flow',
+        filterable: false,
+        accessor: 'flowName',
+        width: 150
+      },
+      {
+        Header: 'Node',
+        filterable: false,
+        accessor: 'nodeName',
+        width: 150
+      },
+      {
+        Header: 'Count',
+        filterable: false,
+        accessor: 'count',
+        width: 50
+      }
+    ]
+  }
+
+  fetchData = (state: State) => {
+    this.setState({
+      pageSize: state.pageSize,
+      page: state.page
+    })
+  }
+
+  render() {
+    const pageCount = Math.ceil(this.props.usage.length / this.state.pageSize)
+    return (
+      <Modal
+        container={document.getElementById('app')}
+        className={style.modal}
+        onHide={this.props.handleClose}
+        backdrop={'static'}
+        show
+      >
+        <Modal.Header closeButton>
+          <Modal.Title>Content Usage</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <ReactTable
+            columns={this.getTableColumns()}
+            data={this.props.usage}
+            page={this.state.page}
+            onFetchData={this.fetchData}
+            onPageSizeChange={(pageSize, page) => this.setState({ page, pageSize })}
+            onPageChange={page => this.setState({ page })}
+            defaultPageSize={this.state.pageSize}
+            className="-striped -highlight"
+            pages={pageCount}
+          />
+        </Modal.Body>
+      </Modal>
+    )
+  }
+}

--- a/src/bp/ui-studio/src/web/views/Content/index.tsx
+++ b/src/bp/ui-studio/src/web/views/Content/index.tsx
@@ -72,6 +72,9 @@ class ContentView extends Component<Props, State> {
       element.usage = []
       Object.values(this.props.flows.flowsByName).forEach((flow: FlowView) => {
         const name = flow.name
+          .replace('.flow.json', '')
+          .replace(/^main$/, 'Main')
+          .replace(/^error$/, 'Error handling')
         flow.nodes.forEach((node: NodeView) => {
           const usage: ContentUsage = {
             flowName: name,

--- a/src/bp/ui-studio/src/web/views/Content/index.tsx
+++ b/src/bp/ui-studio/src/web/views/Content/index.tsx
@@ -16,6 +16,7 @@ import {
 } from '~/actions'
 import CreateOrEditModal from '~/components/Content/CreateOrEditModal'
 import { Container } from '~/components/Shared/Interface'
+import { getFlowLabel } from '~/components/Shared/Utils'
 import { isOperationAllowed } from '~/components/Shared/Utils/AccessControl'
 import DocumentationProvider from '~/components/Util/DocumentationProvider'
 import { RootReducer } from '~/reducers'
@@ -81,10 +82,7 @@ class ContentView extends Component<Props, State> {
     this.props.contentItems.forEach(async (element: ContentElementUsage) => {
       element.usage = []
       Object.values(this.props.flows.flowsByName).forEach((flow: FlowView) => {
-        const name = flow.name
-          .replace('.flow.json', '')
-          .replace(/^main$/, 'Main')
-          .replace(/^error$/, 'Error handling')
+        const name = getFlowLabel(flow.name)
         flow.nodes.forEach((node: NodeView) => {
           const usage: ContentUsage = {
             type: 'Flow',

--- a/src/bp/ui-studio/src/web/views/Content/index.tsx
+++ b/src/bp/ui-studio/src/web/views/Content/index.tsx
@@ -1,16 +1,19 @@
 import Promise from 'bluebird'
+import { ActionBuilderProps, ContentElement } from 'botpress/sdk'
 import classnames from 'classnames'
+import { FlowView, NodeView } from 'common/typings'
 import _ from 'lodash'
 import React, { Component } from 'react'
 import { Alert } from 'react-bootstrap'
 import { connect } from 'react-redux'
 import { RouteComponentProps } from 'react-router'
-import { deleteContentItems, fetchContentCategories, fetchContentItems, upsertContentItem } from '~/actions'
+import { deleteContentItems, fetchContentCategories, fetchContentItems, fetchFlows, upsertContentItem } from '~/actions'
 import CreateOrEditModal from '~/components/Content/CreateOrEditModal'
 import { Container } from '~/components/Shared/Interface'
 import { isOperationAllowed } from '~/components/Shared/Utils/AccessControl'
 import DocumentationProvider from '~/components/Util/DocumentationProvider'
 import { RootReducer } from '~/reducers'
+import { FlowReducer } from '~/reducers/flows'
 import { UserReducer } from '~/reducers/user'
 
 import style from './style.scss'
@@ -41,6 +44,7 @@ class ContentView extends Component<Props, State> {
 
     if (this.canRead) {
       this.props.fetchContentCategories()
+      this.props.fetchFlows()
       this.fetchCategoryItems(this.state.selectedId)
     }
   }
@@ -53,7 +57,7 @@ class ContentView extends Component<Props, State> {
     this.init()
   }
 
-  fetchCategoryItems(id) {
+  fetchCategoryItems(id: string) {
     if (!this.canRead) {
       return Promise.resolve()
     }
@@ -64,6 +68,37 @@ class ContentView extends Component<Props, State> {
   }
 
   currentContentType() {
+    this.props.contentItems.forEach((element: ContentElementUsage) => {
+      element.usage = []
+      Object.values(this.props.flows.flowsByName).forEach((flow: FlowView) => {
+        const name = flow.name
+        flow.nodes.forEach((node: NodeView) => {
+          const usage: ContentUsage = {
+            flowName: name,
+            nodeName: node.name,
+            count: 0
+          }
+          node.onEnter &&
+            node.onEnter.forEach((v: string | ActionBuilderProps) => {
+              if (typeof v === 'string' && v.startsWith('say #!' + element.id)) {
+                if (usage.count == 0) {
+                  element.usage.push(usage)
+                }
+                usage.count++
+              }
+            })
+          node.onReceive &&
+            node.onReceive.forEach((v: string | ActionBuilderProps) => {
+              if (typeof v === 'string' && v.startsWith('say #!' + element.id)) {
+                if (usage.count == 0) {
+                  element.usage.push(usage)
+                }
+                usage.count++
+              }
+            })
+        })
+      })
+    })
     return this.state.modifyId
       ? _.get(_.find(this.props.contentItems, { id: this.state.modifyId }), 'contentType')
       : this.state.selectedId
@@ -106,7 +141,7 @@ class ContentView extends Component<Props, State> {
     this.setState({ contentToEdit: data })
   }
 
-  handleCategorySelected = id => {
+  handleCategorySelected = (id: string) => {
     this.fetchCategoryItems(id)
     this.setState({ selectedId: id })
   }
@@ -115,7 +150,7 @@ class ContentView extends Component<Props, State> {
     this.props.deleteContentItems(ids).then(() => this.fetchCategoryItems(this.state.selectedId))
   }
 
-  handleModalShowForEdit = id => {
+  handleModalShowForEdit = (id: string) => {
     const contentToEdit = _.find(this.props.contentItems, { id }).formData
     this.setState({ modifyId: id, showModal: true, contentToEdit })
   }
@@ -195,12 +230,14 @@ class ContentView extends Component<Props, State> {
 const mapStateToProps = (state: RootReducer) => ({
   categories: state.content.categories,
   contentItems: state.content.currentItems,
+  flows: state.flows,
   user: state.user
 })
 
 const mapDispatchToProps = {
   fetchContentCategories,
   fetchContentItems,
+  fetchFlows,
   upsertContentItem,
   deleteContentItems
 }
@@ -213,10 +250,12 @@ export default connect(
 type Props = {
   fetchContentCategories: Function
   fetchContentItems: Function
+  fetchFlows: Function
   upsertContentItem: Function
   deleteContentItems: Function
   categories: any
-  contentItems: any
+  contentItems: ContentElementUsage[]
+  flows: FlowReducer
   user: UserReducer
 } & RouteComponentProps
 
@@ -226,4 +265,14 @@ interface State {
   contentToEdit: object
   modifyId: string
   selectedId: string
+}
+
+type ContentElementUsage = {
+  usage: ContentUsage[]
+} & ContentElement
+
+export interface ContentUsage {
+  flowName: string
+  nodeName: string
+  count: number
 }


### PR DESCRIPTION
Fixes botpress/v12#756

- The PR adds a counter to CMS about how many times the content is used.
- When the count is clicked, a dialog is shown containing all flows/reference nodes

There is a minor issue, that should be resolved:
- [ ] Width of column header is not aligned with cells