### PR TITLE
fix(builtin): handle markdown property

### DIFF
--- a/modules/builtin/src/migrations/v12_5_0-1577776334-text-markdown.ts
+++ b/modules/builtin/src/migrations/v12_5_0-1577776334-text-markdown.ts
@@ -1,0 +1,43 @@
+import * as sdk from 'botpress/sdk'
+
+const migration: sdk.ModuleMigration = {
+  info: {
+    description: 'Setting Markdown property to true for text content type',
+    target: 'bot',
+    type: 'content'
+  },
+  up: async ({ bp, metadata }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
+    const migrateBotTextContent = async (botId: string) => {
+      const elementsDir = 'content-elements'
+
+      const bpfs = bp.ghost.forBot(botId)
+      const entFiles = await bpfs.directoryListing(elementsDir, '*.json')
+      for (const fileName of entFiles) {
+        const fileContentElements = await bpfs.readFileAsObject<sdk.ContentElement[]>(elementsDir, fileName)
+        for (const element of fileContentElements) {
+          const formData = element.formData
+          for (const key of Object.keys(formData)) {
+            if (key.startsWith('typing$')) {
+              const language = key.substr(key.indexOf('$') + 1, key.length)
+              const markdownKey = 'markdown$' + language
+              if (!(markdownKey in formData)) {
+                formData[markdownKey] = true
+              }
+            }
+          }
+        }
+        await bpfs.upsertFile(elementsDir, fileName, JSON.stringify(fileContentElements, undefined, 2))
+      }
+    }
+    if (metadata.botId) {
+      await migrateBotTextContent(metadata.botId)
+    } else {
+      const bots = await bp.bots.getAllBots()
+      await Promise.map(bots.keys(), botId => migrateBotTextContent(botId))
+    }
+
+    return { success: true, message: 'Text content type updated successfully' }
+  }
+}
+
+export default migration


### PR DESCRIPTION
As hinted in [Forum](https://help.botpress.io/t/markdown-not-working-under-linux-12-2-for-me/2795), on migrating bots created prior to `12.2.0`, the markdown flag is not set to true (even if it is shown in DM).

Test case:

1. With `12.1.3`, create a bot with a single node which says a text of `Hello *my name* is Linda!`
2. Run the emulator, giving any input, the result is rendered as Markdown
3. Export this bot
4. Import this bot with `master` branch
5. Run the emulator, giving any input
 a. Expected Result: rendered as Markdown
 b. Actual Result: exact type with `*`

Workaround:
- Remove the markdown flag from the node, save, then add the markdown and save.

<hr/>
This PR handles this issue as part of migration.
<br/>
<br/>  
I initially made the version of the migration file "12.2.0", since this is actually the version where this bug was introduced, but I thought it won't harm if someone has already migrated from "12.1.3", to "12.2.0", then migrate to "master"