### PR TITLE
minor fixes for 12.6

### DIFF
--- a/build/module-builder/yarn.lock
+++ b/build/module-builder/yarn.lock
@@ -4018,27 +4018,12 @@ minipass@^2.2.1, minipass@^2.3.3:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
-minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
 minizlib@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.0.tgz#11e13658ce46bc3a70a267aac58359d1e0c29ceb"
   integrity sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==
   dependencies:
     minipass "^2.2.1"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  dependencies:
-    minipass "^2.9.0"
 
 mississippi@^2.0.0:
   version "2.0.0"
@@ -4219,22 +4204,6 @@ node-libs-browser@^2.0.0:
     url "^0.11.0"
     util "^0.10.3"
     vm-browserify "0.0.4"
-
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
 
 node-pre-gyp@^0.10.0:
   version "0.10.3"
@@ -5719,19 +5688,6 @@ tar@^4, tar@^4.4.6:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
-
 through2@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
@@ -6241,11 +6197,6 @@ yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
   integrity sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=
-
-yallist@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
-  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yar@^9.0.2:
   version "9.0.2"

--- a/docs/guide/docs/advanced/configuration.md
+++ b/docs/guide/docs/advanced/configuration.md
@@ -37,19 +37,47 @@ Logs are very useful to debug and understand what happens when the bot doesn't b
 
 When you start Botpress from the binary (or using the Docker image), the bot is in `debug` mode. This means that a lot of information will be displayed in the console to understand what happens.
 
-There are 4 different levels of logs:
+There are 5 different levels of logs:
 
 - Debug: display very detailed information about the bot operations
 - Info: gives general information or "good to know" stuff
 - Warn: means that something didn't go as expected, but the bot was able to recover
 - Error: there was an error that should be addressed
+- Critical: something prevents the bot or the server from behaving correctly (may not work at all)
 
-By default, you will see `debug` with all other log levels in the console, and `errors` will be saved in the database (useful to keep track of them).
-When you start Botpress in `production` mode, `debug` logs will be disabled for better performances.
+### Change Log Verbosity
 
-It is also possible to send log output to a file in a specific folder. Check below for the required configuration
+There are three different configuration of verbosity for the logger:
+
+- Production (verbosity: 0)
+- Developer (verbosity: 1)
+- Debug (verbosity: 2)
+
+By default, Botpress uses the `Debug` configuration.
+When you run Botpress in production `BP_PRODUCTION=true` or with cluster mode `CLUSTER_ENABLED=true`, logs will be configured as `Production`
+
+You can configure the level of verbosity using an environment variable (`VERBOSITY_LEVEL=0` for production) or using command line (ex: `-vv` for Debug)
+
+#### Production
+
+- The console will display `info`, `warn`, `error` and `critical` logs
+- In the studio's log console, bot developers will see `debug` logs for their bot
+- No stack traces\* will be displayed in the console
+
+#### Developer
+
+- Same thing as `Production`, but the console will also include stack traces\*
+
+#### Debug
+
+- Includes everything from `Production` and `Developer`
+- Debug logs will be displayed in the main console
+
+\* Stack traces are additional information used by developers to identify the source of an error. They are useful when developing, but in production they can hide important log messages.
 
 ### How to save logs on the file system
+
+It is also possible to send log output to a file in a specific folder. Check below for the required configuration
 
 Edit your `botpress.config.json` file and change your file to match the following:
 

--- a/modules/nlu/src/backend/module-lifecycle/on-server-ready.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-ready.ts
@@ -12,7 +12,11 @@ export function getOnServerReady(state: NLUState) {
       const ghost = bp.ghost.forBot(botId)
       const model = await getModel(ghost, hash, language)
       if (model) {
-        await state.nluByBot[botId].engine.loadModel(model)
+        if (state.nluByBot[botId]) {
+          await state.nluByBot[botId].engine.loadModel(model)
+        } else {
+          bp.logger.warn(`Can't load model for unmounted bot ${botId}`)
+        }
       }
     }
 

--- a/src/bp/common/typings.ts
+++ b/src/bp/common/typings.ts
@@ -188,7 +188,7 @@ export interface ServerHealth {
 }
 
 export interface BotHealth {
-  status: 'healthy' | 'unhealthy' | 'unmounted' | 'disabled'
+  status: 'healthy' | 'unhealthy' | 'disabled'
   errorCount: number
   criticalCount: number
   warningCount: number

--- a/src/bp/common/typings.ts
+++ b/src/bp/common/typings.ts
@@ -188,7 +188,7 @@ export interface ServerHealth {
 }
 
 export interface BotHealth {
-  status: 'mounted' | 'unmounted' | 'disabled' | 'error'
+  status: 'healthy' | 'unhealthy' | 'unmounted' | 'disabled'
   errorCount: number
   criticalCount: number
   warningCount: number

--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -282,7 +282,7 @@ export class Botpress {
 
     disabledBots.forEach(botId => BotService.setBotStatus(botId, 'disabled'))
 
-    await Promise.map(botsToMount, botId => this.botService.mountBot(botId))
+    await Promise.map(botsToMount, botId => this.botService.mountBot(botId), { concurrency: 5 })
   }
 
   private async initializeServices() {

--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -282,6 +282,7 @@ export class Botpress {
 
     disabledBots.forEach(botId => BotService.setBotStatus(botId, 'disabled'))
 
+    this.logger.info(`Discovered ${botsToMount.length} bots, mounting them...`)
     await Promise.map(botsToMount, botId => this.botService.mountBot(botId), { concurrency: 5 })
   }
 

--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -283,7 +283,9 @@ export class Botpress {
     disabledBots.forEach(botId => BotService.setBotStatus(botId, 'disabled'))
 
     this.logger.info(`Discovered ${botsToMount.length} bots, mounting them...`)
-    await Promise.map(botsToMount, botId => this.botService.mountBot(botId), { concurrency: 5 })
+
+    const maxConcurrentMount = parseInt(process.env.MAX_CONCURRENT_MOUNT || '5')
+    await Promise.map(botsToMount, botId => this.botService.mountBot(botId), { concurrency: maxConcurrentMount })
   }
 
   private async initializeServices() {

--- a/src/bp/core/config/config-loader.ts
+++ b/src/bp/core/config/config-loader.ts
@@ -97,9 +97,9 @@ export class ConfigProvider {
   }
 
   public async createDefaultConfigIfMissing() {
-    if (!(await this.ghostService.global().fileExists('/', 'botpress.config.json'))) {
-      await this._copyConfigSchemas()
+    await this._copyConfigSchemas()
 
+    if (!(await this.ghostService.global().fileExists('/', 'botpress.config.json'))) {
       const botpressConfigSchema = await this.ghostService
         .root()
         .readFileAsObject<any>('/', 'botpress.config.schema.json')
@@ -120,8 +120,10 @@ export class ConfigProvider {
     const schemasToCopy = ['botpress.config.schema.json', 'bot.config.schema.json']
 
     for (const schema of schemasToCopy) {
-      const schemaContent = fs.readFileSync(path.join(__dirname, 'schemas', schema))
-      await this.ghostService.root().upsertFile('/', schema, schemaContent)
+      if (!(await this.ghostService.root().fileExists('/', schema))) {
+        const schemaContent = fs.readFileSync(path.join(__dirname, 'schemas', schema))
+        await this.ghostService.root().upsertFile('/', schema, schemaContent)
+      }
     }
   }
 

--- a/src/bp/core/database/index.ts
+++ b/src/bp/core/database/index.ts
@@ -53,10 +53,11 @@ export default class Database {
   }
 
   async initialize(databaseType?: DatabaseType, databaseUrl?: string) {
+    const logger = this.logger
     const { DATABASE_URL, DATABASE_POOL } = process.env
 
     let poolOptions = {
-      log: message => this.logger.warn(`[pool] ${message}`)
+      log: message => logger.warn(`[pool] ${message}`)
     }
 
     try {
@@ -78,9 +79,9 @@ export default class Database {
     const config: Knex.Config = {
       useNullAsDefault: true,
       log: {
-        error: this.logger.error,
-        warn: this.logger.warn,
-        debug: this.logger.debug
+        error: message => logger.error(`[knex] ${message}`),
+        warn: message => logger.warn(`[knex] ${message}`),
+        debug: message => logger.debug(`[knex] ${message}`)
       }
     }
 

--- a/src/bp/core/database/index.ts
+++ b/src/bp/core/database/index.ts
@@ -97,6 +97,9 @@ export default class Database {
     }
 
     this.knex = patchKnex(Knex(config))
+    this.knex.on('error', err => {
+      this.logger.attachError(err).error(err)
+    })
 
     await this.bootstrap()
   }

--- a/src/bp/core/logger/logger.ts
+++ b/src/bp/core/logger/logger.ts
@@ -216,7 +216,7 @@ export class PersistedConsoleLogger implements Logger {
 
   debug(message: string, metadata?: any): void {
     if (this.currentMessageLevel === undefined) {
-      this.currentMessageLevel = LogLevel.DEV
+      this.currentMessageLevel = LogLevel.DEBUG
     }
 
     this.print(LoggerLevel.Debug, message, metadata)

--- a/src/bp/core/routers/modules.ts
+++ b/src/bp/core/routers/modules.ts
@@ -90,9 +90,10 @@ export class ModulesRouter extends CustomRouter {
           } else {
             await this.moduleLoader.reloadModule(fullPath, moduleName)
           }
+          return res.send({ rebootRequired: false })
+        } else {
+          return res.send({ rebootRequired: true })
         }
-
-        res.sendStatus(200)
       })
     )
 

--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -236,6 +236,7 @@ export class BotService {
   }
 
   async importBot(botId: string, archive: Buffer, workspaceId: string, allowOverwrite?: boolean): Promise<void> {
+    const startTime = Date.now()
     if (!isValidBotId(botId)) {
       throw new InvalidOperationError(`Can't import bot; the bot ID contains invalid characters`)
     }
@@ -314,6 +315,7 @@ export class BotService {
     } finally {
       this._invalidateBotIds()
       tmpDir.removeCallback()
+      debug.forBot(botId, `Bot import took ${Date.now() - startTime}ms`)
     }
   }
 
@@ -623,7 +625,7 @@ export class BotService {
 
     await this._updateBotHealthDebounce()
     this._invalidateBotIds()
-    debug(`Unmount bot ${botId} took ${Date.now() - startTime}ms`)
+    debug.forBot(botId, `Unmount took ${Date.now() - startTime}ms`)
   }
 
   private _invalidateBotIds(): void {

--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -57,6 +57,7 @@ const STATUS_EXPIRY = ms('20s')
 const DEFAULT_BOT_HEALTH: BotHealth = { status: 'unmounted', errorCount: 0, warningCount: 0, criticalCount: 0 }
 
 const getBotStatusKey = (serverId: string) => `bp_server_${serverId}_bots`
+const debug = DEBUG('services:bots')
 
 @injectable()
 export class BotService {
@@ -549,6 +550,7 @@ export class BotService {
 
   // Do not use directly use the public version instead due to broadcasting
   private async _localMount(botId: string): Promise<boolean> {
+    const startTime = Date.now()
     if (this.isBotMounted(botId)) {
       return true
     }
@@ -600,11 +602,13 @@ export class BotService {
       return false
     } finally {
       await this._updateBotHealthDebounce()
+      debug(`Mount bot ${botId} took ${Date.now() - startTime}ms`)
     }
   }
 
   // Do not use directly use the public version instead due to broadcasting
   private async _localUnmount(botId: string, isDisabled?: boolean) {
+    const startTime = Date.now()
     if (!this.isBotMounted(botId)) {
       this._invalidateBotIds()
       return
@@ -621,6 +625,7 @@ export class BotService {
 
     await this._updateBotHealthDebounce()
     this._invalidateBotIds()
+    debug(`Unmount bot ${botId} took ${Date.now() - startTime}ms`)
   }
 
   private _invalidateBotIds(): void {

--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -600,7 +600,7 @@ export class BotService {
       return false
     } finally {
       await this._updateBotHealthDebounce()
-      debug(`Mount bot ${botId} took ${Date.now() - startTime}ms`)
+      debug.forBot(botId, `Mount took ${Date.now() - startTime}ms`)
     }
   }
 

--- a/src/bp/ui-admin/src/Pages/Components/Dropdown.tsx
+++ b/src/bp/ui-admin/src/Pages/Components/Dropdown.tsx
@@ -51,7 +51,7 @@ const Dropdown: FC<Props> = props => {
       }}
     >
       <Button
-        text={activeItem && activeItem.label}
+        text={props.small ? <small>{activeItem && activeItem.label}</small> : activeItem && activeItem.label}
         icon={props.icon}
         rightIcon={props.rightIcon || 'double-caret-vertical'}
         small={props.small}

--- a/src/bp/ui-admin/src/Pages/Server/BotHealth.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/BotHealth.tsx
@@ -12,6 +12,9 @@ import { switchWorkspace } from '~/reducers/user'
 import { toastFailure, toastSuccess } from '~/utils/toaster'
 import { getActiveWorkspace } from '~/Auth'
 
+import Dropdown, { Option } from '../Components/Dropdown'
+import { filterText } from '../Logs/utils'
+
 type Props = {
   health?: ServerHealth[]
   botsByWorkspace?: { [workspaceId: string]: string[] }
@@ -21,6 +24,14 @@ type Props = {
 } & RouteComponentProps
 
 const getKey = entry => `${entry.hostname} (${entry.serverId})`
+
+const STATUS: Option[] = [
+  { label: 'All', value: '' },
+  { label: 'Healthy', value: 'healthy' },
+  { label: 'Unhealthy', value: 'unhealthy' },
+  { label: 'Disabled', value: 'disabled' },
+  { label: 'Unmounted', value: 'unmounted' }
+]
 
 const BotHealth: FC<Props> = props => {
   const [data, setData] = useState<any>()
@@ -53,6 +64,10 @@ const BotHealth: FC<Props> = props => {
     setData(data)
   }
 
+  const filterStatus = ({ onChange }) => {
+    return <Dropdown items={STATUS} defaultItem={STATUS[0]} onChange={option => onChange(option.value)} small />
+  }
+
   const goToBotLogs = async (botId: string) => {
     if (props.botsByWorkspace) {
       const workspace = _.findKey(props.botsByWorkspace, x => x.includes(botId))
@@ -76,17 +91,12 @@ const BotHealth: FC<Props> = props => {
           {
             Header: 'Status',
             Cell: cell => {
-              const hasCriticalIssue = !!Object.values(cell.original.data).find((x: any) => x.criticalCount > 0)
-              if (hasCriticalIssue) {
-                return <span className="logCritical">Unhealthy</span>
-              }
-
               switch (_.get(cell.original, `data[${key}].status`)) {
                 default:
                   return 'N/A'
-                case 'error':
-                  return <span className="logError">Error</span>
-                case 'mounted':
+                case 'unhealthy':
+                  return <span className="logCritical">Unhealthy</span>
+                case 'healthy':
                   return <span className="logInfo">Healthy</span>
                 case 'disabled':
                   return 'Disabled'
@@ -94,7 +104,9 @@ const BotHealth: FC<Props> = props => {
                   return 'Unmounted'
               }
             },
-            width: 80,
+            Filter: filterStatus,
+            filterable: true,
+            width: 100,
             accessor: `data[${key}].status`
           },
           {
@@ -134,7 +146,9 @@ const BotHealth: FC<Props> = props => {
             </span>
           )
         },
-        width: 250
+        width: 250,
+        Filter: filterText,
+        filterable: true
       },
       ...hostColumns,
       {
@@ -168,7 +182,13 @@ const BotHealth: FC<Props> = props => {
   }
 
   return (
-    <ReactTable columns={columns} data={data} defaultPageSize={10} className="-striped -highlight monitoringOverview" />
+    <ReactTable
+      columns={columns}
+      data={data}
+      defaultPageSize={10}
+      defaultSorted={[{ id: 'botId', desc: false }]}
+      className="-striped -highlight monitoringOverview"
+    />
   )
 }
 

--- a/src/bp/ui-admin/src/Pages/Server/BotHealth.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/BotHealth.tsx
@@ -29,8 +29,7 @@ const STATUS: Option[] = [
   { label: 'All', value: '' },
   { label: 'Healthy', value: 'healthy' },
   { label: 'Unhealthy', value: 'unhealthy' },
-  { label: 'Disabled', value: 'disabled' },
-  { label: 'Unmounted', value: 'unmounted' }
+  { label: 'Disabled', value: 'disabled' }
 ]
 
 const BotHealth: FC<Props> = props => {
@@ -100,8 +99,6 @@ const BotHealth: FC<Props> = props => {
                   return <span className="logInfo">Healthy</span>
                 case 'disabled':
                   return 'Disabled'
-                case 'unmounted':
-                  return 'Unmounted'
               }
             },
             Filter: filterStatus,

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/index.tsx
@@ -10,13 +10,13 @@ import {
   Position
 } from '@blueprintjs/core'
 import { BotConfig } from 'botpress/sdk'
+import { confirmDialog } from 'botpress/shared'
 import { ServerHealth } from 'common/typings'
 import _ from 'lodash'
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
 import { generatePath, RouteComponentProps } from 'react-router'
 import { Alert, Col, Row } from 'reactstrap'
-import { confirmDialog } from 'botpress/shared'
 import { toastSuccess } from '~/utils/toaster'
 import { toastFailure } from '~/utils/toaster'
 import { filterList } from '~/utils/util'
@@ -178,7 +178,7 @@ class Bots extends Component<Props> {
 
     return _.some(
       this.props.health.map(x => x.bots[botId]),
-      s => s && s.status === 'error'
+      s => s && s.status === 'unhealthy'
     )
   }
 


### PR DESCRIPTION
Couple of minor ajustments:

- Mounting 5 bots at a time on initial startup (configurable) 
- Ensure the config schemas are on the ghost
- Added debug information on bot service (eg: bot mount time)
- Fixed bot status (Healthy, Unhealthy, Unmounted, Disabled)
- Logging one "critical" log will change the bot status to unhealthy
- Linked knex & tarn logger to our logger (for timestamp & source)
- Updated docs for logging