### PR TITLE
fix(core): remove folders in Windows

### DIFF
--- a/src/bp/core/services/ghost/disk-driver.ts
+++ b/src/bp/core/services/ghost/disk-driver.ts
@@ -11,7 +11,7 @@ import { FileRevision, StorageDriver } from '.'
 
 @injectable()
 export default class DiskStorageDriver implements StorageDriver {
-  resolvePath = p => path.resolve(process.PROJECT_LOCATION, p)
+  resolvePath = (p: string) => path.resolve(process.PROJECT_LOCATION, p)
 
   async upsertFile(filePath: string, content: string | Buffer): Promise<void>
   async upsertFile(filePath: string, content: string | Buffer, recordRevision: boolean = false): Promise<void> {
@@ -56,7 +56,7 @@ export default class DiskStorageDriver implements StorageDriver {
 
   async deleteDir(dirPath: string): Promise<void> {
     try {
-      return fse.removeSync(this.resolvePath(dirPath))
+      return fse.remove(this.resolvePath(dirPath))
     } catch (e) {
       throw new VError(e, `[Disk Storage] Error deleting directory "${dirPath}"`)
     }


### PR DESCRIPTION
In Windows 10, deleting a bot doesn't delete its folder. The folder is empty, but it gives a false hint that the bot still exists.

Steps:
1. Create a bot
2. Delete this bot
  a. Expected: `data\bots\bot_id` doesn't exist
  b. Actual: `data\bots\bot_id` is existing as empty folder

Please test this in other OSs.

Possibly related to https://github.com/jprichardson/node-fs-extra/issues/590