### PR TITLE
feat(ui): variables tab

### DIFF
--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/VariablesEditor/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/VariablesEditor/index.tsx
@@ -1,0 +1,25 @@
+import React, { FC, useEffect, useState } from 'react'
+import { connect } from 'react-redux'
+import { RootReducer } from '~/reducers'
+
+interface OwnProps {}
+
+interface StateProps {}
+
+interface DispatchProps {}
+
+type Props = StateProps & DispatchProps & OwnProps
+
+const VariablesEditor: FC<Props> = props => {
+  return (
+    <div>
+      <h1>Variables</h1>
+    </div>
+  )
+}
+
+const mapStateToProps = (state: RootReducer) => ({})
+
+const mapDispatchToProps = {}
+
+export default connect<StateProps, DispatchProps, OwnProps>(mapStateToProps, mapDispatchToProps)(VariablesEditor)

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/WorkflowToolbar.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/WorkflowToolbar.tsx
@@ -10,6 +10,10 @@ const WorkflowToolbar = props => {
     {
       id: 'workflow',
       title: lang.tr('workflow')
+    },
+    {
+      id: 'variables',
+      title: lang.tr('variables')
     }
   ]
 
@@ -28,7 +32,7 @@ const WorkflowToolbar = props => {
     }
   ]
 
-  return <MainContent.Header tabs={tabs} buttons={buttons} />
+  return <MainContent.Header tabs={tabs} buttons={buttons} tabChange={props.tabChange} />
 }
 
 const mapStateToProps = state => ({

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/index.tsx
@@ -59,6 +59,7 @@ import style from '~/views/FlowBuilder/diagram/style.scss'
 import { SaySomethingNodeModel, SaySomethingWidgetFactory } from '~/views/OneFlow/diagram/nodes/SaySomethingNode'
 
 import TriggerEditor from './TriggerEditor'
+import VariablesEditor from './VariablesEditor'
 import WorkflowToolbar from './WorkflowToolbar'
 
 interface OwnProps {
@@ -94,7 +95,8 @@ class Diagram extends Component<Props> {
   state = {
     highlightFilter: '',
     currentTriggerNode: null,
-    isTriggerEditOpen: false
+    isTriggerEditOpen: false,
+    currentTab: 'workflow'
   }
 
   constructor(props) {
@@ -643,16 +645,26 @@ class Diagram extends Component<Props> {
     return target && target.model instanceof RouterNodeModel
   }
 
+  handleTabChanged = (tab: string) => {
+    this.setState({ currentTab: tab })
+  }
+
   render() {
     return (
       <MainContent.Wrapper>
-        <WorkflowToolbar />
+        <WorkflowToolbar tabChange={this.handleTabChanged} />
+        {this.state.currentTab === 'variables' && <VariablesEditor />}
         <Fragment>
           <div
             id="diagramContainer"
             ref={ref => (this.diagramContainer = ref)}
             tabIndex={1}
-            style={{ outline: 'none', width: '100%', height: '100%' }}
+            style={{
+              outline: 'none',
+              width: '100%',
+              height: '100%',
+              display: this.state.currentTab === 'workflow' ? 'inherit' : 'none'
+            }}
             onContextMenu={this.handleContextMenu}
             onDrop={this.handleToolDropped}
             onDragOver={event => event.preventDefault()}


### PR DESCRIPTION
Adds access to the variable tab in the studio.

There are many problems that occur if the diagram isn't rendered so I just made it `display : none` instead.