### PR TITLE
chore(nlu): clear token and embeddings cache when nlu or lang-server version change 

### DIFF
--- a/modules/nlu/package.json
+++ b/modules/nlu/package.json
@@ -20,6 +20,7 @@
     "@types/slate": "^0.47.1",
     "@types/slate-react": "^0.22.5",
     "@types/tar": "^4.0.3",
+    "@types/semver": "^7.2.0",
     "rimraf": "^3.0.2"
   },
   "dependencies": {
@@ -39,6 +40,7 @@
     "ms": "^2.1.1",
     "nanoid": "^2.0.1",
     "object-sizeof": "^1.5.2",
+    "semver": "^7.3.2",
     "seedrandom": "^3.0.5",
     "slate": "^0.47.4",
     "slate-react": "^0.22.4",

--- a/modules/nlu/src/backend/index.ts
+++ b/modules/nlu/src/backend/index.ts
@@ -14,7 +14,9 @@ import { getOnServerReady } from './module-lifecycle/on-server-ready'
 import { getOnSeverStarted } from './module-lifecycle/on-server-started'
 import { NLUState } from './typings'
 
-const state: NLUState = { nluByBot: {} }
+import nluInfo from '../../package.json'
+
+const state: NLUState = { nluByBot: {}, nluVersion: nluInfo.version, langServerVersion: '' }
 
 const onServerStarted = getOnSeverStarted(state)
 const onServerReady = getOnServerReady(state)

--- a/modules/nlu/src/backend/index.ts
+++ b/modules/nlu/src/backend/index.ts
@@ -14,9 +14,7 @@ import { getOnServerReady } from './module-lifecycle/on-server-ready'
 import { getOnSeverStarted } from './module-lifecycle/on-server-started'
 import { NLUState } from './typings'
 
-import nluInfo from '../../package.json'
-
-const state: NLUState = { nluByBot: {}, nluVersion: nluInfo.version, langServerVersion: '' }
+const state: NLUState = { nluByBot: {} }
 
 const onServerStarted = getOnSeverStarted(state)
 const onServerReady = getOnServerReady(state)

--- a/modules/nlu/src/backend/language/language-provider.ts
+++ b/modules/nlu/src/backend/language/language-provider.ts
@@ -167,6 +167,11 @@ export class RemoteLanguageProvider implements LanguageProvider {
   }
 
   private clearOldCacheFiles = async () => {
+    const cacheExists = await fse.pathExists(this._cacheDir)
+    if (!cacheExists) {
+      return
+    }
+
     const allCacheFiles = await fse.readdir(this._cacheDir)
 
     const currentHash = this.computeVersionHash()

--- a/modules/nlu/src/backend/language/language-provider.ts
+++ b/modules/nlu/src/backend/language/language-provider.ts
@@ -199,11 +199,7 @@ export class RemoteLanguageProvider implements LanguageProvider {
       )
     }
 
-    const fileEndsWithIncorrectHash = (fileName: string) => {
-      const extensionIdx = fileName.lastIndexOf('.')
-      const fileNameWithoutExtension = fileName.slice(0, extensionIdx)
-      return !fileNameWithoutExtension.endsWith(currentHash)
-    }
+    const fileEndsWithIncorrectHash = (fileName: string) => !fileName.includes(currentHash)
 
     const filesToDelete = allCacheFiles
       .filter(fileStartWithPrefix)

--- a/modules/nlu/src/backend/language/language-provider.ts
+++ b/modules/nlu/src/backend/language/language-provider.ts
@@ -151,7 +151,7 @@ export class RemoteLanguageProvider implements LanguageProvider {
   }
 
   private extractLangServerVersion(data: any) {
-    let version = semver.valid(semver.coerce(data.version))
+    const version = semver.valid(semver.coerce(data.version))
 
     if (!version) {
       throw new Error('Lang server has an invalid version')

--- a/modules/nlu/src/backend/language/language-provider.ts
+++ b/modules/nlu/src/backend/language/language-provider.ts
@@ -8,10 +8,11 @@ import lru from 'lru-cache'
 import moment from 'moment'
 import ms from 'ms'
 import path from 'path'
+import crypto from 'crypto'
 
 import { setSimilarity, vocabNGram } from '../tools/strings'
 import { isSpace, processUtteranceTokens, restoreOriginalUtteranceCasing } from '../tools/token-utils'
-import { Gateway, LangsGateway, LanguageProvider, LanguageSource, NLUHealth, Token2Vec } from '../typings'
+import { Gateway, LangsGateway, LanguageProvider, LanguageSource, NLUHealth, Token2Vec, NLUState } from '../typings'
 
 const debug = DEBUG('nlu').sub('lang')
 
@@ -20,10 +21,15 @@ const JUNK_VOCAB_SIZE = 500
 const JUNK_TOKEN_MIN = 1
 const JUNK_TOKEN_MAX = 20
 
+const VECTOR_FILE_PREFIX = 'lang_vectors'
+const TOKEN_FILE_PREFIX = 'utterance_tokens'
+const JUNK_FILE_PREFIX = 'junk_words'
+
 export class RemoteLanguageProvider implements LanguageProvider {
-  private _vectorsCachePath = path.join(process.APP_DATA_PATH, 'cache', 'lang_vectors.json')
-  private _junkwordsCachePath = path.join(process.APP_DATA_PATH, 'cache', 'junk_words.json')
-  private _tokensCachePath = path.join(process.APP_DATA_PATH, 'cache', 'utterance_tokens.json')
+  private _cacheDir = path.join(process.APP_DATA_PATH, 'cache')
+  private _vectorsCachePath: string
+  private _junkwordsCachePath: string
+  private _tokensCachePath: string
 
   private _vectorsCache: lru<string, Float32Array>
   private _tokensCache: lru<string, string[]>
@@ -32,6 +38,8 @@ export class RemoteLanguageProvider implements LanguageProvider {
   private _cacheDumpDisabled: boolean = false
   private _validProvidersCount: number
   private _languageDims: number
+
+  private _state: NLUState
 
   private discoveryRetryPolicy = {
     interval: 1000,
@@ -51,7 +59,8 @@ export class RemoteLanguageProvider implements LanguageProvider {
     debug(`[${lang.toUpperCase()}] Language Provider added %o`, source)
   }
 
-  async initialize(sources: LanguageSource[], logger: typeof sdk.logger): Promise<LanguageProvider> {
+  async initialize(sources: LanguageSource[], logger: typeof sdk.logger, state: NLUState): Promise<LanguageProvider> {
+    this._state = state
     this._validProvidersCount = 0
 
     this._vectorsCache = new lru<string, Float32Array>({
@@ -120,11 +129,16 @@ export class RemoteLanguageProvider implements LanguageProvider {
           }
           this._validProvidersCount++
           data.languages.forEach(x => this.addProvider(x.lang, source, client))
+
+          this._state.langServerVersion = data.version
         }, this.discoveryRetryPolicy)
       } catch (err) {
         this.handleLanguageServerError(err, source.endpoint, logger)
       }
     })
+
+    this.computeCacheFilesPaths()
+    this.clearOldCacheFiles()
 
     debug(`loaded ${Object.keys(this.langs).length} languages from ${sources.length} sources`)
 
@@ -133,6 +147,42 @@ export class RemoteLanguageProvider implements LanguageProvider {
     await this.restoreTokensCache()
 
     return this
+  }
+
+  private computeCacheFilesPaths = () => {
+    const versionHash = this.computeVersionHash()
+    this._vectorsCachePath = path.join(this._cacheDir, `${VECTOR_FILE_PREFIX}_${versionHash}.json`)
+    this._junkwordsCachePath = path.join(this._cacheDir, `${JUNK_FILE_PREFIX}_${versionHash}.json`)
+    this._tokensCachePath = path.join(this._cacheDir, `${TOKEN_FILE_PREFIX}_${versionHash}.json`)
+  }
+
+  private clearOldCacheFiles = () => {
+    const allCacheFiles = fse.readdirSync(this._cacheDir)
+
+    const currentHash = this.computeVersionHash()
+
+    const fileStartWithPrefix = (fileName: string) => {
+      return (
+        fileName.startsWith(VECTOR_FILE_PREFIX) ||
+        fileName.startsWith(TOKEN_FILE_PREFIX) ||
+        fileName.startsWith(JUNK_FILE_PREFIX)
+      )
+    }
+
+    const fileEndsWithIncorrectHash = (fileName: string) => {
+      const extensionIdx = fileName.lastIndexOf('.')
+      const fileNameWithoutExtension = fileName.slice(0, extensionIdx)
+      return !fileNameWithoutExtension.endsWith(currentHash)
+    }
+
+    const filesToDelete = allCacheFiles
+      .filter(fileStartWithPrefix)
+      .filter(fileEndsWithIncorrectHash)
+      .map(f => path.join(this._cacheDir, f))
+
+    for (const f of filesToDelete) {
+      fse.unlinkSync(f)
+    }
   }
 
   private handleLanguageServerError = (err, endpoint: string, logger) => {
@@ -437,6 +487,15 @@ export class RemoteLanguageProvider implements LanguageProvider {
 
     // we restore original chars and casing
     return tokenUtterances.map((tokens, i) => restoreOriginalUtteranceCasing(tokens, utterances[i]))
+  }
+
+  private computeVersionHash = () => {
+    const { nluVersion, langServerVersion } = this._state
+    const content = `${nluVersion}:${langServerVersion}`
+    return crypto
+      .createHash('md5')
+      .update(content)
+      .digest('hex')
   }
 }
 

--- a/modules/nlu/src/backend/language/language-provider.ts
+++ b/modules/nlu/src/backend/language/language-provider.ts
@@ -134,6 +134,7 @@ export class RemoteLanguageProvider implements LanguageProvider {
             this._languageDims = data.dimentions // note typo in language server
           }
 
+          // TODO: also check that the domain and version is consistent across all sources
           if (this._languageDims !== data.dimentions) {
             throw new Error('Language sources have different dimensions')
           }

--- a/modules/nlu/src/backend/language/language-provider.ts
+++ b/modules/nlu/src/backend/language/language-provider.ts
@@ -139,7 +139,7 @@ export class RemoteLanguageProvider implements LanguageProvider {
     })
 
     this.computeCacheFilesPaths()
-    this.clearOldCacheFiles()
+    await this.clearOldCacheFiles()
 
     debug(`loaded ${Object.keys(this.langs).length} languages from ${sources.length} sources`)
 
@@ -150,7 +150,7 @@ export class RemoteLanguageProvider implements LanguageProvider {
     return this
   }
 
-  private extractLangServerVersion(data: any) {
+  private extractLangServerVersion(data) {
     const version = semver.valid(semver.coerce(data.version))
 
     if (!version) {
@@ -166,8 +166,8 @@ export class RemoteLanguageProvider implements LanguageProvider {
     this._tokensCachePath = path.join(this._cacheDir, `${TOKEN_FILE_PREFIX}_${versionHash}.json`)
   }
 
-  private clearOldCacheFiles = () => {
-    const allCacheFiles = fse.readdirSync(this._cacheDir)
+  private clearOldCacheFiles = async () => {
+    const allCacheFiles = await fse.readdir(this._cacheDir)
 
     const currentHash = this.computeVersionHash()
 
@@ -191,7 +191,7 @@ export class RemoteLanguageProvider implements LanguageProvider {
       .map(f => path.join(this._cacheDir, f))
 
     for (const f of filesToDelete) {
-      fse.unlinkSync(f)
+      await fse.unlink(f)
     }
   }
 

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -1,6 +1,7 @@
 import retry from 'bluebird-retry'
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
+import semver from 'semver'
 
 import { Config } from '../../config'
 import Engine from '../engine'
@@ -11,6 +12,8 @@ import { getLatestModel } from '../model-service'
 import { InvalidLanguagePredictorError } from '../predict-pipeline'
 import { removeTrainingSession, setTrainingSession } from '../train-session-service'
 import { NLUState, Token2Vec, Tools, TrainingSession } from '../typings'
+
+import nluInfo from '../../../package.json'
 
 export const initializeLanguageProvider = async (bp: typeof sdk, state: NLUState) => {
   const globalConfig = (await bp.config.getModuleConfig('nlu')) as Config
@@ -142,8 +145,18 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
   }
 }
 
+function setNluVersion(bp: typeof sdk, state: NLUState) {
+  if (!semver.valid(nluInfo.version)) {
+    bp.logger.error('nlu package.json file has an incorrect version format')
+    return
+  }
+
+  state.nluVersion = semver.clean(nluInfo.version)
+}
+
 export function getOnSeverStarted(state: NLUState) {
   return async (bp: typeof sdk) => {
+    setNluVersion(bp, state)
     await initDucklingExtractor(bp)
     await initializeLanguageProvider(bp, state)
     initializeEngine(bp, state)

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -16,7 +16,7 @@ export const initializeLanguageProvider = async (bp: typeof sdk, state: NLUState
   const globalConfig = (await bp.config.getModuleConfig('nlu')) as Config
 
   try {
-    const languageProvider = await LangProvider.initialize(globalConfig.languageSources, bp.logger)
+    const languageProvider = await LangProvider.initialize(globalConfig.languageSources, bp.logger, state)
     const { validProvidersCount, validLanguages } = languageProvider.getHealth()
     const health = {
       isEnabled: validProvidersCount > 0 && validLanguages.length > 0,

--- a/modules/nlu/src/backend/typings.ts
+++ b/modules/nlu/src/backend/typings.ts
@@ -72,8 +72,8 @@ export interface EntityService {
 }
 
 export interface NLUState {
-  nluVersion: string
-  langServerVersion: string
+  nluVersion?: string
+  langServerVersion?: string
   nluByBot: _.Dictionary<BotState>
   languageProvider?: LanguageProvider
   health?: NLUHealth

--- a/modules/nlu/src/backend/typings.ts
+++ b/modules/nlu/src/backend/typings.ts
@@ -73,12 +73,18 @@ export interface EntityService {
 
 export interface NLUState {
   nluVersion?: string
-  langServerVersion?: string
+  langServerInfo?: LangServerInfo
   nluByBot: _.Dictionary<BotState>
   languageProvider?: LanguageProvider
   health?: NLUHealth
   broadcastLoadModel?: (botId: string, hash: string, language: string) => Promise<void>
   broadcastCancelTraining?: (botId: string, language: string) => Promise<void>
+}
+
+export interface LangServerInfo {
+  version: string
+  domain: string
+  dim: number
 }
 
 export interface BotState {

--- a/modules/nlu/src/backend/typings.ts
+++ b/modules/nlu/src/backend/typings.ts
@@ -72,6 +72,8 @@ export interface EntityService {
 }
 
 export interface NLUState {
+  nluVersion: string
+  langServerVersion: string
   nluByBot: _.Dictionary<BotState>
   languageProvider?: LanguageProvider
   health?: NLUHealth

--- a/modules/nlu/yarn.lock
+++ b/modules/nlu/yarn.lock
@@ -37,6 +37,13 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/semver@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.2.0.tgz#0d72066965e910531e1db4621c15d0ca36b8d83b"
+  integrity sha512-TbB0A8ACUWZt3Y6bQPstW9QNbhNeebdgLX4T/ZfkrswAfUzRiXrgd9seol+X379Wa589Pu4UEx9Uok0D4RjRCQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/slate-react@^0.22.5":
   version "0.22.5"
   resolved "https://registry.yarnpkg.com/@types/slate-react/-/slate-react-0.22.5.tgz#a10796758aa6b3133e1c777959facbf8806959f7"
@@ -570,6 +577,11 @@ selection-is-backward@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/selection-is-backward/-/selection-is-backward-1.0.0.tgz#97a54633188a511aba6419fc5c1fa91b467e6be1"
   integrity sha1-l6VGMxiKURq6ZBn8XB+pG0Z+a+E=
+
+semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 slate-base64-serializer@^0.2.107:
   version "0.2.107"

--- a/src/bp/core/services/migration/index.ts
+++ b/src/bp/core/services/migration/index.ts
@@ -263,7 +263,7 @@ ${_.repeat(' ', 9)}========================================`)
         const [rawVersion, timestamp, title] = path.basename(filepath).split('-')
         return {
           filename: path.basename(filepath),
-          version: semver.valid(rawVersion.replace(/_/g, '.')),
+          version: semver.valid(rawVersion.replace(/_/g, '.')) as string,
           title: (title || '').replace(/\.js$/i, ''),
           date: Number(timestamp),
           location: path.join(rootPath, filepath)

--- a/src/bp/lang-server/api.ts
+++ b/src/bp/lang-server/api.ts
@@ -24,6 +24,7 @@ import {
 } from './util'
 
 export type APIOptions = {
+  version: string
   host: string
   port: number
   authToken?: string
@@ -91,7 +92,7 @@ export default async function(
 
   app.get('/info', (req, res) => {
     res.send({
-      version: '1',
+      version: options.version,
       ready: languageService.isReady,
       dimentions: languageService.dim,
       domain: languageService.domain,

--- a/src/bp/lang-server/index.ts
+++ b/src/bp/lang-server/index.ts
@@ -51,7 +51,7 @@ export default async function(options: ArgV) {
   const version = '1.0.0' // TODO: declare this elsewhere
 
   const apiOptions: APIOptions = {
-    version,
+    version: version,
     host: options.host,
     port: options.port,
     authToken: options.authToken,
@@ -62,7 +62,7 @@ export default async function(options: ArgV) {
 
   logger.info(chalk`========================================
 {bold ${center(`Botpress Language Server`, 40, 9)}}
-{dim ${center(`Version ${langServerVersion}`, 40, 9)}}
+{dim ${center(`Version ${version}`, 40, 9)}}
 {dim ${center(`OS ${process.distro}`, 40, 9)}}
 ${_.repeat(' ', 9)}========================================`)
 

--- a/src/bp/lang-server/index.ts
+++ b/src/bp/lang-server/index.ts
@@ -48,7 +48,10 @@ export default async function(options: ArgV) {
   const langService = new LanguageService(options.dim, options.domain, options.langDir)
   const downloadManager = new DownloadManager(options.dim, options.domain, options.langDir, options.metadataLocation)
 
+  const version = '1.0.0' // TODO: declare this elsewhere
+
   const apiOptions: APIOptions = {
+    version,
     host: options.host,
     port: options.port,
     authToken: options.authToken,
@@ -59,6 +62,7 @@ export default async function(options: ArgV) {
 
   logger.info(chalk`========================================
 {bold ${center(`Botpress Language Server`, 40, 9)}}
+{dim ${center(`Version ${langServerVersion}`, 40, 9)}}
 {dim ${center(`OS ${process.distro}`, 40, 9)}}
 ${_.repeat(' ', 9)}========================================`)
 

--- a/src/bp/lang-server/index.ts
+++ b/src/bp/lang-server/index.ts
@@ -51,7 +51,7 @@ export default async function(options: ArgV) {
   const version = '1.0.0' // TODO: declare this elsewhere
 
   const apiOptions: APIOptions = {
-    version: version,
+    version,
     host: options.host,
     port: options.port,
     authToken: options.authToken,


### PR DESCRIPTION
Cache files in `~/botpress/cache/` are now named with a hash of nlu and lang-server version.

ex: `utterance_tokens_b9c3c1429c206da2da6eea97d056d460.json`

The hash is computed only from the major and minor of each version number so a patch update does not make the cache dirty.

ie: 1.1.0 and 1.1.69 both will create the same hash, but 1.1.0 and 1.69.0 won't.
