### PR TITLE
fix(dev): fail build on module error

### DIFF
--- a/build/gulp.modules.js
+++ b/build/gulp.modules.js
@@ -43,8 +43,8 @@ const buildModule = (modulePath, cb) => {
   const targetOs = getTargetOSConfig()
   const linkCmd = process.env.LINK ? `&& yarn link "module-builder"` : ''
   const buildCommand = process.argv.find(x => x.toLowerCase() === '--prod')
-    ? `cross-env NODE_ENV=production yarn build --nomap`
-    : 'yarn build'
+    ? `cross-env NODE_ENV=production yarn build --nomap --fail-on-error`
+    : 'yarn build --fail-on-error'
 
   exec(
     `cross-env npm_config_target_platform=${targetOs} yarn ${linkCmd} && ${buildCommand}`,

--- a/build/module-builder/src/build.ts
+++ b/build/module-builder/src/build.ts
@@ -60,6 +60,9 @@ export async function buildBackend(modulePath: string) {
   const tsConfigFile = ts.findConfigFile(modulePath, ts.sys.fileExists, 'tsconfig.json')
   const skipCheck = process.argv.find(x => x.toLowerCase() === '--skip-check')
 
+  // By default you don't want it to fail when watching, hence the flag
+  const failOnError = process.argv.find(x => x.toLowerCase() === '--fail-on-error')
+
   let validCode = true
   if (!skipCheck && tsConfigFile) {
     validCode = runTypeChecker(modulePath)
@@ -72,6 +75,8 @@ export async function buildBackend(modulePath: string) {
     compileBackend(modulePath, babelConfig)
 
     normal(`Generated backend (${Date.now() - start} ms)`, path.basename(modulePath))
+  } else if (failOnError) {
+    process.exit(1)
   }
 }
 


### PR DESCRIPTION
When building the backend of modules, if there's a typing error it will simply print a log but will not exit the build process. That's necessary so the watcher doesn't die on each error.

The error is displayed when building modules individually, but isn't when building everything.