### PR TITLE
fix(ndu): intent sync with topics

### DIFF
--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -17,7 +17,7 @@ import {
   getIntent,
   getIntents,
   saveIntent,
-  syncIntentTopics,
+  updateContextsFromTopics,
   updateIntent
 } from './intents/intent-service'
 import recommendations from './intents/recommendations'
@@ -153,7 +153,7 @@ export default async (bp: typeof sdk, state: NLUState) => {
     if (action === 'delete' || action === 'create') {
       try {
         const ghost = bp.ghost.forBot(req.params.botId)
-        await syncIntentTopics(ghost, [condition.params.intentName])
+        await updateContextsFromTopics(ghost, [condition.params.intentName])
         return res.sendStatus(200)
       } catch (err) {
         return res.status(400).send(err.message)
@@ -169,7 +169,7 @@ export default async (bp: typeof sdk, state: NLUState) => {
     const ghost = bp.ghost.forBot(botId)
 
     try {
-      await syncIntentTopics(ghost, intentNames)
+      await updateContextsFromTopics(ghost, intentNames)
       res.sendStatus(200)
     } catch (err) {
       bp.logger

--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -16,8 +16,8 @@ import {
   deleteIntent,
   getIntent,
   getIntents,
-  getIntentsTopics,
   saveIntent,
+  syncIntentTopics,
   updateIntent
 } from './intents/intent-service'
 import recommendations from './intents/recommendations'
@@ -146,26 +146,37 @@ export default async (bp: typeof sdk, state: NLUState) => {
     }
   })
 
-  router.post('/refreshIntentsTopics', async (req, res) => {
+  router.post('/condition/intentChanged', async (req, res) => {
+    const { action } = req.body
+    const condition = req.body.condition as sdk.DecisionTriggerCondition
+
+    if (action === 'delete' || action === 'create') {
+      try {
+        const ghost = bp.ghost.forBot(req.params.botId)
+        await syncIntentTopics(ghost, [condition.params.intentName])
+        return res.sendStatus(200)
+      } catch (err) {
+        return res.status(400).send(err.message)
+      }
+    }
+
+    res.sendStatus(200)
+  })
+
+  router.post('/sync/intents/topics', async (req, res) => {
     const { botId } = req.params
     const { intentNames } = req.body
     const ghost = bp.ghost.forBot(botId)
 
     try {
-      const intentTopics = await getIntentsTopics(ghost, intentNames)
-      for (const intentName of intentNames) {
-        const intentDef = await getIntent(ghost, intentName)
-        intentDef.contexts = intentTopics.filter(x => x.intentName === intentName).map(x => x.topicName)
-        await saveIntent(ghost, intentDef)
-      }
-
+      await syncIntentTopics(ghost, intentNames)
       res.sendStatus(200)
     } catch (err) {
       bp.logger
         .forBot(botId)
         .attachError(err)
         .error('Could not update intent topics')
-      res.sendStatus(400)
+      res.status(400).send(err.message)
     }
   })
 

--- a/modules/nlu/src/backend/conditions.ts
+++ b/modules/nlu/src/backend/conditions.ts
@@ -6,6 +6,7 @@ export const dialogConditions: sdk.Condition[] = [
     id: 'user_intent_is',
     label: 'User asks something (intent)',
     description: `The user's intention is {intentName}`,
+    callback: '/mod/nlu/condition/intentChanged',
     displayOrder: 0,
     params: {
       intentName: { label: 'Name of intent', type: 'string' }

--- a/modules/nlu/src/backend/intents/intent-service.ts
+++ b/modules/nlu/src/backend/intents/intent-service.ts
@@ -108,7 +108,7 @@ export async function updateIntentsSlotsEntities(
  * This method read every workflow to extract their intent usage, so they can be in sync with their topics.
  * The list of intent names is not required, but it saves some processing
  */
-export async function syncIntentTopics(ghost: sdk.ScopedGhostService, intentNames?: string[]): Promise<void> {
+export async function updateContextsFromTopics(ghost: sdk.ScopedGhostService, intentNames?: string[]): Promise<void> {
   const flowsPaths = await ghost.directoryListing('flows', '*.flow.json')
   const flows: sdk.Flow[] = await Promise.map(flowsPaths, async (flowPath: string) => ({
     name: flowPath,

--- a/modules/nlu/src/backend/intents/intent-service.ts
+++ b/modules/nlu/src/backend/intents/intent-service.ts
@@ -104,26 +104,39 @@ export async function updateIntentsSlotsEntities(
   })
 }
 
-export async function getIntentsTopics(ghost: sdk.ScopedGhostService, intentNames: string[]) {
+/**
+ * This method read every workflow to extract their intent usage, so they can be in sync with their topics.
+ * The list of intent names is not required, but it saves some processing
+ */
+export async function syncIntentTopics(ghost: sdk.ScopedGhostService, intentNames?: string[]): Promise<void> {
   const flowsPaths = await ghost.directoryListing('flows', '*.flow.json')
   const flows: sdk.Flow[] = await Promise.map(flowsPaths, async (flowPath: string) => ({
     name: flowPath,
     ...(await ghost.readFileAsObject<FlowView>('flows', flowPath))
   }))
 
-  const topics: { topicName: string; intentName: string }[] = []
+  const intents: { [intentName: string]: string[] } = {}
+
   for (const flow of flows) {
     const topicName = flow.name.split('/')[0]
-    for (const node of flow.nodes) {
-      if (node.type === 'trigger') {
-        const tn = node as sdk.TriggerNode
-        const match = tn.conditions.find(x => x.id === 'user_intent_is' && intentNames.includes(x.params?.intentName))
-        if (match) {
-          topics.push({ topicName, intentName: match.params.intentName })
-        }
+
+    for (const node of flow.nodes.filter(x => x.type === 'trigger')) {
+      const tn = node as sdk.TriggerNode
+      const match = tn.conditions.find(x => x.id === 'user_intent_is')
+      const name = match?.params?.intentName
+
+      if (name && name !== 'none' && (!intentNames || intentNames.includes(name))) {
+        intents[name] = _.uniq([...(intents[name] || []), topicName])
       }
     }
   }
 
-  return _.uniq(topics)
+  for (const intentName of Object.keys(intents)) {
+    const intentDef = await getIntent(ghost, intentName)
+
+    if (!_.isEqual(intentDef.contexts.sort(), intents[intentName].sort())) {
+      intentDef.contexts = intents[intentName]
+      await saveIntent(ghost, intentDef)
+    }
+  }
 }

--- a/modules/nlu/src/views/api.ts
+++ b/modules/nlu/src/views/api.ts
@@ -7,7 +7,7 @@ export interface NLUApi {
   fetchIntent: (x: string) => Promise<NLU.IntentDefinition>
   createIntent: (x: Partial<NLU.IntentDefinition>) => Promise<any>
   updateIntent: (targetIntent: string, intent: Partial<NLU.IntentDefinition>, updateTopics?: boolean) => Promise<any>
-  refreshIntentTopics: (intentNames: string[]) => Promise<void>
+  syncIntentTopics: (intentNames?: string[]) => Promise<void>
   deleteIntent: (x: string) => Promise<any>
   fetchEntities: () => Promise<NLU.EntityDefinition[]>
   fetchEntity: (x: string) => Promise<NLU.EntityDefinition>
@@ -32,7 +32,7 @@ export const makeApi = (bp: { axios: AxiosInstance }): NLUApi => ({
   updateIntent: (targetIntent: string, intent: Partial<NLU.IntentDefinition>) =>
     bp.axios.post(`/mod/nlu/intents/${targetIntent}`, intent),
   deleteIntent: (name: string) => bp.axios.post(`/mod/nlu/intents/${name}/delete`),
-  refreshIntentTopics: (intentNames: string[]) => bp.axios.post(`/mod/nlu/refreshIntentsTopics`, { intentNames }),
+  syncIntentTopics: (intentNames?: string[]) => bp.axios.post(`/mod/nlu/sync/intents/topics`, { intentNames }),
   fetchEntities: () => bp.axios.get('/mod/nlu/entities').then(res => res.data),
   fetchEntity: (entityName: string) => bp.axios.get(`/mod/nlu/entities/${entityName}`).then(res => res.data),
   createEntity: (entity: NLU.EntityDefinition) => bp.axios.post(`/mod/nlu/entities/`, entity),

--- a/modules/nlu/src/views/full/intents/LiteEditor.tsx
+++ b/modules/nlu/src/views/full/intents/LiteEditor.tsx
@@ -39,7 +39,7 @@ export const LiteEditor: FC<Props> = props => {
     // Ensure the current topic is in the intent's contexts
     if (props.forceSave && dirtyIntents.length) {
       // tslint:disable-next-line: no-floating-promises
-      api.refreshIntentTopics([...dirtyIntents, currentIntent])
+      api.syncIntentTopics()
     }
   }, [props.forceSave])
 

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -1173,6 +1173,8 @@ declare module 'botpress/sdk' {
     params?: ConditionParams
     /** In which order the conditions will be displayed in the dropdown menu. 0 is the first item */
     displayOrder?: number
+    /** This callback url is called when the condition is deleted or pasted in the flow */
+    callback?: string
     /** The editor will use the custom component to provide the requested parameters */
     editor?: {
       module: string

--- a/src/bp/ui-shared/src/typings.d.ts
+++ b/src/bp/ui-shared/src/typings.d.ts
@@ -9,7 +9,7 @@ declare module 'botpress/shared' {
   export function BaseDialog(props: BaseDialogProps): JSX.Element
   export function DialogBody(props: { children: any }): JSX.Element
   export function DialogFooter(props: { children: any }): JSX.Element
-  export function confirmDialog(message: string, options: ConfirmDialogOptions): Promise<boolean>
+  export function confirmDialog(message: string | JSX.Element, options: ConfirmDialogOptions): Promise<boolean>
   export function Dropdown(props: DropdownProps): JSX.Element
   export function TreeView<T>(props: TreeViewProps<T>): JSX.Element
 

--- a/src/bp/ui-studio/src/web/actions/index.ts
+++ b/src/bp/ui-studio/src/web/actions/index.ts
@@ -175,7 +175,7 @@ export const removeFlowNode = wrapAction(requestRemoveFlowNode, async (payload, 
     await FlowsAPI.deleteFlow(state.flows, deletedFlows[0])
   }
 
-  if (payload.type === 'trigger') {
+  if (payload.type === 'trigger' && window.USE_ONEFLOW) {
     await onTriggerEvent('delete', payload.conditions, state)
   }
 })
@@ -185,7 +185,7 @@ export const pasteFlowNode = wrapAction(requestPasteFlowNode, async (payload, st
 
   const node = state.flows.nodeInBuffer
 
-  if (node.type === 'trigger') {
+  if (node.type === 'trigger' && window.USE_ONEFLOW) {
     await onTriggerEvent('create', node.conditions, state)
   }
 })

--- a/src/bp/ui-studio/src/web/actions/index.ts
+++ b/src/bp/ui-studio/src/web/actions/index.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import * as sdk from 'botpress/sdk'
 import { FlowView } from 'common/typings'
 import _ from 'lodash'
 import { createAction } from 'redux-actions'
@@ -11,6 +12,17 @@ import BatchRunner from './BatchRunner'
 export default function debounceAction(action: any, delay: number, options?: _.DebounceSettings) {
   const debounced = _.debounce((dispatch, actionArgs) => dispatch(action(...actionArgs)), delay, options)
   return (...actionArgs) => dispatch => debounced(dispatch, actionArgs)
+}
+
+const onTriggerEvent = async (action: 'delete' | 'create', conditions: sdk.DecisionTriggerCondition[], state) => {
+  const conditionDefs = state.ndu.conditions as sdk.Condition[]
+
+  for (const condition of conditions) {
+    const callback = conditionDefs.find(x => x.id === condition.id)?.callback
+    if (callback) {
+      await axios.post(`${window.BOT_API_PATH}/${callback}`, { action, condition })
+    }
+  }
 }
 
 // Flows
@@ -162,9 +174,21 @@ export const removeFlowNode = wrapAction(requestRemoveFlowNode, async (payload, 
   if (deletedFlows.length) {
     await FlowsAPI.deleteFlow(state.flows, deletedFlows[0])
   }
+
+  if (payload.type === 'trigger') {
+    await onTriggerEvent('delete', payload.conditions, state)
+  }
 })
 
-export const pasteFlowNode = wrapAction(requestPasteFlowNode, updateCurrentFlow)
+export const pasteFlowNode = wrapAction(requestPasteFlowNode, async (payload, state) => {
+  await updateCurrentFlow(payload, state)
+
+  const node = state.flows.nodeInBuffer
+
+  if (node.type === 'trigger') {
+    await onTriggerEvent('create', node.conditions, state)
+  }
+})
 export const pasteFlowNodeElement = wrapAction(requestPasteFlowNodeElement, updateCurrentFlow)
 
 // actions that do not modify flow

--- a/src/bp/ui-studio/src/web/components/Shared/Utils/Toaster.tsx
+++ b/src/bp/ui-studio/src/web/components/Shared/Utils/Toaster.tsx
@@ -16,8 +16,10 @@ export const toastSuccess = (
 export const toastFailure = (
   message: string,
   timeout: Timeout = Timeout.MEDIUM,
-  onDismiss?: (didTimeoutExpire: boolean) => void
-) => toast(message, Intent.DANGER, timeout, onDismiss)
+  onDismiss?: (didTimeoutExpire: boolean) => void,
+  // Must be delayed when used in a lifecycle event (eg: useEffect)
+  options?: { delayed: boolean }
+) => toast(message, Intent.DANGER, timeout, onDismiss, options)
 
 export const toastInfo = (
   message: string,
@@ -25,11 +27,21 @@ export const toastInfo = (
   onDismiss?: (didTimeoutExpire: boolean) => void
 ) => toast(message, Intent.PRIMARY, timeout, onDismiss)
 
-const toast = (message, intent, timeout, onDismiss) => {
-  Toaster.create({ className: 'recipe-toaster', position: Position.TOP_RIGHT }).show({
-    message,
-    intent,
-    timeout,
-    onDismiss
-  })
+const toast = (message, intent, timeout, onDismiss, options?) => {
+  const showToast = () => {
+    Toaster.create({ className: 'recipe-toaster', position: Position.TOP_RIGHT }).show({
+      message,
+      intent,
+      timeout,
+      onDismiss
+    })
+  }
+
+  if (!options.delayed) {
+    showToast()
+  } else {
+    setTimeout(() => {
+      showToast()
+    }, 500)
+  }
 }

--- a/src/bp/ui-studio/src/web/reducers/flows.ts
+++ b/src/bp/ui-studio/src/web/reducers/flows.ts
@@ -669,7 +669,7 @@ reducer = reduceReducers(
 
       [requestRemoveFlowNode]: (state, { payload }) => {
         const flowsToRemove = []
-        const nodeToRemove = _.find(state.flowsByName[state.currentFlow].nodes, { id: payload })
+        const nodeToRemove = _.find(state.flowsByName[state.currentFlow].nodes, { id: payload?.id })
 
         if (nodeToRemove.type === 'skill-call') {
           if (findNodesThatReferenceFlow(state, nodeToRemove.flow).length <= 1) {
@@ -684,7 +684,7 @@ reducer = reduceReducers(
             ..._.omit(state.flowsByName, flowsToRemove),
             [state.currentFlow]: {
               ...state.flowsByName[state.currentFlow],
-              nodes: state.flowsByName[state.currentFlow].nodes.filter(node => node.id !== payload)
+              nodes: state.flowsByName[state.currentFlow].nodes.filter(node => node.id !== payload.id)
             }
           }
         }

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
@@ -408,7 +408,7 @@ class Diagram extends Component<Props> {
           _.includes(nodeTypes, element.nodeType) ||
           _.includes(nodeTypes, element.type)
         ) {
-          this.props.removeFlowNode(element.id)
+          this.props.removeFlowNode(element)
         } else if (element.type === 'default') {
           element.remove()
           this.checkForLinksUpdate()

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/TriggerEditor/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/TriggerEditor/index.tsx
@@ -1,4 +1,5 @@
 import { Button, ButtonGroup, Intent } from '@blueprintjs/core'
+import axios from 'axios'
 import { Condition } from 'botpress/sdk'
 import { confirmDialog } from 'botpress/shared'
 import cx from 'classnames'
@@ -87,9 +88,14 @@ const EditGoalModal: FC<Props> = props => {
     save([...conditions])
   }
 
-  const onConditionDeleted = async ({ id }: Condition) => {
+  const onConditionDeleted = async (condition: Condition) => {
     if (await confirmDialog('Are you sure to delete this condition?', { acceptLabel: 'Delete' })) {
-      save([...conditions.filter(condition => condition.id !== id)])
+      save([...conditions.filter(cond => cond.id !== condition.id)])
+
+      const def = props.backendConditions.find(x => x.id === condition.id)
+      if (def.callback) {
+        await axios.post(`${window.BOT_API_PATH}/${def.callback}`, { action: 'delete', condition })
+      }
     }
   }
 

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/index.tsx
@@ -92,7 +92,7 @@ interface DispatchProps {
   fetchFlows: any
   pasteFlowNode: ({ x, y }) => void
   copyFlowNode: () => void
-  removeFlowNode: (nodeId: string) => void
+  removeFlowNode: (element: any) => void
   buildSkill: ({ location: any, id: string }) => void
 }
 
@@ -513,7 +513,7 @@ class Diagram extends Component<Props> {
           _.includes(nodeTypes, element.nodeType) ||
           _.includes(nodeTypes, element.type)
         ) {
-          this.props.removeFlowNode(element.id)
+          this.props.removeFlowNode(element)
         } else if (element.type === 'default') {
           element.remove()
           this.checkForLinksUpdate()

--- a/src/bp/ui-studio/src/web/views/OneFlow/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/index.tsx
@@ -88,7 +88,7 @@ const FlowBuilder = (props: Props) => {
         status === 403
           ? 'Unauthorized flow update. You have insufficient role privileges to modify flows.'
           : 'There was an error while saving, deleting or renaming a flow. Last modification might not have been saved on server. Please reload page before continuing flow edition'
-      toastFailure(message, Timeout.LONG, props.clearErrorSaveFlows)
+      toastFailure(message, Timeout.LONG, props.clearErrorSaveFlows, { delayed: true })
     }
   }, [props.errorSavingFlows])
 


### PR DESCRIPTION
When a NLU trigger node is deleted or copy/pasted, conditions can register a callback URL to be aware of those events. It is also triggered when the condition is deleted from the trigger.

This fixes a bunch of sync issues, where intents were not in the corresponding topic.