### PR TITLE
fix(scheduler): prevent sending events before startup

### DIFF
--- a/modules/.scheduler/src/backend/index.ts
+++ b/modules/.scheduler/src/backend/index.ts
@@ -33,14 +33,14 @@ let db = undefined
 const onServerStarted = async (bp: typeof sdk & Extension) => {
   db = new SchedulerDb(bp)
   await db.initialize()
-
-  const daemon = Daemon(bp, db)
-  await daemon.revive()
-  daemon.start()
 }
 
 const onServerReady = async (bp: typeof sdk & Extension) => {
   await api(bp, db)
+
+  const daemon = Daemon(bp, db)
+  await daemon.revive()
+  daemon.start()
 }
 
 const obj: sdk.ModuleEntryPoint = {

--- a/src/bp/core/routers/admin/index.ts
+++ b/src/bp/core/routers/admin/index.ts
@@ -117,12 +117,16 @@ export class AdminRouter extends CustomRouter {
     router.get(
       '/docker_images',
       this.asyncMiddleware(async (req, res) => {
-        const { data } = await axios.get(
-          'https://hub.docker.com/v2/repositories/botpress/server/tags/?page_size=125&page=1&name=v',
-          process.PROXY ? { httpsAgent: new httpsProxyAgent(process.PROXY) } : {}
-        )
+        try {
+          const { data } = await axios.get(
+            'https://hub.docker.com/v2/repositories/botpress/server/tags/?page_size=125&page=1&name=v',
+            process.PROXY ? { httpsAgent: new httpsProxyAgent(process.PROXY) } : {}
+          )
 
-        res.send(data)
+          res.send(data)
+        } catch (err) {
+          res.send({ results: [] })
+        }
       })
     )
 


### PR DESCRIPTION
2 fixes:
- Scheduler was sending events before the server was ready
- Catching errors while trying to fetch docker images