### PR TITLE
fix(nlu): do not assume there is at least one prediction

### DIFF
--- a/modules/nlu/src/backend/predict-pipeline.ts
+++ b/modules/nlu/src/backend/predict-pipeline.ts
@@ -271,7 +271,7 @@ async function predictIntent(input: PredictStep, predictors: Predictors): Promis
 
         if (
           (alternatePreds && alternatePreds.filter(p => p.label !== NONE_INTENT)[0]?.confidence) ??
-          0 >= preds.filter(p => p.label !== NONE_INTENT)[0].confidence
+          0 >= preds.filter(p => p.label !== NONE_INTENT)[0]?.confidence
         ) {
           preds = _.chain([...alternatePreds, ...preds])
             .groupBy('label')


### PR DESCRIPTION
This bug occurs when their's no predictor for a QNA (used in exact match), but their is an alternateUtterance.

The bug was introduced when allowing exact matching for intents with less than 3 utterances (a fix we did last week on master).

This is quite a rare case I believe...

Hit me up if you want a bot to reproduce the issue. 