### PR TITLE
fix(core): id validation on bot admin actions

### DIFF
--- a/src/bp/core/routers/admin/bots.ts
+++ b/src/bp/core/routers/admin/bots.ts
@@ -144,7 +144,7 @@ export class BotsRouter extends CustomRouter {
             .forBot(req.params.botId)
             .attachError(err)
             .error(`Cannot request bot: ${req.params.botId} for stage change`)
-          res.status(400)
+          res.status(400).send(err.message)
         }
       })
     )
@@ -156,11 +156,19 @@ export class BotsRouter extends CustomRouter {
         const { botId } = req.params
         const bot = <BotConfig>req.body
 
-        await this.botService.updateBot(botId, bot)
+        try {
+          await this.botService.updateBot(botId, bot)
+          return sendSuccess(res, 'Updated bot', {
+            botId
+          })
+        } catch (err) {
+          this.logger
+            .forBot(req.params.botId)
+            .attachError(err)
+            .error(`Cannot update bot: ${botId}`)
 
-        return sendSuccess(res, 'Updated bot', {
-          botId
-        })
+          res.status(400).send(err.message)
+        }
       })
     )
 
@@ -170,10 +178,18 @@ export class BotsRouter extends CustomRouter {
       this.asyncMiddleware(async (req, res) => {
         const { botId } = req.params
 
-        await this.botService.deleteBot(botId)
-        await this.workspaceService.deleteBotRef(botId)
+        try {
+          await this.botService.deleteBot(botId)
+          await this.workspaceService.deleteBotRef(botId)
+          return sendSuccess(res, 'Removed bot from team', { botId })
+        } catch (err) {
+          this.logger
+            .forBot(botId)
+            .attachError(err)
+            .error(`Could not delete bot: ${botId}`)
 
-        return sendSuccess(res, 'Removed bot from team', { botId })
+          res.status(400).send(err.message)
+        }
       })
     )
 
@@ -216,11 +232,18 @@ export class BotsRouter extends CustomRouter {
       this.needPermissions('read', this.resource),
       this.asyncMiddleware(async (req, res) => {
         const botId = req.params.botId
-        const revisions = await this.botService.listRevisions(botId)
-
-        return sendSuccess(res, 'Bot revisions', {
-          revisions
-        })
+        try {
+          const revisions = await this.botService.listRevisions(botId)
+          return sendSuccess(res, 'Bot revisions', {
+            revisions
+          })
+        } catch (err) {
+          this.logger
+            .forBot(botId)
+            .attachError(err)
+            .error(`Could not list revisions for bot ${botId}`)
+          res.status(400).send(err.message)
+        }
       })
     )
 
@@ -229,8 +252,16 @@ export class BotsRouter extends CustomRouter {
       this.needPermissions('write', this.resource),
       this.asyncMiddleware(async (req, res) => {
         const botId = req.params.botId
-        await this.botService.createRevision(botId)
-        return sendSuccess(res, `Created a new revision for bot ${botId}`)
+        try {
+          await this.botService.createRevision(botId)
+          return sendSuccess(res, `Created a new revision for bot ${botId}`)
+        } catch (err) {
+          this.logger
+            .forBot(botId)
+            .attachError(err)
+            .error(`Could not create revision for bot: ${botId}`)
+          res.status(400).send(err.message)
+        }
       })
     )
 

--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -170,6 +170,10 @@ export class BotService {
       throw new InvalidOperationError(`An error occurred while updating the bot: ${error.message}`)
     }
 
+    if (!(await this.botExists(botId))) {
+      throw new Error(`Bot "${botId}" doesn't exist`)
+    }
+
     if (!process.IS_PRO_ENABLED && updatedBot.languages && updatedBot.languages.length > 1) {
       throw new Error('A single language is allowed on community edition.')
     }
@@ -470,6 +474,10 @@ export class BotService {
   async deleteBot(botId: string) {
     this.stats.track('bot', 'delete')
 
+    if (!(await this.botExists(botId))) {
+      throw new Error(`Bot "${botId}" doesn't exist`)
+    }
+
     await this.unmountBot(botId)
     await this._cleanupRevisions(botId, true)
     await this.ghostService.forBot(botId).deleteFolder('/')
@@ -613,6 +621,10 @@ export class BotService {
 
   public async listRevisions(botId: string): Promise<string[]> {
     const globalGhost = this.ghostService.global()
+    if (!(await this.botExists(botId))) {
+      throw new Error(`Bot "${botId}" doesn't exist`)
+    }
+
     const workspaceId = await this.workspaceService.getBotWorkspaceId(botId)
 
     let stageID = ''
@@ -633,6 +645,10 @@ export class BotService {
   }
 
   public async createRevision(botId: string): Promise<void> {
+    if (!(await this.botExists(botId))) {
+      throw new Error(`Bot "${botId}" doesn't exist`)
+    }
+
     const workspaceId = await this.workspaceService.getBotWorkspaceId(botId)
     let revName = botId + REV_SPLIT_CHAR + Date.now()
 
@@ -648,6 +664,10 @@ export class BotService {
   }
 
   public async rollback(botId: string, revision: string): Promise<void> {
+    if (!(await this.botExists(botId))) {
+      throw new Error(`Bot "${botId}" doesn't exist`)
+    }
+
     const workspaceId = await this.workspaceService.getBotWorkspaceId(botId)
     const revParts = revision.replace(/\.tgz$/i, '').split(REV_SPLIT_CHAR)
     if (revParts.length < 2) {

--- a/src/bp/core/services/workspace-service.ts
+++ b/src/bp/core/services/workspace-service.ts
@@ -88,8 +88,10 @@ export class WorkspaceService {
     }
 
     const index = workspace.bots.findIndex(x => x === botId)
+    if (index === -1) {
+      return
+    }
     workspace.bots.splice(index, 1)
-
     return this.save(workspaces)
   }
 


### PR DESCRIPTION
This PR adds some validation on some critical bot actions.

For instance:
Try to delete a bot with a non existing bot Id. It provokes an unwanted behaviour, same goes for update, etc.