### PR TITLE
fix: broken build, allow replyContentToEvent for outgoing events

### DIFF
--- a/src/bp/core/services/middleware/event-engine.ts
+++ b/src/bp/core/services/middleware/event-engine.ts
@@ -212,7 +212,7 @@ export class EventEngine {
 
   async replyContentToEvent(
     payload: sdk.Content.All,
-    event: sdk.IO.IncomingEvent,
+    event: sdk.IO.Event,
     options: { incomingEventId?: string; eventType?: string } = {}
   ) {
     payload.metadata = {
@@ -220,11 +220,15 @@ export class EventEngine {
       ...(payload.metadata ?? {})
     }
 
+    payload = !(event as sdk.IO.IncomingEvent).state
+      ? payload
+      : await this.translatePayload!(payload, event as sdk.IO.IncomingEvent)
+
     const replyEvent = Event({
       ..._.pick(event, ['botId', 'channel', 'target', 'threadId']),
       direction: 'outgoing',
       type: options.eventType ?? payload.type ?? 'default',
-      payload: await this.translatePayload!(payload, event),
+      payload,
       incomingEventId: options.incomingEventId
     })
 

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -2183,7 +2183,7 @@ declare module 'botpress/sdk' {
 
     export function replyContentToEvent(
       payload: Content.All,
-      event: IO.IncomingEvent,
+      event: IO.Event,
       options: { incomingEventId?: string; eventType?: string }
     ): Promise<void>
 


### PR DESCRIPTION
I am not used to work in core, but the build is broken on dev since commit #3800 ... So yeah, I feel like this solves the problem but I need an approval to confirm I'm not breaking anything.

build was broken in [promptHandler.ts](https://github.com/botpress/botpress/blob/dev/modules/builtin/src/backend/promptHandler.ts) at line 20