### PR TITLE
fix(qna) : crash when content answers is undefined

### DIFF
--- a/modules/qna/src/backend/utils.ts
+++ b/modules/qna/src/backend/utils.ts
@@ -40,7 +40,7 @@ export const getQnaEntryPayloads = async (
     collectFeedback: true
   }
 
-  if (qnaEntry.answers[lang].length > 0) {
+  if (qnaEntry.answers && qnaEntry.answers[lang]?.length > 0) {
     const electedAnswer = getRandomAnswer(qnaEntry.answers[lang])
     const textArgs = { ...args }
 
@@ -61,22 +61,24 @@ export const getQnaEntryPayloads = async (
     )
   }
 
-  for (const contentAnswer of qnaEntry.contentAnswers[lang]) {
-    renderer = `#${contentAnswer.contentType}`
-    const contentArgs = {
-      ...args,
-      ...contentAnswer,
-      typing: payloads.length === 0
-    }
+  if (qnaEntry.contentAnswers) {
+    for (const contentAnswer of qnaEntry.contentAnswers[lang]) {
+      renderer = `#${contentAnswer.contentType}`
+      const contentArgs = {
+        ...args,
+        ...contentAnswer,
+        typing: payloads.length === 0
+      }
 
-    payloads.push(
-      ...(await bp.cms.renderElement(renderer, contentArgs, {
-        botId: event.botId,
-        channel: event.channel,
-        target: event.target,
-        threadId: event.threadId
-      }))
-    )
+      payloads.push(
+        ...(await bp.cms.renderElement(renderer, contentArgs, {
+          botId: event.botId,
+          channel: event.channel,
+          target: event.target,
+          threadId: event.threadId
+        }))
+      )
+    }
   }
 
   return payloads

--- a/modules/qna/src/backend/utils.ts
+++ b/modules/qna/src/backend/utils.ts
@@ -40,7 +40,7 @@ export const getQnaEntryPayloads = async (
     collectFeedback: true
   }
 
-  if (qnaEntry.answers && qnaEntry.answers[lang]?.length > 0) {
+  if (qnaEntry.answers?.[lang]?.length > 0) {
     const electedAnswer = getRandomAnswer(qnaEntry.answers[lang])
     const textArgs = { ...args }
 
@@ -61,24 +61,26 @@ export const getQnaEntryPayloads = async (
     )
   }
 
-  if (qnaEntry.contentAnswers) {
-    for (const contentAnswer of qnaEntry.contentAnswers[lang]) {
-      renderer = `#${contentAnswer.contentType}`
-      const contentArgs = {
-        ...args,
-        ...contentAnswer,
-        typing: payloads.length === 0
-      }
+  if (!qnaEntry.contentAnswers) {
+    return payloads
+  }
 
-      payloads.push(
-        ...(await bp.cms.renderElement(renderer, contentArgs, {
-          botId: event.botId,
-          channel: event.channel,
-          target: event.target,
-          threadId: event.threadId
-        }))
-      )
+  for (const contentAnswer of qnaEntry.contentAnswers[lang]) {
+    renderer = `#${contentAnswer.contentType}`
+    const contentArgs = {
+      ...args,
+      ...contentAnswer,
+      typing: payloads.length === 0
     }
+
+    payloads.push(
+      ...(await bp.cms.renderElement(renderer, contentArgs, {
+        botId: event.botId,
+        channel: event.channel,
+        target: event.target,
+        threadId: event.threadId
+      }))
+    )
   }
 
   return payloads


### PR DESCRIPTION
Some bots (including our template bots) have the `contentAnswers` field set at undefined on their QNAs which causes a crash so I added some checks to avoid that.

I don't know when `contentAnswers` was added but a migration would have been required (or alternatively the typings should have declared it as optional).