### PR TITLE
fix(broadcast): filters not working

### DIFF
--- a/modules/broadcast/src/backend/daemon.ts
+++ b/modules/broadcast/src/backend/daemon.ts
@@ -35,7 +35,7 @@ export default async (botId: string, bp: typeof sdk, db: Database) => {
             bp.logger.warn('Filter returned something other ' + 'than a boolean (or a Promise of a boolean)')
           }
 
-          return typeof v !== 'undefined' && v !== null
+          return typeof v !== 'undefined' && v !== null && v !== true
         })
       })
     }

--- a/modules/broadcast/src/backend/daemon.ts
+++ b/modules/broadcast/src/backend/daemon.ts
@@ -28,7 +28,7 @@ export default async (botId: string, bp: typeof sdk, db: Database) => {
         }
 
         const fn = new Function('bp', 'userId', 'channel', fnBody)
-        return !fn(bp, row.userId, row.platform)
+        return fn(bp, row.userId, row.platform)
       }).then(values => {
         return _.some(values, v => {
           if (!_.isBoolean(v)) {

--- a/modules/broadcast/src/translations/en.json
+++ b/modules/broadcast/src/translations/en.json
@@ -10,7 +10,7 @@
   "usersTime": "users time",
   "yourTime": "your time",
   "noFilter": "No filter",
-  "filters": "filters",
+  "selectionFilters": "Selection filters",
   "youHaveNoBroadcasts": "You have no broadcasts",
   "newBroadcast": "New Broadcast",
 

--- a/modules/broadcast/src/translations/fr.json
+++ b/modules/broadcast/src/translations/fr.json
@@ -10,7 +10,7 @@
   "usersTime": "temps des utilisateurs",
   "yourTime": "votre temps",
   "noFilter": "Pas de filtre",
-  "filters": "filtres",
+  "selectionFilters": "Filtres de sélection",
   "youHaveNoBroadcasts": "Vous n'avez aucune diffusion",
   "newBroadcast": "Nouvelle diffusion",
 

--- a/modules/broadcast/src/views/full/index.jsx
+++ b/modules/broadcast/src/views/full/index.jsx
@@ -286,7 +286,7 @@ export default class BroadcastModule extends React.Component {
         return lang.tr('module.broadcast.noFilter')
       }
 
-      return <Tag>{filters.length + ' ' + lang.tr('module.broadcast.filters')}</Tag>
+      return <Tag>{filters.length + ' ' + lang.tr('module.broadcast.selectionFilters')}</Tag>
     }
 
     return _.mapValues(broadcasts, value => {


### PR DESCRIPTION
Broadcast filters are currently a bit confusing.

If you only want to send messages only to the web channel, you need to write `channel !== 'web'`

This PR removes the ! before the condition allowing you to write `channel == web` like written in the documentation