### PR TITLE
fix(nlu-testing): allow testing both intent and slot without ctx

### DIFF
--- a/modules/nlu-testing/src/views/full/TestModal.tsx
+++ b/modules/nlu-testing/src/views/full/TestModal.tsx
@@ -57,7 +57,7 @@ export const TestModal: FC<Props> = props => {
     const { expectedCtx, expectedIntent, slotConditions: slotsConds, testingCtx: context, utterance } = state
 
     const conditions = [
-      ['context', 'is', expectedCtx],
+      expectedCtx ? ['context', 'is', expectedCtx] : [],
       expectedIntent?.name ? ['intent', 'is', expectedIntent.name] : [],
       ..._.toPairs(slotsConds)
         .filter(([_, value]) => !!value)


### PR DESCRIPTION
I don't know why, but when there was a testing ctx, an intent and a slot, expectedCtx was null and the test could not be saved in backend.

I havent investigated more than that, I just want to use nlu-testing right now so, this fixes my problem.