### PR TITLE
fix(skill-choice): also match on choice value

### DIFF
--- a/modules/basic-skills/src/actions/choice_parse_answer.js
+++ b/modules/basic-skills/src/actions/choice_parse_answer.js
@@ -31,13 +31,15 @@ const validateChoice = async data => {
   }
 
   if (!choice) {
+    const preview = (event.preview || '').toLowerCase()
+    const userText = ((event.payload && event.payload.text) || '').toLowerCase()
+    const choiceValue = ((event.payload && event.payload.payload) || '').toLowerCase()
+
     choice = _.findKey(data.keywords, keywords =>
-      _.some(
-        keywords || [],
-        k =>
-          _.includes((event.preview || '').toLowerCase(), (k || '').toLowerCase()) ||
-          (event.payload && _.includes(_.get(event, 'payload.text', '').toLowerCase(), (k || '').toLowerCase()))
-      )
+      _.some(keywords || [], k => {
+        const keyword = (k || '').toLowerCase()
+        return preview.includes(keyword) || userText.includes(keyword) || choiceValue.includes(keyword)
+      })
     )
   }
 


### PR DESCRIPTION
Skill choice checks the keywords in the preview or the payload text (which is what was typed by the user), but it may cause problem with translations. 

So i've also added a comparison for the payload value, which is what the user associates with the label when creating a choice.

The value should be the same for all languages, so it's something we should keep in mind for the future