### PR TITLE
fix(core): continue chain when one mw times out

### DIFF
--- a/src/bp/core/services/middleware/middleware.test.ts
+++ b/src/bp/core/services/middleware/middleware.test.ts
@@ -40,7 +40,7 @@ describe('Middleware', () => {
 
     const fn1 = (event, next) => {
       mock1(event)
-      // next() We swallow the event
+      next(undefined, false) // We swallow the event
     }
 
     middleware.use(fn1)
@@ -56,8 +56,9 @@ describe('Middleware', () => {
   it('should pass event to middleware', async () => {
     const mock = jest.fn()
 
-    middleware.use(event => {
+    middleware.use((event, cb) => {
       mock(event)
+      cb(undefined, true)
     })
 
     const event = {} as IO.Event

--- a/src/bp/core/services/middleware/middleware.ts
+++ b/src/bp/core/services/middleware/middleware.ts
@@ -30,7 +30,7 @@ export class MiddlewareChain {
       const mwPromise = Promise.fromCallback<boolean>(cb => mw(event, cb))
       const result = await Promise.race([timePromise, mwPromise])
       if (timedOut) {
-        break
+        continue
       } else if (typeof result !== 'undefined') {
         // middleware calling next(null, false) will swallow the event
         if (!result) {


### PR DESCRIPTION
When NLU times out (2s of processing), it prevents other middleware from running. Since we always consider the possibility that previous middleware didn't process the event, it should continue the chain.

Time out occurs when the first model is training or before it is loaded in memory