### PR TITLE
fix(code-editor): ignore bot mount errors

### DIFF
--- a/modules/code-editor/src/backend/api.ts
+++ b/modules/code-editor/src/backend/api.ts
@@ -1,17 +1,18 @@
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 
-import { EditorByBot, RequestWithPerms } from './typings'
+import Editor from './editor'
+import { RequestWithPerms } from './typings'
 import { getPermissionsMw, validateFilePayloadMw } from './utils_router'
 
-export default async (bp: typeof sdk, editorByBot: EditorByBot) => {
+export default async (bp: typeof sdk, editor: Editor) => {
   const loadPermsMw = getPermissionsMw(bp)
   const router = bp.http.createRouterForBot('code-editor')
 
   router.get('/files', loadPermsMw, async (req: RequestWithPerms, res, next) => {
     try {
       const rawFiles = req.query.rawFiles === 'true'
-      res.send(await editorByBot[req.params.botId].getAllFiles(req.permissions, rawFiles))
+      res.send(await editor.forBot(req.params.botId).getAllFiles(req.permissions, rawFiles))
     } catch (err) {
       bp.logger.attachError(err).error('Error fetching files')
       next(err)
@@ -20,7 +21,7 @@ export default async (bp: typeof sdk, editorByBot: EditorByBot) => {
 
   router.post('/save', loadPermsMw, validateFilePayloadMw('write'), async (req: RequestWithPerms, res, next) => {
     try {
-      await editorByBot[req.params.botId].saveFile(req.body)
+      await editor.forBot(req.params.botId).saveFile(req.body)
       res.sendStatus(200)
     } catch (err) {
       bp.logger.attachError(err).error('Could not save file')
@@ -30,14 +31,14 @@ export default async (bp: typeof sdk, editorByBot: EditorByBot) => {
 
   router.post('/readFile', loadPermsMw, validateFilePayloadMw('read'), async (req: RequestWithPerms, res, next) => {
     try {
-      res.send({ fileContent: await editorByBot[req.params.botId].readFileContent(req.body) })
+      res.send({ fileContent: await editor.forBot(req.params.botId).readFileContent(req.body) })
     } catch (err) {
       next(err)
     }
   })
 
   router.post('/download', loadPermsMw, validateFilePayloadMw('read'), async (req: RequestWithPerms, res, next) => {
-    const buffer = await editorByBot[req.params.botId].readFileBuffer(req.body)
+    const buffer = await editor.forBot(req.params.botId).readFileBuffer(req.body)
 
     res.setHeader('Content-Disposition', `attachment; filename=${req.body.name}`)
     res.setHeader('Content-Type', 'application/octet-stream')
@@ -46,7 +47,7 @@ export default async (bp: typeof sdk, editorByBot: EditorByBot) => {
 
   router.post('/exists', loadPermsMw, validateFilePayloadMw('write'), async (req: RequestWithPerms, res, next) => {
     try {
-      res.send(await editorByBot[req.params.botId].fileExists(req.body))
+      res.send(await editor.forBot(req.params.botId).fileExists(req.body))
     } catch (err) {
       next(err)
     }
@@ -54,7 +55,7 @@ export default async (bp: typeof sdk, editorByBot: EditorByBot) => {
 
   router.post('/rename', loadPermsMw, validateFilePayloadMw('write'), async (req: RequestWithPerms, res, next) => {
     try {
-      await editorByBot[req.params.botId].renameFile(req.body.file, req.body.newName)
+      await editor.forBot(req.params.botId).renameFile(req.body.file, req.body.newName)
       res.sendStatus(200)
     } catch (err) {
       bp.logger.attachError(err).error('Could not rename file')
@@ -64,7 +65,7 @@ export default async (bp: typeof sdk, editorByBot: EditorByBot) => {
 
   router.post('/remove', loadPermsMw, validateFilePayloadMw('write'), async (req: RequestWithPerms, res, next) => {
     try {
-      await editorByBot[req.params.botId].deleteFile(req.body)
+      await editor.forBot(req.params.botId).deleteFile(req.body)
       res.sendStatus(200)
     } catch (err) {
       bp.logger.attachError(err).error('Could not delete file')
@@ -83,7 +84,7 @@ export default async (bp: typeof sdk, editorByBot: EditorByBot) => {
 
   router.get('/typings', async (req, res, next) => {
     try {
-      res.send(await editorByBot[req.params.botId].loadTypings())
+      res.send(await editor.loadTypings())
     } catch (err) {
       bp.logger.attachError(err).error('Could not load typings. Code completion will not be available')
       next(err)

--- a/modules/code-editor/src/backend/editor.ts
+++ b/modules/code-editor/src/backend/editor.ts
@@ -27,10 +27,14 @@ export default class Editor {
   private _typings: TypingDefinitions
   private _config: Config
 
-  constructor(bp: typeof sdk, botId: string, config: Config) {
+  constructor(bp: typeof sdk, config: Config) {
     this.bp = bp
-    this._botId = botId
     this._config = config
+  }
+
+  forBot(botId: string) {
+    this._botId = botId
+    return this
   }
 
   async getAllFiles(permissions: FilePermissions, rawFiles?: boolean): Promise<FilesDS> {

--- a/modules/code-editor/src/backend/index.ts
+++ b/modules/code-editor/src/backend/index.ts
@@ -4,27 +4,14 @@ import { Config } from '../config'
 
 import api from './api'
 import Editor from './editor'
-import { EditorByBot } from './typings'
-
-const editorByBot: EditorByBot = {}
 
 const onServerReady = async (bp: typeof sdk) => {
-  await api(bp, editorByBot)
-}
-
-const onBotMount = async (bp: typeof sdk, botId: string) => {
   const config = (await bp.config.getModuleConfig('code-editor')) as Config
-  editorByBot[botId] = new Editor(bp, botId, config)
-}
-
-const onBotUnmount = async (bp: typeof sdk, botId: string) => {
-  delete editorByBot[botId]
+  await api(bp, new Editor(bp, config))
 }
 
 const entryPoint: sdk.ModuleEntryPoint = {
   onServerReady,
-  onBotMount,
-  onBotUnmount,
   definition: {
     name: 'code-editor',
     menuIcon: 'code',


### PR DESCRIPTION
When a bot fails to mount, the code editor wasn't working proprely for that bot, preventing someone from fixing a problematic configuration.

https://github.com/botpress/v12/issues/928