### PR TITLE
fix(nlu): filter inputs to have unique IDs

### DIFF
--- a/modules/nlu/src/views/full/entities/SidePanelSection.tsx
+++ b/modules/nlu/src/views/full/entities/SidePanelSection.tsx
@@ -64,7 +64,13 @@ export const EntitySidePanelSection: FC<Props> = props => {
         text="New entity"
         onClick={() => setShowEntityModal(!showEntityModal)}
       />
-      <SearchBar icon="filter" placeholder="filter entities" onChange={setEntitiesFilter} showButton={false} />
+      <SearchBar
+        id="entities-filter"
+        icon="filter"
+        placeholder="filter entities"
+        onChange={setEntitiesFilter}
+        showButton={false}
+      />
       <ItemList
         items={entityItems}
         onElementClicked={({ value: name }) => props.setCurrentItem({ type: 'entity', name })}

--- a/modules/nlu/src/views/full/intents/SidePanelSection.tsx
+++ b/modules/nlu/src/views/full/intents/SidePanelSection.tsx
@@ -74,7 +74,13 @@ export const IntentSidePanelSection: FC<Props> = props => {
   return (
     <div>
       <Button className={Classes.MINIMAL} icon="new-object" text="New intent" onClick={createIntent} />
-      <SearchBar icon="filter" placeholder="filter intents" onChange={setIntentsFilter} showButton={false} />
+      <SearchBar
+        id="intents-filter"
+        icon="filter"
+        placeholder="filter intents"
+        onChange={setIntentsFilter}
+        showButton={false}
+      />
       <ItemList
         items={intentItems}
         onElementClicked={({ value: name }) => props.setCurrentItem({ type: 'intent', name })}

--- a/src/bp/ui-studio/src/web/components/Shared/Interface/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Shared/Interface/index.tsx
@@ -90,7 +90,7 @@ export const SearchBar = (props: SearchBarProps) => {
     <div className={style.searchBar}>
       <ControlGroup fill={true}>
         <InputGroup
-          id="input-filter"
+          id={props.id}
           leftIcon={props.icon}
           placeholder={props.placeholder || 'Search'}
           value={text}

--- a/src/bp/ui-studio/src/web/components/Shared/Interface/typings.d.ts
+++ b/src/bp/ui-studio/src/web/components/Shared/Interface/typings.d.ts
@@ -156,6 +156,8 @@ export interface KeyboardShortcutsProps {
 }
 
 export interface SearchBarProps {
+  /** The input element ID */
+  id?: string
   /** Text to display when there's no input value */
   placeholder?: string
   /** This is called whenever the text in the input changes */


### PR DESCRIPTION
Currently, when opening "NLU" tab, there is an error in Browser console:

```
[DOM] Found 2 elements with non-unique id #input-filter: 
```

The reason is that there are two input elements (for intent- and entity- filters) in `SidePanelSection`, which share the same ID.

The PR makes them have separate IDs.