### PR TITLE
feat: added command to build specific modules

### DIFF
--- a/build/gulp.modules.js
+++ b/build/gulp.modules.js
@@ -93,7 +93,21 @@ const buildModuleBuilder = cb => {
 }
 
 const buildModules = () => {
-  const modules = getAllModulesRoot()
+  const allModules = getAllModulesRoot()
+
+  const command = process.argv[process.argv.length - 2]
+  const moduleArgs = process.argv[process.argv.length - 1].split(',')
+
+  let moduleFilter = m => true
+  if (command === '--m') {
+    moduleFilter = m => moduleArgs.includes(m)
+  } else if (command === '--a') {
+    // if command="--a nlu" we match nlu, nlu-testing and nlu-extras
+    moduleFilter = m => moduleArgs.some(arg => !!m.match(new RegExp(`${arg}`)))
+  }
+
+  const modules = allModules.filter(m => moduleFilter(path.basename(m)))
+
   const tasks = modules.map(m => {
     const config = readModuleConfig(m)
     const moduleName = _.get(config, 'name', 'Unknown')

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,12 +26,16 @@ gulp.task('default', cb => {
   console.log(`
     Development Cheat Sheet
     ==================================
-    yarn cmd dev:modules  Creates a symlink to modules bundles (restart server to apply backend changes - refresh for UI)
-                          After this command, type "yarn watch" in each module folder you want to watch for changes
-    yarn cmd watch:core   Recompiles the server on file modification (restart server to apply)
-    yarn cmd watch:studio Recompiles the bundle on file modification (no restart required - refresh page manually)
-    yarn cmd watch:admin  Recompiles the bundle on file modification (no restart required - page refresh automatically)
-    yarn cmd watch:shared Recompiles the bundle on file modification (no restart required - refresh page manually)
+    yarn cmd dev:modules                Creates a symlink to modules bundles (restart server to apply backend changes - refresh for UI)
+                                        After this command, type "yarn watch" in each module folder you want to watch for changes
+    yarn cmd watch:core                 Recompiles the server on file modification (restart server to apply)
+    yarn cmd watch:studio               Recompiles the bundle on file modification (no restart required - refresh page manually)
+    yarn cmd watch:admin                Recompiles the bundle on file modification (no restart required - page refresh automatically)
+    yarn cmd watch:shared               Recompiles the bundle on file modification (no restart required - refresh page manually)
+    yarn cmd build:modules --m m1,m2,m3 Builds modules m1, m2 and m3 only
+                                        Here m1 is the module name like nlu
+                                        Modules are separated with a comma (,) and no spaces
+    yarn cmd build:modules --a m1       Builds all modules that matches *m1*
   `)
   cb()
 })


### PR DESCRIPTION
Added cli options to build specific modules.

The command looks like this:

```
yarn cmd build:modules    // already exists, build all modules
```
```
yarn cmd build:modules --m nlu,nlu-testing    // new, builds only nlu and nlu-testing
```
```
yarn cmd build:modules --a nlu    // also new, builds nlu, nlu-testing, nlu-extras and every modules that matches nlu
```