### PR TITLE
feat(nlu): added migration to update old slots to new albert variables

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,8 +15,7 @@
         "NODE_PATH": "${workspaceFolder}/out/bp",
         "DEBUG": "bp:none",
         "BLUEBIRD_DEBUG": "1",
-        "TELEMETRY_URL": "https://telemetry.botpress.dev/ingest",
-        "TESTMIG_BP_VERSION": "13.0.0"
+        "TELEMETRY_URL": "https://telemetry.botpress.dev/ingest"
       },
       "smartStep": true,
       "outFiles": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,8 @@
         "NODE_PATH": "${workspaceFolder}/out/bp",
         "DEBUG": "bp:none",
         "BLUEBIRD_DEBUG": "1",
-        "TELEMETRY_URL": "https://telemetry.botpress.dev/ingest"
+        "TELEMETRY_URL": "https://telemetry.botpress.dev/ingest",
+        "TESTMIG_BP_VERSION": "13.0.0"
       },
       "smartStep": true,
       "outFiles": [

--- a/src/bp/core/services/nlu/entities-service.ts
+++ b/src/bp/core/services/nlu/entities-service.ts
@@ -47,7 +47,7 @@ export class EntityService {
     entityName = sanitizeFileName(entityName)
 
     if (!(await this.entityExists(botId, entityName))) {
-      throw new Error('Entity does not exist')
+      throw new Error(`Entity does not exist: ${entityName}`)
     }
     return this.ghostService.forBot(botId).readFileAsObject(ENTITIES_DIR, `${entityName}.json`)
   }
@@ -55,7 +55,7 @@ export class EntityService {
   public async deleteEntity(botId: string, entityName: string): Promise<void> {
     const nameSanitized = sanitizeFileName(entityName)
     if (!(await this.entityExists(botId, nameSanitized))) {
-      throw new Error('Entity does not exist')
+      throw new Error(`Entity does not exist: ${entityName}`)
     }
 
     CacheManager.deleteCache(entityName, botId)

--- a/src/bp/migrations/v13_0_0-1597692131619-replace_slots_by_vars.ts
+++ b/src/bp/migrations/v13_0_0-1597692131619-replace_slots_by_vars.ts
@@ -123,6 +123,7 @@ class ComplexEntityCreator {
       .sortBy()
       .value()
       .join('_')
+      .toLowerCase()
   }
 }
 

--- a/src/bp/migrations/v13_0_0-1597692131619-replace_slots_by_vars.ts
+++ b/src/bp/migrations/v13_0_0-1597692131619-replace_slots_by_vars.ts
@@ -1,0 +1,147 @@
+import * as sdk from 'botpress/sdk'
+import { Migration } from 'core/services/migration'
+import _ from 'lodash'
+
+const INTENT_DIR = 'intents'
+const ENTITIES_DIR = 'entities'
+
+type OldSlotDefinition = sdk.NLU.SlotDefinition & {
+  entities: string[]
+}
+
+type OldIntent = Omit<sdk.NLU.IntentDefinition, 'slots'> & {
+  slots: OldSlotDefinition[]
+}
+
+async function getEntities(scopedGhost: sdk.ScopedGhostService): Promise<sdk.NLU.EntityDefinition[]> {
+  const entitiesFiles = await scopedGhost.directoryListing(ENTITIES_DIR, '*.json')
+  return Promise.map(entitiesFiles, async fname => {
+    const rawContent = await scopedGhost.readFileAsString(ENTITIES_DIR, fname)
+    return JSON.parse(rawContent)
+  })
+}
+
+class ComplexEntityCreator {
+  private newComplexs: _.Dictionary<sdk.NLU.EntityDefinition> = {}
+
+  constructor(private entities: sdk.NLU.EntityDefinition[]) {}
+
+  buildNewComplex(entities: string[]) {
+    entities = entities.filter(e => e !== 'any')
+
+    const name = this.makeName(entities)
+    if (!!this.newComplexs[name]) {
+      return name
+    }
+
+    const getEntitiesOfType = (type: 'list' | 'pattern') => {
+      return this.entities
+        .filter(e => e.type === type)
+        .filter(e => entities.includes(e.name))
+        .map(e => e.name)
+    }
+
+    const list_entities = getEntitiesOfType('list')
+    const pattern_entities = getEntitiesOfType('pattern')
+    const newEntity: sdk.NLU.EntityDefinition = {
+      id: name,
+      name,
+      type: 'complex',
+      list_entities,
+      pattern_entities,
+      examples: []
+    }
+    this.newComplexs[name] = newEntity
+
+    return name
+  }
+
+  appendExample(entity: string, example: string) {
+    this.newComplexs[entity]?.examples?.push(example)
+  }
+
+  getNewComplexs(): sdk.NLU.EntityDefinition[] {
+    return Object.values(this.newComplexs)
+  }
+
+  private makeName(entities: string[]): string {
+    return _(entities)
+      .filter(e => e.length)
+      .sortBy()
+      .value()
+      .join('_')
+  }
+}
+
+const migration: Migration = {
+  info: {
+    description: 'Migrate slots to new Albert variables',
+    target: 'bot',
+    type: 'content'
+  },
+  up: async ({ bp, metadata }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
+    async function updateBot(botId: string): Promise<void> {
+      const scopedGhost = bp.ghost.forBot(botId!)
+      const intentFiles = await scopedGhost.directoryListing(INTENT_DIR, '*.json')
+
+      const allEntities = await getEntities(scopedGhost)
+      const complexCreator = new ComplexEntityCreator(allEntities)
+
+      for (const intentFile of intentFiles) {
+        const rawContent = await scopedGhost.readFileAsString(INTENT_DIR, intentFile)
+        const intent: OldIntent = JSON.parse(rawContent)
+        for (const slot of intent.slots) {
+          if (slot.entities.length > 1) {
+            const newName = complexCreator.buildNewComplex(slot.entities)
+            slot.entities = [newName]
+          }
+
+          slot.entity = slot.entities[0]
+          delete slot.entities
+        }
+
+        const findEntity = function(slotName: string): string | undefined {
+          return intent.slots.find(s => s.name === slotName)?.entity
+        }
+
+        const ALL_SLOTS_REGEX = /\[(.+?)\]\(([\w_\. :-]+)\)/gi // taken from 'nlu-core/utterance/utterance-parser.ts'
+        for (const lang of Object.keys(intent.utterances)) {
+          intent.utterances[lang] = intent.utterances[lang].map((utt: string) =>
+            utt.replace(ALL_SLOTS_REGEX, function(_wholeMatch, slotExample: string, slotName: string) {
+              const slotEntity = findEntity(slotName)
+              if (slotEntity === 'any') {
+                complexCreator.appendExample(slotEntity, slotExample)
+              }
+              return `$${slotName}`
+            })
+          )
+        }
+
+        for (const newComplex of complexCreator.getNewComplexs()) {
+          const rawContent = JSON.stringify(newComplex, undefined, 2)
+          const fName = `${newComplex.name}.json`
+          await scopedGhost.upsertFile(ENTITIES_DIR, fName, rawContent)
+        }
+
+        const newContent = JSON.stringify(intent, undefined, 2)
+        await scopedGhost.upsertFile(INTENT_DIR, intentFile, newContent)
+      }
+    }
+
+    try {
+      if (metadata.botId) {
+        await updateBot(metadata.botId)
+      } else {
+        const bots = await bp.bots.getAllBots()
+        for (const botId of Array.from(bots.keys())) {
+          await updateBot(botId)
+        }
+      }
+      return { success: true, message: 'Slots updated successfully' }
+    } catch (err) {
+      return { success: false, message: `Slot migration could not finish due to error: ${err.message}` }
+    }
+  }
+}
+
+export default migration

--- a/src/bp/migrations/v13_0_0-1597692131619-replace_slots_by_vars.ts
+++ b/src/bp/migrations/v13_0_0-1597692131619-replace_slots_by_vars.ts
@@ -26,8 +26,19 @@ class ComplexEntityCreator {
 
   constructor(private entities: sdk.NLU.EntityDefinition[]) {}
 
-  buildNewComplex(entities: string[]) {
-    entities = entities.filter(e => e !== 'any')
+  buildAny(name: string) {
+    this.newComplexs[name] = {
+      id: name,
+      name,
+      type: 'complex',
+      list_entities: [],
+      pattern_entities: [],
+      examples: []
+    }
+  }
+
+  buildNewComplex(allEntities: string[]) {
+    const entities = allEntities.filter(e => e !== 'any')
 
     const name = this.makeName(entities)
     if (!!this.newComplexs[name]) {
@@ -57,14 +68,17 @@ class ComplexEntityCreator {
   }
 
   appendExample(entity: string, example: string) {
-    this.newComplexs[entity]?.examples?.push(example)
+    const examples = this.newComplexs[entity]?.examples
+    if (examples && !examples.includes(example)) {
+      examples.push(example)
+    }
   }
 
   getNewComplexs(): sdk.NLU.EntityDefinition[] {
     return Object.values(this.newComplexs)
   }
 
-  private makeName(entities: string[]): string {
+  makeName(entities: string[]): string {
     return _(entities)
       .filter(e => e.length)
       .sortBy()
@@ -91,30 +105,40 @@ const migration: Migration = {
         const rawContent = await scopedGhost.readFileAsString(INTENT_DIR, intentFile)
         const intent: OldIntent = JSON.parse(rawContent)
         for (const slot of intent.slots) {
-          if (slot.entities.length > 1) {
+          if (slot.entities.length === 1 && slot.entities[0] === 'any') {
+            const entityName = slot.name
+            complexCreator.buildAny(entityName) // build entity from slot name
+            slot.entity = entityName
+          } else if (slot.entities.length > 1) {
             const newName = complexCreator.buildNewComplex(slot.entities)
-            slot.entities = [newName]
+            slot.entity = newName
+          } else {
+            slot.entity = slot.entities[0]
           }
-
-          slot.entity = slot.entities[0]
-          delete slot.entities
         }
 
-        const findEntity = function(slotName: string): string | undefined {
-          return intent.slots.find(s => s.name === slotName)?.entity
+        const findEntities = function(slotName: string): string[] | undefined {
+          return intent.slots.find(s => s.name === slotName)?.entities
         }
 
         const ALL_SLOTS_REGEX = /\[(.+?)\]\(([\w_\. :-]+)\)/gi // taken from 'nlu-core/utterance/utterance-parser.ts'
         for (const lang of Object.keys(intent.utterances)) {
           intent.utterances[lang] = intent.utterances[lang].map((utt: string) =>
             utt.replace(ALL_SLOTS_REGEX, function(_wholeMatch, slotExample: string, slotName: string) {
-              const slotEntity = findEntity(slotName)
-              if (slotEntity === 'any') {
-                complexCreator.appendExample(slotEntity, slotExample)
+              const slotEntities = findEntities(slotName)
+              if (slotEntities) {
+                const isOnlyAny = slotEntities.length === 1 && slotEntities[0] === 'any'
+                const newComplex = isOnlyAny ? slotName : complexCreator.makeName(slotEntities.filter(e => e !== 'any'))
+                complexCreator.appendExample(newComplex, slotExample)
               }
+
               return `$${slotName}`
             })
           )
+        }
+
+        for (const slot of intent.slots) {
+          delete slot.entities
         }
 
         for (const newComplex of complexCreator.getNewComplexs()) {


### PR DESCRIPTION
This should not be merged yet as we still have few things to discuss before writing migrations scripts.
 
I know everybody's working on Albert demo right now, but I took some advance and wrote this migration script.

The logic looks like this:

**1**. Create new complexs:
If slot has multiple entities or only one any:
    
   We replace 'any' by the slot's name. // This covers most cases of any usage
   We create a new complex with name `entities.join("_")`

else:

   We take the only member of entities for entity

**2**. While replacing markdown notation \[slotExample](slotName) by $slotName, I append slotExample to new complexes examples.
