### PR TITLE
fix(flow): show invalid transitions in red

### DIFF
--- a/src/bp/ui-shared/src/typings.d.ts
+++ b/src/bp/ui-shared/src/typings.d.ts
@@ -9,7 +9,7 @@ declare module 'botpress/shared' {
   export function BaseDialog(props: BaseDialogProps): JSX.Element
   export function DialogBody(props: { children: any }): JSX.Element
   export function DialogFooter(props: { children: any }): JSX.Element
-  export function confirmDialog(message: string, options: ConfirmDialogOptions): Promise<boolean>
+  export function confirmDialog(message: string | JSX.Element, options: ConfirmDialogOptions): Promise<boolean>
   export function Dropdown(props: DropdownProps): JSX.Element
   export function TreeView<T>(props: TreeViewProps<T>): JSX.Element
 

--- a/src/bp/ui-studio/src/web/reducers/selectors.ts
+++ b/src/bp/ui-studio/src/web/reducers/selectors.ts
@@ -11,6 +11,11 @@ export const getAllFlows = createSelector([_getFlowsByName], flowsByName => {
   return _.values(flowsByName)
 })
 
+export const getFlowNames = createSelector([getAllFlows], flows => {
+  const normalFlows = _.reject(flows, x => x.name && x.name.startsWith('skills/'))
+  return normalFlows.map(x => x.name)
+})
+
 export const getFlowNamesList = createSelector([getAllFlows], flows => {
   const normalFlows = _.reject(flows, x => x.name && x.name.startsWith('skills/'))
 

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/Ports.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/Ports.tsx
@@ -4,7 +4,7 @@ import classnames from 'classnames'
 import _ from 'lodash'
 import React from 'react'
 import { connect } from 'react-redux'
-import { RouteComponentProps, withRouter } from 'react-router-dom'
+import { Link, RouteComponentProps, withRouter } from 'react-router-dom'
 import { DefaultPortModel, PortWidget } from 'storm-react-diagrams'
 import { getFlowNames, getFlowNamesList } from '~/reducers'
 
@@ -51,17 +51,15 @@ type Props = {
 export class StandardPortWidgetDisconnected extends React.PureComponent<Props> {
   renderSubflowNode() {
     const index = Number(this.props.name.replace('out', ''))
-    const subflow = this.props.next[index].node.replace(/\.flow\.json$/i, '')
-    const isInvalid = !this.props.flowsName.find(x => x === this.props.next[index].node)
+    const subflow = this.props.node.next[index].node.replace(/\.flow\.json$/i, '')
+    const isInvalid = !this.props.flowsName.find(x => x === this.props.node.next[index].node)
 
     return (
       <div className={classnames(style.label, { [style.invalidFlow]: isInvalid })}>
         {isInvalid ? (
           <Tooltip content="The destination for this transition is invalid">{subflow}</Tooltip>
         ) : (
-          <a href="javascript:void(0);" onClick={() => this.props.history.push(`/flows/${subflow}`)}>
-            {subflow}
-          </a>
+          <Link to={`/flows/${subflow}`}>{subflow}</Link>
         )}
       </div>
     )

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/Ports.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/Ports.tsx
@@ -1,8 +1,12 @@
+import { Tooltip } from '@blueprintjs/core'
+import * as sdk from 'botpress/sdk'
 import classnames from 'classnames'
 import _ from 'lodash'
 import React from 'react'
+import { connect } from 'react-redux'
 import { RouteComponentProps, withRouter } from 'react-router-dom'
 import { DefaultPortModel, PortWidget } from 'storm-react-diagrams'
+import { getFlowNames, getFlowNamesList } from '~/reducers'
 
 import { newNodeTypes } from '../manager'
 
@@ -40,19 +44,25 @@ type Props = {
   className?: string
   name: string
   node: any
+  next?: sdk.NodeTransition[]
+  flowsName: any
 } & RouteComponentProps
 
-export class StandardPortWidgetDisconnected extends React.Component<Props> {
+export class StandardPortWidgetDisconnected extends React.PureComponent<Props> {
   renderSubflowNode() {
-    const node = this.props.node
     const index = Number(this.props.name.replace('out', ''))
-    const subflow = node.next[index].node.replace(/\.flow\.json$/i, '')
+    const subflow = this.props.next[index].node.replace(/\.flow\.json$/i, '')
+    const isInvalid = !this.props.flowsName.find(x => x === this.props.next[index].node)
 
     return (
-      <div className={style.label}>
-        <a href="javascript:void(0);" onClick={() => this.props.history.push(`/flows/${subflow}`)}>
-          {subflow}
-        </a>
+      <div className={classnames(style.label, { [style.invalidFlow]: isInvalid })}>
+        {isInvalid ? (
+          <Tooltip content="The destination for this transition is invalid">{subflow}</Tooltip>
+        ) : (
+          <a href="javascript:void(0);" onClick={() => this.props.history.push(`/flows/${subflow}`)}>
+            {subflow}
+          </a>
+        )}
       </div>
     )
   }
@@ -122,4 +132,6 @@ export class StandardPortWidgetDisconnected extends React.Component<Props> {
   }
 }
 
-export const StandardPortWidget = withRouter(StandardPortWidgetDisconnected)
+const mapStateToProps = state => ({ flowsName: getFlowNames(state) })
+
+export const StandardPortWidget = connect(mapStateToProps)(withRouter(StandardPortWidgetDisconnected))

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/StandardNode.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/StandardNode.tsx
@@ -47,7 +47,7 @@ export class StandardNodeWidget extends Component<{ node: StandardNodeModel; dia
                 return (
                   <div key={`${i}.${item}`} className={classnames(style.item)}>
                     <ConditionItem condition={item} position={i} />
-                    <StandardPortWidget name={outputPortName} node={node} />
+                    <StandardPortWidget name={outputPortName} node={node} next={node.next} />
                   </div>
                 )
               })}

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/style.scss
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/style.scss
@@ -167,6 +167,10 @@
   color: blue;
 }
 
+.subflowPort .invalidFlow {
+  color: red !important;
+}
+
 .returnPort .label {
   color: darkcyan;
 }

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/style.scss.d.ts
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/style.scss.d.ts
@@ -5,6 +5,7 @@ interface CssExports {
   'fn': string;
   'highlightedNode': string;
   'iconContainer': string;
+  'invalidFlow': string;
   'item': string;
   'label': string;
   'missingConnection': string;


### PR DESCRIPTION
Shows invalid transitions in red, instead of a clickable link

![image](https://user-images.githubusercontent.com/42552874/76814419-1c5e7680-67d1-11ea-83b5-a76860350aef.png)
