### PR TITLE
fix(core): locked bots prevent migration completion

### DIFF
--- a/modules/nlu/src/migrations/v12_0_1-1562193005-migrate_numeral_entities_to_number.ts
+++ b/modules/nlu/src/migrations/v12_0_1-1562193005-migrate_numeral_entities_to_number.ts
@@ -18,7 +18,7 @@ const migration: sdk.ModuleMigration = {
           }
           return slot
         })
-        await bpfs.upsertFile('./intents', file, JSON.stringify(content, undefined, 2))
+        await bpfs.upsertFile('./intents', file, JSON.stringify(content, undefined, 2), { ignoreLock: true })
       }
     }
 

--- a/modules/nlu/src/migrations/v12_2_3-1573576448-updated_entities.ts
+++ b/modules/nlu/src/migrations/v12_2_3-1573576448-updated_entities.ts
@@ -31,7 +31,7 @@ const migration: sdk.ModuleMigration = {
           }
         }
 
-        await bpfs.upsertFile('./entities', fileName, JSON.stringify(entityDef, undefined, 2))
+        await bpfs.upsertFile('./entities', fileName, JSON.stringify(entityDef, undefined, 2), { ignoreLock: true })
       }
     }
     if (metadata.botId) {

--- a/modules/nlu/src/migrations/v12_3_2-1577993749-entities_misspelling.ts
+++ b/modules/nlu/src/migrations/v12_3_2-1577993749-entities_misspelling.ts
@@ -15,7 +15,7 @@ const migration: sdk.ModuleMigration = {
         const entityDef = (await bpfs.readFileAsObject('./entities', fileName)) as sdk.NLU.EntityDefinition
         entityDef.occurrences = _.cloneDeep(entityDef['occurences'])
         delete entityDef['occurences']
-        await bpfs.upsertFile('./entities', fileName, JSON.stringify(entityDef, undefined, 2))
+        await bpfs.upsertFile('./entities', fileName, JSON.stringify(entityDef, undefined, 2), { ignoreLock: true })
       }
     }
     if (metadata.botId) {

--- a/modules/qna/src/migrations/v12_8_0-1583933939-qna_multi_contexts.ts
+++ b/modules/qna/src/migrations/v12_8_0-1583933939-qna_multi_contexts.ts
@@ -21,7 +21,7 @@ const migration: sdk.ModuleMigration = {
           content.data.contexts = category ? [category] : []
           delete content.data.category
 
-          await bpfs.upsertFile('./qna', file, JSON.stringify(content, undefined, 2))
+          await bpfs.upsertFile('./qna', file, JSON.stringify(content, undefined, 2), { ignoreLock: true })
           hasChanges = true
         }
       }

--- a/src/bp/migrations/v12_10_0-1591119240-migrate_content_in_flow_data_for_ndu_bots.ts
+++ b/src/bp/migrations/v12_10_0-1591119240-migrate_content_in_flow_data_for_ndu_bots.ts
@@ -81,7 +81,9 @@ const migration: Migration = {
             ..._.pick(flow, ['version', 'catchAll', 'startNode', 'skillData', 'triggers', 'label', 'description']),
             nodes: flow.nodes.map(node => _.omit(node, 'x', 'y', 'lastModified'))
           }
-          await ghost.upsertFile('./flows', flow.location!, JSON.stringify(flowContent, undefined, 2))
+          await ghost.upsertFile('./flows', flow.location!, JSON.stringify(flowContent, undefined, 2), {
+            ignoreLock: true
+          })
         } catch (err) {
           bp.logger
             .forBot(botId)


### PR DESCRIPTION
Some migrations were failing when you had a locked bot and caused the server to restart. Added the missing flag only to migrations which touch bot content