### PR TITLE
Fix side form switching between nodes issues

### DIFF
--- a/src/bp/ui-studio/src/web/components/ContentForm/ArrayFieldTemplate.tsx
+++ b/src/bp/ui-studio/src/web/components/ContentForm/ArrayFieldTemplate.tsx
@@ -1,13 +1,18 @@
 import { Button, Intent, Position, Tooltip } from '@blueprintjs/core'
 import { lang } from 'botpress/shared'
 import cx from 'classnames'
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import style from '~/views/OneFlow/sidePanel/form/style.scss'
 
 import SmartInput from '../SmartInput'
 
 const ArrayFieldTemplate = props => {
-  const { canAdd, onAddClick, items, schema } = props
+  const { canAdd, onAddClick, items, schema, formContext } = props
+  const key = useRef(`${formContext?.customKey}`)
+
+  useEffect(() => {
+    key.current = formContext.customKey
+  }, [formContext?.customKey])
 
   const renderDeleteBtn = (element, className?) => (
     <div className={className}>
@@ -33,6 +38,7 @@ const ArrayFieldTemplate = props => {
           <div key={element.key} className={style.innerWrapper}>
             {type === 'string' ? (
               <SmartInput
+                key={`${key.current}${element.key}`}
                 value={element.children?.props?.formData}
                 onChange={element.children?.props?.onChange}
                 className={cx(style.textarea, style.multipleInputs)}

--- a/src/bp/ui-studio/src/web/components/ContentForm/Text.tsx
+++ b/src/bp/ui-studio/src/web/components/ContentForm/Text.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useEffect, useRef, useState } from 'react'
-import shortid from 'shortid'
 import SmartInput from '~/components/SmartInput'
 import style from '~/views/OneFlow/sidePanel/form/style.scss'
 

--- a/src/bp/ui-studio/src/web/components/ContentForm/Text.tsx
+++ b/src/bp/ui-studio/src/web/components/ContentForm/Text.tsx
@@ -1,9 +1,11 @@
-import React, { FC, useEffect, useState } from 'react'
+import React, { FC, useEffect, useRef, useState } from 'react'
+import shortid from 'shortid'
 import SmartInput from '~/components/SmartInput'
 import style from '~/views/OneFlow/sidePanel/form/style.scss'
 
 interface Props {
   formData: any
+  formContext: any
   schema: any
   required?: boolean
   uiSchema: any
@@ -12,21 +14,28 @@ interface Props {
 
 const Text: FC<Props> = props => {
   const [value, setValue] = useState('')
+  const { formContext, formData, schema, required, uiSchema, onChange } = props
+  const key = useRef(`${formContext?.customKey}`)
 
   useEffect(() => {
-    setValue(props.formData)
-  }, [props.formData])
+    setValue(formData)
+  }, [formData])
+
+  useEffect(() => {
+    key.current = `${formContext?.customKey}`
+  }, [formContext?.customKey])
 
   return (
     <div className={style.fieldWrapper}>
       <span className={style.formLabel}>
-        {props.schema.title} {props.required && '*'}
+        {schema.title} {required && '*'}
       </span>
       <div className={style.innerWrapper}>
         <SmartInput
-          singleLine={props.uiSchema.$subtype !== 'textarea'}
+          key={key.current}
+          singleLine={uiSchema.$subtype !== 'textarea'}
           value={value}
-          onChange={props.onChange}
+          onChange={onChange}
           className={style.textarea}
           isSideForm
         />

--- a/src/bp/ui-studio/src/web/components/ContentForm/index.tsx
+++ b/src/bp/ui-studio/src/web/components/ContentForm/index.tsx
@@ -20,6 +20,7 @@ interface Props {
   contentLang: string
   onChange: any
   formData: any
+  customKey: string
   schema: any
   defaultLanguage: string
 }
@@ -29,15 +30,15 @@ const CustomBaseInput = props => {
 
   if (type === 'string') {
     if ($subtype === 'ref') {
-      return <RefWidget {...props} />
+      return <RefWidget key={props?.formContext?.customKey} {...props} />
     } else if ($subtype === 'media') {
-      return <UploadWidget {...props} />
+      return <UploadWidget key={props?.formContext?.customKey} {...props} />
     } else if ($subtype === 'flow') {
-      return <FlowPickWidget {...props} />
+      return <FlowPickWidget key={props?.formContext?.customKey} {...props} />
     }
   }
 
-  return <SmartInput {...props} singleLine={true} className={style.textarea} />
+  return <SmartInput key={props?.formContext?.customKey} {...props} singleLine={true} className={style.textarea} />
 }
 
 const widgets = {
@@ -89,6 +90,7 @@ const ContentForm: FC<Props> = props => {
 
   const context = {
     ...formData,
+    customKey: props.customKey,
     activeLang: contentLang,
     defaultLang: defaultLanguage
   }

--- a/src/bp/ui-studio/src/web/views/OneFlow/sidePanel/form/SaySomethingForm.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/sidePanel/form/SaySomethingForm.tsx
@@ -183,6 +183,7 @@ const SaySomethingForm: FC<Props> = props => {
           schema={currentContentType?.schema.json}
           uiSchema={currentContentType?.schema.ui}
           formData={currentFlowNode?.content?.formData}
+          customKey={currentFlowNode?.name}
           isEditing={true}
           onChange={handleEdit}
         >


### PR DESCRIPTION
Previously switching from a say node of type text with content to one without content would leave the content of the previous node in the new one, similar issues were notices with different types.

I added customKey so we can pass a key to the component so React can tell two components apart from each other. The issue was that when switching from one node to another, the form and components are the same so instead of rerendering React would just leave it as is when the value was empty. With the customKey, you can pass the id of the node so React knows that they are two different components even if the same form is used