### PR TITLE
chore(deps): react: use UNSAFE_ prefix

### DIFF
--- a/src/bp/ui-studio/src/web/components/Content/Select/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Content/Select/index.tsx
@@ -75,7 +75,7 @@ class SelectContent extends Component<Props, State> {
     this.props.container.removeEventListener('keyup', this.handleChangeActiveItem)
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     const { categories } = newProps
     if (!categories || this.state.step !== formSteps.INITIAL || this.state.contentType) {
       return

--- a/src/bp/ui-studio/src/web/components/ContentForm/UploadWidget.js
+++ b/src/bp/ui-studio/src/web/components/ContentForm/UploadWidget.js
@@ -16,7 +16,7 @@ class UploadWidget extends Component {
     }
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     if (!newProps.value && !this.state.expanded) {
       this.setState({ expanded: true })
     }

--- a/src/bp/ui-studio/src/web/components/PluginInjectionSite/module.tsx
+++ b/src/bp/ui-studio/src/web/components/PluginInjectionSite/module.tsx
@@ -112,7 +112,7 @@ Please check our migration guide here: https://botpress.io/docs/developers/migra
     this._isMounted = false
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.loadModule(nextProps.moduleName, nextProps.componentName)
   }
 

--- a/src/bp/ui-studio/src/web/components/SmartInput/MentionSuggestions/index.jsx
+++ b/src/bp/ui-studio/src/web/components/SmartInput/MentionSuggestions/index.jsx
@@ -102,12 +102,12 @@ export class MentionSuggestions extends Component {
     focusedOptionIndex: 0
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.key = genKey()
     this.props.callbacks.onChange = this.onEditorStateChange
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.suggestions.length === 0 && this.state.isActive) {
       this.closeDropdown()
     } else if (

--- a/src/bp/ui-studio/src/web/components/SmartInput/MentionSuggestionsPortal/index.jsx
+++ b/src/bp/ui-studio/src/web/components/SmartInput/MentionSuggestionsPortal/index.jsx
@@ -26,7 +26,7 @@ export default class MentionSuggestionsPortal extends Component {
     this.props.setEditorState(this.props.getEditorState())
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.updatePortalClientRect(nextProps)
   }
 

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/common/EditableInput.jsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/common/EditableInput.jsx
@@ -15,7 +15,7 @@ export default class EditableInput extends Component {
     this.props.onMount && this.props.onMount(this.input)
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({ value: nextProps.value || nextProps.defaultValue })
   }
 

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/ActionModalForm.jsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/ActionModalForm.jsx
@@ -23,7 +23,7 @@ class ActionModalForm extends Component {
 
   textToItemId = text => _.get(text.match(/^say #!(.*)$/), '[1]')
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { item } = nextProps
 
     if (this.props.show || !nextProps.show) {

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/ParametersTable.jsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/ParametersTable.jsx
@@ -15,7 +15,7 @@ export default class ParametersTable extends Component {
     this.state = { arguments: this.transformArguments(props.value) }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({ arguments: this.transformArguments(nextProps.value) })
   }
 

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/skills/index.jsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/skills/index.jsx
@@ -41,7 +41,7 @@ class SkillsBuilder extends React.Component {
     })
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.skillId !== this.props.skillId || nextProps.opened !== this.props.opened) {
       this.setState({
         ...this.resetState(),


### PR DESCRIPTION
Was triggered by #2900 , reverted by #2908

Full description: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html

Ideally, we should change the code to get away from those methods, but that's another change.

The following dependencies should be tackled:

`HotKeys`, `Route`, `Router`, `Switch`, `Redirect`, `Tour`, `DiagramWidget`, `InjectedModuleView`, `t`