### PR TITLE
chore(docs): fix pricing link

### DIFF
--- a/docs/guide/docs/pro/about-pro.md
+++ b/docs/guide/docs/pro/about-pro.md
@@ -14,14 +14,14 @@ title: About
 | Unlimited Bots             | ✔️        | ✔️  |
 | Unlimited Admins           |           | ✔️  |
 | White-Label Chat Interface |           | ✔️  |
-| RBAC                       |           | ✔️  |
+| Role-Based Access Control  |           | ✔️  |
 | High-Availability          |           | ✔️  |
 | Increased Performances     |           | ✔️  |
 | Standard Support           |           | ✔️  |
 | Multilanguage Bots         |           | ✔️  |
 
-For more details, visit our [pricing page](https://botpress.com/pricing/).
+For more details, [contact sales team](https://botpress.com/contact-sales/).
 
 ## Activation
 
-To enable Botpress Pro features simply set `pro.enabled` to `true` in your botpress.config.json file
+To enable Botpress Pro features simply set `pro.enabled` to `true` in your `botpress.config.json` file


### PR DESCRIPTION
1. `/pricing` link doesn't exist anymore in the website, it currently refreshes to `request-demo` which doesn't exist. This PR changes it to `contact-sales`, which is the current link for `Request Demo`
2. RBAC is not intuitive (as also hinted in the [Forum](https://forum.botpress.com/t/how-to-attract-new-users-and-make-botpress-more-popular/134/10?u=asashour)), the full name is provided.

Also, I am not sure if the webform in [here](https://botpress.com/docs/pro/licensing) should also point there.