### PR TITLE
feat(nlu): train now button becomes retrain all when auto train is on

### DIFF
--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -305,7 +305,8 @@ export default async (bp: typeof sdk, state: NLUState) => {
   router.post('/train', async (req, res) => {
     try {
       const { botId } = req.params
-      await state.nluByBot[botId].trainOrLoad(true)
+      const isAuto = await isAutoTrainOn(bp, botId)
+      await state.nluByBot[botId].trainOrLoad(isAuto)
       res.sendStatus(200)
     } catch {
       res.sendStatus(500)

--- a/modules/nlu/src/backend/module-lifecycle/on-bot-mount.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-bot-mount.ts
@@ -66,6 +66,12 @@ export function getOnBotMount(state: NLUState) {
                 await engine.loadModel(model)
                 await ModelService.saveModel(ghost, model, hash)
               }
+            } else {
+              Engine.tools.reportTrainingProgress(botId, 'Training not needed', {
+                language: languageCode,
+                progress: 1,
+                status: 'done'
+              })
             }
             try {
               if (model?.success) {

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -12,7 +12,7 @@ import { getPOSTagger, tagSentence } from '../language/pos-tagger'
 import { getLatestModel } from '../model-service'
 import { InvalidLanguagePredictorError } from '../predict-pipeline'
 import { removeTrainingSession, setTrainingSession } from '../train-session-service'
-import { NLUState, Token2Vec, Tools, TrainingSession } from '../typings'
+import { NLUState, Token2Vec, Tools, TrainingSession, NluProgressEvent } from '../typings'
 
 import nluInfo from '../../../package.json'
 
@@ -62,7 +62,7 @@ function initializeEngine(bp: typeof sdk, state: NLUState) {
     reportTrainingProgress: async (botId: string, message: string, trainSession: TrainingSession) => {
       await setTrainingSession(bp, botId, trainSession)
 
-      const ev = {
+      const ev: NluProgressEvent = {
         type: 'nlu',
         working: trainSession.status === 'training',
         botId,

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -62,7 +62,7 @@ function initializeEngine(bp: typeof sdk, state: NLUState) {
     reportTrainingProgress: async (botId: string, message: string, trainSession: TrainingSession) => {
       await setTrainingSession(bp, botId, trainSession)
 
-      const ev: NluProgressEvent = {
+      const ev: NLUProgressEvent = {
         type: 'nlu',
         working: trainSession.status === 'training',
         botId,

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -12,7 +12,7 @@ import { getPOSTagger, tagSentence } from '../language/pos-tagger'
 import { getLatestModel } from '../model-service'
 import { InvalidLanguagePredictorError } from '../predict-pipeline'
 import { removeTrainingSession, setTrainingSession } from '../train-session-service'
-import { NLUState, Token2Vec, Tools, TrainingSession, NluProgressEvent } from '../typings'
+import { NLUState, Token2Vec, Tools, TrainingSession, NLUProgressEvent } from '../typings'
 
 import nluInfo from '../../../package.json'
 

--- a/modules/nlu/src/backend/typings.ts
+++ b/modules/nlu/src/backend/typings.ts
@@ -168,6 +168,14 @@ export interface Tools {
   mlToolkit: typeof sdk.MLToolkit
 }
 
+export interface NluProgressEvent {
+  type: 'nlu'
+  working: boolean
+  botId: string
+  message: string
+  trainSession: TrainingSession
+}
+
 export interface SystemEntityExtractor {
   extractMultiple(input: string[], lang: string, useCache?: Boolean): Promise<EntityExtractionResult[][]>
   extract(input: string, lang: string): Promise<EntityExtractionResult[]>

--- a/modules/nlu/src/backend/typings.ts
+++ b/modules/nlu/src/backend/typings.ts
@@ -168,7 +168,7 @@ export interface Tools {
   mlToolkit: typeof sdk.MLToolkit
 }
 
-export interface NluProgressEvent {
+export interface NLUProgressEvent {
   type: 'nlu'
   working: boolean
   botId: string

--- a/modules/nlu/src/translations/en.json
+++ b/modules/nlu/src/translations/en.json
@@ -74,5 +74,6 @@
     "tagSelectionMessage": "Click on a slot or use numbers as keyboard shortcuts"
   },
   "title": "Language Understanding",
-  "trainNow": "Train now"
+  "trainNow": "Train now",
+  "retrainAll": "Retrain all"
 }

--- a/modules/nlu/src/translations/en.json
+++ b/modules/nlu/src/translations/en.json
@@ -75,5 +75,5 @@
   },
   "title": "Language Understanding",
   "trainNow": "Train now",
-  "retrainAll": "Retrain all"
+  "retrainAll": "Force train"
 }

--- a/modules/nlu/src/translations/fr.json
+++ b/modules/nlu/src/translations/fr.json
@@ -75,5 +75,5 @@
   },
   "title": "Compréhension du langage",
   "trainNow": "Entraîner maintenant",
-  "retrainAll": "Réentrainer tout"
+  "retrainAll": "Forcer un entraînement"
 }

--- a/modules/nlu/src/translations/fr.json
+++ b/modules/nlu/src/translations/fr.json
@@ -74,5 +74,6 @@
     "tagSelectionMessage": "Sélectionnez un paramètre ou utilisez les chiffres pour choisir un élément"
   },
   "title": "Compréhension du langage",
-  "trainNow": "Entraîner maintenant"
+  "trainNow": "Entraîner maintenant",
+  "retrainAll": "Réentrainer tout"
 }

--- a/modules/nlu/src/views/full/common/AutoTrainToggle.tsx
+++ b/modules/nlu/src/views/full/common/AutoTrainToggle.tsx
@@ -1,42 +1,18 @@
 import { Switch } from '@blueprintjs/core'
-import { NLUApi } from 'api'
 import { lang } from 'botpress/shared'
-import React, { FC, useEffect, useState } from 'react'
+import React, { FC } from 'react'
 
 import style from './style.scss'
 
-type AutoTrainListener = (status: boolean) => void
-export type AutoTrainObserver = {
-  listeners: AutoTrainListener[]
+interface Props {
+  autoTrain: boolean
+  loading: boolean
+  toggleAutoTrain: () => void
 }
 
-const AutoTrainToggle: FC<{ api: NLUApi; observer: AutoTrainObserver }> = ({ api, observer }) => {
-  const [autoTrain, setAutoTrain] = useState(false)
-  const [loading, setLoading] = useState(true)
+const AutoTrainToggle: FC<Props> = (props: Props) => {
 
-  useEffect(() => {
-    const fetchAutoTrain = async () => {
-      setLoading(true)
-      const isOn = await api.isAutoTrainOn()
-      setAutoTrain(isOn)
-      setLoading(false)
-      notifyListeners(isOn)
-    }
-
-    // tslint:disable-next-line: no-floating-promises
-    fetchAutoTrain()
-  }, [])
-
-  const notifyListeners = (autoTrainStatus: boolean) => {
-    observer.listeners.forEach(l => l(autoTrainStatus))
-  }
-
-  const toggleAutoTrain = async () => {
-    const newStatus = !autoTrain
-    await api.setAutoTrain(newStatus)
-    setAutoTrain(newStatus)
-    notifyListeners(newStatus)
-  }
+  const { autoTrain, loading, toggleAutoTrain } = props
 
   return (
     <Switch

--- a/modules/nlu/src/views/full/common/AutoTrainToggle.tsx
+++ b/modules/nlu/src/views/full/common/AutoTrainToggle.tsx
@@ -5,7 +5,12 @@ import React, { FC, useEffect, useState } from 'react'
 
 import style from './style.scss'
 
-const AutoTrainToggle: FC<{ api: NLUApi }> = ({ api }) => {
+type AutoTrainListener = (status: boolean) => void
+export type AutoTrainObserver = {
+  listeners: AutoTrainListener[]
+}
+
+const AutoTrainToggle: FC<{ api: NLUApi; observer: AutoTrainObserver }> = ({ api, observer }) => {
   const [autoTrain, setAutoTrain] = useState(false)
   const [loading, setLoading] = useState(true)
 
@@ -15,15 +20,22 @@ const AutoTrainToggle: FC<{ api: NLUApi }> = ({ api }) => {
       const isOn = await api.isAutoTrainOn()
       setAutoTrain(isOn)
       setLoading(false)
+      notifyListeners(isOn)
     }
 
     // tslint:disable-next-line: no-floating-promises
     fetchAutoTrain()
   }, [])
 
+  const notifyListeners = (autoTrainStatus: boolean) => {
+    observer.listeners.forEach(l => l(autoTrainStatus))
+  }
+
   const toggleAutoTrain = async () => {
-    await api.setAutoTrain(!autoTrain)
-    setAutoTrain(!autoTrain)
+    const newStatus = !autoTrain
+    await api.setAutoTrain(newStatus)
+    setAutoTrain(newStatus)
+    notifyListeners(newStatus)
   }
 
   return (

--- a/modules/nlu/src/views/full/common/TrainNow.tsx
+++ b/modules/nlu/src/views/full/common/TrainNow.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@blueprintjs/core'
 import { NLUApi } from 'api'
-import { props } from 'bluebird'
 import { lang } from 'botpress/shared'
 import React, { FC, useEffect, useState } from 'react'
 
@@ -29,23 +28,27 @@ const TrainNow: FC<{ api: NLUApi; eventBus: any; autoTrain: boolean }> = ({ api,
 
   }, [])
 
-  const onClick = async () => {
-    if (training) {
-      await api.cancelTraining()
-      setTraining(false)
-    } else {
-      setTraining(true)
-      await api.train()
-    }
+  const trainNow = async () => {
+    setTraining(true)
+    await api.train()
   }
 
-  const renderTrain = () => {
-    return autoTrain ? lang.tr('module.nlu.retrainAll') : lang.tr('module.nlu.trainNow')
+  const cancelTraining = async () => {
+    await api.cancelTraining()
+    setTraining(false)
+  }
+
+  if (training) {
+    return (
+      <Button loading={loading} onClick={cancelTraining}>
+        {lang.tr('module.nlu.cancelTraining')}
+      </Button>
+    )
   }
 
   return (
-    <Button loading={loading} onClick={onClick}>
-      {training ? lang.tr('module.nlu.cancelTraining') : renderTrain()}
+    <Button loading={loading} onClick={trainNow}>
+      {lang.tr(autoTrain ? 'module.nlu.retrainAll' : 'module.nlu.trainNow')}
     </Button>
   )
 }

--- a/modules/nlu/src/views/full/common/TrainNow.tsx
+++ b/modules/nlu/src/views/full/common/TrainNow.tsx
@@ -4,12 +4,9 @@ import { props } from 'bluebird'
 import { lang } from 'botpress/shared'
 import React, { FC, useEffect, useState } from 'react'
 
-import { AutoTrainObserver } from './AutoTrainToggle'
-
-const TrainNow: FC<{ api: NLUApi; eventBus: any; observer: AutoTrainObserver }> = ({ api, eventBus, observer }) => {
+const TrainNow: FC<{ api: NLUApi; eventBus: any; autoTrain: boolean }> = ({ api, eventBus, autoTrain }) => {
   const [loading, setLoading] = useState(true)
   const [training, setTraining] = useState(false)
-  const [forcing, setForcing] = useState(false)
 
   useEffect(() => {
     const fetchIsTraining = async () => {
@@ -30,9 +27,6 @@ const TrainNow: FC<{ api: NLUApi; eventBus: any; observer: AutoTrainObserver }> 
       }
     })
 
-    observer.listeners.push((status: boolean) => {
-      setForcing(status)
-    })
   }, [])
 
   const onClick = async () => {
@@ -46,7 +40,7 @@ const TrainNow: FC<{ api: NLUApi; eventBus: any; observer: AutoTrainObserver }> 
   }
 
   const renderTrain = () => {
-    return forcing ? lang.tr('module.nlu.retrainAll') : lang.tr('module.nlu.trainNow')
+    return autoTrain ? lang.tr('module.nlu.retrainAll') : lang.tr('module.nlu.trainNow')
   }
 
   return (

--- a/modules/nlu/src/views/full/common/TrainNow.tsx
+++ b/modules/nlu/src/views/full/common/TrainNow.tsx
@@ -2,7 +2,7 @@ import { Button } from '@blueprintjs/core'
 import { NLUApi } from 'api'
 import { lang } from 'botpress/shared'
 import React, { FC, useEffect, useState } from 'react'
-import { NluProgressEvent } from '../../../backend/typings'
+import { NLUProgressEvent } from '../../../backend/typings'
 
 const TrainNow: FC<{ api: NLUApi; eventBus: any; autoTrain: boolean }> = ({ api, eventBus, autoTrain }) => {
   const [loading, setLoading] = useState(true)

--- a/modules/nlu/src/views/full/common/TrainNow.tsx
+++ b/modules/nlu/src/views/full/common/TrainNow.tsx
@@ -22,7 +22,7 @@ const TrainNow: FC<{ api: NLUApi; eventBus: any; autoTrain: boolean }> = ({ api,
 
   useEffect(() => {
     eventBus.on('statusbar.event', event => {
-      if (event.type === 'nlu' && (event as NluProgressEvent).trainSession.status === "done") {
+      if (event.type === 'nlu' && (event as NLUProgressEvent).trainSession.status === "done") {
         setTraining(false)
       }
     })

--- a/modules/nlu/src/views/full/common/TrainNow.tsx
+++ b/modules/nlu/src/views/full/common/TrainNow.tsx
@@ -2,6 +2,7 @@ import { Button } from '@blueprintjs/core'
 import { NLUApi } from 'api'
 import { lang } from 'botpress/shared'
 import React, { FC, useEffect, useState } from 'react'
+import { NluProgressEvent } from '../../../backend/typings'
 
 const TrainNow: FC<{ api: NLUApi; eventBus: any; autoTrain: boolean }> = ({ api, eventBus, autoTrain }) => {
   const [loading, setLoading] = useState(true)
@@ -21,7 +22,7 @@ const TrainNow: FC<{ api: NLUApi; eventBus: any; autoTrain: boolean }> = ({ api,
 
   useEffect(() => {
     eventBus.on('statusbar.event', event => {
-      if (event.type === 'nlu' && (event.message === 'Training complete' || event.message === 'Training not needed')) {
+      if (event.type === 'nlu' && (event as NluProgressEvent).trainSession.status === "done") {
         setTraining(false)
       }
     })

--- a/modules/nlu/src/views/full/common/TrainNow.tsx
+++ b/modules/nlu/src/views/full/common/TrainNow.tsx
@@ -26,7 +26,6 @@ const TrainNow: FC<{ api: NLUApi; eventBus: any; autoTrain: boolean }> = ({ api,
         setTraining(false)
       }
     })
-
   }, [])
 
   const trainNow = async () => {

--- a/modules/nlu/src/views/full/common/TrainingControl.tsx
+++ b/modules/nlu/src/views/full/common/TrainingControl.tsx
@@ -1,17 +1,37 @@
 import { NLUApi } from 'api'
-import React, { FC } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 
 import style from './style.scss'
-import AutoTrainToggle, { AutoTrainObserver } from './AutoTrainToggle'
 import TrainNow from './TrainNow'
-
-const autoTrainObserver: AutoTrainObserver = { listeners: [] }
+import AutoTrainToggle from './AutoTrainToggle'
 
 const TrainingControl: FC<{ api: NLUApi; eventBus: any }> = ({ api, eventBus }) => {
+
+  const [autoTrain, setAutoTrain] = useState(false)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchAutoTrain = async () => {
+      setLoading(true)
+      const isOn = await api.isAutoTrainOn()
+      setAutoTrain(isOn)
+      setLoading(false)
+    }
+
+    // tslint:disable-next-line: no-floating-promises
+    fetchAutoTrain()
+  }, [])
+
+  const toggleAutoTrain = async () => {
+    const newStatus = !autoTrain
+    await api.setAutoTrain(newStatus)
+    setAutoTrain(newStatus)
+  }
+
   return (
     <div className={style.trainingControl}>
-      <AutoTrainToggle api={api} observer={autoTrainObserver} />
-      <TrainNow api={api} eventBus={eventBus} observer={autoTrainObserver} />
+      <AutoTrainToggle autoTrain={autoTrain} loading={loading} toggleAutoTrain={toggleAutoTrain} />
+      <TrainNow api={api} eventBus={eventBus} autoTrain={autoTrain} />
     </div>
   )
 }

--- a/modules/nlu/src/views/full/common/TrainingControl.tsx
+++ b/modules/nlu/src/views/full/common/TrainingControl.tsx
@@ -2,14 +2,16 @@ import { NLUApi } from 'api'
 import React, { FC } from 'react'
 
 import style from './style.scss'
-import AutoTrainToggle from './AutoTrainToggle'
+import AutoTrainToggle, { AutoTrainObserver } from './AutoTrainToggle'
 import TrainNow from './TrainNow'
+
+const autoTrainObserver: AutoTrainObserver = { listeners: [] }
 
 const TrainingControl: FC<{ api: NLUApi; eventBus: any }> = ({ api, eventBus }) => {
   return (
     <div className={style.trainingControl}>
-      <AutoTrainToggle api={api} />
-      <TrainNow api={api} eventBus={eventBus} />
+      <AutoTrainToggle api={api} observer={autoTrainObserver} />
+      <TrainNow api={api} eventBus={eventBus} observer={autoTrainObserver} />
     </div>
   )
 }


### PR DESCRIPTION
When auto train is on, `Train now` becomes `Retrain all`:

![image](https://user-images.githubusercontent.com/25970722/85870666-57daea80-b79b-11ea-9fd9-1bbc4b34cc2d.png)

`Retrain all` : Force train all contexts of all languages not matter if training is needed.
`Train now` : Train now, but only if needed.

If `Train now` is clicked and no training is needed for language, then progress will be reported with a special "Training not needed" message.

**This is my first frontend feature in about ~10 months so feel free to tell me if the `observer` I implemented is the botpress way of doing things** 