### PR TITLE
feat(core): handle new content type translations

### DIFF
--- a/modules/builtin/src/content-types/card.js
+++ b/modules/builtin/src/content-types/card.js
@@ -33,8 +33,7 @@ module.exports = {
     }
   },
 
-  uiSchema: {
-  },
+  uiSchema: {},
 
   newSchema: {
     displayedIn: ['qna', 'sayNode'],
@@ -120,7 +119,7 @@ module.exports = {
                 related: {
                   placeholder: 'module.builtin.types.actionButton.urlPlaceholder',
                   type: 'url',
-                  key: 'text',
+                  key: 'url',
                   translated: true,
                   label: 'URL'
                 }
@@ -131,7 +130,7 @@ module.exports = {
                 related: {
                   type: 'textarea',
                   translated: true,
-                  key: 'text',
+                  key: 'payload',
                   label: 'module.builtin.types.actionButton.postFieldLabel'
                 }
               }

--- a/src/bp/core/services/cms.ts
+++ b/src/bp/core/services/cms.ts
@@ -598,12 +598,27 @@ export class CMSService implements IDisposeOnExit {
       }
 
       if (field.fields) {
+        let fields = field.fields
+
+        for (const subfield of field.fields) {
+          if (subfield.options) {
+            for (const option of subfield.options) {
+              if (option.related) {
+                if (fields === field.fields) {
+                  fields = [...field.fields]
+                }
+                fields.push(option.related)
+              }
+            }
+          }
+        }
+
         if (field.type === 'group') {
           for (const item of current[field.key]) {
-            this.applyTranslations(item, field.fields, lang, defaultLang)
+            this.applyTranslations(item, fields, lang, defaultLang)
           }
         } else {
-          this.applyTranslations(current[field.key], field.fields, lang, defaultLang)
+          this.applyTranslations(current[field.key], fields, lang, defaultLang)
         }
       }
     }

--- a/src/bp/core/services/dialog/queue-builder.ts
+++ b/src/bp/core/services/dialog/queue-builder.ts
@@ -57,7 +57,7 @@ export class InstructionsQueueBuilder {
 
       if (this.currentNode.type === 'say_something' && this.currentNode.contents?.length) {
         this.currentNode.contents.forEach(content => {
-          const { contentType } = content[Object.keys(content)[0]]
+          const { contentType } = content
 
           this._queue.enqueue({
             type: 'on-enter',


### PR DESCRIPTION
This should fix all problems with the new content types schemas and translations (most schema fixes are in `max-fix-content-text-lang`).

The current code isn't backward compatibles with older stuff so I'll need to make a migration or reintegrate some bits of the old code to make everything work.