### PR TITLE
feat(ndu): activate trigger only on active workflow

### DIFF
--- a/modules/ndu/src/backend/ndu-engine.ts
+++ b/modules/ndu/src/backend/ndu-engine.ts
@@ -337,6 +337,14 @@ export class UnderstandingEngine {
         continue
       }
 
+      if (
+        trigger.type === 'workflow' &&
+        trigger.activeWorkflow &&
+        event.state?.context.currentFlow !== `${trigger.workflowId}.flow.json`
+      ) {
+        continue
+      }
+
       const id = this.getTriggerId(trigger)
       const result = this._testConditions(event, trigger.conditions)
       event.ndu.triggers[id] = { result, trigger }
@@ -413,6 +421,7 @@ export class UnderstandingEngine {
             })),
             type: 'workflow',
             workflowId: flowName,
+            activeWorkflow: tn.activeWorkflow,
             nodeId: tn.name
           })
         } else if ((<sdk.ListenNode>node)?.triggers?.length) {

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -517,6 +517,8 @@ declare module 'botpress/sdk' {
       type: 'workflow'
       workflowId: string
       nodeId: string
+      /** When true, the user must be inside the specified workflow for the trigger to be active */
+      activeWorkflow?: boolean
     }
 
     export interface FaqTrigger extends GenericTrigger {
@@ -1259,6 +1261,7 @@ declare module 'botpress/sdk' {
 
   export type TriggerNode = FlowNode & {
     conditions: DecisionTriggerCondition[]
+    activeWorkflow?: boolean
   }
 
   export type ListenNode = FlowNode & {

--- a/src/bp/ui-studio/src/web/translations/en.json
+++ b/src/bp/ui-studio/src/web/translations/en.json
@@ -120,7 +120,10 @@
         "backToList": "Back to list",
         "chooseElement": "Choose an element",
         "confirmDeleteCondition": "Are you sure to delete this condition?",
+        "editCondition": "Edit Condition",
         "editTriggers": "Edit Triggers",
+        "listenActiveWorkflow": "Listen in active workflow",
+        "listenActiveWorkflowHelp": "When enabled, this trigger will only be active when the user is in the workflow where it is located.",
         "noResults": "No results.",
         "savedAutomatically": "Changes will be saved automatically",
         "selectCondition": "Select a condition"

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/manager.ts
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/manager.ts
@@ -15,7 +15,7 @@ import { SaySomethingNodeModel } from './nodes_v2/SaySomethingNode'
 import { SuccessNodeModel } from './nodes_v2/SuccessNode'
 import { TriggerNodeModel } from './nodes_v2/TriggerNode'
 
-const passThroughNodeProps: string[] = ['name', 'onEnter', 'onReceive', 'next', 'skill', 'conditions']
+const passThroughNodeProps: string[] = ['name', 'onEnter', 'onReceive', 'next', 'skill', 'conditions', 'activeWorkflow']
 export const DIAGRAM_PADDING: number = 100
 
 // Must be identified by the deleteSelectedElement logic to know it needs to delete something

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes_v2/TriggerNode.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes_v2/TriggerNode.tsx
@@ -40,6 +40,7 @@ export class TriggerWidget extends Component<{ node: TriggerNodeModel; diagramEn
 
 export class TriggerNodeModel extends BaseNodeModel {
   public conditions = []
+  public activeWorkflow: boolean
 
   constructor({
     id,
@@ -49,18 +50,20 @@ export class TriggerNodeModel extends BaseNodeModel {
     onEnter = [],
     next = [],
     conditions = [],
+    activeWorkflow = false,
     isStartNode = false,
     isHighlighted = false
   }) {
     super('trigger', id)
-    this.setData({ name, onEnter, next, isStartNode, isHighlighted, conditions })
+    this.setData({ name, onEnter, next, isStartNode, isHighlighted, conditions, activeWorkflow })
 
     this.x = this.oldX = x
     this.y = this.oldY = y
   }
 
-  setData({ conditions = [], ...data }) {
+  setData({ conditions = [], activeWorkflow = false, ...data }) {
     this.conditions = conditions
+    this.activeWorkflow = activeWorkflow
 
     super.setData(data as any)
   }

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/TriggerEditor/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/TriggerEditor/index.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonGroup, Intent } from '@blueprintjs/core'
+import { Button, ButtonGroup, Icon, Intent, Switch, Tooltip } from '@blueprintjs/core'
 import axios from 'axios'
 import { Condition } from 'botpress/sdk'
 import { confirmDialog, lang } from 'botpress/shared'
@@ -43,10 +43,13 @@ type Props = StateProps & DispatchProps & OwnProps
 const EditTriggerModal: FC<Props> = props => {
   const [isEditing, setEditing] = useState(false)
   const [conditions, setConditions] = useState<Condition[]>([])
-  const [currentFlowCondition, setCurrentFlowCondition] = useState()
+  const [currentFlowCondition, setCurrentFlowCondition] = useState<Condition>()
   const [currentCondition, setCurrentCondition] = useState<Condition>()
   const [topicName, setTopicName] = useState('')
   const [forceSave, setForceSave] = useState(false)
+  const [isActiveWorkflow, setActiveWorkflow] = useState(false)
+
+  const { node, switchFlowNode, updateFlowNode } = props
 
   useEffect(() => {
     setConditions([])
@@ -54,11 +57,12 @@ const EditTriggerModal: FC<Props> = props => {
 
     if (props.node) {
       const {
-        node: { conditions },
+        node: { conditions, activeWorkflow },
         currentFlow
       } = props
 
       setConditions(conditions)
+      setActiveWorkflow(activeWorkflow)
       setTopicName(currentFlow?.location?.split('/')[0])
     }
   }, [props.node])
@@ -101,11 +105,16 @@ const EditTriggerModal: FC<Props> = props => {
     }
   }
 
-  const save = updatedConditions => {
-    const { node, switchFlowNode, updateFlowNode } = props
+  const onActiveWorkflowChanged = e => {
+    setActiveWorkflow(e.currentTarget.checked)
 
-    switchFlowNode?.(node.id)
-    updateFlowNode?.({ conditions: updatedConditions })
+    switchFlowNode(node.id)
+    updateFlowNode({ activeWorkflow: e.currentTarget.checked })
+  }
+
+  const save = updatedConditions => {
+    switchFlowNode(node.id)
+    updateFlowNode({ conditions: updatedConditions, activeWorkflow: isActiveWorkflow })
     setConditions(updatedConditions)
   }
 
@@ -127,7 +136,11 @@ const EditTriggerModal: FC<Props> = props => {
       className={triggerStyles.dialog}
       style={{ width: 750, minHeight: 380 }}
       icon="edit"
-      title={lang.tr('studio.flow.condition.editTriggers')}
+      title={
+        !isEditing
+          ? lang.tr('studio.flow.condition.editTriggers')
+          : `${lang.tr('studio.flow.condition.editCondition')} - ${currentCondition.label}`
+      }
     >
       <DialogBody>
         <div className={cx(triggerStyles.formHeader, { [triggerStyles.editing]: isEditing })}>
@@ -136,13 +149,26 @@ const EditTriggerModal: FC<Props> = props => {
               {lang.tr('studio.flow.condition.backToList')}
             </Button>
           )}
-          <p className={triggerStyles.tip}>{lang.tr('studio.flow.condition.savedAutomatically')}</p>
+          <div className={triggerStyles.tip}>
+            {lang.tr('studio.flow.condition.savedAutomatically')}
+
+            {!isEditing && (
+              <div style={{ padding: 5 }}>
+                <Switch checked={isActiveWorkflow} onChange={onActiveWorkflowChanged}>
+                  {lang.tr('studio.flow.condition.listenActiveWorkflow')}&nbsp;
+                  <Tooltip content={lang.tr('studio.flow.condition.listenActiveWorkflowHelp')}>
+                    <Icon icon="help"></Icon>
+                  </Tooltip>
+                </Switch>
+              </div>
+            )}
+          </div>
         </div>
         {isEditing && (
           <div>
             <ConditionEditor
               condition={currentCondition}
-              params={currentFlowCondition && currentFlowCondition.params}
+              params={currentFlowCondition?.params}
               updateParams={onParamsChanged}
               topicName={topicName}
               contentLang={contentLang}


### PR DESCRIPTION
Most triggers on top-level workflows are global, meaning that even if you're in another workflow, they may score higher and redirect you there.

Sometime, you also want some triggers to be only active when the workflow containing them is currently active. There are "node triggers", but those are only active when the user is right on the specified node, which doesn't fit most use case

![image](https://user-images.githubusercontent.com/42552874/79032211-b0bebd80-7b72-11ea-9ca8-bbdd12cd200a.png)
