### PR TITLE
fix(studio): correct documentation URL

### DIFF
--- a/src/bp/ui-studio/src/web/components/Injected/index.jsx
+++ b/src/bp/ui-studio/src/web/components/Injected/index.jsx
@@ -28,8 +28,7 @@ export default class InjectedComponent extends Component {
         </div>
         {/* TODO Put documentation / help here */}
         <div className="panel-footer">
-          Developer? <a href="https://github.com/botpress/botpress/tree/master/docs">click here</a>
-          to see why this might happen
+          Developer? <a href="https://botpress.io/docs">click here</a> to see why this might happen
         </div>
       </div>
     )


### PR DESCRIPTION
Currently the URL points to the `docs` folder in GitHub. Pointing to the `botpress.io/docs` shows the same information but in a more user-friendly manner.

This also fixes a missing 'space` between the hyperlink and "to see why this"