### PR TITLE
do not build ml submodules

### DIFF
--- a/build/gulp.core.js
+++ b/build/gulp.core.js
@@ -96,10 +96,6 @@ const copyBinaries = () => {
   return gulp.src('src/bp/ml/bin/*.*').pipe(gulp.dest('./out/bp/ml/bin'))
 }
 
-const copyJs = () => {
-  return gulp.src('src/bp/ml/svm-js/**/*.*').pipe(gulp.dest('./out/bp/ml/svm-js'))
-}
-
 const checkTranslations = cb => {
   const reorder = process.argv.find(x => x.toLowerCase() === '--reorder')
   exec(`node build/check-translations.js ${reorder && '--reorder'}`, (err, stdout, stderr) => {
@@ -115,7 +111,6 @@ const build = () => {
     compileTypescript,
     buildSchemas,
     createOutputDirs,
-    copyJs,
     copyBinaries
   ])
 }


### PR DESCRIPTION
@allardy or @slvnperron, can anyone confirm me I'm not breaking anything?

`/svm-js` is now pure typescript so it doesn't need to be copied in `/out`
\+ I don't want the linter failing because of `node-svm` so I exluded the ml submodules