### PR TITLE
fix(dropdown): decision on value instead of label

### DIFF
--- a/modules/extensions/src/views/lite/components/Dropdown.jsx
+++ b/modules/extensions/src/views/lite/components/Dropdown.jsx
@@ -41,7 +41,8 @@ export class Dropdown extends React.Component {
       value = selectedOption.map(x => x.value || x.label).join(',')
     }
 
-    this.props.onSendData && this.props.onSendData({ type: 'quick_reply', text: label, payload: value || label })
+    const payload = value || label
+    this.props.onSendData && this.props.onSendData({ type: 'quick_reply', text: label, payload, preview: payload })
   }
 
   renderSelect(inKeyboard) {


### PR DESCRIPTION
Up for debate.

When the user selects a list item from a dropdown, intent/qna matching is done on the label text instead of the value.

**I believe this kind of change could break existing user bots/implementations if they check event.preview**

