### PR TITLE
fix(ndu): add label for raw condition

### DIFF
--- a/modules/ndu/src/backend/conditions.ts
+++ b/modules/ndu/src/backend/conditions.ts
@@ -71,7 +71,11 @@ export const dialogConditions: sdk.Condition[] = [
   {
     id: 'raw_js',
     label: 'Raw JS expression',
-    params: { expression: { label: 'Expression to evaluate', type: 'string' } },
+    description: `{label}`,
+    params: {
+      expression: { label: 'Expression to evaluate', type: 'string' },
+      label: { label: 'Custom label', type: 'string', defaultValue: 'Raw JS expression' }
+    },
     evaluate: (event, params) => {
       const code = `
       try {

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/TriggerEditor/Condition/InputParams.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/TriggerEditor/Condition/InputParams.tsx
@@ -20,7 +20,11 @@ const InputParams: FC<Props> = props => {
     <div className={style.inputParamWrapper}>
       {Object.keys(props.condition.params).map(key => {
         const { defaultValue, label, type, list } = props.condition.params[key]
-        const value = (props.params && props.params[key]) || defaultValue
+        const value = props.params?.[key]
+
+        if (!value && defaultValue) {
+          updateParam(key, defaultValue)
+        }
 
         return (
           <SingleParam

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/TriggerEditor/Condition/Item.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/TriggerEditor/Condition/Item.tsx
@@ -1,4 +1,4 @@
-import { Button, Colors } from '@blueprintjs/core'
+import { Button, Colors, Position, Tooltip } from '@blueprintjs/core'
 import { Condition } from 'botpress/sdk'
 import cx from 'classnames'
 import _ from 'lodash'
@@ -40,7 +40,29 @@ const ConditionItem: FC<Props> = ({ conditions, condition, onEdit, onDelete, cla
   }
 
   if (diagramNodeView) {
-    return <li>{description || definition.label}</li>
+    const params = Object.keys(condition.params)
+    return (
+      <Tooltip
+        usePortal={false}
+        content={
+          !!params.length && (
+            <div>
+              <strong>Trigger parameters</strong>
+              <br />
+              {params.map(key => {
+                return (
+                  <div>
+                    - {key}: {condition.params[key]}
+                  </div>
+                )
+              })}
+            </div>
+          )
+        }
+      >
+        <li>{description || definition.label}</li>
+      </Tooltip>
+    )
   }
 
   return (

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/TriggerEditor/Condition/Item.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/TriggerEditor/Condition/Item.tsx
@@ -51,7 +51,7 @@ const ConditionItem: FC<Props> = ({ conditions, condition, onEdit, onDelete, cla
               <br />
               {params.map(key => {
                 return (
-                  <div>
+                  <div key={key}>
                     - {key}: {condition.params[key]}
                   </div>
                 )


### PR DESCRIPTION
When you have a lot of raw expressions, it's a bit hard to know what does what. This adds a label to the condition, which can be customized. 

Also adds a tooltip when hovering conditions to see its parameters

![image](https://user-images.githubusercontent.com/42552874/77002893-b7229680-6932-11ea-8b3a-7115bbfc1e80.png)
