### PR TITLE
chore: remove BP_LICENSE_SERVER_HOST

### DIFF
--- a/src/bp/core/config/botpress.config.ts
+++ b/src/bp/core/config/botpress.config.ts
@@ -85,9 +85,9 @@ export type BotpressConfig = {
      */
     port: number
     /**
-     * There are three external URLs that Botpress calls: https://license.botpress.io, https://duckling.botpress.io and https://lang-01.botpress.io
+     * There are two external URLs that Botpress calls: https://duckling.botpress.io and https://lang-01.botpress.io
      * If you are behind a corporate proxy, you can configure it below.
-     * It is also possible to self-host Duckling, please check the documentation
+     * It is also possible to self-host them, please check the documentation
      *
      * @example http://username:password@hostname:port
      */

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -106,12 +106,6 @@ declare type BotpressEnvironmentVariables = {
   readonly BP_LICENSE_KEY?: string
 
   /**
-   * Change the host of the licensing server
-   * @default https://license.botpress.io
-   */
-  readonly BP_LICENSE_SERVER_HOST?: string
-
-  /**
    * Set this to true if you're exposing Botpress through a reverse proxy such as Nginx
    * Read more: https://expressjs.com/en/guide/behind-proxies.html
    */


### PR DESCRIPTION
I could be wrong, but I couldn't find a usage of `BP_LICENSE_SERVER_HOST` of `global.d.ts` in the public code base.
