### PR TITLE
fix(admin): fix docker image link

### DIFF
--- a/src/bp/core/routers/admin/versioning.ts
+++ b/src/bp/core/routers/admin/versioning.ts
@@ -1,8 +1,10 @@
+import axios from 'axios'
 import { Logger } from 'botpress/sdk'
 import { extractArchive } from 'core/misc/archive'
 import { GhostService } from 'core/services'
 import { BotService } from 'core/services/bot-service'
 import { Router } from 'express'
+import httpsProxyAgent from 'https-proxy-agent'
 import _ from 'lodash'
 import mkdirp from 'mkdirp'
 import path from 'path'
@@ -77,6 +79,15 @@ export class VersioningRouter extends CustomRouter {
 
     this.router.get('/bpfs_status', (req, res) => {
       res.send({ isAvailable: process.BPFS_STORAGE === 'database' })
+    })
+
+    this.router.get('/docker_images', async (req, res) => {
+      const { data } = await axios.get(
+        'https://hub.docker.com/v2/repositories/botpress/server/tags/?page_size=125&page=1&name=v',
+        process.PROXY ? { httpsAgent: new httpsProxyAgent(process.PROXY) } : {}
+      )
+
+      res.send(data)
     })
   }
 

--- a/src/bp/ui-admin/src/Pages/Server/LatestReleases.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/LatestReleases.tsx
@@ -15,9 +15,10 @@ interface GithubRelease {
   githubUrl: string
   releaseDate: Date
   daysAgo: string
+  dockerUrl: string
 }
 
-const DownloadLinks: FC<{ version: string }> = props => {
+const DownloadLinks: FC<{ version: string; dockerUrl: string }> = props => {
   const version = `v${props.version.replace(/\./g, '_')}`
 
   return (
@@ -39,7 +40,7 @@ const DownloadLinks: FC<{ version: string }> = props => {
       <br />
       Docker Image
       <hr />
-      <a href="https://hub.docker.com/r/botpress/server" target="_blank">
+      <a href={props.dockerUrl || `https://hub.docker.com/r/botpress/server`} target="_blank">
         <code>botpress/server:{version}</code>
       </a>
     </div>
@@ -64,7 +65,7 @@ const LastRelease: FC<{ latestReleases: GithubRelease[]; fetchLatestVersions: Fu
 
               <div className="container">
                 <div className="content" dangerouslySetInnerHTML={{ __html: snarkdown(release.details) }} />
-                <DownloadLinks version={release.version} />
+                <DownloadLinks version={release.version} dockerUrl={release.dockerUrl} />
               </div>
             </div>
           )


### PR DESCRIPTION
This is mentioned in botpress/v12#894

Issue:
- The individual docker image links are general, and not pointing to the specific version image.

Fix:
- Fetch the individual image link from `hub.docker.com`

The implementation calls `https://hub.docker.com` from the server-side, because Chrome blocks the call from the client-side (CORB)
