### PR TITLE
fix(core): flag to run transitions outside of the sandbox

### DIFF
--- a/src/bp/core/services/dialog/instruction/strategy.ts
+++ b/src/bp/core/services/dialog/instruction/strategy.ts
@@ -166,8 +166,8 @@ export class ActionStrategy implements InstructionStrategy {
 
 @injectable()
 export class TransitionStrategy implements InstructionStrategy {
-  // Avoid using the sandbox for code deemed "safe" and simple expressions
-  private safeRegex = new RegExp(/^[a-zA-Z0-9\s\[\]'"\-_<>=\.]+$/)
+  // Characters considered unsafe which will cause the transition to run in the sandbox
+  private unsafeRegex = new RegExp(/[\(\)\`]/)
 
   async processInstruction(botId, instruction, event): Promise<ProcessingResult> {
     const conditionSuccessful = await this.runCode(instruction, {
@@ -206,7 +206,7 @@ export class TransitionStrategy implements InstructionStrategy {
       throw err
     }`
 
-    if (process.DISABLE_TRANSITION_SANDBOX || this.safeRegex.test(instruction.fn!)) {
+    if (process.DISABLE_TRANSITION_SANDBOX || !this.unsafeRegex.test(instruction.fn!)) {
       const fn = new Function(...Object.keys(sandbox), code)
       return fn(...Object.values(sandbox))
     }

--- a/src/bp/core/services/dialog/instruction/strategy.ts
+++ b/src/bp/core/services/dialog/instruction/strategy.ts
@@ -195,12 +195,6 @@ export class TransitionStrategy implements InstructionStrategy {
       return fn(...Object.values(sandbox))
     }
 
-    const vm = new NodeVM({
-      wrapper: 'none',
-      sandbox: sandbox,
-      timeout: 5000
-    })
-    const runner = new VmRunner()
     const code = `
     try {
       return ${instruction.fn};
@@ -210,8 +204,19 @@ export class TransitionStrategy implements InstructionStrategy {
         return false
       }
       throw err
+    }`
+
+    if (process.DISABLE_TRANSITION_SANDBOX) {
+      const fn = new Function(...Object.keys(sandbox), code)
+      return fn(...Object.values(sandbox))
     }
-    `
+
+    const vm = new NodeVM({
+      wrapper: 'none',
+      sandbox: sandbox,
+      timeout: 5000
+    })
+    const runner = new VmRunner()
     return await runner.runInVm(vm, code)
   }
 }

--- a/src/bp/core/services/dialog/instruction/strategy.ts
+++ b/src/bp/core/services/dialog/instruction/strategy.ts
@@ -167,7 +167,7 @@ export class ActionStrategy implements InstructionStrategy {
 @injectable()
 export class TransitionStrategy implements InstructionStrategy {
   // Avoid using the sandbox for code deemed "safe" and simple expressions
-  private safeRegex = new RegExp(/^[a-zA-Z0-9\s\[\]'"\-<>=]+$/)
+  private safeRegex = new RegExp(/^[a-zA-Z0-9\s\[\]'"\-_<>=\.]+$/)
 
   async processInstruction(botId, instruction, event): Promise<ProcessingResult> {
     const conditionSuccessful = await this.runCode(instruction, {

--- a/src/bp/index.ts
+++ b/src/bp/index.ts
@@ -104,6 +104,7 @@ try {
         process.VERBOSITY_LEVEL = argv.verbose ? Number(argv.verbose) : defaultVerbosity
         process.DISABLE_GLOBAL_SANDBOX = yn(process.env.DISABLE_GLOBAL_SANDBOX)
         process.DISABLE_BOT_SANDBOX = yn(process.env.DISABLE_BOT_SANDBOX)
+        process.DISABLE_TRANSITION_SANDBOX = yn(process.env.DISABLE_TRANSITION_SANDBOX)
         process.IS_LICENSED = true
         process.ASSERT_LICENSED = () => {}
         process.BOTPRESS_VERSION = metadataContent.version

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -51,6 +51,7 @@ declare namespace NodeJS {
     SERVER_ID: string
     DISABLE_GLOBAL_SANDBOX: boolean
     DISABLE_BOT_SANDBOX: boolean
+    DISABLE_TRANSITION_SANDBOX: boolean
     WEB_WORKER: number
     ML_WORKERS: number[]
   }
@@ -191,6 +192,9 @@ declare type BotpressEnvironmentVariables = {
 
   /** When true, bot-scoped actions and hooks are executed outside of the sandbox  */
   readonly DISABLE_BOT_SANDBOX?: boolean
+
+  /** When true, transitions are executed outside of the sandbox  */
+  readonly DISABLE_TRANSITION_SANDBOX?: boolean
 
   /** Runs all migrations from v12.0.0 up to the latest migration found in modules and core */
   readonly TESTMIG_ALL?: boolean


### PR DESCRIPTION
Adds a flag to run transitions outside of the sandbox. Provides a good performance boost when developers are trusted. 

Another small addition, we make a basic check of the transition, if it is deemed safe, it can be run outside of the sandbox. So by default we exclude anything with parameters (ex: includes() or require())