### PR TITLE
fix(bpfs): file exists caused a double read from db

### DIFF
--- a/src/bp/core/services/ghost/db-driver.ts
+++ b/src/bp/core/services/ghost/db-driver.ts
@@ -60,6 +60,21 @@ export default class DBStorageDriver implements StorageDriver {
     }
   }
 
+  async fileExists(filePath: string): Promise<boolean> {
+    try {
+      const exists = await this.database
+        .knex('srv_ghost_files')
+        .where({ file_path: filePath, deleted: false })
+        .select('file_path')
+        .limit(1)
+        .first()
+
+      return !!exists
+    } catch (e) {
+      throw new VError(e, `[DB Driver] Error checking if file  exists "${filePath}"`)
+    }
+  }
+
   async readFile(filePath: string): Promise<Buffer> {
     try {
       const file = await this.database

--- a/src/bp/core/services/ghost/disk-driver.ts
+++ b/src/bp/core/services/ghost/disk-driver.ts
@@ -42,6 +42,14 @@ export default class DiskStorageDriver implements StorageDriver {
     }
   }
 
+  async fileExists(filePath: string): Promise<boolean> {
+    try {
+      return fse.pathExists(this.resolvePath(filePath))
+    } catch (e) {
+      throw new VError(e, `[Disk Storage] Error deleting file "${filePath}"`)
+    }
+  }
+
   async deleteFile(filePath: string): Promise<void>
   async deleteFile(filePath: string, recordRevision: boolean = false): Promise<void> {
     try {

--- a/src/bp/core/services/ghost/index.ts
+++ b/src/bp/core/services/ghost/index.ts
@@ -3,6 +3,7 @@ import { ReplaceInFileConfig } from 'replace-in-file'
 export interface StorageDriver {
   upsertFile(filePath: string, content: Buffer | string, recordRevision: boolean): Promise<void>
   readFile(filePath: string): Promise<Buffer>
+  fileExists(filePath: string): Promise<boolean>
   deleteFile(filePath: string, recordRevision: boolean): Promise<void>
   deleteDir(dirPath: string): Promise<void>
   directoryListing(

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -575,9 +575,14 @@ export class ScopedGhostService {
 
   async fileExists(rootFolder: string, file: string): Promise<boolean> {
     const fileName = this._normalizeFileName(rootFolder, file)
+    const cacheKey = this.objectCacheKey(fileName)
+
     try {
-      await this.primaryDriver.readFile(fileName)
-      return true
+      if (await this.cache.has(cacheKey)) {
+        return true
+      }
+
+      return this.primaryDriver.fileExists(fileName)
     } catch (err) {
       return false
     }


### PR DESCRIPTION
Previously, doing a fileExists was using readFile beind the scene, so that meant that the BD was loading the whole file in memory just to see if it was there. 

It was then followed by a readFile, which meant that the BD was reading the file twice, and sending it to the server.