### PR TITLE
fix(analytics): added export data as csv

### DIFF
--- a/modules/analytics/src/views/full/index.tsx
+++ b/modules/analytics/src/views/full/index.tsx
@@ -396,6 +396,23 @@ const Analytics: FC<any> = ({ bp }) => {
     }
   ]
 
+  const exportCsv = async () => {
+    const data = [
+      `"date","botId","channel","metric","subMetric","value"`,
+      ...state.metrics.map(entry => {
+        return [entry.date, entry.botId, entry.channel, entry.metric, entry.subMetric, entry.value]
+          .map(x => (x || 'N/A').toString().replace(/"/g, '\\"'))
+          .map(x => `"${x}"`)
+          .join(',')
+      })
+    ].join('\r\n')
+
+    const link = document.createElement('a')
+    link.href = URL.createObjectURL(new Blob([data]))
+    link.download = `analytics.csv`
+    link.click()
+  }
+
   return (
     <div className={style.mainWrapper}>
       <div className={style.innerWrapper}>
@@ -426,6 +443,8 @@ const Analytics: FC<any> = ({ bp }) => {
                 value={state.dateRange}
               />
             </Popover>
+
+            <Button className={style.exportButton} onClick={exportCsv} icon="export" text="Export CSV"></Button>
           </div>
         </div>
         <div className={style.sectionsWrapper}>

--- a/modules/analytics/src/views/full/style.scss
+++ b/modules/analytics/src/views/full/style.scss
@@ -3,13 +3,13 @@ $colorMessenger: #83aeee;
 $colorTelegram: #463cff;
 $colorSlack: #ff8989;
 $textColor: #182026;
-$lightText: #5C7080;
-$linkText: #1F8FFA;
+$lightText: #5c7080;
+$linkText: #1f8ffa;
 $danger-color: #d14319;
 $success-color: #56b149;
 
 .mainWrapper {
-  background: #EBF1F5;
+  background: #ebf1f5;
   height: 100%;
   overflow-y: scroll;
   padding: 25px;
@@ -68,6 +68,13 @@ $success-color: #56b149;
     justify-content: left;
     margin-left: 20px;
     width: 220px;
+  }
+
+  .exportButton {
+    height: 40px;
+    justify-content: left;
+    margin-left: 20px;
+    width: 150px;
   }
 
   .filterItem select {
@@ -239,7 +246,7 @@ $success-color: #56b149;
     a {
       &::before {
         color: $lightText;
-        content: counter(li) ".";
+        content: counter(li) '.';
         display: inline-block;
         margin-right: 4px;
       }
@@ -329,5 +336,5 @@ $success-color: #56b149;
     fill: $lightText;
     font-size: 12px;
     font-weight: 400;
-}
+  }
 }

--- a/modules/analytics/src/views/full/style.scss.d.ts
+++ b/modules/analytics/src/views/full/style.scss.d.ts
@@ -10,6 +10,7 @@ interface CssExports {
   'diffNumberUp': string;
   'empty': string;
   'emptyState': string;
+  'exportButton': string;
   'filterItem': string;
   'filters': string;
   'filtersShowing': string;


### PR DESCRIPTION
Added the CSV button that was supposed to be there. Exports the raw metrics used to generate the graph.

![image](https://user-images.githubusercontent.com/42552874/80139043-d042e680-8573-11ea-81ea-e30ef0f810aa.png)

![image](https://user-images.githubusercontent.com/42552874/80139117-e94b9780-8573-11ea-958e-1106a10b9548.png)
