### PR TITLE
fix(core): fix common arguments

### DIFF
--- a/src/bp/common/action.ts
+++ b/src/bp/common/action.ts
@@ -1,7 +1,7 @@
 import { IO } from 'botpress/sdk'
 import _ from 'lodash'
 
-import { EventCommonArgs } from './typings'
+import { EventCommonArgs, OutgoingEventCommonArgs } from './typings'
 
 export interface ActionInstruction {
   actionName: string
@@ -36,16 +36,24 @@ export const parseActionInstruction = (actionInstruction: string): ActionInstruc
 }
 
 export const extractEventCommonArgs = (
-  event: IO.IncomingEvent,
+  event: IO.Event | IO.IncomingEvent,
   args?: { [property: string]: any }
-): EventCommonArgs => {
+): EventCommonArgs | OutgoingEventCommonArgs => {
+  if (event.direction === 'outgoing') {
+    return {
+      ...(args ?? {}),
+      event
+    }
+  }
+  const incomingEvent = event as IO.IncomingEvent
+
   return {
     ...(args ?? {}),
-    event,
-    user: event.state.user ?? {},
-    session: event.state.session ?? ({} as IO.CurrentSession),
-    temp: event.state.temp ?? {},
-    bot: event.state.bot ?? {},
-    workflow: event.state.workflow ?? ({} as IO.WorkflowHistory)
+    event: incomingEvent,
+    user: incomingEvent.state.user ?? {},
+    session: incomingEvent.state.session ?? ({} as IO.CurrentSession),
+    temp: incomingEvent.state.temp ?? {},
+    bot: incomingEvent.state.bot ?? {},
+    workflow: incomingEvent.state.workflow ?? ({} as IO.WorkflowHistory)
   }
 }

--- a/src/bp/common/typings.ts
+++ b/src/bp/common/typings.ts
@@ -215,6 +215,12 @@ export interface LibraryElement {
   path: string
 }
 
+export interface OutgoingEventCommonArgs {
+  event: IO.Event
+  // Any other additional property
+  [property: string]: any
+}
+
 export interface EventCommonArgs {
   event: IO.IncomingEvent
   user: { [attribute: string]: any }

--- a/src/bp/core/services/cms.ts
+++ b/src/bp/core/services/cms.ts
@@ -9,7 +9,7 @@ import nanoid from 'nanoid'
 import path from 'path'
 import { VError } from 'verror'
 
-import { EventCommonArgs, IDisposeOnExit } from '../../common/typings'
+import { EventCommonArgs, IDisposeOnExit, OutgoingEventCommonArgs } from '../../common/typings'
 import { ConfigProvider } from '../config/config-loader'
 import { LoggerProvider } from '../logger/logger'
 import { CodeFile, SafeCodeSandbox } from '../misc/code-sandbox'
@@ -613,11 +613,11 @@ export class CMSService implements IDisposeOnExit {
     }
   }
 
-  async translatePayload(payload: any, event: IO.IncomingEvent) {
-    const defaultLang = (await this.configProvider.getBotConfig(event.botId)).defaultLanguage
-    const lang = _.get(event, 'state.user.language')
+  async translatePayload(payload: any, args: EventCommonArgs | OutgoingEventCommonArgs) {
+    const defaultLang = (await this.configProvider.getBotConfig(args.event.botId)).defaultLanguage
+    const lang = _.get(args.event, 'state.user.language')
 
-    payload = renderRecursive(payload, event.state, lang, defaultLang)
+    payload = renderRecursive(payload, args.event, lang, defaultLang)
 
     if (payload.text) {
       this._prepareTextAndShuffle(payload)

--- a/src/bp/core/services/cms.ts
+++ b/src/bp/core/services/cms.ts
@@ -617,7 +617,7 @@ export class CMSService implements IDisposeOnExit {
     const defaultLang = (await this.configProvider.getBotConfig(args.event.botId)).defaultLanguage
     const lang = _.get(args.event, 'state.user.language')
 
-    payload = renderRecursive(payload, args.event, lang, defaultLang)
+    payload = renderRecursive(payload, args, lang, defaultLang)
 
     if (payload.text) {
       this._prepareTextAndShuffle(payload)

--- a/src/bp/core/services/dialog/instruction/strategy.ts
+++ b/src/bp/core/services/dialog/instruction/strategy.ts
@@ -1,6 +1,6 @@
 import { IO, Logger } from 'botpress/sdk'
 import { extractEventCommonArgs, parseActionInstruction } from 'common/action'
-import { ActionServer } from 'common/typings'
+import { ActionServer, EventCommonArgs } from 'common/typings'
 import ActionServersService from 'core/services/action/action-servers-service'
 import ActionService from 'core/services/action/action-service'
 import { CMSService } from 'core/services/cms'
@@ -48,7 +48,7 @@ export class ActionStrategy implements InstructionStrategy {
   public async invokeSendMessage(args: any, contentType: string, event: IO.IncomingEvent) {
     const eventDestination = _.pick(event, ['channel', 'target', 'botId', 'threadId'])
     const commonArgs = extractEventCommonArgs(event, args)
-    const renderedElements = await this.cms.renderElement(contentType, commonArgs, eventDestination)
+    const renderedElements = await this.cms.renderElement(contentType, commonArgs as EventCommonArgs, eventDestination)
 
     await this.eventEngine.replyToEvent(eventDestination, renderedElements, event.id)
   }


### PR DESCRIPTION
Include a fix for two merged PR that were not reviewed correctly.

The fix for  #3800 is not correct because it provides only the state, while the `extractEventCommonArgs` should have been used to keep the whole event, while exposing shortcuts for `session`, `temp`, `user` and `workflow`

Then #3801 was created to fix the typing error because the first one was not implemented correctly.

Basically, replyContentToEvent is designed to respond to incoming events, but in the case of prompts, we had to also support outgoing events. Ideally the hook "before_outgoing_middleware" would also provide access to the incomingEvent as an argument for the best experience.