### PR TITLE
feat(studio): add ability to move workflow

### DIFF
--- a/src/bp/ui-studio/src/web/translations/en.json
+++ b/src/bp/ui-studio/src/web/translations/en.json
@@ -289,6 +289,7 @@
         "addWorkflow": "Add Workflow",
         "tapIconsToAdd": "Tap icons in the toolbar to import or add your first topic.",
         "renameWorkflow": "Rename Workflow",
+        "moveWorkflow": "Move Workflow to",
         "renameTopic": "Rename Topic",
         "nameWorkflow": "Name Workflow",
         "nameTopic": "Name Topic"

--- a/src/bp/ui-studio/src/web/translations/fr.json
+++ b/src/bp/ui-studio/src/web/translations/fr.json
@@ -287,7 +287,7 @@
         "addWorkflow": "Ajouter workflow",
         "tapIconsToAdd": "Appuyez sur les icônes de la barre d'outils pour importer ou ajouter votre premier sujet.",
         "renameWorkflow": "Renommer workflow",
-        "moveWorkflow": "Déplacer le workflow",
+        "moveWorkflow": "Déplacer le workflow vers",
         "renameTopic": "Renommer sujet",
         "nameWorkflow": "Name Workflow",
         "nameTopic": "Name Topic"

--- a/src/bp/ui-studio/src/web/translations/fr.json
+++ b/src/bp/ui-studio/src/web/translations/fr.json
@@ -287,6 +287,7 @@
         "addWorkflow": "Ajouter workflow",
         "tapIconsToAdd": "Appuyez sur les icônes de la barre d'outils pour importer ou ajouter votre premier sujet.",
         "renameWorkflow": "Renommer workflow",
+        "moveWorkflow": "Déplacer le workflow",
         "renameTopic": "Renommer sujet",
         "nameWorkflow": "Name Workflow",
         "nameTopic": "Name Topic"

--- a/src/bp/ui-studio/src/web/views/OneFlow/sidePanel/TopicList/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/sidePanel/TopicList/index.tsx
@@ -2,6 +2,7 @@ import { Button, Intent, MenuItem } from '@blueprintjs/core'
 import axios from 'axios'
 import { confirmDialog, EmptyState, lang } from 'botpress/shared'
 import cx from 'classnames'
+import { parseFlowName } from 'common/flow'
 import _ from 'lodash'
 import React, { FC, Fragment, useEffect, useState } from 'react'
 import { connect } from 'react-redux'
@@ -101,6 +102,18 @@ const TopicList: FC<Props> = props => {
     }
   }
 
+  const moveFlow = (workflowPath: string, newTopicName: string) => {
+    const parsed = parseFlowName(workflowPath, true)
+    const fullName = buildFlowName({ topic: newTopicName, workflow: parsed.workflow }, true)
+
+    if (!props.flowsName.find(x => x.name === fullName)) {
+      props.renameFlow({ targetFlow: workflowPath, name: fullName })
+      props.updateFlow({ name: fullName })
+    }
+
+    setExpanded({ ...expanded, [newTopicName]: true })
+  }
+
   const deleteTopic = async (name: string, skipDialog = false) => {
     const matcher = new RegExp(`^${name}/`)
     const flowsToDelete = props.flowsName.filter(x => matcher.test(x.name))
@@ -164,6 +177,17 @@ const TopicList: FC<Props> = props => {
               setIsEditingNew(false)
             }}
           />
+          <MenuItem id="btn-moveTo" disabled={props.readOnly} label={lang.tr('studio.flow.sidePanel.moveWorkflow')}>
+            {console.log(props.topics)}
+            {props.topics?.map(topic => (
+              <MenuItem
+                label={topic.name}
+                onClick={() => {
+                  moveFlow(name, topic.name)
+                }}
+              />
+            ))}
+          </MenuItem>
           <MenuItem
             id="btn-delete"
             disabled={lockedFlows.includes(name) || !props.canDelete || props.readOnly}

--- a/src/bp/ui-studio/src/web/views/OneFlow/sidePanel/TopicList/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/sidePanel/TopicList/index.tsx
@@ -178,7 +178,6 @@ const TopicList: FC<Props> = props => {
             }}
           />
           <MenuItem id="btn-moveTo" disabled={props.readOnly} label={lang.tr('studio.flow.sidePanel.moveWorkflow')}>
-            {console.log(props.topics)}
             {props.topics?.map(topic => (
               <MenuItem
                 label={topic.name}


### PR DESCRIPTION
https://trello.com/c/9MwOaGBC/155-add-the-possibility-to-move-workflow-to-another-topic

Adds `Move workflow to` option in the right click menu of side panel. Allows moving workflows to other topics