### PR TITLE
feat(code-editor): add file upload to advanced editor

### DIFF
--- a/docs/guide/docs/advanced/configuration.md
+++ b/docs/guide/docs/advanced/configuration.md
@@ -170,7 +170,17 @@ Botpress supports `.env` files, so you don't have to set them every time you sta
 | FAST_TEXT_CLEANUP_MS      | The model will be kept in memory until it receives no messages to process for that duration | 60000   |
 | REVERSE_PROXY             | When enabled, it uses "x-forwarded-for" to fetch the user IP instead of remoteAddress       | false   |
 
-It is also possible to use environment variables to override module configuration. The pattern is `BP_%MODULE_NAME%_%OPTION_PATH%`, all in upper cases. For example, to define the `confidenceTreshold` option of the module `nlu`, you would use `BP_NLU_CONFIDENCETRESHOLD`. You can list the available environment variables for each modules by enabling the `DEBUG=bp:configuration:modules:*` flag.
+It is also possible to use environment variables to override module configuration. The pattern is `BP_MODULE_%MODULE_NAME%_%OPTION_PATH%`, all in upper cases. For example, to define the `confidenceTreshold` option of the module `nlu`, you would use `BP_MODULE_NLU_CONFIDENCETRESHOLD`. You can list the available environment variables for each modules by enabling the `DEBUG=bp:configuration:modules:*` flag.
+
+### Security
+
+These variables can be used to disable some sensitive features destined to Super Admins.
+
+| Environment Variable            | Description                                                                                                                                        | Default |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| BP_CODE_EDITOR_DISABLE_ADVANCED | The advanced editor lacks some safeguard and is only intended for experienced users. It can be disabled completely using this environment variable | false   |
+| BP_CODE_EDITOR_DISABLE_UPLOAD   | Prevent users from uploading files when using the advanced editor                                                                                  | false   |
+| BP_DISABLE_SERVER_CONFIG        | Prevent Super Admins from accessing the "Production Checklist" page on the Admin panel, since it may contain sensitive informations                | false   |
 
 ## More Information
 

--- a/modules/code-editor/package.json
+++ b/modules/code-editor/package.json
@@ -12,6 +12,7 @@
     "package": "node ../../build/module-builder/bin/entry package"
   },
   "devDependencies": {
+    "@types/multer": "^1.4.3",
     "monaco-editor-webpack-plugin": "^1.9.0",
     "webpack": "^4.20.2"
   },
@@ -20,6 +21,7 @@
     "mobx": "^5.10.1",
     "mobx-react": "^6.1.1",
     "monaco-editor": "^0.17.0",
+    "multer": "^1.4.2",
     "prettier": "^1.19.1",
     "react-icons": "^3.8.0"
   },

--- a/modules/code-editor/package.json
+++ b/modules/code-editor/package.json
@@ -23,7 +23,8 @@
     "monaco-editor": "^0.17.0",
     "multer": "^1.4.2",
     "prettier": "^1.19.1",
-    "react-icons": "^3.8.0"
+    "react-icons": "^3.8.0",
+    "yn": "^4.0.0"
   },
   "resolutions": {
     "fstream": ">=1.0.12",

--- a/modules/code-editor/src/backend/api.ts
+++ b/modules/code-editor/src/backend/api.ts
@@ -1,9 +1,11 @@
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
+import multer from 'multer'
+import path from 'path'
 
 import Editor from './editor'
 import { RequestWithPerms } from './typings'
-import { getPermissionsMw, validateFilePayloadMw } from './utils_router'
+import { getPermissionsMw, validateFilePayloadMw, validateFileUploadMw } from './utils_router'
 
 const debugRead = DEBUG('audit:code-editor:read')
 const debugWrite = DEBUG('audit:code-editor:write')
@@ -103,6 +105,25 @@ export default async (bp: typeof sdk, editor: Editor) => {
       next(err)
     }
   })
+
+  router.post(
+    '/upload',
+    loadPermsMw,
+    validateFileUploadMw,
+    multer().single('file'),
+    async (req: RequestWithPerms, res, next) => {
+      const folder = path.dirname(req.body.location)
+      const filename = path.basename(req.body.location)
+
+      try {
+        await bp.ghost.forRoot().upsertFile(folder, filename, req.file.buffer)
+        res.sendStatus(200)
+      } catch (err) {
+        bp.logger.attachError(err).error('Could not upload file')
+        next(err)
+      }
+    }
+  )
 
   router.get('/permissions', loadPermsMw, async (req: RequestWithPerms, res, next) => {
     try {

--- a/modules/code-editor/src/backend/utils_router.ts
+++ b/modules/code-editor/src/backend/utils_router.ts
@@ -67,3 +67,19 @@ export const validateFilePayloadMw = (actionType: 'read' | 'write') => async (re
     next(err)
   }
 }
+
+export const validateFileUploadMw = async (req, res, next) => {
+  if (!req.permissions || !req.body) {
+    next(new Error('module.code-editor.error.missingParameters'))
+  }
+
+  if (!req.permissions['root.raw'].write) {
+    next(new Error('module.code-editor.error.lackUploadPermissions'))
+  }
+
+  if (process.env.BP_MODULE_CODE_EDITOR_DISABLE_UPLOAD) {
+    next(new Error('module.code-editor.error.fileUploadDisabled'))
+  }
+
+  next()
+}

--- a/modules/code-editor/src/backend/utils_router.ts
+++ b/modules/code-editor/src/backend/utils_router.ts
@@ -1,4 +1,5 @@
 import * as sdk from 'botpress/sdk'
+import yn from 'yn'
 
 import { FileTypes } from './definitions'
 import { EditableFile, FilePermissions } from './typings'
@@ -22,7 +23,7 @@ export const getPermissionsMw = (bp: typeof sdk) => async (req: any, res, next):
       continue
     }
 
-    if (allowRoot) {
+    if (allowRoot && !yn(process.core_env.BP_CODE_EDITOR_DISABLE_ADVANCED)) {
       perms[rootKey] = {
         type,
         write: await permissionsChecker('write', rootKey),
@@ -77,7 +78,7 @@ export const validateFileUploadMw = async (req, res, next) => {
     next(new Error('module.code-editor.error.lackUploadPermissions'))
   }
 
-  if (process.env.BP_MODULE_CODE_EDITOR_DISABLE_UPLOAD) {
+  if (yn(process.core_env.BP_CODE_EDITOR_DISABLE_UPLOAD)) {
     next(new Error('module.code-editor.error.fileUploadDisabled'))
   }
 

--- a/modules/code-editor/src/translations/en.json
+++ b/modules/code-editor/src/translations/en.json
@@ -1,7 +1,11 @@
 {
   "error": {
     "cannotSaveFile": "Could not save your file",
-    "invalidJson": "Invalid JSON file: {details}"
+    "cannotUploadFile": "Cannot upload your file",
+    "fileUploadDisabled": "File upload disabled by an environment variable.",
+    "invalidJson": "Invalid JSON file: {details}",
+    "lackUploadPermissions": "You do not have sufficient permissions to upload files",
+    "missingParameters": "Missing parameters"
   },
   "fileStatus": {
     "fileInformation": "File Information",
@@ -71,7 +75,15 @@
     "fileEnabled": "File enabled successfully!",
     "fileRenamed": "File renamed successfully!",
     "fileSaved": "File saved successfully!",
+    "fileUploaded": "File uploaded successfully!",
     "invalidFilename": "Invalid filename",
     "onlySuperAdmins": "Only Super Admins can use the raw file editor"
+  },
+  "uploadModal": {
+    "completeFilePath": "Complete File Path",
+    "filePathHelp": "Type the complete path to the file, including the extension, relative to /data",
+    "overwrite": "Overwrite existing file",
+    "selectFile": "Select your file",
+    "uploadFile": "Upload File"
   }
 }

--- a/modules/code-editor/src/translations/fr.json
+++ b/modules/code-editor/src/translations/fr.json
@@ -1,7 +1,11 @@
 {
   "error": {
     "cannotSaveFile": "Impossible de sauvegarder le fichier",
-    "invalidJson": "Fichier JSON invalide: {details}"
+    "cannotUploadFile": "Impossible de téléverser votre fichier",
+    "fileUploadDisabled": "L'envoi de fichier a été désactivé via une variable d'environnement.",
+    "invalidJson": "Fichier JSON invalide: {details}",
+    "lackUploadPermissions": "Vous n'avez pas suffisament de permissions pour envoyer un fichier.",
+    "missingParameters": "Paramètres manquants"
   },
   "fileStatus": {
     "fileInformation": "Informations sur le fichier",
@@ -71,7 +75,15 @@
     "fileEnabled": "Fichier activé avec succès!",
     "fileRenamed": "Fichier renommé avec succès!",
     "fileSaved": "Fichier enregistré avec succès!",
+    "fileUploaded": "Fichier envoyé avec succès!",
     "invalidFilename": "Nom de fichier non valide",
     "onlySuperAdmins": "Seuls les super administrateurs peuvent utiliser l'éditeur de fichiers avancé"
+  },
+  "uploadModal": {
+    "completeFilePath": "Chemin complet du fichier",
+    "filePathHelp": "Tapez le chemin complet, incluant les dossier ainsi que l'extension. Chemin relatif à /data",
+    "overwrite": "Écraser le fichier existant",
+    "selectFile": "Sélectionnez votre fichier",
+    "uploadFile": "Téléverser un fichier"
   }
 }

--- a/modules/code-editor/src/views/full/SidePanel.tsx
+++ b/modules/code-editor/src/views/full/SidePanel.tsx
@@ -10,6 +10,7 @@ import { HOOK_SIGNATURES } from '../../typings/hooks'
 import FileStatus from './components/FileStatus'
 import NameModal from './components/NameModal'
 import NewFileModal from './components/NewFileModal'
+import { UploadModal } from './components/UploadModal'
 import { RootStore, StoreDef } from './store'
 import { EditorStore } from './store/editor'
 import { EXAMPLE_FOLDER_LABEL } from './utils/tree'
@@ -28,6 +29,7 @@ class PanelContent extends React.Component<Props> {
     selectedFile: undefined,
     isMoveModalOpen: false,
     isCreateModalOpen: false,
+    isUploadModalOpen: false,
     fileType: undefined,
     hookType: undefined
   }
@@ -210,6 +212,12 @@ class PanelContent extends React.Component<Props> {
         label={lang.tr('module.code-editor.sidePanel.rawFileEditor')}
         actions={[
           {
+            id: 'btn-upload',
+            icon: <Icon icon="upload" />,
+            key: 'upload',
+            onClick: () => this.setState({ selectedFile: undefined, isUploadModalOpen: true })
+          },
+          {
             id: 'btn-add-action',
             icon: <Icon icon="add" />,
             key: 'add',
@@ -327,6 +335,12 @@ class PanelContent extends React.Component<Props> {
           hasPermission={this.hasPermission}
           files={this.props.files}
         />
+        <UploadModal
+          isOpen={this.state.isUploadModalOpen}
+          uploadFile={this.props.store.uploadFile}
+          toggle={() => this.setState({ isUploadModalOpen: !this.state.isUploadModalOpen })}
+          files={this.props.files}
+        />
       </SidePanel>
     )
   }
@@ -342,7 +356,7 @@ export default inject(({ store }: { store: RootStore }) => ({
   permissions: store.permissions
 }))(observer(PanelContent))
 
-type Props = { store?: RootStore; editor?: EditorStore } & Pick<
+type Props = { store?: RootStore; editor?: EditorStore; uploadFile?: any } & Pick<
   StoreDef,
   'files' | 'permissions' | 'createFilePrompt' | 'setFilenameFilter'
 >

--- a/modules/code-editor/src/views/full/components/UploadModal.tsx
+++ b/modules/code-editor/src/views/full/components/UploadModal.tsx
@@ -136,10 +136,7 @@ export const UploadModal: FC<Props> = props => {
         }}
       >
         <div className={Classes.DIALOG_BODY}>
-          <FormGroup
-            label={<span>{lang.tr('module.code-editor.uploadModal.selectFile')}</span>}
-            labelFor="input-archive"
-          >
+          <FormGroup label={<span>{lang.tr('module.code-editor.uploadModal.selectFile')}</span>}>
             <FileInput
               text={filePath || `${lang.tr('chooseFile')}...`}
               onChange={e => readFile((e.target as HTMLInputElement).files)}

--- a/modules/code-editor/src/views/full/components/UploadModal.tsx
+++ b/modules/code-editor/src/views/full/components/UploadModal.tsx
@@ -1,0 +1,189 @@
+import { Button, Callout, Checkbox, Classes, Dialog, FileInput, FormGroup, InputGroup, Intent } from '@blueprintjs/core'
+import { lang } from 'botpress/shared'
+import { toastFailure } from 'botpress/utils'
+import _ from 'lodash'
+import React, { FC } from 'react'
+
+import { FilesDS } from '../../../backend/typings'
+import { sanitizeName } from '../utils'
+
+interface Props {
+  files?: FilesDS
+  isOpen: boolean
+  toggle: () => void
+  uploadFile: any
+}
+
+interface State {
+  file: any
+  fullPath?: string
+  filePath: string
+  isLoading: boolean
+  hasError: boolean
+  alreadyExists: boolean
+  overwrite: boolean
+}
+
+const fetchReducer = (state: State, action): State => {
+  if (action.type === 'clearState') {
+    return {
+      file: undefined,
+      fullPath: '',
+      filePath: '',
+      isLoading: false,
+      hasError: false,
+      alreadyExists: false,
+      overwrite: false
+    }
+  } else if (action.type === 'receivedFile') {
+    const { file, filePath, fullPath } = action.data
+    return { ...state, file, filePath, fullPath }
+  } else if (action.type === 'updateLocation') {
+    const { fullPath, alreadyExists } = action.data
+    return { ...state, fullPath, alreadyExists }
+  } else if (action.type === 'changeOverwrite') {
+    const { overwrite } = action.data
+    return { ...state, overwrite }
+  } else if (action.type === 'startUpload') {
+    return { ...state, isLoading: true }
+  } else if (action.type === 'showError') {
+    return { ...state, isLoading: false, hasError: true }
+  } else {
+    throw new Error(`That action type isn't supported.`)
+  }
+}
+
+export const UploadModal: FC<Props> = props => {
+  const [state, dispatch] = React.useReducer(fetchReducer, {
+    file: undefined,
+    fullPath: '',
+    filePath: '',
+    isLoading: false,
+    hasError: false,
+    alreadyExists: false,
+    overwrite: false
+  })
+
+  const { file, fullPath, filePath, isLoading, hasError, alreadyExists, overwrite } = state
+
+  const submitChanges = async () => {
+    dispatch({ type: 'startUpload' })
+
+    try {
+      const form = new FormData()
+      form.append('location', fullPath)
+      form.append('file', file)
+
+      await props.uploadFile(form)
+      closeDialog()
+    } catch (err) {
+      dispatch({ type: 'hasError' })
+      toastFailure(err.message)
+    }
+  }
+
+  const closeDialog = () => {
+    dispatch({ type: 'clearState' })
+    props.toggle()
+  }
+
+  const readFile = (files: FileList | null) => {
+    if (!files) {
+      return
+    }
+
+    dispatch({
+      type: 'receivedFile',
+      data: {
+        file: files[0],
+        filePath: files[0].name,
+        fullPath: state.fullPath.length ? state.fullPath : files[0].name
+      }
+    })
+  }
+
+  const toggleConfirmation = event => {
+    dispatch({ type: 'changeOverwrite', data: { overwrite: event.currentTarget.checked } })
+  }
+
+  const updateLocation = text => {
+    const sanitized = sanitizeName(text)
+    const existing = !!props.files.raw.find(x => x.location === sanitized)
+
+    dispatch({
+      type: 'updateLocation',
+      data: {
+        fullPath: sanitized,
+        alreadyExists: existing
+      }
+    })
+  }
+
+  return (
+    <Dialog
+      title={lang.tr('module.code-editor.uploadModal.uploadFile')}
+      icon="upload"
+      isOpen={props.isOpen}
+      onClose={closeDialog}
+      transitionDuration={0}
+      canOutsideClickClose={false}
+    >
+      <div
+        onDragOver={e => e.preventDefault()}
+        onDrop={e => {
+          e.preventDefault()
+          readFile(e.dataTransfer.files)
+        }}
+      >
+        <div className={Classes.DIALOG_BODY}>
+          <FormGroup
+            label={<span>{lang.tr('module.code-editor.uploadModal.selectFile')}</span>}
+            labelFor="input-archive"
+          >
+            <FileInput
+              text={filePath || `${lang.tr('chooseFile')}...`}
+              onChange={e => readFile((e.target as HTMLInputElement).files)}
+              fill={true}
+            />
+          </FormGroup>
+
+          <FormGroup
+            label={lang.tr('module.code-editor.uploadModal.completeFilePath')}
+            helperText={lang.tr('module.code-editor.uploadModal.filePathHelp')}
+          >
+            <InputGroup
+              id="input-name"
+              tabIndex={1}
+              placeholder="global/actions/my-file.js"
+              value={fullPath}
+              onChange={e => updateLocation(e.currentTarget.value)}
+              required
+              autoFocus
+            />
+          </FormGroup>
+
+          {alreadyExists && (
+            <Callout intent={Intent.DANGER} title={lang.tr('module.code-editor.store.alreadyExists')}>
+              <Checkbox
+                label={lang.tr('module.code-editor.uploadModal.overwrite')}
+                onClick={toggleConfirmation}
+                checked={overwrite}
+              />
+            </Callout>
+          )}
+        </div>
+        <div className={Classes.DIALOG_FOOTER}>
+          <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+            <Button
+              id="btn-submit"
+              text={isLoading ? lang.tr('pleaseWait') : lang.tr('submit')}
+              disabled={isLoading || hasError || (alreadyExists && !overwrite)}
+              onClick={submitChanges}
+              intent={Intent.PRIMARY}
+            />
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  )
+}

--- a/modules/code-editor/src/views/full/store/api.ts
+++ b/modules/code-editor/src/views/full/store/api.ts
@@ -95,6 +95,17 @@ export default class CodeEditorApi {
     }
   }
 
+  async uploadFile(data: FormData): Promise<boolean> {
+    try {
+      await this.axios.post(`/mod/code-editor/upload`, data, {
+        headers: { 'Content-Type': 'multipart/form-data' }
+      })
+      return true
+    } catch (err) {
+      this.handleApiError(err, 'module.code-editor.error.cannotUploadFile')
+    }
+  }
+
   handleApiError = (error, customMessage?: string) => {
     if (error.response && error.response.status === 403) {
       return // not enough permissions, nothing to do

--- a/modules/code-editor/src/views/full/store/index.ts
+++ b/modules/code-editor/src/views/full/store/index.ts
@@ -201,6 +201,14 @@ class RootStore {
       await this.fetchFiles()
     }
   }
+
+  @action.bound
+  async uploadFile(data: FormData) {
+    if (await this.api.uploadFile(data)) {
+      toastSuccess(lang.tr('module.code-editor.store.fileUploaded'))
+      await this.fetchFiles()
+    }
+  }
 }
 
 export { RootStore }

--- a/modules/code-editor/src/views/full/utils/index.ts
+++ b/modules/code-editor/src/views/full/utils/index.ts
@@ -28,3 +28,9 @@ export const toastFailure = message =>
     intent: Intent.DANGER,
     timeout: 3500
   })
+
+export const sanitizeName = (text: string) =>
+  text
+    .replace(/\s/g, '-')
+    .replace(/[^a-zA-Z0-9\/_.-]/g, '')
+    .replace(/\/\//, '/')

--- a/modules/code-editor/yarn.lock
+++ b/modules/code-editor/yarn.lock
@@ -2,6 +2,74 @@
 # yarn lockfile v1
 
 
+"@types/body-parser@*":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
+  integrity sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/connect@*":
+  version "3.4.33"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz#31610c901eca573b8713c3330abc6e6b9f588546"
+  integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
+  dependencies:
+    "@types/node" "*"
+
+"@types/express-serve-static-core@*":
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.5.tgz#a00ac7dadd746ae82477443e4d480a6a93ea083c"
+  integrity sha512-578YH5Lt88AKoADy0b2jQGwJtrBxezXtVe/MBqWXKZpqx91SnC0pVkVCcxcytz3lWW+cHBYDi3Ysh0WXc+rAYw==
+  dependencies:
+    "@types/node" "*"
+    "@types/range-parser" "*"
+
+"@types/express@*":
+  version "4.17.6"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.6.tgz#6bce49e49570507b86ea1b07b806f04697fac45e"
+  integrity sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
+
+"@types/mime@*":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
+  integrity sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==
+
+"@types/multer@^1.4.3":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@types/multer/-/multer-1.4.3.tgz#bdff74b334c38a8ee1de9fbedb5d1d3dbc377422"
+  integrity sha512-tWsKbF5LYtXrJ7eOfI0aLBgEv9B7fnJe1JRXTj5+Z6EMfX0yHVsRFsNGnKyN8Bs0gtDv+JR37xAqsPnALyVTqg==
+  dependencies:
+    "@types/express" "*"
+
+"@types/node@*":
+  version "13.13.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.2.tgz#160d82623610db590a64e8ca81784e11117e5a54"
+  integrity sha512-LB2R1Oyhpg8gu4SON/mfforE525+Hi/M1ineICEDftqNVTyFg1aRIeGuTvXAoWHc4nbrFncWtJgMmoyRvuGh7A==
+
+"@types/qs@*":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.1.tgz#937fab3194766256ee09fcd40b781740758617e7"
+  integrity sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw==
+
+"@types/range-parser@*":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
+  integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/serve-static@*":
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.3.tgz#eb7e1c41c4468272557e897e9171ded5e2ded9d1"
+  integrity sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/mime" "*"
+
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.8.5.tgz#51b1c5fe6576a34953bf4b253df9f0d490d9e359"
@@ -202,6 +270,11 @@ anymatch@^2.0.0:
   dependencies:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
+
+append-field@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/append-field/-/append-field-1.0.0.tgz#1e3440e915f0b1203d23748e78edd7b9b5b43e56"
+  integrity sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY=
 
 aproba@^1.1.1:
   version "1.2.0"
@@ -422,6 +495,14 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
+busboy@^0.2.11:
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-0.2.14.tgz#6c2a622efcf47c57bbbe1e2a9c37ad36c7925453"
+  integrity sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=
+  dependencies:
+    dicer "0.2.5"
+    readable-stream "1.1.x"
+
 cacache@^12.0.2:
   version "12.0.3"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.3.tgz#be99abba4e1bf5df461cd5a2c1071fc432573390"
@@ -561,7 +642,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.5.0:
+concat-stream@^1.5.0, concat-stream@^1.5.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -698,6 +779,14 @@ des.js@^1.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
 
+dicer@0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.2.5.tgz#5996c086bb33218c812c090bddc09cd12facb70f"
+  integrity sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=
+  dependencies:
+    readable-stream "1.1.x"
+    streamsearch "0.1.2"
+
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -721,6 +810,11 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
+
+ee-first@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+  integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 elliptic@^6.0.0:
   version "6.5.2"
@@ -1219,6 +1313,11 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -1354,6 +1453,11 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
+media-typer@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+  integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+
 memory-fs@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -1396,6 +1500,18 @@ miller-rabin@^4.0.0:
   dependencies:
     bn.js "^4.0.0"
     brorand "^1.0.1"
+
+mime-db@1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
+  integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
+
+mime-types@~2.1.24:
+  version "2.1.26"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
+  integrity sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==
+  dependencies:
+    mime-db "1.43.0"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -1501,6 +1617,20 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
+multer@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/multer/-/multer-1.4.2.tgz#2f1f4d12dbaeeba74cb37e623f234bf4d3d2057a"
+  integrity sha512-xY8pX7V+ybyUpbYMxtjM9KAiD9ixtg5/JkeKUTD6xilfDv0vzzOFcCp4Ljb1UU3tSOM3VTZtKo63OmzOrGi3Cg==
+  dependencies:
+    append-field "^1.0.0"
+    busboy "^0.2.11"
+    concat-stream "^1.5.2"
+    mkdirp "^0.5.1"
+    object-assign "^4.1.1"
+    on-finished "^2.3.0"
+    type-is "^1.6.4"
+    xtend "^4.0.0"
+
 nan@^2.12.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
@@ -1596,6 +1726,13 @@ object.pick@^1.3.0:
   integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
   dependencies:
     isobject "^3.0.1"
+
+on-finished@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
+  integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
+  dependencies:
+    ee-first "1.1.1"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -1828,6 +1965,16 @@ react-icons@^3.8.0:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+readable-stream@1.1.x:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
 
 readdirp@^2.2.1:
   version "2.2.1"
@@ -2082,12 +2229,22 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
 
+streamsearch@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
+  integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
+
 string_decoder@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
+
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -2186,6 +2343,14 @@ tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
+
+type-is@^1.6.4:
+  version "1.6.18"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
+  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.24"
 
 typedarray@^0.0.6:
   version "0.0.6"

--- a/modules/code-editor/yarn.lock
+++ b/modules/code-editor/yarn.lock
@@ -2520,3 +2520,8 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yn@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-4.0.0.tgz#611480051ea43b510da1dfdbe177ed159f00a979"
+  integrity sha512-huWiiCS4TxKc4SfgmTwW1K7JmXPPAmuXWYy4j9qjQo4+27Kni8mGhAAi1cloRWmBe2EqcLgt3IGqQoRL/MtPgg==

--- a/src/bp/core/services/ghost/service.ts
+++ b/src/bp/core/services/ghost/service.ts
@@ -7,6 +7,7 @@ import { diffLines } from 'diff'
 import { EventEmitter2 } from 'eventemitter2'
 import fse from 'fs-extra'
 import { inject, injectable, tagged } from 'inversify'
+import jsonlintMod from 'jsonlint-mod'
 import _ from 'lodash'
 import minimatch from 'minimatch'
 import mkdirp from 'mkdirp'
@@ -14,7 +15,6 @@ import path from 'path'
 import replace from 'replace-in-file'
 import tmp, { file } from 'tmp'
 import { VError } from 'verror'
-import jsonlintMod from 'jsonlint-mod'
 
 import { createArchive } from '../../misc/archive'
 import { TYPES } from '../../types'
@@ -41,7 +41,7 @@ export interface FileChange {
 
 export type FileChangeAction = 'add' | 'edit' | 'del'
 
-const MAX_GHOST_FILE_SIZE = '100mb'
+const MAX_GHOST_FILE_SIZE = process.core_env.BP_BPFS_MAX_FILE_SIZE || '100mb'
 const bpfsIgnoredFiles = ['models/**', 'data/bots/*/models/**', '**/*.js.map']
 const GLOBAL_GHOST_KEY = '__global__'
 const BOTS_GHOST_KEY = '__bots__'

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -216,6 +216,12 @@ declare type BotpressEnvironmentVariables = {
    * @default 4
    */
   readonly BP_NUM_ML_WORKERS?: number
+
+  /**
+   * Overrides the maximum file size allowed for the BPFS
+   * @default 100mb
+   */
+  readonly BP_BPFS_MAX_FILE_SIZE?: string
 }
 
 interface IDebug {

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -222,6 +222,18 @@ declare type BotpressEnvironmentVariables = {
    * @default 100mb
    */
   readonly BP_BPFS_MAX_FILE_SIZE?: string
+
+  /**
+   * Disable the file upload feature on the Code Editor
+   * @default false
+   */
+  readonly BP_CODE_EDITOR_DISABLE_UPLOAD?: boolean
+
+  /**
+   * Disable the advanced editor feature on the Code Editor
+   * @default false
+   */
+  readonly BP_CODE_EDITOR_DISABLE_ADVANCED?: boolean
 }
 
 interface IDebug {


### PR DESCRIPTION
This brings a feature that was lacking from the advanced editor: the ability to upload raw files.
The user must have access to the advanced editor, which means that only super admins can use the feature. 

The environment variable  `BP_MODULE_CODE_EDITOR_DISABLE_UPLOAD` can be used to disable file upload for everyone.

If you need to upload large files, there's a new environment variable to up the limit on the BPFS storage: `BP_BPFS_MAX_FILE_SIZE`. The default size is `100mb`


![image](https://user-images.githubusercontent.com/42552874/80171695-0787b680-85b9-11ea-8afc-de56336ebf4d.png)

There's a basic filename validation to validate before overwriting something:
![image](https://user-images.githubusercontent.com/42552874/80171901-91378400-85b9-11ea-97f6-94fce6a755d9.png)

