### PR TITLE
fix(code-editor): fix signatures of hooks

### DIFF
--- a/modules/code-editor/src/typings/hooks.ts
+++ b/modules/code-editor/src/typings/hooks.ts
@@ -1,32 +1,32 @@
 export const HOOK_SIGNATURES = {
-  before_incoming_middleware: 'async function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
-  after_incoming_middleware: 'async function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
-  before_outgoing_middleware: 'async function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
-  after_event_processed: 'async function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
-  before_suggestions_election: `async function hook(
+  before_incoming_middleware: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
+  after_incoming_middleware: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
+  before_outgoing_middleware: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
+  after_event_processed: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
+  before_suggestions_election: `function hook(
   bp: typeof sdk,
   sessionId: string,
   event: sdk.IO.IncomingEvent,
   suggestions: sdk.IO.Suggestion[])`,
-  after_server_start: 'async function hook(bp: typeof sdk)',
-  after_bot_mount: 'async function hook(bp: typeof sdk, botId: string)',
-  after_bot_unmount: 'async function hook(bp: typeof sdk, botId: string)',
-  before_session_timeout: 'async function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
-  on_incident_status_changed: 'async function hook(bp: typeof sdk, incident: sdk.Incident)',
-  before_bot_import: 'async function hook(bp: typeof sdk, botId: string, tmpFolder: string, hookResult: object)',
-  on_stage_request: `async function hook(
+  after_server_start: 'function hook(bp: typeof sdk)',
+  after_bot_mount: 'function hook(bp: typeof sdk, botId: string)',
+  after_bot_unmount: 'function hook(bp: typeof sdk, botId: string)',
+  before_session_timeout: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
+  on_incident_status_changed: 'function hook(bp: typeof sdk, incident: sdk.Incident)',
+  before_bot_import: 'function hook(bp: typeof sdk, botId: string, tmpFolder: string, hookResult: object)',
+  on_stage_request: `function hook(
   bp: typeof sdk,
   bot: sdk.BotConfig,
   users: Partial<sdk.AuthUser[]>,
   pipeline: sdk.Pipeline,
   hookResult: any)`,
-  after_stage_changed: `async function hook(
+  after_stage_changed: `function hook(
   bp: typeof sdk,
   previousBotConfig: sdk.BotConfig,
   bot: sdk.BotConfig,
   users: Partial<sdk.AuthUser[]>,
   pipeline: sdk.Pipeline)`,
-  on_bot_error: `async function hook(bp: typeof sdk, botId: string, events: sdk.LoggerEntry[])`
+  on_bot_error: `function hook(bp: typeof sdk, botId: string, events: sdk.LoggerEntry[])`
 }
 
 export const BOT_SCOPED_HOOKS = [

--- a/modules/code-editor/src/views/full/utils/wrapper.ts
+++ b/modules/code-editor/src/views/full/utils/wrapper.ts
@@ -5,10 +5,10 @@ const START_COMMENT = `/** Your code starts below */`
 const END_COMMENT = '/** Your code ends here */'
 
 const ACTION_HTTP_SIGNATURE =
-  'async function action(event: sdk.IO.IncomingEvent, args: any, { user, temp, session } = event.state)'
+  'function action(event: sdk.IO.IncomingEvent, args: any, { user, temp, session } = event.state)'
 
 const ACTION_LEGACY_SIGNATURE =
-  'async function action(bp: typeof sdk, event: sdk.IO.IncomingEvent, args: any, { user, temp, session } = event.state)'
+  'function action(bp: typeof sdk, event: sdk.IO.IncomingEvent, args: any, { user, temp, session } = event.state)'
 
 const wrapper = {
   add: (file: EditableFile, content: string) => {


### PR DESCRIPTION
If I understood things correct, in the editor user's code is wrapped into a function. This wrapper isn't saved into actual file and it seems it's there only to _justify_ variables used within the snippet.

But an issue is that `async` keyword in function declaration makes users think they can use `await`s within the snippet without declaring `async` function. So I thought the best way to resolve botpress/v12#971 would be to remove `async` from declaration.

Does it make sense?