### PR TITLE
fix(ui-studio): validate unclosing braces in form fields

### DIFF
--- a/src/bp/ui-studio/src/web/components/ContentForm/FormValidation.ts
+++ b/src/bp/ui-studio/src/web/components/ContentForm/FormValidation.ts
@@ -1,18 +1,22 @@
 import { lang } from 'botpress/shared'
 
-const isValidBraces = (str) => {
+const isValidBraces = str => {
   let depth = 0
   const arr = str.split('')
   for (let i = 0; i < arr.length - 1; i++) {
     const value = str[i] + str[i + 1]
-    if (value == '{{') {
-      depth ++
-    } else if (value == '}}') {
-      depth --
+    if (value === '{{') {
+      depth++
+    } else if (value === '}}') {
+      depth--
     }
-    if (depth < 0) { return false }
+    if (depth < 0) {
+      return false
+    }
   }
-  if (depth > 0) { return false }
+  if (depth > 0) {
+    return false
+  }
   return true
 }
 
@@ -25,7 +29,7 @@ const validateBraces = (formData, errors) => {
         errors[property].addError(lang.tr('contentForm.invalidBraces'))
       }
     } else if (Array.isArray(value)) {
-      value.forEach( (entry, index) => {
+      value.forEach((entry, index) => {
         const subProperties = Object.keys(entry)
         for (const subProperty of subProperties) {
           const subValue = entry[subProperty]

--- a/src/bp/ui-studio/src/web/components/ContentForm/FormValidation.ts
+++ b/src/bp/ui-studio/src/web/components/ContentForm/FormValidation.ts
@@ -1,0 +1,45 @@
+import { lang } from 'botpress/shared'
+
+const isValidBraces = (str) => {
+  let depth = 0
+  const arr = str.split('')
+  for (let i = 0; i < arr.length - 1; i++) {
+    const value = str[i] + str[i + 1]
+    if (value == '{{') {
+      depth ++
+    } else if (value == '}}') {
+      depth --
+    }
+    if (depth < 0) { return false }
+  }
+  if (depth > 0) { return false }
+  return true
+}
+
+const validateBraces = (formData, errors) => {
+  const properties = Object.keys(formData)
+  for (const property of properties) {
+    const value = formData[property]
+    if (typeof value === 'string' && value.includes('{{')) {
+      if (!isValidBraces(value)) {
+        errors[property].addError(lang.tr('contentForm.invalidBraces'))
+      }
+    } else if (Array.isArray(value)) {
+      value.forEach( (entry, index) => {
+        const subProperties = Object.keys(entry)
+        for (const subProperty of subProperties) {
+          const subValue = entry[subProperty]
+          if (typeof subValue === 'string' && subValue.includes('{{') && !isValidBraces(subValue)) {
+            errors[property][index][subProperty].addError(lang.tr('contentForm.invalidBraces'))
+          }
+        }
+      })
+    }
+  }
+  return errors
+}
+
+export const validateForm = (formData, errors) => {
+  errors = validateBraces(formData, errors)
+  return errors
+}

--- a/src/bp/ui-studio/src/web/components/ContentForm/index.tsx
+++ b/src/bp/ui-studio/src/web/components/ContentForm/index.tsx
@@ -15,6 +15,7 @@ import FlowPickWidget from './FlowPickWidget'
 import RefWidget from './RefWidget'
 import Text from './Text'
 import UploadWidget from './UploadWidget'
+import { validateForm } from './FormValidation'
 
 interface Props {
   contentLang: string
@@ -106,6 +107,7 @@ const ContentForm: FC<Props> = props => {
       ArrayFieldTemplate={ArrayFieldTemplate}
       onChange={handleOnChange}
       schema={translatePropsRecursive(schema)}
+      validate={validateForm}
     >
       {props.children}
     </Form>

--- a/src/bp/ui-studio/src/web/components/ContentForm/style.scss
+++ b/src/bp/ui-studio/src/web/components/ContentForm/style.scss
@@ -21,3 +21,7 @@
   top: 4px;
   right: 4px;
 }
+:global(.error-detail) {
+  margin-top: 12px;
+  margin-bottom: 0px;
+}

--- a/src/bp/ui-studio/src/web/translations/en.json
+++ b/src/bp/ui-studio/src/web/translations/en.json
@@ -330,5 +330,8 @@
       "closePanel": "Close Panel",
       "endOfLogs": "End of logs"
     }
+  },
+  "contentForm": {
+    "invalidBraces": "Unclosed braces"
   }
 }

--- a/src/bp/ui-studio/src/web/translations/fr.json
+++ b/src/bp/ui-studio/src/web/translations/fr.json
@@ -328,5 +328,8 @@
       "closePanel": "Fermer le panneau",
       "endOfLogs": "Fin des journaux"
     }
+  },
+  "contentForm": {
+    "invalidBraces": "Accolades non fermées"
   }
 }


### PR DESCRIPTION
This a fix for the issue [#3678](https://github.com/botpress/v12/issues/1069) and also an implementation for future form validations of content flow.

![image](https://user-images.githubusercontent.com/20561190/89134230-afe7d800-d523-11ea-9ba9-badeb20619de.png)
