### PR TITLE
fix(webchat): Arabic word misspelling

### DIFF
--- a/modules/channel-web/src/views/lite/translations/ar.json
+++ b/modules/channel-web/src/views/lite/translations/ar.json
@@ -3,7 +3,7 @@
   "composer.send": "إرسال",
   "header.conversations": "محادثات",
   "conversationList.untitledConversation": "محادثة بلا عنوان",
-  "botInfo.backToConversation": "العوده الى المحادثة",
+  "botInfo.backToConversation": "العودة الى المحادثة",
   "botInfo.startConversation": "بداية محادثة",
   "botInfo.privacyPolicy": "عرض سياسة الخصوصية",
   "botInfo.termsAndConditions": "عرض شروط الخدمة",


### PR DESCRIPTION
As an Arabic native speaker, I propose this PR to fix a misspelling.

In the below section, the description of change in Arabic.

بعد التحيّة ، كما تعلمون فإنّ آخر حرف في كلمة العودة هو جزء من جذر الكلمة ، وليس مضاف إليها. وهو تاء مربوطة وليس هاء.