### PR TITLE
fix(ndu): store details only for logged on users

### DIFF
--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -158,7 +158,7 @@ export default async (bp: typeof sdk, db: Database) => {
         conversationId = await db.getOrCreateRecentConversation(botId, userId, { originatesFromUserMessage: true })
       }
 
-      await sendNewMessage(botId, userId, conversationId, payload, req.credentials)
+      await sendNewMessage(botId, userId, conversationId, payload, req.credentials, !!req.headers.authorization)
 
       return res.sendStatus(200)
     })
@@ -238,7 +238,14 @@ export default async (bp: typeof sdk, db: Database) => {
     return /[a-z0-9-_]+/i.test(userId)
   }
 
-  async function sendNewMessage(botId: string, userId: string, conversationId, payload, credentials: any) {
+  async function sendNewMessage(
+    botId: string,
+    userId: string,
+    conversationId,
+    payload,
+    credentials: any,
+    useDebugger?: boolean
+  ) {
     const config = await bp.config.getModuleConfigForBot('channel-web', botId)
 
     if (
@@ -264,6 +271,10 @@ export default async (bp: typeof sdk, db: Database) => {
       type: payload.type,
       credentials
     })
+
+    if (useDebugger) {
+      event.debugger = true
+    }
 
     const message = await db.appendUserMessage(botId, userId, conversationId, sanitizedPayload, event.id)
 

--- a/src/bp/core/config/botpress.config.ts
+++ b/src/bp/core/config/botpress.config.ts
@@ -587,6 +587,11 @@ export interface EventCollectorConfig {
    * @default []
    */
   ignoredEventProperties: string[]
+  /**
+   * These properties are only stored with the event when the user is logged on the studio
+   * @default ["ndu.triggers","ndu.predictions","nlu.predictions"]
+   */
+  debuggerProperties: string[]
 }
 
 interface ActionServersConfig {

--- a/src/bp/core/services/middleware/event-engine.ts
+++ b/src/bp/core/services/middleware/event-engine.ts
@@ -33,6 +33,7 @@ const eventSchema = {
   flags: joi.any().required(),
   suggestions: joi.array().optional(),
   state: joi.any().optional(),
+  debugger: joi.bool().optional(),
   credentials: joi.any().optional(),
   incomingEventId: joi.string().optional(),
   nlu: joi

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -604,6 +604,8 @@ declare module 'botpress/sdk' {
       /** The date the event was created */
       readonly createdOn: Date
       readonly credentials?: any
+      /** When false, some properties used by the debugger are stripped from the event before storing */
+      debugger?: boolean
       /**
        * Check if the event has a specific flag
        * @param flag The flag symbol to verify. {@link IO.WellKnownFlags} to know more about existing flags


### PR DESCRIPTION
The NDU adds a ton of new data to events. In a big bot, they each take 70kb, instead of 2kb. This adds up quickly. 

This change will strip some fields from the event when the user is not logged on