### PR TITLE
fix(build): remove dupes on changelog & fix command

### DIFF
--- a/build/remove_changelog_dupes.js
+++ b/build/remove_changelog_dupes.js
@@ -17,4 +17,4 @@ for (let i = 0; i < lines.length; i++) {
   }
 }
 
-fs.writeFileSync('CHANGELOG2.md', finalLines.join('\n'), 'UTF-8')
+fs.writeFileSync('CHANGELOG.md', finalLines.join('\n'), 'UTF-8')

--- a/build/remove_changelog_dupes.js
+++ b/build/remove_changelog_dupes.js
@@ -1,0 +1,20 @@
+const fs = require('fs')
+
+const lines = fs
+  .readFileSync('CHANGELOG.md')
+  .toString()
+  .split('\n')
+
+const finalLines = []
+
+for (let i = 0; i < lines.length; i++) {
+  const currentLine = lines[i].split('([')[0]
+  const nextLine = i + 1 < lines.length && lines[i + 1].split('([')[0]
+
+  // ignore the first dupe commit (merge) & keeps all new lines
+  if (currentLine !== nextLine || currentLine === '') {
+    finalLines.push(lines[i])
+  }
+}
+
+fs.writeFileSync('CHANGELOG2.md', finalLines.join('\n'), 'UTF-8')

--- a/docs/guide/website/package.json
+++ b/docs/guide/website/package.json
@@ -5,7 +5,7 @@
     "build": "docusaurus-build",
     "publish-gh-pages": "docusaurus-publish",
     "write-translations": "docusaurus-write-translations",
-    "version": "docusaurus-version",
+    "version": "yarn run docusaurus-version",
     "rename-version": "docusaurus-rename-version"
   },
   "devDependencies": {

--- a/release-version.sh
+++ b/release-version.sh
@@ -28,6 +28,7 @@ select VERSION in patch minor major "Specific Version"
         
         # Update changelog from git history
         yarn cmd changelog
+        node build/remove_changelog_dupes.js
 
         # Create commit
         git add -A


### PR DESCRIPTION
Added a script to remove duplicates from the change log (caused by merges). Also updated the docs command which wasn't working for me (i don't have it installed globally)