### PR TITLE
fix(diag): add monitor & more tests

### DIFF
--- a/src/bp/core/routers/admin/server.ts
+++ b/src/bp/core/routers/admin/server.ts
@@ -163,6 +163,10 @@ export class ServerRouter extends CustomRouter {
     router.get(
       '/diag',
       this.asyncMiddleware(async (req, res) => {
+        if (yn(process.core_env.BP_DISABLE_SERVER_DIAG)) {
+          return res.send('Diagnostic report is disabled by the system administrator (BP_DISABLE_SERVER_DIAG)')
+        }
+
         const tmpFile = tmpNameSync()
         await diag({ outputFile: tmpFile, noExit: true, config: true })
         res.send(await fse.readFile(tmpFile, 'utf-8'))

--- a/src/bp/core/routers/admin/server.ts
+++ b/src/bp/core/routers/admin/server.ts
@@ -6,15 +6,17 @@ import { AlertingService } from 'core/services/alerting-service'
 import { JobService } from 'core/services/job-service'
 import { MonitoringService } from 'core/services/monitoring'
 import { WorkspaceService } from 'core/services/workspace-service'
+import diag from 'diag'
 import { Router } from 'express'
+import fse from 'fs-extra'
 import _ from 'lodash'
 import multer from 'multer'
 import os from 'os'
+import { tmpNameSync } from 'tmp'
 import yn from 'yn'
 
 import { getDebugScopes, setDebugScopes } from '../../../debug'
 import { CustomRouter } from '../customRouter'
-
 export class ServerRouter extends CustomRouter {
   private _rebootServer!: Function
 
@@ -155,6 +157,15 @@ export class ServerRouter extends CustomRouter {
           ])
         }
         res.send(serverConfig)
+      })
+    )
+
+    router.get(
+      '/diag',
+      this.asyncMiddleware(async (req, res) => {
+        const tmpFile = tmpNameSync()
+        await diag({ outputFile: tmpFile, noExit: true, config: true })
+        res.send(await fse.readFile(tmpFile, 'utf-8'))
       })
     )
 

--- a/src/bp/diag/index.ts
+++ b/src/bp/diag/index.ts
@@ -7,14 +7,14 @@ import { BotConfig } from 'botpress/sdk'
 
 import { Workspace } from 'common/typings'
 import { Db, Ghost } from 'core/app'
+import { getOrCreate as redisFactory } from 'core/services/redis'
 import fse from 'fs-extra'
 import _ from 'lodash'
-import yn from 'yn'
-
-import { getOrCreate as redisFactory } from 'core/services/redis'
+import nanoid from 'nanoid'
 import os from 'os'
 import path from 'path'
 import stripAnsi from 'strip-ansi'
+import yn from 'yn'
 
 import IORedis from 'ioredis'
 import { startMonitor } from './monitor'
@@ -71,7 +71,7 @@ export const ENV_VARS = [
 
 const PASSWORD_REGEX = new RegExp(/(.*):(.*)@(.*)/)
 const REDIS_TEST_KEY = 'botpress_redis_test_key'
-const REDIS_TEST_VALUE = 'bp123'
+const REDIS_TEST_VALUE = nanoid()
 
 let redisClient: IORedis.Redis
 let includePasswords = false

--- a/src/bp/diag/index.ts
+++ b/src/bp/diag/index.ts
@@ -87,7 +87,7 @@ let botpressConfig = undefined
 let outputFile: string | undefined = undefined
 
 export const print = (text: string) => {
-  if (outputFile) {
+  if (outputFile && typeof outputFile === 'string') {
     fse.appendFileSync(outputFile!, stripAnsi(text) + os.EOL, 'utf8')
   } else {
     console.log(text)

--- a/src/bp/diag/monitor.ts
+++ b/src/bp/diag/monitor.ts
@@ -1,0 +1,56 @@
+import { BotpressConfig } from 'core/config/botpress.config'
+import express from 'express'
+import { Request } from 'express-serve-static-core'
+import { createServer } from 'http'
+import IORedis from 'ioredis'
+import _ from 'lodash'
+import portFinder from 'portfinder'
+
+import { print } from '.'
+import { printHeader, wrapMethodCall } from './utils'
+
+export const startMonitor = async (config: BotpressConfig, redisClient: IORedis.Redis) => {
+  printHeader('Realtime Test')
+
+  if (redisClient) {
+    await wrapMethodCall('Start Redis Monitor', async () => {
+      redisClient.monitor(async (err, monitor) => {
+        monitor.on('monitor', (time, args, source, database) => {
+          print(`[Redis] ${args} - ${source} ${database}`)
+        })
+      })
+    })
+  }
+
+  if (config) {
+    await startServer(config)
+  }
+
+  print('')
+}
+
+const infoMw = (req: Request, res) => {
+  const { method, ip, originalUrl } = req
+  print(`[HTTP] ${method} ${ip} ${originalUrl}`)
+
+  const summary = `Method: ${method}\nIP: ${ip}\nURL: ${originalUrl}`
+  const headers = `Headers:\n${JSON.stringify(req.headers, undefined, 2)}`
+
+  res.send(`<pre>Received: ${summary} ${headers}</pre>`)
+}
+
+export const startServer = async (config: BotpressConfig) => {
+  const port = await portFinder.getPortPromise({ port: config.httpServer.port })
+
+  await wrapMethodCall(`Start HTTP Server (port ${port})`, async () => {
+    const app = express()
+    app.use(infoMw)
+
+    const httpServer = createServer(app)
+    const hostname = config.httpServer.host === 'localhost' ? undefined : config.httpServer.host
+
+    await Promise.fromCallback(callback => {
+      httpServer.listen(port, hostname, config.httpServer.backlog, callback)
+    })
+  })
+}

--- a/src/bp/diag/monitor.ts
+++ b/src/bp/diag/monitor.ts
@@ -13,11 +13,15 @@ export const startMonitor = async (config: BotpressConfig, redisClient: IORedis.
   printHeader('Realtime Test')
 
   if (redisClient) {
-    await wrapMethodCall('Start Redis Monitor', async () => {
-      redisClient.monitor(async (err, monitor) => {
+    await wrapMethodCall('Start Redis Monitor', () => {
+      redisClient.monitor((err, monitor) => {
         monitor.on('monitor', (time, args, source, database) => {
           print(`[Redis] ${args} - ${source} ${database}`)
         })
+
+        if (err) {
+          print(`Redis monitor error: ${err}`)
+        }
       })
     })
   }
@@ -33,10 +37,10 @@ const infoMw = (req: Request, res) => {
   const { method, ip, originalUrl } = req
   print(`[HTTP] ${method} ${ip} ${originalUrl}`)
 
-  const summary = `Method: ${method}\nIP: ${ip}\nURL: ${originalUrl}`
+  const summary = `Method: ${method}\nIP: ${ip}\nURL: ${originalUrl}\n\n`
   const headers = `Headers:\n${JSON.stringify(req.headers, undefined, 2)}`
 
-  res.send(`<pre>Received: ${summary} ${headers}</pre>`)
+  res.send(`<pre>Received:\n${summary} ${headers}</pre>`)
 }
 
 export const startServer = async (config: BotpressConfig) => {

--- a/src/bp/index.ts
+++ b/src/bp/index.ts
@@ -128,7 +128,11 @@ try {
 
         getos.default().then(distro => {
           process.distro = distro
-          require('./bootstrap')
+          if (yn(process.env.BP_DIAG)) {
+            require('./diag').default(argv)
+          } else {
+            require('./bootstrap')
+          }
         })
       }
     )
@@ -323,20 +327,25 @@ try {
     )
     .command(
       'diag',
-      'Generate a diagnostic report',
+      'Generate a diagnostic report\nAlternative: set BP_DIAG=true',
       {
         config: {
           alias: 'c',
-          description: 'Include all configuration files',
+          description: 'Include all configuration files\nAlternative: set BP_DIAG_CONFIG=true',
           default: false
         },
         includePasswords: {
-          description: 'Passwords will not be obfuscated in the output',
+          description: 'Passwords will not be obfuscated in the output\nAlternative: set BP_DIAG_INCLUDE_PASWORDS=true',
           default: false
         },
         outputFile: {
           alias: 'o',
-          description: 'Send the output to the specified filename'
+          description: 'Send the output to the specified filename\nAlternative: set BP_DIAG_OUTPUT=filename'
+        },
+        monitor: {
+          alias: 'm',
+          description:
+            'Starts an HTTP server and a Redis client, then outputs traces in real time\nAlternative: set BP_DIAG_MONITOR=true'
         }
       },
       argv => {

--- a/src/bp/ui-admin/src/Pages/Server/Checklist/DiagReport.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/Checklist/DiagReport.tsx
@@ -1,0 +1,27 @@
+import { Button } from '@blueprintjs/core'
+import { useState } from 'react'
+import api from '~/api'
+import { toastFailure } from '~/utils/toaster'
+
+export const DiagReport = () => {
+  const [busy, setBusy] = useState(false)
+
+  const getDiagReport = async () => {
+    setBusy(true)
+
+    try {
+      const { data } = await api.getSecured().get('/admin/server/diag')
+
+      const link = document.createElement('a')
+      link.href = URL.createObjectURL(new Blob([data]))
+      link.download = `diagnostic.txt`
+      link.click()
+    } catch (err) {
+      toastFailure(`Couldn't generate diagnostic report: ${err}`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return <Button onClick={getDiagReport} text={busy ? 'Please wait...' : 'Generate report'} disabled={busy}></Button>
+}

--- a/src/bp/ui-admin/src/Pages/Server/Checklist/DiagReport.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/Checklist/DiagReport.tsx
@@ -4,10 +4,10 @@ import api from '~/api'
 import { toastFailure } from '~/utils/toaster'
 
 export const DiagReport = () => {
-  const [busy, setBusy] = useState(false)
+  const [loading, setLoading] = useState(false)
 
   const getDiagReport = async () => {
-    setBusy(true)
+    setLoading(true)
 
     try {
       const { data } = await api.getSecured().get('/admin/server/diag')
@@ -19,9 +19,11 @@ export const DiagReport = () => {
     } catch (err) {
       toastFailure(`Couldn't generate diagnostic report: ${err}`)
     } finally {
-      setBusy(false)
+      setLoading(false)
     }
   }
 
-  return <Button onClick={getDiagReport} text={busy ? 'Please wait...' : 'Generate report'} disabled={busy}></Button>
+  return (
+    <Button onClick={getDiagReport} text={loading ? 'Please wait...' : 'Generate report'} disabled={loading}></Button>
+  )
 }

--- a/src/bp/ui-admin/src/Pages/Server/Checklist/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/Checklist/index.tsx
@@ -8,6 +8,7 @@ import PageContainer from '~/App/PageContainer'
 
 import { fetchServerConfig } from '../../../reducers/server'
 
+import { DiagReport } from './DiagReport'
 import Item from './Item'
 
 const NOT_SET = 'Not set'
@@ -324,7 +325,7 @@ export const Checklist: FC<Props> = props => {
           Passwords and secrets will be obfuscated
           <br />
           <br />
-          <Button onClick={getDiagReport} text="Generate report"></Button>
+          <DiagReport />
         </Item>
       </div>
     </Container>

--- a/src/bp/ui-admin/src/Pages/Server/Checklist/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/Checklist/index.tsx
@@ -1,4 +1,4 @@
-import { Callout, Intent, Tag } from '@blueprintjs/core'
+import { Button, Callout, Intent, Tag } from '@blueprintjs/core'
 import { ServerConfig } from 'common/typings'
 import _ from 'lodash'
 import React, { FC, useEffect, useState } from 'react'
@@ -83,6 +83,15 @@ export const Checklist: FC<Props> = props => {
       .map(x => debug[x])
 
     setAuditTrail(_.some(audit, Boolean))
+  }
+
+  const getDiagReport = async () => {
+    const { data } = await api.getSecured().get('/admin/server/diag')
+
+    const link = document.createElement('a')
+    link.href = URL.createObjectURL(new Blob([data]))
+    link.download = `diagnostic.txt`
+    link.click()
   }
 
   const checkStickySessions = async () => {
@@ -305,6 +314,17 @@ export const Checklist: FC<Props> = props => {
           status="none"
         >
           Check the documentation for more information
+        </Item>
+
+        <Item title="Generate a diagnostic report" status="none">
+          This tool will generate a report which can help diagnose problems. It will test the connectivity to various
+          components, ensure that proper folders are writable, and will also include the various configuration files.
+          <br />
+          <br />
+          Passwords and secrets will be obfuscated
+          <br />
+          <br />
+          <Button onClick={getDiagReport} text="Generate report"></Button>
         </Item>
       </div>
     </Container>

--- a/src/bp/ui-admin/src/Pages/Server/Checklist/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Server/Checklist/index.tsx
@@ -86,15 +86,6 @@ export const Checklist: FC<Props> = props => {
     setAuditTrail(_.some(audit, Boolean))
   }
 
-  const getDiagReport = async () => {
-    const { data } = await api.getSecured().get('/admin/server/diag')
-
-    const link = document.createElement('a')
-    link.href = URL.createObjectURL(new Blob([data]))
-    link.download = `diagnostic.txt`
-    link.click()
-  }
-
   const checkStickySessions = async () => {
     const results: string[] = await Promise.all(
       _.times(NB_PING_FOR_STICKY_SESSIONS, async () => {

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -171,6 +171,12 @@ declare type BotpressEnvironmentVariables = {
   readonly BP_DISABLE_SERVER_CONFIG?: boolean
 
   /**
+   * Disable API call to generate a diagnostic report. Command line/environment variables will still work
+   * @default false
+   */
+  readonly BP_DISABLE_SERVER_DIAG?: boolean
+
+  /**
    * Prevents Botpress from closing cleanly when an error is encountered.
    * This only affects fatal errors, it will not affect business rules checks (eg: licensing)
    */


### PR DESCRIPTION
Made the diagnostic tool a bit more robust and versatile. For Redis, it will actually try to set a key then read it after.

Added environment variables so it's easier to use on docker:
- BP_DIAG = Start the diagnostic
- BP_DIAG_CONFIG = Also include config files
- BP_DIAG_INCLUDE_PASSWORDS = Also include passwords
- BP_DIAG_MONITOR = Starts test servers
- BP_DIAG_OUTPUT = Send the output to a file

### New tool: Monitor
It will start an HTTP server on the configured port, and will echo to the browser and in the console what it receives. 

If Redis is configured, it will open a monitor channel and output what it receives on the console

![image](https://user-images.githubusercontent.com/42552874/89357667-235a2880-d68f-11ea-96c9-7f221d6023fc.png)


![image](https://user-images.githubusercontent.com/42552874/89357489-a333c300-d68e-11ea-80ef-691c625ab993.png)

@hacheybj @BPMJoannette  Thinking of other stuff that could be checked /tested ? 