### PR TITLE
feat(hook): bot-scoped hooks

### DIFF
--- a/modules/code-editor/src/backend/definitions.ts
+++ b/modules/code-editor/src/backend/definitions.ts
@@ -1,7 +1,8 @@
 import { HOOK_SIGNATURES } from '../typings/hooks'
 
-import { MAIN_GLOBAL_CONFIG_FILES } from './editor'
 import { EditableFile } from './typings'
+
+export const MAIN_GLOBAL_CONFIG_FILES = ['botpress.config.json', 'workspaces.json']
 
 export interface FileDefinition {
   allowGlobal?: boolean // When true, this type of file can be stored as global
@@ -37,7 +38,7 @@ export const FileTypes: { [type: string]: FileDefinition } = {
   },
   hook: {
     allowGlobal: true,
-    allowScoped: false,
+    allowScoped: true,
     permission: 'hooks',
     ghost: {
       baseDir: '/hooks',

--- a/modules/code-editor/src/backend/definitions.ts
+++ b/modules/code-editor/src/backend/definitions.ts
@@ -1,4 +1,4 @@
-import { HOOK_SIGNATURES } from '../typings/hooks'
+import { BOT_SCOPED_HOOKS, HOOK_SIGNATURES } from '../typings/hooks'
 
 import { EditableFile } from './typings'
 
@@ -23,7 +23,7 @@ export interface FileDefinition {
   /** Validation if the selected file can be deleted */
   canDelete?: (file: EditableFile) => boolean
   /** An additional validation that must be done for that type of file. Return a string indicating the error message */
-  validate?: (file: EditableFile) => Promise<string | undefined>
+  validate?: (file: EditableFile, isWriting?: boolean) => Promise<string | undefined>
 }
 
 export const FileTypes: { [type: string]: FileDefinition } = {
@@ -47,7 +47,10 @@ export const FileTypes: { [type: string]: FileDefinition } = {
       upsertFilename: (file: EditableFile) => file.location.replace(file.hookType, ''),
       shouldSyncToDisk: true
     },
-    validate: async (file: EditableFile) => {
+    validate: async (file: EditableFile, isWriting?: boolean) => {
+      if (isWriting && file.botId && !BOT_SCOPED_HOOKS.includes(file.hookType)) {
+        return `This hook can't be scoped to a bot`
+      }
       return HOOK_SIGNATURES[file.hookType] === undefined && `Invalid hook type "${file.hookType}"`
     }
   },

--- a/modules/code-editor/src/backend/editor.ts
+++ b/modules/code-editor/src/backend/editor.ts
@@ -18,7 +18,7 @@ import {
 } from './utils'
 
 export const FILENAME_REGEX = /^[0-9a-zA-Z_\-.]+$/
-export const MAIN_GLOBAL_CONFIG_FILES = ['botpress.config.json', 'workspaces.json']
+
 const RAW_FILES_FILTERS = ['**/*.map']
 
 export default class Editor {

--- a/modules/code-editor/src/backend/utils.ts
+++ b/modules/code-editor/src/backend/utils.ts
@@ -99,7 +99,7 @@ export const validateFilePayload = async (
   }
 
   if (def.validate) {
-    const result = await def.validate(editableFile)
+    const result = await def.validate(editableFile, actionType === 'write')
     if (result) {
       throw new Error(result)
     }

--- a/modules/code-editor/src/typings/hooks.ts
+++ b/modules/code-editor/src/typings/hooks.ts
@@ -23,5 +23,8 @@ export const BOT_SCOPED_HOOKS = [
   'before_outgoing_middleware',
   'after_event_processed',
   'before_suggestions_election',
-  'before_session_timeout'
+  'before_session_timeout',
+  'after_bot_mount',
+  'after_bot_unmount',
+  'before_bot_import'
 ]

--- a/modules/code-editor/src/typings/hooks.ts
+++ b/modules/code-editor/src/typings/hooks.ts
@@ -1,18 +1,18 @@
 export const HOOK_SIGNATURES = {
-  before_incoming_middleware: 'async function action(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
-  after_incoming_middleware: 'async function action(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
-  before_outgoing_middleware: 'async function action(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
-  after_event_processed: 'async function action(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
+  before_incoming_middleware: 'async function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
+  after_incoming_middleware: 'async function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
+  before_outgoing_middleware: 'async function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
+  after_event_processed: 'async function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
   before_suggestions_election:
-    'async function action(bp: typeof sdk, sessionId: string, event: sdk.IO.IncomingEvent, suggestions: sdk.IO.Suggestion[])',
-  after_server_start: 'async function action(bp: typeof sdk)',
-  after_bot_mount: 'async function action(bp: typeof sdk, botId: string)',
-  after_bot_unmount: 'async function action(bp: typeof sdk, botId: string)',
-  before_session_timeout: 'async function action(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
-  on_incident_status_changed: 'async function action(bp: typeof sdk, incident: sdk.Incident)',
-  before_bot_import: 'async function action(bp: typeof sdk, botId: string, tmpFolder: string, hookResult: object)',
+    'async function hook(bp: typeof sdk, sessionId: string, event: sdk.IO.IncomingEvent, suggestions: sdk.IO.Suggestion[])',
+  after_server_start: 'async function hook(bp: typeof sdk)',
+  after_bot_mount: 'async function hook(bp: typeof sdk, botId: string)',
+  after_bot_unmount: 'async function hook(bp: typeof sdk, botId: string)',
+  before_session_timeout: 'async function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
+  on_incident_status_changed: 'async function hook(bp: typeof sdk, incident: sdk.Incident)',
+  before_bot_import: 'async function hook(bp: typeof sdk, botId: string, tmpFolder: string, hookResult: object)',
   on_stage_request:
-    'async function action(bp: typeof sdk, bot: sdk.BotConfig, users: Partial<sdk.AuthUser[]>, pipeline: sdk.Pipeline, hookResult: any)',
+    'async function hook(bp: typeof sdk, bot: sdk.BotConfig, users: Partial<sdk.AuthUser[]>, pipeline: sdk.Pipeline, hookResult: any)',
   after_stage_changed:
-    'async function action(bp: typeof sdk, previousBotConfig: sdk.BotConfig, bot: sdk.BotConfig, users: Partial<sdk.AuthUser[]>, pipeline: sdk.Pipeline)'
+    'async function hook(bp: typeof sdk, previousBotConfig: sdk.BotConfig, bot: sdk.BotConfig, users: Partial<sdk.AuthUser[]>, pipeline: sdk.Pipeline)'
 }

--- a/modules/code-editor/src/typings/hooks.ts
+++ b/modules/code-editor/src/typings/hooks.ts
@@ -16,3 +16,12 @@ export const HOOK_SIGNATURES = {
   after_stage_changed:
     'async function hook(bp: typeof sdk, previousBotConfig: sdk.BotConfig, bot: sdk.BotConfig, users: Partial<sdk.AuthUser[]>, pipeline: sdk.Pipeline)'
 }
+
+export const BOT_SCOPED_HOOKS = [
+  'before_incoming_middleware',
+  'after_incoming_middleware',
+  'before_outgoing_middleware',
+  'after_event_processed',
+  'before_suggestions_election',
+  'before_session_timeout'
+]

--- a/modules/code-editor/src/views/full/FileNavigator.tsx
+++ b/modules/code-editor/src/views/full/FileNavigator.tsx
@@ -176,15 +176,17 @@ class FileNavigator extends React.Component<Props, State> {
           </Menu>,
           { left: e.clientX, top: e.clientY }
         )
-      } else if (file.type === 'hook' && BOT_SCOPED_HOOKS.includes(file.hookType)) {
+      } else if (file.type === 'hook') {
         ContextMenu.show(
           <Menu>
-            <MenuItem
-              id="btn-duplicateCurrent"
-              icon="duplicate"
-              text="Copy example to my bot"
-              onClick={() => this.props.duplicateFile(file, { forCurrentBot: true, keepSameName: true })}
-            />
+            {BOT_SCOPED_HOOKS.includes(file.hookType) && (
+              <MenuItem
+                id="btn-duplicateCurrent"
+                icon="duplicate"
+                text="Copy example to my bot"
+                onClick={() => this.props.duplicateFile(file, { forCurrentBot: true, keepSameName: true })}
+              />
+            )}
             <MenuItem
               id="btn-duplicateCurrent"
               icon="duplicate"

--- a/modules/code-editor/src/views/full/FileNavigator.tsx
+++ b/modules/code-editor/src/views/full/FileNavigator.tsx
@@ -16,6 +16,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 
 import { EditableFile } from '../../backend/typings'
+import { BOT_SCOPED_HOOKS } from '../../typings/hooks'
 
 import { RootStore, StoreDef } from './store'
 import { EditorStore } from './store/editor'
@@ -175,7 +176,7 @@ class FileNavigator extends React.Component<Props, State> {
           </Menu>,
           { left: e.clientX, top: e.clientY }
         )
-      } else if (file.type === 'hook') {
+      } else if (file.type === 'hook' && BOT_SCOPED_HOOKS.includes(file.hookType)) {
         ContextMenu.show(
           <Menu>
             <MenuItem

--- a/modules/code-editor/src/views/full/FileNavigator.tsx
+++ b/modules/code-editor/src/views/full/FileNavigator.tsx
@@ -163,19 +163,38 @@ class FileNavigator extends React.Component<Props, State> {
     }
 
     if (file.isExample) {
-      ContextMenu.show(
-        <Menu>
-          <MenuItem
-            id="btn-duplicateCurrent"
-            icon="duplicate"
-            text={file.type === 'action' ? 'Copy example to my bot' : 'Copy example to global hooks'}
-            onClick={() =>
-              this.props.duplicateFile(file, { forCurrentBot: file.type === 'action', keepSameName: true })
-            }
-          />
-        </Menu>,
-        { left: e.clientX, top: e.clientY }
-      )
+      if (file.type === 'action') {
+        ContextMenu.show(
+          <Menu>
+            <MenuItem
+              id="btn-duplicateCurrent"
+              icon="duplicate"
+              text="Copy example to my bot"
+              onClick={() => this.props.duplicateFile(file, { forCurrentBot: true, keepSameName: true })}
+            />
+          </Menu>,
+          { left: e.clientX, top: e.clientY }
+        )
+      } else if (file.type === 'hook') {
+        ContextMenu.show(
+          <Menu>
+            <MenuItem
+              id="btn-duplicateCurrent"
+              icon="duplicate"
+              text="Copy example to my bot"
+              onClick={() => this.props.duplicateFile(file, { forCurrentBot: true, keepSameName: true })}
+            />
+            <MenuItem
+              id="btn-duplicateCurrent"
+              icon="duplicate"
+              text="Copy example to global hooks"
+              onClick={() => this.props.duplicateFile(file, { forCurrentBot: false, keepSameName: true })}
+            />
+          </Menu>,
+          { left: e.clientX, top: e.clientY }
+        )
+      }
+
       return
     }
 

--- a/modules/code-editor/src/views/full/SidePanel.tsx
+++ b/modules/code-editor/src/views/full/SidePanel.tsx
@@ -245,15 +245,15 @@ class PanelContent extends React.Component<Props> {
             'before_session_timeout'
           ].includes(x.id)
         )
+      },
+      {
+        label: 'Bot Hooks',
+        items: hooks.filter(x => ['after_bot_mount', 'after_bot_unmount', 'before_bot_import'].includes(x.id))
       }
     ]
 
     if (showGlobalHooks) {
       items.push(
-        {
-          label: 'Bot Hooks',
-          items: hooks.filter(x => ['after_bot_mount', 'after_bot_unmount', 'before_bot_import'].includes(x.id))
-        },
         {
           label: 'General Hooks',
           items: hooks.filter(x => ['after_server_start'].includes(x.id))

--- a/modules/code-editor/src/views/full/SidePanel.tsx
+++ b/modules/code-editor/src/views/full/SidePanel.tsx
@@ -256,13 +256,11 @@ class PanelContent extends React.Component<Props> {
       items.push(
         {
           label: 'General Hooks',
-          items: hooks.filter(x => ['after_server_start'].includes(x.id))
+          items: hooks.filter(x => ['after_server_start', 'on_incident_status_changed'].includes(x.id))
         },
         {
           label: 'Pipeline Hooks',
-          items: hooks.filter(x =>
-            ['on_incident_status_changed', 'on_stage_request', 'after_stage_changed'].includes(x.id)
-          )
+          items: hooks.filter(x => ['on_stage_request', 'after_stage_changed'].includes(x.id))
         }
       )
     }

--- a/modules/code-editor/src/views/full/SidePanel.tsx
+++ b/modules/code-editor/src/views/full/SidePanel.tsx
@@ -3,10 +3,12 @@ import { SearchBar, SectionAction, SidePanel, SidePanelSection } from 'botpress/
 import { inject, observer } from 'mobx-react'
 import React from 'react'
 
+import { FileType } from '../../backend/typings'
 import { HOOK_SIGNATURES } from '../../typings/hooks'
 
 import FileStatus from './components/FileStatus'
 import NameModal from './components/NameModal'
+import NewFileModal from './components/NewFileModal'
 import { RootStore, StoreDef } from './store'
 import { EditorStore } from './store/editor'
 import { EXAMPLE_FOLDER_LABEL } from './utils/tree'
@@ -23,7 +25,10 @@ class PanelContent extends React.Component<Props> {
     rawFiles: [],
     selectedNode: '',
     selectedFile: undefined,
-    isMoveModalOpen: false
+    isMoveModalOpen: false,
+    isCreateModalOpen: false,
+    fileType: undefined,
+    hookType: undefined
   }
 
   componentDidMount() {
@@ -57,6 +62,7 @@ class PanelContent extends React.Component<Props> {
     this.addFiles('global.actions', `Global`, actionFiles)
 
     const hookFiles = []
+    this.addFiles('bot.hooks', `Bot (${window['BOT_NAME']})`, hookFiles)
     this.addFiles('global.hooks', 'Global', hookFiles)
 
     const botConfigFiles = []
@@ -85,9 +91,13 @@ class PanelContent extends React.Component<Props> {
     this.setState({ selectedNode: fullyQualifiedId })
   }
 
-  hasPermission(perm: string, isWrite?: boolean): boolean {
+  hasPermission = (perm: string, isWrite?: boolean): boolean => {
     const { permissions } = this.props
     return permissions && permissions[perm] && permissions[perm][isWrite ? 'write' : 'read']
+  }
+
+  createFilePrompt(type: FileType, hookType?: string) {
+    this.setState({ fileType: type, hookType, isCreateModalOpen: true })
   }
 
   renderSectionModuleConfig() {
@@ -131,28 +141,17 @@ class PanelContent extends React.Component<Props> {
   }
 
   renderSectionActions() {
-    const items: SectionAction[] = [
-      {
-        id: 'btn-add-action-bot',
-        label: 'Action - Bot',
-        icon: <Icon icon="new-text-box" />,
-        onClick: () => this.props.createFilePrompt('action', false)
-      }
-    ]
-
-    if (this.hasPermission('global.actions', true)) {
-      items.push({
-        id: `btn-add-action-global`,
-        label: 'Action - Global',
-        icon: <Icon icon="new-text-box" />,
-        onClick: () => this.props.createFilePrompt('action', true)
-      })
-    }
-
     return (
       <SidePanelSection
         label={'Actions'}
-        actions={[{ id: 'btn-add-action', icon: <Icon icon="add" />, key: 'add', items }]}
+        actions={[
+          {
+            id: 'btn-add-action',
+            icon: <Icon icon="add" />,
+            key: 'add',
+            onClick: () => this.createFilePrompt('action')
+          }
+        ]}
       >
         <FileNavigator
           id="actions"
@@ -167,14 +166,12 @@ class PanelContent extends React.Component<Props> {
   }
 
   renderSectionHooks() {
-    if (!this.hasPermission('global.hooks')) {
+    if (!this.hasPermission('global.hooks') && !this.hasPermission('bot.hooks')) {
       return null
     }
 
-    const actions = this.hasPermission('global.hooks', true) ? this._buildHooksActions() : []
-
     return (
-      <SidePanelSection label={'Hooks'} actions={actions}>
+      <SidePanelSection label={'Hooks'} actions={this._buildHooksActions(this.hasPermission('global.hooks', true))}>
         <FileNavigator
           id="hooks"
           files={this.state.hookFiles}
@@ -225,50 +222,57 @@ class PanelContent extends React.Component<Props> {
     )
   }
 
-  _buildHooksActions() {
+  _buildHooksActions(showGlobalHooks: boolean) {
     const hooks = Object.keys(HOOK_SIGNATURES).map(hookType => ({
       id: hookType,
       label: hookType
         .split('_')
         .map(x => x.charAt(0).toUpperCase() + x.slice(1))
         .join(' '),
-      onClick: () => this.props.createFilePrompt('hook', true, hookType)
+      onClick: () => this.createFilePrompt('hook', hookType)
     }))
+
+    const items = [
+      {
+        label: 'Event Hooks',
+        items: hooks.filter(x =>
+          [
+            'before_incoming_middleware',
+            'after_incoming_middleware',
+            'before_outgoing_middleware',
+            'after_event_processed',
+            'before_suggestions_election',
+            'before_session_timeout'
+          ].includes(x.id)
+        )
+      }
+    ]
+
+    if (showGlobalHooks) {
+      items.push(
+        {
+          label: 'Bot Hooks',
+          items: hooks.filter(x => ['after_bot_mount', 'after_bot_unmount', 'before_bot_import'].includes(x.id))
+        },
+        {
+          label: 'General Hooks',
+          items: hooks.filter(x => ['after_server_start'].includes(x.id))
+        },
+        {
+          label: 'Pipeline Hooks',
+          items: hooks.filter(x =>
+            ['on_incident_status_changed', 'on_stage_request', 'after_stage_changed'].includes(x.id)
+          )
+        }
+      )
+    }
 
     return [
       {
         id: 'btn-add-hook',
         icon: <Icon icon="add" />,
         key: 'add',
-        items: [
-          {
-            label: 'Event Hooks',
-            items: hooks.filter(x =>
-              [
-                'before_incoming_middleware',
-                'after_incoming_middleware',
-                'before_outgoing_middleware',
-                'after_event_processed',
-                'before_suggestions_election',
-                'before_session_timeout'
-              ].includes(x.id)
-            )
-          },
-          {
-            label: 'Bot Hooks',
-            items: hooks.filter(x => ['after_bot_mount', 'after_bot_unmount', 'before_bot_import'].includes(x.id))
-          },
-          {
-            label: 'General Hooks',
-            items: hooks.filter(x => ['after_server_start'].includes(x.id))
-          },
-          {
-            label: 'Pipeline Hooks',
-            items: hooks.filter(x =>
-              ['on_incident_status_changed', 'on_stage_request', 'after_stage_changed'].includes(x.id)
-            )
-          }
-        ]
+        items
       }
     ]
   }
@@ -293,6 +297,15 @@ class PanelContent extends React.Component<Props> {
             )}
           </React.Fragment>
         )}
+        <NewFileModal
+          isOpen={this.state.isCreateModalOpen}
+          toggle={() => this.setState({ isCreateModalOpen: !this.state.isCreateModalOpen })}
+          openFile={this.props.editor.openFile}
+          selectedType={this.state.fileType}
+          selectedHookType={this.state.hookType}
+          hasPermission={this.hasPermission}
+          files={this.props.files}
+        />
       </SidePanel>
     )
   }

--- a/modules/code-editor/src/views/full/components/NewFileModal.tsx
+++ b/modules/code-editor/src/views/full/components/NewFileModal.tsx
@@ -3,8 +3,9 @@ import _ from 'lodash'
 import React, { FC, useEffect, useState } from 'react'
 
 import { FileTypes } from '../../../backend/definitions'
-import { EditableFile, FilesDS } from '../../../backend/typings'
-import { baseAction, baseHook } from '../utils/templates'
+import { FilesDS } from '../../../backend/typings'
+import { BOT_SCOPED_HOOKS } from '../../../typings/hooks'
+import { baseAction } from '../utils/templates'
 
 interface Props {
   isOpen: boolean
@@ -59,6 +60,10 @@ const NewFileModal: FC<Props> = props => {
   const fileDefinition = FileTypes[props.selectedType]
   const canGlobalWrite = props.hasPermission(`global.${fileDefinition.permission}`, true)
 
+  const canBeBotScoped =
+    props.selectedType !== 'hook' ||
+    (props.selectedType === 'hook' && BOT_SCOPED_HOOKS.includes(props.selectedHookType))
+
   return (
     <Dialog
       isOpen={props.isOpen}
@@ -81,7 +86,7 @@ const NewFileModal: FC<Props> = props => {
             />
           </FormGroup>
 
-          {fileDefinition.allowScoped && (
+          {fileDefinition.allowScoped && canBeBotScoped && (
             <Checkbox
               label="Create for the current bot"
               checked={isScoped}

--- a/modules/code-editor/src/views/full/components/NewFileModal.tsx
+++ b/modules/code-editor/src/views/full/components/NewFileModal.tsx
@@ -42,11 +42,15 @@ const NewFileModal: FC<Props> = props => {
       content: props.selectedType === 'action' ? baseAction : ' ',
       type: props.selectedType,
       hookType: props.selectedHookType,
-      botId: isScoped ? window.BOT_ID : undefined
+      botId: canBeBotScoped() && isScoped ? window.BOT_ID : undefined
     })
 
     closeModal()
   }
+
+  const canBeBotScoped = () =>
+    props.selectedType !== 'hook' ||
+    (props.selectedType === 'hook' && BOT_SCOPED_HOOKS.includes(props.selectedHookType))
 
   const closeModal = () => {
     setName('')
@@ -59,10 +63,6 @@ const NewFileModal: FC<Props> = props => {
 
   const fileDefinition = FileTypes[props.selectedType]
   const canGlobalWrite = props.hasPermission(`global.${fileDefinition.permission}`, true)
-
-  const canBeBotScoped =
-    props.selectedType !== 'hook' ||
-    (props.selectedType === 'hook' && BOT_SCOPED_HOOKS.includes(props.selectedHookType))
 
   return (
     <Dialog
@@ -86,7 +86,7 @@ const NewFileModal: FC<Props> = props => {
             />
           </FormGroup>
 
-          {fileDefinition.allowScoped && canBeBotScoped && (
+          {fileDefinition.allowScoped && canBeBotScoped() && (
             <Checkbox
               label="Create for the current bot"
               checked={isScoped}

--- a/modules/code-editor/src/views/full/components/NewFileModal.tsx
+++ b/modules/code-editor/src/views/full/components/NewFileModal.tsx
@@ -1,0 +1,111 @@
+import { Button, Callout, Checkbox, Classes, Dialog, FormGroup, InputGroup, Intent } from '@blueprintjs/core'
+import _ from 'lodash'
+import React, { FC, useEffect, useState } from 'react'
+
+import { FileTypes } from '../../../backend/definitions'
+import { EditableFile, FilesDS } from '../../../backend/typings'
+import { baseAction, baseHook } from '../utils/templates'
+
+interface Props {
+  isOpen: boolean
+  toggle: () => void
+  openFile: (args: any) => void
+  files?: FilesDS
+  selectedType: string
+  selectedHookType: string
+  hasPermission(perm: string, isWrite?: boolean): boolean
+}
+
+const sanitizeName = (text: string) =>
+  text
+    .replace(/\s/g, '-')
+    .replace(/[^a-zA-Z0-9\/_.-]/g, '')
+    .replace(/\/\//, '/')
+
+const NewFileModal: FC<Props> = props => {
+  const [name, setName] = useState('')
+  const [isScoped, setScoped] = useState(true)
+
+  useEffect(() => {
+    setName('')
+  }, [props.isOpen])
+
+  const submit = async e => {
+    e.preventDefault()
+
+    const finalName = name.endsWith('.js') || name.endsWith('.json') ? name : name + '.js'
+
+    await props.openFile({
+      name: finalName,
+      location: finalName,
+      content: props.selectedType === 'action' ? baseAction : ' ',
+      type: props.selectedType,
+      hookType: props.selectedHookType,
+      botId: isScoped ? window.BOT_ID : undefined
+    })
+
+    closeModal()
+  }
+
+  const closeModal = () => {
+    setName('')
+    props.toggle()
+  }
+
+  if (!props.selectedType) {
+    return null
+  }
+
+  const fileDefinition = FileTypes[props.selectedType]
+  const canGlobalWrite = props.hasPermission(`global.${fileDefinition.permission}`, true)
+
+  return (
+    <Dialog
+      isOpen={props.isOpen}
+      onClose={closeModal}
+      transitionDuration={0}
+      icon="add"
+      title={`Create a new ${props.selectedType}`}
+    >
+      <form onSubmit={submit}>
+        <div className={Classes.DIALOG_BODY}>
+          <FormGroup label="File name" helperText="No special characters allowed. Must end in .js">
+            <InputGroup
+              id="input-name"
+              tabIndex={1}
+              placeholder="my-file.js"
+              value={name}
+              onChange={e => setName(sanitizeName(e.currentTarget.value))}
+              required
+              autoFocus
+            />
+          </FormGroup>
+
+          {fileDefinition.allowScoped && (
+            <Checkbox
+              label="Create for the current bot"
+              checked={isScoped}
+              disabled={!fileDefinition.allowGlobal || !canGlobalWrite}
+              onChange={e => setScoped(e.currentTarget.checked)}
+            />
+          )}
+        </div>
+
+        <div className={Classes.DIALOG_FOOTER}>
+          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+            <Button
+              type="submit"
+              id="btn-submit"
+              text="Submit"
+              intent={Intent.PRIMARY}
+              onClick={submit}
+              disabled={!name}
+            />
+          </div>
+        </div>
+      </form>
+    </Dialog>
+  )
+}
+
+export default NewFileModal

--- a/src/bp/core/services/action/action-service.ts
+++ b/src/bp/core/services/action/action-service.ts
@@ -16,7 +16,7 @@ import { TYPES } from '../../types'
 import { ActionExecutionError } from '../dialog/errors'
 
 import { ActionMetadata, extractMetadata } from './metadata'
-import { extractRequiredFiles, getBaseLookupPaths, prepareRequire, prepareRequireTester } from './utils'
+import { extractRequiredFiles, filterDisabled, getBaseLookupPaths, prepareRequire, prepareRequireTester } from './utils'
 import { VmRunner } from './vm'
 
 const debug = DEBUG('actions')
@@ -105,8 +105,6 @@ export class ScopedActionService {
     if (this._actionsCache) {
       return this._actionsCache
     }
-
-    const filterDisabled = (filesPaths: string[]): string[] => filesPaths.filter(x => !path.basename(x).startsWith('.'))
 
     // node_production_modules are node_modules that are compressed for production
     const exclude = ['**/node_modules/**', '**/node_production_modules/**']

--- a/src/bp/core/services/action/utils.ts
+++ b/src/bp/core/services/action/utils.ts
@@ -48,3 +48,6 @@ export const extractRequiredFiles = (code: string) => {
 
   return files
 }
+
+export const filterDisabled = (filesPaths: string[]): string[] =>
+  filesPaths.filter(x => !path.basename(x).startsWith('.'))

--- a/src/bp/core/services/hook/hook-service.ts
+++ b/src/bp/core/services/hook/hook-service.ts
@@ -169,7 +169,7 @@ export class HookService {
   }
 
   async executeHook(hook: Hooks.BaseHook): Promise<void> {
-    const botId = hook.args?.event?.botId
+    const botId = hook.args?.event?.botId || hook.args?.botId
     const scripts = await this.extractScripts(hook, botId)
     await Promise.mapSeries(_.orderBy(scripts, ['filename'], ['asc']), script => this.runScript(script, hook))
   }

--- a/src/bp/core/services/hook/hook-service.ts
+++ b/src/bp/core/services/hook/hook-service.ts
@@ -13,6 +13,7 @@ import { NodeVM } from 'vm2'
 import { GhostService } from '..'
 import { clearRequireCache, requireAtPaths } from '../../modules/require'
 import { TYPES } from '../../types'
+import { filterDisabled } from '../action/utils'
 import { VmRunner } from '../action/vm'
 import { Incident } from '../alerting-service'
 
@@ -130,7 +131,7 @@ export namespace Hooks {
 }
 
 class HookScript {
-  constructor(public path: string, public filename: string, public code: string) {}
+  constructor(public path: string, public filename: string, public code: string, public botId?: string) {}
 }
 
 @injectable()
@@ -168,7 +169,8 @@ export class HookService {
   }
 
   async executeHook(hook: Hooks.BaseHook): Promise<void> {
-    const scripts = await this.extractScripts(hook)
+    const botId = hook.args?.event?.botId
+    const scripts = await this.extractScripts(hook, botId)
     await Promise.mapSeries(_.orderBy(scripts, ['filename'], ['asc']), script => this.runScript(script, hook))
   }
 
@@ -194,27 +196,40 @@ export class HookService {
     }
   }
 
-  private async extractScripts(hook: Hooks.BaseHook): Promise<HookScript[]> {
-    if (this._scriptsCache.has(hook.folder)) {
-      return this._scriptsCache.get(hook.folder)!
+  private async extractScripts(hook: Hooks.BaseHook, botId?: string): Promise<HookScript[]> {
+    const scriptKey = botId ? `${hook.folder}_${botId}` : hook.folder
+
+    if (this._scriptsCache.has(scriptKey)) {
+      return this._scriptsCache.get(scriptKey)!
     }
 
     try {
-      const filesPaths = await this.ghost.global().directoryListing('hooks/' + hook.folder, '*.js')
-      const enabledFiles = filesPaths.filter(x => !path.basename(x).startsWith('.'))
+      const globalHooks = filterDisabled(await this.ghost.global().directoryListing('hooks/' + hook.folder, '*.js'))
+      const scripts = await Promise.map(globalHooks, async path => this._getHookScript(hook.folder, path))
 
-      const scripts = await Promise.map(enabledFiles, async path => {
-        const script = await this.ghost.global().readFileAsString('hooks/' + hook.folder, path)
-        const filename = path.replace(/^.*[\\\/]/, '')
-        return new HookScript(path, filename, script)
-      })
+      if (botId) {
+        const botHooks = filterDisabled(await this.ghost.forBot(botId).directoryListing('hooks/' + hook.folder, '*.js'))
+        scripts.push(...(await Promise.map(botHooks, async path => this._getHookScript(hook.folder, path, botId))))
+      }
 
-      this._scriptsCache.set(hook.folder, scripts)
+      this._scriptsCache.set(scriptKey, scripts)
       return scripts
     } catch (err) {
-      this._scriptsCache.delete(hook.folder)
+      this._scriptsCache.delete(scriptKey)
       return []
     }
+  }
+
+  private async _getHookScript(hookFolder: string, path: string, botId?: string) {
+    let script: string
+    if (!botId) {
+      script = await this.ghost.global().readFileAsString('hooks/' + hookFolder, path)
+    } else {
+      script = await this.ghost.forBot(botId).readFileAsString('hooks/' + hookFolder, path)
+    }
+
+    const filename = path.replace(/^.*[\\\/]/, '')
+    return new HookScript(path, filename, script, botId)
   }
 
   private _prepareRequire(fullPath: string, hookType: string) {
@@ -234,7 +249,9 @@ export class HookService {
   }
 
   private async runScript(hookScript: HookScript, hook: Hooks.BaseHook) {
-    const hookPath = `/data/global/hooks/${hook.folder}/${hookScript.path}.js`
+    const scope = hookScript.botId ? `bots/${hookScript.botId}` : 'global'
+    const hookPath = `/data/${scope}/hooks/${hook.folder}/${hookScript.path}.js`
+
     const dirPath = path.resolve(path.join(process.PROJECT_LOCATION, hookPath))
 
     const _require = this._prepareRequire(dirPath, hook.folder)

--- a/src/e2e/modules/code-editor.test.ts
+++ b/src/e2e/modules/code-editor.test.ts
@@ -1,4 +1,4 @@
-import { clickOn } from '../expectPuppeteer'
+import { clickOn, fillField } from '../expectPuppeteer'
 import {
   autoAnswerDialog,
   clickOnTreeNode,
@@ -24,9 +24,9 @@ describe('Module - Code Editor', () => {
   })
 
   it('Create new action', async () => {
-    autoAnswerDialog('hello')
     await clickOn('#btn-add-action')
-    await clickOn('#btn-add-action-bot')
+    await fillField('#input-name', 'hello')
+    await clickOn('#btn-submit')
 
     await page.focus('#monaco-editor')
     await page.mouse.click(469, 297)


### PR DESCRIPTION
This PR makes all Event and Bot Hooks possible to be scoped to a specific bot. They are also exported and imported when the bot moves around. Updated the UX for action creation.

Global hooks are always executed.

![image](https://user-images.githubusercontent.com/42552874/73976173-be975e80-48f5-11ea-998f-3cd8ad7187b3.png)
