### PR TITLE
fix(core): disable no repeat policy for new servers

### DIFF
--- a/src/bp/core/config/botpress.config.ts
+++ b/src/bp/core/config/botpress.config.ts
@@ -254,6 +254,12 @@ export type BotpressConfig = {
    */
   showPoweredBy: boolean
   /**
+   * When true, the bot will avoid repeating itself. By default it is disabled.
+   * Use in conjunction with BP_DECISION_MIN_NO_REPEAT to set the time before the bot will repeat itself
+   * @default false
+   */
+  noRepeatPolicy: boolean
+  /**
    * By adding this, you'll make possible to translate a bot in more languages than those supported by your botpress language server
    * Warning: This means that Botpress NLU won't be working properly and you'll need to handle NLU on your own with a **beforeIncoming** Hook.
    * @example [{name: 'Swedish', code: 'sv'}]

--- a/src/bp/core/services/dialog/decision-engine.ts
+++ b/src/bp/core/services/dialog/decision-engine.ts
@@ -2,12 +2,12 @@ import { IO, Logger } from 'botpress/sdk'
 import { ConfigProvider } from 'core/config/config-loader'
 import { WellKnownFlags } from 'core/sdk/enums'
 import { TYPES } from 'core/types'
-import { inject, injectable, tagged } from 'inversify'
+import { inject, injectable, postConstruct, tagged } from 'inversify'
+import { AppLifecycle, AppLifecycleEvents } from 'lifecycle'
 import _ from 'lodash'
 import moment from 'moment'
 import ms from 'ms'
 
-import { CMSService } from '../cms'
 import { EventEngine } from '../middleware/event-engine'
 import { StateManager } from '../middleware/state-manager'
 
@@ -29,12 +29,18 @@ export class DecisionEngine {
     @inject(TYPES.ConfigProvider) private configProvider: ConfigProvider,
     @inject(TYPES.DialogEngine) private dialogEngine: DialogEngine,
     @inject(TYPES.EventEngine) private eventEngine: EventEngine,
-    @inject(TYPES.StateManager) private stateManager: StateManager,
-    @inject(TYPES.CMSService) private cms: CMSService
+    @inject(TYPES.StateManager) private stateManager: StateManager
   ) {}
 
   private readonly MIN_CONFIDENCE = process.env.BP_DECISION_MIN_CONFIENCE || 0.5
   private readonly MIN_NO_REPEAT = ms(process.env.BP_DECISION_MIN_NO_REPEAT || '20s')
+  private noRepeatPolicy = false
+
+  @postConstruct()
+  async initialize() {
+    await AppLifecycle.waitFor(AppLifecycleEvents.CONFIGURATION_LOADED)
+    this.noRepeatPolicy = (await this.configProvider.getBotpressConfig()).noRepeatPolicy
+  }
 
   public async processEvent(sessionId: string, event: IO.IncomingEvent) {
     const isInMiddleOfFlow = _.get(event, 'state.context.currentFlow', false)
@@ -140,7 +146,7 @@ export class DecisionEngine {
 
       if (replies[i].confidence < this.MIN_CONFIDENCE) {
         replies[i].decision = { status: 'dropped', reason: `confidence lower than ${this.MIN_CONFIDENCE}` }
-      } else if (violatesRepeatPolicy) {
+      } else if (this.noRepeatPolicy && violatesRepeatPolicy) {
         replies[i].decision = { status: 'dropped', reason: `bot would repeat itself (within ${this.MIN_NO_REPEAT}ms)` }
       } else if (bestReply) {
         replies[i].decision = { status: 'dropped', reason: 'best suggestion already elected' }

--- a/src/bp/migrations/v12_7_1-1583439770-no_repeat_policy.ts
+++ b/src/bp/migrations/v12_7_1-1583439770-no_repeat_policy.ts
@@ -1,0 +1,16 @@
+import * as sdk from 'botpress/sdk'
+import { Migration } from 'core/services/migration'
+
+const migration: Migration = {
+  info: {
+    description: 'Add no repeat policy in botpress config',
+    target: 'core',
+    type: 'config'
+  },
+  up: async ({ configProvider }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
+    await configProvider.mergeBotpressConfig({ noRepeatPolicy: true })
+    return { success: true, message: 'Configuration updated successfully' }
+  }
+}
+
+export default migration


### PR DESCRIPTION
The policy is disabled for new servers. A migration will add the property to avoid impacting existing bots. Since the duration is a global config, i've made that config also global, since we will remove that in the future. 