### PR TITLE
chore(dev): better tool for linting

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -24,7 +24,7 @@ jobs:
           yarn
       - name: Run TSLint
         run: |
-          yarn run tslint
+          yarn run tslint-old
       - name: Get file changes
         id: get_file_changes
         uses: dorner/file-changes-action@v1.2.0

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -36,5 +36,6 @@ jobs:
         run: |
           echo ::set-output name=files::$(node build/tslint-filter-files.js ${{ steps.get_file_changes.outputs.files }})
       - name: Run TSLint (new rules)
+        if: ${{ steps.filtered_files.outputs.files > 0 }}
         run: |
           yarn run tslint -c tslint.newrules.json ${{ steps.filtered_files.outputs.files }}

--- a/config/lint-staged.config.js
+++ b/config/lint-staged.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  '**/*.{ts,tsx}': ['tslint -c tslint.newrules.json']
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,8 @@ const rimraf = require('rimraf')
 const changelog = require('gulp-conventional-changelog')
 const yn = require('yn')
 const { spawnSync } = require('child_process')
+const { argv } = require('yargs')
+const _ = require('lodash')
 
 process.on('uncaughtException', err => {
   console.error('An error occurred in your gulpfile: ', err)
@@ -37,8 +39,9 @@ gulp.task('default', cb => {
                                         Here m1 is the module name like nlu
                                         Modules are separated with a comma (,) and no spaces
     yarn cmd build:modules --a m1       Builds all modules that matches *m1*
-    yarn run lint                       Runs the linter on staged files
-    yarn run lint --fix                 Runs the linter and try to fix rules which are fixable, then stages fixes
+    yarn cmd lint --baseBranch=dev      Runs the linter on file difference between base and current branch
+    yarn cmd lint --staged              Runs the linter on staged files
+    yarn cmd lint --fix                 Runs the linter and try to fix rules which are fixable, then stages fixes
   `)
   cb()
 })
@@ -102,11 +105,24 @@ gulp.task('changelog', () => {
 })
 
 gulp.task('lint', cb => {
-  const command =
-    process.argv[3] === '--fix'
-      ? 'yarn run lint-staged --no-stash -c build/lint-staged.fix.config.js'
-      : 'yarn run lint-staged --no-stash'
+  if (argv.staged) {
+    const command = `yarn run lint-staged --no-stash -c config/lint-staged${argv.fix ? '.fix' : ''}.config.js`
+    spawnSync(command, { shell: true, stdio: 'inherit' }, err => cb(err))
+    cb()
+    return
+  }
 
-  spawnSync(command, { shell: true, stdio: 'inherit' }, err => cb(err))
+  const baseBranch = argv.baseBranch || 'dev'
+  const gitResult = spawnSync('git', ['--no-pager', 'diff', `${baseBranch}..`, '--name-only'], { stdio: 'pipe' })
+
+  const files = String(gitResult.output)
+    .split('\n')
+    .filter(file => /\.tsx?$/.test(file))
+
+  for (const batch of _.chunk(files, 100)) {
+    const command = `yarn run tslint -c tslint.newrules.json ${argv.fix ? '--fix' : ''}`
+    spawnSync(command, [batch.join(' ')], { shell: true, stdio: 'inherit' }, err => cb(err))
+  }
+
   cb()
 })

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "package": "yarn cmd package",
     "test": "cross-env NATIVE_EXTENSIONS_DIR=./build/native-extensions node_modules/.bin/jest -i --detectOpenHandles -c jest.config.js",
     "itest": "cross-env NATIVE_EXTENSIONS_DIR=./build/native-extensions node_modules/.bin/jest -i --detectOpenHandles -c jest.e2e.config.js all",
-    "tslint": "node_modules/.bin/tslint --project tslint.json",
+    "tslint-old": "node_modules/.bin/tslint --project tslint.json",
     "commitmsg": "commitlint -e $GIT_PARAMS"
   },
   "dependencies": {


### PR DESCRIPTION
Added some commands to help with the new linting rules:

- `yarn cmd lint`: will run the linter on all files which were changed between dev and the current branch
- `yarn cmd lint --baseBranch=somebranch` same thing, but use a branch other than dev
- `yarn cmd lint --staged` runs the linter only on staged files
- `yarn cmd lint --fix` try to auto-fix issues

Had to rename the script to "tslint-old" because `yarn run tslint` was causing interference with `yarn tslint`