### PR TITLE
fix(core): run migration easily

### DIFF
--- a/modules/builtin/src/migrations/v12_5_0-1577776334-text-markdown.ts
+++ b/modules/builtin/src/migrations/v12_5_0-1577776334-text-markdown.ts
@@ -9,6 +9,7 @@ const migration: sdk.ModuleMigration = {
     type: 'content'
   },
   up: async ({ bp, metadata }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
+    let hasChanged = false
     const checkFile = (fileContent: string, nbElements: number) => {
       const parsed = JSON.parse(fileContent)
       return parsed.length === nbElements
@@ -22,6 +23,7 @@ const migration: sdk.ModuleMigration = {
 
           if (!(markdownKey in formData)) {
             formData[markdownKey] = true
+            hasChanged = true
           }
         }
       }
@@ -55,7 +57,10 @@ const migration: sdk.ModuleMigration = {
       await Promise.map(bots.keys(), botId => migrateBotTextContent(botId))
     }
 
-    return { success: true, message: 'Text content type updated successfully' }
+    return {
+      success: true,
+      message: hasChanged ? 'Text content type updated successfully' : 'Property already updated, skipping...'
+    }
   }
 }
 

--- a/modules/code-editor/src/migrations/v12_1_0-1565637584-restrict_rights_on_global_files.ts
+++ b/modules/code-editor/src/migrations/v12_1_0-1565637584-restrict_rights_on_global_files.ts
@@ -53,7 +53,7 @@ const migration: sdk.ModuleMigration = {
 
         for (const role of roles) {
           if (isMigrationAlreadyDone(role.rules)) {
-            return { success: true, message: 'no-need for migration' }
+            return { success: true, message: 'Rules are already updated, skipping...' }
           }
           role.rules.push(...newRules)
         }

--- a/modules/hitl/src/migrations/v12_1_0-1564677070-add_source_column_to_hitl_messages.ts
+++ b/modules/hitl/src/migrations/v12_1_0-1564677070-add_source_column_to_hitl_messages.ts
@@ -13,6 +13,8 @@ const migration: sdk.ModuleMigration = {
 
       if (!exists) {
         await bp.database.schema.alterTable(tableName, table => table.string(column))
+      } else {
+        return { success: true, message: 'Source column already exists, skipping...' }
       }
     } catch (err) {
       return { success: false, message: err.message }

--- a/modules/hitl/src/migrations/v12_1_0-1564677070-add_source_column_to_hitl_messages.ts
+++ b/modules/hitl/src/migrations/v12_1_0-1564677070-add_source_column_to_hitl_messages.ts
@@ -13,14 +13,12 @@ const migration: sdk.ModuleMigration = {
 
       if (!exists) {
         await bp.database.schema.alterTable(tableName, table => table.string(column))
-      } else {
-        return { success: true, message: 'Source column already exists, skipping...' }
       }
+
+      return { success: true, message: exists ? 'Source column created.' : 'Source column already exists, skipping...' }
     } catch (err) {
       return { success: false, message: err.message }
     }
-
-    return { success: true, message: 'Source column created.' }
   }
 }
 

--- a/modules/nlu/src/migrations/v12_7_1-1583507028-prune_and_compress_models.ts
+++ b/modules/nlu/src/migrations/v12_7_1-1583507028-prune_and_compress_models.ts
@@ -9,6 +9,7 @@ const migration: sdk.ModuleMigration = {
     type: 'content'
   },
   up: async ({ bp, metadata }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
+    let hasChanged = false
     const migrateModels = async (bot: sdk.BotConfig) => {
       const ghost = bp.ghost.forBot(bot.id)
 
@@ -22,6 +23,7 @@ const migration: sdk.ModuleMigration = {
             if (!model.hash) {
               return ghost.deleteFile(MODELS_DIR, mod) // model is really outdated
             }
+            hasChanged = true
             return saveModel(ghost, model, model.hash) // Triggers model compression
           } catch (err) {
             // model is probably an archive
@@ -36,7 +38,10 @@ const migration: sdk.ModuleMigration = {
       await Promise.map(bots.values(), migrateModels)
     }
 
-    return { success: true, message: 'Model compression completed successfully' }
+    return {
+      success: true,
+      message: hasChanged ? 'Model compression completed successfully' : 'Nothing to compress, skipping...'
+    }
   }
 }
 

--- a/src/bp/core/services/migration/index.ts
+++ b/src/bp/core/services/migration/index.ts
@@ -25,7 +25,9 @@ const types = {
   content: 'Changes to Content Files (*.json)'
 }
 /**
- * Use a combination of these environment variables to easily test migrations.
+ * Use a combination of these environment variables to easily test migrations.à
+ * TESTMIG_ALL: Runs every migration since 12.0.0
+ * TESTMIG_NEW: Runs new migrations after package.json version
  * TESTMIG_BP_VERSION: Change the target version of your migration
  * TESTMIG_CONFIG_VERSION: Override the current version of the server
  * TESTMIG_IGNORE_COMPLETED: Ignore completed migrations (so they can be run again and again)
@@ -61,11 +63,11 @@ export class MigrationService {
 
     const allMigrations = this.getAllMigrations()
 
-    if (process.core_env.TESTMIG_ALL) {
+    if (process.core_env.TESTMIG_ALL || process.core_env.TESTMIG_NEW) {
       const versions = allMigrations.map(x => x.version).sort(semver.compare)
 
       this.currentVersion = _.last(versions)!
-      configVersion = process.BOTPRESS_VERSION
+      configVersion = yn(process.core_env.TESTMIG_NEW) ? process.BOTPRESS_VERSION : '12.0.0'
     }
 
     const missingMigrations = this.filterMissing(allMigrations, configVersion)
@@ -233,7 +235,11 @@ ${_.repeat(' ', 9)}========================================`)
   }
 
   private async _getCompletedMigrations(): Promise<string[]> {
-    if (yn(process.core_env.TESTMIG_IGNORE_COMPLETED) || yn(process.core_env.TESTMIG_ALL)) {
+    if (
+      yn(process.core_env.TESTMIG_IGNORE_COMPLETED) ||
+      yn(process.core_env.TESTMIG_ALL) ||
+      yn(process.core_env.TESTMIG_NEW)
+    ) {
       return []
     }
 

--- a/src/bp/core/services/migration/index.ts
+++ b/src/bp/core/services/migration/index.ts
@@ -61,10 +61,10 @@ export class MigrationService {
 
     const allMigrations = this.getAllMigrations()
 
-    if (process.env.RUNMIG) {
+    if (process.core_env.TESTMIG_ALL) {
       const versions = allMigrations.map(x => x.version).sort(semver.compare)
 
-      this.currentVersion = versions[versions.length - 1]
+      this.currentVersion = _.last(versions)!
       configVersion = process.BOTPRESS_VERSION
     }
 
@@ -233,7 +233,7 @@ ${_.repeat(' ', 9)}========================================`)
   }
 
   private async _getCompletedMigrations(): Promise<string[]> {
-    if (yn(process.env.TESTMIG_IGNORE_COMPLETED) || yn(process.env.RUNMIG)) {
+    if (yn(process.core_env.TESTMIG_IGNORE_COMPLETED) || yn(process.core_env.TESTMIG_ALL)) {
       return []
     }
 

--- a/src/bp/migrations/v12_7_0-1583166156-pipeline_reviewers.ts
+++ b/src/bp/migrations/v12_7_0-1583166156-pipeline_reviewers.ts
@@ -11,18 +11,24 @@ const migration: Migration = {
   up: async ({ inversify }: MigrationOpts) => {
     const workspaceService = inversify.get<WorkspaceService>(TYPES.WorkspaceService)
     const workspaces = await workspaceService.getWorkspaces()
+    let changed = false
 
     for (const workspace of workspaces) {
       for (const stage of workspace.pipeline) {
-        stage.reviewers = []
-        stage.minimumApprovals = 0
-        stage.reviewSequence = 'parallel'
+        if (!stage.reviewers) {
+          stage.reviewers = []
+          stage.minimumApprovals = 0
+          stage.reviewSequence = 'parallel'
+          changed = true
+        }
       }
     }
 
-    await workspaceService.save(workspaces)
+    if (changed) {
+      await workspaceService.save(workspaces)
+    }
 
-    return { success: true, message: 'Configuration updated successfully' }
+    return { success: true, message: changed ? 'Configuration updated successfully' : 'Nothing to update.' }
   }
 }
 

--- a/src/bp/migrations/v12_7_0-1583166156-pipeline_reviewers.ts
+++ b/src/bp/migrations/v12_7_0-1583166156-pipeline_reviewers.ts
@@ -28,7 +28,7 @@ const migration: Migration = {
       await workspaceService.save(workspaces)
     }
 
-    return { success: true, message: changed ? 'Configuration updated successfully' : 'Nothing to update.' }
+    return { success: true, message: changed ? 'Configuration updated successfully' : 'Nothing to update, skipping...' }
   }
 }
 

--- a/src/bp/migrations/v12_7_1-1583439770-no_repeat_policy.ts
+++ b/src/bp/migrations/v12_7_1-1583439770-no_repeat_policy.ts
@@ -8,8 +8,13 @@ const migration: Migration = {
     type: 'config'
   },
   up: async ({ configProvider }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
-    await configProvider.mergeBotpressConfig({ noRepeatPolicy: true })
-    return { success: true, message: 'Configuration updated successfully' }
+    const config = await configProvider.getBotpressConfig()
+    if (config.noRepeatPolicy === undefined) {
+      await configProvider.mergeBotpressConfig({ noRepeatPolicy: true })
+      return { success: true, message: 'Configuration updated successfully' }
+    } else {
+      return { success: true, message: 'Field already exists, skipping...' }
+    }
   }
 }
 

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -192,8 +192,11 @@ declare type BotpressEnvironmentVariables = {
    */
   readonly DISABLE_GLOBAL_SANDBOX?: boolean
 
-  /** Runs all future migrations, ignore completed migrations & sets the config version to the version in package.json */
+  /** Runs all migrations from v12.0.0 up to the latest migration found in modules and core */
   readonly TESTMIG_ALL?: boolean
+
+  /** Runs future migrations, ignore completed migrations & sets the config version to the version in package.json */
+  readonly TESTMIG_NEW?: boolean
 
   /** Migration Testing: Simulate a specific version for the server, ex: 12.5.0 */
   readonly TESTMIG_BP_VERSION?: string

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -192,6 +192,9 @@ declare type BotpressEnvironmentVariables = {
    */
   readonly DISABLE_GLOBAL_SANDBOX?: boolean
 
+  /** Runs all future migrations, ignore completed migrations & sets the config version to the version in package.json */
+  readonly RUNMIG?: boolean
+
   /** Migration Testing: Simulate a specific version for the server, ex: 12.5.0 */
   readonly TESTMIG_BP_VERSION?: string
 

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -193,7 +193,7 @@ declare type BotpressEnvironmentVariables = {
   readonly DISABLE_GLOBAL_SANDBOX?: boolean
 
   /** Runs all future migrations, ignore completed migrations & sets the config version to the version in package.json */
-  readonly RUNMIG?: boolean
+  readonly TESTMIG_ALL?: boolean
 
   /** Migration Testing: Simulate a specific version for the server, ex: 12.5.0 */
   readonly TESTMIG_BP_VERSION?: string


### PR DESCRIPTION
Testing migrations is a pain in the ass, and we almost always have the same use case (test before the package.json version is updated). I added the variable "TESTMIG_NEW" which will:
- Set the current botpress version to the highest detected migration version, 
- Consider the current botpress config version as the one in package.json
- Re-run completed migrations

 I'm leaving the TESTMIG vars there to fine-test migrations

