### PR TITLE
fix(core): module was not unloaded correctly

### DIFF
--- a/src/bp/core/module-loader.ts
+++ b/src/bp/core/module-loader.ts
@@ -18,6 +18,7 @@ import path from 'path'
 
 import { createForModule } from './api' // TODO
 import { ConfigProvider } from './config/config-loader'
+import { clearModuleScriptCache } from './modules/require'
 import ModuleResolver from './modules/resolver'
 import { GhostService } from './services'
 import { BotService } from './services/bot-service'
@@ -221,7 +222,7 @@ export class ModuleLoader {
     await resourceLoader.disableResources()
 
     this.entryPoints.delete(moduleName)
-    delete require.cache[require.resolve(moduleLocation)]
+    clearModuleScriptCache(moduleLocation)
     delete process.LOADED_MODULES[moduleName]
   }
 

--- a/src/bp/core/modules/require.ts
+++ b/src/bp/core/modules/require.ts
@@ -6,6 +6,9 @@ import path from 'path'
 let requireCache = {}
 const getRequireCacheKey = (scriptPath, module) => `req-${scriptPath}_${module}`
 
+// Clears index.js from cache & all its dependencies recursively, stopping after this number of iterations
+const MAX_CHILD_DEPS_LEVEL = 3
+
 export const explodePath = (location: string): string[] => {
   const parts: string[] = location.split(path.sep)
   const paths: string[] = []
@@ -106,7 +109,7 @@ export const clearModuleScriptCache = (moduleLocation: string, depth: number = 0
   if (file) {
     for (const { filename } of file.children) {
       // Circular reference protection, we only unload the user's module files
-      if (depth < 3 && !filename.includes('node_modules')) {
+      if (depth < MAX_CHILD_DEPS_LEVEL && !filename.includes('node_modules')) {
         clearModuleScriptCache(filename, depth++)
       }
     }

--- a/src/bp/core/modules/require.ts
+++ b/src/bp/core/modules/require.ts
@@ -98,3 +98,16 @@ export const buildLookupPaths = (module: string, locations: string[]) => {
     })
   )
 }
+
+export const clearModuleScriptCache = (moduleLocation: string) => {
+  const cacheKey = require.resolve(moduleLocation)
+  const file = require.cache[cacheKey]
+
+  if (file) {
+    for (const { filename } of file.children) {
+      clearModuleScriptCache(filename)
+    }
+
+    delete require.cache[cacheKey]
+  }
+}

--- a/src/bp/core/routers/modules.ts
+++ b/src/bp/core/routers/modules.ts
@@ -89,6 +89,7 @@ export class ModulesRouter extends CustomRouter {
             await this.moduleLoader.unloadModule(fullPath, moduleName)
           } else {
             await this.moduleLoader.reloadModule(fullPath, moduleName)
+            this.logger.info(`Module ${moduleName} reloaded successfully!`)
           }
           return res.send({ rebootRequired: false })
         } else {


### PR DESCRIPTION
When using the new modules page to unload or load a module, the require cache was not cleared for children of index.js. 

From now on, we no longer need to restart the server when we make changes to the backend of a module, we simply need to unload and reload it.