### PR TITLE
feat(core): track bot upgrade history

### DIFF
--- a/src/bp/core/config/bot.config.ts
+++ b/src/bp/core/config/bot.config.ts
@@ -23,6 +23,13 @@ export type BotConfig = {
   locked: boolean
   pipeline_status: BotPipelineStatus
   oneflow?: boolean
+  history: UpgradeHistory[]
+}
+
+export interface UpgradeHistory {
+  reason: 'created' | 'migrated' | 'imported'
+  version: string
+  date: Date
 }
 
 export interface BotPipelineStatus {

--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -289,7 +289,11 @@ export class BotService {
               promoted_by: 'system',
               promoted_on: new Date()
             }
-          }
+          },
+          history: [
+            ...(originalConfig.history || []),
+            { version: process.BOTPRESS_VERSION, date: new Date(), reason: 'imported' }
+          ]
         }
         if (await this.botExists(botId)) {
           await this.unmountBot(botId)
@@ -541,7 +545,8 @@ export class BotService {
           ...DEFAULT_BOT_CONFIGS,
           ...templateConfig,
           ...botConfig,
-          version: process.BOTPRESS_VERSION
+          version: process.BOTPRESS_VERSION,
+          history: [{ version: process.BOTPRESS_VERSION, date: new Date(), reason: 'created' }]
         }
 
         if (!mergedConfigs.imports.contentTypes) {

--- a/src/bp/core/services/migration/index.ts
+++ b/src/bp/core/services/migration/index.ts
@@ -121,7 +121,12 @@ export class MigrationService {
       return this.logger.error(`Could not complete bot migration. It may behave unexpectedly.`)
     }
 
-    await this.configProvider.mergeBotConfig(botId, { version: this.currentVersion })
+    const existingConfig = await this.configProvider.getBotConfig(botId)
+
+    await this.configProvider.mergeBotConfig(botId, {
+      version: this.currentVersion,
+      history: [...(existingConfig.history || []), { version: botVersion, date: new Date(), reason: 'migrated' }]
+    })
   }
 
   private async executeMigrations(missingMigrations: MigrationFile[]) {

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -1010,6 +1010,13 @@ declare module 'botpress/sdk' {
     locked: boolean
     pipeline_status: BotPipelineStatus
     oneflow?: boolean
+    history: UpgradeHistory[]
+  }
+
+  export interface UpgradeHistory {
+    reason: 'created' | 'migrated' | 'imported'
+    version: string
+    date: Date
   }
 
   export type Pipeline = Stage[]


### PR DESCRIPTION
After being unable to find the cause of issues with the content of some bots, it sparked an idea.

Basically, we could add an history to the bot config to track major events: creation date & version, import, and migration events.

Maybe we can add or change stuff, but i'd like to have your input there.

![image](https://user-images.githubusercontent.com/42552874/80173126-df01bb80-85bc-11ea-9bae-8daf56e94c9e.png)
