### PR TITLE
remove special chars for classification

### DIFF
--- a/modules/nlu/src/backend/engine2/utterance.ts
+++ b/modules/nlu/src/backend/engine2/utterance.ts
@@ -120,7 +120,8 @@ export default class Utterance {
 
     for (const token of this.tokens) {
       const norm = computeNorm(token.vectors as number[])
-      if (norm <= 0) {
+      if (norm <= 0 || !token.isWord) {
+        // ignore special char tokens in sentence embeddings
         continue
       }
 

--- a/modules/nlu/src/backend/tools/token-utils.test.ts
+++ b/modules/nlu/src/backend/tools/token-utils.test.ts
@@ -1,5 +1,6 @@
 import { LATIN_CHARSET } from './chars'
 import {
+  isWord,
   makeTokens,
   mergeSimilarCharsetTokens,
   mergeSpecialCharactersTokens,
@@ -7,6 +8,14 @@ import {
   restoreOriginalUtteranceCasing,
   SPACE
 } from './token-utils'
+
+test('isWord', () => {
+  expect(isWord('lol123')).toBeTruthy()
+  expect(isWord('hey 123')).toBeFalsy()
+  expect(isWord('!')).toBeFalsy()
+  expect(isWord('^jo!')).toBeFalsy()
+  expect(isWord('?¿')).toBeFalsy()
+})
 
 // We might want to get rid of this once engine2 is done
 describe('Tokens generation', () => {

--- a/modules/nlu/src/backend/tools/token-utils.ts
+++ b/modules/nlu/src/backend/tools/token-utils.ts
@@ -6,7 +6,9 @@ import { IsLatin, LATIN_CHARSET, SPECIAL_CHARSET } from './chars'
 
 export const SPACE = '\u2581'
 
-export const isWord = (str: string) => _.every(SPECIAL_CHARSET, c => !str.includes(c)) && !isSpace(str)
+export const isWord = (str: string) => _.every(SPECIAL_CHARSET, c => !RegExp(c).test(str)) && !hasSpace(str)
+
+export const hasSpace = (str: string) => _.some(str, isSpace)
 
 export const isSpace = (str: string) => _.every(str, c => c === SPACE || c === ' ')
 


### PR DESCRIPTION
basically this ensures that we get the same sentence embeddings with the followings

"hello my friend" and "hello! My friend!" and "hello?, my friend?"

also fixes the exact match index