### PR TITLE
feat(core): prompt confirm filled

### DIFF
--- a/modules/builtin/src/backend/prompts/common.ts
+++ b/modules/builtin/src/backend/prompts/common.ts
@@ -41,6 +41,12 @@ const common: FormDefinition = {
     },
     {
       type: 'checkbox',
+      key: 'confirmFilled',
+      defaultValue: true,
+      label: 'module.builtin.confirmVariableFilled'
+    },
+    {
+      type: 'checkbox',
       key: 'cancellable',
       defaultValue: true,
       label: 'Prompt can be cancelled'

--- a/src/bp/core/services/dialog/prompt-manager.ts
+++ b/src/bp/core/services/dialog/prompt-manager.ts
@@ -285,7 +285,13 @@ export class PromptManager {
       return generateDisambiguate(actions, status, shortlisted)
     } else {
       if (others.length === 1 && !this.prompts.find(x => x.id === status.config.type)?.config.noConfirmation) {
-        return generateCandidate(actions, status, others[0])
+        if (status.config.confirmFilled) {
+          return generateCandidate(actions, status, others[0])
+        } else {
+          if (tryElect(others[0].value_raw)) {
+            return generateResolved(actions, status, others[0].value_raw)
+          }
+        }
       } else if (others.length > 1) {
         return generateDisambiguate(actions, status, others)
       }

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -1755,6 +1755,8 @@ declare module 'botpress/sdk' {
   }
 
   export interface PromptNodeParams {
+    /** Whether to ask confirmation before taking an already filled value */
+    confirmFilled: boolean
     cancellable?: boolean
     confirmCancellation?: boolean
     /** The name of the variable that will be filled with the value extracted */


### PR DESCRIPTION
https://trello.com/c/IPL3331U/127-add-confirm-variable-if-already-filled-in-prompts-advanced-settings

This PR adds an advanced setting to prompts that allows you to disable the `Is the value x correct?` message when slots that are already filled.