### PR TITLE
fix(nlu): cancel training properly

### DIFF
--- a/modules/nlu/src/backend/engine2/engine2.ts
+++ b/modules/nlu/src/backend/engine2/engine2.ts
@@ -91,7 +91,6 @@ export default class E2 implements Engine2 {
         })
 
       trainDebug.forBot(this.botId, `Successfully finished ${languageCode} training`)
-      await this.loadModel(model)
     }
 
     return model

--- a/modules/nlu/src/backend/engine2/training-pipeline.ts
+++ b/modules/nlu/src/backend/engine2/training-pipeline.ts
@@ -488,7 +488,7 @@ export const Trainer: Trainer = async (input: TrainInput, tools: Tools): Promise
       // TODO use bp.logger once this is moved in Engine2
       console.log('Could not finish training NLU model', err)
     }
-    _.merge(model, { success: false })
+    model.success = false
   } finally {
     model.finishedAt = new Date()
     return model as Model

--- a/src/bp/ml/toolkit.ts
+++ b/src/bp/ml/toolkit.ts
@@ -54,7 +54,7 @@ function overloadTrainers() {
             if (err.name === 'CancelError') {
               process.off('message', messageHandler)
               // process.send!({ type: 'cancel', id })
-              completedCb(undefined)
+              completedCb(err)
             }
           }
         }

--- a/src/bp/ml/toolkit.ts
+++ b/src/bp/ml/toolkit.ts
@@ -47,24 +47,27 @@ function overloadTrainers() {
     return Promise.fromCallback(completedCb => {
       const id = nanoid()
       const messageHandler = (msg: Message) => {
-        if (progressCb && msg.type === 'progress' && msg.id === id) {
+        if (msg.id !== id) {
+          return
+        }
+        if (progressCb && msg.type === 'progress') {
           try {
             progressCb(msg.payload.progress)
           } catch (err) {
-            process.off('message', messageHandler)
             completedCb(err)
+            process.off('message', messageHandler)
             // TODO once svm binding supports cancelation,if error is Cancel Error send cancel message
           }
         }
 
-        if (msg.type === 'done' && msg.id === id) {
-          process.off('message', messageHandler)
+        if (msg.type === 'done') {
           completedCb(undefined, msg.payload.result)
+          process.off('message', messageHandler)
         }
 
-        if (msg.type === 'error' && msg.id === id) {
-          process.off('message', messageHandler)
+        if (msg.type === 'error') {
           completedCb(msg.payload.error)
+          process.off('message', messageHandler)
         }
       }
 

--- a/src/bp/ml/toolkit.ts
+++ b/src/bp/ml/toolkit.ts
@@ -51,11 +51,9 @@ function overloadTrainers() {
           try {
             progressCb(msg.payload.progress)
           } catch (err) {
-            if (err.name === 'CancelError') {
-              process.off('message', messageHandler)
-              // process.send!({ type: 'cancel', id })
-              completedCb(err)
-            }
+            process.off('message', messageHandler)
+            completedCb(err)
+            // TODO once svm binding supports cancelation,if error is Cancel Error send cancel message
           }
         }
 


### PR DESCRIPTION
This fixes an error with training on multiple processes, CancelError was never thrown in ml Toolkit and models were returned as undefined and with the success flag. This would cause a parsing error.