### PR TITLE
feat(nlu): tokenize using vocab when s-piece is struggling

### DIFF
--- a/modules/nlu/src/backend/tools/token-utils.test.ts
+++ b/modules/nlu/src/backend/tools/token-utils.test.ts
@@ -92,6 +92,32 @@ describe('Raw token processing', () => {
     expect(processUtteranceTokens(moreToks)).toEqual(['jag', SPACE, 'är', SPACE, 'väldigt', SPACE, 'hungrig'])
   })
 
+  test('processUtteranceTokens with vocab should help tokenization', () => {
+    const toks = [`${SPACE}i`, `'`, `m`, `${SPACE}having`, `${SPACE}some`, `${SPACE}trouble`, `${SPACE}tol`, `ogin`]
+    const vocab = {
+      to: [1, 2, 3, 4],
+      login: [1, 2, 3, 4]
+    }
+
+    expect(processUtteranceTokens(toks, vocab)).toEqual([
+      `i`,
+      `'`,
+      `m`,
+      SPACE,
+      `having`,
+      SPACE,
+      `some`,
+      SPACE,
+      `trouble`,
+      SPACE,
+      `to`,
+      `login`
+    ])
+
+    const moreToks = [`${SPACE}jag`, `${SPACE}ä`, `r`, `${SPACE}väl`, `digt`, `${SPACE}hungrig`]
+    expect(processUtteranceTokens(moreToks)).toEqual(['jag', SPACE, 'är', SPACE, 'väldigt', SPACE, 'hungrig'])
+  })
+
   test('restoreUtteranceTokens', () => {
     const original = 'I left NASA to work at Botpress'
     const tokens = ['i', SPACE, 'left', SPACE, 'nasa', SPACE, 'to', SPACE, 'work', SPACE, 'at', SPACE, 'bot', 'press']

--- a/modules/nlu/src/backend/tools/token-utils.ts
+++ b/modules/nlu/src/backend/tools/token-utils.ts
@@ -3,6 +3,7 @@ import _ from 'lodash'
 import { Token2Vec } from '../typings'
 
 import { LATIN_CHARSET, SPECIAL_CHARSET } from './chars'
+import vocabTokenizer from './vocab-tokenizer'
 
 export const SPACE = '\u2581'
 
@@ -27,6 +28,7 @@ export function tokenizeLatinTextForTests(text: string): string[] {
 }
 
 type CustomMatcher = (tok: string) => boolean
+type CustomTransformer = (prevTok: string, nextTok: string) => string[]
 
 /**
  * Merges consecutive tokens that all respect the provided regex
@@ -39,13 +41,14 @@ type CustomMatcher = (tok: string) => boolean
 export const mergeSimilarCharsetTokens = (
   tokens: string[],
   charPatterns: string[],
-  matcher: CustomMatcher = () => true
+  matcher: CustomMatcher = () => true,
+  transformer: CustomTransformer = (prev: string, next: string) => [`${prev}${next}`]
 ): string[] => {
   const charMatcher = new RegExp(`^(${charPatterns.join('|')})+$`, 'i')
   return tokens.reduce((mergedToks: string[], nextTok: string) => {
     const prev = _.last(mergedToks)
     if (prev && charMatcher.test(prev) && charMatcher.test(nextTok) && (matcher(prev) || matcher(nextTok))) {
-      return [...mergedToks.slice(0, mergedToks.length - 1), `${_.last(mergedToks) || ''}${nextTok}`]
+      return [...mergedToks.slice(0, mergedToks.length - 1), ...transformer(prev, nextTok)]
     } else {
       return [...mergedToks, nextTok]
     }
@@ -59,7 +62,12 @@ const mergeLatin = (tokens: string[], vocab: Token2Vec): string[] => {
   const oovMatcher = (token: string) => {
     return token && !vocab[token.toLowerCase()]
   }
-  return mergeSimilarCharsetTokens(tokens, LATIN_CHARSET, oovMatcher)
+
+  const fedVocabTokenizer = vocabTokenizer(Object.keys(vocab))
+  const vocabTransformer = (prev: string, next: string) => {
+    return fedVocabTokenizer(`${prev}${next}`)
+  }
+  return mergeSimilarCharsetTokens(tokens, LATIN_CHARSET, oovMatcher, vocabTransformer)
 }
 
 export const processUtteranceTokens = (tokens: string[], vocab: Token2Vec = {}): string[] => {

--- a/modules/nlu/src/backend/tools/token-utils.ts
+++ b/modules/nlu/src/backend/tools/token-utils.ts
@@ -3,7 +3,7 @@ import _ from 'lodash'
 import { Token2Vec } from '../typings'
 
 import { LATIN_CHARSET, SPECIAL_CHARSET } from './chars'
-import vocabTokenizer from './vocab-tokenizer'
+import getVocabTokenizer from './vocab-tokenizer'
 
 export const SPACE = '\u2581'
 
@@ -63,9 +63,9 @@ const mergeLatin = (tokens: string[], vocab: Token2Vec): string[] => {
     return token && !vocab[token.toLowerCase()]
   }
 
-  const fedVocabTokenizer = vocabTokenizer(Object.keys(vocab))
+  const vocabTokenizer = getVocabTokenizer(Object.keys(vocab))
   const vocabTransformer = (prev: string, next: string) => {
-    return fedVocabTokenizer(`${prev}${next}`)
+    return vocabTokenizer(`${prev}${next}`)
   }
   return mergeSimilarCharsetTokens(tokens, LATIN_CHARSET, oovMatcher, vocabTransformer)
 }

--- a/modules/nlu/src/backend/tools/vocab-tokenizer.test.ts
+++ b/modules/nlu/src/backend/tools/vocab-tokenizer.test.ts
@@ -1,0 +1,59 @@
+import vocabTokenizer from './vocab-tokenizer'
+
+test('vocab tokenizer should split', () => {
+  // arange
+  const vocab = ['shes', 'a', 'witch', 'burn', 'her']
+  const sentencepieceToken = 'shesa'
+  const fedVocabTokenizer = vocabTokenizer(vocab)
+
+  // act
+  const actual = fedVocabTokenizer(sentencepieceToken)
+
+  // assert
+  expect(actual).toHaveLength(2)
+  expect(actual[0]).toBe('shes')
+  expect(actual[1]).toBe('a')
+})
+
+test('vocab tokenizer should split with the correct token', () => {
+  // arange
+  const vocab = ['she', 'shes', 'is', 's', 'a', 'sa', 'witch', 'burn', 'her']
+  const sentencepieceToken = 'shesa'
+  const fedVocabTokenizer = vocabTokenizer(vocab)
+
+  // act
+  const actual = fedVocabTokenizer(sentencepieceToken)
+
+  // assert
+  expect(actual).toHaveLength(2)
+  expect(actual[0]).toBe('shes')
+  expect(actual[1]).toBe('a')
+})
+
+test('vocab tokenizer should not try more than combinations of length 2', () => {
+  // arange
+  const vocab = ['she', 'shes', 'is', 's', 'a', 'sa', 'witch', 'burn', 'her']
+  const sentencepieceToken = 'shesawitch'
+  const fedVocabTokenizer = vocabTokenizer(vocab)
+
+  // act
+  const actual = fedVocabTokenizer(sentencepieceToken)
+
+  // assert
+  expect(actual).toHaveLength(1)
+  expect(actual[0]).toBe('shesawitch')
+})
+
+test('vocab tokenizer should not split', () => {
+  // arange
+  const vocab = ['she', 'shes', 'is', 's', 'a', 'witch', 'burn', 'her']
+  const sentencepieceToken = 'arthur'
+  const fedVocabTokenizer = vocabTokenizer(vocab)
+
+  // act
+  const actual = fedVocabTokenizer(sentencepieceToken)
+
+  // assert
+  expect(actual).toHaveLength(1)
+  expect(actual[0]).toBe('arthur')
+})

--- a/modules/nlu/src/backend/tools/vocab-tokenizer.test.ts
+++ b/modules/nlu/src/backend/tools/vocab-tokenizer.test.ts
@@ -1,13 +1,13 @@
-import vocabTokenizer from './vocab-tokenizer'
+import getVocabTokenizer from './vocab-tokenizer'
 
 test('vocab tokenizer should split', () => {
   // arange
   const vocab = ['shes', 'a', 'witch', 'burn', 'her']
   const sentencepieceToken = 'shesa'
-  const fedVocabTokenizer = vocabTokenizer(vocab)
+  const vocabTokenizer = getVocabTokenizer(vocab)
 
   // act
-  const actual = fedVocabTokenizer(sentencepieceToken)
+  const actual = vocabTokenizer(sentencepieceToken)
 
   // assert
   expect(actual).toHaveLength(2)
@@ -19,10 +19,10 @@ test('vocab tokenizer should split with the correct token', () => {
   // arange
   const vocab = ['she', 'shes', 'is', 's', 'a', 'sa', 'witch', 'burn', 'her']
   const sentencepieceToken = 'shesa'
-  const fedVocabTokenizer = vocabTokenizer(vocab)
+  const vocabTokenizer = getVocabTokenizer(vocab)
 
   // act
-  const actual = fedVocabTokenizer(sentencepieceToken)
+  const actual = vocabTokenizer(sentencepieceToken)
 
   // assert
   expect(actual).toHaveLength(2)
@@ -34,10 +34,10 @@ test('vocab tokenizer should not try more than combinations of length 2', () => 
   // arange
   const vocab = ['she', 'shes', 'is', 's', 'a', 'sa', 'witch', 'burn', 'her']
   const sentencepieceToken = 'shesawitch'
-  const fedVocabTokenizer = vocabTokenizer(vocab)
+  const vocabTokenizer = getVocabTokenizer(vocab)
 
   // act
-  const actual = fedVocabTokenizer(sentencepieceToken)
+  const actual = vocabTokenizer(sentencepieceToken)
 
   // assert
   expect(actual).toHaveLength(1)
@@ -48,10 +48,10 @@ test('vocab tokenizer should not split', () => {
   // arange
   const vocab = ['she', 'shes', 'is', 's', 'a', 'witch', 'burn', 'her']
   const sentencepieceToken = 'arthur'
-  const fedVocabTokenizer = vocabTokenizer(vocab)
+  const vocabTokenizer = getVocabTokenizer(vocab)
 
   // act
-  const actual = fedVocabTokenizer(sentencepieceToken)
+  const actual = vocabTokenizer(sentencepieceToken)
 
   // assert
   expect(actual).toHaveLength(1)

--- a/modules/nlu/src/backend/tools/vocab-tokenizer.ts
+++ b/modules/nlu/src/backend/tools/vocab-tokenizer.ts
@@ -1,0 +1,67 @@
+import _ from 'lodash'
+
+type VocabMatch = {
+  start: number
+  end: number
+  length: number
+  src: string
+}
+
+export default (vocab: string[]) => (token: string) => {
+  const matchingVocabTokens = _(vocab)
+    .map(t => {
+      try {
+        const regexp = new RegExp(t, 'i')
+        return token.match(regexp)
+      } catch {
+        return undefined
+      }
+    })
+    .filter(x => !!x)
+    .map(match => {
+      const start = match.index
+      const src = match[0]
+      const length = src.length
+      const end = start + length
+      return {
+        start,
+        end,
+        length,
+        src
+      } as VocabMatch
+    })
+    .orderBy(match => match.length, 'desc')
+    .value()
+
+  const coverAllToken = matchesCoverAllToken(token)
+
+  for (let p of pairs(matchingVocabTokens.length)) {
+    const [first, second] = _(p)
+      .map(idx => matchingVocabTokens[idx])
+      .orderBy(m => m.start)
+      .value()
+
+    if (coverAllToken(first, second)) {
+      return [first.src, second.src]
+    }
+  }
+
+  return [token]
+}
+
+function pairs(length: number) {
+  return {
+    *[Symbol.iterator](): Generator<[number, number]> {
+      for (let i = 0; i < length; i++) {
+        for (let j = i + 1; j < length; j++) {
+          yield [i, j]
+        }
+      }
+    }
+  }
+}
+
+const matchesCoverAllToken = (token: string) => (first: VocabMatch, second: VocabMatch) => {
+  const totalMatchLength = first.length + second.length
+  return first.start === 0 && second.end === token.length && totalMatchLength === token.length
+}

--- a/modules/nlu/src/backend/tools/vocab-tokenizer.ts
+++ b/modules/nlu/src/backend/tools/vocab-tokenizer.ts
@@ -35,7 +35,7 @@ export default (vocab: string[]) => (token: string) => {
 
   const coverAllToken = matchesCoverAllToken(token)
 
-  for (let p of pairs(matchingVocabTokens.length)) {
+  for (const p of pairs(matchingVocabTokens.length)) {
     const [first, second] = _(p)
       .map(idx => matchingVocabTokens[idx])
       .orderBy(m => m.start)


### PR DESCRIPTION
For input `I'm having some trouble tologin`, sentencepiece might split `tologin` in `tol` and `ogin`.

Currently on branch dev, if `tol` or `ogin` are not part of vocabulary, we don't split them (we merge them back)...

This PR is about giving a chance to sentencepiece when its struggling to split tokens correctly. In that scenario we try to split `tologin` by looking at the vocab.

**PBDS**

This PR's impact on BPDS is positive but quite small. It's hard to tell exactly of much percent we've gain because I'm still waiting for my random seed PR...

I know there's at least one test that used to fail but doesnt anymore.

**edit**

There's a 0.1% accuracy increase on BPDS-regression