### PR TITLE
fix(studio): erasing enum name resets name to previous

### DIFF
--- a/src/bp/ui-shared/src/Contents/Components/Fields/Text.tsx
+++ b/src/bp/ui-shared/src/Contents/Components/Fields/Text.tsx
@@ -11,7 +11,7 @@ const Text: FC<TextProps> = ({
   onBlur,
   onChange,
   placeholder,
-  field: { valueManipulation, type, min, max, maxLength, defaultValue },
+  field: { valueManipulation, type, min, max, maxLength, defaultValue, required },
   value,
   childRef
 }) => {
@@ -47,6 +47,15 @@ const Text: FC<TextProps> = ({
     return value
   }
 
+  const beforeOnBlur = () => {
+    if (!localValue && required) {
+      setLocalValue(defaultValue)
+      onBlur?.(defaultValue)
+      return
+    }
+    onBlur?.(localValue)
+  }
+
   return (
     <input
       ref={ref => childRef?.(ref)}
@@ -61,7 +70,7 @@ const Text: FC<TextProps> = ({
         onChange?.(value)
         setLocalValue(value)
       }}
-      onBlur={() => onBlur?.(localValue)}
+      onBlur={beforeOnBlur}
       value={localValue}
     />
   )

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/VariableTypesForm/EnumForm.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/VariableTypesForm/EnumForm.tsx
@@ -95,7 +95,8 @@ const EnumForm: FC<Props> = ({
               label: 'name',
               required: true,
               maxLength: 150,
-              placeholder: 'studio.library.variableName'
+              placeholder: 'studio.library.variableName',
+              defaultValue: formData.name
             },
             {
               key: 'occurrences',


### PR DESCRIPTION
https://trello.com/c/SLPE0YtR/328-if-i-delete-an-enumeration-name-in-the-panel-and-click-elsewhere-the-app-goes-blank

Did the fix at the source inside ui-shared instead of in the studio. If the field is required, then defaultValue is taken instead of undefined or null...

What do you guys think about this? 
