### PR TITLE
fix(channel-messenger): fix initialization

### DIFF
--- a/modules/channel-messenger/README.md
+++ b/modules/channel-messenger/README.md
@@ -17,8 +17,10 @@ Messenger requires you to have a Facebook App and a Facebook Page to setup your 
 #### Enable the Messenger Channel
 
 - Run Botpress Server a first time to auto-generate the global configuration file
+- Enable `channel-messenger` module in the global configuration file
 - Head over to `data/global/config/channel-messenger.json`. If it doesn't exist, restart Botpress Server.
 - Set the following properties:
+  - `enabled` to `true`
   - `appSecret`. You will find this value in your Facebook App page.
   - `verifyToken`. This is a random string you need to generate and keep secret. You'll need to copy/paste this token in the Facebook App portal when setting up your webhook.
 - Make sure you have an HTTPS url pointing to your Botpress Server and set the [`EXTERNAL_URL`](https://botpress.com/docs/manage/configuration#exposing-your-bot-on-the-internet) environment variable

--- a/modules/channel-messenger/src/backend/index.ts
+++ b/modules/channel-messenger/src/backend/index.ts
@@ -5,7 +5,7 @@ import { MessengerService } from './messenger'
 
 let service: MessengerService
 
-const onServerStarted = async (bp: typeof sdk) => {
+const onServerReady = async (bp: typeof sdk) => {
   service = new MessengerService(bp)
   try {
     await service.initialize()
@@ -28,7 +28,7 @@ const onModuleUnmount = async (bp: typeof sdk) => {
 }
 
 const entryPoint: sdk.ModuleEntryPoint = {
-  onServerStarted,
+  onServerReady,
   onBotMount,
   onBotUnmount,
   onModuleUnmount,

--- a/modules/channel-messenger/src/backend/messenger.ts
+++ b/modules/channel-messenger/src/backend/messenger.ts
@@ -28,14 +28,12 @@ export class MessengerService {
   async initialize() {
     const config = (await this.bp.config.getModuleConfig('channel-messenger')) as Config
 
-    if (!config.verifyToken?.length) {
-      throw new Error(
-        'You need to set a non-empty value for "verifyToken" in data/global/config/channel-messenger.json'
-      )
+    if (!config.verifyToken?.length || config.verifyToken === 'verify_token') {
+      throw new Error('You need to set a valid value for "verifyToken" in data/global/config/channel-messenger.json')
     }
 
-    if (!config.appSecret?.length) {
-      throw new Error(`You need to set a non-empty value for "appSecret" in data/global/config/channel-messenger.json`)
+    if (!config.appSecret?.length || config.appSecret === 'app_secret') {
+      throw new Error(`You need to set a valid value for "appSecret" in data/global/config/channel-messenger.json`)
     }
 
     this.appSecret = config.appSecret

--- a/modules/channel-messenger/src/backend/messenger.ts
+++ b/modules/channel-messenger/src/backend/messenger.ts
@@ -28,13 +28,13 @@ export class MessengerService {
   async initialize() {
     const config = (await this.bp.config.getModuleConfig('channel-messenger')) as Config
 
-    if (!config.verifyToken || !config.verifyToken.length) {
+    if (!config.verifyToken?.length) {
       throw new Error(
         'You need to set a non-empty value for "verifyToken" in data/global/config/channel-messenger.json'
       )
     }
 
-    if (!config.appSecret || !config.appSecret.length) {
+    if (!config.appSecret?.length) {
       throw new Error(`You need to set a non-empty value for "appSecret" in data/global/config/channel-messenger.json`)
     }
 
@@ -46,7 +46,7 @@ export class MessengerService {
     })
 
     const publicPath = await this.router.getPublicPath()
-    if (publicPath.indexOf('https://') !== 0) {
+    if (!publicPath.startsWith('https://')) {
       this.bp.logger.warn('Messenger requires HTTPS to be setup to work properly. See EXTERNAL_URL botpress config.')
     }
     this.bp.logger.info(`Messenger Webhook URL is ${publicPath.replace('BOT_ID', '___')}/webhook`)
@@ -80,7 +80,7 @@ export class MessengerService {
 
       const { data } = await this.http.get('/', { params: { access_token: config.accessToken } })
 
-      if (!data || !data.id) {
+      if (!data?.id) {
         return this.bp.logger
           .forBot(botId)
           .error(
@@ -288,7 +288,7 @@ export class MessengerClient {
 
   async setupPersistentMenu(): Promise<void> {
     const config = await this.getConfig()
-    if (!config.persistentMenu || !config.persistentMenu.length) {
+    if (!config.persistentMenu?.length) {
       await this.deleteProfileFields(['persistent_menu'])
       return
     }

--- a/modules/channel-messenger/src/config.ts
+++ b/modules/channel-messenger/src/config.ts
@@ -15,12 +15,14 @@ export interface Config {
    * This this in the GLOBAL config (same for all bots)
    * Your app's "App Secret"
    * Find this secret in your developers.facebook.com -> your app -> Settings -> Basic -> App Secret -> Show
+   * @default app_secret
    */
   appSecret: string
   /**
    * Set this in the GLOBAL config (same for all the bots)
    * The verify token, should be a random string unique to your server. This is a random (hard to guess) string of your choosing.
    * Docs: https://developers.facebook.com/docs/messenger-platform/getting-started/webhook-setup/#verify_webhook
+   * @default verify_token
    */
   verifyToken: string
   /**


### PR DESCRIPTION
As hinted in the [Forum](https://forum.botpress.com/t/cannot-enable-facebook-messenger-channel/3112), the `channel-messenger` doesn't currently work, it simply hangs during initialization.

The reason is because [router.getPublicPath()](https://github.com/botpress/botpress/blob/master/modules/channel-messenger/src/backend/messenger.ts#L48) awaits [AppLifecycle.waitFor(AppLifecycleEvents.HTTP_SERVER_READY)](https://github.com/botpress/botpress/blob/master/src/bp/core/routers/bots/index.ts#L155).

The fix is to call `initialize()` `onServerReady` instead of `onServerStarted`