### PR TITLE
fix(nlu): no filtering of qnas when fetching intents

### DIFF
--- a/modules/nlu/src/api.ts
+++ b/modules/nlu/src/api.ts
@@ -5,6 +5,7 @@ import * as sdk from 'botpress/sdk'
 
 export interface NLUApi {
   fetchContexts: () => Promise<string[]>
+  fetchIntentsOnly: () => Promise<NLU.IntentDefinition[]>
   fetchIntents: () => Promise<NLU.IntentDefinition[]>
   fetchIntent: (x: string) => Promise<NLU.IntentDefinition>
   createIntent: (x: Partial<NLU.IntentDefinition>) => Promise<any>
@@ -25,10 +26,11 @@ export interface NLUApi {
 
 export const makeApi = (bp: { axios: AxiosInstance }): NLUApi => ({
   fetchContexts: () => bp.axios.get('/nlu/contexts').then(res => res.data),
-  fetchIntents: async () => {
+  fetchIntentsOnly: async () => {
     const { data } = await bp.axios.get('/nlu/intents')
     return data.filter(x => !x.name.startsWith('__qna__'))
   },
+  fetchIntents: async () => bp.axios.get('/nlu/intents').then(res => res.data),
   fetchIntent: (intentName: string) => bp.axios.get(`/nlu/intents/${intentName}`).then(res => res.data),
   createIntent: (intent: Partial<NLU.IntentDefinition>) => bp.axios.post('/nlu/intents', intent),
   updateIntent: (targetIntent: string, intent: Partial<NLU.IntentDefinition>) =>

--- a/modules/nlu/src/backend/index.ts
+++ b/modules/nlu/src/backend/index.ts
@@ -38,7 +38,7 @@ const onTopicChanged = async (bp: typeof sdk, botId: string, oldName?: string, n
   }
 
   const api = await createApi(bp, botId)
-  const intentDefs = await api.fetchIntents()
+  const intentDefs = await api.fetchIntents() // Can the topic of a QNA be renamed??
 
   for (const intentDef of intentDefs) {
     const ctxIdx = intentDef.contexts.indexOf(oldName as string)

--- a/modules/nlu/src/views/full/index.tsx
+++ b/modules/nlu/src/views/full/index.tsx
@@ -36,7 +36,7 @@ const NLU: FC<Props> = props => {
 
   const loadIntents = () =>
     api
-      .fetchIntents()
+      .fetchIntentsOnly()
       .then(setIntents)
       .then(x => setCurrentItem(undefined))
       .then(x => setCurrentItem(currentItem)) // this is little hack to trigger update for IntentEditor->Slots->SlotModal

--- a/modules/nlu/src/views/full/intents/LiteEditor.tsx
+++ b/modules/nlu/src/views/full/intents/LiteEditor.tsx
@@ -57,7 +57,7 @@ export const LiteEditor: FC<Props> = props => {
   }, [isModalOpen])
 
   const loadIntents = async () => {
-    setIntents(await api.fetchIntents())
+    setIntents(await api.fetchIntentsOnly())
   }
 
   const createIntent = async (sanitizedName: string, rawName: string) => {


### PR DESCRIPTION
When entity-service and intent-service was moved in the core, we introduced a small bug. The QNA's where filtered out of the intentDefs before training.

Here's a quick fix for this.