### PR TITLE
fix(core): allowoverride import generates duplicate bots in workspace

### DIFF
--- a/src/bp/core/services/workspace-service.ts
+++ b/src/bp/core/services/workspace-service.ts
@@ -73,7 +73,9 @@ export class WorkspaceService {
       throw new Error(`Specified workspace "${workspaceId}" doesn't exist`)
     }
 
-    workspace.bots.push(botId)
+    if (!workspace.bots.includes(botId))  {
+      workspace.bots.push(botId)
+    }
     return this.save(workspaces)
   }
 

--- a/src/bp/core/services/workspace-service.ts
+++ b/src/bp/core/services/workspace-service.ts
@@ -73,7 +73,7 @@ export class WorkspaceService {
       throw new Error(`Specified workspace "${workspaceId}" doesn't exist`)
     }
 
-    if (!workspace.bots.includes(botId))  {
+    if (!workspace.bots.includes(botId)) {
       workspace.bots.push(botId)
     }
     return this.save(workspaces)


### PR DESCRIPTION
When we import an existing bot with allowoverride option, it genrates duplicate botId in the workspace's bots array.

The impact of this bug is it creates multiple webhooks for the same channel and the same bot (see screenshots). Also it tries to create multiple shortlink.

![image](https://user-images.githubusercontent.com/20561190/87367962-ab5f7d80-c57c-11ea-8e06-50ec17a5e2f8.png)

![image](https://user-images.githubusercontent.com/20561190/87367979-b4504f00-c57c-11ea-8a1e-eb4e86d7427e.png)
