### PR TITLE
fix(qna): fix redirection and incorrect message

### DIFF
--- a/modules/nlu/src/backend/engine2/utterance.ts
+++ b/modules/nlu/src/backend/engine2/utterance.ts
@@ -252,10 +252,7 @@ export async function buildUtteranceBatch(
   tools: Tools
 ): Promise<Utterance[]> {
   const parsed = raw_utterances.map(u => parseUtterance(replaceConsecutiveSpaces(u)))
-  const tokenUtterances = await tools.tokenize_utterances(
-    parsed.map(p => p.utterance),
-    language
-  )
+  const tokenUtterances = await tools.tokenize_utterances(parsed.map(p => p.utterance), language)
   const POSUtterances = tools.partOfSpeechUtterances(tokenUtterances, language)
   const uniqTokens = _.uniq(_.flatten(tokenUtterances))
   const vectors = await tools.vectorize_tokens(uniqTokens, language)

--- a/modules/qna/src/views/full/Editor/EditorModal.tsx
+++ b/modules/qna/src/views/full/Editor/EditorModal.tsx
@@ -1,4 +1,5 @@
 import { Dialog } from '@blueprintjs/core'
+import { Flow } from 'botpress/sdk'
 import _ from 'lodash'
 import React, { FC } from 'react'
 
@@ -17,7 +18,7 @@ interface Props {
   categories: any
   bp: any
   flowsList: any
-  flows: any
+  flows: Flow[]
 }
 
 const EditorModal: FC<Props> = props => {

--- a/modules/qna/src/views/full/Item/RedirectInfo.tsx
+++ b/modules/qna/src/views/full/Item/RedirectInfo.tsx
@@ -1,26 +1,47 @@
+import { Icon, Intent, Tooltip } from '@blueprintjs/core'
+import { Flow } from 'botpress/sdk'
+import { getFlowLabel } from 'botpress/utils'
+import _ from 'lodash'
 import React, { FC } from 'react'
 
 import style from '../style.scss'
 
 interface Props {
+  id: string
   redirectFlow: string
   redirectNode: string
+  flows?: Flow[]
+  onEditItem: (id: string) => void
 }
 
-const RedirectInfo: FC<Props> = ({ redirectFlow, redirectNode }) => {
+const RedirectInfo: FC<Props> = ({ id, redirectFlow, redirectNode, flows, onEditItem }) => {
   if (!redirectFlow || !redirectNode) {
     return null
   }
 
-  const flowName = redirectFlow.replace('.flow.json', '')
+  const flowName = redirectFlow.replace(/\.flow\.json$/i, '')
   const flowBuilderLink = `/studio/${window.BOT_ID}/flows/${flowName}/#search:${redirectNode}`
+  let incorrectRedirection = false
+  if (flows) {
+    const flow = _.find(flows, f => f.name === redirectFlow)
+    incorrectRedirection = !flow || !_.find(flow.nodes, n => n.name === redirectNode)
+  }
 
   return (
     <React.Fragment>
-      <div className={style.itemRedirectTitle}>Redirect to:</div>
+      <div className={style.itemRedirectTitle}>
+        Redirect to:
+        {incorrectRedirection && (
+          <a onClick={() => onEditItem(id)}>
+            <Tooltip content="Incorrect redirection">
+              <Icon icon="warning-sign" intent={Intent.DANGER} />
+            </Tooltip>
+          </a>
+        )}
+      </div>
       <a href={flowBuilderLink}>
         <div className={style.itemFlow}>
-          Flow: <span className={style.itemFlowName}>{redirectFlow}</span>
+          Flow: <span className={style.itemFlowName}>{getFlowLabel(redirectFlow)}</span>
         </div>
         <div className={style.itemNode}>
           Node: <span className={style.itemNodeName}>{redirectNode}</span>

--- a/modules/qna/src/views/full/Item/index.tsx
+++ b/modules/qna/src/views/full/Item/index.tsx
@@ -1,9 +1,11 @@
 import { Button, Icon, Intent, Switch, Tooltip } from '@blueprintjs/core'
+import { Flow } from 'botpress/sdk'
 import { AccessControl } from 'botpress/utils'
 import cx from 'classnames'
 import React, { FC } from 'react'
 
 import style from '../style.scss'
+import { ACTIONS } from '../Editor'
 
 import RedirectInfo from './RedirectInfo'
 import Variations from './Variations'
@@ -12,6 +14,7 @@ interface Props {
   id: string
   item: any
   contentLang: string
+  flows?: Flow[]
   // Hides category and redirect info
   isVersion2?: boolean
   onEditItem: (id: string) => void
@@ -28,11 +31,12 @@ const Item: FC<Props> = props => {
 
   const questions = item.questions[contentLang] || []
   const answers = item.answers[contentLang] || []
+  const missingTranslations = !questions.length || (item.action !== ACTIONS.REDIRECT && !answers.length)
 
   return (
     <div className={cx(style.qnaItem, style.well)} key={id}>
       <div className={style.itemContainer} role="entry">
-        {!questions.length && (
+        {missingTranslations && (
           <div className={style.itemQuestions}>
             <a className={style.firstQuestionTitle} onClick={() => props.onEditItem(id)}>
               <Tooltip content="Missing translation">
@@ -48,7 +52,7 @@ const Item: FC<Props> = props => {
           </div>
         )}
 
-        {questions.length > 0 && (
+        {!missingTranslations && (
           <div className={style.itemQuestions}>
             <span className={style.itemQuestionsTitle}>Q:</span>
             <a className={style.firstQuestionTitle} onClick={() => props.onEditItem(id)}>
@@ -69,7 +73,13 @@ const Item: FC<Props> = props => {
         {!props.isVersion2 && (
           <div>
             <div className={style.itemRedirect}>
-              {<RedirectInfo redirectFlow={item.redirectFlow} redirectNode={item.redirectNode} />}
+              <RedirectInfo
+                id={props.id}
+                redirectFlow={item.redirectFlow}
+                redirectNode={item.redirectNode}
+                flows={props.flows}
+                onEditItem={props.onEditItem}
+              />
             </div>
           </div>
         )}

--- a/modules/qna/src/views/full/index.tsx
+++ b/modules/qna/src/views/full/index.tsx
@@ -27,7 +27,7 @@ export default class QnaAdmin extends Component<Props> {
   state = {
     items: [],
     currentItemId: undefined,
-    flows: null,
+    flows: [],
     flowsList: [],
     filter: '',
     showBulkImport: undefined,
@@ -280,6 +280,7 @@ export default class QnaAdmin extends Component<Props> {
         key={id}
         id={id}
         item={data}
+        flows={this.state.flows}
         contentLang={this.props.contentLang}
         onEditItem={this.editItem(id)}
         onToggleItem={this.toggleEnableItem.bind(this)}


### PR DESCRIPTION
The points covered:

1. A `flow` or `node` can currently be invalidated after the Q&A item creation, if they are deleted in Flow dialog, this would make the Q&A item has "incorrect redirection". This PR shows them with an error in the item list, and doesn't allow saving unless they are both fine.
2. "Missing translations" in `Editor/index.tsx` was changed when the answers are empty only when `isText`, in other words, test case:
  a. Create an item with a single question, no answer, but a redirection
  b. Save it
  c. Open it, you will get an error, "missing translations"
3. Logic in item list was changed to follow the one in point `2`
4. Flow name in item list is now user-friendly
5. The save button was renamed to `Add`/`Save` instead of `Save`/`Edit`
6. Full test of "missing translations" wasn't done because of lack of PRO license
7. Lite view wasn't tested, because I don't know how, so the "flows" was marked optional