### PR TITLE
fix: specify accept extensions in file upload

### DIFF
--- a/modules/qna/src/views/full/ImportModal.tsx
+++ b/modules/qna/src/views/full/ImportModal.tsx
@@ -143,6 +143,7 @@ Either the file is empty, or it doesn't match any known format.`)
             <FileInput
               text={filePath || 'Choose file...'}
               onChange={e => readFile((e.target as HTMLInputElement).files)}
+              inputProps={{ accept: '.json' }}
               fill={true}
             />
           </FormGroup>

--- a/src/bp/ui-admin/src/Pages/Server/Versioning/UploadArchive.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/Versioning/UploadArchive.tsx
@@ -114,6 +114,7 @@ const UploadArchive = () => {
               <FileInput
                 text={filePath || 'Choose file...'}
                 onChange={e => readArchive((e.target as HTMLInputElement).files)}
+                inputProps={{ accept: '.tgz' }}
                 fill={true}
               />
             </FormGroup>

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/ImportBotModal.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/ImportBotModal.tsx
@@ -139,16 +139,12 @@ class ImportBotModal extends Component<Props, State> {
                 autoFocus={true}
               />
             </FormGroup>
-            <FormGroup
-              label="Bot Archive"
-              labelInfo="*"
-              labelFor="archive"
-              helperText="File must be a valid .zip or .tgz archive"
-            >
+            <FormGroup label="Bot Archive" labelInfo="*" labelFor="archive">
               <FileInput
                 tabIndex={2}
                 text={this.state.filePath || 'Choose file...'}
                 onChange={event => this.handleFileChanged((event.target as HTMLInputElement).files)}
+                inputProps={{ accept: '.zip,.tgz' }}
               />
             </FormGroup>
           </div>


### PR DESCRIPTION
This PR lets' the file upload accept by default specific extensions.

It is done in other areas, e.g. [here](https://github.com/botpress/botpress/blob/master/src/bp/ui-studio/src/web/views/Content/ImportModal.tsx#L124)

I don't know if we should add `.csv` in [here](https://github.com/botpress/botpress/blob/master/modules/nlu-testing/src/views/full/ImportModal.tsx#L80)

Also, the `helperText` in `ImportBotModal.tsx` is not needed.