### PR TITLE
fix(prompts): fix jump, pattern, string

### DIFF
--- a/modules/builtin/src/backend/prompts/common.ts
+++ b/modules/builtin/src/backend/prompts/common.ts
@@ -51,6 +51,7 @@ const common: FormDefinition = {
     {
       type: 'checkbox',
       key: 'cancellable',
+      defaultValue: true,
       label: 'Prompt can be cancelled'
     },
     {

--- a/modules/builtin/src/backend/prompts/string.ts
+++ b/modules/builtin/src/backend/prompts/string.ts
@@ -12,14 +12,18 @@ class PromptString implements Prompt {
 
   extraction(event: IO.IncomingEvent): ExtractionResult[] {
     const text = event.payload.text
-    if (text) {
-      return [
-        {
-          value: text,
-          confidence: 1
-        }
-      ]
+
+    // Do not extract on the first turn
+    if (!event.state.context.activePrompt?.turn || !text) {
+      return []
     }
+
+    return [
+      {
+        value: text,
+        confidence: 1
+      }
+    ]
   }
 
   validate(value): ValidationResult {


### PR DESCRIPTION
- Fix error message when no valid information was extracted from the text
- Fix cancelling the "jump to" confirmation dialog
- Fix pattern extractor
- Making prompts cancellable by default
- Fix string extraction