### PR TITLE
fix(core): ajusting more errors

### DIFF
--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -1,7 +1,8 @@
 import apicache from 'apicache'
 import aws from 'aws-sdk'
 import * as sdk from 'botpress/sdk'
-import { asyncMiddleware as asyncMw } from 'common/http'
+import { asyncMiddleware as asyncMw, BPRequest } from 'common/http'
+import { Response } from 'express'
 import _ from 'lodash'
 import moment from 'moment'
 import multer from 'multer'
@@ -87,7 +88,7 @@ export default async (bp: typeof sdk, db: Database) => {
   router.get(
     '/botInfo',
     perBotCache('1 minute'),
-    asyncMiddleware(async (req, res) => {
+    asyncMiddleware(async (req: BPRequest, res: Response) => {
       const { botId } = req.params
       const security = ((await bp.config.getModuleConfig('channel-web')) as Config).security // usage of global because a user could overwrite bot scoped configs
       const config = (await bp.config.getModuleConfigForBot('channel-web', botId)) as Config
@@ -113,7 +114,7 @@ export default async (bp: typeof sdk, db: Database) => {
   router.post(
     '/messages/:userId',
     bp.http.extractExternalToken,
-    asyncMiddleware(async (req, res) => {
+    asyncMiddleware(async (req: BPRequest, res: Response) => {
       const { botId, userId = undefined } = req.params
 
       if (!validateUserId(userId)) {
@@ -165,7 +166,7 @@ export default async (bp: typeof sdk, db: Database) => {
     '/messages/:userId/files',
     upload.single('file'),
     bp.http.extractExternalToken,
-    asyncMiddleware(async (req: any, res) => {
+    asyncMiddleware(async (req: BPRequest & any, res: Response) => {
       const { botId = undefined, userId = undefined } = req.params || {}
 
       if (!validateUserId(userId)) {
@@ -198,7 +199,7 @@ export default async (bp: typeof sdk, db: Database) => {
     })
   )
 
-  router.get('/conversations/:userId/:conversationId', async (req, res) => {
+  router.get('/conversations/:userId/:conversationId', async (req: BPRequest, res: Response) => {
     const { userId, conversationId, botId } = req.params
 
     if (!validateUserId(userId)) {
@@ -210,7 +211,7 @@ export default async (bp: typeof sdk, db: Database) => {
     return res.send(conversation)
   })
 
-  router.get('/conversations/:userId', async (req, res) => {
+  router.get('/conversations/:userId', async (req: BPRequest, res: Response) => {
     const { botId = undefined, userId = undefined } = req.params || {}
 
     if (!validateUserId(userId)) {
@@ -285,7 +286,7 @@ export default async (bp: typeof sdk, db: Database) => {
   router.post(
     '/events/:userId',
     bp.http.extractExternalToken,
-    asyncMiddleware(async (req, res) => {
+    asyncMiddleware(async (req: BPRequest, res: Response) => {
       const payload = req.body || {}
       const { botId = undefined, userId = undefined } = req.params || {}
       await bp.users.getOrCreateUser('web', userId, botId)
@@ -310,7 +311,7 @@ export default async (bp: typeof sdk, db: Database) => {
   router.post(
     '/saveFeedback',
     bp.http.extractExternalToken,
-    asyncMiddleware(async (req, res) => {
+    asyncMiddleware(async (req: BPRequest, res: Response) => {
       const { eventId, target, feedback } = req.body
 
       if (!target || !eventId || !feedback) {
@@ -329,7 +330,7 @@ export default async (bp: typeof sdk, db: Database) => {
   router.post(
     '/feedbackInfo',
     bp.http.extractExternalToken,
-    asyncMiddleware(async (req, res) => {
+    asyncMiddleware(async (req: BPRequest, res: Response) => {
       const { target, eventIds } = req.body
 
       if (!target || !eventIds) {
@@ -343,7 +344,7 @@ export default async (bp: typeof sdk, db: Database) => {
   router.post(
     '/conversations/:userId/:conversationId/reset',
     bp.http.extractExternalToken,
-    asyncMiddleware(async (req, res) => {
+    asyncMiddleware(async (req: BPRequest, res: Response) => {
       const { botId, userId, conversationId } = req.params
       await bp.users.getOrCreateUser('web', userId, botId)
 
@@ -360,13 +361,13 @@ export default async (bp: typeof sdk, db: Database) => {
     })
   )
 
-  router.post('/conversations/:userId/new', async (req, res) => {
+  router.post('/conversations/:userId/new', async (req: BPRequest, res: Response) => {
     const { userId, botId } = req.params
     const convoId = await db.createConversation(botId, userId)
     res.send({ convoId })
   })
 
-  router.post('/conversations/:userId/:conversationId/reference/:reference', async (req, res) => {
+  router.post('/conversations/:userId/:conversationId/reference/:reference', async (req: BPRequest, res: Response) => {
     try {
       const { botId, userId, reference } = req.params
       let { conversationId } = req.params
@@ -413,14 +414,14 @@ export default async (bp: typeof sdk, db: Database) => {
     }
   })
 
-  router.get('/preferences/:userId', async (req, res) => {
+  router.get('/preferences/:userId', async (req: BPRequest, res: Response) => {
     const { userId, botId } = req.params
     const { result } = await bp.users.getOrCreateUser('web', userId, botId)
 
     return res.send({ language: result.attributes.language })
   })
 
-  router.post('/preferences/:userId', async (req, res) => {
+  router.post('/preferences/:userId', async (req: BPRequest, res: Response) => {
     const { userId, botId } = req.params
     const payload = req.body || {}
     const preferredLanguage = payload.language
@@ -469,7 +470,7 @@ export default async (bp: typeof sdk, db: Database) => {
     return [metadata, ...messagesAsTxt].join('')
   }
 
-  router.get('/conversations/:userId/:conversationId/download/txt', async (req, res) => {
+  router.get('/conversations/:userId/:conversationId/download/txt', async (req: BPRequest, res: Response) => {
     const { userId, conversationId, botId } = req.params
 
     if (!validateUserId(userId)) {

--- a/modules/code-editor/src/backend/api.ts
+++ b/modules/code-editor/src/backend/api.ts
@@ -1,4 +1,5 @@
 import * as sdk from 'botpress/sdk'
+import { asyncMiddleware as asyncMw, BPRequest, UnexpectedError } from 'common/http'
 import _ from 'lodash'
 import multer from 'multer'
 import path from 'path'
@@ -12,6 +13,7 @@ const debugWrite = DEBUG('audit:code-editor:write')
 
 export default async (bp: typeof sdk, editor: Editor) => {
   const loadPermsMw = getPermissionsMw(bp)
+  const asyncMiddleware = asyncMw(bp.logger)
   const router = bp.http.createRouterForBot('code-editor')
 
   const audit = (debugMethod: Function, label: string, req: RequestWithPerms, args?: any) => {
@@ -31,40 +33,52 @@ export default async (bp: typeof sdk, editor: Editor) => {
     )
   }
 
-  router.get('/files', loadPermsMw, async (req: RequestWithPerms, res, next) => {
-    try {
-      const rawFiles = req.query.rawFiles === 'true'
-      const includeBuiltin = req.query.includeBuiltin === 'true'
-      res.send(await editor.forBot(req.params.botId).getAllFiles(req.permissions, rawFiles, includeBuiltin))
-    } catch (err) {
-      bp.logger.attachError(err).error('Error fetching files')
-      next(err)
-    }
-  })
+  router.get(
+    '/files',
+    loadPermsMw,
+    asyncMiddleware(async (req: BPRequest & RequestWithPerms, res) => {
+      try {
+        const rawFiles = req.query.rawFiles === 'true'
+        const includeBuiltin = req.query.includeBuiltin === 'true'
+        res.send(await editor.forBot(req.params.botId).getAllFiles(req.permissions, rawFiles, includeBuiltin))
+      } catch (err) {
+        throw new UnexpectedError('Error fetching files', err)
+      }
+    })
+  )
 
-  router.post('/save', loadPermsMw, validateFilePayloadMw('write'), async (req: RequestWithPerms, res, next) => {
-    try {
-      audit(debugWrite, 'saveFile', req)
+  router.post(
+    '/save',
+    loadPermsMw,
+    validateFilePayloadMw('write'),
+    asyncMiddleware(async (req: BPRequest & RequestWithPerms, res) => {
+      try {
+        audit(debugWrite, 'saveFile', req)
 
-      await editor.forBot(req.params.botId).saveFile(req.body)
-      res.sendStatus(200)
-    } catch (err) {
-      bp.logger.attachError(err).error('Could not save file')
-      next(err)
-    }
-  })
+        await editor.forBot(req.params.botId).saveFile(req.body)
+        res.sendStatus(200)
+      } catch (err) {
+        throw new UnexpectedError('Cannot save file', err)
+      }
+    })
+  )
 
-  router.post('/readFile', loadPermsMw, validateFilePayloadMw('read'), async (req: RequestWithPerms, res, next) => {
-    try {
-      const fileContent = await editor.forBot(req.params.botId).readFileContent(req.body)
+  router.post(
+    '/readFile',
+    loadPermsMw,
+    validateFilePayloadMw('read'),
+    asyncMiddleware(async (req: BPRequest & RequestWithPerms, res) => {
+      try {
+        const fileContent = await editor.forBot(req.params.botId).readFileContent(req.body)
 
-      audit(debugRead, 'readFile', req, { file: { size: fileContent?.length } })
+        audit(debugRead, 'readFile', req, { file: { size: fileContent?.length } })
 
-      res.send({ fileContent })
-    } catch (err) {
-      next(err)
-    }
-  })
+        res.send({ fileContent })
+      } catch (err) {
+        throw new UnexpectedError('Error reading file', err)
+      }
+    })
+  )
 
   router.post('/download', loadPermsMw, validateFilePayloadMw('read'), async (req: RequestWithPerms, res, next) => {
     const buffer = await editor.forBot(req.params.botId).readFileBuffer(req.body)
@@ -82,36 +96,44 @@ export default async (bp: typeof sdk, editor: Editor) => {
     }
   })
 
-  router.post('/rename', loadPermsMw, validateFilePayloadMw('write'), async (req: RequestWithPerms, res, next) => {
-    try {
-      audit(debugWrite, 'renameFile', req, { newName: req.body.newName })
+  router.post(
+    '/rename',
+    loadPermsMw,
+    validateFilePayloadMw('write'),
+    asyncMiddleware(async (req: BPRequest & RequestWithPerms, res) => {
+      try {
+        audit(debugWrite, 'renameFile', req, { newName: req.body.newName })
 
-      await editor.forBot(req.params.botId).renameFile(req.body.file, req.body.newName)
-      res.sendStatus(200)
-    } catch (err) {
-      bp.logger.attachError(err).error('Could not rename file')
-      next(err)
-    }
-  })
+        await editor.forBot(req.params.botId).renameFile(req.body.file, req.body.newName)
+        res.sendStatus(200)
+      } catch (err) {
+        throw new UnexpectedError('Could not rename file', err)
+      }
+    })
+  )
 
-  router.post('/remove', loadPermsMw, validateFilePayloadMw('write'), async (req: RequestWithPerms, res, next) => {
-    try {
-      audit(debugWrite, 'deleteFile', req)
+  router.post(
+    '/remove',
+    loadPermsMw,
+    validateFilePayloadMw('write'),
+    asyncMiddleware(async (req: BPRequest & RequestWithPerms, res, next) => {
+      try {
+        audit(debugWrite, 'deleteFile', req)
 
-      await editor.forBot(req.params.botId).deleteFile(req.body)
-      res.sendStatus(200)
-    } catch (err) {
-      bp.logger.attachError(err).error('Could not delete file')
-      next(err)
-    }
-  })
+        await editor.forBot(req.params.botId).deleteFile(req.body)
+        res.sendStatus(200)
+      } catch (err) {
+        throw new UnexpectedError('Could not delete file', err)
+      }
+    })
+  )
 
   router.post(
     '/upload',
     loadPermsMw,
     validateFileUploadMw,
     multer().single('file'),
-    async (req: RequestWithPerms, res, next) => {
+    asyncMiddleware(async (req: BPRequest & RequestWithPerms, res) => {
       const folder = path.dirname(req.body.location)
       const filename = path.basename(req.body.location)
 
@@ -119,27 +141,31 @@ export default async (bp: typeof sdk, editor: Editor) => {
         await bp.ghost.forRoot().upsertFile(folder, filename, req.file.buffer)
         res.sendStatus(200)
       } catch (err) {
-        bp.logger.attachError(err).error('Could not upload file')
-        next(err)
+        throw new UnexpectedError('Could not upload file', err)
       }
-    }
+    })
   )
 
-  router.get('/permissions', loadPermsMw, async (req: RequestWithPerms, res, next) => {
-    try {
-      res.send(req.permissions)
-    } catch (err) {
-      bp.logger.attachError(err).error('Error fetching permissions')
-      next(err)
-    }
-  })
+  router.get(
+    '/permissions',
+    loadPermsMw,
+    asyncMiddleware(async (req: BPRequest & RequestWithPerms, res) => {
+      try {
+        res.send(req.permissions)
+      } catch (err) {
+        throw new UnexpectedError('Could not fetch permissions', err)
+      }
+    })
+  )
 
-  router.get('/typings', async (_req, res, next) => {
-    try {
-      res.send(await editor.loadTypings())
-    } catch (err) {
-      bp.logger.attachError(err).error('Could not load typings. Code completion will not be available')
-      next(err)
-    }
-  })
+  router.get(
+    '/typings',
+    asyncMiddleware(async (_req, res) => {
+      try {
+        res.send(await editor.loadTypings())
+      } catch (err) {
+        throw new UnexpectedError('Could not load typings. Code completion will not be available', err)
+      }
+    })
+  )
 }

--- a/modules/extensions/src/backend/index.ts
+++ b/modules/extensions/src/backend/index.ts
@@ -1,9 +1,11 @@
 import * as sdk from 'botpress/sdk'
+import { asyncMiddleware as asyncMw } from 'common/http'
 
 import en from '../translations/en.json'
 import fr from '../translations/fr.json'
 
 const onServerReady = async (bp: typeof sdk) => {
+  const asyncMiddleware = asyncMw(bp.logger)
   const router = bp.http.createRouterForBot('extensions')
   const config = (await bp.config.getBotpressConfig()).eventCollector
 
@@ -11,18 +13,21 @@ const onServerReady = async (bp: typeof sdk) => {
     res.send({ collectionInterval: config.collectionInterval })
   })
 
-  router.get('/events/:eventId', async (req, res) => {
-    const storedEvents = await bp.events.findEvents({
-      incomingEventId: req.params.eventId,
-      direction: 'incoming',
-      botId: req.params.botId
-    })
-    if (storedEvents.length) {
-      return res.send(storedEvents.map(s => s.event)[0])
-    }
+  router.get(
+    '/events/:eventId',
+    asyncMiddleware(async (req, res) => {
+      const storedEvents = await bp.events.findEvents({
+        incomingEventId: req.params.eventId,
+        direction: 'incoming',
+        botId: req.params.botId
+      })
+      if (storedEvents.length) {
+        return res.send(storedEvents.map(s => s.event)[0])
+      }
 
-    res.sendStatus(404)
-  })
+      res.sendStatus(404)
+    })
+  )
 }
 
 const entryPoint: sdk.ModuleEntryPoint = {

--- a/modules/misunderstood/src/backend/api.ts
+++ b/modules/misunderstood/src/backend/api.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import * as sdk from 'botpress/sdk'
+import { asyncMiddleware as asyncMw, StandardError, UnexpectedError } from 'common/http'
 import { Request, Response } from 'express'
 
 import { FLAGGED_MESSAGE_STATUSES, FlaggedEvent } from '../types'
@@ -7,90 +8,109 @@ import { FLAGGED_MESSAGE_STATUSES, FlaggedEvent } from '../types'
 import Db from './db'
 
 export default async (bp: typeof sdk, db: Db) => {
+  const asyncMiddleware = asyncMw(bp.logger)
   const router = bp.http.createRouterForBot('misunderstood')
 
-  router.post('/events', async (req: Request, res: Response) => {
-    const { botId } = req.params
-    const event: FlaggedEvent = req.body
+  router.post(
+    '/events',
+    asyncMiddleware(async (req: Request, res: Response) => {
+      const { botId } = req.params
+      const event: FlaggedEvent = req.body
 
-    if (event.botId !== botId) {
-      res.status(403).send('Invalid bot ID')
-      return
-    }
-
-    try {
-      await db.addEvent(event)
-      res.sendStatus(201)
-    } catch (err) {
-      res.status(500).send(err.message)
-    }
-  })
-
-  router.post('/events/:id/status', async (req: Request, res: Response) => {
-    const { id, botId } = req.params
-    const { status, ...resolutionData } = req.body
-
-    try {
-      await db.updateStatus(botId, id, status, resolutionData)
-      res.sendStatus(200)
-    } catch (err) {
-      res.status(500).send(err.message)
-    }
-  })
-
-  router.get('/events/count', async (req: Request, res: Response) => {
-    const { botId } = req.params
-    const { language } = req.query
-
-    try {
-      const data = await db.countEvents(botId, language)
-      res.json(data)
-    } catch (err) {
-      res.status(500).send(err.message)
-    }
-  })
-
-  router.get(`/events/:status(${FLAGGED_MESSAGE_STATUSES.join('|')})`, async (req: Request, res: Response) => {
-    const { botId, status } = req.params
-    const { language } = req.query
-
-    try {
-      const data = await db.listEvents(botId, language, status)
-      res.json(data)
-    } catch (err) {
-      res.status(500).send(err.message)
-    }
-  })
-
-  router.get('/events/:id(\\d+)', async (req: Request, res: Response) => {
-    const { botId, id } = req.params
-
-    try {
-      const data = await db.getEventDetails(botId, id)
-
-      if (data) {
-        res.json(data)
-      } else {
-        res.sendStatus(404)
+      if (event.botId !== botId) {
+        res.status(403).send('Invalid bot ID')
+        return
       }
-    } catch (err) {
-      res.status(500).send(err.message)
-    }
-  })
 
-  router.post('/apply-all-pending', async (req: Request, res: Response) => {
-    const { botId } = req.params
+      try {
+        await db.addEvent(event)
+        res.sendStatus(201)
+      } catch (err) {
+        throw new UnexpectedError('Could not create entry', err)
+      }
+    })
+  )
 
-    try {
-      await db.applyChanges(botId)
-      const axiosConfig = await bp.http.getAxiosConfigForBot(botId, { localUrl: true })
-      setTimeout(() => {
-        // tslint:disable-next-line: no-floating-promises
-        axios.post('/mod/nlu/train', {}, axiosConfig)
-      }, 1000)
-      res.sendStatus(200)
-    } catch (err) {
-      res.status(500).send(err.message)
-    }
-  })
+  router.post(
+    '/events/:id/status',
+    asyncMiddleware(async (req: Request, res: Response) => {
+      const { id, botId } = req.params
+      const { status, ...resolutionData } = req.body
+
+      try {
+        await db.updateStatus(botId, id, status, resolutionData)
+        res.sendStatus(200)
+      } catch (err) {
+        throw new UnexpectedError('Could not update event', err)
+      }
+    })
+  )
+
+  router.get(
+    '/events/count',
+    asyncMiddleware(async (req: Request, res: Response) => {
+      const { botId } = req.params
+      const { language } = req.query
+
+      try {
+        const data = await db.countEvents(botId, language)
+        res.json(data)
+      } catch (err) {
+        throw new StandardError(err)
+      }
+    })
+  )
+
+  router.get(
+    `/events/:status(${FLAGGED_MESSAGE_STATUSES.join('|')})`,
+    asyncMiddleware(async (req: Request, res: Response) => {
+      const { botId, status } = req.params
+      const { language } = req.query
+
+      try {
+        const data = await db.listEvents(botId, language, status)
+        res.json(data)
+      } catch (err) {
+        throw new StandardError('Error listing events', err)
+      }
+    })
+  )
+
+  router.get(
+    '/events/:id(\\d+)',
+    asyncMiddleware(async (req: Request, res: Response) => {
+      const { botId, id } = req.params
+
+      try {
+        const data = await db.getEventDetails(botId, id)
+
+        if (data) {
+          res.json(data)
+        } else {
+          res.sendStatus(404)
+        }
+      } catch (err) {
+        throw new StandardError('Error fetching event details', err)
+      }
+    })
+  )
+
+  router.post(
+    '/apply-all-pending',
+    asyncMiddleware(async (req: Request, res: Response) => {
+      const { botId } = req.params
+
+      try {
+        await db.applyChanges(botId)
+        const axiosConfig = await bp.http.getAxiosConfigForBot(botId, { localUrl: true })
+        setTimeout(() => {
+          // tslint:disable-next-line: no-floating-promises
+          axios.post('/mod/nlu/train', {}, axiosConfig)
+        }, 1000)
+        res.sendStatus(200)
+      } catch (err) {
+        throw new StandardError('Could not apply changes', err)
+      }
+    })
+  )
 }

--- a/modules/misunderstood/src/backend/api.ts
+++ b/modules/misunderstood/src/backend/api.ts
@@ -18,8 +18,7 @@ export default async (bp: typeof sdk, db: Db) => {
       const event: FlaggedEvent = req.body
 
       if (event.botId !== botId) {
-        res.status(403).send('Invalid bot ID')
-        return
+        throw new StandardError('Invalid bot ID')
       }
 
       try {

--- a/modules/uipath/src/backend/api.ts
+++ b/modules/uipath/src/backend/api.ts
@@ -1,9 +1,11 @@
 import * as sdk from 'botpress/sdk'
+import { asyncMiddleware as asyncMw, UnexpectedError } from 'common/http'
 import jsonwebtoken from 'jsonwebtoken'
 
 import { jwtAuthorizerMiddleware } from './auth'
 
 export default async (bp: typeof sdk) => {
+  const asyncMiddleware = asyncMw(bp.logger)
   const authRouter = bp.http.createRouterForBot('uipath/auth', {
     checkAuthentication: true
   })
@@ -12,35 +14,41 @@ export default async (bp: typeof sdk) => {
     checkAuthentication: false
   })
 
-  authRouter.get('/token', async (req, res) => {
-    const expiresIn = req.query.expiresIn || '1m'
+  authRouter.get(
+    '/token',
+    asyncMiddleware(async (req, res) => {
+      const expiresIn = req.query.expiresIn || '1m'
 
-    try {
-      const token = jsonwebtoken.sign({}, process.APP_SECRET, { expiresIn })
-      res.send({ token })
-    } catch (err) {
-      res.status(400).send(err)
-    }
-  })
+      try {
+        const token = jsonwebtoken.sign({}, process.APP_SECRET, { expiresIn })
+        res.send({ token })
+      } catch (err) {
+        throw new UnexpectedError('Could not get token', err)
+      }
+    })
+  )
 
   rootRouter.use(jwtAuthorizerMiddleware)
-  rootRouter.post('/message', async (req, res) => {
-    try {
-      const { channel, target, botId, threadId, message } = req.body
+  rootRouter.post(
+    '/message',
+    asyncMiddleware(async (req, res) => {
+      try {
+        const { channel, target, botId, threadId, message } = req.body
 
-      await bp.events.replyToEvent(
-        {
-          channel,
-          target,
-          botId,
-          threadId
-        },
-        [message]
-      )
+        await bp.events.replyToEvent(
+          {
+            channel,
+            target,
+            botId,
+            threadId
+          },
+          [message]
+        )
 
-      res.sendStatus(200)
-    } catch (err) {
-      res.status(400).send(err)
-    }
-  })
+        res.sendStatus(200)
+      } catch (err) {
+        throw new UnexpectedError('Could not send message', err)
+      }
+    })
+  )
 }

--- a/src/bp/core/routers/admin/languages.ts
+++ b/src/bp/core/routers/admin/languages.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import { Logger } from 'botpress/sdk'
+import { StandardError, UnexpectedError } from 'common/http'
 import { ConfigProvider } from 'core/config/config-loader'
 import { ModuleLoader } from 'core/module-loader'
 import { WorkspaceService } from 'core/services/workspace-service'
@@ -72,7 +73,7 @@ export class LanguagesRouter extends CustomRouter {
             ...(await this.getExtraLangs())
           })
         } catch (err) {
-          res.status(500).send(err.message)
+          throw new UnexpectedError('Could not fetch languages', err)
         }
       })
     )
@@ -96,7 +97,7 @@ export class LanguagesRouter extends CustomRouter {
           const client = await this.getSourceClient()
           await client.get('/info').then(({ data }) => res.send(data))
         } catch (err) {
-          res.status(500).send(err.message)
+          throw new StandardError('Could not get language info', err)
         }
       })
     )
@@ -109,7 +110,7 @@ export class LanguagesRouter extends CustomRouter {
           const client = await this.getSourceClient()
           await client.post('/languages/' + req.params.lang).then(({ data }) => res.send(data))
         } catch (err) {
-          res.status(500).send(err)
+          throw new StandardError('Could not add language', err)
         }
       })
     )
@@ -122,7 +123,7 @@ export class LanguagesRouter extends CustomRouter {
           const client = await this.getSourceClient()
           await client.post(`/languages/${req.params.lang}/load`).then(({ data }) => res.send(data))
         } catch (err) {
-          res.status(500).send(err.message)
+          throw new StandardError('Could not load language', err)
         }
       })
     )
@@ -135,7 +136,7 @@ export class LanguagesRouter extends CustomRouter {
           const client = await this.getSourceClient()
           await client.post(`/languages/${req.params.lang}/delete`).then(({ data }) => res.send(data))
         } catch (err) {
-          res.status(500).send(err.message)
+          throw new StandardError('Could not delete language', err)
         }
       })
     )

--- a/src/bp/core/routers/admin/versioning.ts
+++ b/src/bp/core/routers/admin/versioning.ts
@@ -1,4 +1,5 @@
 import { Logger } from 'botpress/sdk'
+import { UnexpectedError } from 'common/http'
 import { extractArchive } from 'core/misc/archive'
 import { GhostService } from 'core/services'
 import { BotService } from 'core/services/bot-service'
@@ -68,7 +69,7 @@ export class VersioningRouter extends CustomRouter {
 
           res.sendStatus(200)
         } catch (error) {
-          res.status(500).send('Error while pushing changes')
+          throw new UnexpectedError('Error while pushing changes', error)
         } finally {
           tmpDir.removeCallback()
         }

--- a/src/bp/core/routers/bots/index.ts
+++ b/src/bp/core/routers/bots/index.ts
@@ -1,5 +1,6 @@
 import { Logger, RouterOptions } from 'botpress/sdk'
 import { Serialize } from 'cerialize'
+import { UnexpectedError } from 'common/http'
 import { gaId, machineUUID } from 'common/stats'
 import { FlowView } from 'common/typings'
 import { BotpressConfig } from 'core/config/botpress.config'
@@ -360,7 +361,7 @@ export class BotsRouter extends CustomRouter {
             return res.send(423) // Mutex locked
           }
 
-          res.status(400).send(err.message)
+          throw new UnexpectedError('Error saving flow', err)
         }
       })
     )

--- a/src/bp/core/routers/modules.ts
+++ b/src/bp/core/routers/modules.ts
@@ -1,4 +1,5 @@
 import { FlowGeneratorMetadata, Logger } from 'botpress/sdk'
+import { UnexpectedError } from 'common/http'
 import { ModuleInfo } from 'common/typings'
 import { ConfigProvider } from 'core/config/config-loader'
 import ModuleResolver from 'core/modules/resolver'
@@ -56,8 +57,7 @@ export class ModulesRouter extends CustomRouter {
 
           res.sendStatus(200)
         } catch (err) {
-          this.logger.attachError(err).error(`Could not unpack module`)
-          res.sendStatus(500)
+          throw new UnexpectedError('Could not unpack module', err)
         }
       })
     )
@@ -145,7 +145,7 @@ export class ModulesRouter extends CustomRouter {
           const metadata: FlowGeneratorMetadata = { botId: req.query.botId }
           res.send(this.skillService.finalizeFlow(await flowGenerator(req.body, metadata)))
         } catch (err) {
-          res.status(400).send(`Error while trying to generate the flow: ${err}`)
+          throw new UnexpectedError('Could not generate flow', err)
         }
       })
     )


### PR DESCRIPTION
Not a lot of changes, basically just wrapped async routers with asyncMiddleware, and replacing some res.status().send() by thrown errors, but causes a lot of reformatting