### PR TITLE
fix(ui): say node allow multiline content

### DIFF
--- a/src/bp/ui-shared/src/FormFields/SuperInput/index.tsx
+++ b/src/bp/ui-shared/src/FormFields/SuperInput/index.tsx
@@ -234,6 +234,7 @@ export default ({
         placeholder={placeholder}
         className={style.superInput}
         tagifyRef={tagifyRef}
+        InputMode="textarea"
         settings={{
           dropdown: {
             classname: 'color-blue',


### PR DESCRIPTION
https://trello.com/c/JVFLAmO7/112-multiline-content-doesnt-work-it-just-strips-n

It wasn't possible to make this work with documented behaviour. I had to search through the source code to find this random `InputMode` property that does exactly what we want...

