### PR TITLE
chore(dev): watch multiple modules

### DIFF
--- a/build/gulp.modules.js
+++ b/build/gulp.modules.js
@@ -179,17 +179,17 @@ const watchModules = cb => {
   const command = process.argv[process.argv.length - 2]
   const moduleArgs = process.argv[process.argv.length - 1].split(',')
 
-  const modules =
-    command === '--m'
-      ? allModuleNames.filter(m => moduleArgs.includes(m))
-      : allModuleNames.filter(m => moduleArgs.find(x => m.includes(x)))
-
   if (!['--m', '--a'].includes(command)) {
     console.error(`Argument missing. Use --m for specific modules, or --a for a partial match. 
 Modules must be comma-separated.
 Example: 'yarn watch:modules --m channel-web,nlu,qna' or 'yarn watch:modules --a web,qna,basic'`)
     return cb()
   }
+
+  const modules =
+    command === '--m'
+      ? allModuleNames.filter(m => moduleArgs.includes(m))
+      : allModuleNames.filter(m => moduleArgs.find(x => m.includes(x)))
 
   if (!modules.length) {
     console.error('No module found matching provided arguments')

--- a/build/gulp.modules.js
+++ b/build/gulp.modules.js
@@ -174,9 +174,52 @@ const createAllModulesSymlink = () => {
   return gulp.series(tasks)
 }
 
+const watchModules = cb => {
+  const allModuleNames = getAllModulesRoot().map(x => path.basename(x))
+  const command = process.argv[process.argv.length - 2]
+  const moduleArgs = process.argv[process.argv.length - 1].split(',')
+
+  const modules =
+    command === '--m'
+      ? allModuleNames.filter(m => moduleArgs.includes(m))
+      : allModuleNames.filter(m => moduleArgs.find(x => m.includes(x)))
+
+  if (!['--m', '--a'].includes(command)) {
+    console.error(`Argument missing. Use --m for specific modules, or --a for a partial match. 
+Modules must be comma-separated.
+Example: 'yarn watch:modules --m channel-web,nlu,qna' or 'yarn watch:modules --a web,qna,basic'`)
+    return cb()
+  }
+
+  if (!modules.length) {
+    console.error('No module found matching provided arguments')
+    return cb()
+  }
+
+  console.log(`Watching Modules: ${modules.join(', ')}`)
+
+  modules.forEach(moduleName => {
+    try {
+      gulp.src(`./out/bp/data/assets/modules/${moduleName}`, { allowEmpty: true }).pipe(rimraf())
+      gulp
+        .src(`./modules/${moduleName}/assets/`)
+        .pipe(symlink(`./out/bp/data/assets/modules/${moduleName}/`, { type: 'dir' }))
+    } catch (err) {
+      console.log('Cant create symlink for', moduleName)
+    }
+
+    const watch = exec('yarn && yarn watch', { cwd: `modules/${moduleName}` }, err => cb(err))
+    watch.stdout.pipe(process.stdout)
+    watch.stderr.pipe(process.stderr)
+  })
+
+  cb()
+}
+
 module.exports = {
   build,
   buildModules,
+  watchModules,
   packageModules,
   buildModuleBuilder,
   cleanModuleAssets,

--- a/build/module-builder/src/build.ts
+++ b/build/module-builder/src/build.ts
@@ -71,7 +71,7 @@ export async function buildBackend(modulePath: string) {
     copyExtraFiles(modulePath)
     compileBackend(modulePath, babelConfig)
 
-    normal(`Generated backend (${Date.now() - start} ms)`)
+    normal(`Generated backend (${Date.now() - start} ms)`, path.basename(modulePath))
   }
 }
 

--- a/build/module-builder/src/log.ts
+++ b/build/module-builder/src/log.ts
@@ -6,21 +6,21 @@ export function configure(verboseLevel) {
   level = verboseLevel
 }
 
-export function log(color, message) {
-  console.log(chalk[color]('[module-builder] ' + message))
+export function log(color: string, message: string, source?: string) {
+  console.log(chalk[color](`[${source || 'module-builder'}] ` + message))
 }
 
-export function debug(message) {
+export function debug(message: string, source?: string) {
   if (!level) {
     return
   }
-  log('cyan', message)
+  log('cyan', message, source)
 }
 
-export function error(message) {
-  log('red', message)
+export function error(message: string, source?: string) {
+  log('red', message, source)
 }
 
-export function normal(message) {
-  log('grey', message)
+export function normal(message: string, source?: string) {
+  log('grey', message, source)
 }

--- a/build/module-builder/src/webpack.ts
+++ b/build/module-builder/src/webpack.ts
@@ -130,16 +130,16 @@ export function config(projectPath) {
 
   const webpackFile = path.join(projectPath, 'webpack.frontend.js')
   if (fs.existsSync(webpackFile)) {
-    debug('Webpack override found for frontend')
+    debug('Webpack override found for frontend', path.basename(projectPath))
     return require(webpackFile)({ full, lite })
   }
 
   return [full, lite]
 }
 
-function writeStats(err, stats, exitOnError = true, callback?) {
+function writeStats(err, stats, exitOnError = true, callback?, moduleName?: string) {
   if (err || stats.hasErrors()) {
-    error(stats.toString('minimal'))
+    error(stats.toString('minimal'), moduleName)
 
     if (exitOnError) {
       return process.exit(1)
@@ -147,7 +147,7 @@ function writeStats(err, stats, exitOnError = true, callback?) {
   }
 
   for (const child of stats.toJson().children) {
-    normal(`Generated frontend bundle (${child.time} ms)`)
+    normal(`Generated frontend bundle (${child.time} ms)`, moduleName)
   }
 
   callback?.()
@@ -156,13 +156,13 @@ function writeStats(err, stats, exitOnError = true, callback?) {
 export function watch(projectPath: string) {
   const confs = config(projectPath)
   const compiler = webpack(confs)
-  compiler.watch({}, (err, stats) => writeStats(err, stats, false))
+  compiler.watch({}, (err, stats) => writeStats(err, stats, false, undefined, path.basename(projectPath)))
 }
 
 export async function build(projectPath: string): Promise<void> {
   const confs = config(projectPath)
 
   await new Promise(resolve => {
-    webpack(confs, (err, stats) => writeStats(err, stats, true, resolve))
+    webpack(confs, (err, stats) => writeStats(err, stats, true, resolve, path.basename(projectPath)))
   })
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,14 +54,13 @@ gulp.task('watch:studio', ui.watchStudio)
 gulp.task('watch:admin', ui.watchAdmin)
 gulp.task('watch:ui', ui.watchAll)
 gulp.task('watch:shared', ui.watchShared)
+gulp.task('watch:modules', modules.watchModules)
 
 gulp.task('clean:node', cb => rimraf('**/node_modules/**', cb))
 gulp.task('clean:out', cb => rimraf('out', cb))
 gulp.task('clean:data', cb => rimraf('out/bp/data', cb))
 gulp.task('clean:db', cb => rimraf('out/bp/data/storage/core.sqlite', cb))
 
-// Example: yarn cmd dev:module --public nlu or yarn cmd dev:module --private bank
-gulp.task('dev:module', gulp.series([modules.cleanModuleAssets, modules.createModuleSymlink]))
 gulp.task('dev:modules', modules.createAllModulesSymlink())
 
 /**


### PR DESCRIPTION
I often end up with 4 terminals and starting watchers, always forgetting those I already have, etc...
So this brings a small shortcut & a cleaner log for this.

Also creates the symlinks because I spent too much time forgetting to run dev:modules...
And removed dev:module because it's just useless

Type `yarn cmd watch:modules --m channel-web,qna,nlu,code-editor` to launch all those watchers.

![image](https://user-images.githubusercontent.com/42552874/80290987-9c082b00-8717-11ea-904b-5f06bce96e81.png)
