### PR TITLE
fix(prompts): minor adjustments

### DIFF
--- a/src/bp/core/services/dialog/dialog-engine.ts
+++ b/src/bp/core/services/dialog/dialog-engine.ts
@@ -702,9 +702,10 @@ export class DialogEngine {
     event: IO.IncomingEvent,
     context: IO.DialogContext
   ): Promise<IO.IncomingEvent | undefined> {
+    const { searchBackCount } = context.activePrompt!.config
     const previousEvents =
-      context.activePrompt!.stage === 'new'
-        ? await this._getPreviousEvents(event.target, context.activePrompt!.config.searchBackCount)
+      context.activePrompt!.stage === 'new' && searchBackCount > 1
+        ? await this._getPreviousEvents(event.target, searchBackCount - 1)
         : []
 
     const { status: promptStatus, actions } = await this.promptManager.processPrompt(event, previousEvents)
@@ -738,6 +739,10 @@ export class DialogEngine {
 
   private _processResolvedPrompt(event: IO.IncomingEvent, context: IO.DialogContext) {
     const { config, state } = context.activePrompt!
+
+    if (state.electedCandidate) {
+      context.pastPromptCandidates = [...(context.pastPromptCandidates || []), state.electedCandidate]
+    }
 
     this.createVariable(
       {

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -868,6 +868,7 @@ declare module 'botpress/sdk' {
       state: {
         confirmCandidate?: PromptCandidate
         disambiguateCandidates?: PromptCandidate[]
+        electedCandidate?: PromptCandidate
         value?: any
         nextDestination?: { flowName: string; node: string }
       }
@@ -929,6 +930,8 @@ declare module 'botpress/sdk' {
       hasJumped?: boolean
       /** The status of the current active prompt */
       activePrompt?: PromptStatus
+      /** The list of previously extracted candidates */
+      pastPromptCandidates?: PromptCandidate[]
       inputs?: { [variable: string]: SubWorkflowInput }
     }
 


### PR DESCRIPTION
There are two changes here. 
1. Once a candidate is elected, it will be ignored on future prompts. It fixes an issue when you chain 2 prompts of the same type. It is automatically removed after 10 turns.

2. Changed a bit the behavior of searchBackCount. Sometimes you may want to avoid extracting anything from an event before the question was asked. 
- When 0, the current event will not be extracted
- When 1, only the current event is used
- When 2 or more, it will extract from the current event & the past ones