### PR TITLE
fix(core): remove misleading error when using qna redirect

### DIFF
--- a/modules/channel-web/src/backend/socket.ts
+++ b/modules/channel-web/src/backend/socket.ts
@@ -30,7 +30,8 @@ export default async (bp: typeof sdk, db: Database) => {
     const conversationId = event.threadId || (await db.getOrCreateRecentConversation(event.botId, userId))
 
     if (!_.includes(outgoingTypes, messageType)) {
-      return next(new Error('Unsupported event type: ' + event.type))
+      bp.logger.warn(`Unsupported event type: ${event.type}`)
+      return next(undefined, true)
     }
 
     const standardTypes = ['text', 'carousel', 'custom', 'file', 'login_prompt']
@@ -58,7 +59,7 @@ export default async (bp: typeof sdk, db: Database) => {
       )
       bp.realtime.sendPayload(bp.RealTimePayload.forVisitor(userId, 'webchat.message', message))
     } else {
-      throw new Error(`Message type "${messageType}" not implemented yet`)
+      bp.logger.warn(`Message type "${messageType}" not implemented yet`)
     }
 
     next(undefined, false)

--- a/src/bp/core/services/dialog/decision-engine.ts
+++ b/src/bp/core/services/dialog/decision-engine.ts
@@ -254,7 +254,7 @@ export class DecisionEngine {
     const result: SendSuggestionResult = { executeFlows: true }
 
     if (payloads) {
-      await this._sendContent(reply, event)
+      await this._sendContent({ ...reply, payloads }, event)
       result.executeFlows = false
     }
 


### PR DESCRIPTION
To avoid duplication with old decision engine and NDU, i've moved duplicated logic into _sendContent, but forgot to pass the filtered payloads, so it displayed message about unsupported event type (with no impact for the user). 


Also made a small change so the error is soft instead, I don't see why all those logs are necessary for an unsupported type. 

Eg: 
![image](https://user-images.githubusercontent.com/42552874/80006841-6f43e180-8493-11ea-905a-0d5e6f95d9b4.png)

Instead of

![image](https://user-images.githubusercontent.com/42552874/80006819-681cd380-8493-11ea-9a23-2b454d9aea90.png)
