### PR TITLE
fix(ndu): add action go to node

### DIFF
--- a/modules/extensions/src/views/lite/components/debugger/views/Actions.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/views/Actions.tsx
@@ -30,6 +30,12 @@ export const Actions: FC<Props> = props => {
                     <Icon icon="flow-linear" /> Start Workflow {(data as sdk.NDU.FlowRedirect).flow}
                   </div>
                 )
+              case 'goToNode':
+                return (
+                  <div className={style.truncate}>
+                    <Icon icon="flow-linear" /> Go to node {(data as sdk.NDU.FlowRedirect).node}
+                  </div>
+                )
               case 'redirect':
                 return (
                   <div className={style.truncate}>

--- a/modules/extensions/src/views/lite/components/debugger/views/NDU.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/views/NDU.tsx
@@ -47,6 +47,8 @@ export const NDU: FC<{ ndu: sdk.NDU.DialogUnderstanding }> = ({ ndu }) => {
               return <li>Send knowledge {(data as sdk.NDU.SendContent).sourceDetails}</li>
             case 'startWorkflow':
               return <li>Start Workflow {(data as sdk.NDU.FlowRedirect).flow}</li>
+            case 'goToNode':
+              return <li>Go to node {(data as sdk.NDU.FlowRedirect).node}</li>
             case 'redirect':
               return <li>Redirect to {(data as sdk.NDU.FlowRedirect).flow}</li>
             case 'continue':

--- a/modules/ndu/src/backend/ndu-engine.ts
+++ b/modules/ndu/src/backend/ndu-engine.ts
@@ -283,18 +283,30 @@ export class UnderstandingEngine {
     const electedTrigger = event.ndu.triggers[actionToTrigger[topAction]]
 
     if (electedTrigger) {
-      switch (electedTrigger.trigger.type) {
+      const { trigger } = electedTrigger
+
+      switch (trigger.type) {
         case 'workflow':
-          event.ndu.actions = [
-            {
+          const sameWorkflow = trigger.workflowId === currentFlow?.replace('.flow.json', '')
+          const sameNode = trigger.nodeId === currentNode
+
+          event.ndu.actions = [{ action: 'continue' }]
+
+          if (sameWorkflow && !sameNode) {
+            event.ndu.actions.unshift({
+              action: 'goToNode',
+              data: { flow: trigger.workflowId, node: trigger.nodeId }
+            })
+          } else if (!sameWorkflow && !sameNode) {
+            event.ndu.actions.unshift({
               action: 'startWorkflow',
-              data: { flow: electedTrigger.trigger.workflowId, node: electedTrigger.trigger.nodeId }
-            },
-            { action: 'continue' }
-          ]
+              data: { flow: trigger.workflowId, node: trigger.nodeId }
+            })
+          }
+
           break
         case 'faq':
-          const qnaActions = await this.queryQna(electedTrigger.trigger.faqId, event)
+          const qnaActions = await this.queryQna(trigger.faqId, event)
           event.ndu.actions = [...qnaActions]
           break
         case 'node':
@@ -328,11 +340,12 @@ export class UnderstandingEngine {
 
     event.ndu.triggers = {}
 
+    const { currentFlow, currentNode } = event.state.context
+
     for (const trigger of triggers) {
       if (
         trigger.type === 'node' &&
-        (event.state?.context.currentFlow !== `${trigger.workflowId}.flow.json` ||
-          event.state?.context?.currentNode !== trigger.nodeId)
+        (currentFlow !== `${trigger.workflowId}.flow.json` || currentNode !== trigger.nodeId)
       ) {
         continue
       }

--- a/src/bp/core/services/dialog/decision-engine.ts
+++ b/src/bp/core/services/dialog/decision-engine.ts
@@ -66,7 +66,7 @@ export class DecisionEngine {
           source: content.source,
           details: content.sourceDetails!
         })
-      } else if (action === 'redirect' || action === 'startWorkflow') {
+      } else if (action === 'redirect' || action === 'startWorkflow' || action === 'goToNode') {
         const { flow, node } = data as NDU.FlowRedirect
         const flowName = flow.endsWith('.flow.json') ? flow : `${flow}.flow.json`
 

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -545,7 +545,7 @@ declare module 'botpress/sdk' {
     }
 
     export interface Actions {
-      action: 'send' | 'startWorkflow' | 'redirect' | 'continue'
+      action: 'send' | 'startWorkflow' | 'redirect' | 'continue' | 'goToNode'
       data?: SendContent | FlowRedirect
     }
 


### PR DESCRIPTION
The debugger often displays "start workflow" when in fact we're just moving to one node inside the same workflow, so it's a bit misleading. goToNode has the same logic as startWorkflow for now, but the action is clearer