### PR TITLE
fix(channel-web): prefer taking user locale from local storage

### DIFF
--- a/modules/channel-web/src/views/lite/translations/index.tsx
+++ b/modules/channel-web/src/views/lite/translations/index.tsx
@@ -24,7 +24,7 @@ const getUserLocale = (manualLocale?: 'browser' | string) => {
   const storageLocale = code(localStorage.getItem('bp/channel-web/user-lang') || '')
   manualLocale = code(manualLocale === 'browser' ? browserLocale : manualLocale || '')
 
-  return translations[manualLocale] ? manualLocale : translations[storageLocale] ? storageLocale : defaultLocale
+  return translations[storageLocale] ? storageLocale : translations[manualLocale] ? manualLocale : defaultLocale
 }
 
 const initializeLocale = () => {


### PR DESCRIPTION
This fixes changing webchat local on the fly (see https://github.com/botpress/botpress/pull/2697) logic.
It seems to come from [feat(channel-web): allow setting webchat locale](https://github.com/botpress/botpress/commit/a4e786ee555a04673e7d073e380c7e343aad2dae#diff-edbb39021f0b9a24c125b559a4033abeR27)