### PR TITLE
chore(qna): refactor & added lite view

### DIFF
--- a/modules/qna/src/views/full/Editor/EditorModal.tsx
+++ b/modules/qna/src/views/full/Editor/EditorModal.tsx
@@ -1,0 +1,40 @@
+import { Dialog } from '@blueprintjs/core'
+import _ from 'lodash'
+import React, { FC } from 'react'
+
+import Editor from '.'
+
+interface Props {
+  closeQnAModal: () => void
+  fetchData: () => void
+  updateQuestion: any
+  page: any
+  filters: any
+  id: any
+  isEditing: boolean
+  contentLang: any
+  showQnAModal: boolean
+  categories: any
+  bp: any
+  flowsList: any
+  flows: any
+}
+
+const EditorModal: FC<Props> = props => {
+  return (
+    <Dialog
+      title={props.isEditing ? 'Edit Q&A' : 'Create a new Q&A'}
+      icon={props.isEditing ? 'edit' : 'add'}
+      isOpen={props.showQnAModal}
+      onClose={props.closeQnAModal}
+      transitionDuration={0}
+      canOutsideClickClose={false}
+      style={{ width: 700 }}
+      enforceFocus={false}
+    >
+      <Editor {...props} />
+    </Dialog>
+  )
+}
+
+export default EditorModal

--- a/modules/qna/src/views/full/Editor/index.tsx
+++ b/modules/qna/src/views/full/Editor/index.tsx
@@ -9,8 +9,8 @@ import React, { Component } from 'react'
 import { Alert } from 'react-bootstrap'
 import Select from 'react-select'
 
-import style from './style.scss'
-import QnaHint from './QnaHint'
+import style from '../style.scss'
+import QnaHint from '../QnaHint'
 
 const ACTIONS = {
   TEXT: 'text',
@@ -19,22 +19,21 @@ const ACTIONS = {
 }
 
 interface Props {
-  closeQnAModal: any
-  fetchData: any
-  updateQuestion: any
+  closeQnAModal: () => void
+  fetchData: () => void
+  updateQuestion: (data: any) => void
   page: any
   filters: any
-  id: any
-  modalType: any
-  contentLang: any
-  showQnAModal: any
-  categories: any
+  id: string
+  isEditing: boolean
+  contentLang: string
+  categories?: any[]
   bp: any
-  flowsList: any
-  flows: any
+  flowsList?: any[]
+  flows?: any[]
 }
 
-export default class FormModal extends Component<Props> {
+export default class Editor extends Component<Props> {
   state = this.defaultState
 
   get defaultState() {
@@ -71,20 +70,20 @@ export default class FormModal extends Component<Props> {
   async componentDidMount() {
     const { data } = await this.props.bp.axios.get('/mod/nlu/ml-recommendations')
     this.mlRecommendations = data
-  }
 
-  async componentDidUpdate(prevProps) {
-    const { id } = this.props
-    if (prevProps.id === id) {
-      return
-    }
-    if (!id) {
-      return this.setState(this.defaultState)
+    if (!this.props.id) {
+      const defaultCategory = this.props.categories ? this.props.categories[0].value : 'global'
+
+      return this.setState(this.defaultState, () => {
+        if (defaultCategory !== 'global') {
+          this.changeItemProperty('category', defaultCategory)
+        }
+      })
     }
 
     const {
       data: { data: item }
-    } = await this.props.bp.axios.get(`/mod/qna/questions/${id}`)
+    } = await this.props.bp.axios.get(`/mod/qna/questions/${this.props.id}`)
 
     this.setState({
       item,
@@ -173,8 +172,7 @@ export default class FormModal extends Component<Props> {
 
   alertMessage() {
     const hasInvalidInputs = Object.values(this.state.invalidFields).find(Boolean)
-    const missingTranslations =
-      this.props.modalType === 'edit' && (!this.itemAnswers.length || !this.itemQuestions.length)
+    const missingTranslations = this.props.isEditing && (!this.itemAnswers.length || !this.itemQuestions.length)
 
     return (
       <div>
@@ -199,7 +197,7 @@ export default class FormModal extends Component<Props> {
       ...{ [this.props.contentLang]: this.trimItemQuestions(this.itemQuestions) }
     }
 
-    this.props.modalType === 'edit' ? this.onEdit(itemToSend) : this.onCreate(itemToSend)
+    this.props.isEditing ? this.onEdit(itemToSend) : this.onCreate(itemToSend)
   }
 
   get itemAnswers() {
@@ -241,38 +239,31 @@ export default class FormModal extends Component<Props> {
       item: { redirectFlow },
       invalidFields
     } = this.state
-    const { flows, flowsList, showQnAModal, categories, modalType } = this.props
+    const { flows, flowsList, categories, isEditing } = this.props
+
     const currentFlow = flows ? flows.find(({ name }) => name === redirectFlow) || { nodes: [] } : { nodes: [] }
     const nodeList = currentFlow.nodes.map(({ name }) => ({ label: name, value: name }))
-    const isEdit = modalType === 'edit'
 
     return (
-      <Dialog
-        title={isEdit ? 'Edit Q&A' : 'Create a new Q&A'}
-        icon={isEdit ? 'edit' : 'add'}
-        isOpen={showQnAModal}
-        onClose={this.closeAndClear}
-        transitionDuration={0}
-        canOutsideClickClose={false}
-        style={{ width: 700 }}
-        enforceFocus={false}
-      >
+      <div>
         <div className={Classes.DIALOG_BODY}>
           <form>
             {this.alertMessage()}
             <QnaHint questions={this.itemQuestions} mlRecommendations={this.mlRecommendations} />
 
-            <FormGroup label="Category">
-              <Select
-                id="select-category"
-                className={classnames({ qnaCategoryError: invalidFields.category })}
-                value={this.state.item.category}
-                options={categories}
-                onChange={this.handleSelect('category')}
-                style={{ width: 250 }}
-                placeholder="Search or choose category"
-              />
-            </FormGroup>
+            {categories && !!categories.length && (
+              <FormGroup label="Category">
+                <Select
+                  id="select-category"
+                  className={classnames({ qnaCategoryError: invalidFields.category })}
+                  value={this.state.item.category}
+                  options={categories}
+                  onChange={this.handleSelect('category')}
+                  style={{ width: 250 }}
+                  placeholder="Search or choose category"
+                />
+              </FormGroup>
+            )}
 
             <FormGroup helperText="Type/Paste your questions here separated with a new line" label="Questions">
               <TextArea
@@ -292,7 +283,7 @@ export default class FormModal extends Component<Props> {
             <H6>Answers</H6>
             <Checkbox
               label={'Bot will say: '}
-              checked={this.state.isText}
+              checked={!flowsList || (flowsList && this.state.isText)}
               onChange={this.changeItemAction('isText')}
               tabIndex={-1}
             />
@@ -307,41 +298,45 @@ export default class FormModal extends Component<Props> {
               onDelete={this.deleteAnswer}
             />
 
-            <div className={style.qnaAndOr}>
-              <div className={style.qnaAndOrLine} />
-              <div className={style.qnaAndOrText}>and / or</div>
-              <div className={style.qnaAndOrLine} />
-            </div>
-            <div className={style.qnaRedirect}>
-              <div className={style.qnaRedirectToFlow}>
-                <Checkbox
-                  label="Redirect to flow"
-                  id="redirect"
-                  checked={this.state.isRedirect}
-                  onChange={this.changeItemAction('isRedirect')}
-                  tabIndex={-1}
-                />
+            {flowsList && (
+              <React.Fragment>
+                <div className={style.qnaAndOr}>
+                  <div className={style.qnaAndOrLine} />
+                  <div className={style.qnaAndOrText}>and / or</div>
+                  <div className={style.qnaAndOrLine} />
+                </div>
+                <div className={style.qnaRedirect}>
+                  <div className={style.qnaRedirectToFlow}>
+                    <Checkbox
+                      label="Redirect to flow"
+                      id="redirect"
+                      checked={this.state.isRedirect}
+                      onChange={this.changeItemAction('isRedirect')}
+                      tabIndex={-1}
+                    />
 
-                <Select
-                  className={classnames({ qnaCategoryError: invalidFields.redirectFlow })}
-                  tabIndex={-1}
-                  value={this.state.item.redirectFlow}
-                  options={flowsList}
-                  onChange={this.handleSelect('redirectFlow')}
-                />
-              </div>
-              <div className={style.qnaRedirectNode}>
-                <strong>Node</strong>
+                    <Select
+                      className={classnames({ qnaCategoryError: invalidFields.redirectFlow })}
+                      tabIndex={-1}
+                      value={this.state.item.redirectFlow}
+                      options={flowsList}
+                      onChange={this.handleSelect('redirectFlow')}
+                    />
+                  </div>
+                  <div className={style.qnaRedirectNode}>
+                    <strong>Node</strong>
 
-                <Select
-                  className={classnames({ qnaCategoryError: invalidFields.redirectNode })}
-                  tabIndex={-1}
-                  value={this.state.item.redirectNode}
-                  options={nodeList}
-                  onChange={this.handleSelect('redirectNode')}
-                />
-              </div>
-            </div>
+                    <Select
+                      className={classnames({ qnaCategoryError: invalidFields.redirectNode })}
+                      tabIndex={-1}
+                      value={this.state.item.redirectNode}
+                      options={nodeList}
+                      onChange={this.handleSelect('redirectNode')}
+                    />
+                  </div>
+                </div>
+              </React.Fragment>
+            )}
           </form>
         </div>
 
@@ -351,14 +346,14 @@ export default class FormModal extends Component<Props> {
             <AccessControl resource="module.qna" operation="write">
               <Button
                 id="btn-submit"
-                text={isEdit ? 'Edit' : 'Save'}
+                text={isEditing ? 'Edit' : 'Save'}
                 intent={Intent.PRIMARY}
                 onClick={this.handleSubmit}
               />
             </AccessControl>
           </div>
         </div>
-      </Dialog>
+      </div>
     )
   }
 }

--- a/modules/qna/src/views/full/Editor/index.tsx
+++ b/modules/qna/src/views/full/Editor/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, Classes, Dialog, FormGroup, H6, Intent, TextArea } from '@blueprintjs/core'
+import { Button, Callout, Checkbox, Classes, FormGroup, H6, Intent, TextArea } from '@blueprintjs/core'
 // @ts-ignore
 import ElementsList from 'botpress/elements-list'
 import { AccessControl } from 'botpress/utils'
@@ -6,7 +6,6 @@ import classnames from 'classnames'
 import _ from 'lodash'
 import some from 'lodash/some'
 import React, { Component } from 'react'
-import { Alert } from 'react-bootstrap'
 import Select from 'react-select'
 
 import style from '../style.scss'
@@ -176,11 +175,11 @@ export default class Editor extends Component<Props> {
 
     return (
       <div>
-        {this.state.invalidFields.checkbox && <Alert bsStyle="danger">Action checkbox is required</Alert>}
-        {hasInvalidInputs && <Alert bsStyle="danger">Inputs are required.</Alert>}
-        {this.state.hasDuplicates && <Alert bsStyle="danger">Duplicated questions aren't allowed.</Alert>}
-        {this.state.errorMessage && <Alert bsStyle="danger">{this.state.errorMessage}</Alert>}
-        {missingTranslations && <Alert bsStyle="danger">Missing translations</Alert>}
+        {this.state.invalidFields.checkbox && <Callout intent={Intent.DANGER}>Action checkbox is required</Callout>}
+        {hasInvalidInputs && <Callout intent={Intent.DANGER}>Inputs are required.</Callout>}
+        {this.state.hasDuplicates && <Callout intent={Intent.DANGER}>Duplicated questions aren't allowed.</Callout>}
+        {this.state.errorMessage && <Callout intent={Intent.DANGER}>{this.state.errorMessage}</Callout>}
+        {missingTranslations && <Callout intent={Intent.DANGER}>Missing translations</Callout>}
       </div>
     )
   }

--- a/modules/qna/src/views/full/ExportButton.tsx
+++ b/modules/qna/src/views/full/ExportButton.tsx
@@ -1,0 +1,28 @@
+import { Button, MenuItem } from '@blueprintjs/core'
+import { Downloader } from 'botpress/utils'
+import React, { FC, Fragment, useState } from 'react'
+
+interface Props {
+  category?: string
+  asMenu?: boolean
+}
+
+export const ExportButton: FC<Props> = props => {
+  const [url, setUrl] = useState('')
+
+  const startDownload = () => {
+    setUrl(`${window.BOT_API_PATH}/mod/qna/export${props.category ? '/' + props.category : ''}`)
+  }
+
+  return (
+    <Fragment>
+      {props.asMenu ? (
+        <MenuItem id="btn-export" icon="upload" text="Export to JSON" onClick={startDownload} />
+      ) : (
+        <Button id="btn-export" icon="upload" text="Export to JSON" onClick={startDownload} style={{ marginLeft: 5 }} />
+      )}
+
+      <Downloader url={url} />
+    </Fragment>
+  )
+}

--- a/modules/qna/src/views/full/ImportModal.tsx
+++ b/modules/qna/src/views/full/ImportModal.tsx
@@ -1,6 +1,5 @@
 import { Button, Callout, Classes, Dialog, FileInput, FormGroup, Intent, Radio, RadioGroup } from '@blueprintjs/core'
 import 'bluebird-global'
-import { AccessControl } from 'botpress/utils'
 import { toastFailure, toastSuccess } from 'botpress/utils'
 import _ from 'lodash'
 import React, { FC, Fragment, useEffect, useState } from 'react'
@@ -11,6 +10,8 @@ const axiosConfig = { headers: { 'Content-Type': 'multipart/form-data' } }
 interface Props {
   axios: any
   onImportCompleted: () => void
+  isOpen: boolean
+  toggle: () => void
 }
 
 interface Analysis {
@@ -24,7 +25,6 @@ export const ImportModal: FC<Props> = props => {
   const [file, setFile] = useState<any>()
   const [filePath, setFilePath] = useState<string>()
   const [isLoading, setIsLoading] = useState(false)
-  const [isDialogOpen, setDialogOpen] = useState(false)
   const [importAction, setImportAction] = useState('insert')
   const [analysis, setAnalysis] = useState<Analysis>()
   const [statusId, setStatusId] = useState<string>()
@@ -108,7 +108,7 @@ Either the file is empty, or it doesn't match any known format.`)
 
   const closeDialog = () => {
     clearState()
-    setDialogOpen(false)
+    props.toggle()
   }
 
   const clearState = () => {
@@ -234,14 +234,10 @@ Either the file is empty, or it doesn't match any known format.`)
 
   return (
     <Fragment>
-      <AccessControl resource="module.qna" operation="write">
-        <Button icon="download" id="btn-importJson" text="Import JSON" onClick={() => setDialogOpen(true)} />
-      </AccessControl>
-
       <Dialog
         title={analysis ? 'Analysis' : 'Upload File'}
         icon="import"
-        isOpen={isDialogOpen}
+        isOpen={props.isOpen}
         onClose={closeDialog}
         transitionDuration={0}
         canOutsideClickClose={false}

--- a/modules/qna/src/views/full/Item/RedirectInfo.tsx
+++ b/modules/qna/src/views/full/Item/RedirectInfo.tsx
@@ -1,0 +1,33 @@
+import React, { FC } from 'react'
+
+import style from '../style.scss'
+
+interface Props {
+  redirectFlow: string
+  redirectNode: string
+}
+
+const RedirectInfo: FC<Props> = ({ redirectFlow, redirectNode }) => {
+  if (!redirectFlow || !redirectNode) {
+    return null
+  }
+
+  const flowName = redirectFlow.replace('.flow.json', '')
+  const flowBuilderLink = `/studio/${window.BOT_ID}/flows/${flowName}/#search:${redirectNode}`
+
+  return (
+    <React.Fragment>
+      <div className={style.itemRedirectTitle}>Redirect to:</div>
+      <a href={flowBuilderLink}>
+        <div className={style.itemFlow}>
+          Flow: <span className={style.itemFlowName}>{redirectFlow}</span>
+        </div>
+        <div className={style.itemNode}>
+          Node: <span className={style.itemNodeName}>{redirectNode}</span>
+        </div>
+      </a>
+    </React.Fragment>
+  )
+}
+
+export default RedirectInfo

--- a/modules/qna/src/views/full/Item/Variations.tsx
+++ b/modules/qna/src/views/full/Item/Variations.tsx
@@ -1,0 +1,37 @@
+import { Position, Tooltip } from '@blueprintjs/core'
+import { ElementPreview } from 'botpress/utils'
+import React, { FC } from 'react'
+
+import style from '../style.scss'
+
+interface Props {
+  elements: any
+}
+
+const Variations: FC<Props> = ({ elements }) => {
+  if (!elements.length) {
+    return null
+  }
+
+  return (
+    <Tooltip
+      position={Position.RIGHT}
+      content={
+        <ul className={style.tooltip}>
+          {elements.map(variation => (
+            <li key={variation}>
+              {variation.startsWith('#!') ? <ElementPreview itemId={variation.replace('#!', '')} /> : variation}
+            </li>
+          ))}
+        </ul>
+      }
+    >
+      <span style={{ cursor: 'default' }}>
+        &nbsp;
+        <strong>({elements.length})</strong>
+      </span>
+    </Tooltip>
+  )
+}
+
+export default Variations

--- a/modules/qna/src/views/full/Item/index.tsx
+++ b/modules/qna/src/views/full/Item/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Icon, Intent, Switch, Tooltip } from '@blueprintjs/core'
 import { AccessControl } from 'botpress/utils'
+import cx from 'classnames'
 import React, { FC } from 'react'
-import { Well } from 'react-bootstrap'
 
 import style from '../style.scss'
 
@@ -30,7 +30,7 @@ const Item: FC<Props> = props => {
   const answers = item.answers[contentLang] || []
 
   return (
-    <Well className={style.qnaItem} bsSize="small" key={id}>
+    <div className={cx(style.qnaItem, style.well)} key={id}>
       <div className={style.itemContainer} role="entry">
         {!questions.length && (
           <div className={style.itemQuestions}>
@@ -100,7 +100,7 @@ const Item: FC<Props> = props => {
           />
         </AccessControl>
       </div>
-    </Well>
+    </div>
   )
 }
 

--- a/modules/qna/src/views/full/Item/index.tsx
+++ b/modules/qna/src/views/full/Item/index.tsx
@@ -1,0 +1,107 @@
+import { Button, Icon, Intent, Switch, Tooltip } from '@blueprintjs/core'
+import { AccessControl } from 'botpress/utils'
+import React, { FC } from 'react'
+import { Well } from 'react-bootstrap'
+
+import style from '../style.scss'
+
+import RedirectInfo from './RedirectInfo'
+import Variations from './Variations'
+
+interface Props {
+  id: string
+  item: any
+  contentLang: string
+  // Hides category and redirect info
+  isVersion2?: boolean
+  onEditItem: (id: string) => void
+  onDeleteItem: (id: string) => void
+  onToggleItem: (item: any, id: string, checked: boolean) => void
+}
+
+const Item: FC<Props> = props => {
+  if (!props.id || !props.item) {
+    return null
+  }
+
+  const { id, item, contentLang } = props
+
+  const questions = item.questions[contentLang] || []
+  const answers = item.answers[contentLang] || []
+
+  return (
+    <Well className={style.qnaItem} bsSize="small" key={id}>
+      <div className={style.itemContainer} role="entry">
+        {!questions.length && (
+          <div className={style.itemQuestions}>
+            <a className={style.firstQuestionTitle} onClick={() => props.onEditItem(id)}>
+              <Tooltip content="Missing translation">
+                <Icon icon="warning-sign" intent={Intent.DANGER} />
+              </Tooltip>
+              &nbsp;
+              {id
+                .split('_')
+                .slice(1)
+                .join(' ')}{' '}
+              &nbsp;
+            </a>
+          </div>
+        )}
+
+        {questions.length > 0 && (
+          <div className={style.itemQuestions}>
+            <span className={style.itemQuestionsTitle}>Q:</span>
+            <a className={style.firstQuestionTitle} onClick={() => props.onEditItem(id)}>
+              {questions[0]}
+            </a>
+            {<Variations elements={questions} />}
+          </div>
+        )}
+
+        {answers[0] && (
+          <div className={style.itemAnswerContainer}>
+            <span className={style.itemAnswerTitle}>A:</span>
+            <div className={style.itemAnswerText}>{answers[0]}</div>
+            {<Variations elements={answers} />}
+          </div>
+        )}
+
+        {!props.isVersion2 && (
+          <div>
+            <div className={style.itemRedirect}>
+              {<RedirectInfo redirectFlow={item.redirectFlow} redirectNode={item.redirectNode} />}
+            </div>
+          </div>
+        )}
+
+        {item.category && !props.isVersion2 ? (
+          <div className={style.questionCategory}>
+            Category:{' '}
+            <span className={style.questionCategoryTitle}>
+              &nbsp;
+              {item.category}
+            </span>
+          </div>
+        ) : null}
+      </div>
+
+      <div className={style.itemAction}>
+        <AccessControl resource="module.qna" operation="write">
+          <Button
+            icon="trash"
+            className={style.itemActionDelete}
+            onClick={() => props.onDeleteItem(id)}
+            minimal={true}
+          />
+          <Switch
+            checked={item.enabled}
+            onChange={e => props.onToggleItem(item, id, e.currentTarget.checked)}
+            large={true}
+          />
+        </AccessControl>
+      </div>
+    </Well>
+  )
+}
+
+export default Item

--- a/modules/qna/src/views/full/LiteEditor.tsx
+++ b/modules/qna/src/views/full/LiteEditor.tsx
@@ -12,6 +12,7 @@ import {
 import { AccessControl } from 'botpress/utils'
 import React, { useEffect, useState } from 'react'
 
+import style from './style.scss'
 import Editor from './Editor'
 import { ExportButton } from './ExportButton'
 import { ImportModal } from './ImportModal'
@@ -85,8 +86,8 @@ export const LiteEditor = props => {
   return (
     <div>
       {!isEditing && (
-        <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-          <div style={{ width: 250, marginBottom: 15 }}>
+        <div className={style.liteHeader}>
+          <div className={style.liteSearch}>
             <ControlGroup>
               <InputGroup
                 id="input-search"
@@ -109,7 +110,9 @@ export const LiteEditor = props => {
             </ControlGroup>
           </div>
 
-          {/* <div>
+          {/*
+          TODO: Support for import/export scoped to a category
+          <div>
             <Popover minimal position={Position.BOTTOM} captureDismiss={true}>
               <Button id="btn-menu" icon="menu" minimal={true} style={{ float: 'right' }} />
               <Menu>
@@ -134,7 +137,7 @@ export const LiteEditor = props => {
       )}
 
       {!isEditing && data && (
-        <div style={{ width: '100%', overflowY: 'scroll', height: '300px' }}>
+        <div className={style.liteItemContainer}>
           {data.map(item => (
             <Item
               key={item.id}

--- a/modules/qna/src/views/full/LiteEditor.tsx
+++ b/modules/qna/src/views/full/LiteEditor.tsx
@@ -1,0 +1,178 @@
+import {
+  Breadcrumbs,
+  Button,
+  ControlGroup,
+  InputGroup,
+  Intent,
+  Menu,
+  MenuItem,
+  Popover,
+  Position
+} from '@blueprintjs/core'
+import { AccessControl } from 'botpress/utils'
+import React, { useEffect, useState } from 'react'
+
+import Editor from './Editor'
+import { ExportButton } from './ExportButton'
+import { ImportModal } from './ImportModal'
+import Item from './Item'
+
+interface Props {
+  bp: any
+  topicName: string
+}
+
+interface QnaEntry {
+  id: string
+  data: any
+}
+
+export const LiteEditor = props => {
+  const [filter, setFilter] = useState('')
+  const [editId, setEditId] = useState('')
+  const [isEditing, setEditing] = useState(false)
+  const [data, setData] = useState<QnaEntry[]>()
+  const [importDialogOpen, setImportDialogOpen] = useState(false)
+
+  useEffect(() => {
+    // tslint:disable-next-line: no-floating-promises
+    fetchData()
+  }, [])
+
+  const getQueryParams = () => {
+    return {
+      params: {
+        categories: [props.topicName]
+      }
+    }
+  }
+
+  const fetchData = async () => {
+    const { data } = await props.bp.axios.get('/mod/qna/questions', getQueryParams())
+    setData(data.items)
+  }
+
+  const createNew = () => {
+    setEditId('')
+    setEditing(true)
+  }
+
+  const editItem = itemId => {
+    setEditId(itemId)
+    setEditing(true)
+  }
+
+  const cancelEditing = () => setEditing(false)
+
+  const deleteItem = async (id: string) => {
+    const needDelete = confirm('Do you want to delete the question?')
+
+    if (needDelete) {
+      const { data } = await props.bp.axios.post(`/mod/qna/questions/${id}/delete`, getQueryParams())
+      setData(data.items)
+    }
+  }
+
+  const toggleEnableItem = async (item: any, id: string, isChecked: boolean) => {
+    item.enabled = isChecked
+
+    const { data } = await props.bp.axios.post(`/mod/qna/questions/${id}`, item, getQueryParams())
+    setData(data.items)
+  }
+
+  const categories = [{ label: props.topicName, value: props.topicName }]
+
+  return (
+    <div>
+      {!isEditing && (
+        <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
+          <div style={{ width: 250, marginBottom: 15 }}>
+            <ControlGroup>
+              <InputGroup
+                id="input-search"
+                placeholder="Search for a question"
+                tabIndex={1}
+                value={filter}
+                onChange={e => setFilter(e.currentTarget.value)}
+              />
+
+              <AccessControl resource="module.qna" operation="write">
+                <Button
+                  id="btn-create-qna"
+                  text="Add new"
+                  icon="add"
+                  style={{ marginLeft: 20 }}
+                  intent={Intent.PRIMARY}
+                  onClick={() => createNew()}
+                />
+              </AccessControl>
+            </ControlGroup>
+          </div>
+
+          {/* <div>
+            <Popover minimal position={Position.BOTTOM} captureDismiss={true}>
+              <Button id="btn-menu" icon="menu" minimal={true} style={{ float: 'right' }} />
+              <Menu>
+                <MenuItem
+                  icon="download"
+                  id="btn-importJson"
+                  text="Import JSON"
+                  onClick={() => setImportDialogOpen(true)}
+                />
+
+                <ExportButton asMenu={true} />
+              </Menu>
+            </Popover>
+            <ImportModal
+              isOpen={importDialogOpen}
+              toggle={() => setImportDialogOpen(!importDialogOpen)}
+              axios={props.bp.axios}
+              onImportCompleted={fetchData}
+            />
+          </div> */}
+        </div>
+      )}
+
+      {!isEditing && data && (
+        <div style={{ width: '100%', overflowY: 'scroll', height: '300px' }}>
+          {data.map(item => (
+            <Item
+              key={item.id}
+              id={item.id}
+              item={item.data}
+              isVersion2={true}
+              contentLang={props.contentLang}
+              onEditItem={editItem}
+              onDeleteItem={deleteItem}
+              onToggleItem={toggleEnableItem}
+            />
+          ))}
+        </div>
+      )}
+      <div>
+        {isEditing && (
+          <div>
+            <Breadcrumbs
+              items={[
+                { onClick: cancelEditing, icon: 'folder-close', text: 'Q&A' },
+                { icon: 'folder-close', text: editId !== '' ? 'Edit Q&A' : 'Create a new Q&A' }
+              ]}
+            />
+
+            <Editor
+              {...{ ...props }}
+              closeQnAModal={cancelEditing}
+              fetchData={fetchData}
+              id={editId}
+              isEditing={editId !== ''}
+              page={{ offset: 0, limit: 500 }}
+              categories={categories}
+              updateQuestion={questions => setData(questions.items)}
+              filters={{ question: filter, categories }}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/modules/qna/src/views/full/index.tsx
+++ b/modules/qna/src/views/full/index.tsx
@@ -1,9 +1,9 @@
-import { Button, Icon, Intent, Position, Switch, Tooltip } from '@blueprintjs/core'
+import { Button, ControlGroup, Intent } from '@blueprintjs/core'
 import { Container } from 'botpress/ui'
-import { AccessControl, ElementPreview } from 'botpress/utils'
+import { AccessControl } from 'botpress/utils'
 import classnames from 'classnames'
 import React, { Component } from 'react'
-import { ButtonGroup, ButtonToolbar, FormControl, FormGroup, Pagination, Panel, Well } from 'react-bootstrap'
+import { ButtonToolbar, FormControl, FormGroup, Pagination, Panel } from 'react-bootstrap'
 import Select from 'react-select'
 import 'react-select/dist/react-select.css'
 
@@ -172,7 +172,7 @@ export default class QnaAdmin extends Component<Props> {
     <FormGroup className={style.qnaHeader}>
       <ButtonToolbar>
         <div className={style.searchBar}>{this.renderSearch()}</div>
-        <ButtonGroup style={{ float: 'right' }}>
+        <ControlGroup style={{ float: 'right' }}>
           <AccessControl resource="module.qna" operation="write">
             <Button
               text="Import JSON"
@@ -182,7 +182,7 @@ export default class QnaAdmin extends Component<Props> {
             />
           </AccessControl>
           <ExportButton />
-        </ButtonGroup>
+        </ControlGroup>
       </ButtonToolbar>
 
       <ImportModal

--- a/modules/qna/src/views/full/index.tsx
+++ b/modules/qna/src/views/full/index.tsx
@@ -1,8 +1,6 @@
 import { Button, Icon, Intent, Position, Switch, Tooltip } from '@blueprintjs/core'
 import { Container } from 'botpress/ui'
-import { ElementPreview } from 'botpress/utils'
-import { Downloader } from 'botpress/utils'
-import { AccessControl } from 'botpress/utils'
+import { AccessControl, ElementPreview } from 'botpress/utils'
 import classnames from 'classnames'
 import React, { Component } from 'react'
 import { ButtonGroup, ButtonToolbar, FormControl, FormGroup, Pagination, Panel, Well } from 'react-bootstrap'
@@ -11,10 +9,14 @@ import 'react-select/dist/react-select.css'
 
 import './button.css'
 import style from './style.scss'
-import FormModal from './FormModal'
+import EditorModal from './Editor/EditorModal'
+import { ExportButton } from './ExportButton'
 import { ImportModal } from './ImportModal'
+import Item from './Item'
 
-const ITEMS_PER_PAGE = 50
+export { LiteEditor } from './LiteEditor'
+
+const ITEMS_PER_PAGE = 5
 const QNA_PARAM_NAME = 'id'
 
 interface Props {
@@ -34,12 +36,12 @@ export default class QnaAdmin extends Component<Props> {
     overallItemsCount: 0,
     showQnAModal: false,
     category: '',
-    QnAModalType: 'create',
+    isEditing: false,
+    importDialogOpen: false,
     categoryOptions: [],
     filterCategory: [],
     filterQuestion: '',
-    selectedQuestion: [],
-    downloadUrl: undefined
+    selectedQuestion: []
   }
 
   fetchFlows() {
@@ -106,6 +108,7 @@ export default class QnaAdmin extends Component<Props> {
     if (hash && hash.includes(searchCmd)) {
       this.setState({ filterQuestion: hash.replace(searchCmd, '') }, this.filterQuestions)
     } else {
+      // tslint:disable-next-line: no-floating-promises
       this.fetchData()
     }
   }
@@ -115,24 +118,9 @@ export default class QnaAdmin extends Component<Props> {
   onQuestionsFilter = event => this.setState({ filterQuestion: event.target.value }, this.filterQuestions)
 
   filterQuestions = (page = 1) => {
-    const { filterQuestion, filterCategory } = this.state
-    const question = filterQuestion
-    const categories = filterCategory.map(({ value }) => value)
-
     this.props.bp.axios
-      .get('/mod/qna/questions', {
-        params: {
-          question,
-          categories,
-          limit: ITEMS_PER_PAGE,
-          offset: (page - 1) * ITEMS_PER_PAGE
-        }
-      })
+      .get('/mod/qna/questions', { params: this.getQueryParams(page) })
       .then(({ data: { items, count } }) => this.setState({ items, overallItemsCount: count, page }))
-  }
-
-  downloadJson = () => {
-    this.setState({ downloadUrl: `${window.BOT_API_PATH}/mod/qna/export` })
   }
 
   renderPagination = () => {
@@ -185,10 +173,24 @@ export default class QnaAdmin extends Component<Props> {
       <ButtonToolbar>
         <div className={style.searchBar}>{this.renderSearch()}</div>
         <ButtonGroup style={{ float: 'right' }}>
-          <ImportModal axios={this.props.bp.axios} onImportCompleted={this.fetchData} />
-          <Button id="btn-export" icon="upload" text="Export to JSON" onClick={this.downloadJson} style={{ marginLeft: 5 }} />
+          <AccessControl resource="module.qna" operation="write">
+            <Button
+              text="Import JSON"
+              icon="download"
+              id="btn-importJson"
+              onClick={() => this.setState({ importDialogOpen: true })}
+            />
+          </AccessControl>
+          <ExportButton />
         </ButtonGroup>
       </ButtonToolbar>
+
+      <ImportModal
+        axios={this.props.bp.axios}
+        onImportCompleted={this.fetchData}
+        isOpen={this.state.importDialogOpen}
+        toggle={() => this.setState({ importDialogOpen: !this.state.importDialogOpen })}
+      />
     </FormGroup>
   )
 
@@ -218,136 +220,30 @@ export default class QnaAdmin extends Component<Props> {
           text="Add new"
           icon="add"
           intent={Intent.PRIMARY}
-          onClick={() => this.setState({ QnAModalType: 'create', currentItemId: null, showQnAModal: true })}
+          onClick={() => this.setState({ isEditing: false, currentItemId: null, showQnAModal: true })}
         />
       </AccessControl>
     </React.Fragment>
   )
 
-  renderVariationsOverlay = elements => {
-    return (
-      !!elements.length && (
-        <Tooltip
-          position={Position.RIGHT}
-          content={
-            <ul className={style.tooltip}>
-              {elements.map(variation => (
-                <li key={variation}>
-                  {variation.startsWith('#!') ? <ElementPreview itemId={variation.replace('#!', '')} /> : variation}
-                </li>
-              ))}
-            </ul>
-          }
-        >
-          <span style={{ cursor: 'default' }}>
-            &nbsp;
-            <strong>({elements.length})</strong>
-          </span>
-        </Tooltip>
-      )
-    )
-  }
-
-  renderRedirectInfo(redirectFlow, redirectNode) {
-    if (!redirectFlow || !redirectNode) {
-      return null
+  getQueryParams = (overridePage?: number) => {
+    const { filterQuestion, filterCategory, page } = this.state
+    return {
+      question: filterQuestion,
+      categories: filterCategory.map(({ value }) => value),
+      limit: ITEMS_PER_PAGE,
+      offset: ((overridePage || page) - 1) * ITEMS_PER_PAGE
     }
-
-    const flowName = redirectFlow.replace('.flow.json', '')
-    const flowBuilderLink = `/studio/${window.BOT_ID}/flows/${flowName}/#search:${redirectNode}`
-
-    return (
-      <React.Fragment>
-        <div className={style.itemRedirectTitle}>Redirect to:</div>
-        <a href={flowBuilderLink}>
-          <div className={style.itemFlow}>
-            Flow: <span className={style.itemFlowName}>{redirectFlow}</span>
-          </div>
-          <div className={style.itemNode}>
-            Node: <span className={style.itemNodeName}>{redirectNode}</span>
-          </div>
-        </a>
-      </React.Fragment>
-    )
-  }
-
-  renderItem = ({ data: item, id }) => {
-    if (!id) {
-      return null
-    }
-
-    const questions = item.questions[this.props.contentLang] || []
-    const answers = item.answers[this.props.contentLang] || []
-
-    return (
-      <Well className={style.qnaItem} bsSize="small" key={id}>
-        <div className={style.itemContainer} role="entry">
-          {!questions.length && (
-            <div className={style.itemQuestions}>
-              <a className={style.firstQuestionTitle} onClick={this.editItem(id)}>
-                <Tooltip content="Missing translation">
-                  <Icon icon="warning-sign" intent={Intent.DANGER} />
-                </Tooltip>
-                &nbsp;
-                {id
-                  .split('_')
-                  .slice(1)
-                  .join(' ')}{' '}
-                &nbsp;
-              </a>
-            </div>
-          )}
-          {questions.length > 0 && (
-            <div className={style.itemQuestions}>
-              <span className={style.itemQuestionsTitle}>Q:</span>
-              <a className={style.firstQuestionTitle} onClick={this.editItem(id)}>
-                {questions[0]}
-              </a>
-              {this.renderVariationsOverlay(questions)}
-            </div>
-          )}
-          {answers[0] && (
-            <div className={style.itemAnswerContainer}>
-              <span className={style.itemAnswerTitle}>A:</span>
-              <div className={style.itemAnswerText}>{answers[0]}</div>
-              {this.renderVariationsOverlay(answers)}
-            </div>
-          )}
-          <div>
-            <div className={style.itemRedirect}>{this.renderRedirectInfo(item.redirectFlow, item.redirectNode)}</div>
-          </div>
-          {item.category ? (
-            <div className={style.questionCategory}>
-              Category:{' '}
-              <span className={style.questionCategoryTitle}>
-                &nbsp;
-                {item.category}
-              </span>
-            </div>
-          ) : null}
-        </div>
-        <div className={style.itemAction}>
-          <AccessControl resource="module.qna" operation="write">
-            <Button icon="trash" className={style.itemActionDelete} onClick={this.deleteItem(id)} minimal={true} />
-            <Switch checked={item.enabled} onChange={this.toggleEnableItem.bind(this, item, id)} large={true} />
-          </AccessControl>
-        </div>
-      </Well>
-    )
   }
 
   deleteItem = (id: string) => () => {
     const needDelete = confirm('Do you want to delete the question?')
-    const { filterQuestion, filterCategory, page } = this.state
-    const params = {
-      question: filterQuestion,
-      categories: filterCategory.map(({ value }) => value),
-      limit: ITEMS_PER_PAGE,
-      offset: (page - 1) * ITEMS_PER_PAGE
-    }
+    const params = this.getQueryParams()
 
     if (needDelete) {
-      this.props.bp.axios.post(`/mod/qna/questions/${id}/delete`, { params }).then(({ data }) => this.setState({ ...data }))
+      this.props.bp.axios
+        .post(`/mod/qna/questions/${id}/delete`, { params })
+        .then(({ data }) => this.setState({ ...data }))
     }
   }
 
@@ -356,19 +252,13 @@ export default class QnaAdmin extends Component<Props> {
     url.searchParams.set(QNA_PARAM_NAME, id)
     window.history.pushState(window.history.state, '', url.toString())
 
-    this.setState({ QnAModalType: 'edit', currentItemId: id, showQnAModal: true })
+    this.setState({ isEditing: true, currentItemId: id, showQnAModal: true })
   }
 
-  toggleEnableItem = (item: any, id: string, event) => {
-    const { page, filterQuestion, filterCategory } = this.state
-    const params = {
-      limit: ITEMS_PER_PAGE,
-      offset: (page - 1) * ITEMS_PER_PAGE,
-      question: filterQuestion,
-      categories: filterCategory
-    }
+  toggleEnableItem = (item: any, id: string, isChecked: boolean) => {
+    const params = this.getQueryParams()
 
-    item.enabled = event.target.checked
+    item.enabled = isChecked
     this.props.bp.axios
       .post(`/mod/qna/questions/${id}`, item, { params })
       .then(({ data: { items } }) => this.setState({ items }))
@@ -383,10 +273,21 @@ export default class QnaAdmin extends Component<Props> {
   }
 
   questionsList = () => {
-    if (this.state.items.length) {
-      return this.state.items.map(this.renderItem)
+    if (!this.state.items.length) {
+      return <h3>No questions have been added yet.</h3>
     }
-    return <h3>No questions have been added yet.</h3>
+
+    return this.state.items.map(({ id, data }) => (
+      <Item
+        key={id}
+        id={id}
+        item={data}
+        contentLang={this.props.contentLang}
+        onEditItem={this.editItem(id)}
+        onToggleItem={this.toggleEnableItem.bind(this)}
+        onDeleteItem={this.deleteItem(id)}
+      />
+    ))
   }
 
   updateQuestion = ({ items }) => this.setState({ items })
@@ -394,7 +295,6 @@ export default class QnaAdmin extends Component<Props> {
   render() {
     return (
       <Container sidePanelHidden={true}>
-        <Downloader url={this.state.downloadUrl} />
         <div />
         <Panel className={classnames(style.qnaContainer, 'qnaContainer')}>
           <Panel.Body>
@@ -402,7 +302,7 @@ export default class QnaAdmin extends Component<Props> {
             {this.renderPagination()}
             {this.questionsList()}
             {this.renderPagination()}
-            <FormModal
+            <EditorModal
               contentLang={this.props.contentLang}
               flows={this.state.flows}
               flowsList={this.state.flowsList}
@@ -412,7 +312,7 @@ export default class QnaAdmin extends Component<Props> {
               categories={this.state.categoryOptions}
               fetchData={this.fetchData}
               id={this.state.currentItemId}
-              modalType={this.state.QnAModalType}
+              isEditing={this.state.isEditing}
               page={{ offset: (this.state.page - 1) * ITEMS_PER_PAGE, limit: ITEMS_PER_PAGE }}
               updateQuestion={this.updateQuestion}
               filters={{ question: this.state.filterQuestion, categories: this.state.filterCategory }}

--- a/modules/qna/src/views/full/style.scss
+++ b/modules/qna/src/views/full/style.scss
@@ -108,6 +108,11 @@ $elementHeight: 40px;
   margin-bottom: 20px;
 }
 
+.searchBarLite {
+  display: flex;
+  justify-content: space-between;
+}
+
 .searchField {
   width: 200px;
 }

--- a/modules/qna/src/views/full/style.scss
+++ b/modules/qna/src/views/full/style.scss
@@ -306,3 +306,20 @@ $elementHeight: 40px;
     margin-left: -20px;
   }
 }
+
+.liteItemContainer {
+  width: 100%;
+  overflow-y: scroll;
+  height: 300px;
+}
+
+.liteHeader {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.liteSearch {
+  width: 250;
+  margin-bottom: 15;
+}

--- a/modules/qna/src/views/full/style.scss
+++ b/modules/qna/src/views/full/style.scss
@@ -323,3 +323,14 @@ $elementHeight: 40px;
   width: 250;
   margin-bottom: 15;
 }
+
+.well {
+  min-height: 20px;
+  padding: 12px;
+  margin-bottom: 20px;
+  background-color: #f5f5f5;
+  border: 1px solid #e3e3e3;
+  border-radius: 3px;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+}

--- a/modules/qna/src/views/full/style.scss.d.ts
+++ b/modules/qna/src/views/full/style.scss.d.ts
@@ -24,6 +24,9 @@ interface CssExports {
   'itemQuestionsTitle': string;
   'itemRedirect': string;
   'itemRedirectTitle': string;
+  'liteHeader': string;
+  'liteItemContainer': string;
+  'liteSearch': string;
   'paddedRow': string;
   'pale': string;
   'qna': string;

--- a/modules/qna/src/views/full/style.scss.d.ts
+++ b/modules/qna/src/views/full/style.scss.d.ts
@@ -53,6 +53,7 @@ interface CssExports {
   'tooltip': string;
   'variation': string;
   'variationDelete': string;
+  'well': string;
 }
 declare var cssExports: CssExports;
 export = cssExports;

--- a/modules/qna/src/views/full/style.scss.d.ts
+++ b/modules/qna/src/views/full/style.scss.d.ts
@@ -44,6 +44,7 @@ interface CssExports {
   'questionCategoryTitle': string;
   'questionToolbar': string;
   'searchBar': string;
+  'searchBarLite': string;
   'searchField': string;
   'strong': string;
   'tooltip': string;


### PR DESCRIPTION
This refactor is required so we can provide a lite editor that can be used by the future NDU. Split big components into smaller one so we can have a Full and a Lite editor 

No change on the full editor, but provides a compact lite version: 

![image](https://user-images.githubusercontent.com/42552874/71836448-05d5c980-3082-11ea-98cd-7002f771d0ee.png)
