### PR TITLE
fix(nlu): remove sensitive data

### DIFF
--- a/modules/nlu/src/backend/entities/custom-entity-extractor.ts
+++ b/modules/nlu/src/backend/entities/custom-entity-extractor.ts
@@ -158,6 +158,7 @@ function extractForListModel(utterance: Utterance, listModel: ListEntityModel): 
         occurrence: match.occurrence,
         entityId: listModel.id
       },
+      sensitive: listModel.sensitive,
       type: listModel.entityName
     })) as EntityExtractionResult[]
 }
@@ -204,6 +205,7 @@ export const extractPatternEntities = (
         source: res.value,
         entityId: `custom.pattern.${ent.name}`
       },
+      sensitive: ent.sensitive,
       type: ent.name
     }))
   })

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -125,13 +125,13 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
     }
   })
 
-  function removeSensitiveText(event) {
+  function removeSensitiveText(event: sdk.IO.IncomingEvent) {
     if (!event.nlu.entities || !event.payload.text) {
       return
     }
 
     try {
-      const sensitiveEntities = event.nlu.entities.filter(ent => ent.sensitive)
+      const sensitiveEntities = event.nlu.entities.filter(ent => ent.meta.sensitive)
       for (const entity of sensitiveEntities) {
         const stars = '*'.repeat(entity.data.value.length)
         event.payload.text = event.payload.text.replace(entity.data.value, stars)

--- a/modules/nlu/src/backend/predict-pipeline.ts
+++ b/modules/nlu/src/backend/predict-pipeline.ts
@@ -461,6 +461,7 @@ function MapStepToOutput(step: PredictStep, startTime: number): PredictOutput {
           value: e.value
         },
         meta: {
+          sensitive: e.sensitive,
           confidence: e.confidence,
           end: e.endPos,
           source: e.metadata.source,

--- a/modules/nlu/src/backend/typings.ts
+++ b/modules/nlu/src/backend/typings.ts
@@ -134,6 +134,7 @@ export type ExtractedEntity = {
     unit?: string
     occurrence?: string
   }
+  sensitive?: boolean
   value: string
 }
 export type EntityExtractionResult = ExtractedEntity & { start: number; end: number }

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -504,6 +504,7 @@ declare module 'botpress/sdk' {
     }
 
     export interface EntityMeta {
+      sensitive: boolean
       confidence: number
       provider: string
       source: string


### PR DESCRIPTION
bring back that feature

given an entity marked as sensitive i.e credit card number and a incoming text like 
hello my credit card number is 4545 4545 4545 4545

it get's replaced by * so persisted incoming message will look like
hello my credit card number is **** **** **** ****