### PR TITLE
chore(dev): added tool to check translations

### DIFF
--- a/build/check-translations.js
+++ b/build/check-translations.js
@@ -1,0 +1,103 @@
+const _ = require('lodash')
+const glob = require('glob')
+const path = require('path')
+const fs = require('fs')
+const chalk = require('chalk')
+
+const defaultLangCode = 'en'
+const locations = ['modules/*/src/translations/*.json', 'src/bp/ui-*/src/**/translations/*.json']
+
+const start = () => {
+  const fix = process.argv.find(x => x.toLowerCase() === '--fix')
+  if (fix) {
+    console.log(chalk.bold(`Reordering keys in translations...\r\n`))
+    fixTranslations()
+  }
+
+  console.log(
+    chalk.bold(`
+Checking consistency of translation files`)
+  )
+  console.log(`A missing key may either be in the default language (${defaultLangCode}) or in the displayed language.
+  `)
+
+  listMissingKeys()
+
+  if (!fix) {
+    console.log(`\r\nType yarn cmd check-translations --fix to reorder keys in all translation files`)
+  }
+}
+
+const fixTranslations = () => {
+  for (const filePath of getTranslationElements().files) {
+    const content = readFile(filePath)
+    const sorted = sortObject(content)
+
+    fs.writeFileSync(filePath, JSON.stringify(sorted, undefined, 2), 'UTF-8')
+  }
+}
+
+const listMissingKeys = () => {
+  for (const folder of getTranslationElements().folders) {
+    const defaultLang = readFile(path.resolve(folder, defaultLangCode + '.json'))
+    const languages = glob.sync(`${folder}/*.json`, { ignore: [`**/${defaultLangCode}.json`] })
+
+    for (const lang of languages) {
+      const currentLang = readFile(lang)
+      const differences = _.difference(Object.keys(squash(defaultLang)), Object.keys(squash(currentLang)))
+
+      if (differences.length) {
+        console.log(chalk.bold(`\r\nKeys missing in ${folder} (${path.basename(lang)})`))
+        differences.map(x => console.log(`- ${x}`))
+      }
+    }
+  }
+}
+
+const getTranslationElements = () => {
+  const folders = []
+  const files = []
+
+  for (const location of locations) {
+    const fileList = glob.sync(location)
+    files.push(...fileList)
+    folders.push(..._.uniq(fileList.map(x => path.dirname(x))))
+  }
+
+  return { files, folders }
+}
+
+const sortObject = object => {
+  const sortedObj = {}
+
+  _.each(_.keys(object).sort(), key => {
+    if (_.isObject(object[key]) && !_.isArray(object[key])) {
+      sortedObj[key] = sortObject(object[key])
+    } else {
+      sortedObj[key] = object[key]
+    }
+  })
+
+  return sortedObj
+}
+
+const squash = (space, root = {}, path = '') => {
+  for (const [key, value] of Object.entries(space)) {
+    if (typeof value === 'object' && value !== null) {
+      squash(value, root, path + key + '.')
+    } else {
+      root[path + key] = value
+    }
+  }
+  return root
+}
+
+const readFile = filePath => {
+  try {
+    return JSON.parse(fs.readFileSync(filePath))
+  } catch (err) {
+    console.error(`Couldn't parse file ${filePath}`)
+  }
+}
+
+start()

--- a/build/check-translations.js
+++ b/build/check-translations.js
@@ -8,10 +8,10 @@ const defaultLangCode = 'en'
 const locations = ['modules/*/src/translations/*.json', 'src/bp/ui-*/src/**/translations/*.json']
 
 const start = () => {
-  const fix = process.argv.find(x => x.toLowerCase() === '--fix')
-  if (fix) {
+  const reorder = process.argv.find(x => x.toLowerCase() === '--reorder')
+  if (reorder) {
     console.log(chalk.bold(`Reordering keys in translations...\r\n`))
-    fixTranslations()
+    reorderTranslations()
   }
 
   console.log(
@@ -23,12 +23,12 @@ Checking consistency of translation files`)
 
   listMissingKeys()
 
-  if (!fix) {
-    console.log(`\r\nType yarn cmd check-translations --fix to reorder keys in all translation files`)
+  if (!reorder) {
+    console.log(`\r\nType yarn cmd check-translations --reorder to reorder keys in all translation files`)
   }
 }
 
-const fixTranslations = () => {
+const reorderTranslations = () => {
   for (const filePath of getTranslationElements().files) {
     const content = readFile(filePath)
     const sorted = sortObject(content)

--- a/build/gulp.core.js
+++ b/build/gulp.core.js
@@ -101,8 +101,8 @@ const copyJs = () => {
 }
 
 const checkTranslations = cb => {
-  const fix = process.argv.find(x => x.toLowerCase() === '--fix')
-  exec(`node build/check-translations.js ${fix && '--fix'}`, (err, stdout, stderr) => {
+  const reorder = process.argv.find(x => x.toLowerCase() === '--reorder')
+  exec(`node build/check-translations.js ${fix && '--reorder'}`, (err, stdout, stderr) => {
     console.log(stdout, stderr)
     cb(err)
   })

--- a/build/gulp.core.js
+++ b/build/gulp.core.js
@@ -102,7 +102,7 @@ const copyJs = () => {
 
 const checkTranslations = cb => {
   const reorder = process.argv.find(x => x.toLowerCase() === '--reorder')
-  exec(`node build/check-translations.js ${fix && '--reorder'}`, (err, stdout, stderr) => {
+  exec(`node build/check-translations.js ${reorder && '--reorder'}`, (err, stdout, stderr) => {
     console.log(stdout, stderr)
     cb(err)
   })

--- a/build/gulp.core.js
+++ b/build/gulp.core.js
@@ -8,6 +8,7 @@ const file = require('gulp-file')
 const buildJsonSchemas = require('./jsonschemas')
 const fs = require('fs')
 const mkdirp = require('mkdirp')
+const exec = require('child_process').exec
 
 const maybeFetchPro = () => {
   const isProBuild = process.env.EDITION === 'pro' || fs.existsSync('pro')
@@ -99,6 +100,14 @@ const copyJs = () => {
   return gulp.src('src/bp/ml/svm-js/**/*.*').pipe(gulp.dest('./out/bp/ml/svm-js'))
 }
 
+const checkTranslations = cb => {
+  const fix = process.argv.find(x => x.toLowerCase() === '--fix')
+  exec(`node build/check-translations.js ${fix && '--fix'}`, (err, stdout, stderr) => {
+    console.log(stdout, stderr)
+    cb(err)
+  })
+}
+
 const build = () => {
   return gulp.series([
     maybeFetchPro,
@@ -114,5 +123,6 @@ const build = () => {
 module.exports = {
   build,
   watch,
-  createMigration
+  createMigration,
+  checkTranslations
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,6 +70,8 @@ gulp.task('dev:modules', modules.createAllModulesSymlink())
  */
 gulp.task('migration:create', core.createMigration)
 
+gulp.task('check-translations', core.checkTranslations)
+
 gulp.task('changelog', () => {
   // see options here: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages
   const changelogOts = {


### PR DESCRIPTION
Added a new command to the gulpfile to check translations, before they become unmanageable.

## yarn cmd check-translations 
This command list all keys which are not defined in the specified language, compared to the default lang (en)

![image](https://user-images.githubusercontent.com/42552874/78385305-a1a3a280-75a9-11ea-88c2-7fb1eeb90c3a.png)

## yarn cmd check-translations --reorder
This one will reorder keys alphabetically in all translation files, so the format is identical everywhere.

![image](https://user-images.githubusercontent.com/42552874/78385618-25f62580-75aa-11ea-8cd0-49be003c02c0.png)



