### PR TITLE
fix(prompt): incorrect context passed to renderTemplate

### DIFF
--- a/src/bp/core/services/cms.ts
+++ b/src/bp/core/services/cms.ts
@@ -613,11 +613,11 @@ export class CMSService implements IDisposeOnExit {
     }
   }
 
-  async translatePayload(payload: any, event: IO.Event) {
+  async translatePayload(payload: any, event: IO.IncomingEvent) {
     const defaultLang = (await this.configProvider.getBotConfig(event.botId)).defaultLanguage
     const lang = _.get(event, 'state.user.language')
 
-    payload = renderRecursive(payload, { event }, lang, defaultLang)
+    payload = renderRecursive(payload, event.state, lang, defaultLang)
 
     if (payload.text) {
       this._prepareTextAndShuffle(payload)

--- a/src/bp/core/services/middleware/event-engine.ts
+++ b/src/bp/core/services/middleware/event-engine.ts
@@ -88,7 +88,7 @@ export class EventEngine {
   public onBeforeIncomingMiddleware?: (event) => Promise<void>
   public onAfterIncomingMiddleware?: (event) => Promise<void>
   public onBeforeOutgoingMiddleware?: (event) => Promise<void>
-  public translatePayload?: (payload: sdk.Content.All, event: sdk.IO.Event) => Promise<any>
+  public translatePayload?: (payload: sdk.Content.All, event: sdk.IO.IncomingEvent) => Promise<any>
 
   private readonly _incomingPerf = new TimedPerfCounter('mw_incoming')
   private readonly _outgoingPerf = new TimedPerfCounter('mw_outgoing')
@@ -212,7 +212,7 @@ export class EventEngine {
 
   async replyContentToEvent(
     payload: sdk.Content.All,
-    event: sdk.IO.Event,
+    event: sdk.IO.IncomingEvent,
     options: { incomingEventId?: string; eventType?: string } = {}
   ) {
     payload.metadata = {

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -2183,7 +2183,7 @@ declare module 'botpress/sdk' {
 
     export function replyContentToEvent(
       payload: Content.All,
-      event: IO.Event,
+      event: IO.IncomingEvent,
       options: { incomingEventId?: string; eventType?: string }
     ): Promise<void>
 


### PR DESCRIPTION
Prompts use the `replyContentToEvent` function which ended up calling the `renderTemplate` function with the whole event as context instead of `event.state`. So variables could not be obtained because we use `workflow.variables.name` to access them which assumes state is the passed context.