### PR TITLE
fix(channel-web) Delay autoscroll on new messages

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
@@ -38,7 +38,7 @@ class MessageList extends React.Component<MessageListProps, State> {
         }
         return
       }
-      this.tryScrollToBottom()
+      this.tryScrollToBottom(true)
     })
 
     // this should account for keyboard rendering as it triggers a resize of the messagesDiv


### PR DESCRIPTION
When new messages are added, sometimes messages were cut-off.
Delaying the scroll gives a bit of time for the messages to render before we scroll down.