### PR TITLE
fix(core): base implementation for global error handling

### DIFF
--- a/modules/analytics/src/backend/api.ts
+++ b/modules/analytics/src/backend/api.ts
@@ -1,25 +1,30 @@
 import * as sdk from 'botpress/sdk'
+import { asyncMiddleware as asyncMw, StandardError } from 'common/http'
 import _ from 'lodash'
 import moment from 'moment'
 
 import Database from './db'
 
 export default (bp: typeof sdk, db: Database) => {
+  const asyncMiddleware = asyncMw(bp.logger)
   const router = bp.http.createRouterForBot('analytics')
 
-  router.get('/channel/:channel', async (req, res) => {
-    const { botId, channel } = req.params
-    const { start, end } = req.query
+  router.get(
+    '/channel/:channel',
+    asyncMiddleware(async (req, res) => {
+      const { botId, channel } = req.params
+      const { start, end } = req.query
 
-    try {
-      const startDate = unixToDate(start)
-      const endDate = unixToDate(end)
-      const metrics = await db.getMetrics(botId, { startDate, endDate, channel })
-      res.send({ metrics })
-    } catch (err) {
-      res.status(400).send(err.message)
-    }
-  })
+      try {
+        const startDate = unixToDate(start)
+        const endDate = unixToDate(end)
+        const metrics = await db.getMetrics(botId, { startDate, endDate, channel })
+        res.send({ metrics })
+      } catch (err) {
+        throw new StandardError('Cannot get analytics', err)
+      }
+    })
+  )
 
   const unixToDate = unix => {
     const momentDate = moment.unix(unix)

--- a/modules/code-editor/src/backend/typings.d.ts
+++ b/modules/code-editor/src/backend/typings.d.ts
@@ -1,5 +1,5 @@
 import Editor from './editor'
-import { RequestWithUser } from 'botpress/common/typings'
+import { RequestWithUser } from 'common/typings'
 export type EditorByBot = { [botId: string]: Editor }
 
 export interface TypingDefinitions {

--- a/modules/ndu/src/backend/ndu-engine.ts
+++ b/modules/ndu/src/backend/ndu-engine.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
-import { FlowView } from 'botpress/common/typings'
 import * as sdk from 'botpress/sdk'
+import { FlowView } from 'common/typings'
 import _ from 'lodash'
 
 import { Config } from '../config'

--- a/modules/nlu/src/backend/intents/intent-service.ts
+++ b/modules/nlu/src/backend/intents/intent-service.ts
@@ -1,5 +1,5 @@
-import { FlowView } from 'botpress/common/typings'
 import * as sdk from 'botpress/sdk'
+import { FlowView } from 'common/typings'
 import _ from 'lodash'
 
 import { EntityService } from '../typings'

--- a/modules/tsconfig.shared.json
+++ b/modules/tsconfig.shared.json
@@ -15,7 +15,7 @@
     "lib": ["es7"],
     "types": ["reflect-metadata", "bluebird-global"],
     "paths": {
-      "botpress/common/typings": ["../../out/bp/common/typings.d.ts"],
+      "common/*": ["../../src/bp/common/*"],
       "botpress/sdk": ["../../src/bp/sdk/botpress.d.ts"]
     }
   },

--- a/src/bp/common/http.ts
+++ b/src/bp/common/http.ts
@@ -1,0 +1,96 @@
+import { Logger, StrategyUser } from 'botpress/sdk'
+import { NextFunction, Request, Response } from 'express'
+
+import { TokenUser } from './typings'
+
+// This method is only used for basic escaping of error messages, do not use for page display
+const escapeHtmlSimple = (str: string) => {
+  return str
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\//g, '&#x2F;')
+    .replace(/\\/g, '&#x5C;')
+    .replace(/`/g, '&#96;')
+}
+
+export type BPRequest = Request & {
+  authUser: StrategyUser | undefined
+  tokenUser: TokenUser | undefined
+  credentials: any | undefined
+  workspace?: string
+}
+
+export type AsyncMiddleware = (
+  fn: (req: BPRequest, res: Response, next?: NextFunction | undefined) => Promise<any>
+) => (req: Request, res: Response, next: NextFunction) => void
+
+export const asyncMiddleware = (logger: Logger, routerName?: string): AsyncMiddleware => fn => (req, res, next) => {
+  Promise.resolve(fn(req as BPRequest, res, next)).catch(err => {
+    if (typeof err === 'string') {
+      err = {
+        skipLogging: false,
+        message: err
+      }
+    }
+
+    err.router = routerName
+    if (!err.skipLogging && !process.IS_PRODUCTION) {
+      const botId = err.botId || req.params.botId
+
+      if (!botId) {
+        logger.attachError(err).debug(`[${routerName || 'api'}]`)
+      } else {
+        logger
+          .forBot(botId)
+          .attachError(err)
+          .debug(`[${botId}]`)
+      }
+    }
+
+    next(err)
+  })
+}
+
+/**
+ * The object that wraps HTTP errors.
+ *
+ * @constructor
+ * @param message - The error message that will be sent to the end-user
+ * @param statusCode - The HTTP status code
+ * @param errorCode - Botpress error codes e.g. BP_0001, BP_0002, etc.
+ */
+export class ResponseError extends Error {
+  errorCode: string | undefined
+  statusCode: number
+
+  skipLogging = false
+
+  constructor(message: string, statusCode: number, errorCode?: string) {
+    super(escapeHtmlSimple(message))
+    Error.captureStackTrace(this, this.constructor)
+    this.statusCode = statusCode
+    this.errorCode = errorCode
+  }
+}
+
+/**
+ * A standard error, which doesn't print stack traces, but return an error message to the user
+ */
+export class StandardError extends ResponseError {
+  constructor(message: string, detailedMessage?: string) {
+    super(`${message}: ${detailedMessage}`, 400)
+    this.skipLogging = true
+  }
+
+  type = 'StandardError'
+}
+
+export class UnexpectedError extends ResponseError {
+  constructor(message: string, detailedMessage?: string) {
+    super(`${message}: ${detailedMessage}`, 400)
+  }
+
+  type = 'UnexpectedError'
+}
+
+// TODO: Move other ResponseError from routers to this file

--- a/src/bp/core/routers/admin/bots.ts
+++ b/src/bp/core/routers/admin/bots.ts
@@ -1,4 +1,5 @@
 import { BotConfig, Logger } from 'botpress/sdk'
+import { UnexpectedError } from 'common/http'
 import { RequestWithUser } from 'common/typings'
 import { ConfigProvider } from 'core/config/config-loader'
 import { BotService } from 'core/services/bot-service'
@@ -161,11 +162,7 @@ export class BotsRouter extends CustomRouter {
 
           return res.sendStatus(200)
         } catch (err) {
-          this.logger
-            .forBot(req.params.botId)
-            .attachError(err)
-            .error(`Cannot request bot: ${req.params.botId} for stage change`)
-          res.status(400).send(err.message)
+          throw new UnexpectedError('Cannot request state change for bot', err)
         }
       })
     )
@@ -180,11 +177,7 @@ export class BotsRouter extends CustomRouter {
 
           return res.sendStatus(200)
         } catch (err) {
-          this.logger
-            .forBot(req.params.botId)
-            .attachError(err)
-            .error(`Cannot request bot: ${req.params.botId} for stage change`)
-          res.status(400).send(err.message)
+          throw new UnexpectedError('Cannot approve state change for bot', err)
         }
       })
     )
@@ -202,12 +195,7 @@ export class BotsRouter extends CustomRouter {
             botId
           })
         } catch (err) {
-          this.logger
-            .forBot(req.params.botId)
-            .attachError(err)
-            .error(`Cannot update bot: ${botId}`)
-
-          res.status(400).send(err.message)
+          throw new UnexpectedError('Cannot update bot', err)
         }
       })
     )
@@ -223,12 +211,7 @@ export class BotsRouter extends CustomRouter {
           await this.workspaceService.deleteBotRef(botId)
           return sendSuccess(res, 'Removed bot from team', { botId })
         } catch (err) {
-          this.logger
-            .forBot(botId)
-            .attachError(err)
-            .error(`Could not delete bot: ${botId}`)
-
-          res.status(400).send(err.message)
+          throw new UnexpectedError('Cannot delete bot', err)
         }
       })
     )
@@ -278,11 +261,7 @@ export class BotsRouter extends CustomRouter {
             revisions
           })
         } catch (err) {
-          this.logger
-            .forBot(botId)
-            .attachError(err)
-            .error(`Could not list revisions for bot ${botId}`)
-          res.status(400).send(err.message)
+          throw new UnexpectedError('Cannot list revisions for bot', err)
         }
       })
     )
@@ -296,11 +275,7 @@ export class BotsRouter extends CustomRouter {
           await this.botService.createRevision(botId)
           return sendSuccess(res, `Created a new revision for bot ${botId}`)
         } catch (err) {
-          this.logger
-            .forBot(botId)
-            .attachError(err)
-            .error(`Could not create revision for bot: ${botId}`)
-          res.status(400).send(err.message)
+          throw new UnexpectedError('Cannot create new revision for bot', err)
         }
       })
     )

--- a/src/bp/core/routers/customRouter.ts
+++ b/src/bp/core/routers/customRouter.ts
@@ -1,7 +1,6 @@
 import { Logger } from 'botpress/sdk'
+import { AsyncMiddleware, asyncMiddleware } from 'common/http'
 import { Router } from 'express'
-
-import { AsyncMiddleware, asyncMiddleware } from './util'
 
 export abstract class CustomRouter {
   protected readonly asyncMiddleware: AsyncMiddleware

--- a/src/bp/core/routers/errors.ts
+++ b/src/bp/core/routers/errors.ts
@@ -1,24 +1,4 @@
-/**
- * The object that wraps HTTP errors.
- *
- * @constructor
- * @param message - The error message that will be sent to the end-user
- * @param statusCode - The HTTP status code
- * @param errorCode - Botpress error codes e.g. BP_0001, BP_0002, etc.
- */
-export class ResponseError extends Error {
-  errorCode: string
-  statusCode: number
-
-  skipLogging = false
-
-  constructor(message: string, statusCode: number, errorCode: string) {
-    super(message)
-    Error.captureStackTrace(this, this.constructor)
-    this.statusCode = statusCode
-    this.errorCode = errorCode
-  }
-}
+import { ResponseError } from 'common/http'
 
 export class BadRequestError extends ResponseError {
   type = 'BadRequestError'

--- a/src/bp/core/routers/util.ts
+++ b/src/bp/core/routers/util.ts
@@ -24,6 +24,8 @@ const debugSuccess = DEBUG('audit:collab:success')
 const debugSuperSuccess = DEBUG('audit:admin:success')
 const debugSuperFailure = DEBUG('audit:admin:fail')
 
+// TODO: Remove BPRequest, AsyncMiddleware and asyncMiddleware from this file
+
 export type BPRequest = Request & {
   authUser: StrategyUser | undefined
   tokenUser: TokenUser | undefined

--- a/src/bp/core/server.ts
+++ b/src/bp/core/server.ts
@@ -321,9 +321,9 @@ export default class HTTPServer {
     })
 
     this.app.use(function handleUnexpectedError(err, req, res, next) {
-      const statusCode = err.statusCode || 500
-      const errorCode = err.errorCode || 'BP_000'
-      const message = err.message || 'Unexpected error'
+      const statusCode = err.statusCode || 400
+      const errorCode = err.errorCode
+      const message = err.message || err || 'Unexpected error'
       const details = err.details || ''
       const docs = err.docs || 'https://botpress.com/docs'
       const devOnly = process.IS_PRODUCTION ? {} : { showStackInDev: true, stack: err.stack, full: err.message }

--- a/src/bp/core/services/auth/errors.ts
+++ b/src/bp/core/services/auth/errors.ts
@@ -1,4 +1,4 @@
-import { ResponseError } from 'core/routers/errors'
+import { ResponseError } from 'common/http'
 
 export class InvalidOperationError extends ResponseError {
   constructor(message: string) {

--- a/src/bp/ui-studio/src/web/views/Config/index.tsx
+++ b/src/bp/ui-studio/src/web/views/Config/index.tsx
@@ -216,7 +216,7 @@ class ConfigView extends Component<Props, State> {
         this.setState({ error: undefined, isSaving: false })
       }
     } catch (err) {
-      this.setState({ error: err, isSaving: false })
+      this.setState({ error: err.response?.data, isSaving: false })
     }
   }
 


### PR DESCRIPTION
In the core, we have the asyncMiddleware which handles very nicely exceptions, but we have some custom implementations / none at all in some modules. Calling `res.status.send` skips some of the middlewares of the chain, which should be avoided.

This PR contains only the basic implementation with some examples so we can use the same implementation everywhere. Updates will need to be in other PR once this one is merged.

I moved the async middleware to the common files so it can also be used by modules, along with two type of errors for now: Standard and Unexpected. 

- Standard Error doesn't log anything at all, but return the error to the user on the studio.
- Unexpected Error also return the error to the user, and it also logs the stack trace. 




```js
// will provide the name of the module to the middleware
const asyncMiddleware = asyncMw(bp.logger)

const router = bp.http.createRouterForBot('analytics')

 router.get(
    '/channel/:channel',
    asyncMiddleware(async (req, res) => {
    // Note that the try/catch is optional, it will also handle existing errors nicely
      try {
        // calling something which can throw an error
        res.send({ metrics })
      } catch (err) {
        // will be handled by the global router handler, but without stack traces
        throw new StandardError('Cannot get analytics', err)
      }
    })
  )
```

It also handles correctly the simple `throw new Error()`, but the unexpected error accept a second parameter for the underlying error.

The async middleware was slightly modified to detect automatically the bot ID (so it will use the scoped logger if it was found). 

![image](https://user-images.githubusercontent.com/42552874/81252192-42dfa780-8ff3-11ea-81c5-c79063f50257.png)

TODO (future PR, "nice-to-have")

- Remove AsyncMiddleware from router/utils and switch all other instances to common/http
- Move common router errors to common/http 
- Update all modules to use the asyncMiddleware and common errors
