### PR TITLE
chore(core): a bit prettier logs

### DIFF
--- a/src/bp/core/logger/logger.ts
+++ b/src/bp/core/logger/logger.ts
@@ -151,7 +151,7 @@ export class PersistedConsoleLogger implements Logger {
     }
 
     const serializedMetadata = metadata ? serializeArgs(metadata) : ''
-    const timeFormat = 'HH:mm:ss.SSS'
+    const timeFormat = 'L HH:mm:ss.SSS'
     const time = moment().format(timeFormat)
 
     const displayName = process.env.INDENT_LOGS ? this.name.substr(0, 15).padEnd(15, ' ') : this.name


### PR DESCRIPTION
Sorted modules by status and removed useless prefix.  Also added date to logger lines for debugging purposes on server logs.
```
01/17/2020 12:47:32.133 Launcher Using 10 modules
                        ⦿ analytics
                        ⦿ basic-skills
                        ⦿ builtin
                        ⦿ channel-web
                        ⦿ code-editor
                        ⦿ examples
                        ⦿ extensions
                        ⦿ nlu
                        ⦿ qna
                        ⦿ testing
                        ⊝ channel-messenger (disabled)
                        ⊝ channel-slack (disabled)
                        ⊝ channel-teams (disabled)
                        ⊝ channel-telegram (disabled)
                        ⊝ hitl (disabled)
                        ⊝ misunderstood (disabled)
                        ⊝ nlu-extras (disabled)
                        ⊝ nlu-testing (disabled)
                        ⊝ uipath (disabled)
01/17/2020 12:47:33.290 Server Loaded 10 modules
01/17/2020 12:47:33.391 CMS Loaded 7 content types
01/17/2020 12:47:34.832 Server Started in 2697ms
01/17/2020 12:47:34.834 Launcher Botpress is listening at: http://localhost:3000
01/17/2020 12:47:34.836 Launcher Botpress is exposed at: http://localhost:3000
```