### PR TITLE
fix(builtin): Small talk template bot

### DIFF
--- a/modules/builtin/src/bot-templates/small-talk/content-elements/builtin_text.json
+++ b/modules/builtin/src/bot-templates/small-talk/content-elements/builtin_text.json
@@ -3,9 +3,7 @@
     "id": "builtin_text-iVBzXn",
     "formData": {
       "text$en": "I'm sorry, I did not understand. Please ask me something else.",
-      "typing$en": true,
-      "text$fr": "Pardon, je n'ai pas compris. Veuillez me poser un autre question.",
-      "typing$fr": true
+      "typing$en": true
     },
     "createdBy": "admin",
     "createdOn": "2019-07-01T18:28:03.566Z",


### PR DESCRIPTION
A translation was provided for a text element while the bot is English-only. When the bot was loaded, the English text for that element was cut instead of the French text.