### PR TITLE
fix(build) Add nlu-core to scripts

### DIFF
--- a/build/package.pkg.json
+++ b/build/package.pkg.json
@@ -12,6 +12,7 @@
       "./pro/**/*.js",
       "./common/**/*.js",
       "./ml/**/*.js",
+      "./nlu-core/**/*.js",
       "./migrations/**/*.js"
     ],
     "assets": [


### PR DESCRIPTION
This fixes the following happening when Docker images are started on the playground:
![2020-08-17 at 8 48 AM](https://user-images.githubusercontent.com/892367/90403000-4e208580-e06e-11ea-99de-b2076ea471ed.png)
