### PR TITLE
fix(admin) Checklist: use PRO_ENABLED instead of BP_PRODUCTION

### DIFF
--- a/src/bp/ui-admin/src/Pages/Server/Checklist/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/Checklist/index.tsx
@@ -121,7 +121,7 @@ export const Checklist: FC<Props> = props => {
           docs="https://botpress.com/docs/pro/about-pro/"
           status={getEnv('PRO_ENABLED') === 'true' || getConfig('pro.enabled') === 'true' ? 'success' : 'warning'}
           source={[
-            { type: 'env', key: 'PRO_ENABLED', value: getEnv('BP_PRODUCTION') },
+            { type: 'env', key: 'PRO_ENABLED', value: getEnv('PRO_ENABLED') },
             { type: 'env', key: 'BP_LICENSE_KEY', value: getEnv('BP_LICENSE_KEY') },
             { type: 'config', key: 'pro.enabled', value: getConfig('pro.enabled') },
             { type: 'config', key: 'pro.licenseKey', value: getConfig('pro.licenseKey') }
@@ -315,7 +315,4 @@ const mapStateToProps = state => ({
   serverConfig: state.server.serverConfig
 })
 
-export default connect(
-  mapStateToProps,
-  { fetchServerConfig }
-)(Checklist)
+export default connect(mapStateToProps, { fetchServerConfig })(Checklist)


### PR DESCRIPTION
In the checklist, the value for `PRO_ENABLED` was the value of `BP_PRODUCTION`