### PR TITLE
fix(nlu): added back extracted entity in slot when there's one

### DIFF
--- a/modules/nlu/src/backend/predict-pipeline.ts
+++ b/modules/nlu/src/backend/predict-pipeline.ts
@@ -10,7 +10,7 @@ import SlotTagger from './slots/slot-tagger'
 import * as math from './tools/math'
 import { replaceConsecutiveSpaces } from './tools/strings'
 import { EXACT_MATCH_STR_OPTIONS, ExactMatchIndex, TrainArtefacts } from './training-pipeline'
-import { Intent, PatternEntity, SlotExtractionResult, Tools } from './typings'
+import { Intent, PatternEntity, SlotExtractionResult, Tools, EntityExtractionResult } from './typings'
 import Utterance, { buildUtteranceBatch, getAlternateUtterance } from './utterance/utterance'
 
 export type ExactMatchResult = (sdk.MLToolkit.SVM.Prediction & { extractor: 'exact-matcher' }) | undefined
@@ -464,25 +464,31 @@ async function extractSlots(input: PredictStep, predictors: Predictors): Promise
 }
 
 function MapStepToOutput(step: PredictStep, startTime: number): PredictOutput {
-  // legacy pre-ndu
-  const entities = step.utterance.entities.map(
-    e =>
-      ({
-        name: e.type,
-        type: e.metadata.entityId,
-        data: {
-          unit: e.metadata.unit,
-          value: e.value
-        },
-        meta: {
-          sensitive: e.sensitive,
-          confidence: e.confidence,
-          end: e.endPos,
-          source: e.metadata.source,
-          start: e.startPos
-        }
-      } as sdk.NLU.Entity)
-  )
+  const entitiesMapper = (e: EntityExtractionResult) =>
+    ({
+      name: e.type,
+      type: e.metadata.entityId,
+      data: {
+        unit: e.metadata.unit,
+        value: e.value
+      },
+      meta: {
+        sensitive: e.sensitive,
+        confidence: e.confidence,
+        end: e.end,
+        source: e.metadata.source,
+        start: e.start
+      }
+    } as sdk.NLU.Entity)
+
+  const entities = step.utterance.entities
+    .map(e => ({
+      ...e,
+      start: e.startPos, // TODO: a translation from 'startPos' to 'start' should not be needed...
+      end: e.endPos
+    }))
+    .map(entitiesMapper)
+
   // legacy pre-ndu
   const slots = step.utterance.slots.reduce((slots, s) => {
     return {
@@ -512,8 +518,9 @@ function MapStepToOutput(step: PredictStep, startTime: number): PredictOutput {
         confidence: s.slot.confidence,
         name: s.slot.name,
         source: s.slot.source,
-        value: s.slot.value
-      } as sdk.NLU.Slot
+        value: s.slot.value,
+        entity: entitiesMapper(s.slot.entity)
+      }
     }
   }
 

--- a/modules/nlu/src/backend/predict-pipeline.ts
+++ b/modules/nlu/src/backend/predict-pipeline.ts
@@ -464,8 +464,12 @@ async function extractSlots(input: PredictStep, predictors: Predictors): Promise
 }
 
 function MapStepToOutput(step: PredictStep, startTime: number): PredictOutput {
-  const entitiesMapper = (e: EntityExtractionResult) =>
-    ({
+  const entitiesMapper = (e?: EntityExtractionResult) => {
+    if (!e) {
+      return
+    }
+
+    return {
       name: e.type,
       type: e.metadata.entityId,
       data: {
@@ -479,7 +483,8 @@ function MapStepToOutput(step: PredictStep, startTime: number): PredictOutput {
         source: e.metadata.source,
         start: e.start
       }
-    } as sdk.NLU.Entity)
+    } as sdk.NLU.Entity
+  }
 
   const entities = step.utterance.entities
     .map(e => ({
@@ -499,7 +504,8 @@ function MapStepToOutput(step: PredictStep, startTime: number): PredictOutput {
         confidence: s.confidence,
         name: s.name,
         source: s.source,
-        value: s.value
+        value: s.value,
+        entity: entitiesMapper(s.entity)
       } as sdk.NLU.Slot
     }
   }, {} as sdk.NLU.SlotCollection)

--- a/modules/nlu/src/backend/predict-pipeline.ts
+++ b/modules/nlu/src/backend/predict-pipeline.ts
@@ -486,6 +486,7 @@ function MapStepToOutput(step: PredictStep, startTime: number): PredictOutput {
     } as sdk.NLU.Entity
   }
 
+  // legacy pre-ndu
   const entities = step.utterance.entities
     .map(e => ({
       ...e,
@@ -506,7 +507,7 @@ function MapStepToOutput(step: PredictStep, startTime: number): PredictOutput {
         source: s.source,
         value: s.value,
         entity: entitiesMapper(s.entity)
-      } as sdk.NLU.Slot
+      }
     }
   }, {} as sdk.NLU.SlotCollection)
 

--- a/modules/nlu/src/backend/predict-pipeline.ts
+++ b/modules/nlu/src/backend/predict-pipeline.ts
@@ -464,10 +464,9 @@ async function extractSlots(input: PredictStep, predictors: Predictors): Promise
 }
 
 function MapStepToOutput(step: PredictStep, startTime: number): PredictOutput {
-  function entitiesMapper(e?: EntityExtractionResult | UtteranceEntity): sdk.NLU.Entity {
+  const entitiesMapper = (e?: EntityExtractionResult | UtteranceEntity): sdk.NLU.Entity => {
     if (!e) {
-      // tslint:disable:no-null-keyword
-      return null
+      return eval('null')
     }
 
     return {

--- a/modules/nlu/src/backend/predict-pipeline.ts
+++ b/modules/nlu/src/backend/predict-pipeline.ts
@@ -466,6 +466,7 @@ async function extractSlots(input: PredictStep, predictors: Predictors): Promise
 function MapStepToOutput(step: PredictStep, startTime: number): PredictOutput {
   function entitiesMapper(e?: EntityExtractionResult | UtteranceEntity): sdk.NLU.Entity {
     if (!e) {
+      // tslint:disable:no-null-keyword
       return null
     }
 

--- a/modules/nlu/src/backend/predict-pipeline.ts
+++ b/modules/nlu/src/backend/predict-pipeline.ts
@@ -464,9 +464,9 @@ async function extractSlots(input: PredictStep, predictors: Predictors): Promise
 }
 
 function MapStepToOutput(step: PredictStep, startTime: number): PredictOutput {
-  function entitiesMapper(e?: EntityExtractionResult | UtteranceEntity): sdk.NLU.Entity | undefined {
+  function entitiesMapper(e?: EntityExtractionResult | UtteranceEntity): sdk.NLU.Entity {
     if (!e) {
-      return
+      return null
     }
 
     return {

--- a/modules/nlu/src/backend/predict-pipeline.ts
+++ b/modules/nlu/src/backend/predict-pipeline.ts
@@ -466,7 +466,7 @@ async function extractSlots(input: PredictStep, predictors: Predictors): Promise
 function MapStepToOutput(step: PredictStep, startTime: number): PredictOutput {
   const entitiesMapper = (e?: EntityExtractionResult) => {
     if (!e) {
-      return
+      return e
     }
 
     return {
@@ -506,7 +506,7 @@ function MapStepToOutput(step: PredictStep, startTime: number): PredictOutput {
         name: s.name,
         source: s.source,
         value: s.value,
-        entity: entitiesMapper(s.entity)
+        entity: entitiesMapper(s.entity) // TODO: add this mapper to the legacy election pipeline
       }
     }
   }, {} as sdk.NLU.SlotCollection)

--- a/modules/nlu/src/backend/slots/slot-tagger.test.ts
+++ b/modules/nlu/src/backend/slots/slot-tagger.test.ts
@@ -2,6 +2,7 @@ import { BIO, ExtractedEntity, ExtractedSlot, Intent } from '../typings'
 import Utterance, { makeTestUtterance } from '../utterance/utterance'
 
 import { labelizeUtterance, makeExtractedSlots, TagResult } from './slot-tagger'
+import _ from 'lodash'
 
 describe('Slot tagger labels for utterance', () => {
   test('without slots', () => {
@@ -103,13 +104,16 @@ describe('makeExtractedSlots', () => {
       { name: 'threath', probability: 1, tag: BIO.INSIDE }
     )
     const value = 'Artificial Intelligence'
-    u.tagEntity({ type: 'CS_Field', value } as ExtractedEntity, 19, 21)
+    const entity = { type: 'CS_Field', value, confidence: 0.42, sensitive: false, metadata: {} } as ExtractedEntity
+    u.tagEntity(entity, 19, 21)
 
     const extractedSlots = makeExtractedSlots(testIntent, u, tagResults)
-
     expect(extractedSlots.length).toEqual(1)
     expect(extractedSlots[0].slot.source).toEqual('big AI')
     expect(extractedSlots[0].slot.value).toEqual(value)
+
+    const actualEntity = _.omit(extractedSlots[0].slot.entity, "start", "end")
+    expect(actualEntity).toEqual(entity)
   })
 
   test('slot with entities but not set in intent def keeps source as value', () => {
@@ -124,6 +128,7 @@ describe('makeExtractedSlots', () => {
     const extractedSlots = makeExtractedSlots(testIntent, u, tagResults)
 
     expect(extractedSlots.length).toEqual(1)
+    expect(extractedSlots[0].slot.entity).toBeUndefined()
     expect(extractedSlots[0].slot.source).toEqual('is watching')
     expect(extractedSlots[0].slot.value).toEqual('is watching')
   })

--- a/modules/nlu/src/backend/slots/slot-tagger.test.ts
+++ b/modules/nlu/src/backend/slots/slot-tagger.test.ts
@@ -1,8 +1,9 @@
+import _ from 'lodash'
+
 import { BIO, ExtractedEntity, ExtractedSlot, Intent } from '../typings'
 import Utterance, { makeTestUtterance } from '../utterance/utterance'
 
 import { labelizeUtterance, makeExtractedSlots, TagResult } from './slot-tagger'
-import _ from 'lodash'
 
 describe('Slot tagger labels for utterance', () => {
   test('without slots', () => {
@@ -112,7 +113,7 @@ describe('makeExtractedSlots', () => {
     expect(extractedSlots[0].slot.source).toEqual('big AI')
     expect(extractedSlots[0].slot.value).toEqual(value)
 
-    const actualEntity = _.omit(extractedSlots[0].slot.entity, "start", "end")
+    const actualEntity = _.omit(extractedSlots[0].slot.entity, 'start', 'end')
     expect(actualEntity).toEqual(entity)
   })
 

--- a/modules/nlu/src/backend/slots/slot-tagger.test.ts
+++ b/modules/nlu/src/backend/slots/slot-tagger.test.ts
@@ -109,6 +109,7 @@ describe('makeExtractedSlots', () => {
     u.tagEntity(entity, 19, 21)
 
     const extractedSlots = makeExtractedSlots(testIntent, u, tagResults)
+
     expect(extractedSlots.length).toEqual(1)
     expect(extractedSlots[0].slot.source).toEqual('big AI')
     expect(extractedSlots[0].slot.value).toEqual(value)

--- a/modules/nlu/src/backend/slots/slot-tagger.ts
+++ b/modules/nlu/src/backend/slots/slot-tagger.ts
@@ -122,7 +122,7 @@ export function makeExtractedSlots(
       )
       if (associatedEntityInRange) {
         extracted.slot.entity = {
-          ..._.omit(associatedEntityInRange, "startPos", "endPos", "startTokenIdx", "endTokenIdx"),
+          ..._.omit(associatedEntityInRange, 'startPos', 'endPos', 'startTokenIdx', 'endTokenIdx'),
           start: associatedEntityInRange.startPos,
           end: associatedEntityInRange.endPos
         }
@@ -136,7 +136,7 @@ export default class SlotTagger {
   private _crfModelFn = ''
   private _crfTagger!: sdk.MLToolkit.CRF.Tagger
 
-  constructor(private mlToolkit: typeof sdk.MLToolkit) { }
+  constructor(private mlToolkit: typeof sdk.MLToolkit) {}
 
   load(crf: Buffer) {
     this._crfModelFn = tmp.tmpNameSync()

--- a/modules/nlu/src/backend/slots/slot-tagger.ts
+++ b/modules/nlu/src/backend/slots/slot-tagger.ts
@@ -112,15 +112,20 @@ export function makeExtractedSlots(
           }
         ]
       }
-    }, [])
+    }, [] as SlotExtractionResult[])
     .map((extracted: SlotExtractionResult) => {
       const associatedEntityInRange = utterance.entities.find(
         e =>
-          ((e.startPos <= extracted.start && e.endPos >= extracted.end) || // entity is fully within the tagged slot
-            (e.startPos >= extracted.start && e.endPos <= extracted.end)) && // slot is fully contained by an entity
+          ((e.startPos <= extracted.start && e.endPos >= extracted.end) || // slot is fully contained by an entity
+            (e.startPos >= extracted.start && e.endPos <= extracted.end)) && // entity is fully within the tagged slot
           _.includes(intent.slot_entities, e.type) // entity is part of the possible entities
       )
       if (associatedEntityInRange) {
+        extracted.slot.entity = {
+          ..._.omit(associatedEntityInRange, "startPos", "endPos", "startTokenIdx", "endTokenIdx"),
+          start: associatedEntityInRange.startPos,
+          end: associatedEntityInRange.endPos
+        }
         extracted.slot.value = associatedEntityInRange.value
       }
       return extracted
@@ -131,7 +136,7 @@ export default class SlotTagger {
   private _crfModelFn = ''
   private _crfTagger!: sdk.MLToolkit.CRF.Tagger
 
-  constructor(private mlToolkit: typeof sdk.MLToolkit) {}
+  constructor(private mlToolkit: typeof sdk.MLToolkit) { }
 
   load(crf: Buffer) {
     this._crfModelFn = tmp.tmpNameSync()

--- a/modules/nlu/src/backend/typings.ts
+++ b/modules/nlu/src/backend/typings.ts
@@ -10,12 +10,6 @@ export const BIO = {
 
 export type Tag = 'o' | 'B' | 'I'
 
-export interface KnownSlot extends sdk.NLU.SlotDefinition {
-  start: number
-  end: number
-  source: string
-}
-
 export type Token2Vec = { [token: string]: number[] }
 
 export interface Gateway {
@@ -122,7 +116,7 @@ export type ListEntityModel = {
   cache?: EntityCache | EntityCacheDump
 }
 
-export type ExtractedSlot = { confidence: number; name: string; source: string; value: any }
+export type ExtractedSlot = { confidence: number; name: string; source: string; value: any; entity?: EntityExtractionResult }
 export type SlotExtractionResult = { slot: ExtractedSlot; start: number; end: number }
 export type ExtractedEntity = {
   confidence: number

--- a/modules/nlu/src/backend/typings.ts
+++ b/modules/nlu/src/backend/typings.ts
@@ -116,7 +116,14 @@ export type ListEntityModel = {
   cache?: EntityCache | EntityCacheDump
 }
 
-export type ExtractedSlot = { confidence: number; name: string; source: string; value: any; entity?: EntityExtractionResult }
+export type ExtractedSlot = {
+  confidence: number
+  name: string
+  source: string
+  value: any
+  entity?: EntityExtractionResult
+}
+
 export type SlotExtractionResult = { slot: ExtractedSlot; start: number; end: number }
 export type ExtractedEntity = {
   confidence: number

--- a/modules/nlu/src/backend/utterance/utterance.ts
+++ b/modules/nlu/src/backend/utterance/utterance.ts
@@ -47,8 +47,8 @@ export type UtteranceToken = Readonly<{
 export const DefaultTokenToStringOptions: TokenToStringOptions = { lowerCase: false, realSpaces: true, trim: false }
 
 export default class Utterance {
-  public slots: ReadonlyArray<UtteranceRange & UtteranceSlot> = []
-  public entities: ReadonlyArray<UtteranceRange & UtteranceEntity> = []
+  public slots: ReadonlyArray<UtteranceSlot> = []
+  public entities: ReadonlyArray<UtteranceEntity> = []
   private _tokens: ReadonlyArray<UtteranceToken> = []
   private _globalTfidf?: TFIDF
   private _kmeans?: sdk.MLToolkit.KMeans.KmeansResult

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -498,7 +498,7 @@ declare module 'botpress/sdk' {
     }
 
     export interface EntityBody {
-      extras: any
+      extras?: any
       value: any
       unit: string
     }
@@ -506,11 +506,11 @@ declare module 'botpress/sdk' {
     export interface EntityMeta {
       sensitive: boolean
       confidence: number
-      provider: string
+      provider?: string
       source: string
       start: number
       end: number
-      raw: any
+      raw?: any
     }
 
     export interface Slot {

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -517,7 +517,7 @@ declare module 'botpress/sdk' {
       name: string
       value: any
       source: any
-      entity: Entity
+      entity?: Entity
       confidence: number
       start: number
       end: number

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -517,7 +517,7 @@ declare module 'botpress/sdk' {
       name: string
       value: any
       source: any
-      entity?: Entity
+      entity: Entity
       confidence: number
       start: number
       end: number


### PR DESCRIPTION
I previously opened a PR with this code on `dev`, but @slvnperron asked me to open it on master instead, so I cherry-picked my way to this branch.

Made few modifications since then, like making the `entity` in the `sdk.NLU.Slot` optionnal because it is.

**Note to myself**
Once this PR is merged, pulling `master` into `dev` might not work because of conflicts. I have to make sure the new code finds its way to the legacy election pipeline.

