### PR TITLE
fix(core): support multiple levels of sub flows

### DIFF
--- a/src/bp/core/services/dialog/dialog-engine.ts
+++ b/src/bp/core/services/dialog/dialog-engine.ts
@@ -39,7 +39,7 @@ export class DialogEngine {
     // Property type skill-call means that the node points to a subflow.
     // We skip this step if we're exiting from a subflow, otherwise it will result in an infinite loop.
     if (_.get(currentNode, 'type') === 'skill-call' && !this._exitingSubflow(event)) {
-      return this._goToSubflow(botId, event, sessionId, currentNode, currentFlow)
+      return this._goToSubflow(botId, event, sessionId, currentFlow, currentNode)
     }
 
     const queueBuilder = new InstructionsQueueBuilder(currentNode, currentFlow)
@@ -220,11 +220,13 @@ export class DialogEngine {
     return event.state.context
   }
 
-  protected async _transition(sessionId, event, transitionTo) {
+  protected async _transition(sessionId: string, event: IO.IncomingEvent, transitionTo: string) {
     let context: IO.DialogContext = event.state.context
     if (!event.state.__error) {
       this._detectInfiniteLoop(event.state.__stacktrace, event.botId)
     }
+
+    context.jumpPoints = context.jumpPoints?.filter(x => !x.used)
 
     if (transitionTo.includes('.flow.json')) {
       BOTPRESS_CORE_EVENT('bp_core_enter_flow', { botId: event.botId, channel: event.channel, flowName: transitionTo })
@@ -236,15 +238,11 @@ export class DialogEngine {
       context = {
         currentFlow: flow.name,
         currentNode: startNode.name,
-        // We keep a reference of the previous flow so we can return to it later on.
-        // TODO: drop previousFlow/previousNode in favor of jumpPoints
-        previousFlow: event.state.context.currentFlow,
-        previousNode: event.state.context.currentNode,
         jumpPoints: [
-          ...(event.state.context.jumpPoints || []),
+          ...(context.jumpPoints || []),
           {
-            flow: event.state.context.currentFlow,
-            node: event.state.context.currentNode
+            flow: context.currentFlow!,
+            node: context.currentNode!
           }
         ]
       }
@@ -259,16 +257,17 @@ export class DialogEngine {
       )
     } else if (transitionTo.indexOf('#') === 0) {
       // Return to the parent node (coming from a flow)
-      const jumpPoints = event.state.context.jumpPoints
-      if (!jumpPoints) {
-        this._debug(
-          event.botId,
-          event.target,
-          'no previous flow found, current node is ' + event.state.context.currentNode
-        )
+      const jumpPoints = context.jumpPoints
+      const prevJumpPoint = _.findLast(jumpPoints, j => !j.used)
+
+      if (!jumpPoints || !prevJumpPoint) {
+        this._debug(event.botId, event.target, 'no previous flow found, current node is ' + context.currentNode)
         return event
       }
-      const prevJumpPoint = jumpPoints.pop()
+
+      // Multiple transitions on a node triggers each a processEvent, if we simply remove it, the second transition is no longer "exiting a subflow"
+      prevJumpPoint.used = true
+
       const parentFlow = this._findFlow(event.botId, prevJumpPoint.flow)
       const specificNode = transitionTo.split('#')[1]
       const parentNode = this._findNode(event.botId, parentFlow, specificNode || prevJumpPoint.node)
@@ -290,7 +289,7 @@ export class DialogEngine {
         event.botId,
         event.target,
         context.currentFlow,
-        context.currentFlow,
+        context.currentNode,
         parentFlow.name,
         parentNode.name
       )
@@ -303,7 +302,7 @@ export class DialogEngine {
       // Transition to the target node in the current flow
       this._logTransition(event.botId, event.target, context.currentFlow, context.currentNode, transitionTo)
 
-      event.state.__stacktrace.push({ flow: context.currentFlow, node: transitionTo })
+      event.state.__stacktrace.push({ flow: context.currentFlow!, node: transitionTo })
       // When we're in a skill, we must remember the location of the main node for when we will exit
       const isInSkill = context.currentFlow && context.currentFlow.startsWith('skills/')
       if (isInSkill) {
@@ -317,19 +316,14 @@ export class DialogEngine {
     return this.processEvent(sessionId, event)
   }
 
-  private async _goToSubflow(botId, event, sessionId, parentNode, parentFlow) {
+  private async _goToSubflow(botId: string, event: IO.IncomingEvent, sessionId: string, parentFlow, parentNode) {
     const subflowName = parentNode.flow // Name of the subflow to transition to
     const subflow = this._findFlow(botId, subflowName)
     const subflowStartNode = this._findNode(botId, subflow, subflow.startNode)
 
-    // We only update previousNodeName and previousFlowName when we transition to a subflow.
-    // When the subflow ends, we will transition back to previousNodeName / previousFlowName.
-
     event.state.context = {
       currentFlow: subflow.name,
       currentNode: subflowStartNode.name,
-      previousFlow: parentFlow.name,
-      previousNode: parentNode.name,
       jumpPoints: [
         ...(event.state.context.jumpPoints || []),
         {
@@ -407,9 +401,11 @@ export class DialogEngine {
       )
   }
 
-  private _exitingSubflow(event) {
-    const { currentFlow, currentNode, previousFlow, previousNode } = event.state.context
-    return previousFlow === currentFlow && previousNode === currentNode
+  private _exitingSubflow(event: IO.IncomingEvent) {
+    const { currentFlow, currentNode, jumpPoints } = event.state.context
+    const recentUsed = jumpPoints?.find(j => j.used)
+
+    return recentUsed?.flow === currentFlow && recentUsed?.node === currentNode
   }
 
   private _debug(botId: string, target: string, action: string, args?: any) {

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -733,6 +733,8 @@ declare module 'botpress/sdk' {
       flow: string
       /** The name of the previous node to return to when we exit a subflow */
       node: string
+      /** When a jump point is used, it will be removed from the list on the next transition */
+      used?: boolean
     }
 
     export interface DialogContext {


### PR DESCRIPTION
The dialog engine only supports one level of sub flow at the moment, because of the way it uses "previousFlow/previousNode" to move back to its parent. The first time it will work, but it won't for the next one since the previousFlow/Node is no longer valid.

There was already the concept of jump points to handle this, so i've just completed the todo that was there.

Basically, when transitioning to a sub flow, it will add the parent at the end of the jumpPoints. then when it go back to the parent node, the jump point is marked as "used". We can't remove it, because each transitions will trigger processEvent, and if it is removed, only the first transition would work correctly.

Once the jumpPoint was used successfully (eg: the user went on the parent node, THEN transitioned to the next node), it is removed from the list.

Sub flows are not implemented yet, so nothing should be different with these changes