### PR TITLE
fix(nlu) AutoTrain toggle state

### DIFF
--- a/modules/nlu/src/views/full/common/AutoTrainToggle.tsx
+++ b/modules/nlu/src/views/full/common/AutoTrainToggle.tsx
@@ -25,7 +25,15 @@ const AutoTrainToggle: FC<{ api: NLUApi }> = ({ api }) => {
     setAutoTrain(!autoTrain)
   }
 
-  return <Switch label="AutoTrain" disabled={loading} className={style.autoTrainToggle} onClick={toggleAutoTrain} />
+  return (
+    <Switch
+      label="AutoTrain"
+      checked={autoTrain}
+      disabled={loading}
+      className={style.autoTrainToggle}
+      onClick={toggleAutoTrain}
+    />
+  )
 }
 
 export default AutoTrainToggle


### PR DESCRIPTION
Fixes the state of the AutoTrain toggle. It was not bound to the `autoTrain` state variable.