### PR TITLE
Update for slack bot hook exposed

### DIFF
--- a/docs/guide/docs/channels/slack.md
+++ b/docs/guide/docs/channels/slack.md
@@ -40,7 +40,7 @@ These steps are required so users can click on quick reply buttons, select dropd
 
 1. Open the page `Interactive Components`, then turn the switch to `On`
 
-2. Set the request URL to: `EXTERNAL_URL/api/v1/bots/YOUR_BOT_ID/mod/channel-slack/callback`
+2. Set the request URL to: `EXTERNAL_URL/api/v1/bots/YOUR_BOT_ID/mod/channel-slack/bots/YOUR_BOT_ID/callback`
 
 - Replace EXTERNAL_URL by the value of `externalUrl` in your botpress.config.json
 - Replace YOUR_BOT_ID by your bot ID


### PR DESCRIPTION
When the container started (version 12.5.0 on the Docker container `botpress/server:v12_5_0`), the endpoint exposed reported by the logs on startup referenced the bot's ID again after the `/channel-slack/` portion. Once I corrected to this in `https://api.slack.com/apps/SLACK_BOT_ID/interactive-messages?` my chat bot started replying in Slack.