### PR TITLE
fix(channel-web): faster load times

### DIFF
--- a/modules/channel-web/src/backend/loader.ts
+++ b/modules/channel-web/src/backend/loader.ts
@@ -1,0 +1,62 @@
+import * as sdk from 'botpress/sdk'
+import ms from 'ms'
+
+import { Config } from '../config'
+
+import Database from './db'
+
+export default class Loader {
+  constructor(private bp: typeof sdk, private db: Database) {}
+
+  async load(userId, botId, convId): Promise<any> {
+    const userP = this.bp.users.getOrCreateUser('web', userId, botId)
+    const moduleConfigP = this.bp.config.getModuleConfig('channel-web') as Promise<Config>
+    const moduleConfigBotP = this.bp.config.getModuleConfigForBot('channel-web', botId) as Promise<Config>
+    const botConfigP = this.bp.bots.getBotById(botId)
+
+    const [user, moduleConfig, moduleConfigBot, botConfig] = await Promise.all([
+      userP,
+      moduleConfigP,
+      moduleConfigBotP,
+      botConfigP
+    ])
+
+    const conversations = await this.db.listConversations(userId, botId)
+
+    let shouldCreate = false
+    if (conversations.length === 0) {
+      shouldCreate = true
+    } else {
+      const lifeTimeMargin = Date.now() - ms(moduleConfigBot.recentConversationLifetime)
+      const isConversationExpired = new Date(conversations[0].last_heard_on).getTime() < lifeTimeMargin
+      shouldCreate = isConversationExpired && moduleConfigBot.startNewConvoOnTimeout
+    }
+
+    if (shouldCreate) {
+      convId = await this.db.createConversation(botId, userId)
+    } else if (!convId) {
+      convId = conversations[0].id
+    }
+
+    const conversation = await this.db.getConversation(userId, convId, botId)
+
+    return {
+      fetchBotInfo: {
+        showBotInfoPage:
+          (moduleConfigBot.infoPage && moduleConfigBot.infoPage.enabled) || moduleConfigBot.showBotInfoPage,
+        name: botConfig.name,
+        description: (moduleConfigBot.infoPage && moduleConfigBot.infoPage.description) || botConfig.description,
+        details: botConfig.details,
+        languages: botConfig.languages,
+        security: moduleConfig.security
+      },
+      fetchConversations: {
+        conversations: [...conversations],
+        startNewConvoOnTimeout: moduleConfigBot.startNewConvoOnTimeout,
+        recentConversationLifetime: moduleConfigBot.recentConversationLifetime
+      },
+      fetchConversation: conversation,
+      fetchPreferences: { language: user.result.attributes.language }
+    }
+  }
+}

--- a/modules/channel-web/src/views/lite/core/api.tsx
+++ b/modules/channel-web/src/views/lite/core/api.tsx
@@ -12,7 +12,7 @@ export default class WebchatApi {
     this.axios = axiosInstance
     this.axios.interceptors.request.use(
       config => {
-        if (!config.url.includes('/botInfo')) {
+        if (!config.url.includes('/botInfo') && !config.url.includes('/setup')) {
           const prefix = config.url.indexOf('?') > 0 ? '&' : '?'
           config.url += prefix + '__ts=' + new Date().getTime()
         }
@@ -44,6 +44,20 @@ export default class WebchatApi {
           'X-BP-ExternalAuth': `Bearer ${externalAuthToken}`
         }
       }
+    }
+  }
+
+  async setup(convId, msg) {
+    try {
+      const data = {
+        botId: window.BOT_ID,
+        userId: this.userId,
+        convId,
+        msg
+      }
+      return this.axios.post(`/setup`, data, this.axiosConfig)
+    } catch (err) {
+      await this.handleApiError(err)
     }
   }
 

--- a/modules/channel-web/src/views/lite/core/socket.tsx
+++ b/modules/channel-web/src/views/lite/core/socket.tsx
@@ -44,6 +44,12 @@ export default class BpSocket {
   /** Waits until the VISITOR ID is set  */
   public waitForUserId(): Promise<void> {
     return new Promise((resolve, reject) => {
+      if (window.__BP_VISITOR_ID) {
+        this.userId = window.__BP_VISITOR_ID
+        this.onUserIdChanged(this.userId)
+        this.postToParent('', { userId: this.userId })
+        resolve()
+      }
       const interval = setInterval(() => {
         if (window.__BP_VISITOR_ID) {
           clearInterval(interval)
@@ -53,12 +59,12 @@ export default class BpSocket {
           this.postToParent('', { userId: this.userId })
           resolve()
         }
-      }, 250)
+      }, 10)
 
       setTimeout(() => {
         clearInterval(interval)
         reject()
-      }, 300000)
+      }, 10000)
     })
   }
 }

--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -27,7 +27,6 @@ class Web extends React.Component<MainProps> {
     super(props)
 
     checkLocationOrigin()
-    initializeAnalytics()
   }
 
   componentDidMount() {
@@ -47,6 +46,8 @@ class Web extends React.Component<MainProps> {
     // tslint:disable-next-line: no-floating-promises
     this.initializeIfChatDisplayed()
     this.props.setLoadingCompleted()
+
+    initializeAnalytics()
   }
 
   componentWillUnmount() {
@@ -65,7 +66,6 @@ class Web extends React.Component<MainProps> {
 
     if (this.props.activeView === 'side' || this.props.isFullscreen) {
       this.hasBeenInitialized = true
-      await this.socket.waitForUserId()
       await this.props.initializeChat()
     }
   }
@@ -93,8 +93,6 @@ class Web extends React.Component<MainProps> {
     config.reference && this.props.setReference()
 
     this.setupObserver()
-    // tslint:disable-next-line: no-floating-promises
-    this.props.fetchBotInfo()
   }
 
   extractConfig() {


### PR DESCRIPTION
Speeds up the load time for the web channel a bit. It's about 2x faster (although this varies a lot).

This was done by batching all the back and forth communication between the client and the server into one big request. There was also an interval somewhere that waited for 250 ms so I reduced it to 10 ms. Also I removed a second use of that interval that was seemingly useless.

Overall the gain in performance is not incredible. Most of the load time (roughly 80%) was left unchanged as it's loading dependencies and executing code that isn't part of the web channel. If we want to get even more performance (I'm thinking 10x faster), we should look into removing most of the frontend dependencies for the web channel.

For example, examining some of the logic it seems that the web channel loads ui-admin as a dependency (34,000+ lines)? If that's the case I can see why it's so slow. Even the bundle of the channel-web itself is 32,000+ lines of code which is way too large. React dev tools (8000+ lines) are also downloaded (whether or not you are in production mode).

As for Google Analytics we load a measly 2000 lines of code and anyways it can be loaded last so this dependency is alright.

So in total we're loading 75,000+ lines of JS code for a textbox and a send button (and some carousels). At this point I wouldn't be surprised if our web channel integration was larger than the websites it's being integrated on.