### PR TITLE
fix(studio): don't show reselection of checkboxes

### DIFF
--- a/src/bp/ui-studio/src/web/components/Content/Select/Widget.tsx
+++ b/src/bp/ui-studio/src/web/components/Content/Select/Widget.tsx
@@ -60,7 +60,7 @@ class ContentPickerWidget extends Component<Props> {
     const { contentType } = contentItem
     await this.props
       .upsertContentItem({ modifyId: itemId, contentType, formData: this.state.contentToEdit })
-      .then(() => this.setState({ showItemEdit: false, contentToEdit: null }))
+      .then(() => this.setState({ showItemEdit: false }))
       .then(() => this.props.fetchContentItem(this.props.itemId, { force: true }))
       .then(this.props.refresh || (() => {}))
       .then(this.props.onUpdate || (() => {}))


### PR DESCRIPTION
When saving the `ContentPickerWidget`, the checkboxes are set to the default values, which gives a hint that they were changed.

Steps to reproduce:
1. Have a Standard Node, with "On Enter" action of some text to say.
2. Edit this action
3. Click on the "pencil" button to edit
4. Unselect "Use markdown" and "Show typing indicator"
5. Click on "Submit"
  a. Expected behavior: when the dialog is closed, the checkboxes remain at their condition of unselection
  b. Actual behavior: the checkboxes are always to to true (their default value), quickly before being hidden.

See the below recording:

![markdownSelected](https://user-images.githubusercontent.com/2410127/72069636-e3dd8080-32e7-11ea-9a7a-e2b8bb01c8df.gif)
