### PR TITLE
chore: remove unnecessary "await"

### DIFF
--- a/build/docs/set_docusaurus_url.js
+++ b/build/docs/set_docusaurus_url.js
@@ -4,8 +4,8 @@ const setBaseUrl = async () => {
   const file = './docs/guide/website/siteConfig.js'
   const args = process.argv.slice(2)
 
-  const content = await fs.readFileSync(file, 'utf-8')
+  const content = fs.readFileSync(file, 'utf-8')
   const replaced = content.replace(/baseUrl.*/, `baseUrl: '${args}',`)
-  await fs.writeFileSync(file, replaced, 'utf-8')
+  fs.writeFileSync(file, replaced, 'utf-8')
 }
 setBaseUrl()

--- a/modules/nlu/src/views/full/intents/SidePanelSection.tsx
+++ b/modules/nlu/src/views/full/intents/SidePanelSection.tsx
@@ -46,7 +46,7 @@ export const IntentSidePanelSection: FC<Props> = props => {
     }
 
     await props.api.createIntent(intentDef)
-    await props.reloadIntents()
+    props.reloadIntents()
     props.setCurrentItem({ name: sanitizedName, type: 'intent' })
   }
 

--- a/src/bp/core/services/dialog/flow/service.ts
+++ b/src/bp/core/services/dialog/flow/service.ts
@@ -1,19 +1,18 @@
 import { Flow, Logger } from 'botpress/sdk'
 import { ObjectCache } from 'common/object-cache'
-import { FlowView, NodeView, FlowMutex } from 'common/typings'
+import { FlowMutex, FlowView, NodeView } from 'common/typings'
 import { ModuleLoader } from 'core/module-loader'
+import { RealTimePayload } from 'core/sdk/impl'
+import { KeyValueStore } from 'core/services/kvs'
+import RealtimeService from 'core/services/realtime'
 import { inject, injectable, tagged } from 'inversify'
 import _ from 'lodash'
+import moment = require('moment')
 import nanoid from 'nanoid/generate'
 
 import { GhostService } from '../..'
 import { TYPES } from '../../../types'
 import { validateFlowSchema } from '../validator'
-
-import { RealTimePayload } from 'core/sdk/impl'
-import RealtimeService from 'core/services/realtime'
-import { KeyValueStore } from 'core/services/kvs'
-import moment = require('moment')
 
 const PLACING_STEP = 250
 const MIN_POS_X = 50

--- a/src/bp/core/services/migration/index.ts
+++ b/src/bp/core/services/migration/index.ts
@@ -66,7 +66,7 @@ export class MigrationService {
     this.displayMigrationStatus(configVersion, missingMigrations, this.logger)
 
     if (!process.AUTO_MIGRATE) {
-      await this.logger.error(
+      this.logger.error(
         `Botpress needs to migrate your data. Please make a copy of your data, then start it with "./bp --auto-migrate"`
       )
 
@@ -97,10 +97,10 @@ export class MigrationService {
       const result = await this.loadedMigrations[filename].up(opts)
       debug.forBot(botId, `Migration step finished`, { filename, result })
       if (result.success) {
-        await this.logger.info(`- ${result.message || 'Success'}`)
+        this.logger.info(`- ${result.message || 'Success'}`)
       } else {
         hasFailures = true
-        await this.logger.error(`- ${result.message || 'Failure'}`)
+        this.logger.error(`- ${result.message || 'Failure'}`)
       }
     })
 
@@ -149,15 +149,15 @@ export class MigrationService {
       const result = await this.loadedMigrations[filename].up(opts)
       if (result.success) {
         await this._saveCompletedMigration(filename, result)
-        await this.logger.info(`- ${result.message || 'Success'}`)
+        this.logger.info(`- ${result.message || 'Success'}`)
       } else {
         hasFailures = true
-        await this.logger.error(`- ${result.message || 'Failure'}`)
+        this.logger.error(`- ${result.message || 'Failure'}`)
       }
     })
 
     if (hasFailures) {
-      await this.logger.error(
+      this.logger.error(
         `Some steps failed to complete. Please fix errors manually, then restart Botpress so the update process may finish.`
       )
 

--- a/src/bp/lang-server/api.ts
+++ b/src/bp/lang-server/api.ts
@@ -185,7 +185,7 @@ export default async function(
   })
 
   router.post('/:lang/delete', adminTokenMw, validateLanguageMw, async (req: RequestWithLang, res, next) => {
-    await languageService.remove(req.language!)
+    languageService.remove(req.language!)
     res.sendStatus(200)
   })
 

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/index.tsx
@@ -79,7 +79,7 @@ class Bots extends Component<Props> {
   async deleteBot(botId) {
     if (window.confirm("Are you sure you want to delete this bot? This can't be undone.")) {
       await api.getSecured().post(`/admin/bots/${botId}/delete`)
-      await this.props.fetchBots()
+      this.props.fetchBots()
     }
   }
 
@@ -113,7 +113,7 @@ class Bots extends Component<Props> {
 
   async requestStageChange(botId) {
     await api.getSecured({ timeout: 60000 }).post(`/admin/bots/${botId}/stage`)
-    await this.props.fetchBots()
+    this.props.fetchBots()
     toastSuccess('Bot promoted to next stage')
   }
 


### PR DESCRIPTION
1. When `await` is added before a synchronous method, it doesn't add a value, and there is a hint that:

> 'await' has no effect on the type of this expression.
<hr>
2. Another question: in some parts of the code for `floating-promises`, they are ignored in some places with:

> // tslint:disable-next-line: no-floating-promises

And they can also be ignored by adding `void` before them. Any preferences to remove this warning? Add `.then().catch()` ? Or should we leave things as is? 


![image](https://user-images.githubusercontent.com/2410127/72049342-0c04b980-32bf-11ea-94e8-385550787970.png)
