### PR TITLE
fix(nlu): rm sys entities from features + check vectors length

### DIFF
--- a/modules/nlu/src/backend/intents/entities-featurizer.test.ts
+++ b/modules/nlu/src/backend/intents/entities-featurizer.test.ts
@@ -1,18 +1,18 @@
 import _ from 'lodash'
 
-import { UtteranceEntity, UtteranceRange, makeTestUtterance } from '../utterance/utterance'
+import { makeTestUtterance, UtteranceEntity, UtteranceRange } from '../utterance/utterance'
 
 import { getEntitiesEncoding } from './entities-featurizer'
 
 type Entity = UtteranceRange & UtteranceEntity
-function buildEntity(type: string): Entity {
+function buildEntity(type: string, extractor?: 'system' | 'list' | 'pattern'): Entity {
   return {
     confidence: 0,
     endPos: 0,
     endTokenIdx: 0,
     metadata: {
       entityId: 'The Mordor',
-      extractor: 'list',
+      extractor: extractor || 'list',
       source: 'Bilbo baggins'
     },
     startPos: 0,
@@ -45,6 +45,34 @@ describe('Entities featurizer', () => {
 
     // Assert
     const expected = [0, 1, 0, 5]
+    expect(actual.length).toBe(expected.length)
+    for (const x of _.zip(actual, expected)) {
+      const [act, ex] = x
+      expect(act).toBe(ex)
+    }
+  })
+
+  test('System entities should not be counted in features', () => {
+    // Arrange
+    const definitions = ['Tata', 'Toto', 'Tutu', 'Titi']
+
+    const utt = makeTestUtterance(
+      '"Fool of a Took! Throw yourself in next time, and rid us of your stupidity" - Gandalf'
+    )
+    utt.entities = [
+      buildEntity('Tutu'),
+      buildEntity('Tutu', 'system'),
+      buildEntity('Toto', 'system'),
+      buildEntity('Tutu'),
+      buildEntity('Toto'),
+      buildEntity('Titi')
+    ]
+
+    // Act
+    const actual = getEntitiesEncoding(utt, definitions)
+
+    // Assert
+    const expected = [0, 1, 1, 2]
     expect(actual.length).toBe(expected.length)
     for (const x of _.zip(actual, expected)) {
       const [act, ex] = x

--- a/modules/nlu/src/backend/intents/entities-featurizer.test.ts
+++ b/modules/nlu/src/backend/intents/entities-featurizer.test.ts
@@ -5,14 +5,15 @@ import { makeTestUtterance, UtteranceEntity, UtteranceRange } from '../utterance
 import { getEntitiesEncoding } from './entities-featurizer'
 
 type Entity = UtteranceRange & UtteranceEntity
-function buildEntity(type: string, extractor?: 'system' | 'list' | 'pattern'): Entity {
+type ExtractorType = 'system' | 'list' | 'pattern'
+function buildEntity(type: string, extractor: ExtractorType = 'list'): Entity {
   return {
     confidence: 0,
     endPos: 0,
     endTokenIdx: 0,
     metadata: {
       entityId: 'The Mordor',
-      extractor: extractor || 'list',
+      extractor,
       source: 'Bilbo baggins'
     },
     startPos: 0,

--- a/modules/nlu/src/backend/intents/entities-featurizer.ts
+++ b/modules/nlu/src/backend/intents/entities-featurizer.ts
@@ -6,7 +6,12 @@ export function getEntitiesEncoding(utt: Utterance, customEntities: string[]): n
   const zeros = Array(customEntities.length).fill(0)
   let entityMap: _.Dictionary<number> = _.zipObject(customEntities, zeros)
 
-  const entitiesOccurence = _.countBy(utt.entities.map(e => e.type))
+  const entitiesOccurence = _(utt.entities)
+    .filter(e => e.metadata.extractor !== 'system')
+    .map(e => e.type)
+    .countBy()
+    .value()
+
   entityMap = { ...entityMap, ...entitiesOccurence }
 
   return _.chain(entityMap)

--- a/src/bp/ml/svm.test.ts
+++ b/src/bp/ml/svm.test.ts
@@ -4,27 +4,55 @@ import '../import-rewire'
 
 import { Predictor, Trainer } from './svm'
 
-test('Trainer', async () => {
-  // prettier-ignore
-  const line: sdk.MLToolkit.SVM.DataPoint[] = [
-    { coordinates: [0, 0], label: 'A' },
-    { coordinates: [0, 1], label: 'A' },
-    { coordinates: [1, 0], label: 'B' },
-    { coordinates: [1, 1], label: 'B' }
-  ]
+/**
+ * WARNING:
+ *  If test fails it may be because of your Linux distribution.
+ *  Try editing 'jest-before.ts' file your distribution.
+ */
+describe('SVM', () => {
+  test('Trainer should work with basic problems', async () => {
+    // prettier-ignore
+    const line: sdk.MLToolkit.SVM.DataPoint[] = [
+      { coordinates: [0, 0], label: 'A' },
+      { coordinates: [0, 1], label: 'A' },
+      { coordinates: [1, 0], label: 'B' },
+      { coordinates: [1, 1], label: 'B' }
+    ]
 
-  const trainer = new Trainer()
-  const mod = await trainer.train(line, { classifier: 'C_SVC', kernel: 'LINEAR', c: 1 })
+    const trainer = new Trainer()
+    const mod = await trainer.train(line, { classifier: 'C_SVC', kernel: 'LINEAR', c: 1 })
 
-  const predictor = new Predictor(mod)
+    const predictor = new Predictor(mod)
 
-  const r1 = await predictor.predict([0, 0])
-  const r2 = await predictor.predict([1, 1])
-  const r3 = await predictor.predict([0, 1])
-  const r4 = await predictor.predict([1, 0])
+    const r1 = await predictor.predict([0, 0])
+    const r2 = await predictor.predict([1, 1])
+    const r3 = await predictor.predict([0, 1])
+    const r4 = await predictor.predict([1, 0])
 
-  expect(r1[0].label).toBe('A')
-  expect(r2[0].label).toBe('B')
-  expect(r3[0].label).toBe('A')
-  expect(r4[0].label).toBe('B')
+    expect(r1[0].label).toBe('A')
+    expect(r2[0].label).toBe('B')
+    expect(r3[0].label).toBe('A')
+    expect(r4[0].label).toBe('B')
+  })
+
+  test('Trainer should throw when vectors have different lengths', async () => {
+    // prettier-ignore
+    const line: sdk.MLToolkit.SVM.DataPoint[] = [
+      { coordinates: [0, 0, 0], label: 'A' },
+      { coordinates: [0, 1], label: 'A' },
+      { coordinates: [1, 0], label: 'B' },
+      { coordinates: [1, 1], label: 'B' }
+    ]
+
+    const trainer = new Trainer()
+
+    let errorThrown = false
+    try {
+      await trainer.train(line, { classifier: 'C_SVC', kernel: 'LINEAR', c: 1 })
+    } catch (err) {
+      errorThrown = true
+    }
+
+    expect(errorThrown).toBeTruthy()
+  })
 })

--- a/src/bp/ml/svm.ts
+++ b/src/bp/ml/svm.ts
@@ -39,6 +39,14 @@ export class Trainer implements sdk.MLToolkit.SVM.Trainer {
       args.probability = false // not supported
     }
 
+    const vectorsLengths = _(points)
+      .map(p => p.coordinates.length)
+      .uniq()
+      .value()
+    if (vectorsLengths.length > 1) {
+      throw new Error('All vectors must be of the same size')
+    }
+
     this.labels = []
     const dataset: Data[] = points.map(c => [c.coordinates, this.getLabelIdx(c.label)])
 


### PR DESCRIPTION
Entities encoding introduced a small regression...

By not filtering out the system entities, some vectors where longer than others.

This made the svm training return a bunch of `NaN`'s which later made the svm prediction crash...

Added few unit tests to make sure this doesnt happend again.

