### PR TITLE
fix(code-editor): only one of enabled or disabled

### DIFF
--- a/modules/code-editor/src/views/full/FileNavigator.tsx
+++ b/modules/code-editor/src/views/full/FileNavigator.tsx
@@ -190,20 +190,11 @@ class FileNavigator extends React.Component<Props, State> {
         <MenuDivider />
         <MenuItem id="btn-duplicate" icon="duplicate" text="Duplicate" onClick={() => this.props.duplicateFile(file)} />
         <MenuDivider />
-        <MenuItem
-          id="btn-enable"
-          icon="endorsed"
-          text="Enable"
-          disabled={!isDisabled}
-          onClick={() => this.props.enableFile(file)}
-        />
-        <MenuItem
-          id="btn-disable"
-          icon="disable"
-          text="Disable"
-          disabled={isDisabled}
-          onClick={() => this.props.disableFile(file)}
-        />
+        {isDisabled ? (
+          <MenuItem id="btn-enable" icon="endorsed" text="Enable" onClick={() => this.props.enableFile(file)} />
+        ) : (
+          <MenuItem id="btn-disable" icon="disable" text="Disable" onClick={() => this.props.disableFile(file)} />
+        )}
       </Menu>,
       { left: e.clientX, top: e.clientY }
     )


### PR DESCRIPTION
On right-clicking created actions, there are both `enabled` and `disabled` options, as shown in in the below screenshot.

This PR ensures only the relevant one is shown, since the other option is always useless.

![image](https://user-images.githubusercontent.com/2410127/72262925-2cfb4080-3618-11ea-8807-711a74917a0d.png)
