### PR TITLE
fix(shared): delay toast failure & added other toasts

### DIFF
--- a/modules/code-editor/src/views/full/store/api.ts
+++ b/modules/code-editor/src/views/full/store/api.ts
@@ -1,5 +1,4 @@
-import { lang } from 'botpress/shared'
-import { toastFailure } from 'botpress/shared'
+import { lang, toast } from 'botpress/shared'
 import _ from 'lodash'
 
 import { EditableFile, FilePermissions, FilesDS } from '../../../backend/typings'
@@ -104,7 +103,7 @@ export default class CodeEditorApi {
     const errorInfo = data.full || data.message
 
     customMessage
-      ? toastFailure(`${lang.tr(customMessage)}: ${lang.tr(errorInfo, { details: data.details })}`)
-      : toastFailure(errorInfo, data.details)
+      ? toast.failure(`${lang.tr(customMessage)}: ${lang.tr(errorInfo, { details: data.details })}`)
+      : toast.failure(errorInfo, data.details)
   }
 }

--- a/src/bp/ui-shared/src/Toaster/index.tsx
+++ b/src/bp/ui-shared/src/Toaster/index.tsx
@@ -3,36 +3,56 @@ import _ from 'lodash'
 
 import { lang } from '../translations'
 
-export enum Timeout {
-  SHORT = 1000,
-  MEDIUM = 3000,
-  LONG = 5000
-}
-
 export interface ToastOptions {
-  delayed: boolean
-  timeout: Timeout
+  // Delaying to avoid the react lifecycle issue (executing before it is rendered)
+  delayed?: boolean
+  timeout?: 'short' | 'medium' | 'long'
   onDismiss?: (didTimeoutExpire: boolean) => void
 }
 
-export const toastFailure = (
+const success = (
   message: string,
   details?: string,
   options: ToastOptions = {
     delayed: false,
-    timeout: Timeout.MEDIUM
+    timeout: 'short'
+  }
+) => showToast(lang(message, { details }), Intent.SUCCESS, options)
+
+const failure = (
+  message: string,
+  details?: string,
+  options: ToastOptions = {
+    delayed: true,
+    timeout: 'medium'
   }
 ) => {
-  toast(lang(message, { details }), Intent.DANGER, options.timeout, options.onDismiss, options)
+  showToast(lang(message, { details }), Intent.DANGER, options)
 }
 
-const toast = (message, intent, timeout, onDismiss, options?) => {
+const info = (
+  message: string,
+  details?: string,
+  options: ToastOptions = {
+    delayed: false,
+    timeout: 'short'
+  }
+) => showToast(lang(message, { details }), Intent.PRIMARY, options)
+
+const showToast = (message: string, intent, options?: ToastOptions) => {
+  let timeout = 1000
+  if (options?.timeout === 'medium') {
+    timeout = 3000
+  } else if (options?.timeout === 'long') {
+    timeout = 5000
+  }
+
   const showToast = () => {
     Toaster.create({ className: 'recipe-toaster', position: Position.TOP_RIGHT }).show({
       message,
       intent,
       timeout,
-      onDismiss
+      onDismiss: options?.onDismiss
     })
   }
 
@@ -41,6 +61,8 @@ const toast = (message, intent, timeout, onDismiss, options?) => {
   } else {
     setTimeout(() => {
       showToast()
-    }, 500)
+    }, 200)
   }
 }
+
+export const toast = { success, failure, info }

--- a/src/bp/ui-shared/src/index.tsx
+++ b/src/bp/ui-shared/src/index.tsx
@@ -3,7 +3,7 @@ import { lang, langAvaibale, langExtend, langInit, langLocale } from './translat
 import { BaseDialog, DialogBody, DialogFooter } from './BaseDialog'
 import confirmDialog from './ConfirmDialog'
 import Dropdown from './Dropdown'
-import { toastFailure } from './Toaster'
+import { toast } from './Toaster'
 import TreeView from './TreeView'
 
 exports.BaseDialog = BaseDialog
@@ -19,5 +19,6 @@ exports.lang = {
   getLocale: langLocale,
   getAvailable: langAvaibale
 }
-exports.toastFailure = toastFailure
+
+exports.toast = toast
 exports.Dropdown = Dropdown

--- a/src/bp/ui-shared/src/translations/index.tsx
+++ b/src/bp/ui-shared/src/translations/index.tsx
@@ -50,7 +50,12 @@ const langInit = () => {
     {
       locale,
       messages,
-      defaultLocale
+      defaultLocale,
+      onError: err => {
+        if (isDev) {
+          console.error(err)
+        }
+      }
     },
     cache
   )

--- a/src/bp/ui-shared/src/typings.d.ts
+++ b/src/bp/ui-shared/src/typings.d.ts
@@ -20,7 +20,12 @@ declare module 'botpress/shared' {
     getLocale(): string
     getAvailable(): string[]
   }
-  export function toastFailure(message: string, details?: string, options?: ToastOptions)
+
+  export const toast: {
+    success: (message: string, details?: string, options?: ToastOptions) => void
+    failure: (message: string, details?: string, options?: ToastOptions) => void
+    info: (message: string, details?: string, options?: ToastOptions) => void
+  }
 
   export const style: { TooltipStyle }
   export { Option }

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/index.tsx
@@ -1,4 +1,4 @@
-import { lang } from 'botpress/shared'
+import { lang, toast } from 'botpress/shared'
 import { FlowView } from 'common/typings'
 import _ from 'lodash'
 import React, { Component } from 'react'
@@ -15,7 +15,6 @@ import {
   switchFlow
 } from '~/actions'
 import { Container } from '~/components/Shared/Interface'
-import { Timeout, toastFailure, toastInfo } from '~/components/Shared/Utils'
 import { isOperationAllowed } from '~/components/Shared/Utils/AccessControl'
 import DocumentationProvider from '~/components/Util/DocumentationProvider'
 import { isInputFocused } from '~/keyboardShortcuts'
@@ -116,9 +115,9 @@ class FlowBuilder extends Component<Props, State> {
     }
 
     if (!prevProps.errorSavingFlows && this.props.errorSavingFlows) {
-      const { status } = this.props.errorSavingFlows
-      const message = status === 403 ? lang.tr('studio.flow.unauthUpdate') : lang.tr('studio.flow.errorWhileSaving')
-      toastFailure(message, Timeout.LONG, this.props.clearErrorSaveFlows)
+      const { status, data } = this.props.errorSavingFlows
+      const message = status === 403 ? 'studio.flow.unauthUpdate' : 'studio.flow.errorWhileSaving'
+      toast.failure(message, data, { timeout: 'long', delayed: true, onDismiss: this.props.clearErrorSaveFlows })
     }
 
     const flowsHaveChanged = !_.isEqual(prevProps.flowsByName, this.props.flowsByName)
@@ -212,7 +211,7 @@ class FlowBuilder extends Component<Props, State> {
       },
       save: e => {
         e.preventDefault()
-        toastInfo(lang.tr('studio.flow.nowSaveAuto'), Timeout.LONG)
+        toast.info('studio.flow.nowSaveAuto')
       },
       delete: e => {
         if (!isInputFocused()) {


### PR DESCRIPTION
Added missing toasts to shared, and updated their signature at the same time. Translations are built-in, so you can just pass the ID directly.

The failure is delayed a bit otherwise it causes issue when used in a react lifecycle (eg: when doing an API call). Also hiding messages "Translations not found" when not developing, 

