### PR TITLE
chore(dev): fix some dx issues

### DIFF
--- a/build/gulp.ui.js
+++ b/build/gulp.ui.js
@@ -7,14 +7,15 @@ const yn = require('yn')
 const verbose = process.argv.includes('--verbose')
 
 const build = () => {
+  gulp.task('build:shared', gulp.series([cleanShared, sharedBuild]))
   gulp.task('build:studio', gulp.series([buildStudio, cleanStudio, cleanStudioAssets, copyStudio]))
   gulp.task('build:admin', gulp.series([buildAdmin, copyAdmin]))
 
   if (yn(process.env.GULP_PARALLEL)) {
-    return gulp.parallel(['build:studio', 'build:admin'])
+    return gulp.series(['build:shared', gulp.parallel(['build:studio', 'build:admin'])])
   }
 
-  return gulp.series(['build:studio', 'build:admin'])
+  return gulp.series(['build:shared', 'build:studio', 'build:admin'])
 }
 
 // Required since modules are using some dependencies from the studio
@@ -95,7 +96,7 @@ const cleanShared = () => {
 const watchShared = gulp.series([
   cleanShared,
   cb => {
-    const shared = exec('yarn && yarn start', { cwd: 'src/bp/ui-shared' }, err => cb(err))
+    const shared = exec('yarn && yarn watch', { cwd: 'src/bp/ui-shared' }, err => cb(err))
     shared.stdout.pipe(process.stdout)
     shared.stderr.pipe(process.stderr)
   }

--- a/src/bp/ui-shared/package.json
+++ b/src/bp/ui-shared/package.json
@@ -8,7 +8,7 @@
     "node": ">=10"
   },
   "scripts": {
-    "start": "node ./webpack.config.js --watch",
+    "watch": "node ./webpack.config.js --watch",
     "build": "cross-env NODE_ENV=production node ./webpack.config.js --compile --nomap & yarn scss",
     "scss": "node-sass src/theme/main.scss dist/theme.css --importer=node_modules/node-sass-tilde-importer"
   },

--- a/src/bp/ui-shared/tsconfig.json
+++ b/src/bp/ui-shared/tsconfig.json
@@ -18,6 +18,7 @@
     "noImplicitAny": false,
     "baseUrl": "./src",
     "paths": {
+      "~/*": ["*"],
       "botpress/sdk": ["../../sdk/botpress.d.ts"],
       "common/*": ["../../../../out/bp/common/*"],
       "@blueprintjs/core": ["../../ui-studio/node_modules/@blueprintjs/core"],

--- a/src/bp/ui-shared/webpack.config.js
+++ b/src/bp/ui-shared/webpack.config.js
@@ -20,6 +20,7 @@ const config = {
   resolve: {
     extensions: ['.tsx', '.ts', '.js', '.css'],
     alias: {
+      '~': path.resolve(__dirname, './src'),
       common: path.resolve(__dirname, '../../../out/bp/common')
     }
   },
@@ -48,9 +49,12 @@ const config = {
               localIdentName: '[name]__[local]___[hash:base64:5]'
             }
           },
-          { loader: 'postcss-loader', options: {
-            options: {},
-          } },
+          {
+            loader: 'postcss-loader',
+            options: {
+              options: {}
+            }
+          },
           { loader: 'sass-loader' }
         ]
       },


### PR DESCRIPTION
- Renamed the `start` command to `watch` to be consistent across all UI-related packages
- Shared will also be built when using `build:ui`
- Configured the shortcut `~` so we stop having a ton of `../../../..` paths everywhere