### PR TITLE
fix(core): fix debugging for sub-processes

### DIFF
--- a/src/bp/cluster.ts
+++ b/src/bp/cluster.ts
@@ -41,7 +41,7 @@ export const setupMasterNode = (logger: sdk.Logger) => {
   process.SERVER_ID = process.env.SERVER_ID || nanoid('1234567890abcdefghijklmnopqrstuvwxyz', 10)
 
   // Fix an issue with pkg when passing custom options for v8
-  cluster.setupMaster({ execArgv: [] })
+  cluster.setupMaster({ execArgv: process.execArgv.filter(x => !x.startsWith('--max_old_space_size')) })
 
   registerMsgHandler('reboot_server', (_message, worker) => {
     logger.warn(`Restarting server...`)

--- a/src/bp/cluster.ts
+++ b/src/bp/cluster.ts
@@ -41,7 +41,7 @@ export const setupMasterNode = (logger: sdk.Logger) => {
   process.SERVER_ID = process.env.SERVER_ID || nanoid('1234567890abcdefghijklmnopqrstuvwxyz', 10)
 
   // Fix an issue with pkg when passing custom options for v8
-  cluster.setupMaster({ execArgv: process.execArgv.filter(x => !x.startsWith('--max_old_space_size')) })
+  cluster.setupMaster({ execArgv: process.pkg ? [] : process.execArgv })
 
   registerMsgHandler('reboot_server', (_message, worker) => {
     logger.warn(`Restarting server...`)


### PR DESCRIPTION
We need to remove the oldspace option for subprocesses, but we need to pass other options (when debugging, it needs the inspect flag).