### PR TITLE
fix(nlu): fix nlu predictions for intents with no trained predictors

### DIFF
--- a/modules/nlu/src/backend/predict-pipeline.ts
+++ b/modules/nlu/src/backend/predict-pipeline.ts
@@ -241,7 +241,7 @@ async function predictIntent(input: PredictStep, predictors: Predictors): Promis
 
       const predictor = predictors.intent_classifier_per_ctx[ctx]
       if (predictor) {
-        const features = [...input.utterance.sentenceEmbedding, input.utterance.tokens.length]
+        const features = [...input.utterance.sentenceEmbedding, input.utterance.tokens.length] // TODO: extract this logic 'getIntentFeatures()' in a place for intent featurizing
         const tmp = await predictor.predict(features)
         preds.push(...tmp)
       }


### PR DESCRIPTION
This PR should be reviewed by commits

**Commit # 1 : return empty intent predictions list when no predictions**

This PR was originally written by @BPMJoannette, but had to be rewritten after the merge of minor 12.10 into master.

On a customer bot, `step.intent_predictions.per_ctx[label].map()` was throwing when there was no predictions for a context.

This problem will occur everytime a bot contains a qna or intent with less than 3 utterances, no matter the quesiton asked.

this commit solves the issue.

**Commit # 2 : when there's no intentPreds at all, return none intent**

This commit solves a different issue, still related to the first one.

The problem occurs for the same reason as stated above, but only occurs when we ask the bot the specific qna we have less than 3 utterances for.

This commit does'nt solve the actual problem, but at least make sure the none intent will be returned if there's nothing else to return.

**Commit # 3 : fix(nlu): predict exact match even if there's no predictor**

At predict time, we still want to predict an exact match even tho theres no trained svm


The third commit alone, solve all issues, but the two firsts are for safety.