### PR TITLE
feat(channel-web): more req per sec

### DIFF
--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -284,10 +284,10 @@ export default async (bp: typeof sdk, db: Database) => {
       event.debugger = true
     }
 
-    bp.events.sendEvent(event)
-
     const message = await db.appendUserMessage(botId, userId, conversationId, sanitizedPayload, event.id, user)
     bp.realtime.sendPayload(bp.RealTimePayload.forVisitor(userId, 'webchat.message', message))
+
+    await bp.events.sendEvent(event)
   }
 
   router.post(

--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -252,7 +252,7 @@ export default async (bp: typeof sdk, db: Database) => {
     payload,
     credentials: any,
     useDebugger?: boolean,
-    user: sdk.User = undefined
+    user?: sdk.User
   ) {
     const config = await bp.config.getModuleConfigForBot('channel-web', botId)
 

--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -19,6 +19,15 @@ const ERR_CONV_ID_REQ = '`conversationId` is required and must be valid'
 const ERR_BAD_LANGUAGE = '`language` is required and must be valid'
 
 const USER_ID_MAX_LENGTH = 40
+const SUPPORTED_MESSAGES = [
+  'text',
+  'quick_reply',
+  'form',
+  'login_prompt',
+  'visit',
+  'request_start_conversation',
+  'postback'
+]
 
 export default async (bp: typeof sdk, db: Database) => {
   const asyncMiddleware = asyncMw(bp.logger)
@@ -127,11 +136,7 @@ export default async (bp: typeof sdk, db: Database) => {
       let { conversationId = undefined } = req.query || {}
       conversationId = conversationId && parseInt(conversationId)
 
-      if (
-        !['text', 'quick_reply', 'form', 'login_prompt', 'visit', 'request_start_conversation', 'postback'].includes(
-          payload.type
-        )
-      ) {
+      if (!SUPPORTED_MESSAGES.includes(payload.type)) {
         // TODO: Support files
         return res.status(400).send(ERR_MSG_TYPE)
       }
@@ -155,7 +160,8 @@ export default async (bp: typeof sdk, db: Database) => {
         conversationId = await db.getOrCreateRecentConversation(botId, userId, { originatesFromUserMessage: true })
       }
 
-      await sendNewMessage(botId, userId, conversationId, payload, req.credentials, !!req.headers.authorization)
+      // tslint:disable-next-line: no-floating-promises
+      sendNewMessage(botId, userId, conversationId, payload, req.credentials, !!req.headers.authorization, user.result)
 
       return res.sendStatus(200)
     })
@@ -245,7 +251,8 @@ export default async (bp: typeof sdk, db: Database) => {
     conversationId,
     payload,
     credentials: any,
-    useDebugger?: boolean
+    useDebugger?: boolean,
+    user: sdk.User = undefined
   ) {
     const config = await bp.config.getModuleConfigForBot('channel-web', botId)
 
@@ -277,10 +284,10 @@ export default async (bp: typeof sdk, db: Database) => {
       event.debugger = true
     }
 
-    const message = await db.appendUserMessage(botId, userId, conversationId, sanitizedPayload, event.id)
+    bp.events.sendEvent(event)
 
+    const message = await db.appendUserMessage(botId, userId, conversationId, sanitizedPayload, event.id, user)
     bp.realtime.sendPayload(bp.RealTimePayload.forVisitor(userId, 'webchat.message', message))
-    return bp.events.sendEvent(event)
   }
 
   router.post(

--- a/modules/channel-web/src/backend/db.ts
+++ b/modules/channel-web/src/backend/db.ts
@@ -153,6 +153,14 @@ export default class WebchatDb {
 
     this.queued_messages.push(message)
     this.queued_convos[`${conversationId}_${userId}_${botId}`] = this.knex.date.now()
+
+    return {
+      ...message,
+      sent_on: new Date(),
+      message_raw: raw,
+      message_data: data,
+      payload: payload
+    }
   }
 
   async appendBotMessage(botName, botAvatar, conversationId, payload, incomingEventId) {
@@ -174,12 +182,13 @@ export default class WebchatDb {
 
     this.queued_messages.push(message)
 
-    return Object.assign(message, {
+    return {
+      ...message,
       sent_on: new Date(),
-      message_raw: this.knex.json.get(message.message_raw),
-      message_data: this.knex.json.get(message.message_data),
-      payload: this.knex.json.get(message.payload)
-    })
+      message_raw: raw,
+      message_data: data,
+      payload: payload
+    }
   }
 
   async createConversation(botId, userId, { originatesFromUserMessage = false } = {}) {

--- a/modules/channel-web/src/backend/db.ts
+++ b/modules/channel-web/src/backend/db.ts
@@ -144,7 +144,7 @@ export default class WebchatDb {
       message_raw: this.knex.json.set(raw),
       message_data: this.knex.json.set(data),
       payload: this.knex.json.set(payload),
-      sent_on: this.knex.date.now()
+      sent_on: new Date().toISOString()
     }
 
     this.queued_messages.push(message)
@@ -173,7 +173,7 @@ export default class WebchatDb {
       message_raw: this.knex.json.set(raw),
       message_data: this.knex.json.set(data),
       payload: this.knex.json.set(payload),
-      sent_on: this.knex.date.now()
+      sent_on: new Date().toISOString()
     }
 
     this.queued_messages.push(message)

--- a/modules/channel-web/src/backend/db.ts
+++ b/modules/channel-web/src/backend/db.ts
@@ -17,8 +17,8 @@ export default class WebchatDb {
   constructor(private bp: typeof sdk) {
     this.users = bp.users
     this.knex = bp['database'] // TODO Fixme
-    setInterval(() => this.flushMessages(), ms('1s'))
-    setInterval(() => this.flushConvoUpdates(), ms('1s'))
+    setInterval(() => this.flushMessages(), ms('5s'))
+    setInterval(() => this.flushConvoUpdates(), ms('5s'))
   }
 
   async flushMessages() {
@@ -26,8 +26,6 @@ export default class WebchatDb {
       return
     }
     this.message_lock = true
-
-    console.log(`inserting ${this.queued_messages.length} messages`)
 
     try {
       const original = this.queued_messages
@@ -70,8 +68,6 @@ export default class WebchatDb {
         }
 
         this.queued_convos = []
-
-        console.log(`updating ${queries.length} convos`)
 
         await Promise.all(queries)
           .then(trx.commit)

--- a/modules/channel-web/src/backend/socket.ts
+++ b/modules/channel-web/src/backend/socket.ts
@@ -45,7 +45,7 @@ export default async (bp: typeof sdk, db: Database) => {
       const payload = bp.RealTimePayload.forVisitor(userId, 'webchat.typing', { timeInMs: typing, conversationId })
       // Don't store "typing" in DB
       bp.realtime.sendPayload(payload)
-      await Promise.delay(typing)
+      // await Promise.delay(typing)
     } else if (messageType === 'data') {
       const payload = bp.RealTimePayload.forVisitor(userId, 'webchat.data', event.payload)
       bp.realtime.sendPayload(payload)

--- a/modules/channel-web/src/backend/typings.d.ts
+++ b/modules/channel-web/src/backend/typings.d.ts
@@ -1,0 +1,16 @@
+import { Raw } from 'knex'
+
+export interface DBMessage {
+  id: string
+  userId: string
+  incomingEventId: string
+  conversationId: number
+  avatar_url: string | undefined
+  full_name: string
+  message_data: any | undefined
+  message_raw: any | undefined
+  message_text: string | undefined
+  message_type: string | undefined
+  payload: any
+  sent_on: Raw<any>
+}

--- a/modules/channel-web/src/views/lite/store/index.ts
+++ b/modules/channel-web/src/views/lite/store/index.ts
@@ -15,6 +15,7 @@ import {
   EventFeedback,
   Message,
   MessageWrapper,
+  QueuedMessage,
   StudioConnector
 } from '../typings'
 import { downloadFile, trackMessage } from '../utils'
@@ -67,6 +68,8 @@ class RootStore {
 
   @observable
   public botUILanguage: string = chosenLocale
+
+  public delayedMessages: QueuedMessage[] = []
 
   constructor({ fullscreen }) {
     this.composer = new ComposerStore(this)
@@ -126,8 +129,12 @@ class RootStore {
       return
     }
 
-    this.currentConversation.messages.push({ ...event, conversationId: +event.conversationId })
-    this.currentConversation.typingUntil = event.userId ? this.currentConversation.typingUntil : undefined
+    const message: Message = { ...event, conversationId: +event.conversationId }
+    if (this.isBotTyping.get() && !event.userId) {
+      this.delayedMessages.push({ message, showAt: this.currentConversation.typingUntil })
+    } else {
+      this.currentConversation.messages.push(message)
+    }
   }
 
   @action.bound
@@ -383,15 +390,18 @@ class RootStore {
     this.isBotTyping.set(true)
 
     this._typingInterval = setInterval(() => {
-      const typeUntil = this.currentConversation && this.currentConversation.typingUntil
-      if (!typeUntil || isBefore(new Date(typeUntil), new Date())) {
+      const typeUntil = new Date(this.currentConversation && this.currentConversation.typingUntil)
+      if (!typeUntil || isBefore(typeUntil, new Date())) {
         this._expireTyping()
+      } else {
+        this.emptyDelayedMessagesQueue(false)
       }
     }, 50)
   }
 
   @action.bound
   private _expireTyping() {
+    this.emptyDelayedMessagesQueue(true)
     this.isBotTyping.set(false)
     this.currentConversation.typingUntil = undefined
 
@@ -405,6 +415,19 @@ class RootStore {
       this.botUILanguage = lang
       localStorage.setItem('bp/channel-web/user-lang', lang)
     })
+  }
+
+  @action.bound
+  private emptyDelayedMessagesQueue(removeAll: boolean) {
+    while (this.delayedMessages.length) {
+      const message = this.delayedMessages[0]
+      if (removeAll || isBefore(message.showAt, new Date())) {
+        this.currentConversation.messages.push(message.message)
+        this.delayedMessages.shift()
+      } else {
+        break
+      }
+    }
   }
 
   /** Returns the current conversation ID, or the last one if it didn't expired. Otherwise, returns nothing. */

--- a/modules/channel-web/src/views/lite/typings.d.ts
+++ b/modules/channel-web/src/views/lite/typings.d.ts
@@ -251,6 +251,11 @@ export interface Message {
   timeInMs: number
 }
 
+export interface QueuedMessage {
+  message: Message
+  showAt: Date
+}
+
 export interface HTMLInputEvent extends Event {
   target: HTMLInputElement & EventTarget
 }


### PR DESCRIPTION
Removes some awaits, batches db calls and adds caching to users to allow more requests per seconds.

# Benchmarks

**http_req_duration** : stats for requests duration performing a test of 100 rps for 1 min
**http_reqs** : stats for requests per second in a test of 50 workers sending 5000 requests

## Without NDU & QNA

#### New
http_req_duration : avg=2.72ms   min=915.9µs  med=996.7µs  max=93.75ms
http_reqs : 5050    643.147186/s

#### Old
http_req_duration : avg=6.66ms   min=1.98ms   med=2.99ms   max=189.53ms p(90)=6.01ms   p(95)=12.96ms
http_reqs : 5050    195.00504/s

## With NDU & QNA

New
http_req_duration : avg=50.59ms  min=0s       med=36.9ms   max=568.59ms p(90)=104.71ms p(95)=151.55ms
http_reqs : 5050    656.746671/s

Old
http_req_duration : avg=344.6ms  min=2.98ms   med=345.04ms max=742.99ms p(90)=503.65ms p(95)=542.57ms
http_reqs : 5050    121.348228/s