### PR TITLE
feat(core): reboot individual servers

### DIFF
--- a/src/bp/core/routers/admin/server.ts
+++ b/src/bp/core/routers/admin/server.ts
@@ -176,7 +176,7 @@ export class ServerRouter extends CustomRouter {
     this._rebootServer = await this.jobService.broadcast<void>(this.__local_rebootServer.bind(this))
   }
 
-  private async __local_rebootServer(hostname?: string) {
+  private __local_rebootServer(hostname?: string) {
     if (!hostname || hostname === os.hostname()) {
       process.send!({ type: 'reboot_server' })
     }

--- a/src/bp/core/routers/admin/server.ts
+++ b/src/bp/core/routers/admin/server.ts
@@ -7,6 +7,7 @@ import { MonitoringService } from 'core/services/monitoring'
 import { WorkspaceService } from 'core/services/workspace-service'
 import { Router } from 'express'
 import _ from 'lodash'
+import os from 'os'
 import yn from 'yn'
 
 import { getDebugScopes, setDebugScopes } from '../../../debug'
@@ -89,9 +90,9 @@ export class ServerRouter extends CustomRouter {
           return res.status(400).send(`Rebooting the server is disabled in the botpress.config.json file`)
         }
 
-        this.logger.info(`User ${user} requested a server reboot`)
+        this.logger.info(`User ${user} requested a server reboot for ${req.query.hostname}`)
 
-        await this._rebootServer()
+        await this._rebootServer(req.query.hostname)
         res.sendStatus(200)
       })
     )
@@ -175,7 +176,9 @@ export class ServerRouter extends CustomRouter {
     this._rebootServer = await this.jobService.broadcast<void>(this.__local_rebootServer.bind(this))
   }
 
-  private __local_rebootServer() {
-    process.send && process.send({ type: 'reboot_server' })
+  private async __local_rebootServer(hostname?: string) {
+    if (!hostname || hostname === os.hostname()) {
+      process.send!({ type: 'reboot_server' })
+    }
   }
 }

--- a/src/bp/ui-admin/src/Pages/Components/Monitoring/ServerControl.tsx
+++ b/src/bp/ui-admin/src/Pages/Components/Monitoring/ServerControl.tsx
@@ -1,0 +1,71 @@
+import { Button, Classes, Dialog, Intent } from '@blueprintjs/core'
+import React, { FC, useEffect, useState } from 'react'
+import { toastFailure } from '~/utils/toaster'
+
+import api from '../../../api'
+
+interface Props {
+  hostname: string
+  isOpen?: boolean
+  toggle: () => void
+}
+
+const ServerControl: FC<Props> = props => {
+  const [isRestarting, setRestarting] = useState(false)
+
+  useEffect(() => {
+    setRestarting(false)
+  }, [props.isOpen])
+
+  const restartServer = async () => {
+    try {
+      await api.getSecured().post(`/admin/server/rebootServer?hostname=${props.hostname}`)
+      setRestarting(true)
+    } catch (err) {
+      toastFailure(err.message)
+    }
+  }
+
+  return (
+    <Dialog
+      title="Server Control"
+      isOpen={props.isOpen}
+      onClose={props.toggle}
+      transitionDuration={0}
+      canOutsideClickClose={false}
+    >
+      <div className={Classes.DIALOG_BODY}>
+        {!isRestarting ? (
+          <div>
+            You are about to restart the Botpress server hosted on <br /> <strong>{props.hostname}</strong>. <br />{' '}
+            <br />
+            Are you sure?
+          </div>
+        ) : (
+          <div>
+            Server restart in progress. To know when the server is back up, watch the uptime for that server in the
+            Overview. You can close this window safely.
+          </div>
+        )}
+      </div>
+
+      <div className={Classes.DIALOG_FOOTER}>
+        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+          {!isRestarting ? (
+            <div>
+              <Button id="btn-cancel" text="Cancel" onClick={props.toggle} intent={Intent.NONE} />
+              <Button id="btn-restart" text="Restart server now" onClick={restartServer} intent={Intent.DANGER} />
+            </div>
+          ) : (
+            <div>
+              {' '}
+              <Button id="btn-cancel" text="Close" onClick={props.toggle} intent={Intent.NONE} />
+            </div>
+          )}
+        </div>
+      </div>
+    </Dialog>
+  )
+}
+
+export default ServerControl

--- a/src/bp/ui-admin/src/Pages/Components/Monitoring/SummaryTable.tsx
+++ b/src/bp/ui-admin/src/Pages/Components/Monitoring/SummaryTable.tsx
@@ -1,9 +1,20 @@
-import React from 'react'
+import { Button, Tooltip } from '@blueprintjs/core'
+import moment from 'moment'
+import React, { useState } from 'react'
 import ReactTable from 'react-table'
 import 'react-table/react-table.css'
-import moment from 'moment'
+
+import ServerControl from './ServerControl'
 
 const SummaryTable = ({ data }) => {
+  const [isModalOpen, setModalOpen] = useState(false)
+  const [host, setHost] = useState('')
+
+  const restartServer = async host => {
+    setHost(host)
+    setModalOpen(true)
+  }
+
   const columns = [
     {
       Header: 'Host',
@@ -61,17 +72,30 @@ const SummaryTable = ({ data }) => {
       width: 120,
       className: 'center',
       accessor: 'errors.count'
+    },
+    {
+      Cell: x => (
+        <Tooltip content="Restart server">
+          <Button icon="power" onClick={() => restartServer(x.original.host)} />
+        </Tooltip>
+      ),
+
+      filterable: false,
+      width: 45
     }
   ]
 
   return (
-    <ReactTable
-      columns={columns}
-      data={data}
-      defaultPageSize={5}
-      defaultSorted={[{ id: 'host' }]}
-      className="-striped -highlight monitoringOverview"
-    />
+    <React.Fragment>
+      <ReactTable
+        columns={columns}
+        data={data}
+        defaultPageSize={5}
+        defaultSorted={[{ id: 'host' }]}
+        className="-striped -highlight monitoringOverview"
+      />
+      <ServerControl hostname={host} isOpen={isModalOpen} toggle={() => setModalOpen(!isModalOpen)} />
+    </React.Fragment>
   )
 }
 


### PR DESCRIPTION
Added a small feature to restart servers easily.  Unlike the "Configuration Outdated" dialog, this requires Redis & Monitoring to be enabled, and doesn't restart the whole cluster (you can restart them one at a time).

![image](https://user-images.githubusercontent.com/42552874/72838013-80dfd800-3c5d-11ea-92cb-8e7e747f9b53.png)
