### PR TITLE
refactor(nlu): build model outside the training pipeline

### DIFF
--- a/modules/nlu/src/backend/model-service.ts
+++ b/modules/nlu/src/backend/model-service.ts
@@ -8,7 +8,8 @@ import tar from 'tar'
 import tmp from 'tmp'
 
 import { TrainArtefacts, TrainInput, TrainOutput } from './training-pipeline'
-import { EntityCache } from './typings'
+import { EntityCache, Intent } from './typings'
+import Utterance from './utterance/utterance'
 
 export interface Model {
   hash: string
@@ -18,7 +19,7 @@ export interface Model {
   success: boolean
   data: {
     input: TrainInput
-    output?: TrainOutput
+    intents?: Intent<Utterance>[]
     artefacts?: TrainArtefacts
   }
 }

--- a/modules/nlu/src/backend/train-error.ts
+++ b/modules/nlu/src/backend/train-error.ts
@@ -1,0 +1,6 @@
+export class TrainingCanceledError extends Error {
+  constructor() {
+    super('Training cancelled')
+    this.name = 'CancelError'
+  }
+}

--- a/modules/nlu/src/backend/training-pipeline.ts
+++ b/modules/nlu/src/backend/training-pipeline.ts
@@ -6,7 +6,6 @@ import { extractListEntities, extractPatternEntities } from './entities/custom-e
 import { getSentenceEmbeddingForCtx } from './intents/context-classifier-featurizer'
 import { isPOSAvailable } from './language/pos-tagger'
 import { getStopWordsForLang } from './language/stopWords'
-import { Model } from './model-service'
 import { featurizeInScopeUtterances, featurizeOOSUtterances } from './out-of-scope-featurizer'
 import SlotTagger from './slots/slot-tagger'
 import { replaceConsecutiveSpaces } from './tools/strings'
@@ -24,9 +23,10 @@ import {
   TrainingSession
 } from './typings'
 import Utterance, { buildUtteranceBatch, UtteranceToken, UtteranceToStringOptions } from './utterance/utterance'
+import { TrainingCanceledError } from './train-error'
 
 // TODO make this return artefacts only and move the make model login in E2
-export type Trainer = (input: TrainInput, tools: Tools) => Promise<Model>
+export type Trainer = (input: TrainInput, tools: Tools) => Promise<TrainOutput>
 
 export type TrainInput = Readonly<{
   botId: string
@@ -38,7 +38,7 @@ export type TrainInput = Readonly<{
   trainingSession: TrainingSession
 }>
 
-export type TrainOutput = Readonly<{
+export type TrainStep = Readonly<{
   botId: string
   languageCode: string
   list_entities: ListEntityModel[]
@@ -49,6 +49,10 @@ export type TrainOutput = Readonly<{
   tfIdf?: TFIDF
   kmeans?: sdk.MLToolkit.KMeans.KmeansResult
 }>
+
+export type TrainOutput = TrainArtefacts & {
+  intents: Intent<Utterance>[]
+}
 
 export interface TrainArtefacts {
   list_entities: ListEntityModel[]
@@ -86,7 +90,7 @@ const KMEANS_OPTIONS = {
   seed: 666 // so training is consistent
 } as sdk.MLToolkit.KMeans.KMeansOptions
 
-const PreprocessInput = async (input: TrainInput, tools: Tools): Promise<TrainOutput> => {
+const PreprocessInput = async (input: TrainInput, tools: Tools): Promise<TrainStep> => {
   debugTraining.forBot(input.botId, 'Preprocessing intents')
   input = _.cloneDeep(input)
   const list_entities = await Promise.map(input.list_entities, list =>
@@ -101,7 +105,7 @@ const PreprocessInput = async (input: TrainInput, tools: Tools): Promise<TrainOu
     list_entities,
     intents,
     vocabVectors
-  } as TrainOutput
+  } as TrainStep
 }
 
 const makeListEntityModel = async (entity: ListEntity, botId: string, languageCode: string, tools: Tools) => {
@@ -145,7 +149,7 @@ export const computeKmeans = (intents: Intent<Utterance>[], tools: Tools): sdk.M
   return tools.mlToolkit.KMeans.kmeans(data, k, KMEANS_OPTIONS)
 }
 
-const ClusterTokens = (input: TrainOutput, tools: Tools): TrainOutput => {
+const ClusterTokens = (input: TrainStep, tools: Tools): TrainStep => {
   const kmeans = computeKmeans(input.intents, tools)
   const copy = { ...input, kmeans }
   copy.intents.forEach(x => x.utterances.forEach(u => u.setKmeans(kmeans)))
@@ -181,7 +185,7 @@ const buildVectorsVocab = (intents: Intent<Utterance>[]): _.Dictionary<number[]>
   )
 }
 
-export const BuildExactMatchIndex = (input: TrainOutput): ExactMatchIndex => {
+export const BuildExactMatchIndex = (input: TrainStep): ExactMatchIndex => {
   return _.chain(input.intents)
     .filter(i => i.name !== NONE_INTENT)
     .flatMap(i =>
@@ -200,7 +204,7 @@ export const BuildExactMatchIndex = (input: TrainOutput): ExactMatchIndex => {
 }
 
 const TrainIntentClassifier = async (
-  input: TrainOutput,
+  input: TrainStep,
   tools: Tools,
   progress: progressCB
 ): Promise<_.Dictionary<string> | undefined> => {
@@ -257,7 +261,7 @@ const TrainIntentClassifier = async (
 }
 
 const TrainContextClassifier = async (
-  input: TrainOutput,
+  input: TrainStep,
   tools: Tools,
   progress: progressCB
 ): Promise<string | undefined> => {
@@ -313,7 +317,7 @@ export const ProcessIntents = async (
   })
 }
 
-export const ExtractEntities = async (input: TrainOutput, tools: Tools): Promise<TrainOutput> => {
+export const ExtractEntities = async (input: TrainStep, tools: Tools): Promise<TrainStep> => {
   const utterances: Utterance[] = _.chain(input.intents)
     .filter(i => i.name !== NONE_INTENT)
     .flatMap('utterances')
@@ -351,7 +355,7 @@ export const ExtractEntities = async (input: TrainOutput, tools: Tools): Promise
   return input
 }
 
-export const AppendNoneIntent = async (input: TrainOutput, tools: Tools): Promise<TrainOutput> => {
+export const AppendNoneIntent = async (input: TrainStep, tools: Tools): Promise<TrainStep> => {
   if (input.intents.length === 0) {
     return input
   }
@@ -410,7 +414,7 @@ export const AppendNoneIntent = async (input: TrainOutput, tools: Tools): Promis
   return { ...input, intents: [...input.intents, intent] }
 }
 
-export const TfidfTokens = async (input: TrainOutput): Promise<TrainOutput> => {
+export const TfidfTokens = async (input: TrainStep): Promise<TrainStep> => {
   const tfidfInput = input.intents.reduce(
     (tfidfInput, intent) => ({
       ...tfidfInput,
@@ -425,7 +429,7 @@ export const TfidfTokens = async (input: TrainOutput): Promise<TrainOutput> => {
   return copy
 }
 
-const TrainSlotTagger = async (input: TrainOutput, tools: Tools, progress: progressCB): Promise<Buffer> => {
+const TrainSlotTagger = async (input: TrainStep, tools: Tools, progress: progressCB): Promise<Buffer> => {
   const hasSlots = _.flatMap(input.intents, i => i.slot_definitions).length > 0
 
   if (!hasSlots) {
@@ -442,11 +446,7 @@ const TrainSlotTagger = async (input: TrainOutput, tools: Tools, progress: progr
   return slotTagger.serialized
 }
 
-const TrainOutOfScope = async (
-  input: TrainOutput,
-  tools: Tools,
-  progress: progressCB
-): Promise<_.Dictionary<string>> => {
+const TrainOutOfScope = async (input: TrainStep, tools: Tools, progress: progressCB): Promise<_.Dictionary<string>> => {
   debugTraining.forBot(input.botId, 'Training out of scope classifier')
   const trainingOptions: sdk.MLToolkit.SVM.SVMOptions = {
     c: [10],
@@ -490,15 +490,7 @@ const TrainOutOfScope = async (
 }
 
 const NB_STEPS = 5 // change this if the training pipeline changes
-export const Trainer: Trainer = async (input: TrainInput, tools: Tools): Promise<Model> => {
-  const model: Partial<Model> = {
-    startedAt: new Date(),
-    languageCode: input.languageCode,
-    data: {
-      input
-    }
-  }
-
+export const Trainer: Trainer = async (input: TrainInput, tools: Tools): Promise<TrainOutput> => {
   let totalProgress = 0
   let normalizedProgress = 0
   const debouncedProgress = _.debounce(tools.reportTrainingProgress, 75, { maxWait: 750 })
@@ -520,51 +512,33 @@ export const Trainer: Trainer = async (input: TrainInput, tools: Tools): Promise
     normalizedProgress = scaledProgress
     debouncedProgress(input.botId, 'Training', { ...input.trainingSession, progress: normalizedProgress })
   }
-  try {
-    let output = await PreprocessInput(input, tools)
-    output = await TfidfTokens(output)
-    output = ClusterTokens(output, tools)
-    output = await ExtractEntities(output, tools)
-    output = await AppendNoneIntent(output, tools)
-    const exact_match_index = BuildExactMatchIndex(output)
-    reportProgress()
-    const [oos_model, ctx_model, intent_model_by_ctx, slots_model] = await Promise.all([
-      TrainOutOfScope(output, tools, reportProgress),
-      TrainContextClassifier(output, tools, reportProgress),
-      TrainIntentClassifier(output, tools, reportProgress),
-      TrainSlotTagger(output, tools, reportProgress)
-    ])
 
-    const artefacts: TrainArtefacts = {
-      list_entities: output.list_entities,
-      oos_model,
-      tfidf: output.tfIdf,
-      ctx_model,
-      intent_model_by_ctx,
-      slots_model,
-      vocabVectors: output.vocabVectors,
-      exact_match_index
-      // kmeans: {} add this when mlKmeans supports loading from serialized data,
-    }
+  let step = await PreprocessInput(input, tools)
+  step = await TfidfTokens(step)
+  step = ClusterTokens(step, tools)
+  step = await ExtractEntities(step, tools)
+  step = await AppendNoneIntent(step, tools)
+  const exact_match_index = BuildExactMatchIndex(step)
+  reportProgress()
+  const [oos_model, ctx_model, intent_model_by_ctx, slots_model] = await Promise.all([
+    TrainOutOfScope(step, tools, reportProgress),
+    TrainContextClassifier(step, tools, reportProgress),
+    TrainIntentClassifier(step, tools, reportProgress),
+    TrainSlotTagger(step, tools, reportProgress)
+  ])
 
-    _.merge(model, { success: true, data: { artefacts, output } })
-  } catch (err) {
-    if (err instanceof TrainingCanceledError) {
-      debugTraining.forBot(input.botId, 'Training aborted')
-    } else {
-      // TODO use bp.logger once this is moved in Engine2
-      console.log('Could not finish training NLU model', err)
-    }
-    model.success = false
-  } finally {
-    model.finishedAt = new Date()
-    return model as Model
+  const output: TrainOutput = {
+    intents: step.intents,
+    list_entities: step.list_entities,
+    oos_model,
+    tfidf: step.tfIdf,
+    ctx_model,
+    intent_model_by_ctx,
+    slots_model,
+    vocabVectors: step.vocabVectors,
+    exact_match_index
+    // kmeans: {} add this when mlKmeans supports loading from serialized data,
   }
-}
 
-class TrainingCanceledError extends Error {
-  constructor() {
-    super('Training cancelled')
-    this.name = 'CancelError'
-  }
+  return output
 }


### PR DESCRIPTION
Most differences concern the rename of TrainOutput type to TrainStep.

Mostly, this PR is about building the model outside the training pipeline and get rid of few reduntant information in the model.

I deliberately kept this refactor small to make the reviewing step faster.

@EFF, if you feel there's no need right now for this refactor, I really don't mind cancelling this PR as it only took me about 20 minutes to do...