### PR TITLE
feat(core): diagnostic tests

### DIFF
--- a/src/bp/core/services/redis.ts
+++ b/src/bp/core/services/redis.ts
@@ -1,0 +1,54 @@
+import RedisIo, { Cluster, ClusterNode, ClusterOptions, Redis, RedisOptions } from 'ioredis'
+import _ from 'lodash'
+
+const _clients: { [key: string]: Redis } = {}
+
+export const getOrCreate = (type: 'subscriber' | 'commands' | 'socket', url?: string): Redis => {
+  if (_clients[type]) {
+    return _clients[type]
+  }
+
+  const originalPromise = global.Promise
+  try {
+    // we swap back to native promises for ioredis
+    // reason: https://github.com/luin/ioredis/blob/1d06cf4bd968fd9762b87d7cd3d756c396158ce0/lib/connectors/StandaloneConnector.ts#L54
+    // TODO: remove this workaround when ioredis supports other promises or if we get rid of bluebird-global
+    global.Promise = global['NativePromise'] || global.Promise
+
+    const RETRY_STRATEGY = times => {
+      if (times > 10) {
+        throw new Error(`Unable to connect to the Redis cluster after multiple attempts.`)
+      }
+      return Math.min(times * 200, 5000)
+    }
+
+    let redisNodes: ClusterNode[] = []
+    try {
+      redisNodes = process.env.REDIS_URL ? JSON.parse(process.env.REDIS_URL) : []
+    } catch {}
+
+    let options = {}
+    try {
+      options = process.env.REDIS_OPTIONS ? JSON.parse(process.env.REDIS_OPTIONS) : {}
+    } catch {}
+
+    const redisOptions: RedisOptions = {
+      retryStrategy: RETRY_STRATEGY
+    }
+
+    if (redisNodes.length > 0) {
+      const clusterOptions: ClusterOptions = {
+        clusterRetryStrategy: RETRY_STRATEGY,
+        redisOptions
+      }
+
+      _clients[type] = new Cluster(redisNodes, _.merge(clusterOptions, options)) as RedisIo.Cluster & RedisIo.Redis
+    } else {
+      _clients[type] = new RedisIo(url || process.env.REDIS_URL, _.merge(redisOptions, options))
+    }
+  } finally {
+    global.Promise = originalPromise
+  }
+
+  return _clients[type]
+}

--- a/src/bp/diag/index.ts
+++ b/src/bp/diag/index.ts
@@ -11,9 +11,9 @@ import { Db, Ghost } from 'core/app'
 import fse from 'fs-extra'
 import _ from 'lodash'
 
+import { getOrCreate as redisFactory } from 'core/services/redis'
 import os from 'os'
 import path from 'path'
-import { getOrCreate as redisFactory } from 'pro/services/async-redis'
 import stripAnsi from 'strip-ansi'
 
 import {

--- a/src/bp/diag/index.ts
+++ b/src/bp/diag/index.ts
@@ -27,7 +27,7 @@ import {
 } from './utils'
 
 export const OBFUSCATED = '***obfuscated***'
-export const SECRET_KEYS = ['secret', 'pw', 'password', 'token', 'key']
+export const SECRET_KEYS = ['secret', 'pw', 'password', 'token', 'key', 'cert']
 export const ENV_VARS = [
   'PORT',
   'DATABASE_URL',

--- a/src/bp/diag/index.ts
+++ b/src/bp/diag/index.ts
@@ -113,6 +113,7 @@ const testConnectivity = async () => {
 
   await wrapMethodCall('Connecting to Database', async () => {
     await Db.initialize()
+    printRow('Database Type', Db.knex.isLite ? 'SQLite' : 'Postgres')
 
     if ((await Db.knex.raw('select 1+1 as result')) === undefined) {
       throw new Error('Database error')

--- a/src/bp/diag/index.ts
+++ b/src/bp/diag/index.ts
@@ -1,0 +1,249 @@
+import 'bluebird-global'
+// tslint:disable-next-line:ordered-imports
+import '../sdk/rewire'
+// tslint:disable-next-line:ordered-imports
+
+import { BotConfig } from 'botpress/sdk'
+
+import { Workspace } from 'common/typings'
+import { Db, Ghost } from 'core/app'
+
+import fse from 'fs-extra'
+import _ from 'lodash'
+
+import os from 'os'
+import path from 'path'
+import { getOrCreate as redisFactory } from 'pro/services/async-redis'
+import stripAnsi from 'strip-ansi'
+
+import {
+  printHeader,
+  printObject,
+  printRow,
+  printSub,
+  testWebsiteAccess,
+  testWriteAccess,
+  wrapMethodCall
+} from './utils'
+
+export const OBFUSCATED = '***obfuscated***'
+export const SECRET_KEYS = ['secret', 'pw', 'password', 'token', 'key']
+export const ENV_VARS = [
+  'PORT',
+  'DATABASE_URL',
+  'DATABASE_POOL',
+  'EXTERNAL_URL',
+  'NODE_PATH',
+  'NODE_ENV',
+  'BPFS_STORAGE',
+  'NATIVE_EXTENSIONS_DIR',
+  'REDIS_URL',
+  'PRO_ENABLED',
+  'CLUSTER_ENABLED',
+  'AUTO_MIGRATE',
+  'REVERSE_PROXY',
+  'APP_DATA_PATH',
+  'USE_REDIS_STATE',
+  'DISABLE_GLOBAL_SANDBOX',
+  'DISABLE_BOT_SANDBOX',
+  'DISABLE_TRANSITION_SANDBOX',
+  'FORCE_TRAIN_ON_MOUNT',
+  'VERBOSITY_LEVEL',
+  'DEBUG',
+  'PG_HOST',
+  'PG_PORT',
+  'DEBUG_LOGGER',
+  'HOME',
+  'APPDATA',
+  'SKIP_MIGRATIONS',
+  'MONITORING_INTERVAL',
+  'REDIS_OPTIONS',
+  'TZ',
+  'LANG',
+  'LC_ALL',
+  'LC_TYPE',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'NO_PROXY'
+]
+
+const PASSWORD_REGEX = new RegExp(/(.*):(.*)@(.*)/)
+
+let includePasswords = false
+let botpressConfig = undefined
+let outputFile = undefined
+
+export const print = (text: string) => {
+  console.log(text)
+
+  if (outputFile) {
+    fse.appendFileSync(outputFile!, stripAnsi(text) + os.EOL, 'utf8')
+  }
+}
+
+const printModulesConfig = async (botId?: string) => {
+  const ghost = botId ? Ghost.forBot(botId) : Ghost.global()
+  const configs = await ghost.directoryListing('config/', '*.json')
+
+  await Promise.mapSeries(configs, async file => {
+    printSub(`${botId ? `Bot ${botId}` : 'Global'} - Module ${path.basename(file, '.json')}`)
+    printObject(await ghost.readFileAsObject<any>('./config', file), includePasswords)
+  })
+}
+
+const printGeneralInfos = () => {
+  printHeader('General')
+  printRow('Botpress Version', process.BOTPRESS_VERSION)
+  printRow('Node Version', process.version.substr(1))
+  printRow('Running Binary', process.pkg ? 'Yes' : 'No')
+  printRow('Enterprise', process.IS_PRO_AVAILABLE ? (process.IS_PRO_ENABLED ? 'Enabled' : 'Available') : 'Unavailable')
+  printRow('Hostname', os.hostname())
+  printRow(
+    'Host Information',
+    `${process.distro} with ${os.cpus().length} CPUs and ${_.round(os.totalmem() / (1024 * 1024 * 1024))} GB RAM`
+  )
+
+  testWriteAccess('Executable Location', process.PROJECT_LOCATION)
+  testWriteAccess('Data Folder', path.resolve(process.PROJECT_LOCATION, 'data'))
+  testWriteAccess('App Data Folder', process.APP_DATA_PATH)
+}
+
+const testConnectivity = async () => {
+  printHeader('Connectivity ')
+
+  await wrapMethodCall('Connecting to Database', async () => {
+    await Db.initialize()
+
+    if ((await Db.knex.raw('select 1+1 as result')) === undefined) {
+      throw new Error('Database error')
+    }
+
+    const useDbDriver = process.BPFS_STORAGE === 'database'
+    await Ghost.initialize(useDbDriver)
+  })
+
+  if (process.env.CLUSTER_ENABLED && redisFactory) {
+    await wrapMethodCall('Connecting to Redis', async () => {
+      const client = redisFactory('commands')
+
+      if ((await client.ping().timeout(1000)) !== 'PONG') {
+        throw new Error('Server down')
+      }
+    })
+  }
+}
+
+const testNetworkConnections = async () => {
+  printHeader('Network Connections')
+
+  const hosts = [
+    {
+      label: 'Google (external access)',
+      url: 'https://google.com'
+    },
+    {
+      label: 'Licensing Server',
+      url: 'https://license.botpress.io/prices'
+    }
+  ]
+
+  try {
+    const nluConfig = await Ghost.global().readFileAsObject<any>('config/', 'nlu.json')
+    const duckling = process.env.BP_MODULE_NLU_DUCKLINGURL || nluConfig?.ducklingURL
+    const langServer = process.env.BP_MODULE_NLU_LANGUAGESOURCES || nluConfig?.languageSources?.[0]?.endpoint
+
+    if (duckling) {
+      hosts.push({ label: 'Duckling Server', url: duckling })
+    }
+
+    if (langServer) {
+      hosts.push({ label: 'Language Server', url: `${langServer}/languages` })
+    }
+  } catch (err) {}
+
+  await Promise.map(hosts, host => testWebsiteAccess(host.label, host.url))
+}
+
+const printDatabaseTables = async () => {
+  let tables
+  if (Db.knex.isLite) {
+    tables = await Db.knex.raw("SELECT name FROM sqlite_master WHERE type='table'").then(res => res.map(x => x.name))
+  } else {
+    tables = await Db.knex('pg_catalog.pg_tables')
+      .select('tablename')
+      .where({ schemaname: 'public' })
+      .then(res => res.map(x => x.tablename))
+  }
+
+  printHeader('Database Tables')
+  print(tables.sort().join(', '))
+}
+
+const listEnvironmentVariables = () => {
+  printHeader('Environment Variables')
+
+  const env = [...ENV_VARS, ...Object.keys(process.env).filter(x => x.startsWith('BP_') || x.startsWith('EXPOSED_'))]
+
+  env
+    .sort()
+    .filter(x => process.env[x] !== undefined)
+    .map(key => {
+      let value = process.env[key]!
+
+      if (!includePasswords) {
+        if (PASSWORD_REGEX.test(value)) {
+          value = value.replace(PASSWORD_REGEX, `$1:${OBFUSCATED}@$3`)
+        } else if (SECRET_KEYS.find(x => key.toLowerCase().includes(x))) {
+          value = OBFUSCATED
+        }
+      }
+
+      printRow(key, value)
+    })
+}
+
+const printConfig = async () => {
+  printHeader('Botpress Config')
+  printObject(botpressConfig, includePasswords)
+
+  printHeader('Module Configuration')
+  await printModulesConfig()
+}
+
+const printBotsList = async () => {
+  const workspaces = await Ghost.global().readFileAsObject<Workspace[]>('/', `workspaces.json`)
+  const botIds = (await Ghost.bots().directoryListing('/', 'bot.config.json')).map(path.dirname)
+
+  await Promise.mapSeries(botIds, async botId => {
+    printHeader(`Bot "${botId}" (workspace: ${workspaces.find(x => x.bots.includes(botId))?.id})`)
+
+    const botConfig = await Ghost.forBot(botId).readFileAsObject<BotConfig>('/', 'bot.config.json')
+    printObject(botConfig, includePasswords)
+
+    await printModulesConfig(botId)
+  })
+}
+
+export default async function(options) {
+  includePasswords = options.includePasswords
+  outputFile = options.outputFile
+
+  printGeneralInfos()
+  listEnvironmentVariables()
+
+  await testConnectivity()
+  try {
+    // Must be after the connectivity test, but before network connections so we have duckling/lang server urls
+    botpressConfig = await Ghost.global().readFileAsObject<any>('/', 'botpress.config.json')
+  } catch (err) {}
+
+  await testNetworkConnections()
+
+  if (options.config) {
+    await printConfig()
+    await printBotsList()
+    await printDatabaseTables()
+  }
+
+  process.exit(0)
+}

--- a/src/bp/diag/utils.ts
+++ b/src/bp/diag/utils.ts
@@ -1,0 +1,81 @@
+import axios from 'axios'
+import chalk from 'chalk'
+import center from 'core/logger/center'
+import { OBFUSCATED, print, SECRET_KEYS } from 'diag'
+import dns from 'dns'
+import fs from 'fs'
+import _ from 'lodash'
+import os from 'os'
+import path from 'path'
+import { URL } from 'url'
+
+export const obfuscateSecrets = item => {
+  return _.reduce(
+    item,
+    (res, value: any, key: string) => {
+      if (SECRET_KEYS.find(x => key.toLowerCase().includes(x))) {
+        res[key] = OBFUSCATED
+      } else if (!_.isArray(value) && _.isObject(value)) {
+        res[key] = obfuscateSecrets(value)
+      } else {
+        res[key] = value
+      }
+
+      return res
+    },
+    {}
+  )
+}
+
+export const printHeader = (text: string) =>
+  print(`${os.EOL}${'='.repeat(100)}${os.EOL}||${center(text, 95, 1)}||${os.EOL}${'='.repeat(100)}`)
+
+export const printSub = (text: string) => print(`${os.EOL}${text}${os.EOL}${'~'.repeat(100)}`)
+
+export const printRow = (label: string, details: string) => print(`${`${label}:`.padEnd(40)} ${details}`)
+
+export const printObject = (obj: any, includePasswords?: boolean) =>
+  print(JSON.stringify(_.omit(includePasswords ? obj : obfuscateSecrets(obj), '$schema'), undefined, 2))
+
+export const testWriteAccess = (label: string, folder: string) => {
+  try {
+    const file = path.resolve(process.PROJECT_LOCATION, folder, 'testwrite123')
+    fs.writeFileSync(file, '')
+    fs.unlinkSync(file)
+
+    printRow(label, `${folder} (${chalk.green('writable')})`)
+  } catch (err) {
+    printRow(label, `${folder} (${chalk.red(`not writable: ${err}`)})`)
+  }
+}
+
+export const dnsLookup = (hostname: string) => {
+  return new Promise((resolve, reject) => {
+    dns.lookup(hostname, (err, res) => (err ? reject(err) : resolve(res)))
+  })
+}
+
+export const testWebsiteAccess = async (label: string, url: string) => {
+  const start = Date.now()
+  let ip
+  try {
+    ip = await dnsLookup(new URL(url).host)
+    await axios.get(url)
+
+    printRow(label, `${chalk.green('success')} (${Date.now() - start}ms)`)
+  } catch (err) {
+    printRow(label, `${chalk.red(`failure: ${err.message}`)} (${Date.now() - start}ms)`)
+  }
+
+  print(` - ${url} (${ip})\n`)
+}
+
+export const wrapMethodCall = async (label: string, method: any) => {
+  const start = Date.now()
+  try {
+    await method()
+    printRow(label, `${chalk.green('success')} (${Date.now() - start}ms)`)
+  } catch (err) {
+    printRow(label, `${chalk.red(`failure: ${err.message}`)} (${Date.now() - start}ms)`)
+  }
+}

--- a/src/bp/diag/utils.ts
+++ b/src/bp/diag/utils.ts
@@ -49,10 +49,13 @@ export const testWriteAccess = (label: string, folder: string) => {
   }
 }
 
-export const dnsLookup = (hostname: string) => {
-  return new Promise((resolve, reject) => {
+export const dnsLookup = async (hostname: string) => {
+  const timePromise = new Promise(() => {}).timeout(5000)
+  const lookupPromise = new Promise((resolve, reject) => {
     dns.lookup(hostname, (err, res) => (err ? reject(err) : resolve(res)))
   })
+
+  return Promise.race([timePromise, lookupPromise])
 }
 
 export const testWebsiteAccess = async (label: string, url: string) => {


### PR DESCRIPTION
Wanted to ship something like this for a long time. Just a tool to diagnose problems. 

By default it will generate a simple output and obfuscate passwords. Add the --config flag to include the botpress configuration file, and each module's configurations file, for each bot. 

Passwords and tokens are obfuscated by default, but there is an option to also include them

Got the basic stuff there, waiting for additional contributions :)

bp diag --config --includePasswords -o mySpecialFile

![image](https://user-images.githubusercontent.com/42552874/88465309-e1abcf80-ce8f-11ea-94ce-200406f85923.png)
