### PR TITLE
refactor(nlu): moved intent election + ambiguity in its own middleware

### DIFF
--- a/modules/analytics/src/backend/setup.ts
+++ b/modules/analytics/src/backend/setup.ts
@@ -60,7 +60,7 @@ export default async (bp: typeof sdk, db: Database, interactionsToTrack: string[
     name: 'analytics.incoming',
     direction: 'incoming',
     handler: incomingMiddleware,
-    order: 12, // after nlu and qna
+    order: 13, // after nlu and qna
     description: 'Tracks incoming messages for Analytics purposes'
   })
 

--- a/modules/ndu/src/backend/middleware.ts
+++ b/modules/ndu/src/backend/middleware.ts
@@ -6,7 +6,7 @@ export const registerMiddleware = async (bp: typeof sdk, bots: MountedBots) => {
   bp.events.registerMiddleware({
     name: 'ndu.incoming',
     direction: 'incoming',
-    order: 13,
+    order: 14,
     description: 'Where magic happens',
     handler: async (event: sdk.IO.IncomingEvent, next: sdk.IO.MiddlewareNextCallback) => {
       if (bots[event.botId]) {

--- a/modules/nlu-extras/src/backend/middleware.ts
+++ b/modules/nlu-extras/src/backend/middleware.ts
@@ -18,7 +18,7 @@ export const registerMiddleware = async (bp: typeof sdk) => {
   bp.events.registerMiddleware({
     name: 'nlu-extras.incoming',
     direction: 'incoming',
-    order: 11,
+    order: 12,
     description:
       'Process natural language in the form of text. Structured data with an action and parameters for that action is injected in the incoming message event.',
     handler: async (event: sdk.IO.IncomingEvent, next: sdk.IO.MiddlewareNextCallback) => {

--- a/modules/nlu/src/backend/engine.ts
+++ b/modules/nlu/src/backend/engine.ts
@@ -9,6 +9,7 @@ import SlotTagger from './slots/slot-tagger'
 import { isPatternValid } from './tools/patterns-utils'
 import { computeKmeans, ProcessIntents, Trainer, TrainInput, TrainOutput } from './training-pipeline'
 import { EntityCacheDump, ListEntity, ListEntityModel, NLUEngine, Tools, TrainingSession } from './typings'
+import elect from './legacy-election'
 
 const trainDebug = DEBUG('nlu').sub('training')
 
@@ -191,5 +192,9 @@ export default class Engine implements NLUEngine {
 
     // error handled a level highr
     return Predict(input, Engine.tools, this.predictorsByLang)
+  }
+
+  async elect(predictionOutput: PredictOutput): Promise<PredictOutput> {
+    return elect(predictionOutput)
   }
 }

--- a/modules/nlu/src/backend/legacy-election.ts
+++ b/modules/nlu/src/backend/legacy-election.ts
@@ -1,0 +1,169 @@
+import * as sdk from 'botpress/sdk'
+import * as math from './tools/math'
+import _ from 'lodash'
+
+const OOS_AS_NONE_TRESH = 0.3
+const LOW_INTENT_CONFIDENCE_TRESH = 0.4
+const NONE_INTENT = 'none' // should extract constant in comon place
+
+type EventUnderstanding = sdk.IO.EventUnderstanding
+
+export default async function elect(predictionOutput: EventUnderstanding): Promise<EventUnderstanding> {
+  let nlu = predictionOutput
+  nlu = electIntent(nlu)
+  nlu = detectAmbiguity(nlu)
+  nlu = await extractElectedIntentSlots(nlu)
+  return nlu
+}
+
+function electIntent(input: EventUnderstanding): EventUnderstanding {
+  const allCtx = Object.keys(input.predictions)
+
+  const ctx_predictions = allCtx.map(label => {
+    const { confidence } = input.predictions[label]
+    return { label, confidence }
+  })
+
+  const oss_label = 'oos'
+  const oos_predictions = {
+    label: oss_label,
+    confidence: input.predictions[oss_label].confidence
+  }
+
+  const perCtxIntentPrediction = _.chain(input.predictions)
+    .mapValues(v => v.intents)
+    .value()
+
+  const totalConfidence = Math.min(
+    1,
+    _.sumBy(
+      ctx_predictions.filter(x => input.includedContexts.includes(x.label)),
+      'confidence'
+    )
+  )
+  const ctxPreds = ctx_predictions.map(x => ({ ...x, confidence: x.confidence / totalConfidence }))
+
+  // taken from svm classifier #349
+  let predictions = _.chain(ctxPreds)
+    .flatMap(({ label: ctx, confidence: ctxConf }) => {
+      const intentPreds = _.chain(perCtxIntentPrediction[ctx] || [])
+        .thru(preds => {
+          if (oos_predictions?.confidence > OOS_AS_NONE_TRESH) {
+            return [
+              ...preds,
+              {
+                label: NONE_INTENT,
+                confidence: oos_predictions?.confidence ?? 1,
+                context: ctx,
+                l0Confidence: ctxConf
+              }
+            ]
+          } else {
+            return preds
+          }
+        })
+        .map(p => ({ ...p, confidence: _.round(p.confidence, 2) }))
+        .orderBy('confidence', 'desc')
+        .value()
+
+      if (intentPreds[0].confidence === 1 || intentPreds.length === 1) {
+        return [{ label: intentPreds[0].label, l0Confidence: ctxConf, context: ctx, confidence: 1 }]
+      }
+
+      if (predictionsReallyConfused(intentPreds)) {
+        intentPreds.unshift({ label: NONE_INTENT, context: ctx, confidence: 1, slots: {} })
+      }
+
+      const lnstd = math.std(intentPreds.filter(x => x.confidence !== 0).map(x => Math.log(x.confidence))) // because we want a lognormal distribution
+      let p1Conf = math.GetZPercent((Math.log(intentPreds[0].confidence) - Math.log(intentPreds[1].confidence)) / lnstd)
+      if (isNaN(p1Conf)) {
+        p1Conf = 0.5
+      }
+
+      return [
+        {
+          label: intentPreds[0].label,
+          l0Confidence: ctxConf,
+          context: ctx,
+          confidence: _.round(ctxConf * p1Conf, 3)
+        },
+        {
+          label: intentPreds[1].label,
+          l0Confidence: ctxConf,
+          context: ctx,
+          confidence: _.round(ctxConf * (1 - p1Conf), 3)
+        }
+      ]
+    })
+    .orderBy('confidence', 'desc')
+    .filter(p => input.includedContexts.includes(p.context))
+    .uniqBy(p => p.label)
+    .map(p => ({ name: p.label, context: p.context, confidence: p.confidence }))
+    .value()
+
+  const ctx = _.get(predictions, '0.context', 'global')
+  const shouldConsiderOOS =
+    predictions.length &&
+    predictions[0].name !== NONE_INTENT &&
+    predictions[0].confidence < LOW_INTENT_CONFIDENCE_TRESH &&
+    oos_predictions?.confidence > OOS_AS_NONE_TRESH
+  if (!predictions.length || shouldConsiderOOS) {
+    predictions = _.orderBy(
+      [
+        ...predictions.filter(p => p.name !== NONE_INTENT),
+        { name: NONE_INTENT, context: ctx, confidence: oos_predictions?.confidence ?? 1 }
+      ],
+      'confidence'
+    )
+  }
+
+  const elected = _.maxBy(predictions, 'confidence')
+  return {
+    ...input,
+    intents: predictions,
+    intent: elected
+  }
+}
+
+function detectAmbiguity(input: EventUnderstanding): EventUnderstanding {
+  // +- 10% away from perfect median leads to ambiguity
+  const preds = input.intents
+  const perfectConfusion = 1 / preds.length
+  const low = perfectConfusion - 0.1
+  const up = perfectConfusion + 0.1
+  const confidenceVec = preds.map(p => p.confidence)
+
+  const ambiguous =
+    preds.length > 1 &&
+    (math.allInRange(confidenceVec, low, up) ||
+      (preds[0].name === NONE_INTENT && math.allInRange(confidenceVec.slice(1), low, up)))
+
+  return { ...input, ambiguous }
+}
+
+async function extractElectedIntentSlots(input: EventUnderstanding): Promise<EventUnderstanding> {
+  const intentWasElectedWithoutAmbiguity = input?.intent?.name && !_.isEmpty(input.predictions) && !input.ambiguous
+  if (!intentWasElectedWithoutAmbiguity) {
+    return input
+  }
+
+  const electedIntent = input.predictions[input.intent.context].intents.find(i => i.label === input.intent.name)
+  return { ...input, slots: electedIntent.slots }
+}
+
+// taken from svm classifier #295
+// this means that the 3 best predictions are really close, do not change magic numbers
+function predictionsReallyConfused(predictions: sdk.MLToolkit.SVM.Prediction[]): boolean {
+  if (predictions.length <= 2) {
+    return false
+  }
+
+  const std = math.std(predictions.map(p => p.confidence))
+  const diff = (predictions[0].confidence - predictions[1].confidence) / std
+  if (diff >= 2.5) {
+    return false
+  }
+
+  const bestOf3STD = math.std(predictions.slice(0, 3).map(p => p.confidence))
+  return bestOf3STD <= 0.03
+}

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -79,6 +79,16 @@ async function initDucklingExtractor(bp: typeof sdk): Promise<void> {
 
 const EVENTS_TO_IGNORE = ['session_reference', 'session_reset', 'bp_dialog_timeout', 'visit', 'say_something', '']
 
+const ignoreEvent = (bp: typeof sdk, state: NLUState, event: sdk.IO.IncomingEvent) => {
+  return (
+    !state.nluByBot[event.botId] ||
+    !state.health.isEnabled ||
+    !event.preview ||
+    EVENTS_TO_IGNORE.includes(event.type) ||
+    event.hasFlag(bp.IO.WellKnownFlags.SKIP_NATIVE_NLU)
+  )
+}
+
 const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
   bp.events.registerMiddleware({
     name: 'nlu.incoming',
@@ -87,13 +97,7 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
     description:
       'Process natural language in the form of text. Structured data with an action and parameters for that action is injected in the incoming message event.',
     handler: async (event: sdk.IO.IncomingEvent, next: sdk.IO.MiddlewareNextCallback) => {
-      if (
-        !state.nluByBot[event.botId] ||
-        !state.health.isEnabled ||
-        !event.preview ||
-        EVENTS_TO_IGNORE.includes(event.type) ||
-        event.hasFlag(bp.IO.WellKnownFlags.SKIP_NATIVE_NLU)
-      ) {
+      if (ignoreEvent(bp, state, event)) {
         return next()
       }
 
@@ -142,11 +146,37 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
   }
 }
 
+const registerElectionMiddleware = async (bp: typeof sdk, state: NLUState) => {
+  bp.events.registerMiddleware({
+    name: 'nlu-election.incoming',
+    direction: 'incoming',
+    order: 11,
+    description: 'Perform intent election for the outputed NLU.',
+    handler: async (event: sdk.IO.IncomingEvent, next: sdk.IO.MiddlewareNextCallback) => {
+      if (ignoreEvent(bp, state, event) || !event.nlu) {
+        return next()
+      }
+
+      const { engine } = state.nluByBot[event.botId]
+
+      try {
+        const nluResults = await engine.elect(event.nlu)
+        _.merge(event, { nlu: nluResults })
+      } catch (err) {
+        bp.logger.warn('Error extracting metadata for incoming text: ' + err.message)
+      } finally {
+        next()
+      }
+    }
+  })
+}
+
 export function getOnSeverStarted(state: NLUState) {
   return async (bp: typeof sdk) => {
     await initDucklingExtractor(bp)
     await initializeLanguageProvider(bp, state)
     initializeEngine(bp, state)
     await registerMiddleware(bp, state)
+    await registerElectionMiddleware(bp, state)
   }
 }

--- a/modules/nlu/src/backend/tools/cross-validation.ts
+++ b/modules/nlu/src/backend/tools/cross-validation.ts
@@ -104,7 +104,9 @@ export async function crossValidate(
 
   for (const ex of testSet) {
     for (const ctx of ex.ctxs) {
-      const res = await engine.predict(ex.utterance.toString(), [ctx])
+      // TODO: call converse API instead of calling legacy election by hand
+      let res = await engine.predict(ex.utterance.toString(), [ctx])
+      res = await engine.elect(res)
       intentF1Scorers[ctx].record(res.intent.name, ex.intent)
       const intentHasSlots = !!intentMap[ex.intent].slots.length
       if (intentHasSlots) {

--- a/modules/nlu/src/backend/typings.ts
+++ b/modules/nlu/src/backend/typings.ts
@@ -59,6 +59,7 @@ export interface NLUEngine {
   loadModel: (m: any) => Promise<void>
   train: (...args) => Promise<any>
   predict: (t: string, ctx: string[]) => Promise<sdk.IO.EventUnderstanding>
+  elect: (nlu: sdk.IO.EventUnderstanding) => Promise<sdk.IO.EventUnderstanding>
 }
 
 export interface EntityService {

--- a/modules/qna/src/backend/setup.ts
+++ b/modules/qna/src/backend/setup.ts
@@ -25,7 +25,7 @@ export const initModule = async (bp: typeof sdk, bots: ScopedBots) => {
         next()
       }
     },
-    order: 11, // must be after the NLU middleware and before the dialog middleware
+    order: 12, // must be after the NLU middleware and before the dialog middleware
     description: 'Listen for predefined questions and send canned responses.'
   })
 

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -668,7 +668,7 @@ declare module 'botpress/sdk' {
     export interface EventUnderstanding {
       intent?: NLU.Intent
       /** Predicted intents needs disambiguation */
-      readonly ambiguous: boolean
+      readonly ambiguous?: boolean
       intents?: NLU.Intent[]
       /** The language used for prediction. Will be equal to detected language when its part of supported languages, falls back to default language otherwise */
       readonly language: string

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -666,10 +666,10 @@ declare module 'botpress/sdk' {
     }
 
     export interface EventUnderstanding {
-      intent: NLU.Intent
+      intent?: NLU.Intent
       /** Predicted intents needs disambiguation */
       readonly ambiguous: boolean
-      intents: NLU.Intent[]
+      intents?: NLU.Intent[]
       /** The language used for prediction. Will be equal to detected language when its part of supported languages, falls back to default language otherwise */
       readonly language: string
       /** Language detected from users input. */

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -526,7 +526,7 @@ declare module 'botpress/sdk' {
     export interface Predictions {
       [context: string]: {
         confidence: number
-        intents: { label: string; confidence: number }[]
+        intents: { label: string; confidence: number; slots: SlotCollection }[]
       }
     }
   }
@@ -675,7 +675,7 @@ declare module 'botpress/sdk' {
       /** Language detected from users input. */
       readonly detectedLanguage: string
       readonly entities: NLU.Entity[]
-      readonly slots: NLU.SlotCollection
+      readonly slots?: NLU.SlotCollection
       readonly errored: boolean
       readonly includedContexts: string[]
       readonly predictions?: NLU.Predictions


### PR DESCRIPTION
First part of a bigger refactor.

Moved intent election and ambiguity detection in their own middleware (still in NLU module).

***sdk modification***
properties 

1. intent
1. intents
1. slots 
1. ambiguous 

of type EventUnderstanding in sdk are now optionnal because all the needed information to recover these informations is in field 'prediction'

Eventually, every module that uses theses 4 informations will call intent-is and intent-ambiguous conditions by using the sdk: bp.dialogs. Conditions will then either use legacy or new NDU intent election logic.

For now, the election logic has only been moved to its own middleware