### PR TITLE
fix(bots): issue when promoting bot with autorevision

### DIFF
--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -381,7 +381,7 @@ export class BotService {
     await this.hookService.executeHook(new Hooks.OnStageChangeRequest(api, alteredBot, users, pipeline, hookResult))
     if (_.isArray(hookResult.actions)) {
       await Promise.map(hookResult.actions, async action => {
-        if (bpConfig.autoRevision) {
+        if (bpConfig.autoRevision && (await this.botExists(alteredBot.id))) {
           await this.createRevision(alteredBot.id)
         }
         if (action === 'promote_copy') {

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/index.tsx
@@ -114,6 +114,7 @@ class Bots extends Component<Props> {
   async requestStageChange(botId) {
     await api.getSecured().post(`/admin/bots/${botId}/stage`)
     await this.props.fetchBots()
+    toastSuccess('Bot promoted to next stage')
   }
 
   isLicensed = () => {


### PR DESCRIPTION
Fix issue when autoRevision is enabled and a bot is promoted to the next stage for the first time. It was missing a check before trying to create the revision