### PR TITLE
chore(deps): update typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "gulp-run": "^1.7.1",
     "gulp-sourcemaps": "^2.6.4",
     "gulp-typedoc": "^2.2.1",
-    "gulp-typescript": "^5.0.0-alpha.3",
+    "gulp-typescript": "^6.0.0-alpha.1",
     "husky": "^1.1.2",
     "jest": "^24.5.0",
     "jest-circus": "^24.5.0",
@@ -152,7 +152,7 @@
     "tslint": "^5.11.0",
     "tslint-gitstaged": "^0.4.0",
     "typedoc": "^0.13.0",
-    "typescript": "^3.1.3",
+    "typescript": "^3.7.4",
     "typescript-json-schema": "^0.32.0"
   },
   "optionalDependencies": {

--- a/src/bp/core/config/botpress.config.ts
+++ b/src/bp/core/config/botpress.config.ts
@@ -30,22 +30,6 @@ export interface DialogConfig {
   sessionTimeoutInterval: string
 }
 
-/**
- * Configuration file definition for the Converse API
- */
-export type ConverseConfig = {
-  /**
-   * The timeout of the converse API requests
-   * @default 5s
-   */
-  timeout: string
-  /**
-   * The text limitation of the converse API requests
-   * @default 360
-   */
-  maxMessageLength: number
-}
-
 export interface LogsConfig {
   /**
    * The database output will not record Debug logs.

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/CreateBotModal.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/CreateBotModal.tsx
@@ -200,7 +200,7 @@ class CreateBotModal extends Component<Props, State> {
                   tabIndex="3"
                   options={this.state.templates}
                   value={this.state.selectedTemplate}
-                  onChange={selectedTemplate => this.setState({ selectedTemplate })}
+                  onChange={selectedTemplate => this.setState({ selectedTemplate: selectedTemplate as any })}
                   getOptionLabel={o => o.name}
                   getOptionValue={o => o.id}
                 />
@@ -212,7 +212,7 @@ class CreateBotModal extends Component<Props, State> {
                   tabIndex="4"
                   options={this.state.categories}
                   value={this.state.selectedCategory}
-                  onChange={selectedCategory => this.setState({ selectedCategory })}
+                  onChange={selectedCategory => this.setState({ selectedCategory: selectedCategory as any })}
                 />
               </FormGroup>
             )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1017,10 +1017,15 @@ ansi-colors@^1.0.1:
   dependencies:
     ansi-wrap "^0.1.0"
 
-ansi-colors@^3.0.5, ansi-colors@^3.2.4:
+ansi-colors@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
+
+ansi-colors@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
+  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
 ansi-cyan@^0.1.1:
   version "0.1.1"
@@ -4325,16 +4330,16 @@ gulp-typedoc@^2.2.1:
     fancy-log "^1.3.2"
     plugin-error "^0.1.2"
 
-gulp-typescript@^5.0.0-alpha.3:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/gulp-typescript/-/gulp-typescript-5.0.1.tgz#96c6565a6eb31e08c2aae1c857b1a079e6226d94"
-  integrity sha512-YuMMlylyJtUSHG1/wuSVTrZp60k1dMEFKYOvDf7OvbAJWrDtxxD4oZon4ancdWwzjj30ztiidhe4VXJniF0pIQ==
+gulp-typescript@^6.0.0-alpha.1:
+  version "6.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/gulp-typescript/-/gulp-typescript-6.0.0-alpha.1.tgz#fcb0dbbc79c34201f0945c6323c194a8f5455a04"
+  integrity sha512-KoT0TTfjfT7w3JItHkgFH1T/zK4oXWC+a8xxKfniRfVcA0Fa1bKrIhztYelYmb+95RB80OLMBreknYkdwzdi2Q==
   dependencies:
-    ansi-colors "^3.0.5"
+    ansi-colors "^4.1.1"
     plugin-error "^1.0.1"
     source-map "^0.7.3"
-    through2 "^3.0.0"
-    vinyl "^2.1.0"
+    through2 "^3.0.1"
+    vinyl "^2.2.0"
     vinyl-fs "^3.0.3"
 
 gulp-util@^3.0.0:
@@ -9538,7 +9543,7 @@ through2@^0.4.1:
     readable-stream "~1.0.17"
     xtend "~2.1.1"
 
-through2@^3.0.0:
+through2@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/through2/-/through2-3.0.1.tgz#39276e713c3302edf9e388dd9c812dd3b825bd5a"
   integrity sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==
@@ -9836,10 +9841,15 @@ typescript@^2.5.0:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
   integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
-typescript@^3.0.1, typescript@^3.1.3:
+typescript@^3.0.1:
   version "3.3.4000"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
   integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
+
+typescript@^3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 uglify-js@^3.1.4:
   version "3.5.2"


### PR DESCRIPTION
Okay, I think it was time to update the typescript version (we had 3.1.3 which was released more than 14 months ago). There's a bunch of changes, so I suggest you take a look to the release notes from 3.2 to 3.7 https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html

Happy to see that one:  :heart_eyes: 

![image](https://user-images.githubusercontent.com/42552874/72406679-15f94300-372b-11ea-9f6b-97931a3d21a1.png)

Code completion handles optional values automatically

They also added the Omit helper for typings
