### PR TITLE
fix(mltoolkit): no need for gridsearch in svm when only one combination

### DIFF
--- a/modules/nlu/src/backend/training-pipeline.ts
+++ b/modules/nlu/src/backend/training-pipeline.ts
@@ -491,8 +491,7 @@ const TrainOutOfScope = async (
 ): Promise<_.Dictionary<string> | undefined> => {
   debugTraining.forBot(input.botId, 'Training out of scope classifier')
   const trainingOptions: sdk.MLToolkit.SVM.SVMOptions = {
-    c: [10],
-    gamma: [0.1],
+    c: [10], // so there's no grid search
     kernel: 'LINEAR',
     classifier: 'C_SVC'
   }

--- a/src/bp/ml/svm/config.ts
+++ b/src/bp/ml/svm/config.ts
@@ -44,11 +44,11 @@ const defaultConf: SvmConfig = {
   weight_label: [],
   weight: [],
   degree: [2],
-  gamma: [0.01, 0.1, 0.25, 0.5, 0.75],
-  coef0: [0.125, 0.5],
+  gamma: [0.01, 0.1, 0.25, 0.5, 0.75], // not for linear svc
+  coef0: [0.125, 0.5], // not for linear svc
   C: [0.1, 1, 2, 5, 10, 20, 100],
-  nu: [0.01, 0.125, 0.5, 1],
-  p: [0.01, 0.125, 0.5, 1],
+  nu: [0.01, 0.125, 0.5, 1], // not for linear svc
+  p: [0.01, 0.125, 0.5, 1], // not for linear svc
   kFold: 4,
   normalize: true,
   reduce: false,

--- a/src/bp/ml/svm/grid-search/index.ts
+++ b/src/bp/ml/svm/grid-search/index.ts
@@ -34,6 +34,21 @@ export default async function(
 
   const evaluator = evaluators(config)
 
+  if (combs.length === 1) {
+    progressCb({ done: 1, total: 1 })
+    const comb = combs[0]
+    const params = defaultParameters({
+      ...config,
+      C: comb[0],
+      gamma: comb[1],
+      p: comb[2],
+      nu: comb[3],
+      degree: comb[4],
+      coef0: comb[5]
+    })
+    return { params }
+  }
+
   const total = combs.length * subsets.length
   let done = 0
 

--- a/src/bp/ml/svm/grid-search/typings.ts
+++ b/src/bp/ml/svm/grid-search/typings.ts
@@ -1,6 +1,6 @@
 import { Report, SvmParameters } from '../typings'
 
-export type GridSearchResult = { params: SvmParameters; report: Report }
+export type GridSearchResult = { params: SvmParameters; report?: Report }
 
 export type GridSearchProgress = {
   done: number


### PR DESCRIPTION
this fix can divide training time by a factor of almost 2 on big bots