### PR TITLE
fix(core): implement lock for single-node

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
   verbose: true,
   modulePaths: ['<rootDir>/src/bp/'],
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx'],
+  modulePathIgnorePatterns: ['out'],
   transform: {
     '^.+\\.(ts|tsx|js)$': 'ts-jest'
   },

--- a/src/bp/core/services/job-service.test.ts
+++ b/src/bp/core/services/job-service.test.ts
@@ -1,0 +1,63 @@
+import 'bluebird-global'
+import 'jest-extended'
+import 'reflect-metadata'
+
+import { CEJobService } from './job-service'
+
+describe('Lock', () => {
+  const jobService = new CEJobService()
+  const resourceName = 'testLock'
+  const DURATION = 50
+
+  beforeEach(async () => {
+    try {
+      await jobService.clearLock(resourceName)
+    } catch (err) {}
+  })
+
+  it('Obtain a lock ', async () => {
+    const lock = await jobService.acquireLock(resourceName, DURATION)
+    expect(lock).not.toBeUndefined()
+
+    await lock?.unlock()
+  })
+
+  it('Try to obtain a second lock', async () => {
+    const lock = await jobService.acquireLock(resourceName, DURATION)
+    expect(lock).not.toBeUndefined()
+
+    const lock2 = await jobService.acquireLock(resourceName, DURATION)
+    expect(lock2).toBeUndefined()
+  })
+
+  it('Obtain a second lock, after clearing the previous one', async () => {
+    const lock = await jobService.acquireLock(resourceName, DURATION)
+    expect(lock).not.toBeUndefined()
+
+    await jobService.clearLock(resourceName)
+
+    const lock2 = await jobService.acquireLock(resourceName, DURATION)
+    expect(lock2).not.toBeUndefined()
+  })
+
+  it('Test lock expiration', async () => {
+    const lock = await jobService.acquireLock(resourceName, DURATION)
+    expect(lock).not.toBeUndefined()
+
+    await Promise.delay(DURATION * 2)
+
+    const lock2 = await jobService.acquireLock(resourceName, DURATION)
+    expect(lock2).not.toBeUndefined()
+  })
+
+  it('Extend the duration of the lock', async () => {
+    const lock = await jobService.acquireLock(resourceName, DURATION)
+    expect(lock).not.toBeUndefined()
+
+    await lock?.extend(DURATION * 3)
+    await Promise.delay(DURATION * 2)
+
+    const lock2 = await jobService.acquireLock(resourceName, DURATION)
+    expect(lock2).toBeUndefined()
+  })
+})


### PR DESCRIPTION
There's an issue with broadcast if there's a lot of messages to send, since we always return "true" when not using redis. The next interval will also acquire a lock, and will also process some of the same messages.

Since there was a todo, i've added a basic implementation for the locking mechanism.