### PR TITLE
chore: remove unused SlotDefinition.Entity

### DIFF
--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -414,7 +414,6 @@ declare module 'botpress/sdk' {
     export interface SlotDefinition {
       name: string
       entities: string[]
-      entity?: string
       color: number
     }
 


### PR DESCRIPTION
I guess it should be removed, since it is not used, and `entities` property has been required since https://github.com/botpress/botpress/commit/d4c194701619bb5b872621cc998cdc182208c951