### PR TITLE
fix(nlu): encode URI before calling duckling

### DIFF
--- a/modules/nlu/src/backend/entities/duckling_extractor.ts
+++ b/modules/nlu/src/backend/entities/duckling_extractor.ts
@@ -201,7 +201,7 @@ export class DucklingEntityExtractor implements SystemEntityExtractor {
       return await retry(async () => {
         const { data } = await DucklingEntityExtractor.client.post(
           '/parse',
-          `lang=${lang}&text=${text}&reftime=${refTime}&tz=${tz}`
+          `lang=${lang}&text=${encodeURI(text)}&reftime=${refTime}&tz=${tz}`
         )
 
         if (!_.isArray(data)) {


### PR DESCRIPTION
There's an issue calling duckling with `%` signs. This PR solves it.

Here's the difference calling duckling from terminal

```
# without encoding % signs

C:\Users\franc> curl -XPOST http://localhost:8000/parse --data "lang=en&text=it is 5:30 pm and I'm 100% drunk::::&reftime=1594058531928&tz=America/Toronto"
Need a 'text' parameter to parse


# with % signs encoded

C:\Users\franc> curl -XPOST http://localhost:8000/parse --data "lang=en&text=it%20is%205:30%20pm%20and%20I'm%20100%25%20drunk::%E2%96%81::&reftime=1594058531928&tz=America/Toronto"
[{"body":"5:30 pm","start":6,"value":{"values":[{"value":"2020-07-06T17:30:00.000-04:00","grain":"minute","type":"value"},{"value":"2020-07-07T17:30:00.000-04:00","grain":"minute","type":"value"},{"value":"2020-07-08T17:30:00.000-04:00","grain":"minute","type":"value"}],"value":"2020-07-06T17:30:00.000-04:00","grain":"minute","type":"value"},"end":13,"dim":"time","latent":false},{"body":"100","start":22,"value":{"value":100,"type":"value"},"end":25,"dim":"number","latent":false}]


```