### PR TITLE
fix(core): moved heavy operation

### DIFF
--- a/src/bp/core/logger/logger.ts
+++ b/src/bp/core/logger/logger.ts
@@ -34,6 +34,8 @@ function serializeArgs(args: any): string {
   }
 }
 
+const hostname = os.hostname()
+
 @injectable()
 // Suggestion: Would be best to have a CompositeLogger that separates the Console and DB loggers
 export class PersistedConsoleLogger implements Logger {
@@ -68,7 +70,7 @@ export class PersistedConsoleLogger implements Logger {
     @inject(TYPES.LoggerFilePersister) private loggerFilePersister: LoggerFilePersister
   ) {
     this.displayLevel = process.VERBOSITY_LEVEL
-    this.serverHostname = os.hostname()
+    this.serverHostname = hostname
   }
 
   forBot(botId: string): this {

--- a/src/bp/core/services/dialog/instruction/strategy.ts
+++ b/src/bp/core/services/dialog/instruction/strategy.ts
@@ -181,12 +181,6 @@ export class ActionStrategy implements InstructionStrategy {
 
 @injectable()
 export class TransitionStrategy implements InstructionStrategy {
-  constructor(
-    @inject(TYPES.Logger)
-    @tagged('name', 'Transition')
-    private logger: Logger
-  ) {}
-
   async processInstruction(botId, instruction, event): Promise<ProcessingResult> {
     const conditionSuccessful = await this.runCode(instruction, {
       event,


### PR DESCRIPTION
Constructor is called everytime the logger is injected, so the hostname call was heavy on the request.

The transition logger isn't used but was still creating a couple of instances when processing requests.