### PR TITLE
fix(core): img link with custom path & preview

### DIFF
--- a/modules/builtin/src/content-types/carousel.js
+++ b/modules/builtin/src/content-types/carousel.js
@@ -1,6 +1,5 @@
 const base = require('./_base')
 const Card = require('./card')
-const url = require('url')
 
 function render(data) {
   const events = []
@@ -20,7 +19,7 @@ function render(data) {
       collectFeedback: data.collectFeedback,
       elements: data.items.map(card => ({
         title: card.title,
-        picture: card.image ? url.resolve(data.BOT_URL, card.image) : null,
+        picture: card.image ? `${data.BOT_URL}${card.image}` : null,
         subtitle: card.subtitle,
         buttons: (card.actions || []).map(a => {
           if (a.action === 'Say something') {
@@ -54,7 +53,7 @@ function renderMessenger(data) {
   const renderElements = data => {
     return data.items.map(card => ({
       title: card.title,
-      image_url: card.image ? url.resolve(data.BOT_URL, card.image) : null,
+      image_url: card.image ? `${data.BOT_URL}${card.image}` : null,
       subtitle: card.subtitle,
       buttons: (card.actions || []).map(a => {
         if (a.action === 'Say something') {
@@ -125,7 +124,7 @@ function renderSlack(data) {
           },
           accessory: card.image && {
             type: 'image',
-            image_url: url.resolve(data.BOT_URL, card.image),
+            image_url: `${data.BOT_URL}${card.image}`,
             alt_text: 'image'
           }
         },

--- a/modules/builtin/src/content-types/image.js
+++ b/modules/builtin/src/content-types/image.js
@@ -169,8 +169,9 @@ module.exports = {
     if (fileName.includes('-')) {
       fileName = tail(fileName.split('-')).join('-')
     }
+    const link = `${formData.BOT_URL}${formData.image}`
     const title = formData.title ? ' | ' + formData.title : ''
-    return `Image: [![${formData.title || ''}](<${formData.image}>)](<${formData.image}>) - (${fileName}) ${title}`
+    return `Image: [![${formData.title || ''}](<${link}>)](<${link}>) - (${fileName}) ${title}`
   },
 
   renderElement: renderElement

--- a/src/bp/core/services/cms.ts
+++ b/src/bp/core/services/cms.ts
@@ -535,11 +535,13 @@ export class CMSService implements IDisposeOnExit {
         result[lang] = 'No preview'
       } else {
         const translated = this.getOriginalProps(formData, contentType, lang)
-        let preview = contentType.computePreviewText(translated)
+        let preview = contentType.computePreviewText({ ...translated, ...this._getAdditionalData() })
 
         if (!preview) {
           const defaultTranslation = this.getOriginalProps(formData, contentType, defaultLang)
-          preview = '(missing translation) ' + contentType.computePreviewText(defaultTranslation)
+          preview =
+            '(missing translation) ' +
+            contentType.computePreviewText({ ...defaultTranslation, ...this._getAdditionalData() })
         }
 
         result[lang] = preview
@@ -597,6 +599,10 @@ export class CMSService implements IDisposeOnExit {
     }, {})
   }
 
+  private _getAdditionalData() {
+    return { BOT_URL: process.EXTERNAL_URL }
+  }
+
   async renderElement(contentId: string, args, eventDestination: IO.EventDestination) {
     const { botId, channel } = eventDestination
     contentId = contentId.replace(/^#?/i, '')
@@ -648,9 +654,7 @@ export class CMSService implements IDisposeOnExit {
       }
     }
 
-    const additionalData = { BOT_URL: process.EXTERNAL_URL }
-
-    let payloads = contentTypeRenderer.renderElement({ ...additionalData, ...args }, channel)
+    let payloads = contentTypeRenderer.renderElement({ ...this._getAdditionalData(), ...args }, channel)
     if (!_.isArray(payloads)) {
       payloads = [payloads]
     }


### PR DESCRIPTION
Some links were fixed for the image, but not in carousel. Preview was not workign either when using custom paths, since url.resolve ignored it.