### PR TITLE
feat(shared): tree view component

### DIFF
--- a/src/bp/ui-shared/src/Interface/typings.d.ts
+++ b/src/bp/ui-shared/src/Interface/typings.d.ts
@@ -1,5 +1,6 @@
 import { IconName, MaybeElement, Position } from '@blueprintjs/core'
 import React from 'react'
+import { TreeViewProps } from '../TreeView'
 
 export interface ConfirmDialogOptions {
   title?: string
@@ -17,4 +18,5 @@ export interface ConfirmDialogProps extends ConfirmDialogOptions {
 
 declare module 'botpress/shared' {
   export function confirmDialog(message: string, options: ConfirmDialogOptions): Promise<boolean>
+  export function TreeView<T>(props: TreeViewProps<T>): JSX.Element
 }

--- a/src/bp/ui-shared/src/TreeView/index.tsx
+++ b/src/bp/ui-shared/src/TreeView/index.tsx
@@ -1,0 +1,288 @@
+import { Classes, ContextMenu, ITreeNode, Tree } from '@blueprintjs/core'
+import _ from 'lodash'
+import React, { useEffect, useReducer, useState } from 'react'
+
+export const FOLDER_ICON = 'folder-close'
+export const DOCUMENT_ICON = 'document'
+
+export interface TreeViewProps<T> {
+  /** List of elements to display in the tree view */
+  elements?: T[]
+  /** Name of the property to use on elements to get the full path. Defaults to "path" */
+  pathProps?: string
+  nodeRenderer: ElementRenderer<T>
+  folderRenderer?: ElementRenderer<string>
+  /** Called after the tree has been built. Can be used to reorder elements before display */
+  postProcessing?: PostProcessing<T>
+  /** You can also parse nodes manually and provide them to the view */
+  nodes?: TreeNode<T>[]
+  /** Filters the displayed nodes (expands all folders when filtering) */
+  filter?: Filter
+  /** The full paths of nodes which should be expanded */
+  expandedPaths?: string[]
+  /** Ensure that elements having "field" set to "value" are displayed (their parent will be expanded) */
+  visibleElements?: { value: string; field: string }[]
+  /** Whether or not to highlight the folder's name on click */
+  highlightFolders?: boolean
+
+  onDoubleClick?: (element: T) => void
+  onClick?: (element: T) => void
+  onExpandToggle?: (node: TreeNode<T>, isExpanded: boolean) => void
+  onContextMenu?: (element: T) => JSX.Element | undefined
+}
+
+type TreeNode<T> = ITreeNode<T> & {
+  id: string
+  type: string
+  parent?: TreeNode<T>
+  fullPath: string
+  childNodes?: TreeNode<T>[]
+}
+
+type ElementRenderer<T> = (element: T) => { label: JSX.Element | string; icon?: any }
+type PostProcessing<T> = (nodes: TreeNode<T>[]) => TreeNode<T>[]
+
+interface Filter {
+  text: string
+  /** The field to compare text on the provided element */
+  field: string
+}
+
+interface BuildTreeParams<T> {
+  elements: T[]
+  filter?: Filter
+  nodeRenderer: ElementRenderer<T>
+  folderRenderer?: ElementRenderer<string>
+  postProcessing?: PostProcessing<T>
+  pathProps?: string
+}
+
+const TreeView = <T extends {}>(props: TreeViewProps<T>) => {
+  const [nodes, setNodes] = useState<TreeNode<T>[]>([])
+  const [expanded, setExpanded] = useState(props.expandedPaths || [])
+  const [, forceUpdate] = useReducer(x => x + 1, 0)
+
+  const { elements, filter, nodeRenderer, folderRenderer, postProcessing } = props
+
+  useEffect(() => {
+    if (!elements || (elements && !nodeRenderer)) {
+      return
+    }
+
+    const nodes = buildTree({ elements, nodeRenderer, filter, folderRenderer, postProcessing })
+    traverseTree(nodes, node => {
+      if (props.visibleElements?.find(x => node.nodeData?.[x.field] === x.value)) {
+        handleNodeExpansion(node.parent!, true)
+        node.parent!.isExpanded = true
+        node.isSelected = true
+      }
+
+      if (filter?.text) {
+        node.isExpanded = true
+      }
+    })
+
+    setNodes(nodes)
+  }, [elements, filter])
+
+  useEffect(() => {
+    props.nodes && setNodes(props.nodes)
+  }, [props.nodes])
+
+  useEffect(() => {
+    setExpanded(props.expandedPaths || [])
+  }, [props.expandedPaths])
+
+  const handleNodeExpansion = (node: TreeNode<T>, isExpanded: boolean) => {
+    isExpanded ? setExpanded([...expanded, node.fullPath]) : setExpanded(expanded.filter(x => x !== node.fullPath))
+    node.isExpanded = isExpanded
+
+    props.onExpandToggle?.(node, isExpanded)
+  }
+
+  const handleNodeClick = (selectedNode: TreeNode<T>) => {
+    if (selectedNode.nodeData) {
+      props.onClick?.(selectedNode.nodeData)
+    }
+
+    traverseTree(nodes, node => {
+      if (node === selectedNode) {
+        if (props.highlightFolders || (!props.highlightFolders && node.type !== 'folder')) {
+          node.isSelected = !node.isSelected
+        }
+
+        if (!node.nodeData) {
+          node.isExpanded ? handleNodeExpansion(node, false) : handleNodeExpansion(node, true)
+        }
+      } else {
+        node.isSelected = false
+      }
+    })
+
+    forceUpdate()
+  }
+
+  const handleNodeDoubleClick = (selectedNode: TreeNode<T>) => {
+    if (selectedNode.nodeData) {
+      props.onDoubleClick?.(selectedNode.nodeData)
+    }
+  }
+
+  const handleContextMenu = (node: TreeNode<T>, _path, e) => {
+    if (!node.nodeData) {
+      return
+    }
+
+    e.preventDefault()
+
+    const contextMenu = props.onContextMenu?.(node.nodeData)
+    if (!contextMenu) {
+      return
+    }
+
+    ContextMenu.show(contextMenu, { left: e.clientX, top: e.clientY })
+  }
+
+  if (!nodes) {
+    return null
+  }
+
+  return (
+    <Tree
+      contents={nodes}
+      onNodeClick={node => handleNodeClick(node as TreeNode<T>)}
+      onNodeDoubleClick={node => handleNodeDoubleClick(node as TreeNode<T>)}
+      onNodeCollapse={node => handleNodeExpansion(node as TreeNode<T>, false)}
+      onNodeExpand={node => handleNodeExpansion(node as TreeNode<T>, true)}
+      onNodeContextMenu={(node, _p, e) => handleContextMenu(node as TreeNode<T>, _p, e)}
+      className={Classes.ELEVATION_0}
+    />
+  )
+}
+
+function splitPath<T>(
+  fullPath: string,
+  nodeData: T,
+  nodeRenderer: ElementRenderer<T>,
+  folderRenderer: ElementRenderer<string>
+) {
+  const splitPath = fullPath.split('/')
+  const nodeLabel = splitPath[splitPath.length - 1]
+  const parentFolders = splitPath.slice(0, splitPath.length - 1)
+
+  const folders: TreeNode<T>[] = []
+  const currentPath: string[] = []
+
+  for (const folder of parentFolders) {
+    currentPath.push(folder)
+    const { label, icon } = folderRenderer(folder)
+
+    folders.push({
+      id: folder,
+      label,
+      icon: icon || FOLDER_ICON,
+      fullPath: currentPath.join('/'),
+      type: 'folder',
+      childNodes: undefined
+    })
+  }
+
+  currentPath.push(nodeLabel)
+
+  const id = currentPath.join('/')
+  const { label, icon } = nodeRenderer(nodeData)
+
+  return {
+    folders,
+    leafNode: { id, label, icon: icon || DOCUMENT_ICON, fullPath: id, type: 'node' }
+  }
+}
+
+function buildTree<T>({
+  elements,
+  nodeRenderer,
+  filter,
+  folderRenderer,
+  postProcessing,
+  pathProps
+}: BuildTreeParams<T>): TreeNode<T>[] {
+  if (!elements) {
+    return []
+  }
+
+  if (!folderRenderer) {
+    folderRenderer = label => ({ label })
+  }
+
+  const tree: TreeNode<T> = {
+    id: 'root',
+    label: '<root>',
+    type: 'root',
+    fullPath: '',
+    childNodes: []
+  }
+
+  const lowerCaseFilter = filter?.text?.toLowerCase()
+
+  for (const nodeData of elements) {
+    const nodePath = nodeData[pathProps || 'path']
+    if (!nodePath) {
+      console.error(`Invalid path`)
+      return []
+    }
+
+    const { folders, leafNode } = splitPath(nodePath, nodeData, nodeRenderer, folderRenderer!)
+    if (!filter?.text || leafNode[filter.field || 'id']?.toLowerCase().includes(lowerCaseFilter)) {
+      addNode(tree, folders, leafNode, { nodeData })
+    }
+  }
+
+  sortChildren(tree)
+
+  return postProcessing ? postProcessing(tree.childNodes!) : tree.childNodes!
+}
+
+function traverseTree<T>(nodes: TreeNode<T>[], callback: (node: TreeNode<T>) => void) {
+  if (nodes == null) {
+    return
+  }
+
+  for (const node of nodes) {
+    callback(node)
+    traverseTree(node.childNodes!, callback)
+  }
+}
+
+function addNode<T>(tree: TreeNode<T>, folders: TreeNode<T>[], leafNode: TreeNode<T>, data) {
+  for (const folderDesc of folders) {
+    let folder = _.find(tree.childNodes, x => x.id === folderDesc.id)
+    if (!folder) {
+      folder = { ...folderDesc, parent: tree, childNodes: [] }
+      tree.childNodes?.push(folder)
+    }
+    tree = folder
+  }
+
+  tree.childNodes?.push({ ...leafNode, parent: tree, ...data })
+}
+
+const sortChildren = tree => {
+  if (!tree.childNodes) {
+    return
+  }
+
+  tree.childNodes.sort((a, b) => {
+    if (a.type === b.type) {
+      return a.name < b.name ? -1 : 1
+    }
+    if (a.type === 'folder') {
+      return -1
+    } else {
+      return 1
+    }
+  })
+
+  tree.childNodes.forEach(sortChildren)
+}
+
+export default TreeView

--- a/src/bp/ui-shared/src/TreeView/index.tsx
+++ b/src/bp/ui-shared/src/TreeView/index.tsx
@@ -1,73 +1,12 @@
-import { Classes, ContextMenu, ITreeNode, Tree } from '@blueprintjs/core'
+import { Classes, ContextMenu, Tree } from '@blueprintjs/core'
 import _ from 'lodash'
-import React, { useEffect, useReducer, useRef, useState } from 'react'
+import React, { useEffect, useReducer, useState } from 'react'
+
+import { TreeNode, TreeViewProps } from './typings'
+import { buildTree, traverseTree, usePrevious } from './utils'
 
 export const FOLDER_ICON = 'folder-close'
 export const DOCUMENT_ICON = 'document'
-
-export interface TreeViewProps<T> {
-  /** List of elements to display in the tree view */
-  elements?: T[]
-  /** Name of the property to use on elements to get the full path. Defaults to "path" */
-  pathProps?: string
-  nodeRenderer: ElementRenderer<T>
-  folderRenderer?: ElementRenderer<string>
-  /** Called after the tree has been built. Can be used to reorder elements before display */
-  postProcessing?: PostProcessing<T>
-  /** You can also parse nodes manually and provide them to the view */
-  nodes?: TreeNode<T>[]
-  /** Filters the displayed nodes (expands all folders when filtering) */
-  filter?: Filter
-  /** The full paths of nodes which should be expanded */
-  expandedPaths?: string[]
-  /** Ensure that elements having "field" set to "value" are displayed (their parent will be expanded) */
-  visibleElements?: { value: string; field: string }[]
-  /** Whether or not to highlight the folder's name on click */
-  highlightFolders?: boolean
-
-  onDoubleClick?: (element: T | string, elementType: ElementType) => void
-  onClick?: (element: T | string, elementType: ElementType) => void
-  onContextMenu?: (element: T | string, elementType: ElementType) => JSX.Element | undefined
-  onExpandToggle?: (node: TreeNode<T>, isExpanded: boolean) => void
-}
-
-type ElementType = 'document' | 'folder'
-
-type TreeNode<T> = ITreeNode<T> & {
-  id: string
-  type: string
-  parent?: TreeNode<T>
-  fullPath: string
-  childNodes?: TreeNode<T>[]
-}
-
-type ElementRenderer<T> = (element: T) => { label: JSX.Element | string; icon?: any }
-type PostProcessing<T> = (nodes: TreeNode<T>[]) => TreeNode<T>[]
-
-interface Filter {
-  text: string
-  /** The field to compare text on the provided element */
-  field: string
-}
-
-interface BuildTreeParams<T> {
-  elements: T[]
-  filter?: Filter
-  nodeRenderer: ElementRenderer<T>
-  folderRenderer?: ElementRenderer<string>
-  postProcessing?: PostProcessing<T>
-  pathProps?: string
-}
-
-const usePrevious = value => {
-  const ref = useRef()
-
-  useEffect(() => {
-    ref.current = value
-  }, [value])
-
-  return ref.current
-}
 
 const TreeView = <T extends {}>(props: TreeViewProps<T>) => {
   const [nodes, setNodes] = useState<TreeNode<T>[]>([])
@@ -75,36 +14,29 @@ const TreeView = <T extends {}>(props: TreeViewProps<T>) => {
   const prevElements = usePrevious(props.elements)
   const [, forceUpdate] = useReducer(x => x + 1, 0)
 
-  const { elements, filter, nodeRenderer, folderRenderer, postProcessing, pathProps } = props
+  const { elements, filterText, filterProps, nodeRenderer, folderRenderer, postProcessing, pathProps } = props
 
   useEffect(() => {
-    if (!elements || (!!elements?.length && _.isEqual(props.elements, prevElements))) {
+    if (!elements || (elements?.length && _.isEqual(props.elements, prevElements))) {
       return
     }
 
     const nodes = buildTree({
       elements,
-      filter,
+      filterText,
+      filterProps,
       nodeRenderer,
       folderRenderer,
       postProcessing,
       pathProps
     })
 
-    traverseTree(nodes, node => {
-      if (props.visibleElements?.find(x => node.nodeData?.[x.field] === x.value)) {
-        handleNodeExpansion(node.parent!, true)
-        node.parent!.isExpanded = true
-        node.isSelected = true
-      }
+    refreshNodes(nodes)
+  }, [elements, filterText])
 
-      if (filter?.text || expanded.find(path => path === node.fullPath)) {
-        node.isExpanded = true
-      }
-    })
-
-    setNodes(nodes)
-  }, [elements, filter])
+  useEffect(() => {
+    nodes && refreshNodes(nodes)
+  }, [props.visibleElements])
 
   useEffect(() => {
     props.nodes && setNodes(props.nodes)
@@ -113,6 +45,22 @@ const TreeView = <T extends {}>(props: TreeViewProps<T>) => {
   useEffect(() => {
     setExpanded(props.expandedPaths || [])
   }, [props.expandedPaths])
+
+  const refreshNodes = nodes => {
+    traverseTree(nodes, node => {
+      if (props.visibleElements?.find(x => node.nodeData?.[x.field] === x.value)) {
+        handleNodeExpansion(node.parent!, true)
+        node.parent!.isExpanded = true
+        node.isSelected = true
+      }
+
+      if (filterText || expanded.find(path => path === node.fullPath)) {
+        node.isExpanded = true
+      }
+    })
+
+    setNodes(nodes)
+  }
 
   const handleNodeExpansion = (node: TreeNode<T>, isExpanded: boolean) => {
     isExpanded ? setExpanded([...expanded, node.fullPath]) : setExpanded(expanded.filter(x => x !== node.fullPath))
@@ -172,7 +120,7 @@ const TreeView = <T extends {}>(props: TreeViewProps<T>) => {
     <Tree
       contents={nodes}
       onNodeClick={node => handleNodeClick(node as TreeNode<T>)}
-      onNodeDoubleClick={node => handleNodeDoubleClick(node as TreeNode<T>)}
+      onNodeDoubleClick={handleNodeDoubleClick}
       onNodeCollapse={node => handleNodeExpansion(node as TreeNode<T>, false)}
       onNodeExpand={node => handleNodeExpansion(node as TreeNode<T>, true)}
       onNodeContextMenu={(node, _p, e) => handleContextMenu(node as TreeNode<T>, _p, e)}
@@ -181,129 +129,4 @@ const TreeView = <T extends {}>(props: TreeViewProps<T>) => {
   )
 }
 
-function splitPath<T>(
-  fullPath: string,
-  nodeData: T,
-  nodeRenderer: ElementRenderer<T>,
-  folderRenderer: ElementRenderer<string>
-) {
-  const splitPath = fullPath.split('/')
-  const nodeLabel = splitPath[splitPath.length - 1]
-  const parentFolders = splitPath.slice(0, splitPath.length - 1)
-
-  const folders: TreeNode<T>[] = []
-  const currentPath: string[] = []
-
-  for (const folder of parentFolders) {
-    currentPath.push(folder)
-    const { label, icon } = folderRenderer(folder)
-
-    folders.push({
-      id: folder,
-      label,
-      icon: icon || FOLDER_ICON,
-      fullPath: currentPath.join('/'),
-      type: 'folder',
-      childNodes: undefined
-    })
-  }
-
-  currentPath.push(nodeLabel)
-
-  const id = currentPath.join('/')
-  const { label, icon } = nodeRenderer(nodeData)
-
-  return {
-    folders,
-    leafNode: { id, label, icon: icon || DOCUMENT_ICON, fullPath: id, type: 'node' }
-  }
-}
-
-function buildTree<T>({
-  elements,
-  nodeRenderer,
-  filter,
-  folderRenderer,
-  postProcessing,
-  pathProps
-}: BuildTreeParams<T>): TreeNode<T>[] {
-  if (!elements) {
-    return []
-  }
-
-  if (!folderRenderer) {
-    folderRenderer = label => ({ label })
-  }
-
-  const tree: TreeNode<T> = {
-    id: 'root',
-    label: '<root>',
-    type: 'root',
-    fullPath: '',
-    childNodes: []
-  }
-
-  const lowerCaseFilter = filter?.text?.toLowerCase()
-
-  for (const nodeData of elements) {
-    const nodePath = nodeData[pathProps || 'path']
-    if (!nodePath) {
-      console.error(`Invalid path`)
-      return []
-    }
-
-    const { folders, leafNode } = splitPath(nodePath, nodeData, nodeRenderer, folderRenderer!)
-    if (!filter?.text || nodeData[filter.field || 'id']?.toLowerCase().includes(lowerCaseFilter)) {
-      addNode(tree, folders, leafNode, { nodeData })
-    }
-  }
-
-  sortChildren(tree)
-
-  return postProcessing ? postProcessing(tree.childNodes!) : tree.childNodes!
-}
-
-function traverseTree<T>(nodes: TreeNode<T>[], callback: (node: TreeNode<T>) => void) {
-  if (nodes == null) {
-    return
-  }
-
-  for (const node of nodes) {
-    callback(node)
-    traverseTree(node.childNodes!, callback)
-  }
-}
-
-function addNode<T>(tree: TreeNode<T>, folders: TreeNode<T>[], leafNode: TreeNode<T>, data) {
-  for (const folderDesc of folders) {
-    let folder = _.find(tree.childNodes, x => x.id === folderDesc.id)
-    if (!folder) {
-      folder = { ...folderDesc, parent: tree, childNodes: [] }
-      tree.childNodes?.push(folder)
-    }
-    tree = folder
-  }
-
-  tree.childNodes?.push({ ...leafNode, parent: tree, ...data })
-}
-
-const sortChildren = tree => {
-  if (!tree.childNodes) {
-    return
-  }
-
-  tree.childNodes.sort((a, b) => {
-    if (a.type === b.type) {
-      return a.name < b.name ? -1 : 1
-    }
-    if (a.type === 'folder') {
-      return -1
-    } else {
-      return 1
-    }
-  })
-
-  tree.childNodes.forEach(sortChildren)
-}
-
-export default TreeView
+export default React.memo(TreeView)

--- a/src/bp/ui-shared/src/TreeView/index.tsx
+++ b/src/bp/ui-shared/src/TreeView/index.tsx
@@ -30,18 +30,6 @@ const TreeView = <T extends {}>(props: TreeViewProps<T>) => {
       pathProps
     })
 
-    refreshNodes(nodes)
-  }, [elements, filterText])
-
-  useEffect(() => {
-    props.nodes && setNodes(props.nodes)
-  }, [props.nodes])
-
-  useEffect(() => {
-    setExpanded(props.expandedPaths || [])
-  }, [props.expandedPaths])
-
-  const refreshNodes = nodes => {
     traverseTree(nodes, node => {
       if (props.visibleElements?.find(x => node.nodeData?.[x.field] === x.value)) {
         handleNodeExpansion(node.parent!, true)
@@ -55,7 +43,15 @@ const TreeView = <T extends {}>(props: TreeViewProps<T>) => {
     })
 
     setNodes(nodes)
-  }
+  }, [elements, filterText])
+
+  useEffect(() => {
+    props.nodes && setNodes(props.nodes)
+  }, [props.nodes])
+
+  useEffect(() => {
+    setExpanded(props.expandedPaths || [])
+  }, [props.expandedPaths])
 
   const handleNodeExpansion = (node: TreeNode<T>, isExpanded: boolean) => {
     isExpanded ? setExpanded([...expanded, node.fullPath]) : setExpanded(expanded.filter(x => x !== node.fullPath))
@@ -114,11 +110,11 @@ const TreeView = <T extends {}>(props: TreeViewProps<T>) => {
   return (
     <Tree
       contents={nodes}
-      onNodeClick={node => handleNodeClick(node as TreeNode<T>)}
+      onNodeClick={handleNodeClick}
+      onNodeContextMenu={handleContextMenu}
       onNodeDoubleClick={handleNodeDoubleClick}
       onNodeCollapse={node => handleNodeExpansion(node as TreeNode<T>, false)}
       onNodeExpand={node => handleNodeExpansion(node as TreeNode<T>, true)}
-      onNodeContextMenu={(node, _p, e) => handleContextMenu(node as TreeNode<T>, _p, e)}
       className={Classes.ELEVATION_0}
     />
   )

--- a/src/bp/ui-shared/src/TreeView/index.tsx
+++ b/src/bp/ui-shared/src/TreeView/index.tsx
@@ -3,7 +3,7 @@ import _ from 'lodash'
 import React, { useEffect, useReducer, useState } from 'react'
 
 import { TreeNode, TreeViewProps } from './typings'
-import { buildTree, traverseTree, usePrevious } from './utils'
+import { buildTree, traverseTree } from './utils'
 
 export const FOLDER_ICON = 'folder-close'
 export const DOCUMENT_ICON = 'document'
@@ -11,13 +11,12 @@ export const DOCUMENT_ICON = 'document'
 const TreeView = <T extends {}>(props: TreeViewProps<T>) => {
   const [nodes, setNodes] = useState<TreeNode<T>[]>([])
   const [expanded, setExpanded] = useState(props.expandedPaths || [])
-  const prevElements = usePrevious(props.elements)
   const [, forceUpdate] = useReducer(x => x + 1, 0)
 
   const { elements, filterText, filterProps, nodeRenderer, folderRenderer, postProcessing, pathProps } = props
 
   useEffect(() => {
-    if (!elements || (elements?.length && _.isEqual(props.elements, prevElements))) {
+    if (!elements) {
       return
     }
 
@@ -33,10 +32,6 @@ const TreeView = <T extends {}>(props: TreeViewProps<T>) => {
 
     refreshNodes(nodes)
   }, [elements, filterText])
-
-  useEffect(() => {
-    nodes && refreshNodes(nodes)
-  }, [props.visibleElements])
 
   useEffect(() => {
     props.nodes && setNodes(props.nodes)

--- a/src/bp/ui-shared/src/TreeView/typings.d.ts
+++ b/src/bp/ui-shared/src/TreeView/typings.d.ts
@@ -3,7 +3,9 @@ export interface TreeViewProps<T> {
   elements?: T[]
   /** Name of the property to use on elements to get the full path. Defaults to "path" */
   pathProps?: string
-  nodeRenderer: ElementRenderer<T>
+  /** Custom renderer to choose the label and the icon for the leaf node. Defaults to "label" */
+  nodeRenderer?: ElementRenderer<T>
+  /** Each / segments will be passed through this renderer to customize the display */
   folderRenderer?: ElementRenderer<string>
   /** Called after the tree has been built. Can be used to reorder elements before display */
   postProcessing?: PostProcessing<T>
@@ -11,7 +13,7 @@ export interface TreeViewProps<T> {
   nodes?: TreeNode<T>[]
   /** Filters the displayed nodes (expands all folders when filtering) */
   filterText?: string
-  /** The name of the property where to check the filter (default: id) */
+  /** The name of the property where to check the filter (Defaults to "path") */
   filterProps?: string
   /** The full paths of nodes which should be expanded */
   expandedPaths?: string[]
@@ -24,6 +26,14 @@ export interface TreeViewProps<T> {
   onClick?: (element: T | string, elementType: ElementType) => void
   onContextMenu?: (element: T | string, elementType: ElementType) => JSX.Element | undefined
   onExpandToggle?: (node: TreeNode<T>, isExpanded: boolean) => void
+}
+
+/** These are the default properties required if you want to avoid providing any renderers */
+interface SampleElement {
+  /** Text displayed on the child node */
+  label: string
+  /** The complete path of the element (including all folders) */
+  path: string
 }
 
 type ElementType = 'document' | 'folder'
@@ -43,7 +53,7 @@ interface BuildTreeParams<T> {
   elements: T[]
   filterText?: string
   filterProps?: string
-  nodeRenderer: ElementRenderer<T>
+  nodeRenderer?: ElementRenderer<T>
   folderRenderer?: ElementRenderer<string>
   postProcessing?: PostProcessing<T>
   pathProps?: string

--- a/src/bp/ui-shared/src/TreeView/typings.d.ts
+++ b/src/bp/ui-shared/src/TreeView/typings.d.ts
@@ -1,0 +1,50 @@
+export interface TreeViewProps<T> {
+  /** List of elements to display in the tree view */
+  elements?: T[]
+  /** Name of the property to use on elements to get the full path. Defaults to "path" */
+  pathProps?: string
+  nodeRenderer: ElementRenderer<T>
+  folderRenderer?: ElementRenderer<string>
+  /** Called after the tree has been built. Can be used to reorder elements before display */
+  postProcessing?: PostProcessing<T>
+  /** You can also parse nodes manually and provide them to the view */
+  nodes?: TreeNode<T>[]
+  /** Filters the displayed nodes (expands all folders when filtering) */
+  filterText?: string
+  /** The name of the property where to check the filter (default: id) */
+  filterProps?: string
+  /** The full paths of nodes which should be expanded */
+  expandedPaths?: string[]
+  /** Ensure that elements having "field" set to "value" are displayed (their parent will be expanded) */
+  visibleElements?: { value: string; field: string }[]
+  /** Whether or not to highlight the folder's name on click */
+  highlightFolders?: boolean
+
+  onDoubleClick?: (element: T | string, elementType: ElementType) => void
+  onClick?: (element: T | string, elementType: ElementType) => void
+  onContextMenu?: (element: T | string, elementType: ElementType) => JSX.Element | undefined
+  onExpandToggle?: (node: TreeNode<T>, isExpanded: boolean) => void
+}
+
+type ElementType = 'document' | 'folder'
+
+export type TreeNode<T> = ITreeNode<T> & {
+  id: string
+  type: string
+  parent?: TreeNode<T>
+  fullPath: string
+  childNodes?: TreeNode<T>[]
+}
+
+type ElementRenderer<T> = (element: T) => { label: JSX.Element | string; icon?: any }
+type PostProcessing<T> = (nodes: TreeNode<T>[]) => TreeNode<T>[]
+
+interface BuildTreeParams<T> {
+  elements: T[]
+  filterText?: string
+  filterProps?: string
+  nodeRenderer: ElementRenderer<T>
+  folderRenderer?: ElementRenderer<string>
+  postProcessing?: PostProcessing<T>
+  pathProps?: string
+}

--- a/src/bp/ui-shared/src/TreeView/utils.tsx
+++ b/src/bp/ui-shared/src/TreeView/utils.tsx
@@ -1,0 +1,137 @@
+import _ from 'lodash'
+import { useEffect, useRef } from 'react'
+
+import { DOCUMENT_ICON, FOLDER_ICON } from '.'
+import { BuildTreeParams, ElementRenderer, TreeNode } from './typings'
+
+function splitPath<T>(
+  fullPath: string,
+  nodeData: T,
+  nodeRenderer: ElementRenderer<T>,
+  folderRenderer: ElementRenderer<string>
+) {
+  const splitPath = fullPath.split('/')
+  const nodeLabel = splitPath[splitPath.length - 1]
+  const parentFolders = splitPath.slice(0, splitPath.length - 1)
+
+  const folders: TreeNode<T>[] = []
+  const currentPath: string[] = []
+
+  for (const folder of parentFolders) {
+    currentPath.push(folder)
+    const { label, icon } = folderRenderer(folder)
+
+    folders.push({
+      id: folder,
+      label,
+      icon: icon || FOLDER_ICON,
+      fullPath: currentPath.join('/'),
+      type: 'folder',
+      childNodes: undefined
+    })
+  }
+
+  currentPath.push(nodeLabel)
+
+  const id = currentPath.join('/')
+  const { label, icon } = nodeRenderer(nodeData)
+
+  return {
+    folders,
+    leafNode: { id, label, icon: icon || DOCUMENT_ICON, fullPath: id, type: 'node' }
+  }
+}
+
+export function buildTree<T>({
+  elements,
+  nodeRenderer,
+  filterText,
+  filterProps,
+  folderRenderer = label => ({ label }),
+  postProcessing,
+  pathProps
+}: BuildTreeParams<T>): TreeNode<T>[] {
+  if (!elements) {
+    return []
+  }
+
+  const tree: TreeNode<T> = {
+    id: 'root',
+    label: '<root>',
+    type: 'root',
+    fullPath: '',
+    childNodes: []
+  }
+
+  const lowerCaseFilter = filterText?.toLowerCase()
+
+  for (const nodeData of elements) {
+    const nodePath = nodeData[pathProps || 'path']
+    if (!nodePath) {
+      console.error(`Invalid path`)
+      return []
+    }
+
+    const { folders, leafNode } = splitPath(nodePath, nodeData, nodeRenderer, folderRenderer!)
+    if (!filterText || nodeData[filterProps || 'id']?.toLowerCase().includes(lowerCaseFilter)) {
+      addNode(tree, folders, leafNode, { nodeData })
+    }
+  }
+
+  sortChildren(tree)
+
+  return postProcessing ? postProcessing(tree.childNodes!) : tree.childNodes!
+}
+
+export function traverseTree<T>(nodes: TreeNode<T>[], callback: (node: TreeNode<T>) => void) {
+  if (!nodes) {
+    return
+  }
+
+  for (const node of nodes) {
+    callback(node)
+    traverseTree(node.childNodes!, callback)
+  }
+}
+
+function addNode<T>(tree: TreeNode<T>, folders: TreeNode<T>[], leafNode: TreeNode<T>, data) {
+  for (const folderDesc of folders) {
+    let folder = _.find(tree.childNodes, x => x.id === folderDesc.id)
+    if (!folder) {
+      folder = { ...folderDesc, parent: tree, childNodes: [] }
+      tree.childNodes?.push(folder)
+    }
+    tree = folder
+  }
+
+  tree.childNodes?.push({ ...leafNode, parent: tree, ...data })
+}
+
+const sortChildren = tree => {
+  if (!tree.childNodes) {
+    return
+  }
+
+  tree.childNodes.sort((a, b) => {
+    if (a.type === b.type) {
+      return a.name < b.name ? -1 : 1
+    }
+    if (a.type === 'folder') {
+      return -1
+    } else {
+      return 1
+    }
+  })
+
+  tree.childNodes.forEach(sortChildren)
+}
+
+export const usePrevious = value => {
+  const ref = useRef()
+
+  useEffect(() => {
+    ref.current = value
+  }, [value])
+
+  return ref.current
+}

--- a/src/bp/ui-shared/src/TreeView/utils.tsx
+++ b/src/bp/ui-shared/src/TreeView/utils.tsx
@@ -44,12 +44,12 @@ function splitPath<T>(
 
 export function buildTree<T>({
   elements,
-  nodeRenderer,
   filterText,
-  filterProps,
-  folderRenderer = label => ({ label }),
+  nodeRenderer = (element: T) => ({ label: element['label'] }),
+  folderRenderer = (label: string) => ({ label }),
   postProcessing,
-  pathProps
+  filterProps = 'path',
+  pathProps = 'path'
 }: BuildTreeParams<T>): TreeNode<T>[] {
   if (!elements) {
     return []
@@ -66,14 +66,14 @@ export function buildTree<T>({
   const lowerCaseFilter = filterText?.toLowerCase()
 
   for (const nodeData of elements) {
-    const nodePath = nodeData[pathProps || 'path']
+    const nodePath = nodeData[pathProps]
     if (!nodePath) {
       console.error(`Invalid path`)
       return []
     }
 
     const { folders, leafNode } = splitPath(nodePath, nodeData, nodeRenderer, folderRenderer!)
-    if (!filterText || nodeData[filterProps || 'id']?.toLowerCase().includes(lowerCaseFilter)) {
+    if (!filterText || nodeData[filterProps]?.toLowerCase().includes(lowerCaseFilter)) {
       addNode(tree, folders, leafNode, { nodeData })
     }
   }

--- a/src/bp/ui-shared/src/index.tsx
+++ b/src/bp/ui-shared/src/index.tsx
@@ -1,3 +1,5 @@
 import confirmDialog from './ConfirmDialog'
+import TreeView from './TreeView'
 
 exports.confirmDialog = confirmDialog
+exports.TreeView = TreeView


### PR DESCRIPTION
We use blueprint TreeView in 4 different places:  Flow builder, Code editor, Goal/Topic list, Content Library.

Each of those had a slightly different implementation  that i've just been copy-pasted around. Behavior is different, there's a lot of duplicate code & boilerplate.

Since I had to play in it again, I got pissed and i've made this component which should be able to replace all the different implementations we have around. 

```js
const nodeRenderer = ({ contentId, type, preview }: LibraryElement) => {
    return {
      label: <MarkdownRenderer content={preview} noLink={true} size="sm"></MarkdownRenderer>
    }
}

<TreeView<LibraryElement>
  elements={props.library}
  nodeRenderer={nodeRenderer}
  onContextMenu={getContextMenu}
  onDoubleClick={element => {
    setEditItem(element.contentId)
    setEditOpen(true)
  }}
  filter={{ text: props.filter, field: 'preview' }}
/>
```