### PR TITLE
fix(core): more details when error with actions required

### DIFF
--- a/src/bp/core/modules/require.ts
+++ b/src/bp/core/modules/require.ts
@@ -67,7 +67,9 @@ export const requireAtPaths = (module: string, locations: string[], scriptPath?:
         const pkgEntry = path.join(loc, pkg.main)
         return (requireCache[requireKey] = require(pkgEntry))
       }
-    } catch (err) {}
+    } catch (err) {
+      throw new Error(`Error while loading module "${module}" at location "${locations.join(', ')}": ${err}`)
+    }
   }
 
   try {


### PR DESCRIPTION
When requiring js files inside actions, if there was a syntax error the message is always "module not found", which is misleading:

![image](https://user-images.githubusercontent.com/42552874/78822813-b1582800-79a9-11ea-9fbc-9aafdc5d8ff2.png)

This change makes the error message a bit clearer on what the actual problem is

![image](https://user-images.githubusercontent.com/42552874/78822798-aac9b080-79a9-11ea-8a7b-4b42aef7b7b9.png)

![image](https://user-images.githubusercontent.com/42552874/78822966-eb292e80-79a9-11ea-92a7-787c7cd76872.png)

@slvnperron Do you remember why that catch was silent, and do you think this change may cause problem elsewhere ? 