### PR TITLE
fix(slack): disconnect websocket onBotUnmount

### DIFF
--- a/modules/channel-slack/src/backend/client.ts
+++ b/modules/channel-slack/src/backend/client.ts
@@ -44,6 +44,10 @@ export class SlackClient {
     await this._setupRealtime()
   }
 
+  async shutdown() {
+    if (this.rtm) await this.rtm.disconnect()
+  }
+
   private async _setupInteractiveListener() {
     this.interactive.action({ type: 'button' }, async payload => {
       debugIncoming(`Received interactive message %o`, payload)

--- a/modules/channel-slack/src/backend/client.ts
+++ b/modules/channel-slack/src/backend/client.ts
@@ -45,7 +45,9 @@ export class SlackClient {
   }
 
   async shutdown() {
-    if (this.rtm) await this.rtm.disconnect()
+    if (this.rtm) {
+      await this.rtm.disconnect()
+    }
   }
 
   private async _setupInteractiveListener() {

--- a/modules/channel-slack/src/backend/index.ts
+++ b/modules/channel-slack/src/backend/index.ts
@@ -37,7 +37,7 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
     return
   }
 
-  client.shutdown()
+  await client.shutdown()
   delete clients[botId]
 }
 

--- a/modules/channel-slack/src/backend/index.ts
+++ b/modules/channel-slack/src/backend/index.ts
@@ -37,6 +37,7 @@ const onBotUnmount = async (bp: typeof sdk, botId: string) => {
     return
   }
 
+  client.shutdown()
   delete clients[botId]
 }
 

--- a/modules/channel-slack/src/backend/typings.ts
+++ b/modules/channel-slack/src/backend/typings.ts
@@ -1,1 +1,3 @@
-export type Clients = { [key: string]: any }
+import { SlackClient } from './client'
+
+export type Clients = { [key: string]: SlackClient }


### PR DESCRIPTION
When unmounting a bot then publishing it (without a server restart), the previously initialized websocket stays connected and Slack seems to send its reply to all of them...

In this example, unmount/publish 3 times:
![image](https://user-images.githubusercontent.com/59566773/76175347-944df080-6182-11ea-8a0f-1e04232bed4c.png)

**Note:** We also have to figure something out for the Enterprise version Cluster Mode (each node registers its own websocket, causing the same problem. And it is not just a concurrency issue on startup like we had with telegram).
