### PR TITLE
fix(studio): better typings

### DIFF
--- a/src/bp/common/typings.ts
+++ b/src/bp/common/typings.ts
@@ -155,6 +155,11 @@ export interface ServerConfig {
   live: { [keyName: string]: string }
 }
 
+export interface NodeProblem {
+  nodeName: string
+  missingPorts: any
+}
+
 export interface ChatUserAuth {
   sessionId: string
   botId: string

--- a/src/bp/ui-studio/src/web/actions/index.ts
+++ b/src/bp/ui-studio/src/web/actions/index.ts
@@ -94,7 +94,7 @@ export const receiveSaveFlows = createAction(
   () => ({ receiveAt: new Date() })
 )
 export const errorSaveFlows = createAction('FLOWS/SAVE/ERROR')
-export const clearErrorSaveFlows = createAction('FLOWS/SAVE/ERROR/CLEAR')
+export const clearErrorSaveFlows: () => void = createAction('FLOWS/SAVE/ERROR/CLEAR')
 
 // actions that modifies flow
 export const requestUpdateFlow = createAction('FLOWS/FLOW/UPDATE')
@@ -228,7 +228,7 @@ export const flowEditorRedo = wrapAction(handleFlowEditorRedo, async (payload, s
   await createNewFlows(state)
 })
 
-export const setDiagramAction = createAction('FLOWS/FLOW/SET_ACTION')
+export const setDiagramAction: (action: string) => void = createAction('FLOWS/FLOW/SET_ACTION')
 
 // Content
 export const receiveContentCategories = createAction('CONTENT/CATEGORIES/RECEIVE')

--- a/src/bp/ui-studio/src/web/actions/index.ts
+++ b/src/bp/ui-studio/src/web/actions/index.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import * as sdk from 'botpress/sdk'
-import { FlowView } from 'common/typings'
+import { FlowPoint, FlowView, NodeProblem } from 'common/typings'
 import _ from 'lodash'
 import { createAction } from 'redux-actions'
 
@@ -115,7 +115,7 @@ const wrapAction = (
   asyncCallback: (payload, state, dispatch) => Promise<any>,
   receiveAction = receiveSaveFlows,
   errorAction = errorSaveFlows
-) => payload => (dispatch, getState) => {
+) => (payload?: any) => (dispatch, getState) => {
   dispatch(requestAction(payload))
   // tslint:disable-next-line: no-floating-promises
   asyncCallback(payload, getState(), dispatch)
@@ -138,35 +138,44 @@ const saveDirtyFlows = async state => {
   return Promise.all(promises)
 }
 
-export const updateFlow = wrapAction(requestUpdateFlow, updateCurrentFlow)
+export const updateFlow: (flow: Partial<FlowView>) => void = wrapAction(requestUpdateFlow, updateCurrentFlow)
 
-export const renameFlow = wrapAction(requestRenameFlow, async (payload, state) => {
-  const { targetFlow, name } = payload
-  await FlowsAPI.renameFlow(state.flows, targetFlow, name)
-  await saveDirtyFlows(state)
-})
+export const renameFlow: (flow: { targetFlow: string; name: string }) => void = wrapAction(
+  requestRenameFlow,
+  async (payload, state) => {
+    const { targetFlow, name } = payload
+    await FlowsAPI.renameFlow(state.flows, targetFlow, name)
+    await saveDirtyFlows(state)
+  }
+)
 
-export const createFlow = wrapAction(requestCreateFlow, async (payload, state) => {
+export const createFlow: (name: string) => void = wrapAction(requestCreateFlow, async (payload, state) => {
   const name = payload
   const flowState = state.flows
   await FlowsAPI.createFlow(flowState, name)
 })
 
-export const deleteFlow = wrapAction(requestDeleteFlow, async (payload, state) => {
+export const deleteFlow: (flowName: string) => void = wrapAction(requestDeleteFlow, async (payload, state) => {
   await FlowsAPI.deleteFlow(state.flows, payload)
   await saveDirtyFlows(state)
 })
 
-export const duplicateFlow = wrapAction(requestDuplicateFlow, async (payload, state) => {
-  const { name } = payload
-  const flowState = state.flows
-  await FlowsAPI.createFlow(flowState, name)
-})
+export const duplicateFlow: (flow: { flowNameToDuplicate: string; name: string }) => void = wrapAction(
+  requestDuplicateFlow,
+  async (payload, state) => {
+    const { name } = payload
+    const flowState = state.flows
+    await FlowsAPI.createFlow(flowState, name)
+  }
+)
 
-export const updateFlowNode = wrapAction(requestUpdateFlowNode, updateCurrentFlow)
-export const createFlowNode = wrapAction(requestCreateFlowNode, updateCurrentFlow)
+type AllPartialNode = (Partial<sdk.FlowNode> | Partial<sdk.TriggerNode> | Partial<sdk.ListenNode>) & Partial<FlowPoint>
 
-export const removeFlowNode = wrapAction(requestRemoveFlowNode, async (payload, state) => {
+export const updateFlowNode: (props: AllPartialNode) => void = wrapAction(requestUpdateFlowNode, updateCurrentFlow)
+
+export const createFlowNode: (props: AllPartialNode) => void = wrapAction(requestCreateFlowNode, updateCurrentFlow)
+
+export const removeFlowNode: (element: any) => void = wrapAction(requestRemoveFlowNode, async (payload, state) => {
   await updateCurrentFlow(payload, state)
 
   // If node is a skill and there's no references to it, then the complete flow is deleted
@@ -180,7 +189,7 @@ export const removeFlowNode = wrapAction(requestRemoveFlowNode, async (payload, 
   }
 })
 
-export const pasteFlowNode = wrapAction(requestPasteFlowNode, async (payload, state) => {
+export const pasteFlowNode: ({ x, y }) => void = wrapAction(requestPasteFlowNode, async (payload, state) => {
   await updateCurrentFlow(payload, state)
 
   const node = state.flows.nodeInBuffer
@@ -192,28 +201,30 @@ export const pasteFlowNode = wrapAction(requestPasteFlowNode, async (payload, st
 export const pasteFlowNodeElement = wrapAction(requestPasteFlowNodeElement, updateCurrentFlow)
 
 // actions that do not modify flow
-export const switchFlow = createAction('FLOWS/SWITCH')
-export const switchFlowNode = createAction('FLOWS/FLOW/SWITCH_NODE')
-export const openFlowNodeProps = createAction('FLOWS/FLOW/OPEN_NODE_PROPS')
-export const closeFlowNodeProps = createAction('FLOWS/FLOW/CLOSE_NODE_PROPS')
+export const switchFlow: (flowName: string) => void = createAction('FLOWS/SWITCH')
+export const switchFlowNode: (nodeId: string) => void = createAction('FLOWS/FLOW/SWITCH_NODE')
+export const openFlowNodeProps: () => void = createAction('FLOWS/FLOW/OPEN_NODE_PROPS')
+export const closeFlowNodeProps: () => void = createAction('FLOWS/FLOW/CLOSE_NODE_PROPS')
 
 export const handleRefreshFlowLinks = createAction('FLOWS/FLOW/UPDATE_LINKS')
 export const refreshFlowsLinks = debounceAction(handleRefreshFlowLinks, 500, { leading: true })
-export const updateFlowProblems = createAction('FLOWS/FLOW/UPDATE_PROBLEMS')
+export const updateFlowProblems: (problems: NodeProblem[]) => void = createAction('FLOWS/FLOW/UPDATE_PROBLEMS')
 
-export const copyFlowNode = createAction('FLOWS/NODE/COPY')
+export const copyFlowNode: () => void = createAction('FLOWS/NODE/COPY')
 export const copyFlowNodeElement = createAction('FLOWS/NODE_ELEMENT/COPY')
 
 export const handleFlowEditorUndo = createAction('FLOWS/EDITOR/UNDO')
 export const handleFlowEditorRedo = createAction('FLOWS/EDITOR/REDO')
 
 export const flowEditorUndo = wrapAction(handleFlowEditorUndo, async (payload, state, dispatch) => {
+  console.log(payload)
   dispatch(refreshFlowsLinks())
   await updateCurrentFlow(payload, state)
   await createNewFlows(state)
 })
 
 export const flowEditorRedo = wrapAction(handleFlowEditorRedo, async (payload, state, dispatch) => {
+  console.log(payload)
   dispatch(refreshFlowsLinks())
   await updateCurrentFlow(payload, state)
   await createNewFlows(state)
@@ -252,7 +263,7 @@ const getBatchedContentItem = id => getBatchedContentRunner.add(id)
 const getSingleContentItem = id => axios.get(`${window.BOT_API_PATH}/content/element/${id}`).then(({ data }) => data)
 
 export const receiveContentItem = createAction('CONTENT/ITEMS/RECEIVE_ONE')
-export const fetchContentItem = (id, { force = false, batched = false } = {}) => (dispatch, getState) => {
+export const fetchContentItem = (id: string, { force = false, batched = false } = {}) => (dispatch, getState) => {
   if (!id || (!force && getState().content.itemsById[id])) {
     return Promise.resolve()
   }
@@ -339,7 +350,7 @@ export const requestInsertNewSkill = createAction('SKILLS/INSERT')
 export const requestInsertNewSkillNode = createAction('SKILLS/INSERT/NODE')
 export const requestUpdateSkill = createAction('SKILLS/UPDATE')
 
-export const buildNewSkill = createAction('SKILLS/BUILD')
+export const buildNewSkill: ({ location: any, id: string }) => void = createAction('SKILLS/BUILD')
 export const cancelNewSkill = createAction('SKILLS/BUILD/CANCEL')
 
 export const insertNewSkill = wrapAction(requestInsertNewSkill, async (payload, state) => {
@@ -442,14 +453,14 @@ export const refreshLibrary = () => (dispatch, getState) => {
   })
 }
 
-export const addElementToLibrary = elementId => dispatch => {
+export const addElementToLibrary = (elementId: string) => dispatch => {
   // tslint:disable-next-line: no-floating-promises
   axios.post(`${window.BOT_API_PATH}/content/library/${elementId}`).then(() => {
     dispatch(refreshLibrary())
   })
 }
 
-export const removeElementFromLibrary = elementId => dispatch => {
+export const removeElementFromLibrary = (elementId: string) => dispatch => {
   // tslint:disable-next-line: no-floating-promises
   axios.post(`${window.BOT_API_PATH}/content/library/${elementId}/delete`).then(() => {
     dispatch(refreshLibrary())

--- a/src/bp/ui-studio/src/web/actions/index.ts
+++ b/src/bp/ui-studio/src/web/actions/index.ts
@@ -217,14 +217,12 @@ export const handleFlowEditorUndo = createAction('FLOWS/EDITOR/UNDO')
 export const handleFlowEditorRedo = createAction('FLOWS/EDITOR/REDO')
 
 export const flowEditorUndo = wrapAction(handleFlowEditorUndo, async (payload, state, dispatch) => {
-  console.log(payload)
   dispatch(refreshFlowsLinks())
   await updateCurrentFlow(payload, state)
   await createNewFlows(state)
 })
 
 export const flowEditorRedo = wrapAction(handleFlowEditorRedo, async (payload, state, dispatch) => {
-  console.log(payload)
   dispatch(refreshFlowsLinks())
   await updateCurrentFlow(payload, state)
   await createNewFlows(state)

--- a/src/bp/ui-studio/src/web/reducers/flows.ts
+++ b/src/bp/ui-studio/src/web/reducers/flows.ts
@@ -1,3 +1,4 @@
+import { FlowNode } from 'botpress/sdk'
 import { FlowView } from 'common/typings'
 import _ from 'lodash'
 import reduceReducers from 'reduce-reducers'
@@ -38,11 +39,13 @@ import {
 import { hashCode, prettyId } from '~/util'
 
 export interface FlowReducer {
-  currentFlow: FlowView | undefined
+  currentFlow?: string
   showFlowNodeProps: boolean
   dirtyFlows: string[]
-  errorSavingFlows: any
+  errorSavingFlows?: { status: number; message: string }
   flowsByName: _.Dictionary<FlowView>
+  currentDiagramAction: string
+  nodeInBuffer?: FlowNode
 }
 
 const MAX_UNDO_STACK_SIZE = 25
@@ -354,7 +357,7 @@ let reducer = handleActions(
       }
     }),
 
-    [updateFlowProblems]: (state, { payload }) => ({
+    [updateFlowProblems as any]: (state, { payload }) => ({
       ...state,
       flowProblems: payload
     }),
@@ -396,22 +399,22 @@ let reducer = handleActions(
       errorSavingFlows: undefined
     }),
 
-    [switchFlowNode]: (state, { payload }) => ({
+    [switchFlowNode as any]: (state, { payload }) => ({
       ...state,
       currentFlowNode: payload
     }),
 
-    [openFlowNodeProps]: state => ({
+    [openFlowNodeProps as any]: state => ({
       ...state,
       showFlowNodeProps: true
     }),
 
-    [closeFlowNodeProps]: state => ({
+    [closeFlowNodeProps as any]: state => ({
       ...state,
       showFlowNodeProps: false
     }),
 
-    [switchFlow]: (state, { payload }) => {
+    [switchFlow as any]: (state, { payload }) => {
       if (state.currentFlow === payload) {
         return state
       }
@@ -690,7 +693,7 @@ reducer = reduceReducers(
         }
       },
 
-      [copyFlowNode]: state => {
+      [copyFlowNode as any]: state => {
         const node = _.find(state.flowsByName[state.currentFlow].nodes, { id: state.currentFlowNode })
         if (!node) {
           return state

--- a/src/bp/ui-studio/src/web/reducers/flows.ts
+++ b/src/bp/ui-studio/src/web/reducers/flows.ts
@@ -394,7 +394,7 @@ let reducer = handleActions(
       errorSavingFlows: payload
     }),
 
-    [clearErrorSaveFlows]: state => ({
+    [clearErrorSaveFlows as any]: state => ({
       ...state,
       errorSavingFlows: undefined
     }),
@@ -426,7 +426,7 @@ let reducer = handleActions(
       }
     },
 
-    [setDiagramAction]: (state, { payload }) => ({
+    [setDiagramAction as any]: (state, { payload }) => ({
       ...state,
       currentDiagramAction: payload
     }),

--- a/src/bp/ui-studio/src/web/reducers/index.ts
+++ b/src/bp/ui-studio/src/web/reducers/index.ts
@@ -7,9 +7,9 @@ import flows, { FlowReducer } from './flows'
 import hints from './hints'
 import language from './language'
 import modules from './modules'
-import ndu from './ndu'
+import ndu, { NduReducer } from './ndu'
 import notifications from './notifications'
-import skills from './skills'
+import skills, { SkillsReducer } from './skills'
 import ui from './ui'
 import user, { UserReducer } from './user'
 export * from './selectors'
@@ -34,4 +34,6 @@ export interface RootReducer {
   flows: FlowReducer
   user: UserReducer
   content: ContentReducer
+  skills: SkillsReducer
+  ndu: NduReducer
 }

--- a/src/bp/ui-studio/src/web/reducers/ndu.ts
+++ b/src/bp/ui-studio/src/web/reducers/ndu.ts
@@ -1,10 +1,16 @@
-import { Condition } from 'botpress/sdk'
+import { Condition, Topic } from 'botpress/sdk'
 import _ from 'lodash'
 import { handleActions } from 'redux-actions'
 import { conditionsReceived, receiveQNACountByTopic, topicsReceived } from '~/actions'
 import { CountByTopic } from '~/views/OneFlow/sidePanel/TopicList'
 
-const defaultState = {
+export interface NduReducer {
+  conditions: Condition[]
+  topics: Topic[]
+  qnaCountByTopic?: CountByTopic[]
+}
+
+const defaultState: NduReducer = {
   conditions: [],
   topics: [],
   qnaCountByTopic: undefined

--- a/src/bp/ui-studio/src/web/reducers/selectors.ts
+++ b/src/bp/ui-studio/src/web/reducers/selectors.ts
@@ -1,3 +1,5 @@
+import { Flow, FlowNode } from 'botpress/sdk'
+import { FlowView } from 'common/typings'
 import _ from 'lodash'
 import { createSelector } from 'reselect'
 
@@ -7,7 +9,7 @@ const _getCurrentFlowNode = state => state.flows?.currentFlowNode
 const _getCurrentHashes = state => state.flows.currentHashes
 const _getInitialHashes = state => state.flows.initialHashes
 
-export const getAllFlows = createSelector([_getFlowsByName], flowsByName => {
+export const getAllFlows = createSelector([_getFlowsByName], (flowsByName): FlowView[] => {
   return _.values(flowsByName)
 })
 
@@ -32,11 +34,16 @@ export const getFlowNamesList = createSelector([getAllFlows], flows => {
   })
 })
 
-export const getCurrentFlow = createSelector([_getFlowsByName, _getCurrentFlow], (flowsByName, currFlow) => {
-  return flowsByName[currFlow]
-})
+export const getCurrentFlow = createSelector(
+  [_getFlowsByName, _getCurrentFlow],
+  (flowsByName, currFlow): FlowView => {
+    return flowsByName[currFlow]
+  }
+)
 
-export const getCurrentFlowNode = createSelector([getCurrentFlow, _getCurrentFlowNode], (currentFlow, currFlowNode) => {
+export const getCurrentFlowNode = createSelector([getCurrentFlow, _getCurrentFlowNode], (currentFlow, currFlowNode):
+  | FlowNode
+  | undefined => {
   return _.find(currentFlow?.nodes, { id: currFlowNode })
 })
 

--- a/src/bp/ui-studio/src/web/reducers/skills.ts
+++ b/src/bp/ui-studio/src/web/reducers/skills.ts
@@ -1,3 +1,4 @@
+import { Skill } from 'botpress/sdk'
 import { handleActions } from 'redux-actions'
 import {
   actionsReceived,
@@ -22,6 +23,10 @@ const defaultState = {
   }
 }
 
+export interface SkillsReducer {
+  installed: Skill[]
+}
+
 const reducer = handleActions(
   {
     [skillsReceived]: (state, { payload }) => ({
@@ -29,7 +34,7 @@ const reducer = handleActions(
       installed: payload
     }),
 
-    [buildNewSkill]: (state, { payload }) => ({
+    [buildNewSkill as any]: (state, { payload }) => ({
       ...state,
       builder: {
         ...state.builder,

--- a/src/bp/ui-studio/src/web/views/OneFlow/sidePanel/Library/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/sidePanel/Library/index.tsx
@@ -1,14 +1,25 @@
 import { Menu, MenuItem } from '@blueprintjs/core'
 import { TreeView } from 'botpress/shared'
 import { LibraryElement } from 'common/typings'
-import React, { useCallback, useState } from 'react'
+import React, { FC, useCallback, useState } from 'react'
 import { connect } from 'react-redux'
 import { removeElementFromLibrary } from '~/actions'
 import MarkdownRenderer from '~/components/Shared/MarkdownRenderer'
+import { RootReducer } from '~/reducers'
 
 import style from '../style.scss'
 
 import Editor from './LiteEditor'
+
+type StateProps = ReturnType<typeof mapStateToProps>
+type DispatchProps = typeof mapDispatchToProps
+
+interface OwnProps {
+  filter: string
+  refreshLibrary: () => void
+}
+
+type Props = OwnProps & StateProps & DispatchProps
 
 const nodeRenderer = ({ contentId, type, preview }: LibraryElement) => {
   return {
@@ -26,7 +37,7 @@ const nodeRenderer = ({ contentId, type, preview }: LibraryElement) => {
   }
 }
 
-const Library = props => {
+const Library: FC<Props> = props => {
   const [isEditOpen, setEditOpen] = useState(false)
   const [editItem, setEditItem] = useState('')
 
@@ -71,9 +82,13 @@ const Library = props => {
   )
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state: RootReducer) => ({
   conditions: state.ndu.conditions,
   library: state.content.library
 })
 
-export default connect(mapStateToProps, { removeElementFromLibrary })(Library)
+const mapDispatchToProps = {
+  removeElementFromLibrary
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Library)

--- a/src/bp/ui-studio/src/web/views/OneFlow/sidePanel/TopicEditor/CreateTopicModal.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/sidePanel/TopicEditor/CreateTopicModal.tsx
@@ -6,16 +6,20 @@ import React, { FC, useState } from 'react'
 import { connect } from 'react-redux'
 import { fetchTopics } from '~/actions'
 import { BaseDialog, DialogBody, DialogFooter } from '~/components/Shared/Interface'
+import { RootReducer } from '~/reducers'
 import { sanitizeName } from '~/util'
 
-interface Props {
+type StateProps = ReturnType<typeof mapStateToProps>
+type DispatchProps = typeof mapDispatchToProps
+
+interface OwnProps {
   isOpen: boolean
-  topics: Topic[]
 
   toggle: () => void
   onCreateFlow: (name: string) => void
-  fetchTopics: () => void
 }
+
+type Props = OwnProps & StateProps & DispatchProps
 
 const CreateTopicModal: FC<Props> = props => {
   const [name, setName] = useState('')
@@ -76,7 +80,7 @@ const CreateTopicModal: FC<Props> = props => {
   )
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state: RootReducer) => ({
   topics: state.ndu.topics
 })
 
@@ -84,4 +88,4 @@ const mapDispatchToProps = {
   fetchTopics
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(CreateTopicModal)
+export default connect<StateProps, DispatchProps, OwnProps>(mapStateToProps, mapDispatchToProps)(CreateTopicModal)

--- a/src/bp/ui-studio/src/web/views/OneFlow/sidePanel/WorkflowEditor/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/sidePanel/WorkflowEditor/index.tsx
@@ -1,11 +1,12 @@
 import { Button, FormGroup, InputGroup, Intent, TextArea } from '@blueprintjs/core'
-import { Flow, Option, Topic } from 'botpress/sdk'
+import { Option } from 'botpress/sdk'
 import { Dropdown } from 'botpress/shared'
 import _ from 'lodash'
 import React, { FC, useEffect, useState } from 'react'
 import { connect } from 'react-redux'
 import { createFlow, renameFlow, updateFlow } from '~/actions'
 import { BaseDialog, DialogBody, DialogFooter } from '~/components/Shared/Interface'
+import { RootReducer } from '~/reducers'
 import { sanitizeName } from '~/util'
 
 import { buildFlowName, parseFlowName } from './utils'
@@ -19,16 +20,8 @@ interface OwnProps {
   toggle: () => void
 }
 
-interface StateProps {
-  flows: Flow[]
-  topics: Topic[]
-}
-
-interface DispatchProps {
-  updateFlow: (params: any) => void
-  renameFlow: (flow: { targetFlow: string; name: string }) => void
-  createFlow: (name: string) => void
-}
+type StateProps = ReturnType<typeof mapStateToProps>
+type DispatchProps = typeof mapDispatchToProps
 
 type Props = StateProps & DispatchProps & OwnProps
 
@@ -143,7 +136,7 @@ const WorkflowEditor: FC<Props> = props => {
   )
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state: RootReducer) => ({
   flows: _.values(state.flows.flowsByName),
   topics: state.ndu.topics
 })

--- a/src/bp/ui-studio/src/web/views/OneFlow/sidePanel/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/sidePanel/index.tsx
@@ -1,5 +1,4 @@
 import { Icon } from '@blueprintjs/core'
-import { FlowView } from 'common/typings'
 import _ from 'lodash'
 import React, { FC, useEffect, useState } from 'react'
 import { connect } from 'react-redux'
@@ -15,7 +14,7 @@ import {
 } from '~/actions'
 import { history } from '~/components/Routes'
 import { SearchBar, SidePanel, SidePanelSection } from '~/components/Shared/Interface'
-import { getAllFlows, getCurrentFlow, getFlowNamesList } from '~/reducers'
+import { getAllFlows, getCurrentFlow, getFlowNamesList, RootReducer } from '~/reducers'
 
 import Inspector from '../../FlowBuilder/inspector'
 import Toolbar from '../../FlowBuilder/sidePanel/Toolbar'
@@ -48,30 +47,11 @@ interface OwnProps {
   history: any
   permissions: PanelPermissions[]
   readOnly: boolean
+  mutexInfo: any
 }
 
-interface StateProps {
-  showFlowNodeProps: boolean
-  flows: FlowView[]
-  currentFlow: any
-  dirtyFlows: any
-  flowPreview: boolean
-  mutexInfo: string
-  topics: any
-  qnaCountByTopic: CountByTopic[]
-  flowsName: { name: string; label: string }[]
-}
-
-interface DispatchProps {
-  refreshConditions: () => void
-  fetchTopics: () => void
-  fetchFlows: () => void
-  deleteFlow: (flowName: string) => void
-  switchFlow: (flowName: string) => void
-  renameFlow: any
-  duplicateFlow: any
-  getQnaCountByTopic: () => void
-}
+type StateProps = ReturnType<typeof mapStateToProps>
+type DispatchProps = typeof mapDispatchToProps
 
 type Props = StateProps & DispatchProps & OwnProps
 
@@ -248,7 +228,7 @@ const SidePanelContent: FC<Props> = props => {
   )
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state: RootReducer) => ({
   currentFlow: getCurrentFlow(state),
   flows: getAllFlows(state),
   flowsName: getFlowNamesList(state),
@@ -268,4 +248,4 @@ const mapDispatchToProps = {
   getQnaCountByTopic
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(SidePanelContent)
+export default connect<StateProps, DispatchProps, OwnProps>(mapStateToProps, mapDispatchToProps)(SidePanelContent)


### PR DESCRIPTION
Found a better way for typings in Redux. This way, we no longer have to duplicate the dispatch/state props in every component using it. We can define them in one place, and it's available everywhere.

I also updated the OneFlow diagram, since some features that were added in FlowBuilder were not duplicated.

I just updated typings under OneFlow for now.