### PR TITLE
feat(ui): variables proto menu

### DIFF
--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/VariablesEditor/Modal.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/VariablesEditor/Modal.tsx
@@ -1,0 +1,47 @@
+import { Button, FormGroup, IDialogProps, InputGroup } from '@blueprintjs/core'
+import { FlowVariable } from 'botpress/sdk'
+import { Dialog } from 'botpress/shared'
+import React, { FC, useEffect, useState } from 'react'
+
+type Props = {
+  variable: FlowVariable
+  saveChanges: (variable: FlowVariable) => void
+} & IDialogProps
+
+const VariableModal: FC<Props> = props => {
+  const [name, setName] = useState<string>()
+  const [type, setType] = useState<string>()
+
+  useEffect(() => {
+    setName(props.variable?.name)
+    setType(props.variable?.type)
+  }, [props.variable])
+
+  const handleSaveClick = () => {
+    const variable = props.variable
+    variable.name = name
+    variable.type = type
+    props.saveChanges(variable)
+    props.onClose()
+  }
+
+  return (
+    <Dialog.Wrapper title="Edit" {...props}>
+      <Dialog.Body>
+        <form>
+          <FormGroup label="Name">
+            <InputGroup value={name || ''} onChange={x => setName(x.currentTarget.value)} />
+          </FormGroup>
+          <FormGroup label="Type">
+            <InputGroup value={type || ''} onChange={x => setType(x.currentTarget.value)} />
+          </FormGroup>
+        </form>
+      </Dialog.Body>
+      <Dialog.Footer>
+        <Button text="Save" onClick={() => handleSaveClick()} />
+      </Dialog.Footer>
+    </Dialog.Wrapper>
+  )
+}
+
+export default VariableModal

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/VariablesEditor/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/VariablesEditor/index.tsx
@@ -1,25 +1,135 @@
-import React, { FC, useEffect, useState } from 'react'
+import { Button, FormGroup, InputGroup } from '@blueprintjs/core'
+import axios from 'axios'
+import { FlowVariable } from 'botpress/sdk'
+import { Dialog } from 'botpress/shared'
+import { FlowView } from 'common/typings'
+import React, { FC, Fragment, useEffect, useState } from 'react'
 import { connect } from 'react-redux'
-import { RootReducer } from '~/reducers'
+import { fetchFlows } from '~/actions'
+import { getCurrentFlow, RootReducer } from '~/reducers'
+
+import VariableModal from './Modal'
 
 interface OwnProps {}
-
-interface StateProps {}
-
-interface DispatchProps {}
+type StateProps = ReturnType<typeof mapStateToProps>
+type DispatchProps = typeof mapDispatchToProps
 
 type Props = StateProps & DispatchProps & OwnProps
 
 const VariablesEditor: FC<Props> = props => {
+  const [editingVariable, setEditingVariable] = useState<FlowVariable>(undefined)
+
+  const affectUpdateFlow = async (flow: FlowView) => {
+    await axios.post(`${window.BOT_API_PATH}/flow/${flow.location}`, { flow })
+    props.fetchFlows()
+  }
+
+  const computeCreateVariable = (flow: FlowView, newVariable: FlowVariable) => {
+    flow.variables.push(newVariable)
+  }
+
+  const computeDeleteVariable = (flow: FlowView, variableName: string) => {
+    flow.variables = flow.variables.filter(v => v.name != variableName)
+  }
+
+  const computeEditVariable = (flow: FlowView, variableName: string, newValues: FlowVariable) => {
+    const index = flow.variables.findIndex(v => v.name == variableName)
+    flow.variables[index] = newValues
+  }
+
+  const handleCreateClick = async () => {
+    const newVariable: FlowVariable = {
+      type: 'string',
+      name: `New Variable ${props.currentFlow.variables.length}`,
+      description: 'A new variable'
+    }
+    const flow = props.currentFlow
+    computeCreateVariable(flow, newVariable)
+    await affectUpdateFlow(flow)
+  }
+
+  const handleDeleteClick = async (variableName: string) => {
+    const flow = props.currentFlow
+    computeDeleteVariable(flow, variableName)
+    await affectUpdateFlow(flow)
+  }
+
+  const handleEditClick = (variableName: string) => {
+    setEditingVariable(props.currentFlow.variables.find(v => v.name === variableName))
+  }
+
+  const handleModalSaveClick = async (newValues: FlowVariable) => {
+    const flow = props.currentFlow
+    computeEditVariable(flow, editingVariable.name, newValues)
+    await affectUpdateFlow(flow)
+  }
+
+  const renderHead = () => {
+    return (
+      <div>
+        <h2>Variables</h2>
+        <Button text="Add" onClick={() => handleCreateClick()} />
+      </div>
+    )
+  }
+
+  const renderTable = () => {
+    return (
+      <table className="bp3-html-table bp3-html-table-striped bp3-html-table-bordered">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>{renderTableRows()}</tbody>
+      </table>
+    )
+  }
+  const renderTableRows = () => {
+    return (
+      <Fragment>
+        {props.currentFlow.variables &&
+          props.currentFlow.variables.map((v, i) => (
+            <tr key={i}>
+              <td>{v.name}</td>
+              <td>{v.type}</td>
+              <td>
+                <Button text="Edit" onClick={() => handleEditClick(v.name)} />
+              </td>
+              <td>
+                <Button text="Delete" onClick={() => handleDeleteClick(v.name)} />
+              </td>
+            </tr>
+          ))}
+      </Fragment>
+    )
+  }
+
+  const renderModal = () => {
+    return (
+      <VariableModal
+        variable={editingVariable}
+        saveChanges={x => handleModalSaveClick(x)}
+        isOpen={editingVariable !== undefined}
+        onClose={() => setEditingVariable(undefined)}
+      />
+    )
+  }
+
   return (
     <div>
-      <h1>Variables</h1>
+      {renderHead()}
+      {renderTable()}
+      {renderModal()}
     </div>
   )
 }
 
-const mapStateToProps = (state: RootReducer) => ({})
+const mapStateToProps = (state: RootReducer) => ({ currentFlow: getCurrentFlow(state) })
 
-const mapDispatchToProps = {}
+const mapDispatchToProps = { fetchFlows }
 
 export default connect<StateProps, DispatchProps, OwnProps>(mapStateToProps, mapDispatchToProps)(VariablesEditor)

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/VariablesEditor/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/VariablesEditor/index.tsx
@@ -25,7 +25,11 @@ const VariablesEditor: FC<Props> = props => {
   }
 
   const computeCreateVariable = (flow: FlowView, newVariable: FlowVariable) => {
-    flow.variables.push(newVariable)
+    if (!flow.variables) {
+      flow.variables = [newVariable]
+    } else {
+      flow.variables.push(newVariable)
+    }
   }
 
   const computeDeleteVariable = (flow: FlowView, variableName: string) => {
@@ -40,7 +44,7 @@ const VariablesEditor: FC<Props> = props => {
   const handleCreateClick = async () => {
     const newVariable: FlowVariable = {
       type: 'string',
-      name: `New Variable ${props.currentFlow.variables.length}`,
+      name: `New Variable ${props.currentFlow.variables?.length ?? 0}`,
       description: 'A new variable'
     }
     const flow = props.currentFlow


### PR DESCRIPTION
Implements a basic functioning menu with calls to the back-end for the final menu to be built on.

I think making this sort of menu could be useful to :
- Prevent loss of momentum on back-end development
- Document new back-end functionalities by using them in code
- Accelerate the development of the full menu by reducing needed communication
- Allow basic testing of the back-end using ui

Basically with this menu done, anyone can come back to it anytime and implement the full design without needing to search for the correct back-end calls or other needed info.