### PR TITLE
feat(logs): new log page & additional bot monitoring

### DIFF
--- a/modules/code-editor/src/typings/hooks.ts
+++ b/modules/code-editor/src/typings/hooks.ts
@@ -14,7 +14,13 @@ export const HOOK_SIGNATURES = {
   on_stage_request:
     'async function hook(bp: typeof sdk, bot: sdk.BotConfig, users: Partial<sdk.AuthUser[]>, pipeline: sdk.Pipeline, hookResult: any)',
   after_stage_changed:
-    'async function hook(bp: typeof sdk, previousBotConfig: sdk.BotConfig, bot: sdk.BotConfig, users: Partial<sdk.AuthUser[]>, pipeline: sdk.Pipeline)'
+    'async function hook(bp: typeof sdk, previousBotConfig: sdk.BotConfig, bot: sdk.BotConfig, users: Partial<sdk.AuthUser[]>, pipeline: sdk.Pipeline)',
+  on_bot_error: `
+  /*
+   * The monitoring service must be enabled for this hook to work properly
+   * It will be triggered with a list of events which occurred during the configured interval
+   */
+  async function hook(bp: typeof sdk, botId: string, events: sdk.LoggerEntry[])`
 }
 
 export const BOT_SCOPED_HOOKS = [
@@ -26,5 +32,6 @@ export const BOT_SCOPED_HOOKS = [
   'before_session_timeout',
   'after_bot_mount',
   'after_bot_unmount',
-  'before_bot_import'
+  'before_bot_import',
+  'on_bot_error'
 ]

--- a/modules/code-editor/src/typings/hooks.ts
+++ b/modules/code-editor/src/typings/hooks.ts
@@ -15,12 +15,7 @@ export const HOOK_SIGNATURES = {
     'async function hook(bp: typeof sdk, bot: sdk.BotConfig, users: Partial<sdk.AuthUser[]>, pipeline: sdk.Pipeline, hookResult: any)',
   after_stage_changed:
     'async function hook(bp: typeof sdk, previousBotConfig: sdk.BotConfig, bot: sdk.BotConfig, users: Partial<sdk.AuthUser[]>, pipeline: sdk.Pipeline)',
-  on_bot_error: `
-  /*
-   * The monitoring service must be enabled for this hook to work properly
-   * It will be triggered with a list of events which occurred during the configured interval
-   */
-  async function hook(bp: typeof sdk, botId: string, events: sdk.LoggerEntry[])`
+  on_bot_error: `async function hook(bp: typeof sdk, botId: string, events: sdk.LoggerEntry[])`
 }
 
 export const BOT_SCOPED_HOOKS = [

--- a/modules/code-editor/src/views/full/SidePanel.tsx
+++ b/modules/code-editor/src/views/full/SidePanel.tsx
@@ -248,7 +248,9 @@ class PanelContent extends React.Component<Props> {
       },
       {
         label: 'Bot Hooks',
-        items: hooks.filter(x => ['after_bot_mount', 'after_bot_unmount', 'before_bot_import'].includes(x.id))
+        items: hooks.filter(x =>
+          ['after_bot_mount', 'after_bot_unmount', 'before_bot_import', 'on_bot_error'].includes(x.id)
+        )
       }
     ]
 

--- a/src/bp/common/monitoring.ts
+++ b/src/bp/common/monitoring.ts
@@ -2,8 +2,17 @@ import { MonitoringStats } from 'core/services/monitoring'
 import _ from 'lodash'
 import ms from 'ms'
 
+export enum Metric {
+  Requests = 'requests.count',
+  EventsIn = 'eventsIn.count',
+  EventsOut = 'eventsOut.count',
+  Warnings = 'warnings.count',
+  Errors = 'errors.count',
+  Criticals = 'criticals.count'
+}
+
 const AVG_KEYS = ['cpu.usage', 'mem.usage']
-const SUM_KEYS = ['requests.count', 'errors.count', 'warnings.count', 'eventsIn.count', 'eventsOut.count']
+const SUM_KEYS = [Metric.Requests, Metric.Errors, Metric.Criticals, Metric.Warnings, Metric.EventsIn, Metric.EventsOut]
 
 /**
  * This object groups all statistics entries by their 'resolution group'. For example, if the resolution is 30 seconds,

--- a/src/bp/common/typings.ts
+++ b/src/bp/common/typings.ts
@@ -177,5 +177,6 @@ export interface ServerHealth {
 export interface BotHealth {
   status: 'mounted' | 'unmounted' | 'disabled' | 'error'
   errorCount: number
+  criticalCount: number
   warningCount: number
 }

--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -23,6 +23,7 @@ import HTTPServer from './server'
 import { GhostService } from './services'
 import { AlertingService } from './services/alerting-service'
 import AuthService from './services/auth/auth-service'
+import { BotMonitoringService } from './services/bot-monitoring-service'
 import { BotService } from './services/bot-service'
 import { CMSService } from './services/cms'
 import { converseApiEvents } from './services/converse'
@@ -94,7 +95,8 @@ export class Botpress {
     @inject(TYPES.EventCollector) private eventCollector: EventCollector,
     @inject(TYPES.AuthService) private authService: AuthService,
     @inject(TYPES.MigrationService) private migrationService: MigrationService,
-    @inject(TYPES.StatsService) private statsService: StatsService
+    @inject(TYPES.StatsService) private statsService: StatsService,
+    @inject(TYPES.BotMonitoringService) private botMonitor: BotMonitoringService
   ) {
     this.botpressPath = path.join(process.cwd(), 'dist')
     this.configLocation = path.join(this.botpressPath, '/config')
@@ -328,7 +330,7 @@ export class Botpress {
       await this.hookService.executeHook(new Hooks.AfterEventProcessed(this.api, event))
     }
 
-    this.monitoringService.onBotError = async (botId: string, events: sdk.LoggerEntry[]) => {
+    this.botMonitor.onBotError = async (botId: string, events: sdk.LoggerEntry[]) => {
       await this.hookService.executeHook(new Hooks.OnBotError(this.api, botId, events))
     }
 
@@ -361,6 +363,7 @@ export class Botpress {
     await this.monitoringService.start()
     await this.alertingService.start()
     await this.eventCollector.start()
+    await this.botMonitor.start()
 
     if (this.config!.dataRetention) {
       await this.dataRetentionJanitor.start()

--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -328,6 +328,10 @@ export class Botpress {
       await this.hookService.executeHook(new Hooks.AfterEventProcessed(this.api, event))
     }
 
+    this.monitoringService.onBotError = async (botId: string, events: sdk.LoggerEntry[]) => {
+      await this.hookService.executeHook(new Hooks.OnBotError(this.api, botId, events))
+    }
+
     await this.dataRetentionService.initialize()
 
     const dialogEngineLogger = await this.loggerProvider('DialogEngine')

--- a/src/bp/core/config/botpress.config.ts
+++ b/src/bp/core/config/botpress.config.ts
@@ -239,6 +239,7 @@ export type BotpressConfig = {
    */
   autoRevision: boolean
   eventCollector: EventCollectorConfig
+  botMonitoring: BotMonitoringConfig
   /**
    * @default { "default": { "type": "basic", "allowSelfSignup": false, "options": { "maxLoginAttempt": 0} }}
    */
@@ -493,11 +494,6 @@ export interface MonitoringConfig {
    * @default 15m
    */
   janitorInterval: string
-  /**
-   * The interval between which logs are accumulated before triggering the OnBotImportantLog hook. Set this value higher if the hook is triggered too often.
-   * @default 1m
-   */
-  botMonitorInterval: string
 }
 
 export interface AlertingConfig {
@@ -526,6 +522,20 @@ export interface AlertingConfig {
    * is called with the incident.
    */
   rules: IncidentRule[]
+}
+
+export interface BotMonitoringConfig {
+  /**
+   * This must be enabled for the hook OnBotError to work properly.
+   * @default true
+   */
+  enabled: boolean
+  /**
+   * The interval between which logs are accumulated before triggering the OnBotError hook.
+   * Set this value higher if the hook is triggered too often.
+   * @default 1m
+   */
+  interval: string
 }
 
 export interface EventCollectorConfig {

--- a/src/bp/core/config/botpress.config.ts
+++ b/src/bp/core/config/botpress.config.ts
@@ -493,6 +493,11 @@ export interface MonitoringConfig {
    * @default 15m
    */
   janitorInterval: string
+  /**
+   * The interval between which logs are accumulated before triggering the OnBotImportantLog hook. Set this value higher if the hook is triggered too often.
+   * @default 1m
+   */
+  botMonitorInterval: string
 }
 
 export interface AlertingConfig {

--- a/src/bp/core/database/tables/bot-specific/logs.ts
+++ b/src/bp/core/database/tables/bot-specific/logs.ts
@@ -7,6 +7,7 @@ export class LogsTable extends Table {
     let created = false
     await this.knex.createTableIfNotExists(this.name, table => {
       table.string('botId').nullable()
+      table.string('hostname').nullable()
       table.timestamp('timestamp')
       table.string('level')
       table.string('scope')

--- a/src/bp/core/logger/logger.ts
+++ b/src/bp/core/logger/logger.ts
@@ -43,6 +43,7 @@ export class PersistedConsoleLogger implements Logger {
   private currentMessageLevel: LogLevel | undefined
   private willPersistMessage: boolean = true
   private emitLogStream = true
+  private serverHostname: string = ''
 
   private static LogStreamEmitter: EventEmitter2 = new EventEmitter2({
     delimiter: '::',
@@ -67,6 +68,7 @@ export class PersistedConsoleLogger implements Logger {
     @inject(TYPES.LoggerFilePersister) private loggerFilePersister: LoggerFilePersister
   ) {
     this.displayLevel = process.VERBOSITY_LEVEL
+    this.serverHostname = os.hostname()
   }
 
   forBot(botId: string): this {
@@ -174,6 +176,7 @@ export class PersistedConsoleLogger implements Logger {
 
     const entry: LoggerEntry = {
       botId: this.botId,
+      hostname: this.serverHostname,
       level: level.toString(),
       scope: displayName,
       message: stripAnsi(indentedMessage),

--- a/src/bp/core/logger/logger.ts
+++ b/src/bp/core/logger/logger.ts
@@ -51,8 +51,6 @@ export class PersistedConsoleLogger implements Logger {
     wildcard: true
   })
 
-  public onBotLog?: (events: LoggerEntry[]) => Promise<void>
-
   public static listenForAllLogs(fn: LoggerListener, botId: string = '*'): IDisposable {
     if (!_.isFunction(fn)) {
       throw new InvalidParameterError('"fn" listener must be a callback function')

--- a/src/bp/core/repositories/logs.ts
+++ b/src/bp/core/repositories/logs.ts
@@ -24,7 +24,7 @@ interface LogSearchParams {
 export class KnexLogsRepository implements LogsRepository {
   private readonly TABLE_NAME = 'srv_logs'
   private readonly DEFAULT_LIMIT = 25
-  private readonly MAX_ROWS = 5000
+  private readonly MAX_ROWS = 1000
 
   constructor(@inject(TYPES.Database) private database: Database) {}
 

--- a/src/bp/core/repositories/logs.ts
+++ b/src/bp/core/repositories/logs.ts
@@ -24,7 +24,7 @@ interface LogSearchParams {
 export class KnexLogsRepository implements LogsRepository {
   private readonly TABLE_NAME = 'srv_logs'
   private readonly DEFAULT_LIMIT = 25
-  private readonly MAX_ROWS = 1000
+  private readonly MAX_ROW_COUNT = 2000
 
   constructor(@inject(TYPES.Database) private database: Database) {}
 
@@ -60,7 +60,7 @@ export class KnexLogsRepository implements LogsRepository {
     botIds,
     fromDate,
     toDate,
-    count = this.MAX_ROWS,
+    count = this.MAX_ROW_COUNT,
     start = 0
   }: LogSearchParams): Promise<LoggerEntry[]> {
     let query = this.database.knex(this.TABLE_NAME).select('*')

--- a/src/bp/core/repositories/logs.ts
+++ b/src/bp/core/repositories/logs.ts
@@ -13,6 +13,7 @@ export interface LogsRepository {
 
 interface LogSearchParams {
   fromDate?: Date
+  toDate?: Date
   botIds?: string[]
   level?: LoggerLevel
   start?: number
@@ -58,13 +59,14 @@ export class KnexLogsRepository implements LogsRepository {
     level,
     botIds,
     fromDate,
+    toDate,
     count = this.MAX_ROWS,
     start = 0
   }: LogSearchParams): Promise<LoggerEntry[]> {
     let query = this.database.knex(this.TABLE_NAME).select('*')
 
-    if (fromDate) {
-      query = query.where(this.database.knex.date.isAfter('timestamp', fromDate))
+    if (fromDate && toDate) {
+      query = query.where(this.database.knex.date.isBetween('timestamp', fromDate, toDate))
     }
 
     if (botIds) {

--- a/src/bp/core/repositories/logs.ts
+++ b/src/bp/core/repositories/logs.ts
@@ -1,3 +1,4 @@
+import { LoggerEntry, LoggerLevel } from 'botpress/sdk'
 import { inject, injectable } from 'inversify'
 
 import Database from '../database'
@@ -5,13 +6,24 @@ import { TYPES } from '../types'
 
 export interface LogsRepository {
   deleteBeforeDate(botId: string, date: Date)
-  getByBot(botId: string, limit?: number)
+  getByBot(botId: string, limit?: number): Promise<LoggerEntry[]>
+  searchLogs(params: LogSearchParams): Promise<LoggerEntry[]>
+  getBotsErrorLogs(from: Date, to: Date): Promise<LoggerEntry[]>
+}
+
+interface LogSearchParams {
+  fromDate?: Date
+  botIds?: string[]
+  level?: LoggerLevel
+  start?: number
+  count?: number
 }
 
 @injectable()
 export class KnexLogsRepository implements LogsRepository {
   private readonly TABLE_NAME = 'srv_logs'
   private readonly DEFAULT_LIMIT = 25
+  private readonly MAX_ROWS = 5000
 
   constructor(@inject(TYPES.Database) private database: Database) {}
 
@@ -24,12 +36,48 @@ export class KnexLogsRepository implements LogsRepository {
       .then()
   }
 
-  async getByBot(botId: string, limit?: number) {
+  async getByBot(botId: string, limit?: number): Promise<LoggerEntry[]> {
     return this.database
       .knex(this.TABLE_NAME)
       .select('*')
       .where({ botId })
       .limit(limit || this.DEFAULT_LIMIT)
       .then()
+  }
+
+  async getBotsErrorLogs(from: Date, to: Date): Promise<LoggerEntry[]> {
+    return this.database
+      .knex(this.TABLE_NAME)
+      .select('*')
+      .whereNotNull('botId')
+      .whereIn('level', ['warn', 'error', 'critical'])
+      .where(this.database.knex.date.isBetween('timestamp', from, to))
+  }
+
+  async searchLogs({
+    level,
+    botIds,
+    fromDate,
+    count = this.MAX_ROWS,
+    start = 0
+  }: LogSearchParams): Promise<LoggerEntry[]> {
+    let query = this.database.knex(this.TABLE_NAME).select('*')
+
+    if (fromDate) {
+      query = query.where(this.database.knex.date.isAfter('timestamp', fromDate))
+    }
+
+    if (botIds) {
+      query = query.whereIn('botId', botIds)
+    }
+
+    if (level) {
+      query = query.where({ level })
+    }
+
+    return query
+      .offset(start)
+      .limit(count)
+      .orderBy('timestamp', 'desc')
   }
 }

--- a/src/bp/core/routers/admin/bots.ts
+++ b/src/bp/core/routers/admin/bots.ts
@@ -9,7 +9,14 @@ import _ from 'lodash'
 
 import { CustomRouter } from '../customRouter'
 import { ConflictError, ForbiddenError } from '../errors'
-import { assertBotpressPro, assertWorkspace, hasPermissions, needPermissions, success as sendSuccess } from '../util'
+import {
+  assertBotpressPro,
+  assertSuperAdmin,
+  assertWorkspace,
+  hasPermissions,
+  needPermissions,
+  success as sendSuccess
+} from '../util'
 
 const chatUserBotFields = [
   'id',
@@ -67,6 +74,20 @@ export class BotsRouter extends CustomRouter {
           bots: isBotAdmin ? bots : bots.map(b => _.pick(b, chatUserBotFields)),
           workspace: _.pick(workspace, ['name', 'pipeline'])
         })
+      })
+    )
+
+    router.get(
+      '/byWorkspaces',
+      assertSuperAdmin,
+      this.asyncMiddleware(async (_req, res) => {
+        const workspaces = await this.workspaceService.getWorkspaces()
+        const bots = workspaces.reduce((obj, workspace) => {
+          obj[workspace.id] = workspace.bots
+          return obj
+        }, {})
+
+        return sendSuccess(res, 'Retrieved bots', { bots })
       })
     )
 

--- a/src/bp/core/routers/admin/index.ts
+++ b/src/bp/core/routers/admin/index.ts
@@ -158,7 +158,8 @@ export class AdminRouter extends CustomRouter {
           botIds = (await this.botService.findBotsByIds(botsRefs)).filter(Boolean).map(x => x.id)
         }
 
-        res.send(await this.logsRepository.searchLogs({ botIds, fromDate: from.toDate() }))
+        const maxRows = req.tokenUser?.isSuperAdmin ? 5000 : 500
+        res.send(await this.logsRepository.searchLogs({ botIds, fromDate: from.toDate(), count: maxRows }))
       })
     )
   }

--- a/src/bp/core/routers/admin/index.ts
+++ b/src/bp/core/routers/admin/index.ts
@@ -160,14 +160,7 @@ export class AdminRouter extends CustomRouter {
           botIds = (await this.botService.findBotsByIds(botsRefs)).filter(Boolean).map(x => x.id)
         }
 
-        const results = await this.logsRepository.searchLogs({
-          fromDate: from.toDate(),
-          toDate: to.toDate(),
-          botIds,
-          count: req.tokenUser?.isSuperAdmin ? 2000 : 400
-        })
-
-        res.send(results)
+        res.send(await this.logsRepository.searchLogs({ fromDate: from.toDate(), toDate: to.toDate(), botIds }))
       })
     )
   }

--- a/src/bp/core/routers/admin/index.ts
+++ b/src/bp/core/routers/admin/index.ts
@@ -4,6 +4,7 @@ import { checkRule } from 'common/auth'
 import LicensingService from 'common/licensing-service'
 import { ConfigProvider } from 'core/config/config-loader'
 import { ModuleLoader } from 'core/module-loader'
+import { LogsRepository } from 'core/repositories/logs'
 import { GhostService } from 'core/services'
 import { AlertingService } from 'core/services/alerting-service'
 import AuthService, { TOKEN_AUDIENCE } from 'core/services/auth/auth-service'
@@ -14,9 +15,11 @@ import { WorkspaceService } from 'core/services/workspace-service'
 import { RequestHandler, Router } from 'express'
 import httpsProxyAgent from 'https-proxy-agent'
 import _ from 'lodash'
+import moment from 'moment'
+import yn from 'yn'
 
 import { CustomRouter } from '../customRouter'
-import { assertSuperAdmin, checkTokenHeader, loadUser } from '../util'
+import { assertSuperAdmin, checkTokenHeader, loadUser, needPermissions } from '../util'
 
 import { BotsRouter } from './bots'
 import { LanguagesRouter } from './languages'
@@ -38,6 +41,7 @@ export class AdminRouter extends CustomRouter {
   private languagesRouter!: LanguagesRouter
   private workspacesRouter!: WorkspacesRouter
   private loadUser!: RequestHandler
+  private needPermissions: (operation: string, resource: string) => RequestHandler
 
   constructor(
     logger: Logger,
@@ -50,7 +54,8 @@ export class AdminRouter extends CustomRouter {
     monitoringService: MonitoringService,
     alertingService: AlertingService,
     moduleLoader: ModuleLoader,
-    jobService: JobService
+    jobService: JobService,
+    private logsRepository: LogsRepository
   ) {
     super('Admin', logger, Router({ mergeParams: true }))
     this.checkTokenHeader = checkTokenHeader(this.authService, TOKEN_AUDIENCE)
@@ -71,6 +76,7 @@ export class AdminRouter extends CustomRouter {
     )
     this.languagesRouter = new LanguagesRouter(logger, moduleLoader, this.workspaceService, configProvider)
     this.loadUser = loadUser(this.authService)
+    this.needPermissions = needPermissions(this.workspaceService)
 
     this.setupRoutes()
   }
@@ -129,5 +135,31 @@ export class AdminRouter extends CustomRouter {
     // This way admins could use these routes to push / pull independently of other workspaces.
     // For now we're restricting to super-admin.
     router.use('/versioning', this.checkTokenHeader, assertSuperAdmin, this.versioningRouter.router)
+
+    router.get(
+      '/logs',
+      this.checkTokenHeader,
+      this.needPermissions('read', 'admin.logs'),
+      this.asyncMiddleware(async (req, res) => {
+        const { fromDate, onlyWorkspace } = req.query
+
+        if (!fromDate) {
+          return res.status(400).send('fromDate must be specified')
+        }
+
+        const from = moment(parseInt(fromDate || ''))
+        if (!from.isValid() || moment().diff(from, 'd') > 365) {
+          return res.status(400).send('fromDate must be a valid timestamp and cannot be more than 365 days')
+        }
+
+        let botIds
+        if (!req.tokenUser?.isSuperAdmin || yn(onlyWorkspace)) {
+          const botsRefs = await this.workspaceService.getBotRefs(req.workspace)
+          botIds = (await this.botService.findBotsByIds(botsRefs)).filter(Boolean).map(x => x.id)
+        }
+
+        res.send(await this.logsRepository.searchLogs({ botIds, fromDate: from.toDate() }))
+      })
+    )
   }
 }

--- a/src/bp/core/routers/admin/index.ts
+++ b/src/bp/core/routers/admin/index.ts
@@ -164,7 +164,7 @@ export class AdminRouter extends CustomRouter {
           fromDate: from.toDate(),
           toDate: to.toDate(),
           botIds,
-          count: req.tokenUser?.isSuperAdmin ? 5000 : 500
+          count: req.tokenUser?.isSuperAdmin ? 2000 : 400
         })
 
         res.send(results)

--- a/src/bp/core/sdk/enums.ts
+++ b/src/bp/core/sdk/enums.ts
@@ -4,6 +4,7 @@ export enum LoggerLevel {
   Info = 'info',
   Warn = 'warn',
   Error = 'error',
+  Critical = 'critical',
   Debug = 'debug'
 }
 

--- a/src/bp/core/server.ts
+++ b/src/bp/core/server.ts
@@ -24,6 +24,7 @@ import { URL } from 'url'
 import { ExternalAuthConfig } from './config/botpress.config'
 import { ConfigProvider } from './config/config-loader'
 import { ModuleLoader } from './module-loader'
+import { LogsRepository } from './repositories/logs'
 import { AdminRouter, AuthRouter, BotsRouter, ModulesRouter } from './routers'
 import { ContentRouter } from './routers/bots/content'
 import { ConverseRouter } from './routers/bots/converse'
@@ -112,7 +113,8 @@ export default class HTTPServer {
     @inject(TYPES.AuthStrategies) private authStrategies: AuthStrategies,
     @inject(TYPES.MonitoringService) private monitoringService: MonitoringService,
     @inject(TYPES.AlertingService) private alertingService: AlertingService,
-    @inject(TYPES.JobService) private jobService: JobService
+    @inject(TYPES.JobService) private jobService: JobService,
+    @inject(TYPES.LogsRepository) private logsRepo: LogsRepository
   ) {
     this.app = express()
 
@@ -152,7 +154,8 @@ export default class HTTPServer {
       this.monitoringService,
       this.alertingService,
       moduleLoader,
-      this.jobService
+      this.jobService,
+      this.logsRepo
     )
     this.shortlinksRouter = new ShortLinksRouter(this.logger)
     this.botsRouter = new BotsRouter({

--- a/src/bp/core/services/bot-monitoring-service.ts
+++ b/src/bp/core/services/bot-monitoring-service.ts
@@ -1,0 +1,116 @@
+import 'bluebird-global'
+import { Logger, LoggerEntry } from 'botpress/sdk'
+import { ConfigProvider } from 'core/config/config-loader'
+import { LogsRepository } from 'core/repositories/logs'
+import { TYPES } from 'core/types'
+import { inject, injectable, tagged } from 'inversify'
+import { Redis } from 'ioredis'
+import _ from 'lodash'
+import moment from 'moment'
+import ms from 'ms'
+import Redlock from 'redlock'
+
+import { JobService } from './job-service'
+
+@injectable()
+export class BotMonitoringService {
+  private _redisClient?: Redis
+  private _redlock!: Redlock
+  private _keyMonitorLock = 'bot_monitor_lock'
+  private _lock
+
+  private _intervalRef: NodeJS.Timeout | undefined
+  private _currentPromise
+  private _lastBotMonitorCheckTs?: Date
+  private _interval?: number
+
+  public onBotError?: (botId: string, events: LoggerEntry[]) => Promise<void>
+
+  constructor(
+    @inject(TYPES.Logger)
+    @tagged('name', 'BotMonitoring')
+    protected logger: Logger,
+    @inject(TYPES.ConfigProvider) private configProvider: ConfigProvider,
+    @inject(TYPES.LogsRepository) private logsRepo: LogsRepository,
+    @inject(TYPES.JobService) private jobService: JobService
+  ) {}
+
+  async start() {
+    const config = await this.configProvider.getBotpressConfig()
+    if (!config?.botMonitoring?.enabled) {
+      return
+    }
+
+    this._redisClient = this.jobService.getRedisClient()
+
+    if (this._redisClient) {
+      this._redlock = new Redlock([this._redisClient], {
+        driftFactor: 0.01,
+        retryCount: 0,
+        retryDelay: 200,
+        retryJitter: 200
+      })
+    }
+
+    if (config.botMonitoring.interval && this.onBotError) {
+      this._interval = ms(config.botMonitoring.interval)
+      this._intervalRef = setInterval(() => this._checkBotMonitor(), this._interval)
+    }
+  }
+
+  stop() {
+    if (this._intervalRef) {
+      clearInterval(this._intervalRef)
+      this._intervalRef = undefined
+    }
+  }
+
+  private _isLockAcquired = async () => {
+    if (!this._redlock) {
+      return true
+    }
+
+    try {
+      const lockDuration = this._interval! + 5000
+      if (this._lock) {
+        await this._lock.extend(lockDuration)
+      } else {
+        this._lock = await this._redlock.lock(this._keyMonitorLock, lockDuration)
+      }
+      return true
+    } catch (error) {
+      this._lock = undefined
+      return false
+    }
+  }
+
+  private async _checkBotMonitor() {
+    if (this._currentPromise || !(await this._isLockAcquired())) {
+      return
+    }
+
+    const from =
+      this._lastBotMonitorCheckTs ||
+      moment()
+        .subtract(this._interval)
+        .toDate()
+
+    this._lastBotMonitorCheckTs = new Date()
+
+    this._currentPromise = this.logsRepo
+      .getBotsErrorLogs(from, this._lastBotMonitorCheckTs)
+      .then(async result => {
+        const grouped = _.groupBy(result, r => r.botId)
+
+        for (const botId in grouped) {
+          await this.onBotError!(botId, grouped[botId])
+        }
+      })
+      .catch(err => {
+        this.logger.attachError(err).error(`Error while processing logs for hook onBotError`)
+      })
+      .finally(() => {
+        this._currentPromise = undefined
+      })
+  }
+}

--- a/src/bp/core/services/bot-monitoring-service.ts
+++ b/src/bp/core/services/bot-monitoring-service.ts
@@ -45,9 +45,7 @@ export class BotMonitoringService {
 
     if (this._redisClient) {
       this._redlock = new Redlock([this._redisClient], {
-        driftFactor: 0.01,
         retryCount: 0,
-        retryDelay: 200,
         retryJitter: 200
       })
     }

--- a/src/bp/core/services/hook/hook-service.ts
+++ b/src/bp/core/services/hook/hook-service.ts
@@ -105,6 +105,12 @@ export namespace Hooks {
     }
   }
 
+  export class OnBotError extends BaseHook {
+    constructor(bp: typeof sdk, botId: string, events: sdk.LoggerEntry[]) {
+      super('on_bot_error', { bp, botId, events })
+    }
+  }
+
   export class OnStageChangeRequest extends BaseHook {
     constructor(
       bp: typeof sdk,

--- a/src/bp/core/services/monitoring.ts
+++ b/src/bp/core/services/monitoring.ts
@@ -87,7 +87,6 @@ export interface MonitoringMetrics {
 }
 
 export interface MonitoringService {
-  onBotError?: (botId: string, events: sdk.LoggerEntry[]) => Promise<void>
   start(): Promise<void>
   stop(): void
   getStats(dateFrom, dateTo): any
@@ -97,7 +96,6 @@ export interface MonitoringService {
 
 @injectable()
 export class CEMonitoringService implements MonitoringService {
-  public onBotError?: (botId: string, events: sdk.LoggerEntry[]) => Promise<void>
   async start(): Promise<void> {}
   stop(): void {}
   getStats(dateFrom, dateTo): any {

--- a/src/bp/core/services/monitoring.ts
+++ b/src/bp/core/services/monitoring.ts
@@ -1,6 +1,7 @@
+import * as sdk from 'botpress/sdk'
+import { Metric } from 'common/monitoring'
 import { injectable } from 'inversify'
 import _ from 'lodash'
-
 /**
  * These methods are exposed outside the class to add minimal overhead when collecting metrics
  * It also avoids possible circular reference (the logger class can't access monitoring service, for example)
@@ -10,11 +11,12 @@ let metricsContainer: MetricsContainer = {}
 
 export const resetMetrics = () => {
   metricsContainer = {
-    'requests.count': 0,
-    'eventsIn.count': 0,
-    'eventsOut.count': 0,
-    'warnings.count': 0,
-    'errors.count': 0
+    [Metric.Requests]: 0,
+    [Metric.EventsIn]: 0,
+    [Metric.EventsOut]: 0,
+    [Metric.Warnings]: 0,
+    [Metric.Errors]: 0,
+    [Metric.Criticals]: 0
   }
 }
 
@@ -81,9 +83,11 @@ export interface MonitoringMetrics {
   eventsOut: { count: number }
   warnings: { count: number }
   errors: { count: number }
+  criticals: { count: number }
 }
 
 export interface MonitoringService {
+  onBotError?: (botId: string, events: sdk.LoggerEntry[]) => Promise<void>
   start(): Promise<void>
   stop(): void
   getStats(dateFrom, dateTo): any
@@ -93,6 +97,7 @@ export interface MonitoringService {
 
 @injectable()
 export class CEMonitoringService implements MonitoringService {
+  public onBotError?: (botId: string, events: sdk.LoggerEntry[]) => Promise<void>
   async start(): Promise<void> {}
   stop(): void {}
   getStats(dateFrom, dateTo): any {

--- a/src/bp/core/services/services.inversify.ts
+++ b/src/bp/core/services/services.inversify.ts
@@ -9,6 +9,7 @@ import ActionService from './action/action-service'
 import { AlertingService, CEAlertingService } from './alerting-service'
 import { AuthStrategies, CEAuthStrategies } from './auth-strategies'
 import AuthService from './auth/auth-service'
+import { BotMonitoringService } from './bot-monitoring-service'
 import { BotService } from './bot-service'
 import { CMSService } from './cms'
 import { ConverseService } from './converse'
@@ -61,6 +62,10 @@ const ServicesContainerModule = new ContainerModule((bind: interfaces.Bind) => {
     .to(CEAlertingService)
     .inSingletonScope()
     .when(() => !process.CLUSTER_ENABLED || !process.IS_PRO_ENABLED)
+
+  bind<BotMonitoringService>(TYPES.BotMonitoringService)
+    .to(BotMonitoringService)
+    .inSingletonScope()
 
   bind<AuthStrategies>(TYPES.AuthStrategies)
     .to(CEAuthStrategies)

--- a/src/bp/core/types.ts
+++ b/src/bp/core/types.ts
@@ -72,6 +72,7 @@ const TYPES = {
   MigrationService: Symbol.for('MigrationService'),
   MonitoringService: Symbol.for('MonitoringService'),
   AlertingService: Symbol.for('AlertingService'),
+  BotMonitoringService: Symbol.for('BotMonitoringService'),
   EventRepository: Symbol.for('EventRepository'),
   EventCollector: Symbol.for('EventCollector'),
   StatsService: Symbol.for('StatsService'),

--- a/src/bp/migrations/v12_6_0-1581612555-add_hostname_to_logs.ts
+++ b/src/bp/migrations/v12_6_0-1581612555-add_hostname_to_logs.ts
@@ -1,0 +1,26 @@
+import * as sdk from 'botpress/sdk'
+import { Migration, MigrationOpts } from 'core/services/migration'
+
+const migration: Migration = {
+  info: {
+    description: `Adds server hostname to the logs table`,
+    type: 'database'
+  },
+  up: async ({ bp }: MigrationOpts): Promise<sdk.MigrationResult> => {
+    if (await bp.database.schema.hasColumn('srv_logs', 'hostname')) {
+      return { success: true, message: 'Column hostname already exists, skipping...' }
+    }
+
+    try {
+      await bp.database.schema.alterTable('srv_logs', table => {
+        table.string('hostname').nullable()
+      })
+
+      return { success: true, message: 'Field created successfully' }
+    } catch (error) {
+      return { success: false, message: error.message }
+    }
+  }
+}
+
+export default migration

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -46,6 +46,7 @@ declare module 'botpress/sdk' {
 
   export interface LoggerEntry {
     botId?: string
+    hostname?: string
     level: string
     scope: string
     message: string

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -57,6 +57,7 @@ declare module 'botpress/sdk' {
     Info = 'info',
     Warn = 'warn',
     Error = 'error',
+    Critical = 'critical',
     Debug = 'debug'
   }
 
@@ -91,6 +92,7 @@ declare module 'botpress/sdk' {
     info(message: string, metadata?: any): void
     warn(message: string, metadata?: any): void
     error(message: string, metadata?: any): void
+    critical(message: string, metadata?: any): void
   }
 
   export type ElementChangedAction = 'create' | 'update' | 'delete'
@@ -118,7 +120,12 @@ declare module 'botpress/sdk' {
      */
     onModuleUnmount?: (bp: typeof import('botpress/sdk')) => Promise<void>
     onFlowChanged?: (bp: typeof import('botpress/sdk'), botId: string, flow: Flow) => Promise<void>
-    onFlowRenamed?: (bp: typeof import('botpress/sdk'), botId: string,  previousFlowName: string, newFlowName: string) => Promise<void>
+    onFlowRenamed?: (
+      bp: typeof import('botpress/sdk'),
+      botId: string,
+      previousFlowName: string,
+      newFlowName: string
+    ) => Promise<void>
     /**
      * This method is called whenever a content element is created, updated or deleted.
      * Modules can act on these events if they need to update references, for example.

--- a/src/bp/ui-admin/package.json
+++ b/src/bp/ui-admin/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@blueprintjs/core": "^3.23.1",
+    "@blueprintjs/datetime": "^3.15.2",
     "@blueprintjs/select": "^3.11.2",
     "@botpress/util-roles": "^10.36.1",
     "axios": "^0.19.0",

--- a/src/bp/ui-admin/src/App/Menu.tsx
+++ b/src/bp/ui-admin/src/App/Menu.tsx
@@ -109,7 +109,14 @@ const Menu: FC<MenuProps> = props => {
           isPro={true}
         />
 
-        <MenuItem id="btn-menu-logs" text="Logs" icon="manual" url="/logs" resource="admin.logs" operation="read" />
+        <MenuItem
+          id="btn-menu-logs"
+          text="Logs"
+          icon="manual"
+          url="/workspace/:workspaceId?/logs"
+          resource="admin.logs"
+          operation="read"
+        />
       </ControlGroup>
 
       <AccessControl superAdmin={true}>

--- a/src/bp/ui-admin/src/App/Menu.tsx
+++ b/src/bp/ui-admin/src/App/Menu.tsx
@@ -108,6 +108,8 @@ const Menu: FC<MenuProps> = props => {
           operation="read"
           isPro={true}
         />
+
+        <MenuItem id="btn-menu-logs" text="Logs" icon="manual" url="/logs" resource="admin.logs" operation="read" />
       </ControlGroup>
 
       <AccessControl superAdmin={true}>
@@ -151,9 +153,4 @@ const Menu: FC<MenuProps> = props => {
 const mapStateToProps = state => ({ licensing: state.license.licensing, version: state.version })
 const mapDispatchToProps = { fetchCurrentVersion, fetchLatestVersions }
 
-export default withRouter(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(Menu)
-)
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Menu))

--- a/src/bp/ui-admin/src/Pages/Components/Dropdown.tsx
+++ b/src/bp/ui-admin/src/Pages/Components/Dropdown.tsx
@@ -1,0 +1,64 @@
+import { Button, Classes, MenuItem } from '@blueprintjs/core'
+import { Select } from '@blueprintjs/select'
+import { FC, useState } from 'react'
+import React from 'react'
+
+export interface Option {
+  label: string
+  value: string
+}
+
+interface Props {
+  items: Option[]
+  defaultItem?: Option
+  onChange: (option: Option) => void
+  icon?: any
+  rightIcon?: any
+  small?: boolean
+  spaced?: boolean
+}
+
+const itemRenderer = (option, { modifiers, handleClick }) => {
+  if (!modifiers.matchesPredicate) {
+    return null
+  }
+
+  return (
+    <MenuItem
+      className={Classes.SMALL}
+      active={modifiers.active}
+      disabled={modifiers.disabled}
+      key={option.label || option}
+      onClick={handleClick}
+      text={option.label || option}
+    />
+  )
+}
+
+const Dropdown: FC<Props> = props => {
+  const [activeItem, setActiveItem] = useState<Option | undefined>(props.defaultItem)
+  const SimpleDropdown = Select.ofType<Option>()
+
+  return (
+    <SimpleDropdown
+      items={props.items}
+      activeItem={activeItem}
+      popoverProps={{ minimal: true }}
+      itemRenderer={itemRenderer}
+      onItemSelect={option => {
+        props.onChange(option)
+        setActiveItem(option)
+      }}
+    >
+      <Button
+        text={activeItem && activeItem.label}
+        icon={props.icon}
+        rightIcon={props.rightIcon || 'double-caret-vertical'}
+        small={props.small}
+        style={{ margin: props.spaced ? '0 5px 0 5px' : 0 }}
+      />
+    </SimpleDropdown>
+  )
+}
+
+export default Dropdown

--- a/src/bp/ui-admin/src/Pages/Components/Monitoring/SummaryTable.tsx
+++ b/src/bp/ui-admin/src/Pages/Components/Monitoring/SummaryTable.tsx
@@ -1,4 +1,5 @@
 import { Button, Tooltip } from '@blueprintjs/core'
+import { Metric } from 'common/monitoring'
 import moment from 'moment'
 import React, { useState } from 'react'
 import ReactTable from 'react-table'
@@ -46,32 +47,38 @@ const SummaryTable = ({ data }) => {
       Header: 'Requests',
       width: 120,
       className: 'center',
-      accessor: 'requests.count'
+      accessor: Metric.Requests
     },
     {
       Header: 'Events In',
       width: 120,
       className: 'center',
-      accessor: 'eventsIn.count',
+      accessor: Metric.EventsIn,
       align: 'right'
     },
     {
       Header: 'Events Out',
       width: 120,
       className: 'center',
-      accessor: 'eventsOut.count'
+      accessor: Metric.EventsOut
     },
     {
       Header: 'Warnings',
       width: 120,
       className: 'center',
-      accessor: 'warnings.count'
+      accessor: Metric.Warnings
     },
     {
       Header: 'Errors',
       width: 120,
       className: 'center',
-      accessor: 'errors.count'
+      accessor: Metric.Errors
+    },
+    {
+      Header: 'Criticals',
+      width: 120,
+      className: 'center',
+      accessor: Metric.Criticals
     },
     {
       Cell: x => (

--- a/src/bp/ui-admin/src/Pages/Logs/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Logs/index.tsx
@@ -1,0 +1,252 @@
+import { Button, Checkbox, ControlGroup } from '@blueprintjs/core'
+import { Select } from '@blueprintjs/select'
+import { BotConfig } from 'botpress/sdk'
+import * as sdk from 'botpress/sdk'
+import { UserProfile } from 'common/typings'
+import _ from 'lodash'
+import moment from 'moment'
+import queryString from 'query-string'
+import React, { FC, useEffect, useState } from 'react'
+import { connect } from 'react-redux'
+import ReactTable, { Column } from 'react-table'
+import { toastSuccess } from '~/utils/toaster'
+import PageContainer from '~/App/PageContainer'
+
+import api from '../../api'
+import { fetchBots } from '../../reducers/bots'
+
+import { dropdownRenderer, filterText, lowercaseFilter } from './utils'
+
+const LEVELS: Option[] = [
+  { label: 'All', value: '' },
+  { label: 'Warning', value: 'warn' },
+  { label: 'Info', value: 'info' },
+  { label: 'Error', value: 'error' },
+  { label: 'Critical', value: 'critical' }
+]
+
+const TIME_SPAN: TimeOption[] = [
+  { label: 'Last hour', value: moment.duration(1, 'h') },
+  { label: 'Last day', value: moment.duration(24, 'h') },
+  { label: 'Last week', value: moment.duration(7, 'd') },
+  { label: 'Last month', value: moment.duration(30, 'd') },
+  { label: 'Last year', value: moment.duration(365, 'd') }
+]
+
+const SCOPE_ITEMS: Option[] = [{ label: 'Everything', value: '' }]
+
+interface Option {
+  label: string
+  value: string
+}
+
+interface TimeOption {
+  label: string
+  value: moment.Duration
+}
+
+interface Props {
+  bots: BotConfig[]
+  fetchBots: () => void
+  profile: UserProfile
+}
+
+const SelectDropdown = Select.ofType<Option>()
+const SelectTimeDropdown = Select.ofType<TimeOption>()
+
+const Logs: FC<Props> = props => {
+  const [data, setData] = useState<sdk.LoggerEntry[]>([])
+  const [timeFilter, setTimeFilter] = useState<TimeOption>(TIME_SPAN[0])
+  const [levelFilter, setLevelFilter] = useState<Option>(LEVELS[0])
+  const [botFilter, setBotFilter] = useState<Option>(SCOPE_ITEMS[0])
+  const [filters, setFilters] = useState()
+
+  const [onlyWorkspace, setOnlyWorkspace] = useState(!props.profile.isSuperAdmin)
+  const [botIds, setBotIds] = useState<string[]>([])
+
+  useEffect(() => {
+    if (!props.bots) {
+      props.fetchBots()
+    }
+
+    // tslint:disable-next-line: no-floating-promises
+    fetchLogs()
+  }, [timeFilter, onlyWorkspace])
+
+  useEffect(() => {
+    const params = queryString.parse(window.location.search)
+    if (params.botId && props.bots) {
+      if (props.bots.find(x => x.id === params.botId)) {
+        setBotFilter({ label: params.botId, value: params.botId })
+        setFilters([{ id: 'botId', value: params.botId }])
+      } else {
+        setBotFilter(SCOPE_ITEMS[0])
+        setFilters([])
+        updateBotIdUrl('')
+      }
+    }
+  }, [props.bots])
+
+  const updateBotIdUrl = (botId: string) => {
+    const url = new URL(window.location.href)
+    if (botId) {
+      url.searchParams.set('botId', botId)
+    } else {
+      url.searchParams.delete('botId')
+    }
+    window.history.pushState(window.history.state, '', url.toString())
+  }
+
+  const fetchLogs = async (isRefreshing?: boolean) => {
+    const date = moment()
+      .subtract(timeFilter.value)
+      .format('x')
+
+    try {
+      const logs = (await api.getSecured().get(`/admin/logs?fromDate=${date}&onlyWorkspace=${onlyWorkspace}`)).data
+
+      setData(logs)
+      setBotIds(_.uniq(logs.map(x => x.botId).filter(Boolean)))
+
+      if (isRefreshing) {
+        toastSuccess('Logs refreshed')
+      }
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  const filterTimeSpan = () => {
+    return (
+      <SelectTimeDropdown
+        items={TIME_SPAN}
+        activeItem={timeFilter}
+        popoverProps={{ minimal: true }}
+        itemRenderer={dropdownRenderer}
+        onItemSelect={option => setTimeFilter(option)}
+      >
+        <Button text={timeFilter && timeFilter.label} rightIcon="double-caret-vertical" />
+      </SelectTimeDropdown>
+    )
+  }
+
+  const filterBot = ({ onChange }) => {
+    if (!props.bots) {
+      return null
+    }
+
+    const items = [...SCOPE_ITEMS, ...botIds.map(id => ({ label: id, value: id }))]
+
+    return (
+      <SelectDropdown
+        items={items}
+        activeItem={botFilter}
+        popoverProps={{ minimal: true }}
+        itemRenderer={dropdownRenderer}
+        onItemSelect={option => {
+          setBotFilter(option)
+          onChange(option.value)
+          updateBotIdUrl(option.value)
+        }}
+      >
+        <Button text={botFilter && botFilter.label} rightIcon="double-caret-vertical" />
+      </SelectDropdown>
+    )
+  }
+
+  const filterLevel = ({ onChange }) => {
+    return (
+      <SelectDropdown
+        items={LEVELS}
+        activeItem={levelFilter}
+        popoverProps={{ minimal: true }}
+        itemRenderer={dropdownRenderer}
+        onItemSelect={option => {
+          setLevelFilter(option)
+          onChange(option.value)
+        }}
+      >
+        <Button text={levelFilter && levelFilter.label} rightIcon="double-caret-vertical" />
+      </SelectDropdown>
+    )
+  }
+
+  const columns: Column[] = [
+    {
+      Header: 'Timestamp',
+      Filter: filterTimeSpan,
+      Cell: ({ original: { timestamp } }) => moment(timestamp).format('YYYY-MM-DD HH:mm:ss'),
+      accessor: 'timestamp',
+      width: 130
+    },
+    {
+      Header: 'Bot ID',
+      Filter: filterBot,
+      accessor: 'botId',
+      width: 150
+    },
+    {
+      Header: 'Level',
+      Cell: ({ original: { level } }) => {
+        switch (level) {
+          case 'info':
+            return <span className="logInfo">Info</span>
+          case 'warn':
+            return <span className="logWarn">Warning</span>
+          case 'error':
+            return <span className="logError">Error</span>
+          case 'critical':
+            return <span className="logCritical">Critical</span>
+        }
+      },
+      Filter: filterLevel,
+      accessor: 'level',
+      width: 110,
+      className: 'center'
+    },
+    {
+      Header: 'Scope',
+      Filter: filterText,
+      accessor: 'scope',
+      width: 100
+    },
+    {
+      Header: 'Message',
+      Filter: filterText,
+      accessor: 'message'
+    }
+  ]
+
+  return (
+    <PageContainer title={<span>Logs </span>} fullWidth={true}>
+      <ControlGroup style={{ justifyContent: 'flex-end' }}>
+        <div>
+          <Button icon="refresh" text="Refresh logs" small={true} onClick={() => fetchLogs(true)}></Button>
+        </div>
+        <Checkbox
+          checked={onlyWorkspace}
+          onChange={e => setOnlyWorkspace(e.currentTarget.checked)}
+          disabled={!props.profile.isSuperAdmin}
+          label={`Only bots from this workspace`}
+          style={{ marginLeft: 10 }}
+        />
+      </ControlGroup>
+
+      <ReactTable
+        columns={columns}
+        data={data}
+        defaultFilterMethod={lowercaseFilter}
+        defaultPageSize={20}
+        filtered={filters}
+        onFilteredChange={filtered => setFilters(filtered)}
+        filterable
+        defaultSorted={[{ id: 'level', desc: false }]}
+        className="-striped -highlight monitoringOverview"
+      />
+    </PageContainer>
+  )
+}
+
+const mapStateToProps = state => ({ bots: state.bots.bots, profile: state.user.profile })
+
+export default connect(mapStateToProps, { fetchBots })(Logs)

--- a/src/bp/ui-admin/src/Pages/Logs/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Logs/index.tsx
@@ -225,13 +225,11 @@ const Logs: FC<Props> = props => {
 
   const renderRowHeader = () => {
     const rows = (data && data.length) || 0
-    const { isSuperAdmin } = props.profile
-    const maxRowsReached = (isSuperAdmin && rows === 2000) || (!isSuperAdmin && rows === 400)
 
     return (
       <small>
         {rows} rows ({getRangeLabel(dateRange)}){' '}
-        {maxRowsReached && <span className="logError">Row limit reached. Choose a different time range</span>}
+        {rows === 2000 && <span className="logError">Row limit reached. Choose a different time range</span>}
       </small>
     )
   }

--- a/src/bp/ui-admin/src/Pages/Logs/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Logs/index.tsx
@@ -191,6 +191,9 @@ const Logs: FC<Props> = props => {
     {
       Header: 'Message',
       Filter: filterText,
+      Cell: ({ original: { message } }) => (
+        <span dangerouslySetInnerHTML={{ __html: message.replace(/\n/g, '<br>').replace(/ /g, '&nbsp;') }}></span>
+      ),
       style: { whiteSpace: 'unset' },
       accessor: 'message'
     }

--- a/src/bp/ui-admin/src/Pages/Logs/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Logs/index.tsx
@@ -16,8 +16,9 @@ import PageContainer from '~/App/PageContainer'
 
 import api from '../../api'
 import { fetchBots } from '../../reducers/bots'
+import Dropdown, { Option } from '../Components/Dropdown'
 
-import { dropdownRenderer, filterText, getDateShortcuts, getRangeLabel, lowercaseFilter } from './utils'
+import { filterText, getDateShortcuts, getRangeLabel, lowercaseFilter } from './utils'
 
 const LEVELS: Option[] = [
   { label: 'All', value: '' },
@@ -29,11 +30,6 @@ const LEVELS: Option[] = [
 
 const EVERYTHING: Option[] = [{ label: 'Everything', value: '' }]
 
-interface Option {
-  label: string
-  value: string
-}
-
 interface Props {
   bots: BotConfig[]
   fetchBots: () => void
@@ -41,7 +37,6 @@ interface Props {
   currentWorkspace: any
 }
 
-const SelectDropdown = Select.ofType<Option>()
 const DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss'
 
 const Logs: FC<Props> = props => {
@@ -119,18 +114,14 @@ const Logs: FC<Props> = props => {
     const items = [...EVERYTHING, ...hostNames.map(id => ({ label: id, value: id }))]
 
     return (
-      <SelectDropdown
+      <Dropdown
         items={items}
-        activeItem={hostFilter}
-        popoverProps={{ minimal: true }}
-        itemRenderer={dropdownRenderer}
-        onItemSelect={option => {
+        defaultItem={hostFilter}
+        onChange={option => {
           setHostFilter(option)
           onChange(option.value)
         }}
-      >
-        <Button text={hostFilter && hostFilter.label} rightIcon="double-caret-vertical" />
-      </SelectDropdown>
+      />
     )
   }
 
@@ -142,36 +133,28 @@ const Logs: FC<Props> = props => {
     const items = [...EVERYTHING, ...botIds.map(id => ({ label: id, value: id }))]
 
     return (
-      <SelectDropdown
+      <Dropdown
         items={items}
-        activeItem={botFilter}
-        popoverProps={{ minimal: true }}
-        itemRenderer={dropdownRenderer}
-        onItemSelect={option => {
+        defaultItem={botFilter}
+        onChange={option => {
           setBotFilter(option)
           onChange(option.value)
           updateBotIdUrl(option.value)
         }}
-      >
-        <Button text={botFilter && botFilter.label} rightIcon="double-caret-vertical" />
-      </SelectDropdown>
+      />
     )
   }
 
   const filterLevel = ({ onChange }) => {
     return (
-      <SelectDropdown
+      <Dropdown
         items={LEVELS}
-        activeItem={levelFilter}
-        popoverProps={{ minimal: true }}
-        itemRenderer={dropdownRenderer}
-        onItemSelect={option => {
+        defaultItem={levelFilter}
+        onChange={option => {
           setLevelFilter(option)
           onChange(option.value)
         }}
-      >
-        <Button text={levelFilter && levelFilter.label} rightIcon="double-caret-vertical" />
-      </SelectDropdown>
+      />
     )
   }
 

--- a/src/bp/ui-admin/src/Pages/Logs/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Logs/index.tsx
@@ -49,6 +49,7 @@ interface Props {
   bots: BotConfig[]
   fetchBots: () => void
   profile: UserProfile
+  currentWorkspace: any
 }
 
 const SelectDropdown = Select.ofType<Option>()
@@ -71,21 +72,18 @@ const Logs: FC<Props> = props => {
 
     // tslint:disable-next-line: no-floating-promises
     fetchLogs()
-  }, [timeFilter, onlyWorkspace])
+  }, [timeFilter, onlyWorkspace, props.currentWorkspace])
 
   useEffect(() => {
     const params = queryString.parse(window.location.search)
-    if (params.botId && props.bots) {
-      if (props.bots.find(x => x.id === params.botId)) {
-        setBotFilter({ label: params.botId, value: params.botId })
-        setFilters([{ id: 'botId', value: params.botId }])
-      } else {
-        setBotFilter(SCOPE_ITEMS[0])
-        setFilters([])
-        updateBotIdUrl('')
-      }
+    if (params.botId) {
+      setBotFilter({ label: params.botId, value: params.botId })
+      setFilters([{ id: 'botId', value: params.botId }])
+    } else {
+      setBotFilter(SCOPE_ITEMS[0])
+      setFilters([])
     }
-  }, [props.bots])
+  }, [botIds, props.bots])
 
   const updateBotIdUrl = (botId: string) => {
     const url = new URL(window.location.href)
@@ -247,6 +245,10 @@ const Logs: FC<Props> = props => {
   )
 }
 
-const mapStateToProps = state => ({ bots: state.bots.bots, profile: state.user.profile })
+const mapStateToProps = state => ({
+  bots: state.bots.bots,
+  profile: state.user.profile,
+  currentWorkspace: state.user.currentWorkspace
+})
 
 export default connect(mapStateToProps, { fetchBots })(Logs)

--- a/src/bp/ui-admin/src/Pages/Logs/utils.tsx
+++ b/src/bp/ui-admin/src/Pages/Logs/utils.tsx
@@ -1,0 +1,32 @@
+import { Classes, InputGroup, MenuItem } from '@blueprintjs/core'
+import _ from 'lodash'
+import React from 'react'
+import { Filter } from 'react-table'
+
+export const dropdownRenderer = (option, { modifiers, handleClick }) => {
+  if (!modifiers.matchesPredicate) {
+    return null
+  }
+  return (
+    <MenuItem
+      className={Classes.SMALL}
+      active={modifiers.active}
+      disabled={modifiers.disabled}
+      key={option.label || option}
+      onClick={handleClick}
+      text={option.label || option}
+    />
+  )
+}
+
+export const filterText = ({ filter, onChange }): any => (
+  <InputGroup value={filter ? filter.value : ''} onChange={event => onChange(event.target.value)} />
+)
+
+export const lowercaseFilter = (filter: Filter, row: any, column: any): boolean => {
+  if (column.id === 'botId') {
+    return row[filter.id] === filter.value
+  }
+
+  return (row[filter.id] || '').toLowerCase().includes(filter.value.toLowerCase())
+}

--- a/src/bp/ui-admin/src/Pages/Logs/utils.tsx
+++ b/src/bp/ui-admin/src/Pages/Logs/utils.tsx
@@ -1,5 +1,5 @@
 import { Classes, InputGroup, MenuItem } from '@blueprintjs/core'
-import { IDateRangeShortcut } from '@blueprintjs/datetime'
+import { DateRange, IDateRangeShortcut } from '@blueprintjs/datetime'
 import _ from 'lodash'
 import moment from 'moment'
 import React from 'react'
@@ -8,7 +8,17 @@ import { Filter } from 'react-table'
 export const getDateShortcuts = (): IDateRangeShortcut[] => {
   return [
     {
-      label: 'Last 1 hour',
+      label: 'Last 15 minutes',
+      dateRange: [
+        moment()
+          .subtract(15, 'm')
+          .toDate(),
+        new Date()
+      ],
+      includeTime: true
+    },
+    {
+      label: 'Last 60 minutes',
       dateRange: [
         moment()
           .subtract(1, 'h')
@@ -18,10 +28,20 @@ export const getDateShortcuts = (): IDateRangeShortcut[] => {
       includeTime: true
     },
     {
-      label: 'Last 6 hours',
+      label: 'Last 4 hours',
       dateRange: [
         moment()
           .subtract(6, 'h')
+          .toDate(),
+        new Date()
+      ],
+      includeTime: true
+    },
+    {
+      label: 'Last 24 hours',
+      dateRange: [
+        moment()
+          .subtract(24, 'h')
           .toDate(),
         new Date()
       ],
@@ -83,6 +103,19 @@ export const getDateShortcuts = (): IDateRangeShortcut[] => {
       ]
     }
   ]
+}
+
+export const DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss'
+
+export const getRangeLabel = (dateRange?: DateRange) => {
+  if (!dateRange) {
+    return
+  }
+
+  const from = moment(dateRange[0])
+  const to = moment(dateRange[1])
+
+  return `${from.format(DATE_FORMAT)} to ${to.format(DATE_FORMAT)} - ${to.from(from, true)}`
 }
 
 export const dropdownRenderer = (option, { modifiers, handleClick }) => {

--- a/src/bp/ui-admin/src/Pages/Logs/utils.tsx
+++ b/src/bp/ui-admin/src/Pages/Logs/utils.tsx
@@ -8,36 +8,37 @@ import { Filter } from 'react-table'
 export const getDateShortcuts = (): IDateRangeShortcut[] => {
   return [
     {
+      label: 'Last 1 hour',
       dateRange: [
         moment()
           .subtract(1, 'h')
           .toDate(),
         new Date()
       ],
-      label: 'Last 1 hour',
       includeTime: true
     },
     {
+      label: 'Last 6 hours',
       dateRange: [
         moment()
           .subtract(6, 'h')
           .toDate(),
         new Date()
       ],
-      label: 'Last 6 hours',
       includeTime: true
     },
     {
+      label: 'Today',
       dateRange: [
         moment()
           .startOf('day')
           .toDate(),
         new Date()
       ],
-      label: 'Today',
       includeTime: true
     },
     {
+      label: 'Yesterday',
       dateRange: [
         moment()
           .startOf('day')
@@ -47,20 +48,20 @@ export const getDateShortcuts = (): IDateRangeShortcut[] => {
           .startOf('day')
           .toDate()
       ],
-      label: 'Yesterday',
       includeTime: true
     },
     {
+      label: 'This week',
       dateRange: [
         moment()
           .startOf('week')
           .toDate(),
         new Date()
       ],
-      label: 'This week',
       includeTime: true
     },
     {
+      label: 'Last week',
       dateRange: [
         moment()
           .startOf('week')
@@ -70,17 +71,16 @@ export const getDateShortcuts = (): IDateRangeShortcut[] => {
           .startOf('week')
           .toDate()
       ],
-      label: 'Last week',
       includeTime: true
     },
     {
+      label: 'Last 30 days',
       dateRange: [
         moment()
           .subtract(30, 'd')
           .toDate(),
         new Date()
-      ],
-      label: 'Last 30 days'
+      ]
     }
   ]
 }
@@ -89,6 +89,7 @@ export const dropdownRenderer = (option, { modifiers, handleClick }) => {
   if (!modifiers.matchesPredicate) {
     return null
   }
+
   return (
     <MenuItem
       className={Classes.SMALL}

--- a/src/bp/ui-admin/src/Pages/Logs/utils.tsx
+++ b/src/bp/ui-admin/src/Pages/Logs/utils.tsx
@@ -1,7 +1,89 @@
 import { Classes, InputGroup, MenuItem } from '@blueprintjs/core'
+import { IDateRangeShortcut } from '@blueprintjs/datetime'
 import _ from 'lodash'
+import moment from 'moment'
 import React from 'react'
 import { Filter } from 'react-table'
+
+export const getDateShortcuts = (): IDateRangeShortcut[] => {
+  return [
+    {
+      dateRange: [
+        moment()
+          .subtract(1, 'h')
+          .toDate(),
+        new Date()
+      ],
+      label: 'Last 1 hour',
+      includeTime: true
+    },
+    {
+      dateRange: [
+        moment()
+          .subtract(6, 'h')
+          .toDate(),
+        new Date()
+      ],
+      label: 'Last 6 hours',
+      includeTime: true
+    },
+    {
+      dateRange: [
+        moment()
+          .startOf('day')
+          .toDate(),
+        new Date()
+      ],
+      label: 'Today',
+      includeTime: true
+    },
+    {
+      dateRange: [
+        moment()
+          .startOf('day')
+          .subtract(24, 'h')
+          .toDate(),
+        moment()
+          .startOf('day')
+          .toDate()
+      ],
+      label: 'Yesterday',
+      includeTime: true
+    },
+    {
+      dateRange: [
+        moment()
+          .startOf('week')
+          .toDate(),
+        new Date()
+      ],
+      label: 'This week',
+      includeTime: true
+    },
+    {
+      dateRange: [
+        moment()
+          .startOf('week')
+          .subtract(7, 'd')
+          .toDate(),
+        moment()
+          .startOf('week')
+          .toDate()
+      ],
+      label: 'Last week',
+      includeTime: true
+    },
+    {
+      dateRange: [
+        moment()
+          .subtract(30, 'd')
+          .toDate(),
+        new Date()
+      ],
+      label: 'Last 30 days'
+    }
+  ]
+}
 
 export const dropdownRenderer = (option, { modifiers, handleClick }) => {
   if (!modifiers.matchesPredicate) {

--- a/src/bp/ui-admin/src/Pages/Server/BotHealth.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/BotHealth.tsx
@@ -3,16 +3,21 @@ import { ServerHealth } from 'common/typings'
 import _ from 'lodash'
 import React, { FC, useEffect, useState } from 'react'
 import { connect } from 'react-redux'
+import { RouteComponentProps, withRouter } from 'react-router'
 import ReactTable from 'react-table'
 import api from '~/api'
-import { fetchBotHealth } from '~/reducers/bots'
+import { fetchBotHealth, fetchBotsByWorkspace } from '~/reducers/bots'
+import { switchWorkspace } from '~/reducers/user'
 import { toastFailure, toastSuccess } from '~/utils/toaster'
 import confirmDialog from '~/App/ConfirmDialog'
 
-interface Props {
+type Props = {
   health?: ServerHealth[]
+  botsByWorkspace?: { [workspaceId: string]: string[] }
   fetchBotHealth: () => void
-}
+  fetchBotsByWorkspace: () => void
+  switchWorkspace: (workspaceName: string) => void
+} & RouteComponentProps
 
 const getKey = entry => `${entry.hostname} (${entry.serverId})`
 
@@ -26,6 +31,10 @@ const BotHealth: FC<Props> = props => {
     } else {
       updateColumns()
       refreshContent()
+    }
+
+    if (!props.botsByWorkspace) {
+      props.fetchBotsByWorkspace()
     }
   }, [props.health])
 
@@ -43,6 +52,15 @@ const BotHealth: FC<Props> = props => {
     setData(data)
   }
 
+  const gotoBotLogs = async (botId: string) => {
+    if (props.botsByWorkspace) {
+      const workspace = _.findKey(props.botsByWorkspace, x => x.includes(botId))
+      workspace && props.switchWorkspace(workspace)
+    }
+
+    props.history.push(`/logs?botId=${botId}`)
+  }
+
   const updateColumns = () => {
     const hostColumns = props.health!.map(entry => {
       const key = getKey(entry)
@@ -52,13 +70,18 @@ const BotHealth: FC<Props> = props => {
           {
             Header: 'Status',
             Cell: cell => {
+              const hasCriticalIssue = !!Object.values(cell.original.data).find((x: any) => x.criticalCount > 0)
+              if (hasCriticalIssue) {
+                return <span className="logCritical">Unhealthy</span>
+              }
+
               switch (_.get(cell.original, `data[${key}].status`)) {
                 default:
                   return 'N/A'
                 case 'error':
-                  return <span style={{ color: 'red' }}>Error</span>
+                  return <span className="logError">Error</span>
                 case 'mounted':
-                  return 'Mounted'
+                  return <span className="logInfo">Healthy</span>
                 case 'disabled':
                   return 'Disabled'
                 case 'unmounted':
@@ -67,6 +90,12 @@ const BotHealth: FC<Props> = props => {
             },
             width: 80,
             accessor: `data[${key}].status`
+          },
+          {
+            Header: 'Critical',
+            width: 60,
+            className: 'center',
+            accessor: `data[${key}].criticalCount`
           },
           {
             Header: 'Errors',
@@ -88,6 +117,17 @@ const BotHealth: FC<Props> = props => {
       {
         Header: 'Bot ID',
         accessor: 'botId',
+        Cell: x => {
+          return (
+            <span>
+              <Tooltip hoverOpenDelay={1000} content="View logs for this bot">
+                <a onClick={() => gotoBotLogs(x.original.botId)} className="link">
+                  {x.original.botId}
+                </a>
+              </Tooltip>
+            </span>
+          )
+        },
         width: 250
       },
       ...hostColumns,
@@ -122,18 +162,15 @@ const BotHealth: FC<Props> = props => {
   }
 
   return (
-    <ReactTable
-      columns={columns}
-      data={data}
-      defaultPageSize={10}
-      defaultSorted={[{ id: 'host', desc: false }]}
-      className="-striped -highlight monitoringOverview"
-    />
+    <ReactTable columns={columns} data={data} defaultPageSize={10} className="-striped -highlight monitoringOverview" />
   )
 }
 
 const mapStateToProps = state => ({
-  health: state.bots.health
+  health: state.bots.health,
+  botsByWorkspace: state.bots.botsByWorkspace
 })
 
-export default connect(mapStateToProps, { fetchBotHealth })(BotHealth)
+export default withRouter(
+  connect(mapStateToProps, { fetchBotHealth, switchWorkspace, fetchBotsByWorkspace })(BotHealth)
+)

--- a/src/bp/ui-admin/src/Pages/Server/BotHealth.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/BotHealth.tsx
@@ -53,7 +53,7 @@ const BotHealth: FC<Props> = props => {
     setData(data)
   }
 
-  const gotoBotLogs = async (botId: string) => {
+  const goToBotLogs = async (botId: string) => {
     if (props.botsByWorkspace) {
       const workspace = _.findKey(props.botsByWorkspace, x => x.includes(botId))
       workspace && props.switchWorkspace(workspace)
@@ -127,7 +127,7 @@ const BotHealth: FC<Props> = props => {
           return (
             <span>
               <Tooltip hoverOpenDelay={1000} content="View logs for this bot">
-                <a onClick={() => gotoBotLogs(x.original.botId)} className="link">
+                <a onClick={() => goToBotLogs(x.original.botId)} className="link">
                   {x.original.botId}
                 </a>
               </Tooltip>

--- a/src/bp/ui-admin/src/Pages/Server/BotHealth.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/BotHealth.tsx
@@ -3,13 +3,14 @@ import { ServerHealth } from 'common/typings'
 import _ from 'lodash'
 import React, { FC, useEffect, useState } from 'react'
 import { connect } from 'react-redux'
-import { RouteComponentProps, withRouter } from 'react-router'
+import { generatePath, RouteComponentProps, withRouter } from 'react-router'
 import ReactTable from 'react-table'
 import api from '~/api'
 import { fetchBotHealth, fetchBotsByWorkspace } from '~/reducers/bots'
 import { switchWorkspace } from '~/reducers/user'
 import { toastFailure, toastSuccess } from '~/utils/toaster'
 import confirmDialog from '~/App/ConfirmDialog'
+import { getActiveWorkspace } from '~/Auth'
 
 type Props = {
   health?: ServerHealth[]
@@ -58,7 +59,12 @@ const BotHealth: FC<Props> = props => {
       workspace && props.switchWorkspace(workspace)
     }
 
-    props.history.push(`/logs?botId=${botId}`)
+    props.history.push(
+      generatePath(`/workspace/:workspaceId?/logs?botId=:botId`, {
+        workspaceId: getActiveWorkspace() || undefined,
+        botId
+      })
+    )
   }
 
   const updateColumns = () => {

--- a/src/bp/ui-admin/src/Pages/Server/Monitoring.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/Monitoring.tsx
@@ -1,3 +1,4 @@
+import { Button, Intent, Position, Tooltip as BpTooltip } from '@blueprintjs/core'
 import { calculateOverviewForHost, groupEntriesByTime, mergeEntriesByTime, Metric } from 'common/monitoring'
 import _ from 'lodash'
 import moment from 'moment'
@@ -5,8 +6,7 @@ import ms from 'ms'
 import React, { Component, Fragment } from 'react'
 import { IoIosArchive } from 'react-icons/io'
 import { connect } from 'react-redux'
-import Select from 'react-select'
-import { Col, Jumbotron, Label, Row } from 'reactstrap'
+import { Col, Jumbotron, Row } from 'reactstrap'
 import {
   Bar,
   CartesianGrid,
@@ -24,6 +24,7 @@ import PageContainer from '~/App/PageContainer'
 
 import { fetchStats, refreshStats } from '../../reducers/monitoring'
 import CheckRequirements from '../Components/CheckRequirements'
+import Dropdown from '../Components/Dropdown'
 import LoadingSection from '../Components/LoadingSection'
 import ChartTooltip from '../Components/Monitoring/ChartTooltip'
 import SummaryTable from '../Components/Monitoring/SummaryTable'
@@ -147,6 +148,18 @@ class Monitoring extends Component<Props, State> {
 
   handleAutoRefreshChanged = event => {
     const autoRefresh = event.target.checked
+    let intervalId: any = undefined
+
+    if (autoRefresh && !this.state.intervalId) {
+      intervalId = setInterval(() => this.refreshStats(), 10000)
+    } else if (!autoRefresh && this.state.intervalId) {
+      clearInterval(this.state.intervalId)
+    }
+    this.setState({ autoRefresh, intervalId })
+  }
+
+  toggleAutoRefresh = () => {
+    const autoRefresh = !this.state.autoRefresh
     let intervalId: any = undefined
 
     if (autoRefresh && !this.state.intervalId) {
@@ -292,49 +305,41 @@ class Monitoring extends Component<Props, State> {
   }
 
   renderHeader() {
-    const reactSelectStyle = {
-      control: base => ({ ...base, minHeight: 30 }),
-      dropdownIndicator: base => ({ ...base, padding: 4 }),
-      clearIndicator: base => ({ ...base, padding: 4 }),
-      valueContainer: base => ({ ...base, padding: '0px 6px' }),
-      input: base => ({ ...base, margin: 0, padding: 0 })
-    }
-
     return (
-      <div className="monitoring-toolbar">
-        <div className="monitoring-toolbar-item" style={{ marginLeft: 'auto' }}>
-          <strong>Time Frame</strong>
-          <Select
-            styles={reactSelectStyle}
-            options={timeFrameOptions}
-            value={this.state.timeFrame}
-            onChange={this.handleTimeFrameChanged}
-            isSearchable={false}
-          />
-        </div>
-        <div className="monitoring-toolbar-item">
-          <strong>Resolution</strong>
-          <Select
-            styles={reactSelectStyle}
-            options={resolutionOptions}
-            value={this.state.resolution}
-            onChange={this.handleResolutionChanged}
-            isSearchable={false}
-          />
-        </div>
-        <div>
-          <strong>Auto-Refresh</strong>
-          <br />
-          <Label>
-            <input
-              style={{ marginTop: 8 }}
-              name="autoRefresh"
-              type="checkbox"
-              checked={this.state.autoRefresh}
-              onChange={this.handleAutoRefreshChanged}
-            />{' '}
-            <strong>Enabled</strong>
-          </Label>
+      <div className="logToolbar-container">
+        <div className="logToolbar-left"></div>
+        <div className="logToolbar-right">
+          <BpTooltip content="Time Frame" position={Position.BOTTOM}>
+            <Dropdown
+              items={timeFrameOptions}
+              defaultItem={this.state.timeFrame}
+              onChange={option => this.setState({ timeFrame: option }, this.queryData)}
+              icon="calendar"
+              small
+              spaced
+            />
+          </BpTooltip>
+
+          <BpTooltip content="Resolution" position={Position.BOTTOM}>
+            <Dropdown
+              items={resolutionOptions}
+              defaultItem={this.state.resolution}
+              onChange={option => this.handleResolutionChanged(option)}
+              icon="key-tab"
+              small
+              spaced
+            />
+          </BpTooltip>
+
+          <BpTooltip content="Auto-Refresh" position={Position.BOTTOM}>
+            <Button
+              icon="automatic-updates"
+              intent={this.state.autoRefresh ? Intent.PRIMARY : Intent.NONE}
+              onClick={this.toggleAutoRefresh}
+              style={{ marginLeft: 10 }}
+              small
+            />
+          </BpTooltip>
         </div>
       </div>
     )

--- a/src/bp/ui-admin/src/Pages/Server/Monitoring.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/Monitoring.tsx
@@ -1,4 +1,4 @@
-import { calculateOverviewForHost, groupEntriesByTime, mergeEntriesByTime } from 'common/monitoring'
+import { calculateOverviewForHost, groupEntriesByTime, mergeEntriesByTime, Metric } from 'common/monitoring'
 import _ from 'lodash'
 import moment from 'moment'
 import ms from 'ms'
@@ -226,18 +226,33 @@ class Monitoring extends Component<Props, State> {
           <YAxis yAxisId="r" domain={[0, 'dataMax']} tick={tickSize} width={30} orientation="right" />
           <Tooltip content={this.renderTooltip} />
           <Legend />
-          <Bar stackId="stack" yAxisId="l" name="HTTP Requests" dataKey="summary.requests.count" fill="#1C4E80" />
-          <Bar stackId="stack" yAxisId="l" name="Events In" dataKey="summary.eventsIn.count" fill="#7E909A" />
-          <Bar stackId="stack" yAxisId="l" name="Events Out" dataKey="summary.eventsOut.count" fill="#6AB187" />
+          <Bar stackId="stack" yAxisId="l" name="HTTP Requests" dataKey={`summary.${Metric.Requests}`} fill="#1C4E80" />
+          <Bar stackId="stack" yAxisId="l" name="Events In" dataKey={`summary.${Metric.EventsIn}`} fill="#7E909A" />
+          <Bar stackId="stack" yAxisId="l" name="Events Out" dataKey={`summary.${Metric.EventsOut}`} fill="#6AB187" />
           <Line
             yAxisId="r"
             name="Warnings"
-            dataKey="summary.warnings.count"
+            dataKey={`summary.${Metric.Warnings}`}
             stroke="#DBAE58"
             strokeWidth={2}
             dot={false}
           />
-          <Line yAxisId="r" name="Errors" dataKey="summary.errors.count" stroke="#AC3E31" strokeWidth={2} dot={false} />
+          <Line
+            yAxisId="r"
+            name="Errors"
+            dataKey={`summary.${Metric.Errors}`}
+            stroke="#db3737"
+            strokeWidth={2}
+            dot={false}
+          />
+          <Line
+            yAxisId="r"
+            name="Criticals"
+            dataKey={`summary.${Metric.Criticals}`}
+            stroke="#AC3E31"
+            strokeWidth={2}
+            dot={false}
+          />
         </ComposedChart>
       </ResponsiveContainer>
     )
@@ -380,7 +395,4 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = { fetchStats, refreshStats, fetchBotStatus: fetchBotHealth }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Monitoring)
+export default connect(mapStateToProps, mapDispatchToProps)(Monitoring)

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemCompact.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemCompact.tsx
@@ -27,9 +27,19 @@ interface Props {
   createRevision?: () => void
   rollback?: () => void
   reloadBot?: () => void
+  viewLogs?: () => void
 }
 
-const BotItemCompact: FC<Props> = ({ bot, hasError, deleteBot, exportBot, createRevision, rollback, reloadBot }) => {
+const BotItemCompact: FC<Props> = ({
+  bot,
+  hasError,
+  deleteBot,
+  exportBot,
+  createRevision,
+  rollback,
+  reloadBot,
+  viewLogs
+}) => {
   const botShortLink = `${window.location.origin + window['ROOT_PATH']}/s/${bot.id}`
   const botStudioLink = isChatUser() ? botShortLink : `studio/${bot.id}`
 
@@ -63,6 +73,10 @@ const BotItemCompact: FC<Props> = ({ bot, hasError, deleteBot, exportBot, create
               <CopyToClipboard text={botShortLink} onCopy={() => toastInfo('Copied to clipboard')}>
                 <MenuItem icon="link" text="Copy link to clipboard" />
               </CopyToClipboard>
+
+              <AccessControl resource="admin.logs" operation="read">
+                <MenuItem text="View Logs" icon="manual" id="btn-viewLogs" onClick={viewLogs} />
+              </AccessControl>
 
               <AccessControl resource="admin.bots.*" operation="write">
                 <MenuItem text="Create Revision" icon="cloud-upload" id="btn-createRevision" onClick={createRevision} />

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemPipeline.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemPipeline.tsx
@@ -29,6 +29,7 @@ interface Props {
   requestStageChange?: () => void
   allowStageChange?: boolean
   reloadBot?: () => void
+  viewLogs?: () => void
 }
 
 const BotItemPipeline: FC<Props> = ({
@@ -40,7 +41,8 @@ const BotItemPipeline: FC<Props> = ({
   allowStageChange,
   createRevision,
   rollback,
-  reloadBot
+  reloadBot,
+  viewLogs
 }) => {
   const botShortLink = `${window.location.origin + window['ROOT_PATH']}/s/${bot.id}`
   const botStudioLink = isChatUser() ? botShortLink : `studio/${bot.id}`
@@ -63,6 +65,10 @@ const BotItemPipeline: FC<Props> = ({
                 <MenuItem icon="link" text="Copy link to clipboard" />
               </CopyToClipboard>
               <MenuDivider />
+
+              <AccessControl resource="admin.logs" operation="read">
+                <MenuItem text="View Logs" icon="manual" id="btn-viewLogs" onClick={viewLogs} />
+              </AccessControl>
 
               {allowStageChange && (
                 <MenuItem

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/index.tsx
@@ -14,7 +14,7 @@ import { ServerHealth } from 'common/typings'
 import _ from 'lodash'
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
-import { RouteComponentProps } from 'react-router'
+import { generatePath, RouteComponentProps } from 'react-router'
 import { Alert, Col, Row } from 'reactstrap'
 import { toastSuccess } from '~/utils/toaster'
 import { toastFailure } from '~/utils/toaster'
@@ -22,6 +22,7 @@ import { filterList } from '~/utils/util'
 import confirmDialog from '~/App/ConfirmDialog'
 import PageContainer from '~/App/PageContainer'
 import SplitPage from '~/App/SplitPage'
+import { getActiveWorkspace } from '~/Auth'
 import { Downloader } from '~/Pages/Components/Downloader'
 
 import api from '../../../api'
@@ -108,7 +109,12 @@ class Bots extends Component<Props> {
   }
 
   viewLogs(botId: string) {
-    this.props.history.push(`/logs?botId=${botId}`)
+    this.props.history.push(
+      generatePath(`/workspace/:workspaceId?/logs?botId=:botId`, {
+        workspaceId: getActiveWorkspace() || undefined,
+        botId
+      })
+    )
   }
 
   renderCreateNewBotButton() {

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/index.tsx
@@ -107,6 +107,10 @@ class Bots extends Component<Props> {
     }
   }
 
+  viewLogs(botId: string) {
+    this.props.history.push(`/logs?botId=${botId}`)
+  }
+
   renderCreateNewBotButton() {
     return (
       <AccessControl resource="admin.bots.*" operation="write">
@@ -190,6 +194,7 @@ class Bots extends Component<Props> {
               createRevision={this.createRevision.bind(this, bot.id)}
               rollback={this.toggleRollbackModal.bind(this, bot.id)}
               reloadBot={this.reloadBot.bind(this, bot.id)}
+              viewLogs={this.viewLogs.bind(this, bot.id)}
             />
           </Fragment>
         ))}
@@ -223,6 +228,7 @@ class Bots extends Component<Props> {
                       createRevision={this.createRevision.bind(this, bot.id)}
                       rollback={this.toggleRollbackModal.bind(this, bot.id)}
                       reloadBot={this.reloadBot.bind(this, bot.id)}
+                      viewLogs={this.viewLogs.bind(this, bot.id)}
                     />
                   </Fragment>
                 ))}

--- a/src/bp/ui-admin/src/reducers/bots.ts
+++ b/src/bp/ui-admin/src/reducers/bots.ts
@@ -6,11 +6,13 @@ import api from '../api'
 export const FETCH_BOTS_REQUESTED = 'bots/FETCH_BOTS_REQUESTED'
 export const FETCH_BOTS_RECEIVED = 'bots/FETCH_BOTS_RECEIVED'
 export const FETCH_BOT_HEALTH_RECEIVED = 'bots/FETCH_BOT_STATUS_RECEIVED'
+export const FETCH_BOTS_BY_WORKSPACE = 'bots/FETCH_BOTS_BY_WORKSPACE'
 export const RECEIVED_BOT_CATEGORIES = 'bots/RECEIVED_BOT_CATEGORIES'
 export const RECEIVED_BOT_TEMPLATES = 'bots/RECEIVED_BOT_TEMPLATES'
 
 export interface BotState {
   bots?: BotConfig[]
+  botsByWorkspace?: { [workspaceId: string]: string[] }
   health?: ServerHealth
   loadingBots: boolean
   botTemplates?: BotTemplate[]
@@ -63,6 +65,12 @@ export default (state = initialState, action) => {
         health: action.health
       }
 
+    case FETCH_BOTS_BY_WORKSPACE:
+      return {
+        ...state,
+        botsByWorkspace: action.bots
+      }
+
     default:
       return state
   }
@@ -105,6 +113,17 @@ export const fetchBots = () => {
       bots: data.payload.bots,
       workspace: data.payload.workspace
     })
+  }
+}
+
+export const fetchBotsByWorkspace = () => {
+  return async dispatch => {
+    const { data } = await api.getSecured().get('/admin/bots/byWorkspaces')
+    if (!data || !data.payload) {
+      return
+    }
+
+    dispatch({ type: FETCH_BOTS_BY_WORKSPACE, bots: data.payload.bots })
   }
 }
 

--- a/src/bp/ui-admin/src/routes/index.tsx
+++ b/src/bp/ui-admin/src/routes/index.tsx
@@ -75,6 +75,7 @@ export const makeMainRoutes = () => {
               <Route path="/workspace/:workspaceId?/bots" component={Bots} />
               <Route path="/workspace/:workspaceId?/users" component={Collaborators} />
               <Route path="/workspace/:workspaceId?/roles" component={Roles} />
+              <Route path="/workspace/:workspaceId?/logs" component={Logs} />
               <Route path="/workspaces" component={Workspaces} />
               <Route path="/logs" component={Logs} />
               <Route path="/debug" component={Debug} />

--- a/src/bp/ui-admin/src/routes/index.tsx
+++ b/src/bp/ui-admin/src/routes/index.tsx
@@ -77,7 +77,6 @@ export const makeMainRoutes = () => {
               <Route path="/workspace/:workspaceId?/roles" component={Roles} />
               <Route path="/workspace/:workspaceId?/logs" component={Logs} />
               <Route path="/workspaces" component={Workspaces} />
-              <Route path="/logs" component={Logs} />
               <Route path="/debug" component={Debug} />
               <Route path="/modules" component={Modules} />
               <Route path="/" render={() => <Redirect from="/" to={`/workspace/${getActiveWorkspace()}/bots`} />} />

--- a/src/bp/ui-admin/src/routes/index.tsx
+++ b/src/bp/ui-admin/src/routes/index.tsx
@@ -6,6 +6,7 @@ import { ConnectedRouter } from 'react-router-redux'
 import ChatAuthResult from '~/Pages/Account/ChatAuthResult'
 import Details from '~/Pages/Bot/Details'
 import { LoginContainer } from '~/Pages/Layouts/LoginContainer'
+import Logs from '~/Pages/Logs'
 import Alerting from '~/Pages/Server/Alerting'
 import Checklist from '~/Pages/Server/Checklist'
 import Languages from '~/Pages/Server/Languages'
@@ -75,6 +76,7 @@ export const makeMainRoutes = () => {
               <Route path="/workspace/:workspaceId?/users" component={Collaborators} />
               <Route path="/workspace/:workspaceId?/roles" component={Roles} />
               <Route path="/workspaces" component={Workspaces} />
+              <Route path="/logs" component={Logs} />
               <Route path="/debug" component={Debug} />
               <Route path="/modules" component={Modules} />
               <Route path="/" render={() => <Redirect from="/" to={`/workspace/${getActiveWorkspace()}/bots`} />} />

--- a/src/bp/ui-admin/src/scss/_monitoring.scss
+++ b/src/bp/ui-admin/src/scss/_monitoring.scss
@@ -52,3 +52,20 @@
     }
   }
 }
+
+.logInfo {
+  color: #0d8050;
+}
+
+.logWarn {
+  color: #bf8c0a;
+}
+
+.logError {
+  color: #db3737;
+}
+
+.logCritical {
+  color: #ac3e31;
+  font-weight: bold;
+}

--- a/src/bp/ui-admin/src/scss/_monitoring.scss
+++ b/src/bp/ui-admin/src/scss/_monitoring.scss
@@ -69,3 +69,19 @@
   color: #ac3e31;
   font-weight: bold;
 }
+
+.logToolbar {
+  &-container {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  &-left {
+    margin-right: auto;
+  }
+
+  &-right {
+    margin-right: 0px;
+    display: flex;
+  }
+}

--- a/src/bp/ui-admin/yarn.lock
+++ b/src/bp/ui-admin/yarn.lock
@@ -916,7 +916,7 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@blueprintjs/core@^3.20.0", "@blueprintjs/core@^3.23.1":
+"@blueprintjs/core@^3.20.0", "@blueprintjs/core@^3.23.0", "@blueprintjs/core@^3.23.1":
   version "3.23.1"
   resolved "https://registry.yarnpkg.com/@blueprintjs/core/-/core-3.23.1.tgz#346bd5430494cc2965fa9cac7366dc94c9dcf918"
   integrity sha512-Lh+uCYAf2a54L739/NntMKUHkMoCintbs/NidX1j950KL0GW0J95niFqmN2B3oV/uJdXsPjZKj6VyOBlI+tUIA==
@@ -931,6 +931,16 @@
     react-popper "^1.3.7"
     react-transition-group "^2.9.0"
     resize-observer-polyfill "^1.5.1"
+    tslib "~1.9.0"
+
+"@blueprintjs/datetime@^3.15.2":
+  version "3.15.2"
+  resolved "https://registry.yarnpkg.com/@blueprintjs/datetime/-/datetime-3.15.2.tgz#c0beffa287cdad7d7521db23ef2918491156044b"
+  integrity sha512-FQw1BqbO9RBKzLWiXHkSVFxyGFRXHaugG5ST4go+p2IibrxuRDjD6YvrFXo+FLEzi+MsftMo6FkPNm2xApfmHw==
+  dependencies:
+    "@blueprintjs/core" "^3.23.0"
+    classnames "^2.2"
+    react-day-picker "7.3.2"
     tslib "~1.9.0"
 
 "@blueprintjs/icons@^3.12.0":
@@ -4989,10 +4999,22 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.1:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.0.5:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -9178,6 +9200,13 @@ react-copy-to-clipboard@^5.0.2:
   dependencies:
     copy-to-clipboard "^3"
     prop-types "^15.5.8"
+
+react-day-picker@7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-7.3.2.tgz#b9b9b0000ba53b2c9df9bccb79664862aba6b60a"
+  integrity sha512-mij2j2Un/v2V2ow+hf/hFBMdl6Eis/C/YhBtlI6Xpbvh3Q6WMix78zEkCdw6i9GldafOrpnupWKofv/h5oSI4g==
+  dependencies:
+    prop-types "^15.6.2"
 
 react-dev-utils@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
This PR brings a couple of features to help diagnose issues and a better coherence between tools.

#### Added a new page on the Admin panel to view logs
- Super admins can view all bots & global log message
- Other users can only view logs for bots of their workspace (permission read `admin.logs` is required)
- Filter by level, bot ID, by scope or message

![image](https://user-images.githubusercontent.com/42552874/74382262-1254ec80-4dbb-11ea-83ce-bd59c2f416e9.png)


![image](https://user-images.githubusercontent.com/42552874/74381870-4d0a5500-4dba-11ea-9df1-c538e983f08d.png)


#### New hook: OnBotError
A new hook is available in the code editor. It doesn't trigger for each event, but it will batch events for a specific interval (configurable), then trigger the hook with a list of events which occurred during that interval.

![image](https://user-images.githubusercontent.com/42552874/74382227-fe10ef80-4dba-11ea-983f-41ceffb6d83e.png)


#### New logger type "critical"
Added a new type of logger "Critical", which automatically mark the bot as "Unhealthy". They are also prominently listed on the page
  
![image](https://user-images.githubusercontent.com/42552874/74372324-70c49f80-4da8-11ea-8c41-eb91528d35bf.png)


#### Small tweak to monitoring page
In the Bot Health section, bot ID are now clickable links to go directly to the logs page, select the correct workspace & filter for the specific bot 

![image](https://user-images.githubusercontent.com/42552874/74396413-e39d3d00-4ddf-11ea-9aa2-b8c2696b4083.png)


#### Added link to access logs for a specific bot directly
![image](https://user-images.githubusercontent.com/42552874/74369467-69e75e00-4da3-11ea-9de4-6354afcc46f3.png)
