### PR TITLE
fix(ui): node keeps expanding when moving around

### DIFF
--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/nodes/Components/NodeHeader.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/nodes/Components/NodeHeader.tsx
@@ -38,6 +38,7 @@ const NodeHeader: FC<Props> = ({
   }
 
   const [inputValue, setInputValue] = useState(getInitialInputValue())
+  const [startMouse, setStartMouse] = useState({ x: 0, y: 0 })
 
   useEffect(() => {
     setInputValue(getInitialInputValue())
@@ -60,7 +61,12 @@ const NodeHeader: FC<Props> = ({
       {!isEditing ? (
         <Button
           icon={setExpanded ? icon : null}
-          onClick={() => setExpanded && setExpanded(!expanded)}
+          onClick={e => {
+            if (e.screenX - startMouse.x == 0 && e.screenY - startMouse.y == 0) {
+              setExpanded && setExpanded(!expanded)
+            }
+          }}
+          onMouseDown={e => setStartMouse({ x: e.screenX, y: e.screenY })}
           className={style.button}
           onContextMenu={e => handleContextMenu && handleContextMenu(e)}
         >

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/nodes/Components/NodeHeader.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/nodes/Components/NodeHeader.tsx
@@ -62,8 +62,8 @@ const NodeHeader: FC<Props> = ({
         <Button
           icon={setExpanded ? icon : null}
           onClick={e => {
-            if (e.screenX - startMouse.x == 0 && e.screenY - startMouse.y == 0) {
-              setExpanded && setExpanded(!expanded)
+            if (e.screenX - startMouse.x === 0 && e.screenY - startMouse.y == 0) {
+              setExpanded?.(!expanded)
             }
           }}
           onMouseDown={e => setStartMouse({ x: e.screenX, y: e.screenY })}


### PR DESCRIPTION
This PR prevents node from expanding/collapsing when you drag them around.

It would be possible to allow collapsing when moving just a little (like 4 pixels) but I tried that and it didn't seem to work better.

https://trello.com/c/sAm8ON1t/230-prevent-nodes-from-opening-and-collapsing-all-the-time