### PR TITLE
fix(core): remove URL port if default

### DIFF
--- a/src/bp/core/server.ts
+++ b/src/bp/core/server.ts
@@ -318,10 +318,17 @@ export default class HTTPServer {
 
     this.setupStaticRoutes(this.app)
 
+    const getHref = (url: string) => {
+      const { href } = new URL(url)
+      return href.substr(0, href.length - 1)
+    }
+
     process.HOST = config.host
     process.PORT = await portFinder.getPortPromise({ port: config.port })
-    process.EXTERNAL_URL = process.env.EXTERNAL_URL || config.externalUrl || `http://${process.HOST}:${process.PORT}`
-    process.LOCAL_URL = `http://${process.HOST}:${process.PORT}${process.ROOT_PATH}`
+    process.EXTERNAL_URL = getHref(
+      process.env.EXTERNAL_URL || config.externalUrl || `http://${process.HOST}:${process.PORT}`
+    )
+    process.LOCAL_URL = getHref(`http://${process.HOST}:${process.PORT}${process.ROOT_PATH}`)
 
     if (process.PORT !== config.port) {
       this.logger.warn(`Configured port ${config.port} is already in use. Using next port available: ${process.PORT}`)


### PR DESCRIPTION
Currently, when the port is the default one for the URL protocol (namely `80` and `443`), this port is always shown in all URLs.

This PR uses `new URL(input).href` to normalize the URL (and remove the port if default).

However, `URL.href` actually contains a trailing slash, and this is what isn't expected in other places.

This PR uses the old behavior, but potentially removes the port (if default).

I would suggest that another PR to be raised for showing the user:

    Botpress is listening at: http://localhost/

with changing all usage so we don't have double slashes e.g. `http://localhost//something`