### PR TITLE
feat(studio): drag&drop trigger/say node to add item

### DIFF
--- a/src/bp/ui-studio/src/web/translations/en.json
+++ b/src/bp/ui-studio/src/web/translations/en.json
@@ -182,6 +182,7 @@
         "add": "add",
         "addAction": "Add new action",
         "addCondition": "Add Condition",
+        "addMessage": "Add Message",
         "cantSeeActions": "Can't see your action?",
         "chatbotExecutes": "Chatbot Executes",
         "chatbotSays": "Chatbot Says",

--- a/src/bp/ui-studio/src/web/translations/fr.json
+++ b/src/bp/ui-studio/src/web/translations/fr.json
@@ -181,6 +181,7 @@
         "add": "ajouter",
         "addAction": "Ajouter une nouvelle action",
         "addCondition": "Ajouter une condition",
+        "addMessage": "Ajouter un message",
         "cantSeeActions": "Vous ne voyez pas votre action?",
         "chatbotExecutes": "L'assistant virtuel exécute",
         "chatbotSays": "L'assistant virtuel dit",

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/index.tsx
@@ -169,6 +169,7 @@ class Diagram extends Component<Props> {
       getCurrentLang: () => this.getStateProperty('currentLang'),
       getConditions: () => this.getPropsProperty('conditions'),
       addCondition: this.addCondition.bind(this),
+      addMessage: this.addMessage.bind(this),
       getExpandedNodes: () => this.getStateProperty('expandedNodes'),
       setExpandedNodes: this.updateExpandedNodes.bind(this)
     }
@@ -324,6 +325,12 @@ class Diagram extends Component<Props> {
     }
   }
 
+  getTextFields = () => {
+    const { fields, advancedSettings } =
+      this.props.contentTypes.find(contentType => contentType.id === 'builtin_text')?.schema?.newJson || {}
+    return [...(fields || []), ...(advancedSettings || [])]
+  }
+
   add = {
     flowNode: (point: Point) => this.props.createFlowNode({ ...point, type: 'standard' }),
     skillNode: (point: Point, skillId: string) => this.props.buildSkill({ location: point, id: skillId }),
@@ -338,15 +345,14 @@ class Diagram extends Component<Props> {
       })
     },
     say: (point: Point, moreProps) => {
-      const { fields, advancedSettings } =
-        this.props.contentTypes.find(contentType => contentType.id === 'builtin_text')?.schema?.newJson || {}
-      const schemaFields = [...(fields || []), ...(advancedSettings || [])]
-
       this.props.createFlowNode({
         ...point,
         type: 'say_something',
         contents: [
-          { contentType: 'builtin_text', ...Contents.createEmptyDataFromSchema(schemaFields, this.state.currentLang) }
+          {
+            contentType: 'builtin_text',
+            ...Contents.createEmptyDataFromSchema(this.getTextFields(), this.state.currentLang)
+          }
         ],
         next: [defaultTransition],
         isNew: true,
@@ -657,8 +663,15 @@ class Diagram extends Component<Props> {
     return this.props[propertyName]
   }
 
-  addCondition(nodeId) {
+  addCondition() {
     this.props.updateFlowNode({ conditions: [...this.props.currentFlowNode.conditions, { params: {} }] })
+  }
+
+  addMessage() {
+    const schema = Contents.createEmptyDataFromSchema(this.getTextFields(), this.state.currentLang)
+    this.props.updateFlowNode({
+      contents: [...this.props.currentFlowNode.contents, { contentType: 'builtin_text', ...schema }]
+    })
   }
 
   switchFlowNode(nodeId) {
@@ -767,6 +780,8 @@ class Diagram extends Component<Props> {
     const data = JSON.parse(event.dataTransfer.getData('diagram-node'))
 
     const point = this.manager.getRealPosition(event)
+    const target = this.diagramWidget.getMouseElement(event)
+    const targetNodeType = target?.model['nodeType']
 
     if (data.type === 'chip') {
       const target = this.diagramWidget.getMouseElement(event)
@@ -778,13 +793,25 @@ class Diagram extends Component<Props> {
     } else if (data.type === 'node') {
       switch (data.id) {
         case 'trigger':
-          this.add.triggerNode(point, {})
+          if (targetNodeType === 'trigger') {
+            await this.props.switchFlowNode(target.model.id)
+            this.addCondition()
+          } else {
+            this.add.triggerNode(point, {})
+          }
+
           break
         case 'prompt':
           this.add.promptNode(point, '')
           break
         case 'say_something':
-          this.add.say(point, {})
+          if (targetNodeType === 'say_something') {
+            await this.props.switchFlowNode(target.model.id)
+            this.addMessage()
+          } else {
+            this.add.say(point, {})
+          }
+
           break
         case 'execute':
           this.add.executeNode(point, data.contentId ? { onReceive: [`${data.contentId}`] } : {})
@@ -851,17 +878,9 @@ class Diagram extends Component<Props> {
       node: { contents },
       index
     } = this.state.editingNodeItem
-    const newContents = [...contents]
+    const newContents = [...contents.filter((_, i) => index !== i)]
 
-    newContents[index] = Object.keys(newContents[index]).reduce((acc, lang) => {
-      if (lang !== this.state.currentLang) {
-        acc = { ...acc, [lang]: { ...newContents[index][lang] } }
-      }
-
-      return acc
-    }, {})
-
-    if (isContentEmpty(newContents[index])) {
+    if (!newContents.length) {
       this.deleteSelectedElements()
     } else {
       this.props.updateFlowNode({ contents: newContents })

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/nodes/Block/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/nodes/Block/index.tsx
@@ -30,6 +30,7 @@ interface Props {
   getConditions: () => DecisionTriggerCondition[]
   switchFlowNode: (id: string) => void
   addCondition: () => void
+  addMessage: () => void
   getCurrentLang: () => string
   getExpandedNodes: () => string[]
   setExpanded: (id: string, expanded: boolean) => void
@@ -57,6 +58,7 @@ const BlockWidget: FC<Props> = ({
   getConditions,
   switchFlowNode,
   addCondition,
+  addMessage,
   getCurrentLang,
   getExpandedNodes,
   setExpanded
@@ -83,6 +85,14 @@ const BlockWidget: FC<Props> = ({
             text={lang.tr('studio.flow.node.addCondition')}
             onClick={() => {
               addCondition()
+            }}
+          />
+        )}
+        {nodeType === 'say_something' && (
+          <MenuItem
+            text={lang.tr('studio.flow.node.addMessage')}
+            onClick={() => {
+              addMessage()
             }}
           />
         )}
@@ -268,6 +278,7 @@ export class BlockWidgetFactory extends AbstractNodeFactory {
   private updateFlowNode: (props: AllPartialNode) => void
   private switchFlowNode: (id: string) => void
   private addCondition: () => void
+  private addMessage: () => void
   private getCurrentLang: () => string
   private getExpandedNodes: () => string[]
   private setExpandedNodes: (id: string, expanded: boolean) => void
@@ -283,6 +294,7 @@ export class BlockWidgetFactory extends AbstractNodeFactory {
     this.getConditions = methods.getConditions
     this.switchFlowNode = methods.switchFlowNode
     this.addCondition = methods.addCondition
+    this.addMessage = methods.addMessage
     this.getCurrentLang = methods.getCurrentLang
     this.getExpandedNodes = methods.getExpandedNodes
     this.setExpandedNodes = methods.setExpandedNodes
@@ -301,6 +313,7 @@ export class BlockWidgetFactory extends AbstractNodeFactory {
         getConditions={this.getConditions}
         switchFlowNode={this.switchFlowNode}
         addCondition={this.addCondition}
+        addMessage={this.addMessage}
         getExpandedNodes={this.getExpandedNodes}
         setExpanded={this.setExpandedNodes}
       />


### PR DESCRIPTION
Added support for multiple messages on a say node (can be added with right click).

It's also possible to drag&drop a node from the left panel onto an existing say or trigger node to add an item (instead of creating a new node)

![image](https://user-images.githubusercontent.com/42552874/91205737-059f4280-e6d4-11ea-91fa-d6e6fc3cfefd.png)
