### PR TITLE
fix(studio): allow access to code editor when bot unmounted

### DIFF
--- a/src/bp/core/routers/bots/index.ts
+++ b/src/bp/core/routers/bots/index.ts
@@ -192,7 +192,7 @@ export class BotsRouter extends CustomRouter {
         const { botId, app } = req.params
 
         const bot = await this.botService.findBotById(botId)
-        if (!bot || !this.botService.isBotMounted(botId)) {
+        if (!bot) {
           return res.sendStatus(404)
         }
 
@@ -226,6 +226,7 @@ export class BotsRouter extends CustomRouter {
               window.SHOW_POWERED_BY = ${!!config.showPoweredBy};
               window.BOT_LOCKED = ${!!bot.locked};
               window.WORKSPACE_ID = "${workspaceId}";
+              window.IS_BOT_MOUNTED = ${this.botService.isBotMounted(botId)};
               window.SOCKET_TRANSPORTS = ["${getSocketTransports(config).join('","')}"];
               ${app === 'studio' ? studioEnv : ''}
               ${app === 'lite' ? liteEnv : ''}

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemCompact.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemCompact.tsx
@@ -82,11 +82,7 @@ const BotItemCompact: FC<Props> = ({ bot, hasError, deleteBot, exportBot, create
             &nbsp;
           </span>
         )}
-        {bot.disabled || hasError ? (
-          <span>{bot.name || bot.id}</span>
-        ) : (
-          <a href={botStudioLink}>{bot.name || bot.id}</a>
-        )}
+        {bot.disabled ? <span>{bot.name || bot.id}</span> : <a href={botStudioLink}>{bot.name || bot.id}</a>}
 
         {!bot.defaultLanguage && (
           <Tooltip position="right" content="Bot language is missing. Please set it in bot config.">

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemPipeline.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemPipeline.tsx
@@ -92,7 +92,7 @@ const BotItemPipeline: FC<Props> = ({
             &nbsp;
           </span>
         )}
-        {bot.disabled || hasError ? <span>{bot.name}</span> : <a href={botStudioLink}>{bot.name}</a>}
+        {bot.disabled ? <span>{bot.name}</span> : <a href={botStudioLink}>{bot.name}</a>}
         {!bot.defaultLanguage && (
           <Tooltip position="right" content="Bot language is missing. Please set it in bot config.">
             <Icon icon="warning-sign" intent={Intent.DANGER} style={{ marginLeft: 10 }} />

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/index.tsx
@@ -99,6 +99,7 @@ class Bots extends Component<Props> {
     try {
       await api.getSecured().post(`/admin/bots/${botId}/reload`)
       this.props.fetchBots()
+      this.props.fetchBotHealth()
       toastSuccess(`Bot remounted successfully`)
     } catch (err) {
       console.log(err)

--- a/src/bp/ui-studio/src/web/components/Layout/Sidebar.jsx
+++ b/src/bp/ui-studio/src/web/components/Layout/Sidebar.jsx
@@ -109,8 +109,16 @@ class Sidebar extends React.Component {
             </a>
           </div>
           <ul className={classnames('nav', style.mainMenu)}>
-            {BASIC_MENU_ITEMS.map(this.renderBasicItem)}
-            {this.props.modules.filter(m => !m.noInterface).map(this.renderModuleItem)}
+            {window.IS_BOT_MOUNTED ? (
+              <React.Fragment>
+                {BASIC_MENU_ITEMS.map(this.renderBasicItem)}
+                {this.props.modules.filter(m => !m.noInterface).map(this.renderModuleItem)}
+              </React.Fragment>
+            ) : (
+              <React.Fragment>
+                {this.props.modules.filter(m => m.name === 'code-editor').map(this.renderModuleItem)}
+              </React.Fragment>
+            )}
             <li className={classnames(style.empty, 'bp-empty')} />
           </ul>
         </div>

--- a/src/bp/ui-studio/src/web/components/Layout/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/index.tsx
@@ -170,7 +170,13 @@ class Layout extends React.Component<ILayoutProps> {
             <div>
               <main ref={el => (this.mainEl = el)} className={layout.main} id="main" tabIndex={9999}>
                 <Switch>
-                  <Route exact path="/" render={() => <Redirect to="/flows" />} />
+                  <Route
+                    exact
+                    path="/"
+                    render={() =>
+                      window.IS_BOT_MOUNTED ? <Redirect to="/flows" /> : <Redirect to="/modules/code-editor" />
+                    }
+                  />
                   <Route exact path="/content" component={Content} />
                   <Route exact path="/flows/:flow*" component={FlowBuilder} />
                   <Route exact path="/modules/:moduleName/:componentName?" render={props => <Module {...props} />} />
@@ -212,7 +218,4 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch =>
   bindActionCreators({ viewModeChanged, updateDocumentationModal, toggleBottomPanel }, dispatch)
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Layout)
+export default connect(mapStateToProps, mapDispatchToProps)(Layout)

--- a/src/bp/ui-studio/src/web/typings.d.ts
+++ b/src/bp/ui-studio/src/web/typings.d.ts
@@ -17,6 +17,7 @@ declare global {
     BOT_ID: string
     BP_BASE_PATH: string
     SEND_USAGE_STATS: boolean
+    IS_BOT_MOUNTED: boolean
     BOT_LOCKED: boolean
     WORKSPACE_ID: string
     BOTPRESS_FLOW_EDITOR_DISABLED: boolean


### PR DESCRIPTION
When there was an error mounting a bot, you couldn't access the studio or the code editor. If the issue was caused by a bad configuration for a channel, for example, you couldn't fix it using the editor.

If a bot fails to mount, you will be able to open the studio and the only module accessible will be the code editor.

![image](https://user-images.githubusercontent.com/42552874/73574270-4a674180-4443-11ea-92ee-9798f8071fbf.png)
