### PR TITLE
feat(condition): put most used conditions first

### DIFF
--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/ConditionForm/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/ConditionForm/index.tsx
@@ -6,6 +6,7 @@ import cx from 'classnames'
 import { Variables } from 'common/typings'
 import _ from 'lodash'
 import React, { FC, Fragment, useEffect, useRef, useState } from 'react'
+import storage from '~/util/storage'
 
 import style from './style.scss'
 
@@ -22,6 +23,20 @@ interface Props {
   formData: { id: string; params: FormData }
   variables: Variables
   events: BotEvent[]
+}
+
+interface ConditionUsage {
+  [id: string]: number
+}
+
+const CONDITIONS_USAGE_KEY = 'bp::conditionUsage'
+
+const getConditionUsage = (): ConditionUsage => {
+  try {
+    return JSON.parse(storage.get(CONDITIONS_USAGE_KEY) || '{}')
+  } catch (err) {
+    return {}
+  }
 }
 
 const ConditionForm: FC<Props> = ({
@@ -43,6 +58,7 @@ const ConditionForm: FC<Props> = ({
   const condition = useRef(formData?.id)
   const [showOptions, setShowOptions] = useState(false)
   const [forceUpdate, setForceUpdate] = useState(false)
+  const [conditionUsage, setConditionUsage] = useState<ConditionUsage>(getConditionUsage())
 
   useEffect(() => {
     condition.current = formData?.id
@@ -62,6 +78,11 @@ const ConditionForm: FC<Props> = ({
     onUpdate({
       id: value
     })
+
+    try {
+      setConditionUsage({ ...conditionUsage, [value]: (conditionUsage[value] ?? 0) + 1 })
+      storage.set(CONDITIONS_USAGE_KEY, JSON.stringify(conditionUsage))
+    } catch (err) {}
   }
 
   const optionsVariablePlaceholder = {
@@ -71,7 +92,12 @@ const ConditionForm: FC<Props> = ({
     topicName: `[${lang.tr('topic').toLowerCase()}]`
   }
 
-  const options = conditions.map(type => ({ value: type.id, label: lang.tr(type.label, optionsVariablePlaceholder) }))
+  const options = conditions.map(type => ({
+    value: type.id,
+    label: lang.tr(type.label, optionsVariablePlaceholder),
+    order: conditionUsage[type.id] ?? 0
+  }))
+
   const selectedCondition = conditions.find(cond => cond.id === condition.current)
   const selectedOption = options.find(cond => cond.value === condition.current)
 
@@ -136,7 +162,7 @@ const ConditionForm: FC<Props> = ({
               filterable
               className={style.formSelect}
               placeholder={lang.tr('studio.condition.pickCondition')}
-              items={options}
+              items={_.orderBy(options, 'order', 'desc')}
               defaultItem={selectedOption}
               rightIcon="chevron-down"
               onChange={option => {


### PR DESCRIPTION
Simple feature: when you select a condition, it increments its usage count by 1. It then reorder the dropdown with that usage count, so the most used conditions are on top.