### PR TITLE
feat(core): flow variables backend

### DIFF
--- a/src/bp/core/routers/api.rest
+++ b/src/bp/core/routers/api.rest
@@ -21,7 +21,7 @@ X-BP-Workspace: default
 ###
 
 
-@botId = gog
+@botId = YOUR_BOT
 
 
 # List all flows
@@ -32,8 +32,8 @@ X-BP-Workspace: default
 ###
 
 
-@flowName = Workflow Ended
-@flowFile = workflow_ended.flow.json
+@flowName = YOUR_WORKFLOW_NAME
+@flowFile = YOUR_WORKFLOW_FILE.flow.json
 
 
 # Edit a flow

--- a/src/bp/core/routers/api.rest
+++ b/src/bp/core/routers/api.rest
@@ -58,7 +58,7 @@ Content-Type: application/json
         "type": "number",
         "name": "score",
         "description": "",
-        "typeData": {
+        "params": {
           "defaultValue": 2
         }
       }

--- a/src/bp/core/routers/api.rest
+++ b/src/bp/core/routers/api.rest
@@ -1,0 +1,68 @@
+@api = {{baseUrl}}/api/v1
+
+
+# Login on the Admin UI
+# @name login
+POST {{api}}/auth/login/basic/default
+Content-Type: application/x-www-form-urlencoded
+
+email={{email}}&password={{password}}
+###
+
+
+@authToken = {{login.response.body.payload.token}}
+
+
+# List all bots
+# @name listBots
+GET {{api}}/admin/bots
+Authorization: Bearer {{authToken}}
+X-BP-Workspace: default
+###
+
+
+@botId = gog
+
+
+# List all flows
+# @name listFlows
+GET {{api}}/bots/{{botId}}/flows
+Authorization: Bearer {{authToken}}
+X-BP-Workspace: default
+###
+
+
+@flowName = Workflow Ended
+@flowFile = workflow_ended.flow.json
+
+
+# Edit a flow
+# @name editFlow
+POST {{api}}/bots/{{botId}}/flow/{{flowFile}}
+Authorization: Bearer {{authToken}}
+X-BP-Workspace: default
+Content-Type: application/json
+
+{
+  "flow": {
+    "catchAll": {},
+    "flow": "{{flowFile}}",
+    "label": "{{flowName}}",
+    "links": [],
+    "location": "{{flowFile}}",
+    "name": "{{flowFile}}",
+    "nodes": [],
+    "version": "0.0.1",
+    "variables": [
+      {
+        "type": "number",
+        "name": "score",
+        "description": "",
+        "typeData": {
+          "defaultValue": 2
+        }
+      }
+    ]
+  }
+}
+###

--- a/src/bp/core/services/dialog/flow/service.ts
+++ b/src/bp/core/services/dialog/flow/service.ts
@@ -138,7 +138,7 @@ export class FlowService {
       nodes: nodeViews,
       links: uiEq.links,
       currentMutex,
-      ..._.pick(flow, ['version', 'catchAll', 'startNode', 'skillData', 'label', 'description'])
+      ..._.pick(flow, ['version', 'catchAll', 'startNode', 'skillData', 'label', 'description', 'variables'])
     }
   }
 
@@ -344,7 +344,16 @@ export class FlowService {
 
     const flowContent = {
       // TODO: NDU Remove triggers
-      ..._.pick(flow, ['version', 'catchAll', 'startNode', 'skillData', 'triggers', 'label', 'description']),
+      ..._.pick(flow, [
+        'version',
+        'catchAll',
+        'startNode',
+        'skillData',
+        'triggers',
+        'label',
+        'description',
+        'variables'
+      ]),
       nodes: flow.nodes.map(node => _.omit(node, 'x', 'y', 'lastModified'))
     }
 

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -1195,6 +1195,16 @@ declare module 'botpress/sdk' {
     timeoutNode?: string
     type?: string
     timeout?: { name: string; flow: string; node: string }[]
+    variables?: FlowVariable[]
+  }
+
+  export interface FlowVariable {
+    type: 'string' | 'number' | 'boolean' | 'date'
+    name: string
+    isInput?: boolean
+    isOutput?: boolean
+    description?: string
+    typeData?: any
   }
 
   export interface DecisionTriggerCondition {

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -1204,7 +1204,7 @@ declare module 'botpress/sdk' {
     isInput?: boolean
     isOutput?: boolean
     description?: string
-    typeData?: any
+    params?: any
   }
 
   export interface DecisionTriggerCondition {

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -1199,7 +1199,7 @@ declare module 'botpress/sdk' {
   }
 
   export interface FlowVariable {
-    type: 'string' | 'number' | 'boolean' | 'date'
+    type: string
     name: string
     isInput?: boolean
     isOutput?: boolean


### PR DESCRIPTION
Adds flow variables to the backend.

I included a api.rest file for testing purposes. I could probably include that as a file attachement instead if we don't want to keep the test files after the PR is merged (or if we don't want to see it in the commits).

I haven't done validations for now, and the variable types probably don't cover all the types we want so there's that for now. 

One question @EFF and I thought about is whether we want variable types to indicate their needed properties, and build the frontend dynamically for that. For example [here](https://app.zeplin.io/project/5e824d8b3e83946cb191a691/screen/5eb9716039b0687707b56f6f) the pattern variable type could indicate that it requires a property of type 'string' named 'pattern', so the UI would dynamically generate a textbox and bind its value to typeData.pattern.