### PR TITLE
fix(examples): update interbot examples

### DIFF
--- a/docs/guide/docs/tutorials/interbot.md
+++ b/docs/guide/docs/tutorials/interbot.md
@@ -7,7 +7,7 @@ title: Inter-bot Communication / Delegation
 
 In this tutorial, you will learn how a chatbot could "delegate" questions or tasks to other bots. We call this concept "inter-bot" communication.
 
-The code for this example is available in the [examples](https://github.com/botpress/botpress/tree/master/examples/interbot) directory of our GitHub repository.
+The code for this example is available in the [examples](https://github.com/botpress/botpress/tree/master/examples/interbot) directory of our GitHub repository (update `workspaces.json` with the three bots if you copied them).
 
 ![Example](assets/tutorials_interbot-example.png)
 
@@ -23,7 +23,7 @@ Head to the admin interface and create three bots names `master`, `sub1` and `su
 
 - Leave `master` bot empty for now.
 - In the `sub1` bot, create some QnA entries that are related to the same domain (pick the default `global` category/context).
-- In the `sub2` bot, do the same thing for an other domain.
+- In the `sub2` bot, do the same thing for another domain.
 
 For example, `sub1` could answer questions about Human Resources, while `sub2` could answer questions related to IT Operations.
 

--- a/examples/interbot/README.md
+++ b/examples/interbot/README.md
@@ -1,5 +1,5 @@
 # Interbot Communication
 
-This is an example of interbot communication. Copy these these files in your `<data>` directory and restart your Botpress Server.
+This is an example of interbot communication. Copy these these files in your `<data>` directory, update your `workspaces.json` with the bot names and restart your Botpress Server.
 
 > **Warning**: this may overwrite some of your bots, you should copy/paste those files in a fresh installation of Botpress Server.

--- a/examples/interbot/bots/master/bot.config.json
+++ b/examples/interbot/bots/master/bot.config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../bot.config.schema.json",
-  "description": "Empty bot",
+  "description": "Master bot",
   "active": true,
   "version": "1.0.0",
   "author": "Botpress, Inc.",
@@ -9,13 +9,7 @@
     "modules": [],
     "incomingMiddleware": [],
     "outgoingMiddleware": [],
-    "contentTypes": [
-      "builtin_text",
-      "builtin_single-choice",
-      "builtin_image",
-      "builtin_carousel",
-      "builtin_card"
-    ]
+    "contentTypes": ["builtin_text", "builtin_single-choice", "builtin_image", "builtin_carousel", "builtin_card"]
   },
   "dialog": {
     "timeoutInterval": "5m"
@@ -28,5 +22,7 @@
   "category": null,
   "disabled": false,
   "private": false,
-  "details": {}
+  "details": {},
+  "defaultLanguage": "en",
+  "languages": ["en"]
 }

--- a/examples/interbot/bots/master/content-elements/builtin_text.json
+++ b/examples/interbot/bots/master/content-elements/builtin_text.json
@@ -2,8 +2,9 @@
   {
     "id": "builtin_text-8mwYrq",
     "formData": {
-      "text": "The bot {{temp.delegation.0.botId}} can help you with that question.\n\n[Talk to {{temp.delegation.0.botId}}]({{{temp.delegation.0.botUrl}}})\n\nBy the way, {{temp.delegation.0.botId}} is telling you:\n> {{{temp.delegation.0.answer}}}",
-      "typing": true
+      "text$en": "The bot {{temp.delegation.0.botId}} can help you with that question.\n\n[Talk to {{temp.delegation.0.botId}}]({{{temp.delegation.0.botUrl}}})\n\nBy the way, {{temp.delegation.0.botId}} is telling you:\n> {{{temp.delegation.0.answer}}}",
+      "typing$en": true,
+      "markdown$en": true
     },
     "createdBy": "admin",
     "createdOn": "2019-03-25T21:49:17.498Z",
@@ -12,8 +13,9 @@
   {
     "id": "builtin_text-JqYzWM",
     "formData": {
-      "text": "I'm sorry, I don't know any bot that can help you with that question.",
-      "typing": true
+      "text$en": "I'm sorry, I don't know any bot that can help you with that question.",
+      "typing$en": true,
+      "markdown$en": true
     },
     "createdBy": "admin",
     "createdOn": "2019-03-25T21:49:49.933Z",

--- a/examples/interbot/bots/sub1/bot.config.json
+++ b/examples/interbot/bots/sub1/bot.config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../bot.config.schema.json",
-  "description": "Empty bot",
+  "description": "Sub bot for Human Resources",
   "active": true,
   "version": "1.0.0",
   "author": "Botpress, Inc.",
@@ -9,13 +9,7 @@
     "modules": [],
     "incomingMiddleware": [],
     "outgoingMiddleware": [],
-    "contentTypes": [
-      "builtin_text",
-      "builtin_single-choice",
-      "builtin_image",
-      "builtin_carousel",
-      "builtin_card"
-    ]
+    "contentTypes": ["builtin_text", "builtin_single-choice", "builtin_image", "builtin_carousel", "builtin_card"]
   },
   "dialog": {
     "timeoutInterval": "5m"
@@ -28,5 +22,7 @@
   "category": null,
   "disabled": false,
   "private": false,
-  "details": {}
+  "details": {},
+  "defaultLanguage": "en",
+  "languages": ["en"]
 }

--- a/examples/interbot/bots/sub1/intents/none.json
+++ b/examples/interbot/bots/sub1/intents/none.json
@@ -1,7 +1,0 @@
-{
-  "name": "none",
-  "filename": "none.json",
-  "contexts": ["global"],
-  "slots": [],
-  "utterances": ["!&#^&*$^*(%", "1234567", "abcdefg"]
-}

--- a/examples/interbot/bots/sub2/bot.config.json
+++ b/examples/interbot/bots/sub2/bot.config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../bot.config.schema.json",
-  "description": "Empty bot",
+  "description": "Sub bot for IT Operations",
   "active": true,
   "version": "1.0.0",
   "author": "Botpress, Inc.",
@@ -9,13 +9,7 @@
     "modules": [],
     "incomingMiddleware": [],
     "outgoingMiddleware": [],
-    "contentTypes": [
-      "builtin_text",
-      "builtin_single-choice",
-      "builtin_image",
-      "builtin_carousel",
-      "builtin_card"
-    ]
+    "contentTypes": ["builtin_text", "builtin_single-choice", "builtin_image", "builtin_carousel", "builtin_card"]
   },
   "dialog": {
     "timeoutInterval": "5m"
@@ -28,5 +22,7 @@
   "category": null,
   "disabled": false,
   "private": false,
-  "details": {}
+  "details": {},
+  "defaultLanguage": "en",
+  "languages": ["en"]
 }

--- a/examples/interbot/bots/sub2/intents/none.json
+++ b/examples/interbot/bots/sub2/intents/none.json
@@ -1,7 +1,0 @@
-{
-  "name": "none",
-  "filename": "none.json",
-  "contexts": ["global"],
-  "slots": [],
-  "utterances": ["!&#^&*$^*(%", "1234567", "abcdefg"]
-}


### PR DESCRIPTION
1. [Fixed] When following the instructions in [Inter-bot tutorial](https://botpress.io/docs/tutorials/interbot) there is an error message:

>You have bots without specified language. Default language is mandatory since Botpress 11.8. 
Please set bot language in the bot config page.

2. [Fixed] The content format is the old one, missing `$en`.

3. Shouldn't `2` be automatically migrated, or migration doesn't happen when manually copying bots folders?

4. There are errors for the models, e.g.:

```
17:03:27.540 Launcher Unhandled Rejection [SyntaxError, Unexpected number in JSON at position 2521792]
STACK TRACE
SyntaxError: Unexpected number in JSON at position 2521792
    at JSON.parse (<anonymous>)
    at deserializeModel (C:\use\botpress\modules\nlu\dist\backend\engine2\model-service.js:40:22)
    at Object.getModel (C:\use\botpress\modules\nlu\dist\backend\engine2\model-service.js:50:12)
```