### PR TITLE
fix(qna): warn instead of block for duplicates

### DIFF
--- a/modules/qna/src/backend/storage.ts
+++ b/modules/qna/src/backend/storage.ts
@@ -147,7 +147,9 @@ export default class Storage {
       .filter(q => newQuestions.includes(q))
 
     if (dupes.length) {
-      throw new Error(`These questions already exist in another entry: ${dupes.join(', ')}`)
+      this.bp.logger
+        .forBot(this.botId)
+        .warn(`These questions already exist in another entry: ${dupes.join(', ')}. Please remove duplicates`)
     }
   }
 


### PR DESCRIPTION
When you have a duplicate, you can't even disable the offending question. Duplicates will not prevent it from working, but it will affect the NLU training. So it makes more sense to mark it as a warning instead.