### PR TITLE
fix(core): small fixes for debugger & lifecycle

### DIFF
--- a/modules/channel-slack/src/backend/client.ts
+++ b/modules/channel-slack/src/backend/client.ts
@@ -132,6 +132,8 @@ export class SlackClient {
         })
       }
     })
+
+    com.on('error', err => this.bp.logger.attachError(err).error(`An error occurred`))
   }
 
   private async _getUserInfo(userId: string) {

--- a/modules/extensions/src/views/lite/components/debugger/index.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/index.tsx
@@ -54,7 +54,6 @@ export class Debugger extends React.Component<Props, State> {
   }
   allowedRetryCount = 0
   currentRetryCount = 0
-  retryTimer: number
   loadEventDebounced = _.debounce(m => this.loadEvent(m), DEBOUNCE_DELAY)
   lastMessage = undefined
 
@@ -153,43 +152,27 @@ export class Debugger extends React.Component<Props, State> {
     }
   }
 
-  loadEvent = async eventId => {
+  loadEvent = async (eventId: string) => {
     if (this.state.unauthorized) {
       return
     }
 
-    clearInterval(this.retryTimer)
-    const event = await this.fetchEvent(eventId)
-    if (!event) {
-      this.setState({ fetching: true })
-
-      this.retryTimer = window.setInterval(async () => {
-        await this.retryLoadEvent(eventId)
-      }, RETRY_PERIOD)
-    }
-    this.setState({ event })
-    this.props.store.view.setHighlightedMessages(eventId)
-  }
-
-  retryLoadEvent = async eventId => {
-    const event = await this.fetchEvent(eventId)
-    this.currentRetryCount++
-
-    if (!event && this.currentRetryCount < this.allowedRetryCount) {
-      return
-    }
-
-    clearInterval(this.retryTimer)
-    this.currentRetryCount = 0
-    this.setState({ event, showEventNotFound: !event, fetching: false })
-  }
-
-  fetchEvent = async eventId => {
     try {
-      const { data } = await this.props.store.bp.axios.get('/mod/extensions/events/' + eventId)
-      return data
+      const { data: event } = await this.props.store.bp.axios.get('/mod/extensions/events/' + eventId)
+
+      this.setState({ event, showEventNotFound: !event, fetching: false })
+
+      this.props.store.view.setHighlightedMessages(eventId)
+      this.currentRetryCount = 0
     } catch (err) {
-      return
+      if (this.currentRetryCount < this.allowedRetryCount) {
+        this.currentRetryCount++
+
+        await Promise.delay(RETRY_PERIOD)
+        await this.loadEvent(eventId)
+      } else {
+        this.currentRetryCount = 0
+      }
     }
   }
 

--- a/modules/extensions/src/views/lite/components/debugger/index.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/index.tsx
@@ -1,4 +1,5 @@
 import { Icon, Tab, Tabs } from '@blueprintjs/core'
+import 'bluebird-global'
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 import ms from 'ms'
@@ -157,6 +158,8 @@ export class Debugger extends React.Component<Props, State> {
       return
     }
 
+    this.setState({ fetching: true })
+
     try {
       const { data: event } = await this.props.store.bp.axios.get('/mod/extensions/events/' + eventId)
 
@@ -172,6 +175,7 @@ export class Debugger extends React.Component<Props, State> {
         await this.loadEvent(eventId)
       } else {
         this.currentRetryCount = 0
+        this.setState({ fetching: false })
       }
     }
   }

--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -287,6 +287,7 @@ export class Botpress {
 
   @WrapErrorsWith('Error while discovering bots')
   async discoverBots(): Promise<void> {
+    await AppLifecycle.waitFor(AppLifecycleEvents.MODULES_READY)
     const botsRef = await this.workspaceService.getBotRefs()
     const botsIds = await this.botService.getBotsIds()
     const unlinked = _.difference(botsIds, botsRef)

--- a/src/bp/core/module-loader.ts
+++ b/src/bp/core/module-loader.ts
@@ -307,6 +307,8 @@ export class ModuleLoader {
         this.logger.warn(`Error in module "${name}" 'onServerReady'. Module will still be loaded. Err: ${err.message}`)
       }
     }
+
+    AppLifecycle.setDone(AppLifecycleEvents.MODULES_READY)
   }
 
   public async loadModulesForBot(botId: string) {

--- a/src/bp/lifecycle.ts
+++ b/src/bp/lifecycle.ts
@@ -5,7 +5,8 @@ export enum AppLifecycleEvents {
   HTTP_SERVER_READY = 'HTTP_SERVER_READY',
   SERVICES_READY = 'SERVICES_READY',
   CONFIGURATION_LOADED = 'CONFIGURATION_LOADED',
-  BOTPRESS_READY = 'BOTPRESS_READY'
+  BOTPRESS_READY = 'BOTPRESS_READY',
+  MODULES_READY = 'MODULES_READY'
 }
 
 type CacheEntry = { promise: Promise<void>; resolve: Function; reject: Function }


### PR DESCRIPTION
The logic to load the event on the debugger was a bit over-complicated and generated some side effects: 

- On a slow connection, the event was fetched multiple times (even if the previous request was successful)
- Sometime the event fetch went into an infinite loop and tried to load an event indefinitely

Just made it simpler.

Also added a check because since we load modules without awaiting (to keep the startup time quick), if a module took more time to load, then the bots would fail to mount because some module might not be available at that point