### PR TITLE
fix(flow): lag issue with a lot of content

### DIFF
--- a/src/bp/ui-studio/src/web/views/FlowBuilder/common/action.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/common/action.tsx
@@ -37,7 +37,7 @@ class ActionItem extends Component<Props> {
     }
 
     if (prevState.itemId !== this.state.itemId && this.state.itemId) {
-      this.props.fetchContentItem(this.state.itemId, { force: true, batched: true }).then(this.props.refreshFlowsLinks)
+      this.props.fetchContentItem(this.state.itemId, { force: true, batched: true })
     }
   }
 

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
@@ -326,9 +326,9 @@ class Diagram extends Component<Props> {
     )
   }
 
-  checkForProblems() {
+  checkForProblems = _.debounce(() => {
     this.props.updateFlowProblems(this.manager.getNodeProblems())
-  }
+  }, 500)
 
   createFlow(name: string) {
     this.props.createFlow(name + '.flow.json')
@@ -378,14 +378,18 @@ class Diagram extends Component<Props> {
     this.checkForLinksUpdate()
   }
 
-  checkForLinksUpdate() {
-    const links = this.manager.getLinksRequiringUpdate()
-    if (links) {
-      this.props.updateFlow({ links })
-    }
+  checkForLinksUpdate = _.debounce(
+    () => {
+      const links = this.manager.getLinksRequiringUpdate()
+      if (links) {
+        this.props.updateFlow({ links })
+      }
 
-    this.checkForProblems()
-  }
+      this.checkForProblems()
+    },
+    500,
+    { leading: true }
+  )
 
   deleteSelectedElements() {
     const elements = _.sortBy(this.diagramEngine.getDiagramModel().getSelectedItems(), 'nodeType')


### PR DESCRIPTION
Fixes an issue where the flow seems to be unresponsive and extremely laggy.

I don't know why the refresh was there and I have no clue why it was there to begin with, but this was causing every nodes in the flow to invalidate themselves every time an element was loaded.

Imagine having 60 content elements with 90 nodes in the flow, it would re-evaluate the 90 nodes at least 60 times....

There's still a lot of room for performance improvements.