### PR TITLE
fix(build): use non-root user

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -4,19 +4,20 @@ ADD . /botpress
 WORKDIR /botpress
 
 RUN apt update && \
-	apt install -y wget ca-certificates && \
-	update-ca-certificates && \
-	wget -O duckling https://s3.amazonaws.com/botpress-binaries/duckling-example-exe && \
-	chmod +x duckling && \
-	chmod +x bp && \
-	chgrp -R 0 /botpress && \
-	chmod -R g=u /botpress && \
-	apt install -y tzdata && \
-	ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && \
-	dpkg-reconfigure --frontend noninteractive tzdata && \
-	./bp extract
+  apt install -y wget ca-certificates && \
+  update-ca-certificates && \
+  wget -O duckling https://s3.amazonaws.com/botpress-binaries/duckling-example-exe && \
+  chmod +x duckling && \
+  chmod +x bp && \
+  groupadd botpress && \
+  useradd botpress -m -g botpress && \
+  chown -R botpress:botpress /botpress && \
+  apt install -y tzdata && \
+  ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && \
+  dpkg-reconfigure --frontend noninteractive tzdata && \
+  ./bp extract
 
-
+USER botpress
 ENV BP_MODULE_NLU_DUCKLINGURL=http://localhost:8000
 ENV BP_IS_DOCKER=true
 


### PR DESCRIPTION
Minor changes to the Dockerfile so Botpress doesn't run as "root". 

The server runs fine on my computer, but i'd like at least 2 other persons to build it and test it to make sure everything is good. @BPMJoannette  @hacheybj 

Test with the docker image: botpress/server:2020-04-24-testbuild