### PR TITLE
fix(examples) Overrides values should be arrays

### DIFF
--- a/examples/custom-component/assets/embedded-webchat.html
+++ b/examples/custom-component/assets/embedded-webchat.html
@@ -15,17 +15,21 @@
       //There are only two possible overrides for the moment.
       overrides: {
         // For now, the composer is the only component which is editable. It represents the zone where the user is typing
-        composer: {
-          // Name of the module, as declared in package.json
-          module: 'custom-component',
-          // The name of your exported component. It must be in your lite view: `/views/lite/index.jsx`
-          component: 'Composer'
-        },
+        composer: [
+          {
+            // Name of the module, as declared in package.json
+            module: 'custom-component',
+            // The name of your exported component. It must be in your lite view: `/views/lite/index.jsx`
+            component: 'Composer'
+          }
+        ],
         // You can use this override to inject your component and interact with the web chat. Make it invisible by returning null
-        below_conversation: {
-          module: 'custom-component',
-          component: 'InjectedBelow'
-        }
+        below_conversation: [
+          {
+            module: 'custom-component',
+            component: 'InjectedBelow'
+          }
+        ]
       }
     })
   </script>


### PR DESCRIPTION
Following this PR https://github.com/botpress/botpress/pull/1932 , values of the `overrides` object should be arrays. 