### PR TITLE
fix(docs): add hint about Content-Type header

### DIFF
--- a/docs/guide/docs/channels/converse.md
+++ b/docs/guide/docs/channels/converse.md
@@ -7,7 +7,7 @@ The Converse API is an easy way to integrate Botpress with any application or an
 
 ## Usage (Public API)
 
-`POST /api/v1/bots/{botId}/converse/{userId}` where **userId** is a unique string identifying a user that chats with your bot (**botId**).
+`POST /api/v1/bots/{botId}/converse/{userId}` where **userId** is a unique string identifying a user that chats with your bot (**botId**), you can use random string for **userId**, also don't forget to set the `Content-Type` HTTP header to `application/json`.
 
 ### Request Body
 


### PR DESCRIPTION
The request would fail if `Content-Type` is not specified.