### PR TITLE
incorrect short urls for index doc file

### DIFF
--- a/build/gulp.docs.js
+++ b/build/gulp.docs.js
@@ -41,14 +41,20 @@ const alterReference = async () => {
 
   fs.writeFileSync(path.join(__dirname, '../docs/reference/public/modules/_botpress_sdk_.html'), newFile)
 
-  $('a').map(function() {
+  $('a').map(function () {
     const href = $(this).attr('href')
     if (href && href.startsWith('_botpress_sdk')) {
       $(this).attr('href', 'modules/' + href)
     }
+
+
+    const hrefsToReplace = ['../enums', '../classes', '../interfaces']
+    if (href && hrefsToReplace.find(x => href.startsWith(x))) {
+      $(this).attr('href', href.replace('../', '/reference/'))
+    }
   })
 
-  const fixedContentPaths = $.html().replace('../assets/', 'assets/')
+  const fixedContentPaths = $.html().replace('../assets/', 'assets/').replace('../globals.html', '/reference/globals.html')
   fs.writeFileSync(path.join(__dirname, '../docs/reference/public/index.html'), fixedContentPaths)
 }
 

--- a/build/gulp.docs.js
+++ b/build/gulp.docs.js
@@ -41,20 +41,23 @@ const alterReference = async () => {
 
   fs.writeFileSync(path.join(__dirname, '../docs/reference/public/modules/_botpress_sdk_.html'), newFile)
 
+  const hrefsToReplace = ['../enums', '../classes', '../interfaces']
   $('a').map(function () {
     const href = $(this).attr('href')
-    if (href && href.startsWith('_botpress_sdk')) {
+    if (!href) {
+      return;
+    }
+
+    if (href.startsWith('_botpress_sdk')) {
       $(this).attr('href', 'modules/' + href)
     }
 
-
-    const hrefsToReplace = ['../enums', '../classes', '../interfaces']
-    if (href && hrefsToReplace.find(x => href.startsWith(x))) {
-      $(this).attr('href', href.replace('../', '/reference/'))
+    if (hrefsToReplace.find(x => href.startsWith(x))) {
+      $(this).attr('href', href.replace('../', ''))
     }
   })
 
-  const fixedContentPaths = $.html().replace('../assets/', 'assets/').replace('../globals.html', '/reference/globals.html')
+  const fixedContentPaths = $.html().replace('../assets/', 'assets/').replace(/\.\.\/globals.html/g, 'globals.html')
   fs.writeFileSync(path.join(__dirname, '../docs/reference/public/index.html'), fixedContentPaths)
 }
 


### PR DESCRIPTION
Index file contains .. urls, that points to ../. It's correct for all sub-folders, but not for index.html, that trying to move one folder up. I've set it /reference/ instead for index.html's related urls.

I'm not sure, how to run docs locally, so I've tested it only with browser dev tools.

**Please test this before merging!**

resolves botpress/v12#897