### PR TITLE
fix(prompts): various fixes

### DIFF
--- a/modules/builtin/src/backend/prompts/common.ts
+++ b/modules/builtin/src/backend/prompts/common.ts
@@ -4,6 +4,14 @@ const common: FormDefinition = {
   fields: [
     {
       type: 'text',
+      key: 'question',
+      translated: true,
+      maxLength: 150,
+      placeholder: 'module.builtin.messagePlaceholder',
+      label: 'message'
+    },
+    {
+      type: 'text',
       key: 'output',
       label: 'module.builtin.setValueTo',
       placeholder: 'module.builtin.setValueToPlaceholder',
@@ -12,14 +20,6 @@ const common: FormDefinition = {
         modifier: 'gi',
         replaceChar: '_'
       }
-    },
-    {
-      type: 'text',
-      key: 'question',
-      translated: true,
-      maxLength: 150,
-      placeholder: 'module.builtin.messagePlaceholder',
-      label: 'message'
     }
   ],
   advancedSettings: [
@@ -36,7 +36,7 @@ const common: FormDefinition = {
       key: 'duration',
       defaultValue: 5,
       min: 0,
-      moreInfo: { label: 'module.builtin.durationMoreInfo' },
+      // moreInfo: { label: 'module.builtin.durationMoreInfo' },
       label: 'module.builtin.duration'
     },
     {
@@ -45,7 +45,7 @@ const common: FormDefinition = {
       defaultValue: 0,
       min: 0,
       max: 10,
-      moreInfo: { label: 'module.builtin.searchBackCountMoreInfo' },
+      // moreInfo: { label: 'module.builtin.searchBackCountMoreInfo' },
       label: 'module.builtin.searchBackCount'
     },
     {
@@ -56,7 +56,7 @@ const common: FormDefinition = {
     {
       type: 'checkbox',
       key: 'confirmCancellation',
-      moreInfo: { label: 'module.builtin.confirmBeforeCancelMoreInfo' },
+      // moreInfo: { label: 'module.builtin.confirmBeforeCancelMoreInfo' },
       label: 'module.builtin.confirmBeforeCancel'
     }
   ]

--- a/modules/builtin/src/backend/prompts/confirm.ts
+++ b/modules/builtin/src/backend/prompts/confirm.ts
@@ -46,6 +46,7 @@ const config: PromptConfig = {
   type: 'confirm',
   label: 'Confirm',
   valueType: 'boolean',
+  noConfirmation: true,
   fields: common.fields,
   advancedSettings: common.advancedSettings
 }

--- a/modules/builtin/src/backend/prompts/confirm.ts
+++ b/modules/builtin/src/backend/prompts/confirm.ts
@@ -22,12 +22,19 @@ class PromptConfirm implements Prompt {
     const topConfirmation = _.chain(event.ndu.triggers)
       .values()
       .filter(val => val.trigger.name?.startsWith('prompt_'))
-      .map(x => ({ name: x.trigger.name, confidence: x.result[Object.keys(x.result)[0]] }))
+      .map(x => ({
+        name: x.trigger.name,
+        confidence: Object.values(x.result).reduce((total, conf) => total * conf)
+      }))
       .orderBy(x => x.confidence, 'desc')
       .first()
       .value()
 
-    return [{ value: topConfirmation?.name === 'prompt_yes', confidence: topConfirmation?.confidence ?? 0 }]
+    if (!topConfirmation || !['prompt_yes', 'prompt_no'].includes(topConfirmation.name)) {
+      return []
+    }
+
+    return [{ value: topConfirmation.name === 'prompt_yes', confidence: topConfirmation.confidence ?? 0 }]
   }
 
   validate(value): sdk.ValidationResult {
@@ -39,8 +46,6 @@ const config: PromptConfig = {
   type: 'confirm',
   label: 'Confirm',
   valueType: 'boolean',
-  minConfidence: 0.3,
-  noValidation: true,
   fields: common.fields,
   advancedSettings: common.advancedSettings
 }

--- a/modules/builtin/src/backend/prompts/enum.ts
+++ b/modules/builtin/src/backend/prompts/enum.ts
@@ -42,11 +42,6 @@ const config: PromptConfig = {
         labelField: 'name'
       },
       label: 'module.builtin.enum'
-    },
-    {
-      type: 'checkbox',
-      key: 'useDropdown',
-      label: 'module.builtin.useDropdown'
     }
   ],
   advancedSettings: common.advancedSettings

--- a/modules/builtin/src/backend/prompts/string.ts
+++ b/modules/builtin/src/backend/prompts/string.ts
@@ -40,6 +40,7 @@ const config: PromptConfig = {
   label: 'String',
   valueType: 'string',
   fields: common.fields,
+  noConfirmation: true,
   advancedSettings: [
     {
       type: 'number',

--- a/modules/channel-slack/src/backend/client.ts
+++ b/modules/channel-slack/src/backend/client.ts
@@ -265,15 +265,13 @@ export class SlackClient {
               type: 'plain_text',
               text: payload.message || 'empty'
             },
-            options: _.isArray(__dropdown)
-              ? __dropdown
-              : __dropdown.options.map(q => ({
-                  text: {
-                    type: 'plain_text',
-                    text: q.label
-                  },
-                  value: q.value
-                }))
+            options: (_.isArray(__dropdown) ? __dropdown : __dropdown.options).map(q => ({
+              text: {
+                type: 'plain_text',
+                text: q.label
+              },
+              value: q.value
+            }))
           }
         ]
       })

--- a/modules/ndu/src/backend/ndu-engine.ts
+++ b/modules/ndu/src/backend/ndu-engine.ts
@@ -456,6 +456,16 @@ export class UnderstandingEngine {
             // TODO: Add triggers on the node itself instead of hardcoded here
             ln.triggers = [
               {
+                name: 'prompt_yes',
+                effect: 'prompt.inform',
+                conditions: [{ id: 'user_intent_yes' }]
+              },
+              {
+                name: 'prompt_no',
+                effect: 'prompt.inform',
+                conditions: [{ id: 'user_intent_no' }]
+              },
+              {
                 name: 'prompt_inform',
                 effect: 'prompt.inform',
                 conditions: [

--- a/src/bp/common/variables.ts
+++ b/src/bp/common/variables.ts
@@ -18,7 +18,7 @@ export class BaseVariable<T, V = any> implements BoxedVariable<T, V> {
     this._config = config
     this._getEnumList = getEnumList
 
-    if (value) {
+    if (value !== undefined) {
       this.trySet(value, confidence ?? 1)
     }
   }

--- a/src/bp/core/services/dialog/janitor.ts
+++ b/src/bp/core/services/dialog/janitor.ts
@@ -80,8 +80,8 @@ export class DialogJanitor extends Janitor {
 
       await this.stateManager.restore(fakeEvent)
 
-      if (fakeEvent.state.session?.prompt) {
-        await this.promptManager.processTimeout(fakeEvent)
+      if (fakeEvent.state.context?.activePrompt) {
+        await this.dialogEngine.processTimeout(sessionId, botId, fakeEvent, true)
       }
 
       await this.sessionRepo.clearPromptTimeoutForSession(sessionId)

--- a/src/bp/core/services/dialog/prompt-manager.ts
+++ b/src/bp/core/services/dialog/prompt-manager.ts
@@ -170,9 +170,13 @@ export class PromptManager {
       .first()
       .value()
 
+    if (status.stage !== 'new') {
+      status.turn++
+    }
+
     if (status.stage === 'confirm-cancel') {
       if (event.ndu?.actions?.find(x => x.action === 'prompt.cancel') || confirmValue?.value === true) {
-        this._setCurrentNodeValue(event, 'cancelled', true) // TODO: move this to engine instead
+        actions.push({ type: 'cancel' })
         return generateRejected(actions, status, 'cancelled')
       }
     }
@@ -286,19 +290,8 @@ export class PromptManager {
     return generatePrompt(actions, status)
   }
 
-  private _setCurrentNodeValue(event: IO.IncomingEvent, variable: string, value: any) {
-    // TODO: move to dialog engine
-    _.set(event.state.temp, `[${event.state.context.currentNode!}].${variable}`, value)
-  }
-
   private _electSlot(event: IO.IncomingEvent, slotName: string) {
     _.set(event.state.session, `slots.${slotName}.elected`, true)
-  }
-
-  public async processTimeout(event) {
-    // TODO: move to dialog engine
-    this._setCurrentNodeValue(event, 'timeout', true)
-    return event
   }
 
   private loadPrompt(type: string, params: any): Prompt {

--- a/src/bp/core/services/dialog/prompt-manager.ts
+++ b/src/bp/core/services/dialog/prompt-manager.ts
@@ -158,7 +158,7 @@ export class PromptManager {
     const tryElect = (value: any): boolean => {
       const { valid, message } = prompt.validate(value)
       if (!valid) {
-        actions.push({ type: 'say', message: message || 'THIS IS THE BUG' })
+        actions.push({ type: 'say', message })
       }
       return valid
     }
@@ -272,7 +272,7 @@ export class PromptManager {
     } else if (shortlisted.length > 1) {
       return generateDisambiguate(actions, status, shortlisted)
     } else {
-      if (others.length === 1) {
+      if (others.length === 1 && !this.prompts.find(x => x.id === status.config.type)?.config.noConfirmation) {
         return generateCandidate(actions, status, others[0])
       } else if (others.length > 1) {
         return generateDisambiguate(actions, status, others)

--- a/src/bp/core/services/middleware/dialog-store.ts
+++ b/src/bp/core/services/middleware/dialog-store.ts
@@ -79,10 +79,6 @@ export class DialogStore {
     }
   }
 
-  public getPrompts(): sdk.PromptDefinition[] {
-    return this._prompts
-  }
-
   public getEnumForBot(botId: string, enumType?: string): sdk.NLU.EntityDefOccurrence[] | undefined {
     return this._enums[botId]?.find(x => x.id === enumType)?.occurrences
   }

--- a/src/bp/core/services/middleware/dialog-store.ts
+++ b/src/bp/core/services/middleware/dialog-store.ts
@@ -91,6 +91,10 @@ export class DialogStore {
     return this._wfVariables[botId]?.[wfName]?.find(x => x.name === varName)
   }
 
+  public getPromptConfig(type: string): sdk.PromptConfig | undefined {
+    return this._prompts.find(x => x.id === type)?.config
+  }
+
   private async _reloadEnums(botId: string) {
     const enumFiles = await this.ghost.forBot(botId).directoryListing(ENUMS_DIR, '*.json')
 

--- a/src/bp/core/services/middleware/state-manager.ts
+++ b/src/bp/core/services/middleware/state-manager.ts
@@ -208,12 +208,7 @@ export class StateManager {
     const dialogSession = await this.sessionRepo.getOrCreateSession(sessionId, event.botId, trx)
     const expiry = createExpiry(botConfig, botpressConfig)
 
-    // Deletes the prompt after the event is stored, so we have traces in the debugger
-    if (session?.prompt?.status?.extracted) {
-      delete session.prompt
-    }
-
-    if (session?.prompt?.status?.turns === 1) {
+    if (context?.activePrompt?.turn === 0) {
       dialogSession.prompt_expiry = expiry.prompt
     }
 

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -779,7 +779,7 @@ declare module 'botpress/sdk' {
     }
 
     export interface DialogAction {
-      type: 'say' | 'listen'
+      type: 'say' | 'listen' | 'cancel'
       message?: MultiLangText | string
       payload?: any
       eventType?: string

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -1612,7 +1612,7 @@ declare module 'botpress/sdk' {
   }
 
   /** The configuration of the prompt which is saved on the flow */
-  export type PromptConfig = {
+  export interface PromptConfig {
     /** An ID used internally to refer to this prompt */
     type: string
     /** The label displayed in the studio */
@@ -1620,7 +1620,12 @@ declare module 'botpress/sdk' {
     icon?: string
     /** The ID representing the type of value that is collected by this prompt */
     valueType: string
-  } & FormDefinition
+    /** Will never trigger a confirmation for a previous value */
+    noConfirmation?: boolean
+    /** Fields to configure the prompt on the studio */
+    fields: FormField[]
+    advancedSettings: FormField[]
+  }
 
   export interface PromptNode {
     type: string

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -785,7 +785,7 @@ declare module 'botpress/sdk' {
       eventType?: string
     }
 
-    export type PromptConfiguration = { type: string } & PromptNodeParams
+    export type PromptConfiguration = { type: string; valueType?: string } & PromptNodeParams
 
     export interface PromptCandidate {
       source: 'slot' | 'prompt'
@@ -1619,13 +1619,7 @@ declare module 'botpress/sdk' {
     label?: string
     icon?: string
     /** The ID representing the type of value that is collected by this prompt */
-    valueType?: string
-    /** A list of ID represented by the type of values collected by this prompt */
-    valueTypes?: string[]
-    /** The minimum confidence required for the value to be considered valid */
-    minConfidence?: number
-    /** Whatever happens, the prompt will never ask the user to validate the provided value */
-    noValidation?: boolean
+    valueType: string
   } & FormDefinition
 
   export interface PromptNode {


### PR DESCRIPTION
- Only fetching last events on the first stage (new)
- Fix "confirm" prompt (intent wasn't triggered & garbage amounted to a "no")
- Fix turn count which wasn't working (always 1)
- Fix an empty search back count which fetched like 200 events
- Fix timeout which stopped working
- Commented "more info" labels temporarily for prompts 
- Various cleanup