### PR TITLE
chore(dev): fix git on vscode when packaging

### DIFF
--- a/modules/.audience/.gitignore
+++ b/modules/.audience/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/.broadcast/.gitignore
+++ b/modules/.broadcast/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/.history/.gitignore
+++ b/modules/.history/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/.knowledge/.gitignore
+++ b/modules/.knowledge/.gitignore
@@ -1,4 +1,5 @@
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/.scheduler/.gitignore
+++ b/modules/.scheduler/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/analytics/.gitignore
+++ b/modules/analytics/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/basic-skills/.gitignore
+++ b/modules/basic-skills/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/bot-improvement/.gitignore
+++ b/modules/bot-improvement/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/builtin/.gitignore
+++ b/modules/builtin/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/channel-messenger/.gitignore
+++ b/modules/channel-messenger/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/channel-slack/.gitignore
+++ b/modules/channel-slack/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/channel-smooch/.gitignore
+++ b/modules/channel-smooch/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/channel-teams/.gitignore
+++ b/modules/channel-teams/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/channel-telegram/.gitignore
+++ b/modules/channel-telegram/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/channel-web/.gitignore
+++ b/modules/channel-web/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/code-editor/.gitignore
+++ b/modules/code-editor/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/examples/.gitignore
+++ b/modules/examples/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/extensions/.gitignore
+++ b/modules/extensions/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/hitl/.gitignore
+++ b/modules/hitl/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/misunderstood/.gitignore
+++ b/modules/misunderstood/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/ndu/.gitignore
+++ b/modules/ndu/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/nlu-extras/.gitignore
+++ b/modules/nlu-extras/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/nlu-testing/.gitignore
+++ b/modules/nlu-testing/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/nlu/.gitignore
+++ b/modules/nlu/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/qna/.gitignore
+++ b/modules/qna/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/testing/.gitignore
+++ b/modules/testing/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json

--- a/modules/uipath/.gitignore
+++ b/modules/uipath/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /node_modules
+/node_production_modules
 /dist
 /assets/web/
 /assets/config.schema.json


### PR DESCRIPTION
When packaging, node_modules are replaced by node_production_modules, and git gets crazy before crashing the extension, and need to reload vscode