### PR TITLE
fix(core): decrement variable lifecycle

### DIFF
--- a/src/bp/core/services/dialog/dialog-engine.ts
+++ b/src/bp/core/services/dialog/dialog-engine.ts
@@ -730,18 +730,25 @@ export class DialogEngine {
   private _processResolvedPrompt(event: IO.IncomingEvent, context: IO.DialogContext) {
     const { config, state } = context.activePrompt!
 
-    this.createVariable(
-      {
-        name: config.output,
-        value: state.value,
-        type: config.valueType!,
-        subType: config.subType,
-        options: {
-          nbOfTurns: config.duration ?? 10
-        }
-      },
-      event
-    )
+    const workflowName = event.state.session.currentWorkflow!
+    const wf = event.state.session.workflows[workflowName]
+    const name = config.output
+
+    const varValue = wf?.variables[name]?.value
+    if (varValue === null || varValue === undefined) {
+      this.createVariable(
+        {
+          name,
+          value: state.value,
+          type: config.valueType!,
+          subType: config.subType,
+          options: {
+            nbOfTurns: config.duration ?? 10
+          }
+        },
+        event
+      )
+    }
 
     this._setCurrentNodeValue(event, 'extracted', true)
   }

--- a/src/bp/core/services/middleware/state-manager.ts
+++ b/src/bp/core/services/middleware/state-manager.ts
@@ -113,7 +113,8 @@ export class StateManager {
       workflows[wf].variables = Object.keys(variables).reduce((acc, id) => {
         const { type, subType, value, nbTurns } = (variables[id] as any) as sdk.UnboxedVariable<any>
 
-        const data = { type, subType, value, nbOfTurns: nbTurns - 1 }
+        const nbOfTurns = Math.max(0, nbTurns - 1)
+        const data = { type, subType, value, nbOfTurns }
         acc[id] = this.dialogStore.getBoxedVar(data, botId, wf, id)
 
         return acc


### PR DESCRIPTION
Solves [this issue](https://trello.com/c/3fLkeOgD/262-prompts-should-override-variables-set-previously-if-they-are-old-variables-should-have-an-expiry-policy-duration-of-the-flow-per).

Then again I'm not used to work in the core, that might not be the best fix.

Here's how this solves the problem:

1. On before incoming mw: we restore the event with the state manager and we build a variable by decrementing number of turns left.
2. On after incoming mw: we process event in decision engine, which then process event in the dialog engine, which then realize there's a prompt with status 'resolved'. 

Now at this moment, the current behavior on branch `dev` is that we build the variable again with the original variable duration. On this branch, we only build the variable if its not already in `event.state.workflow[wfName].variables[varName]`.  

this way, the amount of turns left is decremented each turns and when it is zero, the prompt ask for a value again.