### PR TITLE
fix: replace only file extensions

### DIFF
--- a/build/module-builder/src/build.ts
+++ b/build/module-builder/src/build.ts
@@ -90,7 +90,7 @@ export async function buildBackend(modulePath: string) {
   const outputFiles = []
 
   for (const file of files) {
-    const dest = file.replace(/^src\//i, 'dist/').replace(/.ts$/i, '.js')
+    const dest = file.replace(/^src\//i, 'dist/').replace(/\.ts$/i, '.js')
     mkdirp.sync(path.dirname(dest))
 
     if (copyWithoutTransform.find(x => file.startsWith(`src/${x}`))) {

--- a/modules/.knowledge/src/backend/classifier.ts
+++ b/modules/.knowledge/src/backend/classifier.ts
@@ -39,7 +39,7 @@ export class DocumentClassifier {
     if (mostRecent) {
       const index = await ghost.readFileAsObject<{ [canonical: string]: Snippet }>(
         './models',
-        mostRecent.replace('knowledge_', 'knowledge_meta_').replace('.bin', '.json')
+        mostRecent.replace('knowledge_', 'knowledge_meta_').replace(/\.bin$/i, '.json')
       )
       const buff = await ghost.readFileAsBuffer('./models', mostRecent)
       await this.loadFromBuffer(index, buff)

--- a/modules/code-editor/src/views/full/Editor.tsx
+++ b/modules/code-editor/src/views/full/Editor.tsx
@@ -79,7 +79,7 @@ class Editor extends React.Component<Props> {
 
     const { location, readOnly } = this.props.editor.currentFile
     const fileType = location.endsWith('.json') ? 'json' : 'typescript'
-    const filepath = fileType === 'json' ? location : location.replace('.js', '.ts')
+    const filepath = fileType === 'json' ? location : location.replace(/\.js$/i, '.ts')
 
     const uri = monaco.Uri.parse(`bp://files/${filepath}`)
 

--- a/modules/extensions/src/views/lite/components/debugger/views/Dialog.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/views/Dialog.tsx
@@ -53,7 +53,7 @@ const Flow: SFC<{ stacktrace: sdk.IO.JumpPoint[] }> = props => (
     <H5 color={Colors.DARK_GRAY5}>Flow Nodes</H5>
     <ol>
       {props.stacktrace.map(({ flow, node }, idx) => {
-        const flowName = flow && flow.replace('.flow.json', '')
+        const flowName = flow && flow.replace(/\.flow\.json$/i, '')
         return (
           <li key={`${flow}:${node}:${idx}`}>
             <span>

--- a/modules/nlu/src/backend/storage.ts
+++ b/modules/nlu/src/backend/storage.ts
@@ -14,7 +14,7 @@ export const ID_REGEX = /[\t\s]/gi
 export const sanitizeFilenameNoExt = name =>
   name
     .toLowerCase()
-    .replace('.json', '')
+    .replace(/\.json$/i, '')
     .replace(ID_REGEX, '-')
 
 export default class Storage {

--- a/modules/qna/src/backend/storage.ts
+++ b/modules/qna/src/backend/storage.ts
@@ -218,7 +218,7 @@ export default class Storage {
         questions = questions.slice(opts.start, opts.start + opts.count)
       }
 
-      return Promise.map(questions, itemName => this.getQnaItem(itemName.replace('.json', '')))
+      return Promise.map(questions, itemName => this.getQnaItem(itemName.replace(/\.json$/i, '')))
     } catch (err) {
       this.bp.logger.warn(`Error while reading questions. ${err}`)
       return []

--- a/modules/qna/src/views/full/index.tsx
+++ b/modules/qna/src/views/full/index.tsx
@@ -186,7 +186,13 @@ export default class QnaAdmin extends Component<Props> {
         <div className={style.searchBar}>{this.renderSearch()}</div>
         <ButtonGroup style={{ float: 'right' }}>
           <ImportModal axios={this.props.bp.axios} onImportCompleted={this.fetchData} />
-          <Button id="btn-export" icon="upload" text="Export to JSON" onClick={this.downloadJson} style={{ marginLeft: 5 }} />
+          <Button
+            id="btn-export"
+            icon="upload"
+            text="Export to JSON"
+            onClick={this.downloadJson}
+            style={{ marginLeft: 5 }}
+          />
         </ButtonGroup>
       </ButtonToolbar>
     </FormGroup>
@@ -253,7 +259,7 @@ export default class QnaAdmin extends Component<Props> {
       return null
     }
 
-    const flowName = redirectFlow.replace('.flow.json', '')
+    const flowName = redirectFlow.replace(/\.flow\.json$/i, '')
     const flowBuilderLink = `/studio/${window.BOT_ID}/flows/${flowName}/#search:${redirectNode}`
 
     return (
@@ -347,7 +353,9 @@ export default class QnaAdmin extends Component<Props> {
     }
 
     if (needDelete) {
-      this.props.bp.axios.post(`/mod/qna/questions/${id}/delete`, { params }).then(({ data }) => this.setState({ ...data }))
+      this.props.bp.axios
+        .post(`/mod/qna/questions/${id}/delete`, { params })
+        .then(({ data }) => this.setState({ ...data }))
     }
   }
 

--- a/src/bp/core/services/action/action-service.ts
+++ b/src/bp/core/services/action/action-service.ts
@@ -128,7 +128,7 @@ export class ScopedActionService {
     includeMetadata: boolean
   ): Promise<ActionDefinition> {
     let action: ActionDefinition = {
-      name: file.replace(/.js$/i, ''),
+      name: file.replace(/\.js$/i, ''),
       isRemote: false,
       location: location
     }

--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -587,8 +587,8 @@ export class BotService {
     return revisions
       .filter(rev => rev.startsWith(`${botId}${REV_SPLIT_CHAR}`) && rev.includes(stageID))
       .sort((revA, revB) => {
-        const dateA = revA.split(REV_SPLIT_CHAR)[1].replace('.tgz', '')
-        const dateB = revB.split(REV_SPLIT_CHAR)[1].replace('.tgz', '')
+        const dateA = revA.split(REV_SPLIT_CHAR)[1].replace(/\.tgz$/i, '')
+        const dateB = revB.split(REV_SPLIT_CHAR)[1].replace(/\.tgz$/i, '')
 
         return parseInt(dateA, 10) - parseInt(dateB, 10)
       })
@@ -611,7 +611,7 @@ export class BotService {
 
   public async rollback(botId: string, revision: string): Promise<void> {
     const workspaceId = await this.workspaceService.getBotWorkspaceId(botId)
-    const revParts = revision.replace('.tgz', '').split(REV_SPLIT_CHAR)
+    const revParts = revision.replace(/\.tgz$/i, '').split(REV_SPLIT_CHAR)
     if (revParts.length < 2) {
       throw new VError('invalid revision')
     }

--- a/src/bp/core/services/cms.ts
+++ b/src/bp/core/services/cms.ts
@@ -95,7 +95,7 @@ export class CMSService implements IDisposeOnExit {
     let contentElements: ContentElement[] = []
 
     for (const fileName of fileNames) {
-      const contentType = path.basename(fileName).replace(/.json$/i, '')
+      const contentType = path.basename(fileName).replace(/\.json$/i, '')
       const fileContentElements = await this.ghost
         .forBot(botId)
         .readFileAsObject<ContentElement[]>(this.elementsDir, fileName)

--- a/src/bp/core/services/migration/index.ts
+++ b/src/bp/core/services/migration/index.ts
@@ -250,7 +250,7 @@ export class MigrationService {
         return {
           filename: path.basename(filepath),
           version: semver.valid(rawVersion.replace(/_/g, '.')),
-          title: (title || '').replace('.js', ''),
+          title: (title || '').replace(/\.js$/i, ''),
           date: Number(timestamp),
           location: path.join(rootPath, filepath)
         }

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/RollbackBotModal.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/RollbackBotModal.tsx
@@ -29,7 +29,7 @@ const RollbackBotModal: FC<Props> = props => {
     const { data } = await api.getSecured().get(`/admin/bots/${props.botId}/revisions`)
 
     const revisions = data.payload.revisions.map(rev => {
-      const parts = rev.replace('.tgz', '').split('++')
+      const parts = rev.replace(/\.tgz$/i, '').split('++')
       parts[1] = new Date(parseInt(parts[1], 10)).toLocaleString()
       return {
         label: parts.join(' - '),

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/Ports.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/Ports.tsx
@@ -46,7 +46,7 @@ export class StandardPortWidgetDisconnected extends React.Component<Props> {
   renderSubflowNode() {
     const node = this.props.node
     const index = Number(this.props.name.replace('out', ''))
-    const subflow = node.next[index].node.replace(/\.flow\.json/, '')
+    const subflow = node.next[index].node.replace(/\.flow\.json/i, '')
 
     return (
       <div className={style.label}>

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/index.tsx
@@ -167,7 +167,7 @@ class FlowBuilder extends Component<Props, State> {
   }
 
   pushFlowState = flow => {
-    this.props.history.push(`/flows/${flow.replace(/\.flow\.json/, '')}`)
+    this.props.history.push(`/flows/${flow.replace(/\.flow\.json/i, '')}`)
   }
 
   hideSearch = () => this.setState({ showSearch: false })

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/sidePanel/index.tsx
@@ -41,7 +41,7 @@ const SidePanelContent: FC<Props> = props => {
   const [flowAction, setFlowAction] = useState<any>('create')
   const [filter, setFilter] = useState()
 
-  const goToFlow = flow => history.push(`/flows/${flow.replace(/\.flow\.json/, '')}`)
+  const goToFlow = flow => history.push(`/flows/${flow.replace(/\.flow\.json/i, '')}`)
 
   const normalFlows = reject(props.flows, x => x.name.startsWith('skills/'))
   const flowsName = normalFlows.map(x => {


### PR DESCRIPTION
In some places, when replacing a file extension, a simple `replace` is used, which can also replace file name values (if they accidentally match the extension), which is incorrect.

Some other places of the code correctly use the regular expression.

This PR ensures the replacement happens only at the string end, case insensitively.
