### PR TITLE
fix(prompt): temp storage for each flow

### DIFF
--- a/src/bp/core/services/dialog/dialog-engine.ts
+++ b/src/bp/core/services/dialog/dialog-engine.ts
@@ -224,15 +224,13 @@ export class DialogEngine {
   }
 
   private _setCurrentNodeValue(event: IO.IncomingEvent, variable: string, value: any) {
-    const flowName = event.state.context.currentFlow!
-    const nodeName = event.state.context.currentNode!
-    _.set(event.state.temp, `[${flowName}/${nodeName}].${variable}`, value)
+    const { currentFlow, currentNode } = event.state.context
+    _.set(event.state.temp, `[${currentFlow}/${currentNode}].${variable}`, value)
   }
 
   private _getCurrentNodeValue(event: IO.IncomingEvent, variable: string): any {
-    const flowName = event.state.context.currentFlow!
-    const nodeName = event.state.context.currentNode!
-    return _.get(event.state.temp, `[${flowName}/${nodeName}].${variable}`)
+    const { currentFlow, currentNode } = event.state.context
+    return _.get(event.state.temp, `[${currentFlow}/${currentNode}].${variable}`)
   }
 
   public async jumpTo(sessionId: string, event: IO.IncomingEvent, targetFlowName: string, targetNodeName?: string) {

--- a/src/bp/core/services/dialog/dialog-engine.ts
+++ b/src/bp/core/services/dialog/dialog-engine.ts
@@ -224,11 +224,15 @@ export class DialogEngine {
   }
 
   private _setCurrentNodeValue(event: IO.IncomingEvent, variable: string, value: any) {
-    _.set(event.state.temp, `[${event.state.context.currentNode!}].${variable}`, value)
+    const flowName = event.state.context.currentFlow!
+    const nodeName = event.state.context.currentNode!
+    _.set(event.state.temp, `[${flowName}/${nodeName}].${variable}`, value)
   }
 
   private _getCurrentNodeValue(event: IO.IncomingEvent, variable: string): any {
-    return _.get(event.state.temp, `[${event.state.context.currentNode!}].${variable}`)
+    const flowName = event.state.context.currentFlow!
+    const nodeName = event.state.context.currentNode!
+    return _.get(event.state.temp, `[${flowName}/${nodeName}].${variable}`)
   }
 
   public async jumpTo(sessionId: string, event: IO.IncomingEvent, targetFlowName: string, targetNodeName?: string) {

--- a/src/bp/core/services/dialog/instruction/strategy.ts
+++ b/src/bp/core/services/dialog/instruction/strategy.ts
@@ -192,9 +192,8 @@ export class TransitionStrategy implements InstructionStrategy {
 
     if (instruction.fn?.includes('thisNode')) {
       // TODO: Fix this so that it's cleaner and more generic
-      const nodeName = sandbox.event.state.context.currentNode
-      const flowName = sandbox.event.state.context.currentFlow
-      instruction.fn = instruction.fn.replace(/thisNode/g, `(event.state.temp['${flowName}/${nodeName}'] || {})`)
+      const { currentFlow, currentNode } = sandbox.event.state.context
+      instruction.fn = instruction.fn.replace(/thisNode/g, `(event.state.temp['${currentFlow}/${currentNode}'] || {})`)
     }
 
     const variables = instruction.fn?.match(/\$[a-zA-Z][a-zA-Z0-9_-]*/g) ?? []

--- a/src/bp/core/services/dialog/instruction/strategy.ts
+++ b/src/bp/core/services/dialog/instruction/strategy.ts
@@ -193,7 +193,8 @@ export class TransitionStrategy implements InstructionStrategy {
     if (instruction.fn?.includes('thisNode')) {
       // TODO: Fix this so that it's cleaner and more generic
       const nodeName = sandbox.event.state.context.currentNode
-      instruction.fn = instruction.fn.replace(/thisNode/g, `(event.state.temp['${nodeName}'] || {})`)
+      const flowName = sandbox.event.state.context.currentFlow
+      instruction.fn = instruction.fn.replace(/thisNode/g, `(event.state.temp['${flowName}/${nodeName}'] || {})`)
     }
 
     const variables = instruction.fn?.match(/\$[a-zA-Z][a-zA-Z0-9_-]*/g) ?? []


### PR DESCRIPTION
This PR adds the workflow name to the temp storage path for prompt.

Previously, if you had had a workflow containing a prompt named prompt-1 before calling another flow also containing a prompt named prompt-1, the other flow would consider that the prompt was completed because the variable in temp was still present.