### PR TITLE
Improved UX on the bot config form

### DIFF
--- a/modules/nlu/src/backend/engine2/engine2.ts
+++ b/modules/nlu/src/backend/engine2/engine2.ts
@@ -134,7 +134,7 @@ export default class E2 implements Engine2 {
     const { input, output, artefacts } = model.data
     const tools = E2.tools
 
-    if (input.intents.length > 0) {
+    if (_.flatMap(input.intents, i => i.utterances).length > 0) {
       const ctx_classifier = new tools.mlToolkit.SVM.Predictor(artefacts.ctx_model)
       const intent_classifier_per_ctx = _.toPairs(artefacts.intent_model_by_ctx).reduce(
         (c, [ctx, intentModel]) => ({ ...c, [ctx]: new tools.mlToolkit.SVM.Predictor(intentModel as string) }),
@@ -157,7 +157,7 @@ export default class E2 implements Engine2 {
     } else {
       // we don't want to return undefined as extraction won't be triggered
       // we want to make it possible to extract entities without having any intents
-      return { ...artefacts } as Predictors
+      return { ...artefacts, intents: [], pattern_entities: input.pattern_entities } as Predictors
     }
   }
 

--- a/modules/nlu/src/backend/engine2/predict-pipeline.ts
+++ b/modules/nlu/src/backend/engine2/predict-pipeline.ts
@@ -141,12 +141,13 @@ async function extractEntities(input: PredictStep, predictors: Predictors, tools
 }
 
 async function predictContext(input: PredictStep, predictors: Predictors): Promise<PredictStep> {
-  if (predictors.intents.length === 0) {
+  const classifier = predictors.ctx_classifier
+  if (!classifier) {
     return { ...input, ctx_predictions: [{ label: DEFAULT_CTX, confidence: 1 }] }
   }
 
   const features = input.utterance.sentenceEmbedding
-  const predictions = await predictors.ctx_classifier.predict(features)
+  const predictions = await classifier.predict(features)
 
   return {
     ...input,

--- a/modules/nlu/src/backend/engine2/training-pipeline.ts
+++ b/modules/nlu/src/backend/engine2/training-pipeline.ts
@@ -347,7 +347,9 @@ export const TfidfTokens = async (input: TrainOutput): Promise<TrainOutput> => {
 }
 
 const trainSlotTagger = async (input: TrainOutput, tools: Tools): Promise<Buffer> => {
-  if (input.intents.length === 0) {
+  const hasSlots = _.flatMap(input.intents, i => i.slot_definitions).length > 0
+
+  if (!hasSlots) {
     return Buffer.from('')
   }
   const crfExtractor = new CRFExtractor2(tools.mlToolkit)

--- a/src/bp/core/server.ts
+++ b/src/bp/core/server.ts
@@ -285,8 +285,7 @@ export default class HTTPServer {
         next(new PaymentRequiredError(`Server is unlicensed "${err.message}"`))
       } else {
         if (err.statusCode === 413) {
-          this.logger
-            .error('You may need to increase httpServer.bodyLimit in file data/global/botpress.config.json')
+          this.logger.error('You may need to increase httpServer.bodyLimit in file data/global/botpress.config.json')
         }
         next(err)
       }

--- a/src/bp/index.ts
+++ b/src/bp/index.ts
@@ -1,5 +1,7 @@
 import { EventEmitter } from 'events'
 
+global['NativePromise'] = global.Promise
+
 const yn = require('yn')
 const path = require('path')
 const fs = require('fs')

--- a/src/bp/ui-admin/src/App/AlertBanner.tsx
+++ b/src/bp/ui-admin/src/App/AlertBanner.tsx
@@ -1,0 +1,40 @@
+import React, { FC, MouseEvent } from 'react'
+
+interface Props {
+  message?: string;
+  type: string;
+  hideCloseBtn: boolean;
+  hide: () => void;
+  timeout: number;
+}
+
+const AlertBanner: FC<Props> = ({ type, message, hideCloseBtn, hide, children, timeout }) => {
+  let hideTimeout
+
+  if (timeout !== 0) {
+    hideTimeout = window.setTimeout(() => {
+      hide()
+    }, timeout)
+  }
+
+  const onHide = () => {
+    if (hideTimeout) {
+      window.clearTimeout(hideTimeout)
+    }
+
+    hide()
+  }
+
+  return (
+    <div className={`alert-banner ${type}`}>
+      {message || children}
+      {!hideCloseBtn && <button className="alert-banner--close-btn" onClick={onHide}>×</button>}
+    </div>
+  )
+}
+
+AlertBanner.defaultProps = {
+  timeout: 2000
+};
+
+export default AlertBanner

--- a/src/bp/ui-admin/src/App/PageContainer.tsx
+++ b/src/bp/ui-admin/src/App/PageContainer.tsx
@@ -7,6 +7,7 @@ import AccessControl from './AccessControl'
 interface Props {
   title?: JSX.Element | string
   helpText?: JSX.Element | string
+  contentClassName?: string
   fullWidth?: boolean
   superAdmin?: boolean
 }
@@ -23,7 +24,7 @@ const PageContainer: FC<Props> = props => {
         )}
       </div>
       <div className="bp-sa-overflow">
-        <div className={cx('bp-sa-content', { 'bp-sa-fullwidth': props.fullWidth })}>
+        <div className={`${cx('bp-sa-content', { 'bp-sa-fullwidth': props.fullWidth })} ${props.contentClassName || ''}`}>
           <AccessControl
             superAdmin={props.superAdmin}
             fallback={<Callout intent={Intent.DANGER}>This page is restricted to Super Admins</Callout>}

--- a/src/bp/ui-admin/src/App/StickyActionBar.tsx
+++ b/src/bp/ui-admin/src/App/StickyActionBar.tsx
@@ -1,0 +1,16 @@
+import React, { FC } from 'react'
+
+interface Props {
+}
+
+const StickyActionBar: FC<Props> = props => {
+  return (
+    <div className="sticky-action-bar">
+      <div className="sticky-action-bar--content">
+        {props.children}
+      </div>
+    </div>
+  )
+}
+
+export default StickyActionBar

--- a/src/bp/ui-admin/src/scss/_layout.scss
+++ b/src/bp/ui-admin/src/scss/_layout.scss
@@ -246,6 +246,81 @@
   }
 }
 
+.alert-banner {
+  background: #fcfcfc;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.1);
+  left: 0;
+  padding: 10px 15px;
+  position: fixed;
+  right: 0;
+  text-align: center;
+  top: 0;
+  z-index: 99;
+
+  &.warning {
+    color: #856404;
+    background-color: #fff3cd;
+  }
+
+  &.info {
+    color: #0c5460;
+    background-color: #d1ecf1;
+  }
+
+  &.error {
+    color: #721c24;
+    background-color: #f8d7da;
+  }
+
+  &.success {
+    color: #155724;
+    background-color: #d4edda;
+  }
+
+  &--close-btn {
+    background: none;
+    border: none;
+    color: #252525;
+    font-size: 20px;
+    line-height: 0;
+    margin: 0;
+    padding: 11px 5px;
+    position: absolute;
+    right: 15px;
+    top: 50%;
+    transform: translate(0, -50%);
+
+    &:focus {
+      outline: none;
+    }
+  }
+}
+
+.with-sticky-action-bar {
+  // Height of the sticky action bar (51px) + 14px to have a small gap between the bottom of the form and the bar
+  padding-bottom: 65px;
+}
+
+.sticky-action-bar {
+  background: #fcfcfc;
+  bottom: 0;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.1);
+  left: 0;
+  padding: 10px 15px;
+  position: absolute;
+  right: 0;
+  text-align: right;
+
+  button {
+    margin-left: 15px;
+  }
+
+  &--content {
+    max-width: 1000px;
+    margin: 0 auto;
+  }
+}
+
 .dropdown-picture {
   height: 30px;
   width: 30px;

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -15,7 +15,7 @@
     "baseUrl": "./bp",
     "outDir": "../out",
     "typeRoots": ["./typings", "../node_modules/@types", "./bp/common"],
-    "types": ["reflect-metadata", "jest", "bluebird-global"]
+    "types": ["reflect-metadata", "jest"]
   },
   "exclude": [
     "e2e/**",


### PR DESCRIPTION
Description
Fixed a few issues with the bot config's UX

Changes

Added Cancel button that redirects to the bots list (has confirmation if form was modified)
Redirects to bots list after save
Added StickyActionBar component
Allows to have the buttons at the bottom of the form but still visible at all time
Is reusable
Could possibly be moved to a more general place
Added AlertBanner component
Is visible even if you're scrolled down in the form
Is reusable
Could possibly be moved to a more general place
Added alphabetical sorting on the languages list
Buttons are disabled while saving so users can't spam click buttons
Fixed console error A component is changing a controlled input of type text to be uncontrolled by adding a fallback on the input values