### PR TITLE
feat(core): add content elements usage counting

### DIFF
--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -256,8 +256,8 @@ declare module 'botpress/sdk' {
       }
 
       export interface ModelConstructor {
-        new (): Model
-        new (lazy: boolean, keepInMemory: boolean, queryOnly: boolean): Model
+        new(): Model
+        new(lazy: boolean, keepInMemory: boolean, queryOnly: boolean): Model
       }
 
       export const Model: ModelConstructor
@@ -953,6 +953,7 @@ declare module 'botpress/sdk' {
     createdOn: Date
     modifiedOn: Date
     createdBy: string
+    occurancesCount: number
   }
 
   /**

--- a/src/bp/ui-studio/src/web/views/Content/List.tsx
+++ b/src/bp/ui-studio/src/web/views/Content/List.tsx
@@ -233,6 +233,13 @@ class ListView extends Component<Props, State> {
         width: 150
       },
       {
+        Header: 'Used',
+        filterable: false,
+        sortable: false,
+        accessor: 'occurancesCount',
+        width: 70
+      },
+      {
         Cell: x => (!this.props.readOnly ? <Button small={true} icon="edit" className="icon-edit" /> : ''),
         filterable: false,
         width: 45


### PR DESCRIPTION
Here I calculate number of usages dynamically. Looks like this:

![image](https://user-images.githubusercontent.com/1932290/73186674-ce11ed00-4128-11ea-97ff-c4ddf5aa5547.png)

You can't sort by that column though (would be resource-intensive for dynamic calculation).

resolves botpress/v12#756