### PR TITLE
chore(dx): admin assets were never cleaned up

### DIFF
--- a/build/gulp.ui.js
+++ b/build/gulp.ui.js
@@ -9,7 +9,7 @@ const verbose = process.argv.includes('--verbose')
 const build = () => {
   gulp.task('build:shared', gulp.series([cleanShared, sharedBuild]))
   gulp.task('build:studio', gulp.series([buildStudio, cleanStudio, cleanStudioAssets, copyStudio]))
-  gulp.task('build:admin', gulp.series([buildAdmin, copyAdmin]))
+  gulp.task('build:admin', gulp.series([buildAdmin, cleanAdmin, copyAdmin]))
 
   if (yn(process.env.GULP_PARALLEL)) {
     return gulp.series(['build:shared', gulp.parallel(['build:studio', 'build:admin'])])
@@ -59,6 +59,10 @@ const copyAdmin = () => {
 
 const cleanStudio = () => {
   return gulp.src('./out/bp/ui-studio/public', { allowEmpty: true }).pipe(rimraf())
+}
+
+const cleanAdmin = () => {
+  return gulp.src('./out/bp/ui-admin/public', { allowEmpty: true }).pipe(rimraf())
 }
 
 const cleanStudioAssets = () => {


### PR DESCRIPTION
Admin assets were never cleaned up, so I had like 300 files that BP was copying to the out folder... Around 1gb 