### PR TITLE
fix(nlu): added back entities caching at training time

### DIFF
--- a/src/bp/nlu-core/entities/custom-entity-extractor.ts
+++ b/src/bp/nlu-core/entities/custom-entity-extractor.ts
@@ -3,7 +3,7 @@ import _ from 'lodash'
 import jaroDistance from '../tools/jaro'
 import levenDistance from '../tools/levenshtein'
 import { extractPattern } from '../tools/patterns-utils'
-import { EntityExtractionResult, ListEntityModel, PatternEntity } from '../typings'
+import { EntityExtractionResult, ListEntityModel, PatternEntity, WarmedListEntityModel } from '../typings'
 import Utterance, { UtteranceToken } from '../utterance/utterance'
 
 const ENTITY_SCORE_THRESHOLD = 0.6
@@ -72,6 +72,24 @@ function computeStructuralScore(a: string[], b: string[]): number {
   const token_size_score = Math.min(size1, size2) / Math.max(size1, size2)
 
   return Math.sqrt(final_charset_score * token_qty_score * token_size_score)
+}
+
+// returns list entities having cached results in one array and those without results in another
+function splitModels(
+  listModels: WarmedListEntityModel[],
+  cacheKey: string
+): [WarmedListEntityModel[], WarmedListEntityModel[]] {
+  return listModels.reduce(
+    ([withCached, withoutCached], nextModel) => {
+      if (nextModel.cache.has(cacheKey)) {
+        withCached.push(nextModel)
+      } else {
+        withoutCached.push(nextModel)
+      }
+      return [withCached, withoutCached]
+    },
+    [[], []] as [WarmedListEntityModel[], WarmedListEntityModel[]]
+  )
 }
 
 interface Candidate {
@@ -162,17 +180,39 @@ export const extractListEntities = (
   utterance: Utterance,
   list_entities: ListEntityModel[]
 ): EntityExtractionResult[] => {
+  return _.flatMap(_extractListEntities(utterance, list_entities), ({ extractions }) => extractions)
+}
+
+export const extractListEntitiesWithCache = (
+  utterance: Utterance,
+  list_entities: WarmedListEntityModel[]
+): EntityExtractionResult[] => {
   const cacheKey = utterance.toString({ lowerCase: true })
+  const [listModelsWithCachedRes, listModelsToExtract] = splitModels(list_entities, cacheKey)
 
-  let matches: EntityExtractionResult[] = []
-  for (const listModel of list_entities) {
-    const extracted = extractForListModel(utterance, listModel)
-    if (extracted.length > 0) {
-      matches = matches.concat(...extracted)
+  const cachedMatches: EntityExtractionResult[] = _.flatMap(
+    listModelsWithCachedRes,
+    listModel => listModel.cache.get(cacheKey)!
+  )
+
+  const extractedMatches: EntityExtractionResult[] = _.flatMap(
+    _extractListEntities(utterance, listModelsToExtract),
+    ({ model, extractions }) => {
+      model.cache.set(cacheKey, extractions)
+      return extractions
     }
-  }
+  )
 
-  return matches
+  return [...cachedMatches, ...extractedMatches]
+}
+
+function _extractListEntities<T extends ListEntityModel>(utterance: Utterance, list_entities: T[]) {
+  return list_entities
+    .map(model => ({
+      model,
+      extractions: extractForListModel(utterance, model)
+    }))
+    .filter(({ extractions }) => extractions.length)
 }
 
 export const extractPatternEntities = (

--- a/src/bp/nlu-core/entities/entity-cache-manager.ts
+++ b/src/bp/nlu-core/entities/entity-cache-manager.ts
@@ -1,0 +1,26 @@
+import { ColdListEntityModel, EntityCacheDump } from 'nlu-core/typings'
+
+type CacheByName = {
+  [name: string]: EntityCacheDump
+}
+
+export class EntityCacheManager {
+  private cache: CacheByName = {}
+
+  getCache(listEntity: string): EntityCacheDump {
+    if (!this.cache[listEntity]) {
+      this.cache[listEntity] = []
+    }
+    return this.cache[listEntity]
+  }
+
+  setCacheByBatch(listEntities: ColdListEntityModel[]) {
+    for (const e of listEntities) {
+      this.setCache(e.entityName, e.cache)
+    }
+  }
+
+  setCache(listEntity: string, cache: EntityCacheDump) {
+    this.cache[listEntity] = cache
+  }
+}

--- a/src/bp/nlu-core/model-manager.ts
+++ b/src/bp/nlu-core/model-manager.ts
@@ -24,9 +24,8 @@ export function serializeModel(model: PredictableModel): sdk.NLU.Model {
     }
   }
 
-  const serializableData = _.omit(data, ['output.intents', 'input.trainingSession'])
-  serialized.data.input = JSON.stringify(serializableData.input)
-  serialized.data.output = JSON.stringify(serializableData.output)
+  serialized.data.input = JSON.stringify(data.input)
+  serialized.data.output = JSON.stringify(data.output)
 
   return serialized
 }

--- a/src/bp/nlu-core/predict-pipeline.ts
+++ b/src/bp/nlu-core/predict-pipeline.ts
@@ -9,24 +9,37 @@ import { isPOSAvailable } from './language/pos-tagger'
 import { getUtteranceFeatures } from './out-of-scope-featurizer'
 import SlotTagger from './slots/slot-tagger'
 import { replaceConsecutiveSpaces } from './tools/strings'
-import { ExactMatchIndex, EXACT_MATCH_STR_OPTIONS, TrainOutput } from './training-pipeline'
-import { EntityExtractionResult, ExtractedEntity, Intent, PatternEntity, SlotExtractionResult, Tools } from './typings'
+import { ExactMatchIndex, EXACT_MATCH_STR_OPTIONS } from './training-pipeline'
+import {
+  EntityExtractionResult,
+  ExtractedEntity,
+  Intent,
+  ListEntityModel,
+  PatternEntity,
+  SlotExtractionResult,
+  TFIDF,
+  Token2Vec,
+  Tools
+} from './typings'
 import Utterance, { buildUtteranceBatch, getAlternateUtterance, UtteranceEntity } from './utterance/utterance'
 
 export type ExactMatchResult = (sdk.MLToolkit.SVM.Prediction & { extractor: 'exact-matcher' }) | undefined
 
-export type Predictors = TrainOutput &
-  EntityPredictor & { intents: Intent<Utterance>[] } & Partial<{
-    ctx_classifier: sdk.MLToolkit.SVM.Predictor
-    intent_classifier_per_ctx: _.Dictionary<sdk.MLToolkit.SVM.Predictor>
-    oos_classifier_per_ctx: _.Dictionary<sdk.MLToolkit.SVM.Predictor>
-    kmeans: sdk.MLToolkit.KMeans.KmeansResult
-    slot_tagger: SlotTagger // TODO replace this by MlToolkit.CRF.Tagger
-  }>
-
-export interface EntityPredictor {
+export type Predictors = {
+  list_entities: ListEntityModel[] // no need for cache
+  tfidf: TFIDF
+  vocabVectors: Token2Vec
+  contexts: string[]
+  exact_match_index: ExactMatchIndex
   pattern_entities: PatternEntity[]
-}
+  intents: Intent<Utterance>[]
+} & Partial<{
+  ctx_classifier: sdk.MLToolkit.SVM.Predictor
+  intent_classifier_per_ctx: _.Dictionary<sdk.MLToolkit.SVM.Predictor>
+  oos_classifier_per_ctx: _.Dictionary<sdk.MLToolkit.SVM.Predictor>
+  kmeans: sdk.MLToolkit.KMeans.KmeansResult
+  slot_tagger: SlotTagger // TODO replace this by MlToolkit.CRF.Tagger
+}>
 
 export interface PredictInput {
   defaultLanguage: string

--- a/src/bp/nlu-core/typings.ts
+++ b/src/bp/nlu-core/typings.ts
@@ -69,6 +69,13 @@ export type ListEntity = Readonly<{
   sensitive: boolean
 }>
 
+export type CachedListEntity = ListEntity & {
+  cache: EntityCacheDump
+}
+
+export type EntityCache = LRUCache<string, EntityExtractionResult[]>
+export type EntityCacheDump = LRUCache.Entry<string, EntityExtractionResult[]>[]
+
 export interface ListEntityModel {
   type: 'custom.list'
   id: string
@@ -78,6 +85,14 @@ export interface ListEntityModel {
   sensitive: boolean
   /** @example { 'Air Canada': [ ['Air', '_Canada'], ['air', 'can'] ] } */
   mappingsTokens: _.Dictionary<string[][]>
+}
+
+export type ColdListEntityModel = ListEntityModel & {
+  cache: EntityCacheDump
+}
+
+export type WarmedListEntityModel = ListEntityModel & {
+  cache: EntityCache
 }
 
 export interface ExtractedSlot {


### PR DESCRIPTION
review this [PR](https://github.com/botpress/botpress/pull/3841) first.

Tried making things cleaner... ended up making them weirder lol. I'm just getting super tired of optionnal typing, I prefer complex 
types to simple yet optionnal ones.

Behavior differs from branch dev; There's no more caching at predict time. The reasons for this change are:
1. We don't need to gain speed at predict time (theres only one utterance)
2. Appending a new utterance to the cache (seen at predict time) will bump a old one (seen at training time). This will simply make training longuer.
3. The purpose of the entity cache is to make training faster.

Also, these points are up for debate, but not implemented yet: 

1. I really don't think we should filter out empty extraction results when building cache. I feel like if there's no entity for given utterance once, there also wont be next time we extract entities.

2. Previous Cache dumps should be saved on disk, not only in memory. This way, when reloading botpress, the cache could still be used...

