### PR TITLE
fix(channel-web): support html in truncate

### DIFF
--- a/modules/channel-web/package.json
+++ b/modules/channel-web/package.json
@@ -24,6 +24,7 @@
     "bluebird-global": "^1.0.1",
     "classnames": "^2.2.6",
     "date-fns": "^2.4.1",
+    "html-truncate": "^1.2.2",
     "lodash": "^4.17.11",
     "lodash-decorators": "^6.0.1",
     "mime": "^2.4.3",

--- a/modules/channel-web/src/views/lite/components/messages/renderer/Text.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/renderer/Text.tsx
@@ -1,3 +1,4 @@
+import truncate from 'html-truncate'
 import React, { useState } from 'react'
 import Linkify from 'react-linkify'
 
@@ -13,24 +14,23 @@ import { renderUnsafeHTML } from '../../../utils'
  */
 export const Text = (props: Renderer.Text) => {
   const [showMore, setShowMore] = useState(false)
-  const { maxLength, markdown, escapeHTML, intl } = props
-  let text = props.text
+  const { maxLength, markdown, escapeHTML, intl, text } = props
   let hasShowMore
 
   if (intl && maxLength && text.length > maxLength) {
     hasShowMore = true
-    if (!showMore) {
-      const newMessage = text.substring(0, maxLength)
-
-      text = `${newMessage}${newMessage.substring(-1) !== '.' && '...'}`
-    }
   }
 
-  let message = <p>{text}</p>
+  const truncateIfRequired = message => {
+    return hasShowMore && !showMore ? truncate(message, maxLength) : message
+  }
+
+  let message
   if (markdown) {
     const html = renderUnsafeHTML(text, escapeHTML)
-
-    message = <div dangerouslySetInnerHTML={{ __html: html }} />
+    message = <div dangerouslySetInnerHTML={{ __html: truncateIfRequired(html) }} />
+  } else {
+    message = <p>{truncateIfRequired(text)}</p>
   }
 
   return (

--- a/modules/channel-web/yarn.lock
+++ b/modules/channel-web/yarn.lock
@@ -228,6 +228,11 @@ hoist-non-react-statics@^3.0.0:
   dependencies:
     react-is "^16.7.0"
 
+html-truncate@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/html-truncate/-/html-truncate-1.2.2.tgz#db2e331dcf1cba0bd432a507d16e988609f2575f"
+  integrity sha1-2y4zHc8cugvUMqUH0W6YhgnyV18=
+
 ieee754@1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"


### PR DESCRIPTION
Avoids truncating HTML text (which breaks links). Text may be longer than the length specified, but not the visible part.