### PR TITLE
fix(core): added missing error handlers

### DIFF
--- a/modules/extensions/src/views/lite/components/debugger/style.scss
+++ b/modules/extensions/src/views/lite/components/debugger/style.scss
@@ -327,6 +327,15 @@
       }
     }
 
+    .info {
+      color: var(--ocean);
+
+      margin: 0 0 0 var(--spacing-small);
+      svg {
+        fill: var(--ocean);
+      }
+    }
+
     svg {
       fill: var(--gray);
     }

--- a/modules/extensions/src/views/lite/components/debugger/style.scss.d.ts
+++ b/modules/extensions/src/views/lite/components/debugger/style.scss.d.ts
@@ -15,6 +15,7 @@ interface CssExports {
   'group': string;
   'header': string;
   'hovering': string;
+  'info': string;
   'infoBox': string;
   'inspector': string;
   'inspectorContainer': string;

--- a/modules/extensions/src/views/lite/components/debugger/views/Processing.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/views/Processing.tsx
@@ -51,6 +51,7 @@ export const Processing: FC<{ processing: { [activity: string]: sdk.IO.Processin
   const renderToggleItem = (item, key) => {
     const isExpanded = expanded[key]
     const hasError = item.status === 'error' || !!item.errors?.length
+    const hasLog = !!item.logs?.length
 
     return (
       <Fragment>
@@ -58,21 +59,22 @@ export const Processing: FC<{ processing: { [activity: string]: sdk.IO.Processin
           <Icon icon={isExpanded ? 'chevron-down' : 'chevron-right'} iconSize={10} />
           <span className={cx({ [style.error]: hasError })}>{item.name}</span>
           {hasError && <Icon className={style.error} icon="error" iconSize={10} />}
+          {hasLog && <Icon className={style.info} icon="info-sign" iconSize={10} />}
         </button>
         {isExpanded && (
           <span className={style.expanded}>
-            {item.logs?.length && (
+            {hasLog && (
               <span className={style.infoBox}>
                 {item.logs.map(log => (
-                  <div>{log}</div>
+                  <div key={log}>{log}</div>
                 ))}
               </span>
             )}
 
-            {item.errors?.length && (
+            {hasError && (
               <span className={style.infoBox}>
                 {item.errors.map(entry => (
-                  <div>
+                  <div key={entry.stacktrace}>
                     <b>{lang.tr('module.extensions.processing.type')}:</b> {entry.type}
                     <br />
                     <b>{lang.tr('module.extensions.processing.stacktrace')}:</b> {entry.stacktrace}

--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -35,7 +35,6 @@ import { CMSService } from './services/cms'
 import { converseApiEvents } from './services/converse'
 import { DecisionEngine } from './services/dialog/decision-engine'
 import { DialogEngine } from './services/dialog/dialog-engine'
-import { ProcessingError } from './services/dialog/errors'
 import { DialogJanitor } from './services/dialog/janitor'
 import { SessionIdFactory } from './services/dialog/session/id-factory'
 import { HintsService } from './services/hints'
@@ -442,19 +441,6 @@ export class Botpress {
 
     await this.dataRetentionService.initialize()
 
-    const dialogEngineLogger = await this.loggerProvider('DialogEngine')
-    this.dialogEngine.onProcessingError = (err, hideStack?) => {
-      const message = this.formatProcessingError(err)
-      if (!hideStack) {
-        dialogEngineLogger
-          .forBot(err.botId)
-          .attachError(err)
-          .warn(message)
-      } else {
-        dialogEngineLogger.forBot(err.botId).warn(message)
-      }
-    }
-
     this.notificationService.onNotification = notification => {
       const payload: sdk.RealTimePayload = {
         eventName: 'notifications.new',
@@ -502,14 +488,6 @@ export class Botpress {
 
   private async startRealtime() {
     await this.realtimeService.installOnHttpServer(this.httpServer.httpServer)
-  }
-
-  private formatProcessingError(err: ProcessingError) {
-    return `Error processing '${err.instruction}'
-Err: ${err.message}
-BotId: ${err.botId}
-Flow: ${err.flowName}
-Node: ${err.nodeName}`
   }
 
   private trackStart() {

--- a/src/bp/core/services/dialog/decision-engine.ts
+++ b/src/bp/core/services/dialog/decision-engine.ts
@@ -8,7 +8,7 @@ import _ from 'lodash'
 import moment from 'moment'
 import ms from 'ms'
 
-import { addStepToEvent } from '../middleware/event-collector'
+import { addErrorToEvent, addStepToEvent } from '../middleware/event-collector'
 import { EventEngine } from '../middleware/event-engine'
 import { StateManager } from '../middleware/state-manager'
 
@@ -79,13 +79,32 @@ export class DecisionEngine {
     const hasContinue = event.ndu.actions.find(x => x.action === 'continue')
     const hasPrompt = event.ndu.actions.find(x => x.action.startsWith('prompt.'))
     if (!event.hasFlag(WellKnownFlags.SKIP_DIALOG_ENGINE) && (hasContinue || hasPrompt)) {
-      const processedEvent = await this.dialogEngine.processEvent(sessionId, event)
+      try {
+        const processedEvent = await this.dialogEngine.processEvent(sessionId, event)
 
-      // In case there are no unknown errors, remove skills/ flow from the stacktrace
-      processedEvent.state.__stacktrace = processedEvent.state.__stacktrace.filter(x => !x.flow.startsWith('skills/'))
-      await processEvent(processedEvent)
-      await this.stateManager.persist(processedEvent, false)
-      return
+        // In case there are no unknown errors, remove skills/ flow from the stacktrace
+        processedEvent.state.__stacktrace = processedEvent.state.__stacktrace.filter(x => !x.flow.startsWith('skills/'))
+        await processEvent(processedEvent)
+        await this.stateManager.persist(processedEvent, false)
+        return
+      } catch (err) {
+        this.logger
+          .forBot(event.botId)
+          .attachError(err)
+          .error('An unexpected error occurred.')
+
+        addErrorToEvent(
+          {
+            type: 'dialog-engine',
+            stacktrace: err.stacktrace || err.stack
+          },
+          event
+        )
+
+        addStepToEvent('dialog:error', event)
+
+        await this._processErrorFlow(sessionId, event)
+      }
     }
 
     if (event.hasFlag(WellKnownFlags.FORCE_PERSIST_STATE)) {

--- a/src/bp/core/services/dialog/decision-engine.ts
+++ b/src/bp/core/services/dialog/decision-engine.ts
@@ -81,6 +81,7 @@ export class DecisionEngine {
     if (!event.hasFlag(WellKnownFlags.SKIP_DIALOG_ENGINE) && (hasContinue || hasPrompt)) {
       try {
         const processedEvent = await this.dialogEngine.processEvent(sessionId, event)
+        addStepToEvent('dialog:completed', event)
 
         // In case there are no unknown errors, remove skills/ flow from the stacktrace
         processedEvent.state.__stacktrace = processedEvent.state.__stacktrace.filter(x => !x.flow.startsWith('skills/'))

--- a/src/bp/core/services/dialog/dialog-engine.ts
+++ b/src/bp/core/services/dialog/dialog-engine.ts
@@ -323,18 +323,29 @@ export class DialogEngine {
       delete event.state.context.activePrompt
     }
 
-    const botId = event.botId
-    await this._loadFlows(botId)
+    try {
+      const botId = event.botId
+      await this._loadFlows(botId)
 
-    const targetFlow = this._findFlow(botId, targetFlowName)
-    const targetNode = targetNodeName
-      ? this._findNode(botId, targetFlow, targetNodeName)
-      : this._findNode(botId, targetFlow, targetFlow.startNode)
+      const targetFlow = this._findFlow(botId, targetFlowName)
+      const targetNode = targetNodeName
+        ? this._findNode(botId, targetFlow, targetNodeName)
+        : this._findNode(botId, targetFlow, targetFlow.startNode)
 
-    event.state.context.currentFlow = targetFlow.name
-    event.state.context.currentNode = targetNode.name
-    event.state.context.queue = undefined
-    event.state.context.hasJumped = true
+      event.state.context.currentFlow = targetFlow.name
+      event.state.context.currentNode = targetNode.name
+      event.state.context.queue = undefined
+      event.state.context.hasJumped = true
+    } catch (err) {
+      addErrorToEvent(
+        {
+          type: 'dialog-engine',
+          stacktrace: err.stacktrace || err.stack
+        },
+        event
+      )
+      throw err
+    }
   }
 
   public async processTimeout(botId: string, sessionId: string, event: IO.IncomingEvent, isPrompt?: boolean) {

--- a/src/bp/core/services/dialog/errors.ts
+++ b/src/bp/core/services/dialog/errors.ts
@@ -1,15 +1,3 @@
-export class ProcessingError extends Error {
-  constructor(
-    message: string,
-    public readonly botId: string,
-    public readonly nodeName: string,
-    public readonly flowName: string,
-    public readonly instruction: string
-  ) {
-    super(message)
-  }
-}
-
 export class ActionExecutionError extends Error {
   private hideStack = false
   constructor(

--- a/src/bp/core/services/dialog/instruction/strategy.ts
+++ b/src/bp/core/services/dialog/instruction/strategy.ts
@@ -198,16 +198,7 @@ export class TransitionStrategy implements InstructionStrategy {
       instruction.fn = instruction.fn!.replace(match, `event.state.workflow.variables.${name}`)
     }
 
-    const code = `
-    try {
-      return ${instruction.fn};
-    } catch (err) {
-      if (err instanceof TypeError) {
-        console.log(err)
-        return false
-      }
-      throw err
-    }`
+    const code = `return ${instruction.fn};`
 
     if (process.DISABLE_TRANSITION_SANDBOX || !this.unsafeRegex.test(instruction.fn!)) {
       const fn = new Function(...Object.keys(sandbox), code)

--- a/src/bp/core/services/middleware/state-manager.ts
+++ b/src/bp/core/services/middleware/state-manager.ts
@@ -132,7 +132,7 @@ export class StateManager {
     const sessionId = SessionIdFactory.createIdFromEvent(event)
 
     if (!lastMessages.find(x => x.eventId === event.id)) {
-      addLogToEvent(`No message was sent by the bot`, event)
+      addLogToEvent(`No messages were sent by the bot`, event)
 
       if (_.isEmpty(event.state.context)) {
         addLogToEvent(`End of workflow`, event)

--- a/src/bp/core/services/middleware/state-manager.ts
+++ b/src/bp/core/services/middleware/state-manager.ts
@@ -18,6 +18,7 @@ import { JobService } from '../job-service'
 import { KeyValueStore } from '../kvs'
 
 import { DialogStore } from './dialog-store'
+import { addLogToEvent } from './event-collector'
 
 const getRedisSessionKey = sessionId => `sessionstate_${sessionId}`
 const BATCH_SIZE = 100
@@ -122,13 +123,21 @@ export class StateManager {
   }
 
   public async persist(event: sdk.IO.IncomingEvent, ignoreContext: boolean) {
-    const { workflows } = event.state.session
+    const { workflows, lastMessages } = event.state.session
 
     for (const wf of Object.keys(workflows)) {
       workflows[wf].variables = _.mapValues(workflows[wf].variables, (x: sdk.BoxedVariable<any>) => x.unbox()) as any
     }
 
     const sessionId = SessionIdFactory.createIdFromEvent(event)
+
+    if (!lastMessages.find(x => x.eventId === event.id)) {
+      addLogToEvent(`No message was sent by the bot`, event)
+
+      if (_.isEmpty(event.state.context)) {
+        addLogToEvent(`End of workflow`, event)
+      }
+    }
 
     if (this.useRedis) {
       await this._redisClient.set(

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -883,10 +883,11 @@ declare module 'botpress/sdk' {
     }
 
     export interface EventError {
-      type: 'action-execution' | 'dialog-transition'
+      type: 'action-execution' | 'dialog-transition' | 'dialog-engine' | 'hook-execution'
       stacktrace?: string
       actionName?: string
       actionArgs?: any
+      hookName?: string
       destination?: string
     }
 


### PR DESCRIPTION
I was playing around with the debugger processing and found these points we should discuss:

- In `decision-engine.ts`, we had an error wrapper to gracefully handle dialog-engine errors, which we did not apply to the NDU "processEvent". It also did not execute the error flow (it does for actions/hooks, but not for all possible errors)

- "jumpTo" an invalid flow/node, just throwed an error without letting the user know what happened

- Errors generated by hooks were not displayed at all in the processing section (it only marked the hook as "status: error" without details)

- Fixed error in transitions which were not bubbled up

- Added an informative message when no message were sent by the bot to the user, and if it was the end of the workflow