### PR TITLE
fix(studio): actions menu sometime empty

### DIFF
--- a/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/ActionModalForm.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/ActionModalForm.tsx
@@ -76,6 +76,16 @@ class ActionModalForm extends Component<Props, State> {
       this.setState({ actionType: 'code' })
     }
 
+    this.prepareActions()
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.actions !== this.props.actions) {
+      this.prepareActions()
+    }
+  }
+
+  prepareActions() {
     this.setState({
       avActions: (this.props.actions || []).map(x => {
         return {


### PR DESCRIPTION
The actions menu was sometimes empty, because they were processed only when the component was mounted, and not when actions were loaded. 

Also fixes an issue where newly created actions doesn't show up in the menu until a refresh.

I know the best solution would have been to rewrite the component using hooks, but I don't want to interfere with possible changes in 12.9 around that file.