### PR TITLE
chore(nlu): legacy elect intent middleware

### DIFF
--- a/modules/.knowledge/src/backend/middleware.ts
+++ b/modules/.knowledge/src/backend/middleware.ts
@@ -29,7 +29,7 @@ export const registerMiddleware = async (bp: typeof sdk, classifiers: Classifier
 
       next()
     },
-    order: 15,
+    order: 16,
     description: 'Finds content from Knowledge base files'
   })
 }

--- a/modules/.knowledge/src/backend/middleware.ts
+++ b/modules/.knowledge/src/backend/middleware.ts
@@ -29,7 +29,7 @@ export const registerMiddleware = async (bp: typeof sdk, classifiers: Classifier
 
       next()
     },
-    order: 16,
+    order: 150,
     description: 'Finds content from Knowledge base files'
   })
 }

--- a/modules/analytics/src/backend/setup.ts
+++ b/modules/analytics/src/backend/setup.ts
@@ -60,7 +60,7 @@ export default async (bp: typeof sdk, db: Database, interactionsToTrack: string[
     name: 'analytics.incoming',
     direction: 'incoming',
     handler: incomingMiddleware,
-    order: 12, // after nlu and qna
+    order: 14, // after nlu and qna
     description: 'Tracks incoming messages for Analytics purposes'
   })
 

--- a/modules/analytics/src/backend/setup.ts
+++ b/modules/analytics/src/backend/setup.ts
@@ -60,7 +60,7 @@ export default async (bp: typeof sdk, db: Database, interactionsToTrack: string[
     name: 'analytics.incoming',
     direction: 'incoming',
     handler: incomingMiddleware,
-    order: 14, // after nlu and qna
+    order: 140, // after nlu election and qna
     description: 'Tracks incoming messages for Analytics purposes'
   })
 

--- a/modules/ndu/src/backend/middleware.ts
+++ b/modules/ndu/src/backend/middleware.ts
@@ -6,7 +6,7 @@ export const registerMiddleware = async (bp: typeof sdk, bots: MountedBots) => {
   bp.events.registerMiddleware({
     name: 'ndu.incoming',
     direction: 'incoming',
-    order: 13,
+    order: 15,
     description: 'Where magic happens',
     handler: async (event: sdk.IO.IncomingEvent, next: sdk.IO.MiddlewareNextCallback) => {
       if (bots[event.botId]) {

--- a/modules/ndu/src/backend/middleware.ts
+++ b/modules/ndu/src/backend/middleware.ts
@@ -6,7 +6,7 @@ export const registerMiddleware = async (bp: typeof sdk, bots: MountedBots) => {
   bp.events.registerMiddleware({
     name: 'ndu.incoming',
     direction: 'incoming',
-    order: 15,
+    order: 110,
     description: 'Where magic happens',
     handler: async (event: sdk.IO.IncomingEvent, next: sdk.IO.MiddlewareNextCallback) => {
       if (bots[event.botId]) {

--- a/modules/nlu-extras/src/backend/middleware.ts
+++ b/modules/nlu-extras/src/backend/middleware.ts
@@ -18,7 +18,7 @@ export const registerMiddleware = async (bp: typeof sdk) => {
   bp.events.registerMiddleware({
     name: 'nlu-extras.incoming',
     direction: 'incoming',
-    order: 11,
+    order: 12,
     description:
       'Process natural language in the form of text. Structured data with an action and parameters for that action is injected in the incoming message event.',
     handler: async (event: sdk.IO.IncomingEvent, next: sdk.IO.MiddlewareNextCallback) => {

--- a/modules/nlu-extras/src/backend/middleware.ts
+++ b/modules/nlu-extras/src/backend/middleware.ts
@@ -18,7 +18,7 @@ export const registerMiddleware = async (bp: typeof sdk) => {
   bp.events.registerMiddleware({
     name: 'nlu-extras.incoming',
     direction: 'incoming',
-    order: 12,
+    order: 129,
     description:
       'Process natural language in the form of text. Structured data with an action and parameters for that action is injected in the incoming message event.',
     handler: async (event: sdk.IO.IncomingEvent, next: sdk.IO.MiddlewareNextCallback) => {

--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -78,7 +78,6 @@ export default async (bp: typeof sdk, state: NLUState) => {
 
     try {
       let nlu = await state.nluByBot[botId].engine.predict(value.text, value.contexts)
-      // TODO: call converse API instead of calling legacy election by hand
       nlu = legacyElectionPipeline(nlu)
       res.send({ nlu })
     } catch (err) {

--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -18,6 +18,7 @@ import { initializeLanguageProvider } from './module-lifecycle/on-server-started
 import { crossValidate } from './tools/cross-validation'
 import { getTrainingSession } from './train-session-service'
 import { NLUState } from './typings'
+import legacyElectionPipeline from './legacy-election'
 
 export const PredictSchema = Joi.object().keys({
   contexts: Joi.array()
@@ -76,7 +77,9 @@ export default async (bp: typeof sdk, state: NLUState) => {
     }
 
     try {
-      const nlu = await state.nluByBot[botId].engine.predict(value.text, value.contexts)
+      let nlu = await state.nluByBot[botId].engine.predict(value.text, value.contexts)
+      // TODO: call converse API instead of calling legacy election by hand
+      nlu = legacyElectionPipeline(nlu)
       res.send({ nlu })
     } catch (err) {
       res.status(500).send('Could not extract nlu data')

--- a/modules/nlu/src/backend/legacy-election.ts
+++ b/modules/nlu/src/backend/legacy-election.ts
@@ -1,0 +1,156 @@
+import * as sdk from 'botpress/sdk'
+import _ from 'lodash'
+import * as math from './tools/math'
+
+export type PredictOutput = sdk.IO.EventUnderstanding
+
+const OOS_AS_NONE_TRESH = 0.4
+const LOW_INTENT_CONFIDENCE_TRESH = 0.4
+const NONE_INTENT = 'none' // should extract in comon code
+
+export default function legacyElectionPipeline(predictOutput: PredictOutput) {
+  predictOutput = electIntent(predictOutput)
+  predictOutput = detectAmbiguity(predictOutput)
+  predictOutput = extractElectedIntentSlot(predictOutput)
+  return predictOutput
+}
+
+function electIntent(input: PredictOutput): PredictOutput {
+  const allCtx = Object.keys(input.predictions)
+
+  const ctx_predictions = allCtx.map(label => {
+    const { confidence } = input.predictions[label]
+    return { label, confidence }
+  })
+
+  const perCtxIntentPrediction = _.mapValues(input.predictions, p => p.intents)
+
+  const oos_predictions = _.mapValues(input.predictions, p => p.oos)
+
+  const totalConfidence = Math.min(
+    1,
+    _.sumBy(
+      ctx_predictions.filter(x => input.includedContexts.includes(x.label)),
+      'confidence'
+    )
+  )
+  const ctxPreds = ctx_predictions.map(x => ({ ...x, confidence: x.confidence / totalConfidence }))
+
+  // taken from svm classifier #349
+  let predictions = _.chain(ctxPreds)
+    .flatMap(({ label: ctx, confidence: ctxConf }) => {
+      const intentPreds = _.chain(perCtxIntentPrediction[ctx] || [])
+        .thru(preds => {
+          if (oos_predictions[ctx] >= OOS_AS_NONE_TRESH) {
+            return [
+              ...preds,
+              {
+                label: NONE_INTENT,
+                confidence: oos_predictions[ctx],
+                context: ctx,
+                l0Confidence: ctxConf
+              }
+            ]
+          } else {
+            return preds
+          }
+        })
+        .map(p => ({ ...p, confidence: _.round(p.confidence, 2) }))
+        .orderBy('confidence', 'desc')
+        .value() as (sdk.MLToolkit.SVM.Prediction & { context: string })[]
+      if (intentPreds[0].confidence === 1 || intentPreds.length === 1) {
+        return [{ label: intentPreds[0].label, l0Confidence: ctxConf, context: ctx, confidence: 1 }]
+      } // are we sure theres always at least two intents ? otherwise down there it may crash
+
+      if (predictionsReallyConfused(intentPreds)) {
+        intentPreds.unshift({ label: NONE_INTENT, context: ctx, confidence: 1 })
+      }
+
+      const lnstd = math.std(intentPreds.filter(x => x.confidence !== 0).map(x => Math.log(x.confidence))) // because we want a lognormal distribution
+      let p1Conf = math.GetZPercent((Math.log(intentPreds[0].confidence) - Math.log(intentPreds[1].confidence)) / lnstd)
+      if (isNaN(p1Conf)) {
+        p1Conf = 0.5
+      }
+
+      return [
+        { label: intentPreds[0].label, l0Confidence: ctxConf, context: ctx, confidence: _.round(ctxConf * p1Conf, 3) },
+        {
+          label: intentPreds[1].label,
+          l0Confidence: ctxConf,
+          context: ctx,
+          confidence: _.round(ctxConf * (1 - p1Conf), 3)
+        }
+      ]
+    })
+    .orderBy('confidence', 'desc')
+    .filter(p => input.includedContexts.includes(p.context))
+    .uniqBy(p => p.label)
+    .map(p => ({ name: p.label, context: p.context, confidence: p.confidence }))
+    .value()
+
+  const ctx = _.get(predictions, '0.context', 'global')
+  const shouldConsiderOOS =
+    predictions.length &&
+    predictions[0].name !== NONE_INTENT &&
+    predictions[0].confidence < LOW_INTENT_CONFIDENCE_TRESH &&
+    oos_predictions[ctx] > OOS_AS_NONE_TRESH
+  if (!predictions.length || shouldConsiderOOS) {
+    predictions = _.orderBy(
+      [
+        ...predictions.filter(p => p.name !== NONE_INTENT),
+        { name: NONE_INTENT, context: ctx, confidence: oos_predictions[ctx] || 1 }
+      ],
+      'confidence'
+    )
+  }
+
+  const elected = _.maxBy(predictions, 'confidence')
+  return {
+    ...input,
+    intent: elected,
+    intents: predictions
+  }
+}
+
+function detectAmbiguity(input: PredictOutput): PredictOutput {
+  // +- 10% away from perfect median leads to ambiguity
+  const preds = input.intents
+  const perfectConfusion = 1 / preds.length
+  const low = perfectConfusion - 0.1
+  const up = perfectConfusion + 0.1
+  const confidenceVec = preds.map(p => p.confidence)
+
+  const ambiguous =
+    preds.length > 1 &&
+    (math.allInRange(confidenceVec, low, up) ||
+      (preds[0].name === NONE_INTENT && math.allInRange(confidenceVec.slice(1), low, up)))
+
+  return { ...input, ambiguous }
+}
+
+function extractElectedIntentSlot(input: PredictOutput): PredictOutput {
+  const intentWasElectedWithoutAmbiguity = input?.intent?.name && !_.isEmpty(input.predictions) && !input.ambiguous
+  if (!intentWasElectedWithoutAmbiguity) {
+    return input
+  }
+
+  const electedIntent = input.predictions[input.intent.context].intents.find(i => i.label === input.intent.name)
+  return { ...input, slots: electedIntent.slots }
+}
+
+// taken from svm classifier #295
+// this means that the 3 best predictions are really close, do not change magic numbers
+function predictionsReallyConfused(predictions: sdk.MLToolkit.SVM.Prediction[]): boolean {
+  if (predictions.length <= 2) {
+    return false
+  }
+
+  const std = math.std(predictions.map(p => p.confidence))
+  const diff = (predictions[0].confidence - predictions[1].confidence) / std
+  if (diff >= 2.5) {
+    return false
+  }
+
+  const bestOf3STD = math.std(predictions.slice(0, 3).map(p => p.confidence))
+  return bestOf3STD <= 0.03
+}

--- a/modules/nlu/src/backend/legacy-election.ts
+++ b/modules/nlu/src/backend/legacy-election.ts
@@ -136,7 +136,8 @@ function detectAmbiguity(input: PredictOutput): PredictOutput {
 
 function extractElectedIntentSlot(input: PredictOutput): PredictOutput {
   const intentWasElectedWithoutAmbiguity = input?.intent?.name && !_.isEmpty(input.predictions) && !input.ambiguous
-  if (!intentWasElectedWithoutAmbiguity) {
+  const intentIsNone = input?.intent?.name === NONE_INTENT
+  if (!intentWasElectedWithoutAmbiguity || intentIsNone) {
     return input
   }
 

--- a/modules/nlu/src/backend/legacy-election.ts
+++ b/modules/nlu/src/backend/legacy-election.ts
@@ -58,12 +58,18 @@ function electIntent(input: PredictOutput): PredictOutput {
         .map(p => ({ ...p, confidence: _.round(p.confidence, 2) }))
         .orderBy('confidence', 'desc')
         .value() as (sdk.MLToolkit.SVM.Prediction & { context: string })[]
-      if (intentPreds[0].confidence === 1 || intentPreds.length === 1) {
-        return [{ label: intentPreds[0].label, l0Confidence: ctxConf, context: ctx, confidence: 1 }]
-      } // are we sure theres always at least two intents ? otherwise down there it may crash
 
+      if (intentPreds[0]?.confidence === 1 || intentPreds.length === 1) {
+        return [{ label: intentPreds[0].label, l0Confidence: ctxConf, context: ctx, confidence: 1 }]
+      }
+
+      const noneIntent = { label: NONE_INTENT, context: ctx, confidence: 1 }
       if (predictionsReallyConfused(intentPreds)) {
-        intentPreds.unshift({ label: NONE_INTENT, context: ctx, confidence: 1 })
+        intentPreds.unshift(noneIntent)
+      }
+
+      if (intentPreds.length <= 1) {
+        return noneIntent
       }
 
       const lnstd = math.std(intentPreds.filter(x => x.confidence !== 0).map(x => Math.log(x.confidence))) // because we want a lognormal distribution

--- a/modules/nlu/src/backend/legacy-election.ts
+++ b/modules/nlu/src/backend/legacy-election.ts
@@ -59,17 +59,16 @@ function electIntent(input: PredictOutput): PredictOutput {
         .orderBy('confidence', 'desc')
         .value() as (sdk.MLToolkit.SVM.Prediction & { context: string })[]
 
-      if (intentPreds[0]?.confidence === 1 || intentPreds.length === 1) {
+      const noneIntent = { label: NONE_INTENT, context: ctx, confidence: 1 }
+      if (!intentPreds.length) {
+        return [noneIntent]
+      } else if (intentPreds[0].confidence === 1 || intentPreds.length === 1) {
         return [{ label: intentPreds[0].label, l0Confidence: ctxConf, context: ctx, confidence: 1 }]
       }
+      // else, there is at least two intentPreds
 
-      const noneIntent = { label: NONE_INTENT, context: ctx, confidence: 1 }
       if (predictionsReallyConfused(intentPreds)) {
         intentPreds.unshift(noneIntent)
-      }
-
-      if (intentPreds.length <= 1) {
-        return noneIntent
       }
 
       const lnstd = math.std(intentPreds.filter(x => x.confidence !== 0).map(x => Math.log(x.confidence))) // because we want a lognormal distribution

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -97,9 +97,9 @@ const ignoreEvent = (bp: typeof sdk, state: NLUState, event: sdk.IO.IncomingEven
 
 const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
   bp.events.registerMiddleware({
-    name: 'nlu.incoming',
+    name: 'nlu-predict.incoming',
     direction: 'incoming',
-    order: 10,
+    order: 100,
     description:
       'Process natural language in the form of text. Structured data with an action and parameters for that action is injected in the incoming message event.',
     handler: async (event: sdk.IO.IncomingEvent, next: sdk.IO.MiddlewareNextCallback) => {
@@ -152,9 +152,9 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
   }
 
   bp.events.registerMiddleware({
-    name: 'nlu-election.incoming',
+    name: 'nlu-elect.incoming',
     direction: 'incoming',
-    order: 11,
+    order: 120,
     description: 'Perform intent election for the outputed NLU.',
     handler: async (event: sdk.IO.IncomingEvent, next: sdk.IO.MiddlewareNextCallback) => {
       if (ignoreEvent(bp, state, event) || !event.nlu) {
@@ -162,8 +162,9 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
       }
 
       try {
-        const nluResults = legacyElectionPipeline(event.nlu)
-        _.merge(event, { nlu: nluResults })
+        // TODO: use the 'intent-is' condition logic when bot uses NDU
+        const nlu = legacyElectionPipeline(event.nlu)
+        _.merge(event, { nlu })
       } catch (err) {
         bp.logger.warn('Error extracting metadata for incoming text: ' + err.message)
       } finally {

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -166,7 +166,7 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
         const nlu = legacyElectionPipeline(event.nlu)
         _.merge(event, { nlu })
       } catch (err) {
-        bp.logger.warn('Error extracting metadata for incoming text: ' + err.message)
+        bp.logger.warn('Error making nlu election for incoming text: ' + err.message)
       } finally {
         next()
       }

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -5,6 +5,7 @@ import semver from 'semver'
 
 import { Config } from '../../config'
 import Engine from '../engine'
+import legacyElectionPipeline from '../legacy-election'
 import { DucklingEntityExtractor } from '../entities/duckling_extractor'
 import LangProvider from '../language/language-provider'
 import { getPOSTagger, tagSentence } from '../language/pos-tagger'
@@ -84,6 +85,16 @@ async function initDucklingExtractor(bp: typeof sdk): Promise<void> {
 
 const EVENTS_TO_IGNORE = ['session_reference', 'session_reset', 'bp_dialog_timeout', 'visit', 'say_something', '']
 
+const ignoreEvent = (bp: typeof sdk, state: NLUState, event: sdk.IO.IncomingEvent) => {
+  return (
+    !state.nluByBot[event.botId] ||
+    !state.health.isEnabled ||
+    !event.preview ||
+    EVENTS_TO_IGNORE.includes(event.type) ||
+    event.hasFlag(bp.IO.WellKnownFlags.SKIP_NATIVE_NLU)
+  )
+}
+
 const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
   bp.events.registerMiddleware({
     name: 'nlu.incoming',
@@ -92,13 +103,7 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
     description:
       'Process natural language in the form of text. Structured data with an action and parameters for that action is injected in the incoming message event.',
     handler: async (event: sdk.IO.IncomingEvent, next: sdk.IO.MiddlewareNextCallback) => {
-      if (
-        !state.nluByBot[event.botId] ||
-        !state.health.isEnabled ||
-        !event.preview ||
-        EVENTS_TO_IGNORE.includes(event.type) ||
-        event.hasFlag(bp.IO.WellKnownFlags.SKIP_NATIVE_NLU)
-      ) {
+      if (ignoreEvent(bp, state, event)) {
         return next()
       }
 
@@ -145,6 +150,27 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
       bp.logger.warn('Error removing sensitive information: ' + err.message)
     }
   }
+
+  bp.events.registerMiddleware({
+    name: 'nlu-election.incoming',
+    direction: 'incoming',
+    order: 11,
+    description: 'Perform intent election for the outputed NLU.',
+    handler: async (event: sdk.IO.IncomingEvent, next: sdk.IO.MiddlewareNextCallback) => {
+      if (ignoreEvent(bp, state, event) || !event.nlu) {
+        return next()
+      }
+
+      try {
+        const nluResults = legacyElectionPipeline(event.nlu)
+        _.merge(event, { nlu: nluResults })
+      } catch (err) {
+        bp.logger.warn('Error extracting metadata for incoming text: ' + err.message)
+      } finally {
+        next()
+      }
+    }
+  })
 }
 
 function setNluVersion(bp: typeof sdk, state: NLUState) {

--- a/modules/nlu/src/backend/tools/cross-validation.ts
+++ b/modules/nlu/src/backend/tools/cross-validation.ts
@@ -7,6 +7,7 @@ import { BIO } from '../typings'
 import Utterance, { buildUtteranceBatch } from '../utterance/utterance'
 
 import MultiClassF1Scorer, { F1 } from './f1-scorer'
+import legacyElectionPipeline from '../legacy-election'
 const seedrandom = require('seedrandom')
 
 interface CrossValidationResults {
@@ -106,7 +107,8 @@ export async function crossValidate(
 
   for (const ex of testSet) {
     for (const ctx of ex.ctxs) {
-      const res = await engine.predict(ex.utterance.toString(), [ctx])
+      let res = await engine.predict(ex.utterance.toString(), [ctx])
+      res = legacyElectionPipeline(res)
       intentF1Scorers[ctx].record(res.intent.name, ex.intent)
       const intentHasSlots = !!intentMap[ex.intent].slots.length
       if (intentHasSlots) {
@@ -114,7 +116,8 @@ export async function crossValidate(
       }
     }
     if (allCtx.length > 1) {
-      const res = await engine.predict(ex.utterance.toString(), allCtx)
+      let res = await engine.predict(ex.utterance.toString(), allCtx)
+      res = legacyElectionPipeline(res)
       intentF1Scorers['all'].record(res.intent.name, ex.intent)
     }
   }

--- a/modules/qna/src/backend/setup.ts
+++ b/modules/qna/src/backend/setup.ts
@@ -25,7 +25,7 @@ export const initModule = async (bp: typeof sdk, bots: ScopedBots) => {
         next()
       }
     },
-    order: 13, // must be after the NLU middleware and before the dialog middleware
+    order: 130, // must be after the NLU middleware and before the dialog middleware
     description: 'Listen for predefined questions and send canned responses.'
   })
 

--- a/modules/qna/src/backend/setup.ts
+++ b/modules/qna/src/backend/setup.ts
@@ -25,7 +25,7 @@ export const initModule = async (bp: typeof sdk, bots: ScopedBots) => {
         next()
       }
     },
-    order: 11, // must be after the NLU middleware and before the dialog middleware
+    order: 13, // must be after the NLU middleware and before the dialog middleware
     description: 'Listen for predefined questions and send canned responses.'
   })
 

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -670,16 +670,16 @@ declare module 'botpress/sdk' {
     }
 
     export interface EventUnderstanding {
-      intent: NLU.Intent
+      intent?: NLU.Intent
       /** Predicted intents needs disambiguation */
-      readonly ambiguous: boolean
-      intents: NLU.Intent[]
+      readonly ambiguous?: boolean
+      intents?: NLU.Intent[]
       /** The language used for prediction. Will be equal to detected language when its part of supported languages, falls back to default language otherwise */
       readonly language: string
       /** Language detected from users input. */
       readonly detectedLanguage: string
       readonly entities: NLU.Entity[]
-      readonly slots: NLU.SlotCollection
+      readonly slots?: NLU.SlotCollection
       readonly errored: boolean
       readonly includedContexts: string[]
       readonly predictions?: NLU.Predictions


### PR DESCRIPTION
First part of a bigger refactor.

Moved intent election and ambiguity detection in their own middleware (still in NLU module).

***sdk modification***
properties

1. intent
1. intents
1. slots
1. ambiguous

of type EventUnderstanding in sdk are now optionnal because all the needed information to recover these informations is in field 'prediction'

Eventually, every module that uses theses 4 informations will call intent-is and intent-ambiguous conditions by using the sdk: bp.dialogs. Conditions will then either use legacy or new NDU intent election logic.

For now, the election logic has only been moved to its own middleware

**Middlewares modifications**
Order of middlewares is now:

- nlu-predict: 10 -> 100
- ndu: 13 -> 110
- nlu-election: none -> 120
- nlu-extras: 11 -> 129 (I don't think this mw is really used ?...)
- qna: 11 -> 130
- analytics: 12 -> 140
- knowledge: 15 -> 150 (disabled)