### PR TITLE
fix(channel-web): better text for "new messages", and better grammar

### DIFF
--- a/batch-update.ts
+++ b/batch-update.ts
@@ -52,10 +52,10 @@ function* amendFiles(yarnInstall: boolean) {
     }
   }
 
-  console.log(chalk.bold(`Done processing ${files.length} files`))
+  console.log(chalk.bold(`Done processing ${files.length} file${files.length === 1 ? '' : 's'}`))
 
   if (count > 0) {
-    console.log(chalk.green(`Changed ${chalk.bold(count.toString())} files successfully`))
+    console.log(chalk.green(`Changed ${chalk.bold(count.toString())} file${count === 1 ? '' : 's'} successfully`))
     if (IS_DRY_RUN) {
       console.log(chalk.red.bold(`THIS WAS A DRY RUN, SO NO FILE WAS ACTUALLY CHANGED`))
       console.log(chalk.red(`Run this again with ${chalk.bold('--apply')} to execute the changes`))

--- a/build/module-builder/src/package.ts
+++ b/build/module-builder/src/package.ts
@@ -70,7 +70,7 @@ async function zipFiles(modulePath, outPath) {
     ignore: ['node_modules/**', 'src/**']
   })
 
-  debug(`Zipping ${files.length} files...`)
+  debug(`Zipping ${files.length} file${files.length === 1 ? '' : 's'}...`)
 
   await tar.create({ gzip: true, follow: true, file: outPath, portable: true }, files)
 }

--- a/modules/.knowledge/src/views/index.jsx
+++ b/modules/.knowledge/src/views/index.jsx
@@ -63,7 +63,7 @@ export default class KnowledgeManager extends Component {
   }
 
   handleDeleteSelected = async documents => {
-    if (confirm(`Do you really want to delete ${documents.length} documents?`)) {
+    if (confirm(`Do you really want to delete ${documents.length} document${documents.length === 1 ? '' : 's'}?`)) {
       await this.props.bp.axios.post(`/mod/knowledge/bulk_delete`, documents)
       this.fetchDocuments()
     }

--- a/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
@@ -191,7 +191,11 @@ class MessageList extends React.Component<MessageListProps, State> {
       >
         {this.state.showNewMessageIndicator && (
           <div className="bpw-new-messages-indicator" onClick={e => this.tryScrollToBottom()}>
-            <span>{this.props.intl.formatMessage({ id: 'messages.newMessage' })}</span>
+            <span>
+              {this.props.intl.formatMessage({
+                id: 'messages.newMessage' + (this.props.currentMessages.length > 1 ? 's' : '')
+              })}
+            </span>
           </div>
         )}
         {this.renderMessageGroups()}

--- a/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
@@ -193,7 +193,7 @@ class MessageList extends React.Component<MessageListProps, State> {
           <div className="bpw-new-messages-indicator" onClick={e => this.tryScrollToBottom()}>
             <span>
               {this.props.intl.formatMessage({
-                id: 'messages.newMessage' + (this.props.currentMessages.length > 1 ? 's' : '')
+                id: 'messages.newMessage' + (this.props.currentMessages.length === 1 ? '' : 's')
               })}
             </span>
           </div>

--- a/modules/channel-web/src/views/lite/translations/ar.json
+++ b/modules/channel-web/src/views/lite/translations/ar.json
@@ -14,5 +14,6 @@
   "loginForm.submit": "تقديم",
   "loginForm.formTitle": "نموذج تسجيل الدخول",
   "loginForm.providedCredentials": "تم إدخال تفاصيل الدخول",
-  "messages.newMessage": "رسالة جديدة"
+  "messages.newMessage": "رسالة جديدة",
+  "messages.newMessages": "رسائل جديدة"
 }

--- a/modules/channel-web/src/views/lite/translations/en.json
+++ b/modules/channel-web/src/views/lite/translations/en.json
@@ -14,5 +14,6 @@
   "loginForm.submit": "Submit",
   "loginForm.formTitle": "Login form",
   "loginForm.providedCredentials": "Provided credentials",
-  "messages.newMessage": "New message(s)"
+  "messages.newMessage": "New message",
+  "messages.newMessages": "New messages"
 }

--- a/modules/channel-web/src/views/lite/translations/es.json
+++ b/modules/channel-web/src/views/lite/translations/es.json
@@ -9,5 +9,6 @@
   "botInfo.termsAndConditions": "Ver términos de servicio",
   "botInfo.preferredLanguage": "Preferred Language",
   "store.resetSessionMessage": "Restablecer la conversación",
-  "messages.newMessage": "Nuevo mensaje"
+  "messages.newMessage": "Nuevo mensaje",
+  "messages.newMessages": "Nuevos mensajes"
 }

--- a/modules/channel-web/src/views/lite/translations/fr.json
+++ b/modules/channel-web/src/views/lite/translations/fr.json
@@ -9,5 +9,6 @@
   "botInfo.termsAndConditions": "Termes et conditions",
   "botInfo.preferredLanguage": "Langue préférée",
   "store.resetSessionMessage": "Réinitialisation de la conversation",
-  "messages.newMessage": "Nouveau(x) message(s)"
+  "messages.newMessage": "Nouveau message",
+  "messages.newMessages": "Nouveaux messages"
 }

--- a/modules/channel-web/src/views/lite/translations/pt.json
+++ b/modules/channel-web/src/views/lite/translations/pt.json
@@ -9,5 +9,6 @@
   "botInfo.termsAndConditions": "Ver termos de serviço",
   "botInfo.preferredLanguage": "Preferred Language",
   "store.resetSessionMessage": "Redefinir a conversa",
-  "messages.newMessage": "Nova mensagem"
+  "messages.newMessage": "Nova mensagem",
+  "messages.newMessages": "Novas mensagens"
 }

--- a/modules/channel-web/src/views/lite/translations/ru.json
+++ b/modules/channel-web/src/views/lite/translations/ru.json
@@ -14,5 +14,6 @@
   "loginForm.submit": "Отправить",
   "loginForm.formTitle": "Форма для входа",
   "loginForm.providedCredentials": "Введенные данные",
-  "messages.newMessage": "Новое сообщение"
+  "messages.newMessage": "Новое сообщение",
+  "messages.newMessages": "новые сообщения"
 }

--- a/modules/channel-web/src/views/lite/translations/uk.json
+++ b/modules/channel-web/src/views/lite/translations/uk.json
@@ -14,5 +14,6 @@
   "loginForm.submit": "Надіслати",
   "loginForm.formTitle": "Форма для входу",
   "loginForm.providedCredentials": "Введені дані",
-  "messages.newMessage": "Нове повідомлення"
+  "messages.newMessage": "Нове повідомлення",
+  "messages.newMessages": "нові повідомлення"
 }

--- a/modules/code-editor/src/views/full/components/FileStatus.tsx
+++ b/modules/code-editor/src/views/full/components/FileStatus.tsx
@@ -24,8 +24,11 @@ const FileStatus = props => {
     <SidePanelSection label={'File Information'} actions={actions}>
       <div style={{ padding: 5 }}>
         <strong>Warning</strong>
-        <p>There are {problems.length} errors in your file.</p>
-        <p>Please make sure to fix them before saving.</p>
+        <p>
+          There {problems.length === 1 ? 'is' : 'are'} {problems.length} error{problems.length === 1 ? '' : 's'} in your
+          file.
+        </p>
+        <p>Please make sure to fix {problems.length === 1 ? 'it' : 'them'} before saving.</p>
 
         <span onClick={() => setErrorDisplayed(!showErrors)} style={{ cursor: 'pointer' }}>
           {showErrors && <Icon icon="caret-down" />}

--- a/modules/nlu/src/views/lite/intentEditor/IntentHint.tsx
+++ b/modules/nlu/src/views/lite/intentEditor/IntentHint.tsx
@@ -46,18 +46,26 @@ const IntentHint: FC<Props> = props => {
   }
 
   if (utterances.length && utterances.length < recommendations.minUtterancesForML) {
+    const remaining = recommendations.minUtterancesForML - utterances.length
     hint = (
       <span>
         This intent will use <strong>exact match only</strong>. To enable machine learning, add at least{' '}
-        <strong>{recommendations.minUtterancesForML - utterances.length} more utterances</strong>
+        <strong>
+          {remaining} more utterance{remaining === 1 ? '' : 's'}
+        </strong>
       </span>
     )
   }
 
   if (utterances.length >= recommendations.minUtterancesForML && utterances.length < idealNumberOfUtt) {
+    const remaining = idealNumberOfUtt - utterances.length
     hint = (
       <span>
-        Add <strong>{idealNumberOfUtt - utterances.length} more utterances</strong> to make NLU more resilient.
+        Add{' '}
+        <strong>
+          {remaining} more utterance{remaining === 1 ? ' ' : 's '}
+        </strong>
+        to make NLU more resilient.
       </span>
     )
   }

--- a/modules/qna/src/backend/transfer.ts
+++ b/modules/qna/src/backend/transfer.ts
@@ -58,7 +58,10 @@ export const importQuestions = async (data: ImportData, storage, bp, statusCallb
   return Promise.each(entriesToSave, async (question: QnaEntry) => {
     await (storage as Storage).insert({ ...question, enabled: true })
     questionsSavedCount += 1
-    statusCallback(uploadStatusId, `Saved ${questionsSavedCount}/${entriesToSave.length} questions`)
+    statusCallback(
+      uploadStatusId,
+      `Saved ${questionsSavedCount}/${entriesToSave.length} question${entriesToSave.length === 1 ? '' : 's'}`
+    )
   })
 }
 

--- a/modules/qna/src/views/full/QnaHint.jsx
+++ b/modules/qna/src/views/full/QnaHint.jsx
@@ -32,18 +32,26 @@ const createHint = (utterances, goodMLUtterances, minMLUtterances) => {
   }
 
   if (utterances.length && utterances.length < minMLUtterances) {
+    const remaining = minMLUtterances - utterances.length
     return (
       <span>
         This Q&A will use <strong>exact match only</strong>. To enable machine learning, add at least{' '}
-        <strong>{minMLUtterances - utterances.length} more questions</strong>
+        <strong>
+          {remaining} more question{remaining === 1 ? '' : 's'}
+        </strong>
       </span>
     )
   }
 
   if (utterances.length >= minMLUtterances && utterances.length < idealNumberOfUtt) {
+    const remaining = idealNumberOfUtt - utterances.length
     return (
       <span>
-        Add <strong>{idealNumberOfUtt - utterances.length} more questions</strong> to make your Q&A more resilient.
+        Add{' '}
+        <strong>
+          {remaining} more question{remaining === 1 ? '' : 's'}
+        </strong>{' '}
+        to make your Q&A more resilient.
       </span>
     )
   }

--- a/modules/testing/src/views/full/Scenario.jsx
+++ b/modules/testing/src/views/full/Scenario.jsx
@@ -57,7 +57,8 @@ class Scenario extends React.Component {
           </Panel.Title>
           <div className={style.scenarioStatus}>
             <span>
-              {scenario.status && `${scenario.completedSteps} /`} {scenario.steps.length} interactions
+              {scenario.status && `${scenario.completedSteps} /`} {scenario.steps.length} interaction
+              {scenario.steps.length === 1 ? '' : 's'}
             </span>
             {this.renderStatusLabel(scenario.status)}
           </div>

--- a/src/bp/bootstrap.ts
+++ b/src/bp/bootstrap.ts
@@ -77,7 +77,7 @@ async function start() {
   logger.info(chalk`========================================
 {bold ${center(`Botpress Server`, 40)}}
 {dim ${center(`Version ${sdk.version}`, 40)}}
-{dim ${center(`OS ${process.distro.toString()}`, 40)}}
+{dim ${center(`OS ${process.distro}`, 40)}}
 ========================================`)
 
   if (!fs.existsSync(process.APP_DATA_PATH)) {

--- a/src/bp/bpfs.ts
+++ b/src/bp/bpfs.ts
@@ -131,7 +131,11 @@ class BPFS {
           await this._clearRevisions(this.sourceDir)
         }
 
-        console.log(chalk.green(`Successfully pushed ${localFiles.length} local files to remote server!`))
+        console.log(
+          chalk.green(
+            `Successfully pushed ${localFiles.length} local file${localFiles.length === 1 ? '' : 's'} to remote server!`
+          )
+        )
       } else {
         this._printOutOfSync()
         this._printChangeList(changeList)

--- a/src/bp/core/logger/db-persister.ts
+++ b/src/bp/core/logger/db-persister.ts
@@ -55,7 +55,7 @@ export class LoggerDbPersister {
 
   private runTask = async () => {
     if (process.env.DEBUG_LOGGER) {
-      this.logger.debug(`Saving ${this.batch.length} logs`)
+      this.logger.debug(`Saving ${this.batch.length} log${this.batch.length === 1 ? '' : 's'}`)
     }
 
     if (this.currentPromise || this.batch.length === 0) {

--- a/src/bp/core/logger/file-persister.ts
+++ b/src/bp/core/logger/file-persister.ts
@@ -105,7 +105,7 @@ export class LoggerFilePersister {
     }
 
     if (process.env.DEBUG_LOGGER) {
-      this.logger.debug(`Saving ${this.batch.length} logs`)
+      this.logger.debug(`Saving ${this.batch.length} log${this.batch.length === 1 ? '' : 's'}`)
     }
 
     const content = this.batch.join('')

--- a/src/bp/core/services/migration/index.ts
+++ b/src/bp/core/services/migration/index.ts
@@ -115,7 +115,7 @@ export class MigrationService {
     const opts = await this.getMigrationOpts()
 
     this.logger.info(chalk`========================================
-{bold ${center(`Executing ${missingMigrations.length.toString()} migrations`, 40)}}
+{bold ${center(`Executing ${missingMigrations.length} migration${missingMigrations.length === 1 ? '' : 's'}`, 40)}}
 ========================================`)
 
     const completed = await this._getCompletedMigrations()
@@ -185,7 +185,7 @@ export class MigrationService {
     logger.warn(chalk`========================================
 {bold ${center(`Migration Required`, 40)}}
 {dim ${center(`Version ${configVersion} => ${this.currentVersion} `, 40)}}
-{dim ${center(`${migrations.length} changes`, 40)}}
+{dim ${center(`${migrations.length} change${migrations.length === 1 ? '' : 's'}`, 40)}}
 ========================================`)
 
     Object.keys(types).map(type => {

--- a/src/bp/lang-server/index.ts
+++ b/src/bp/lang-server/index.ts
@@ -49,7 +49,7 @@ export default async function(options: ArgV) {
 
   logger.info(chalk`========================================
 {bold ${center(`Botpress Language Server`, 40)}}
-{dim ${center(`OS ${process.distro.toString()}`, 40)}}
+{dim ${center(`OS ${process.distro}`, 40)}}
 ========================================`)
 
   if (options.authToken && options.authToken.length) {

--- a/src/bp/ui-admin/src/Pages/Workspaces/DeleteWorkspaceModal.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspaces/DeleteWorkspaceModal.tsx
@@ -35,7 +35,9 @@ const DeleteWorkspaceModal: FC<Props> = props => {
     return null
   }
 
-  const botsWarning = `${props.workspace.bots.length} bots will also be deleted`
+  const botsWarning = `${props.workspace.bots.length} bot${
+    props.workspace.bots.length === 1 ? '' : 's'
+  } will also be deleted`
 
   return (
     <Dialog

--- a/src/bp/ui-admin/src/Pages/Workspaces/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspaces/index.tsx
@@ -110,7 +110,7 @@ const Workspaces: FC<Props> = props => {
                 </div>
                 <div style={{ width: 200 }}>
                   <small>
-                    {workspace.bots.length} bots - {workspace.audience} users
+                    {workspace.bots.length} bot{workspace.bots.length === 1 ? '' : 's'} - {workspace.audience} users
                   </small>
                 </div>
               </div>

--- a/src/bp/ui-studio/src/web/views/Content/List.tsx
+++ b/src/bp/ui-studio/src/web/views/Content/List.tsx
@@ -79,7 +79,13 @@ class ListView extends Component<Props, State> {
   }
 
   handleDeleteSelected = () => {
-    if (window.confirm(`Do you really want to delete ${this.state.checkedIds.length} items?`)) {
+    if (
+      window.confirm(
+        `Do you really want to delete ${this.state.checkedIds.length} item${
+          this.state.checkedIds.length === 1 ? '' : 's'
+        }?`
+      )
+    ) {
       this.props.handleDeleteSelected(this.state.checkedIds)
       this.setState({ checkedIds: [], allChecked: false })
     }


### PR DESCRIPTION
Separating the "new message" from "new message**s**" text, since it is more user-friendly.

Arabic translation verified, others were translated with Google.

Please note I didn't test this in webchat, since I couldn't quickly figure out when this message is shown.
<hr>

This PR also includes better grammar for singular and plural nouns, e.g. `1 change`, instead of `1 changes` in various areas in the code.