### PR TITLE
fix(webchat): move sidebar when toggled

### DIFF
--- a/modules/channel-web/src/views/lite/store/view.ts
+++ b/modules/channel-web/src/views/lite/store/view.ts
@@ -258,6 +258,7 @@ class ViewStore {
   showChat() {
     if (this.disableAnimations) {
       this.activeView = 'side'
+      this.postMessage('webchatOpened')
       return this._updateTransitions({ widgetTransition: undefined, sideTransition: 'none' })
     }
 
@@ -280,6 +281,7 @@ class ViewStore {
 
     if (this.disableAnimations) {
       this.activeView = 'widget'
+      this.postMessage('webchatClosed')
       return this._updateTransitions({ widgetTransition: undefined, sideTransition: undefined })
     }
 

--- a/src/bp/ui-studio/src/web/components/Layout/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/index.tsx
@@ -40,6 +40,16 @@ interface ILayoutProps {
   translations: any
 }
 
+const handleWebChatPanel = message => {
+  if (message.data.name === 'webchatOpened') {
+    document.getElementById('main-content-wrapper').classList.toggle('emulator-open', true)
+  }
+
+  if (message.data.name === 'webchatClosed') {
+    document.getElementById('main-content-wrapper').classList.toggle('emulator-open', false)
+  }
+}
+
 const Layout: FC<ILayoutProps> = props => {
   const mainElRef = useRef(null)
   const [langSwitcherOpen, setLangSwitcherOpen] = useState(false)
@@ -53,6 +63,11 @@ const Layout: FC<ILayoutProps> = props => {
     })
 
     setTimeout(() => BotUmountedWarning(), 500)
+
+    window.addEventListener('message', handleWebChatPanel)
+    return () => {
+      window.removeEventListener('message', handleWebChatPanel)
+    }
   }, [])
 
   useEffect(() => {
@@ -64,7 +79,6 @@ const Layout: FC<ILayoutProps> = props => {
 
   const toggleEmulator = () => {
     window.botpressWebChat.sendEvent({ type: 'toggle' })
-    document.getElementById('main-content-wrapper').classList.toggle('emulator-open')
   }
 
   const toggleGuidedTour = () => {


### PR DESCRIPTION
Max implemented the basics when using the Toggle button in the header, but it didn't support using E / CTRL+E and pressing ESC in either the studio or the webchat. 
