### PR TITLE
fix(webchat): always focus composer when toggling

### DIFF
--- a/modules/channel-web/src/views/lite/components/Composer.tsx
+++ b/modules/channel-web/src/views/lite/components/Composer.tsx
@@ -17,7 +17,7 @@ class Composer extends React.Component<ComposerProps> {
   componentDidMount() {
     setTimeout(() => {
       this.textInput.current.focus()
-    }, 0)
+    }, 50)
 
     observe(this.props.focusedArea, focus => {
       focus.newValue === 'input' && this.textInput.current.focus()


### PR DESCRIPTION
First time you open the webchat it focuses correctly because the page is loading, but subsequent toggle (with E) doesn't focus because it happens too quickly