### PR TITLE
fix(ui-studio): don't close create element modal on enter

### DIFF
--- a/src/bp/ui-studio/src/web/components/Content/Select/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Content/Select/index.tsx
@@ -106,7 +106,7 @@ class SelectContent extends Component<Props, State> {
       this.setState({ activeItemIndex: index < itemsCount - 1 ? index + 1 : index })
     } else if (e.key === 'Enter' && this.state.step === formSteps.PICK_CATEGORY) {
       this.setCurrentCategory(this.props.categories.filter(cat => !cat.hidden)[this.state.activeItemIndex].id)
-    } else if (e.key === 'Enter') {
+    } else if (e.key === 'Enter' && !this.state.newItemCategory) {
       this.handlePick(this.props.contentItems[this.state.activeItemIndex])
     }
   }


### PR DESCRIPTION
resolve botpress/v12#965 

An issue was happening due to handler listening for selecting an item from the list.
It wasn't aware of create modal being opened.