### PR TITLE
fix(core): pool issue with knex and transactions

### DIFF
--- a/src/bp/core/database/helpers.ts
+++ b/src/bp/core/database/helpers.ts
@@ -44,7 +44,8 @@ export const patchKnex = (knex: Knex): KnexExtended => {
     tableName: string,
     data: any,
     returnColumns: string | string[] = 'id',
-    idColumnName: string = 'id'
+    idColumnName: string = 'id',
+    trx?: Knex.Transaction
   ): Promise<T> => {
     const handleResult = res => {
       if (!res || res.length !== 1) {
@@ -60,7 +61,8 @@ export const patchKnex = (knex: Knex): KnexExtended => {
         .returning(returnColumns)
         .then(handleResult)
     }
-    return knex.transaction(trx =>
+
+    const getQuery = trx =>
       knex(tableName)
         .insert(data)
         .transacting(trx)
@@ -81,6 +83,14 @@ export const patchKnex = (knex: Knex): KnexExtended => {
                 .then(handleResult)
             })
         )
+
+    // transactions inside another transaction may lead to a deadlock
+    if (trx) {
+      return getQuery(trx)
+    }
+
+    return knex.transaction(trx =>
+      getQuery(trx)
         .then(trx.commit)
         .catch(trx.rollback)
     )

--- a/src/bp/core/services/middleware/state-manager.ts
+++ b/src/bp/core/services/middleware/state-manager.ts
@@ -132,7 +132,7 @@ export class StateManager {
     const botConfig = await this.configProvider.getBotConfig(event.botId)
     const botpressConfig = await this.getBotpressConfig()
 
-    const dialogSession = await this.sessionRepo.getOrCreateSession(sessionId, event.botId)
+    const dialogSession = await this.sessionRepo.getOrCreateSession(sessionId, event.botId, trx)
     const expiry = createExpiry(botConfig, botpressConfig)
 
     dialogSession.session_data = session || {}

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -19,7 +19,8 @@ declare module 'botpress/sdk' {
       tableName: string,
       data: {},
       returnColumns?: string | string[],
-      idColumnName?: string
+      idColumnName?: string,
+      trx?: Knex.Transaction
     ): Promise<T>
   }
 
@@ -1038,7 +1039,7 @@ declare module 'botpress/sdk' {
     flow?: string
     /** Used internally by the flow editor */
     readonly lastModified?: Date
-  } & (NodeActions)
+  } & NodeActions
 
   export type SkillFlowNode = Partial<FlowNode> & Pick<Required<FlowNode>, 'name'>
 


### PR DESCRIPTION
Fixes random error "TimeoutError: Knex: Timeout acquiring a connection. The pool is probably full. Are you missing a .transacting(trx) call?"

The method insertAndRetrieve was initiating a complete transaction to insert & select the entry, which caused problem when inside another transaction, since there is only one connection available on sqlite. 

The first transaction, was waiting on the second, which was waiting for a connection, effectively ending deadlocked. 

This happened when processing the batch of events to store their state. If the janitor deleted the session from the database in the meantime, the getOrCreateSession would try to call insertAndRetrieve before being able to close the transaction.