### PR TITLE
fix(studio): node doesn't auto expand when created

### DIFF
--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/index.tsx
@@ -582,6 +582,7 @@ class Diagram extends Component<Props> {
   editNodeItem(node, index) {
     clearTimeout(this.timeout)
     if (node.isNew) {
+      this.updateExpandedNodes(node.id, true)
       this.props.updateFlowNode({ isNew: false })
     }
 


### PR DESCRIPTION
Small regression when the expanded/collapsed state of nodes was introduced