### PR TITLE
fix(core): bring back previous flow/node

### DIFF
--- a/src/bp/core/services/dialog/dialog-engine.ts
+++ b/src/bp/core/services/dialog/dialog-engine.ts
@@ -238,6 +238,9 @@ export class DialogEngine {
       context = {
         currentFlow: flow.name,
         currentNode: startNode.name,
+        // Those two are not used in the backend logic, but keeping them since users rely on them
+        previousFlow: event.state.context.currentFlow,
+        previousNode: event.state.context.currentNode,
         jumpPoints: [
           ...(context.jumpPoints || []),
           {
@@ -324,6 +327,8 @@ export class DialogEngine {
     event.state.context = {
       currentFlow: subflow.name,
       currentNode: subflowStartNode.name,
+      previousFlow: parentFlow.name,
+      previousNode: parentNode.name,
       jumpPoints: [
         ...(event.state.context.jumpPoints || []),
         {


### PR DESCRIPTION
previousFlow/node were removed since you could use jumpPoints and __stacktrace to get the same information, however since we filter out "skills-" from the stacktrace elements, they can be useful in some case.

Exact same logic as before, but we're using jumpPoints for subflow exit
