### PR TITLE
fix(core): clear message when the workspace property is missing

### DIFF
--- a/src/bp/core/routers/admin/bots.ts
+++ b/src/bp/core/routers/admin/bots.ts
@@ -8,8 +8,8 @@ import Joi from 'joi'
 import _ from 'lodash'
 
 import { CustomRouter } from '../customRouter'
-import { ConflictError, ForbiddenError, NotFoundError } from '../errors'
-import { assertBotpressPro, hasPermissions, needPermissions, success as sendSuccess } from '../util'
+import { ConflictError, ForbiddenError } from '../errors'
+import { assertBotpressPro, assertWorkspace, hasPermissions, needPermissions, success as sendSuccess } from '../util'
 
 const chatUserBotFields = [
   'id',
@@ -51,6 +51,7 @@ export class BotsRouter extends CustomRouter {
 
     router.get(
       '/',
+      assertWorkspace,
       this.asyncMiddleware(async (req, res) => {
         const isBotAdmin = await this.hasPermissions(req, 'read', this.resource)
         const isChatUser = await this.hasPermissions(req, 'read', 'user.bots')

--- a/src/bp/core/routers/admin/users.ts
+++ b/src/bp/core/routers/admin/users.ts
@@ -1,5 +1,5 @@
 import { Logger } from 'botpress/sdk'
-import { CreatedUser, WorkspaceUser } from 'common/typings'
+import { WorkspaceUser } from 'common/typings'
 import AuthService from 'core/services/auth/auth-service'
 import { InvalidOperationError } from 'core/services/auth/errors'
 import { WorkspaceService } from 'core/services/workspace-service'
@@ -145,12 +145,8 @@ export class UsersRouter extends CustomRouter {
           throw new ConflictError(`User "${email}" is already taken`)
         }
 
-        if (!req.workspace) {
-          throw new InvalidOperationError(`Workspace is missing. Set header X-BP-Workspace`)
-        }
-
         const result = await this.authService.createUser({ email, strategy }, strategy)
-        await this.workspaceService.addUserToWorkspace(email, strategy, req.workspace, { role })
+        await this.workspaceService.addUserToWorkspace(email, strategy, req.workspace!, { role })
 
         return sendSuccess(res, 'User created successfully', {
           email,
@@ -186,7 +182,7 @@ export class UsersRouter extends CustomRouter {
 
         const tempPassword = await this.authService.resetPassword(email, strategy)
 
-        return sendSuccess(res, 'Password reseted', {
+        return sendSuccess(res, 'Password reset', {
           tempPassword
         })
       })

--- a/src/bp/core/routers/auth.ts
+++ b/src/bp/core/routers/auth.ts
@@ -12,7 +12,7 @@ import _ from 'lodash'
 
 import { CustomRouter } from './customRouter'
 import { BadRequestError, NotFoundError } from './errors'
-import { checkTokenHeader, success as sendSuccess, validateBodySchema } from './util'
+import { assertWorkspace, checkTokenHeader, success as sendSuccess, validateBodySchema } from './util'
 
 export class AuthRouter extends CustomRouter {
   private checkTokenHeader!: RequestHandler
@@ -72,6 +72,7 @@ export class AuthRouter extends CustomRouter {
     router.get(
       '/me/profile',
       this.checkTokenHeader,
+      assertWorkspace,
       this.asyncMiddleware(async (req: RequestWithUser, res) => {
         const { email, strategy, isSuperAdmin } = req.tokenUser!
         const user = await this.authService.findUser(email, strategy)

--- a/src/bp/core/routers/modules.ts
+++ b/src/bp/core/routers/modules.ts
@@ -1,4 +1,5 @@
 import { FlowGeneratorMetadata, Logger } from 'botpress/sdk'
+import { ConfigProvider } from 'core/config/config-loader'
 import AuthService, { TOKEN_AUDIENCE } from 'core/services/auth/auth-service'
 import { RequestHandler, Router } from 'express'
 
@@ -6,8 +7,7 @@ import { ModuleLoader } from '../module-loader'
 import { SkillService } from '../services/dialog/skill/service'
 
 import { CustomRouter } from './customRouter'
-import { checkTokenHeader, assertSuperAdmin } from './util'
-import { ConfigProvider } from 'core/config/config-loader'
+import { assertSuperAdmin, checkTokenHeader } from './util'
 
 export class ModulesRouter extends CustomRouter {
   private checkTokenHeader!: RequestHandler
@@ -25,7 +25,7 @@ export class ModulesRouter extends CustomRouter {
   }
 
   private setupRoutes(): void {
-    this.router.get('/', (req, res) => {
+    this.router.get('/', (_req, res) => {
       res.json(this.moduleLoader.getLoadedModules())
     })
 
@@ -33,7 +33,7 @@ export class ModulesRouter extends CustomRouter {
       '/reload/:moduleName',
       this.checkTokenHeader,
       assertSuperAdmin,
-      this.asyncMiddleware(async (req, res, next) => {
+      this.asyncMiddleware(async (req, res, _next) => {
         const moduleName = req.params.moduleName
         const config = await this.configProvider.getBotpressConfig()
         const module = config.modules.find(x => x.location.endsWith(moduleName))
@@ -50,15 +50,15 @@ export class ModulesRouter extends CustomRouter {
     this.router.get(
       '/botTemplates',
       this.checkTokenHeader,
-      this.asyncMiddleware(async (req, res, next) => {
-        res.send(await this.moduleLoader.getBotTemplates())
+      this.asyncMiddleware(async (_req, res, _next) => {
+        res.send(this.moduleLoader.getBotTemplates())
       })
     )
 
     this.router.get(
       '/skills',
       this.checkTokenHeader,
-      this.asyncMiddleware(async (req, res, next) => {
+      this.asyncMiddleware(async (_req, res, _next) => {
         res.send(await this.moduleLoader.getAllSkills())
       })
     )


### PR DESCRIPTION
This PR throws an error if expected `X-BP-Workspace` is missing (similar to existing other places).

It was discovered in [Forum](https://help.botpress.io/t/add-new-bot-using-api/2909).

Only the request scenario in that question was tested.