### PR TITLE
fix(examples) Complete module: compilation error

### DIFF
--- a/examples/module-templates/complete-module/src/backend/index.ts
+++ b/examples/module-templates/complete-module/src/backend/index.ts
@@ -14,7 +14,7 @@ const onServerReady = async (bp: typeof sdk) => {
 const onBotMount = async (bp: typeof sdk, botId: string) => {}
 
 // This is called every time a bot is deleted (or disabled)
-const onBotUnmount = async (botId: string) => {}
+const onBotUnmount = async (bp: typeof sdk, botId: string) => {}
 
 // When anything is changed using the flow editor, this is called with the new flow, so you can rename nodes if you reference them
 const onFlowChanged = async (bp: typeof sdk, botId: string, flow: sdk.Flow) => {}


### PR DESCRIPTION
Fixes the following compilation error:
```
[module-builder] [ERROR] in /Users/spg/botpress/modules/my-custom-module/src/backend/index.ts (38,3)
                 TS2322: Type '(botId: string) => Promise<void>' is not assignable to type '(bp: typeof import("botpress/sdk"), botId: string) => Promise<void>'.
  Types of parameters 'botId' and 'bp' are incompatible.
    Type 'typeof import("botpress/sdk")' is not assignable to type 'string'.
```