### PR TITLE
feat(core): add errors and logs to event steps

### DIFF
--- a/modules/extensions/src/views/lite/components/debugger/index.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/index.tsx
@@ -10,6 +10,7 @@ import 'ui-shared/dist/theme.css'
 import Settings from './settings'
 import style from './style.scss'
 import { loadSettings } from './utils'
+import { Inspector } from './views/Inspector'
 import { Processing } from './views/Processing'
 import Summary from './views/Summary'
 import EventNotFound from './EventNotFound'
@@ -36,6 +37,7 @@ interface State {
   visible: boolean
   showSettings: boolean
   showEventNotFound: boolean
+  showInspector: boolean
   fetching: boolean
   unauthorized: boolean
   tab: string
@@ -51,6 +53,7 @@ export class Debugger extends React.Component<Props, State> {
     showSettings: false,
     fetching: false,
     unauthorized: false,
+    showInspector: false,
     tab: window['BP_STORAGE'].get(DEBUGGER_TAB_KEY) || 'content'
   }
   allowedRetryCount = 0
@@ -141,9 +144,15 @@ export class Debugger extends React.Component<Props, State> {
   }
 
   hotkeyListener = (e: KeyboardEvent) => {
-    if (e.ctrlKey && e.key === 'd') {
-      e.preventDefault()
+    if (!e.ctrlKey) {
+      return
+    }
+    e.preventDefault()
+
+    if (e.key === 'd') {
       this.toggleDebugger()
+    } else if (e.key === 'i') {
+      this.setState({ showInspector: !this.state.showInspector })
     }
   }
 
@@ -203,13 +212,20 @@ export class Debugger extends React.Component<Props, State> {
   }
 
   renderEvent() {
-    const lang = this.props.store?.botUILanguage || 'en'
     const { tab, event } = this.state
+
+    if (this.state.showInspector) {
+      return (
+        <div className={style.content}>
+          <Inspector data={event} />
+        </div>
+      )
+    }
 
     return (
       <div className={style.content}>
         {tab === 'content' && <Summary event={event} />}
-        {tab === 'processing' && <Processing processing={event?.processing} lang={lang} />}
+        {tab === 'processing' && <Processing processing={event?.processing} />}
       </div>
     )
   }

--- a/src/bp/core/logger/logger.ts
+++ b/src/bp/core/logger/logger.ts
@@ -225,6 +225,7 @@ export class PersistedConsoleLogger implements Logger {
     this.botId = undefined
     this.attachedError = undefined
     this.emitLogStream = true
+    this.event = undefined
   }
 
   debug(message: string, metadata?: any): void {

--- a/src/bp/core/sdk/impl.ts
+++ b/src/bp/core/sdk/impl.ts
@@ -49,7 +49,8 @@ export class IOEvent implements sdk.IO.Event {
   public readonly debugger?: boolean
   private readonly flags: any
   private readonly nlu?: sdk.IO.EventUnderstanding
-  public processing?: { [activity: string]: Date }
+  public readonly activeProcessing?: sdk.IO.ProcessingEntry
+  public processing?: { [activity: string]: sdk.IO.ProcessingEntry }
   private readonly ndu?: sdk.NDU.DialogUnderstanding
 
   constructor(args: sdk.IO.EventCtorArgs) {
@@ -78,6 +79,8 @@ export class IOEvent implements sdk.IO.Event {
     if (this.direction === 'outgoing') {
       this.incomingEventId = args.incomingEventId
     }
+
+    this.activeProcessing = {}
 
     this.nlu = {
       entities: [],
@@ -108,10 +111,6 @@ export class IOEvent implements sdk.IO.Event {
     }
 
     return this.payload.__preview || this.payload.preview || this.payload.text
-  }
-
-  public addStep(step: string) {
-    this.processing = { ...(this.processing || {}), [step]: new Date() }
   }
 }
 

--- a/src/bp/core/services/action/action-service.ts
+++ b/src/bp/core/services/action/action-service.ts
@@ -24,7 +24,7 @@ import { clearRequireCache, requireFromString } from '../../modules/require'
 import { TYPES } from '../../types'
 import { BotService } from '../bot-service'
 import { ActionExecutionError } from '../dialog/errors'
-import { addStepToEvent } from '../middleware/event-collector'
+import { addErrorToEvent, addStepToEvent } from '../middleware/event-collector'
 import { WorkspaceService } from '../workspace-service'
 
 import { extractMetadata } from './metadata'
@@ -185,6 +185,17 @@ export class ScopedActionService {
         .forBot(this.botId)
         .attachError(err)
         .error(`An error occurred while executing the action "${actionName}`)
+
+      addErrorToEvent(
+        {
+          type: 'action-execution',
+          stacktrace: err.stacktrace || err.stack,
+          actionName: actionName,
+          actionArgs: _.omit(actionArgs, ['event'])
+        },
+        incomingEvent
+      )
+
       addStepToEvent(`action:${actionName}:error`, incomingEvent)
       throw new ActionExecutionError(err.message, actionName, err.stack)
     }

--- a/src/bp/core/services/dialog/instruction/strategy.ts
+++ b/src/bp/core/services/dialog/instruction/strategy.ts
@@ -137,13 +137,6 @@ export class ActionStrategy implements InstructionStrategy {
 
       await service.runAction({ actionName, incomingEvent: event, actionArgs: args, actionServer })
     } catch (err) {
-      event.state.__error = {
-        type: 'action-execution',
-        stacktrace: err.stacktrace || err.stack,
-        actionName: actionName,
-        actionArgs: _.omit(args, ['event'])
-      }
-
       const { onErrorFlowTo } = event.state.temp
       const errorFlow = typeof onErrorFlowTo === 'string' && onErrorFlowTo.length ? onErrorFlowTo : 'error.flow.json'
 

--- a/src/bp/core/services/hook/hook-service.ts
+++ b/src/bp/core/services/hook/hook-service.ts
@@ -285,7 +285,7 @@ export class HookService {
   }
 
   private addEventStep = (hookName: string, status: 'completed' | 'error', hook: Hooks.BaseHook) => {
-    if (hook.args?.event?.addStep) {
+    if (hook.args?.event) {
       const event = hook.args.event as IO.Event
       addStepToEvent(`hook:${hookName}:${status}`, event)
     }

--- a/src/bp/core/services/middleware/event-collector.ts
+++ b/src/bp/core/services/middleware/event-collector.ts
@@ -15,14 +15,14 @@ type BatchEvent = sdk.IO.StoredEvent & { retry?: number }
 export const LAST_EVENT_STEP = 'completed'
 
 export const addStepToEvent = (step: string, event: sdk.IO.Event) => {
-  if (!event.debugger) {
+  if (!event?.debugger) {
     return
   }
 
   event.processing = {
     ...(event.processing || {}),
     [step]: {
-      ...(event.activeProcessing || {}),
+      ...(event?.activeProcessing || {}),
       date: new Date()
     }
   }
@@ -31,14 +31,14 @@ export const addStepToEvent = (step: string, event: sdk.IO.Event) => {
 }
 
 export const addLogToEvent = (logEntry: string, event: sdk.IO.Event) => {
-  if (event.debugger) {
-    event.activeProcessing!.logs = [...(event.activeProcessing!.logs ?? []), logEntry]
+  if (event?.debugger && event?.activeProcessing) {
+    event.activeProcessing.logs = [...(event.activeProcessing.logs ?? []), logEntry]
   }
 }
 
 export const addErrorToEvent = (eventError: sdk.IO.EventError, event: sdk.IO.Event) => {
-  if (event.debugger) {
-    event.activeProcessing!.errors = [...(event.activeProcessing!.errors ?? []), eventError]
+  if (event?.debugger && event?.activeProcessing) {
+    event.activeProcessing.errors = [...(event.activeProcessing.errors ?? []), eventError]
   }
 }
 

--- a/src/bp/core/services/middleware/event-collector.ts
+++ b/src/bp/core/services/middleware/event-collector.ts
@@ -15,7 +15,31 @@ type BatchEvent = sdk.IO.StoredEvent & { retry?: number }
 export const LAST_EVENT_STEP = 'completed'
 
 export const addStepToEvent = (step: string, event: sdk.IO.Event) => {
-  event.processing = { ...(event.processing || {}), [step]: new Date() }
+  if (!event.debugger) {
+    return
+  }
+
+  event.processing = {
+    ...(event.processing || {}),
+    [step]: {
+      ...(event.activeProcessing || {}),
+      date: new Date()
+    }
+  }
+
+  event.activeProcessing = {}
+}
+
+export const addLogToEvent = (logEntry: string, event: sdk.IO.Event) => {
+  if (event.debugger) {
+    event.activeProcessing!.logs = [...(event.activeProcessing!.logs ?? []), logEntry]
+  }
+}
+
+export const addErrorToEvent = (eventError: sdk.IO.EventError, event: sdk.IO.Event) => {
+  if (event.debugger) {
+    event.activeProcessing!.errors = [...(event.activeProcessing!.errors ?? []), eventError]
+  }
 }
 
 const eventsFields = [

--- a/src/bp/core/services/middleware/event-engine.ts
+++ b/src/bp/core/services/middleware/event-engine.ts
@@ -37,6 +37,8 @@ const eventSchema = {
   debugger: joi.bool().optional(),
   credentials: joi.any().optional(),
   incomingEventId: joi.string().optional(),
+  activeProcessing: joi.object().optional(),
+  processing: joi.object().optional(),
   ndu: joi.any().optional(),
   nlu: joi
     .object({

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -103,6 +103,7 @@ declare module 'botpress/sdk' {
   export interface Logger {
     forBot(botId: string): this
     attachError(error: Error): this
+    attachEvent(event: IO.Event): this
     persist(shouldPersist: boolean): this
     level(level: LogLevel): this
     noEmit(): this
@@ -651,9 +652,10 @@ declare module 'botpress/sdk' {
       readonly credentials?: any
       /** When false, some properties used by the debugger are stripped from the event before storing */
       debugger?: boolean
+      activeProcessing?: ProcessingEntry
       /** Track processing steps during the lifetime of the event  */
       processing?: {
-        [activity: string]: Date
+        [activity: string]: ProcessingEntry
       }
       /**
        * Check if the event has a specific flag
@@ -669,8 +671,12 @@ declare module 'botpress/sdk' {
        * @example event.setFlag(bp.IO.WellKnownFlags.SKIP_DIALOG_ENGINE, true)
        */
       setFlag(flag: symbol, value: boolean): void
-      /** Add a new step to the processing of this event (with timestamp) */
-      addStep(step: string): void
+    }
+
+    interface ProcessingEntry {
+      logs?: string[]
+      errors?: EventError[]
+      date?: Date
     }
 
     /**
@@ -772,8 +778,6 @@ declare module 'botpress/sdk' {
        * This includes all the flow/nodes which were traversed for the current event
        */
       __stacktrace: JumpPoint[]
-      /** Contains details about an error that occurred while processing the event */
-      __error?: EventError
     }
 
     export interface PromptStatus {


### PR DESCRIPTION
Adds a property `attachEvent` on loggers so actions/hooks can send the output to the correct element.

Also adds a CTRL+I as a shortcut so we can inspect the whole event on the debugger

![image](https://user-images.githubusercontent.com/42552874/89342884-6a392580-d671-11ea-8641-e7c58ec19b42.png)
