### PR TITLE
fix(core): provide additional port for botpress

### DIFF
--- a/src/bp/core/config/config-loader.ts
+++ b/src/bp/core/config/config-loader.ts
@@ -52,7 +52,7 @@ export class ConfigProvider {
 
     const config = await this.getConfig<BotpressConfig>('botpress.config.json')
 
-    const envPort = process.env.BOTPRESS_PORT || process.env.PORT
+    const envPort = process.env.BP_PORT || process.env.PORT
     config.httpServer.port = envPort ? parseInt(envPort) : config.httpServer.port
     config.httpServer.host = process.env.BP_HOST || config.httpServer.host
     process.PROXY = process.core_env.BP_PROXY || config.httpServer.proxy

--- a/src/bp/core/config/config-loader.ts
+++ b/src/bp/core/config/config-loader.ts
@@ -52,7 +52,8 @@ export class ConfigProvider {
 
     const config = await this.getConfig<BotpressConfig>('botpress.config.json')
 
-    config.httpServer.port = process.env.PORT ? parseInt(process.env.PORT) : config.httpServer.port
+    const envPort = process.env.BOTPRESS_PORT || process.env.PORT
+    config.httpServer.port = envPort ? parseInt(envPort) : config.httpServer.port
     config.httpServer.host = process.env.BP_HOST || config.httpServer.host
     process.PROXY = process.core_env.BP_PROXY || config.httpServer.proxy
 

--- a/src/bp/core/services/action/local-action-server.ts
+++ b/src/bp/core/services/action/local-action-server.ts
@@ -71,7 +71,7 @@ export class LocalActionServer {
   }
 
   public listen() {
-    const port = process.env.BOTPRESS_PORT || process.env.PORT
+    const port = process.env.PORT
 
     this._initializeApp()
     this.app.listen(port, () => this.logger.info(`Local Action Server listening on port ${port}`))

--- a/src/bp/core/services/action/local-action-server.ts
+++ b/src/bp/core/services/action/local-action-server.ts
@@ -71,7 +71,7 @@ export class LocalActionServer {
   }
 
   public listen() {
-    const port = process.env.PORT
+    const port = process.env.BOTPRESS_PORT || process.env.PORT
 
     this._initializeApp()
     this.app.listen(port, () => this.logger.info(`Local Action Server listening on port ${port}`))


### PR DESCRIPTION
resolves botpress/v12#825 

I used `BOTPRESS_PORT` instead of `BP_PORT` as it was used in previous versions.
Let me know if you think it makes sense to rename it.