### PR TITLE
fix(flow): friendly node name

### DIFF
--- a/src/bp/ui-studio/src/web/reducers/flows.ts
+++ b/src/bp/ui-studio/src/web/reducers/flows.ts
@@ -295,6 +295,15 @@ function isActualRename(state, modification): boolean {
   return modification.newName && !_.keys(state.flowsByName).includes(modification.newName)
 }
 
+const getNextNodeName = (type: string, nodes) => {
+  const filteredNodes = nodes
+    .filter(x => x.type === type && x.name.startsWith(`${type}-`))
+    .map(x => Number(x.name.replace(`${type}-`, '')))
+
+  const highest: number = _.max(filteredNodes) ?? 0
+  return `${type}-${highest + 1}`
+}
+
 // *****
 // Reducer that deals with non-recordable (no snapshot taking)
 // *****
@@ -781,7 +790,7 @@ reducer = reduceReducers(
               _.merge(
                 {
                   id: prettyId(),
-                  name: `node-${prettyId(4)}`,
+                  name: getNextNodeName(payload.type, state.flowsByName[state.currentFlow].nodes),
                   x: 0,
                   y: 0,
                   next: [],

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/nodes/Components/NodeHeader.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/nodes/Components/NodeHeader.tsx
@@ -10,6 +10,7 @@ interface Props {
   expanded: boolean
   defaultLabel: string
   name: string
+  type: string
   handleContextMenu: (e: SyntheticEvent) => void
   isEditing: boolean
   saveName: (value: string) => void
@@ -23,6 +24,7 @@ const NodeHeader: FC<Props> = ({
   expanded,
   defaultLabel,
   name,
+  type,
   handleContextMenu,
   isEditing,
   saveName,
@@ -30,7 +32,7 @@ const NodeHeader: FC<Props> = ({
   children,
   className
 }) => {
-  const isDefaultName = name.startsWith('node-')
+  const isDefaultName = name.startsWith(`${type}-`) || name.startsWith(`node-`)
   const getInitialInputValue = () => {
     return isDefaultName ? '' : name
   }

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/nodes/SaySomethingNode/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/nodes/SaySomethingNode/index.tsx
@@ -110,6 +110,7 @@ const SaySomethingWidget: FC<Props> = ({
         saveName={saveName}
         defaultLabel={lang.tr('studio.flow.node.chatbotSays')}
         name={node.name}
+        type={node.type}
         error={error}
       >
         <StandardPortWidget name="in" node={node} className={style.in} />

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/nodes/TriggerNode/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/nodes/TriggerNode/index.tsx
@@ -104,6 +104,7 @@ const TriggerWidget: FC<Props> = ({
         saveName={saveName}
         defaultLabel={lang.tr('studio.flow.node.triggeredBy')}
         name={node.name}
+        type={node.type}
         error={error}
       >
         <StandardPortWidget name="in" node={node} className={style.in} />

--- a/src/bp/ui-studio/src/web/views/OneFlow/sidePanel/form/PromptNode.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/sidePanel/form/PromptNode.tsx
@@ -221,9 +221,7 @@ const SubWorkflowNode: FC<Props> = props => {
           <Contents.Form
             fields={state.config.fields}
             advancedSettings={state.config.advancedSettings}
-            bp={undefined}
             formData={state.params}
-            contentType={undefined}
             onUpdate={updateParam}
           />
 


### PR DESCRIPTION
This will name the nodes by their type instead of node-randomstring. So you will have "execute-1", "execute-2" instead