### PR TITLE
fix(ndu): ignore trigger with no conditions

### DIFF
--- a/modules/ndu/src/backend/ndu-engine.ts
+++ b/modules/ndu/src/backend/ndu-engine.ts
@@ -366,6 +366,10 @@ export class UnderstandingEngine {
         continue
       }
 
+      if (!trigger.conditions.length) {
+        continue
+      }
+
       const id = this.getTriggerId(trigger)
       const result = this._testConditions(event, trigger.conditions)
       event.ndu.triggers[id] = { result, trigger }


### PR DESCRIPTION
Took me some time to find out why my bot was always answering the same answer... If you have a trigger somewhere but forget to add at least one condition, it will always score very high 


![image](https://user-images.githubusercontent.com/42552874/80233835-202db600-8625-11ea-83d8-0b91aeb36389.png)

![image](https://user-images.githubusercontent.com/42552874/80233758-fe343380-8624-11ea-88fd-70538eff304c.png)
