### PR TITLE
fix(module): memoizing module config

### DIFF
--- a/src/bp/core/services/module/config-reader.ts
+++ b/src/bp/core/services/module/config-reader.ts
@@ -5,6 +5,7 @@ import _ from 'lodash'
 import { Memoize } from 'lodash-decorators'
 import path from 'path'
 import { VError } from 'verror'
+import yn from 'yn'
 
 import { GhostService } from '../'
 
@@ -195,6 +196,13 @@ export default class ConfigReader {
   // Don't @Memoize() this fn. It only memoizes on the first argument
   // https://github.com/steelsojka/lodash-decorators/blob/master/src/memoize.ts#L15
   public getForBot(moduleId: string, botId: string, ignoreGlobal?: boolean): Promise<Config> {
-    return this.getMerged(moduleId, botId, ignoreGlobal)
+    const cacheKey = `${moduleId}//${botId}//${!!ignoreGlobal}`
+    return this.getForBotMemoized(cacheKey)
+  }
+
+  @Memoize()
+  public getForBotMemoized(cacheKey: string): Promise<Config> {
+    const [moduleId, botId, ignoreGlobal] = cacheKey.split('//')
+    return this.getMerged(moduleId, botId, yn(ignoreGlobal))
   }
 }


### PR DESCRIPTION
getModuleConfig was memoized, however getModuleConfigForBot was being processed EACH time it was being called. That method merges 4 different configurations: 
- Default Values
- Global module config
- Env variables
- Bot module config file

This process is even worse since if there's no bot module config file, it will always hit the database, since the file will never be in cache (since it doesn't exist). 

For example, that config is being read by:
- each message sent to channel web
- each time a single choice is displayed
- each time a QNA message is processed