### PR TITLE
fix(ui): hide input output

### DIFF
--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/VariableForm/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/VariableForm/index.tsx
@@ -3,7 +3,7 @@ import axios from 'axios'
 import { PromptNode } from 'botpress/sdk'
 import { Contents, Dropdown, lang, MoreOptions, MoreOptionsItems, RightSidebar } from 'botpress/shared'
 import cx from 'classnames'
-import { Variables } from 'common/typings'
+import { FlowView, Variables } from 'common/typings'
 import _ from 'lodash'
 import React, { FC, Fragment, useEffect, useRef, useState } from 'react'
 
@@ -17,9 +17,19 @@ interface Props {
   close: () => void
   onUpdate: (data: any) => void
   formData: PromptNode
+  currentFlow: FlowView
 }
 
-const VariableForm: FC<Props> = ({ customKey, variables, contentLang, close, formData, onUpdate, deleteVariable }) => {
+const VariableForm: FC<Props> = ({
+  customKey,
+  variables,
+  contentLang,
+  close,
+  formData,
+  onUpdate,
+  deleteVariable,
+  currentFlow
+}) => {
   const variableType = useRef(formData?.type)
   const [showOptions, setShowOptions] = useState(false)
   const [forceUpdate, setForceUpdate] = useState(false)
@@ -49,6 +59,11 @@ const VariableForm: FC<Props> = ({ customKey, variables, contentLang, close, for
     ({ value }) =>
       value.type === variableType.current && (!formData.params?.subType || value.subType === formData.params?.subType)
   )
+
+  let advancedSettings = selectedVariableType.config?.advancedSettings || []
+  if (currentFlow.type !== 'reusable') {
+    advancedSettings = advancedSettings.filter(x => !['isInput', 'isOutput'].includes(x.key))
+  }
 
   return (
     <RightSidebar className={style.wrapper} canOutsideClickClose={true} close={close}>
@@ -83,7 +98,7 @@ const VariableForm: FC<Props> = ({ customKey, variables, contentLang, close, for
             currentLang={contentLang}
             axios={axios}
             fields={selectedVariableType.config?.fields || []}
-            advancedSettings={selectedVariableType.config?.advancedSettings || []}
+            advancedSettings={advancedSettings}
             formData={formData?.params || {}}
             onUpdate={data => onUpdate({ params: { ...data }, type: variableType.current })}
           />

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/index.tsx
@@ -1148,6 +1148,7 @@ class Diagram extends Component<Props> {
               customKey={`${node?.id}${node?.prompt?.type}`}
               deleteVariable={this.deleteVariable.bind(this)}
               formData={currentItem}
+              currentFlow={this.props.currentFlow}
               onUpdate={this.updateFlowVariable.bind(this)}
               close={() => {
                 this.timeout = setTimeout(() => {


### PR DESCRIPTION
https://trello.com/c/1kKQILQ0/236-input-output-variables-should-only-be-available-in-subworkflows-and-be-displayed-differently-see-comments-for-zeplin