### PR TITLE
fix(nlu): added back entities caching at training time

### DIFF
--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -10,7 +10,7 @@ import SlotTagger from './slots/slot-tagger'
 import { isPatternValid } from './tools/patterns-utils'
 import { computeKmeans, ProcessIntents, TrainInput, TrainOutput } from './training-pipeline'
 import { TrainingCanceledError, TrainingWorkerQueue } from './training-worker-queue'
-import { CachedListEntity, ComplexEntity, Intent, PatternEntity, Tools } from './typings'
+import { ComplexEntity, Intent, ListEntityWithCache, PatternEntity, Tools } from './typings'
 
 const trainDebug = DEBUG('nlu').sub('training')
 
@@ -83,7 +83,7 @@ export default class Engine implements NLU.Engine {
     const list_entities = entityDefs
       .filter(ent => ent.type === 'list')
       .map(e => {
-        return <CachedListEntity>{
+        return <ListEntityWithCache>{
           name: e.name,
           fuzzyTolerance: e.fuzzy,
           sensitive: e.sensitive,

--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -2,6 +2,7 @@ import { MLToolkit, NLU } from 'botpress/sdk'
 import crypto from 'crypto'
 import _ from 'lodash'
 
+import { EntityCacheManager } from './entities/entity-cache-manager'
 import { initializeTools } from './initialize-tools'
 import { deserializeModel, PredictableModel, serializeModel } from './model-manager'
 import { Predict, PredictInput, Predictors, PredictOutput } from './predict-pipeline'
@@ -9,7 +10,7 @@ import SlotTagger from './slots/slot-tagger'
 import { isPatternValid } from './tools/patterns-utils'
 import { computeKmeans, ProcessIntents, TrainInput, TrainOutput } from './training-pipeline'
 import { TrainingCanceledError, TrainingWorkerQueue } from './training-worker-queue'
-import { ComplexEntity, Intent, ListEntity, PatternEntity, Tools } from './typings'
+import { CachedListEntity, ComplexEntity, Intent, PatternEntity, Tools } from './typings'
 
 const trainDebug = DEBUG('nlu').sub('training')
 
@@ -19,6 +20,7 @@ export default class Engine implements NLU.Engine {
 
   private predictorsByLang: _.Dictionary<Predictors> = {}
   private modelsByLang: _.Dictionary<PredictableModel> = {}
+  private entitiesCacheByLang: _.Dictionary<EntityCacheManager> = {}
 
   constructor(private defaultLanguage: string, private botId: string, private logger: NLU.Logger) {}
 
@@ -74,18 +76,23 @@ export default class Engine implements NLU.Engine {
   ): Promise<NLU.Model | undefined> {
     trainDebug.forBot(this.botId, `Started ${languageCode} training`)
 
+    if (!this.entitiesCacheByLang[languageCode]) {
+      this.entitiesCacheByLang[languageCode] = new EntityCacheManager()
+    }
+
     const list_entities = entityDefs
       .filter(ent => ent.type === 'list')
       .map(e => {
-        return {
+        return <CachedListEntity>{
           name: e.name,
           fuzzyTolerance: e.fuzzy,
           sensitive: e.sensitive,
           synonyms: _.chain(e.occurrences)
             .keyBy('name')
             .mapValues('synonyms')
-            .value()
-        } as ListEntity
+            .value(),
+          cache: this.entitiesCacheByLang[languageCode].getCache(e.name)
+        }
       })
 
     const pattern_entities: PatternEntity[] = entityDefs
@@ -200,10 +207,13 @@ export default class Engine implements NLU.Engine {
       return
     }
 
+    const languageCode = input.languageCode
+    this.entitiesCacheByLang[languageCode].setCacheByBatch(output.list_entities)
+
     return {
       startedAt,
       finishedAt: new Date(),
-      languageCode: input.languageCode,
+      languageCode,
       hash,
       data: {
         input,
@@ -245,6 +255,10 @@ export default class Engine implements NLU.Engine {
   private async _makePredictors(input: TrainInput, output: TrainOutput): Promise<Predictors> {
     const tools = Engine._tools
 
+    /**
+     * TODO: extract this function some place else,
+     * Engine shouldn't be dependant of training pipeline...
+     */
     const intents = await ProcessIntents(
       input.intents,
       input.languageCode,
@@ -255,14 +269,16 @@ export default class Engine implements NLU.Engine {
       Engine._tools
     )
 
+    const basePredictors: Predictors = {
+      ...output,
+      intents,
+      pattern_entities: input.pattern_entities
+    }
+
     if (_.flatMap(input.intents, i => i.utterances).length <= 0) {
       // we don't want to return undefined as extraction won't be triggered
       // we want to make it possible to extract entities without having any intents
-      return {
-        ...output,
-        intents,
-        pattern_entities: input.pattern_entities
-      }
+      return basePredictors
     }
 
     const { ctx_model, intent_model_by_ctx, oos_model } = output
@@ -281,14 +297,12 @@ export default class Engine implements NLU.Engine {
     const kmeans = computeKmeans(intents!, tools) // TODO load from artefacts when persisted
 
     return {
-      ...output,
-      intents,
+      ...basePredictors,
       ctx_classifier,
       oos_classifier_per_ctx: oos_classifier,
       intent_classifier_per_ctx,
       slot_tagger,
-      kmeans,
-      pattern_entities: input.pattern_entities
+      kmeans
     }
   }
 

--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -10,7 +10,7 @@ import SlotTagger from './slots/slot-tagger'
 import { isPatternValid } from './tools/patterns-utils'
 import { computeKmeans, ProcessIntents, TrainInput, TrainOutput } from './training-pipeline'
 import { TrainingCanceledError, TrainingWorkerQueue } from './training-worker-queue'
-import { ComplexEntity, Intent, ListEntityWithCache, PatternEntity, Tools } from './typings'
+import { ComplexEntity, EntityCacheDump, Intent, ListEntity, PatternEntity, Tools } from './typings'
 
 const trainDebug = DEBUG('nlu').sub('training')
 
@@ -83,7 +83,7 @@ export default class Engine implements NLU.Engine {
     const list_entities = entityDefs
       .filter(ent => ent.type === 'list')
       .map(e => {
-        return <ListEntityWithCache>{
+        return <ListEntity & { cache: EntityCacheDump }>{
           name: e.name,
           fuzzyTolerance: e.fuzzy,
           sensitive: e.sensitive,

--- a/src/bp/nlu-core/entities/custom-entity-extractor.ts
+++ b/src/bp/nlu-core/entities/custom-entity-extractor.ts
@@ -3,7 +3,7 @@ import _ from 'lodash'
 import jaroDistance from '../tools/jaro'
 import levenDistance from '../tools/levenshtein'
 import { extractPattern } from '../tools/patterns-utils'
-import { EntityExtractionResult, ListEntityModel, PatternEntity } from '../typings'
+import { EntityExtractionResult, ListEntityModel, PatternEntity, WarmedListEntityModel } from '../typings'
 import Utterance, { UtteranceToken } from '../utterance/utterance'
 
 const ENTITY_SCORE_THRESHOLD = 0.6
@@ -72,6 +72,24 @@ function computeStructuralScore(a: string[], b: string[]): number {
   const token_size_score = Math.min(size1, size2) / Math.max(size1, size2)
 
   return Math.sqrt(final_charset_score * token_qty_score * token_size_score)
+}
+
+// returns list entities having cached results in one array and those without results in another
+function splitModels(
+  listModels: WarmedListEntityModel[],
+  cacheKey: string
+): [WarmedListEntityModel[], WarmedListEntityModel[]] {
+  return listModels.reduce(
+    ([withCached, withoutCached], nextModel) => {
+      if (nextModel.cache.has(cacheKey)) {
+        withCached.push(nextModel)
+      } else {
+        withoutCached.push(nextModel)
+      }
+      return [withCached, withoutCached]
+    },
+    [[], []] as [WarmedListEntityModel[], WarmedListEntityModel[]]
+  )
 }
 
 interface Candidate {
@@ -162,17 +180,39 @@ export const extractListEntities = (
   utterance: Utterance,
   list_entities: ListEntityModel[]
 ): EntityExtractionResult[] => {
+  return _.flatMap(_extractListEntities(utterance, list_entities), ({ extractions }) => extractions)
+}
+
+export const extractListEntitiesWithCache = (
+  utterance: Utterance,
+  list_entities: WarmedListEntityModel[]
+): EntityExtractionResult[] => {
   const cacheKey = utterance.toString({ lowerCase: true })
+  const [listModelsWithCachedRes, listModelsToExtract] = splitModels(list_entities, cacheKey)
 
-  let matches: EntityExtractionResult[] = []
-  for (const listModel of list_entities) {
-    const extracted = extractForListModel(utterance, listModel)
-    if (extracted.length > 0) {
-      matches = matches.concat(...extracted)
+  const cachedMatches: EntityExtractionResult[] = _.flatMap(
+    listModelsWithCachedRes,
+    listModel => listModel.cache.get(cacheKey)!
+  )
+
+  const extractedMatches: EntityExtractionResult[] = _.flatMap(
+    _extractListEntities(utterance, listModelsToExtract),
+    ({ model, extractions }) => {
+      model.cache.set(cacheKey, extractions)
+      return extractions
     }
-  }
+  )
 
-  return matches
+  return [...cachedMatches, ...extractedMatches]
+}
+
+function _extractListEntities<T extends ListEntityModel>(utterance: Utterance, list_entities: T[]) {
+  return list_entities
+    .map(model => ({
+      model,
+      extractions: extractForListModel(utterance, model)
+    }))
+    .filter(({ extractions }) => extractions.length)
 }
 
 export const extractPatternEntities = (

--- a/src/bp/nlu-core/entities/custom-entity-extractor.ts
+++ b/src/bp/nlu-core/entities/custom-entity-extractor.ts
@@ -199,7 +199,7 @@ export const extractListEntitiesWithCache = (
   const extractedMatches: EntityExtractionResult[] = _(withCacheMiss)
     .map(model => {
       const extractions = extractForListModel(utterance, model)
-      extractions.length && model.cache.set(model.entityName, extractions) // TODO: also set cache for utterance without entities
+      extractions.length && model.cache.set(cacheKey, extractions) // TODO: also set cache for utterance without entities
       return extractions
     })
     .flatten()

--- a/src/bp/nlu-core/entities/custom-entity-extractor.ts
+++ b/src/bp/nlu-core/entities/custom-entity-extractor.ts
@@ -199,7 +199,7 @@ export const extractListEntitiesWithCache = (
   const extractedMatches: EntityExtractionResult[] = _(withCacheMiss)
     .map(model => {
       const extractions = extractForListModel(utterance, model)
-      extractions.length && model.cache.set(cacheKey, extractions) // TODO: also set cache for utterance without entities
+      model.cache.set(cacheKey, extractions)
       return extractions
     })
     .flatten()

--- a/src/bp/nlu-core/entities/entity-cache-manager.ts
+++ b/src/bp/nlu-core/entities/entity-cache-manager.ts
@@ -1,0 +1,26 @@
+import { ColdListEntityModel, EntityCacheDump } from 'nlu-core/typings'
+
+type CacheByName = {
+  [name: string]: EntityCacheDump
+}
+
+export class EntityCacheManager {
+  private cache: CacheByName = {}
+
+  getCache(listEntity: string): EntityCacheDump {
+    if (!this.cache[listEntity]) {
+      this.cache[listEntity] = []
+    }
+    return this.cache[listEntity]
+  }
+
+  setCacheByBatch(listEntities: ColdListEntityModel[]) {
+    for (const e of listEntities) {
+      this.setCache(e.entityName, e.cache)
+    }
+  }
+
+  setCache(listEntity: string, cache: EntityCacheDump) {
+    this.cache[listEntity] = cache
+  }
+}

--- a/src/bp/nlu-core/entities/entity-cache-manager.ts
+++ b/src/bp/nlu-core/entities/entity-cache-manager.ts
@@ -14,13 +14,13 @@ export class EntityCacheManager {
     return this.cache[listEntity]
   }
 
-  setCacheByBatch(listEntities: ColdListEntityModel[]) {
+  loadFromData(listEntities: ColdListEntityModel[]) {
     for (const e of listEntities) {
       this.setCache(e.entityName, e.cache)
     }
   }
 
-  setCache(listEntity: string, cache: EntityCacheDump) {
+  private setCache(listEntity: string, cache: EntityCacheDump) {
     this.cache[listEntity] = cache
   }
 }

--- a/src/bp/nlu-core/entities/entity-cache-manager.ts
+++ b/src/bp/nlu-core/entities/entity-cache-manager.ts
@@ -1,7 +1,14 @@
-import { ColdListEntityModel, EntityCacheDump } from 'nlu-core/typings'
+import LRUCache from 'lru-cache'
+import { ColdListEntityModel, EntityCache, EntityCacheDump, EntityExtractionResult } from 'nlu-core/typings'
 
 type CacheByName = {
   [name: string]: EntityCacheDump
+}
+
+export function warmEntityCache(coldCache: EntityCacheDump): EntityCache {
+  const warmedCache = new LRUCache<string, EntityExtractionResult[]>(1000)
+  warmedCache.load(coldCache)
+  return warmedCache
 }
 
 export class EntityCacheManager {

--- a/src/bp/nlu-core/model-manager.ts
+++ b/src/bp/nlu-core/model-manager.ts
@@ -24,9 +24,8 @@ export function serializeModel(model: PredictableModel): sdk.NLU.Model {
     }
   }
 
-  const serializableData = _.omit(data, ['output.intents', 'input.trainingSession'])
-  serialized.data.input = JSON.stringify(serializableData.input)
-  serialized.data.output = JSON.stringify(serializableData.output)
+  serialized.data.input = JSON.stringify(data.input)
+  serialized.data.output = JSON.stringify(data.output)
 
   return serialized
 }

--- a/src/bp/nlu-core/predict-pipeline.ts
+++ b/src/bp/nlu-core/predict-pipeline.ts
@@ -9,24 +9,37 @@ import { isPOSAvailable } from './language/pos-tagger'
 import { getUtteranceFeatures } from './out-of-scope-featurizer'
 import SlotTagger from './slots/slot-tagger'
 import { replaceConsecutiveSpaces } from './tools/strings'
-import { ExactMatchIndex, EXACT_MATCH_STR_OPTIONS, TrainOutput } from './training-pipeline'
-import { EntityExtractionResult, ExtractedEntity, Intent, PatternEntity, SlotExtractionResult, Tools } from './typings'
+import { ExactMatchIndex, EXACT_MATCH_STR_OPTIONS } from './training-pipeline'
+import {
+  EntityExtractionResult,
+  ExtractedEntity,
+  Intent,
+  ListEntityModel,
+  PatternEntity,
+  SlotExtractionResult,
+  TFIDF,
+  Token2Vec,
+  Tools
+} from './typings'
 import Utterance, { buildUtteranceBatch, getAlternateUtterance, UtteranceEntity } from './utterance/utterance'
 
 export type ExactMatchResult = (sdk.MLToolkit.SVM.Prediction & { extractor: 'exact-matcher' }) | undefined
 
-export type Predictors = TrainOutput &
-  EntityPredictor & { intents: Intent<Utterance>[] } & Partial<{
-    ctx_classifier: sdk.MLToolkit.SVM.Predictor
-    intent_classifier_per_ctx: _.Dictionary<sdk.MLToolkit.SVM.Predictor>
-    oos_classifier_per_ctx: _.Dictionary<sdk.MLToolkit.SVM.Predictor>
-    kmeans: sdk.MLToolkit.KMeans.KmeansResult
-    slot_tagger: SlotTagger // TODO replace this by MlToolkit.CRF.Tagger
-  }>
-
-export interface EntityPredictor {
+export type Predictors = {
+  list_entities: ListEntityModel[] // no need for cache
+  tfidf: TFIDF
+  vocabVectors: Token2Vec
+  contexts: string[]
+  exact_match_index: ExactMatchIndex
   pattern_entities: PatternEntity[]
-}
+  intents: Intent<Utterance>[]
+} & Partial<{
+  ctx_classifier: sdk.MLToolkit.SVM.Predictor
+  intent_classifier_per_ctx: _.Dictionary<sdk.MLToolkit.SVM.Predictor>
+  oos_classifier_per_ctx: _.Dictionary<sdk.MLToolkit.SVM.Predictor>
+  kmeans: sdk.MLToolkit.KMeans.KmeansResult
+  slot_tagger: SlotTagger // TODO replace this by MlToolkit.CRF.Tagger
+}>
 
 export interface PredictInput {
   defaultLanguage: string

--- a/src/bp/nlu-core/training-pipeline.ts
+++ b/src/bp/nlu-core/training-pipeline.ts
@@ -1,9 +1,8 @@
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
+import LRUCache from 'lru-cache'
 
-import { getOrCreateCache } from '../core/services/nlu/cache-manager'
-
-import { extractListEntities, extractPatternEntities } from './entities/custom-entity-extractor'
+import { extractListEntitiesWithCache, extractPatternEntities } from './entities/custom-entity-extractor'
 import { getCtxFeatures } from './intents/context-featurizer'
 import { getIntentFeatures } from './intents/intent-featurizer'
 import { isPOSAvailable } from './language/pos-tagger'
@@ -15,6 +14,8 @@ import { replaceConsecutiveSpaces } from './tools/strings'
 import tfidf from './tools/tfidf'
 import { convertToRealSpaces, isSpace, SPACE } from './tools/token-utils'
 import {
+  CachedListEntity,
+  ColdListEntityModel,
   ComplexEntity,
   EntityExtractionResult,
   ExtractedEntity,
@@ -24,7 +25,8 @@ import {
   PatternEntity,
   TFIDF,
   Token2Vec,
-  Tools
+  Tools,
+  WarmedListEntityModel
 } from './typings'
 import { Augmentation, createAugmenter, interleave } from './utterance/augmenter'
 import Utterance, { buildUtteranceBatch, UtteranceToken, UtteranceToStringOptions } from './utterance/utterance'
@@ -35,7 +37,7 @@ export type TrainInput = Readonly<{
   languageCode: string
   pattern_entities: PatternEntity[]
   complex_entities: ComplexEntity[]
-  list_entities: ListEntity[]
+  list_entities: CachedListEntity[]
   contexts: string[]
   intents: Intent<string>[]
   ctxToTrain: string[]
@@ -45,7 +47,7 @@ export type TrainStep = Readonly<{
   botId: string
   nluSeed: number
   languageCode: string
-  list_entities: ListEntityModel[]
+  list_entities: WarmedListEntityModel[]
   pattern_entities: PatternEntity[]
   complex_entities: ComplexEntity[]
   contexts: string[]
@@ -57,7 +59,7 @@ export type TrainStep = Readonly<{
 }>
 
 export interface TrainOutput {
-  list_entities: ListEntityModel[]
+  list_entities: ColdListEntityModel[]
   tfidf: TFIDF
   vocabVectors: Token2Vec
   // kmeans: KmeansResult
@@ -97,7 +99,7 @@ const PreprocessInput = async (input: TrainInput, tools: Tools): Promise<TrainSt
   debugTraining.forBot(input.botId, 'Preprocessing intents')
   input = _.cloneDeep(input)
   const list_entities = await Promise.map(input.list_entities, list =>
-    makeListEntityModel(list, input.botId, input.languageCode, tools)
+    makeListEntityModel(list, input.languageCode, tools)
   )
 
   const intents = await ProcessIntents(
@@ -120,13 +122,16 @@ const PreprocessInput = async (input: TrainInput, tools: Tools): Promise<TrainSt
   } as TrainStep
 }
 
-const makeListEntityModel = async (entity: ListEntity, botId: string, languageCode: string, tools: Tools) => {
+const makeListEntityModel = async (entity: CachedListEntity, languageCode: string, tools: Tools) => {
   const allValues = _.uniq(Object.keys(entity.synonyms).concat(..._.values(entity.synonyms)))
   const allTokens = (await tools.tokenize_utterances(allValues, languageCode)).map(toks =>
     toks.map(convertToRealSpaces)
   )
 
-  return <ListEntityModel>{
+  const cache = new LRUCache(1000)
+  cache.load(entity.cache)
+
+  return <WarmedListEntityModel>{
     type: 'custom.list',
     id: `custom.list.${entity.name}`,
     languageCode,
@@ -139,7 +144,7 @@ const makeListEntityModel = async (entity: ListEntity, botId: string, languageCo
         return allTokens[idx]
       })
     ),
-    cache: getOrCreateCache(entity.name, botId)
+    cache
   }
 }
 
@@ -405,7 +410,7 @@ export const ExtractEntities = async (input: TrainStep, tools: Tools): Promise<T
 
   _.zipWith(utterances, allSysEntities, (utt, sysEntities) => ({ utt, sysEntities }))
     .map(({ utt, sysEntities }) => {
-      const listEntities = extractListEntities(utt, input.list_entities)
+      const listEntities = extractListEntitiesWithCache(utt, input.list_entities)
       const patternEntities = extractPatternEntities(utt, input.pattern_entities)
       return [utt, [...sysEntities, ...listEntities, ...patternEntities]] as [Utterance, EntityExtractionResult[]]
     })
@@ -617,8 +622,13 @@ export const Trainer: Trainer = async (
 
   const [oos_model, ctx_model, intent_model_by_ctx, slots_model] = models
 
+  const coldEntities: ColdListEntityModel[] = step.list_entities.map(e => ({
+    ...e,
+    cache: e.cache.dump()
+  }))
+
   const output: TrainOutput = {
-    list_entities: step.list_entities,
+    list_entities: coldEntities,
     oos_model: oos_model!,
     tfidf: step.tfIdf!,
     ctx_model: ctx_model!,

--- a/src/bp/nlu-core/training-pipeline.ts
+++ b/src/bp/nlu-core/training-pipeline.ts
@@ -1,6 +1,5 @@
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
-import LRUCache from 'lru-cache'
 
 import { extractListEntitiesWithCache, extractPatternEntities } from './entities/custom-entity-extractor'
 import { getCtxFeatures } from './intents/context-featurizer'
@@ -30,6 +29,7 @@ import {
 } from './typings'
 import { Augmentation, createAugmenter, interleave } from './utterance/augmenter'
 import Utterance, { buildUtteranceBatch, UtteranceToken, UtteranceToStringOptions } from './utterance/utterance'
+import { warmEntityCache } from './entities/entity-cache-manager'
 
 type ListEntityWithCache = ListEntity & {
   cache: EntityCacheDump
@@ -132,8 +132,7 @@ const makeListEntityModel = async (entity: ListEntityWithCache, languageCode: st
     toks.map(convertToRealSpaces)
   )
 
-  const cache = new LRUCache(1000)
-  cache.load(entity.cache)
+  const cache = warmEntityCache(entity.cache)
 
   return <WarmedListEntityModel>{
     type: 'custom.list',

--- a/src/bp/nlu-core/training-pipeline.ts
+++ b/src/bp/nlu-core/training-pipeline.ts
@@ -16,12 +16,12 @@ import { convertToRealSpaces, isSpace, SPACE } from './tools/token-utils'
 import {
   ColdListEntityModel,
   ComplexEntity,
+  EntityCacheDump,
   EntityExtractionResult,
   ExtractedEntity,
   Intent,
   ListEntity,
   ListEntityModel,
-  ListEntityWithCache,
   PatternEntity,
   TFIDF,
   Token2Vec,
@@ -30,6 +30,10 @@ import {
 } from './typings'
 import { Augmentation, createAugmenter, interleave } from './utterance/augmenter'
 import Utterance, { buildUtteranceBatch, UtteranceToken, UtteranceToStringOptions } from './utterance/utterance'
+
+type ListEntityWithCache = ListEntity & {
+  cache: EntityCacheDump
+}
 
 export type TrainInput = Readonly<{
   botId: string

--- a/src/bp/nlu-core/training-pipeline.ts
+++ b/src/bp/nlu-core/training-pipeline.ts
@@ -14,7 +14,6 @@ import { replaceConsecutiveSpaces } from './tools/strings'
 import tfidf from './tools/tfidf'
 import { convertToRealSpaces, isSpace, SPACE } from './tools/token-utils'
 import {
-  CachedListEntity,
   ColdListEntityModel,
   ComplexEntity,
   EntityExtractionResult,
@@ -22,6 +21,7 @@ import {
   Intent,
   ListEntity,
   ListEntityModel,
+  ListEntityWithCache,
   PatternEntity,
   TFIDF,
   Token2Vec,
@@ -37,7 +37,7 @@ export type TrainInput = Readonly<{
   languageCode: string
   pattern_entities: PatternEntity[]
   complex_entities: ComplexEntity[]
-  list_entities: CachedListEntity[]
+  list_entities: ListEntityWithCache[]
   contexts: string[]
   intents: Intent<string>[]
   ctxToTrain: string[]
@@ -122,7 +122,7 @@ const PreprocessInput = async (input: TrainInput, tools: Tools): Promise<TrainSt
   } as TrainStep
 }
 
-const makeListEntityModel = async (entity: CachedListEntity, languageCode: string, tools: Tools) => {
+const makeListEntityModel = async (entity: ListEntityWithCache, languageCode: string, tools: Tools) => {
   const allValues = _.uniq(Object.keys(entity.synonyms).concat(..._.values(entity.synonyms)))
   const allTokens = (await tools.tokenize_utterances(allValues, languageCode)).map(toks =>
     toks.map(convertToRealSpaces)

--- a/src/bp/nlu-core/typings.ts
+++ b/src/bp/nlu-core/typings.ts
@@ -69,7 +69,7 @@ export type ListEntity = Readonly<{
   sensitive: boolean
 }>
 
-export type CachedListEntity = ListEntity & {
+export type ListEntityWithCache = ListEntity & {
   cache: EntityCacheDump
 }
 

--- a/src/bp/nlu-core/typings.ts
+++ b/src/bp/nlu-core/typings.ts
@@ -69,6 +69,13 @@ export type ListEntity = Readonly<{
   sensitive: boolean
 }>
 
+export type CachedListEntity = ListEntity & {
+  cache: EntityCacheDump
+}
+
+export type EntityCache = LRUCache<string, EntityExtractionResult[]>
+export type EntityCacheDump = LRUCache.Entry<string, EntityExtractionResult[]>[]
+
 export interface ListEntityModel {
   type: 'custom.list'
   id: string
@@ -78,6 +85,14 @@ export interface ListEntityModel {
   sensitive: boolean
   /** @example { 'Air Canada': [ ['Air', '_Canada'], ['air', 'can'] ] } */
   mappingsTokens: _.Dictionary<string[][]>
+}
+
+export type ColdListEntityModel = ListEntityModel & {
+  cache: EntityCacheDump
+}
+
+export type WarmedListEntityModel = ListEntityModel & {
+  cache: EntityCache
 }
 
 export interface ExtractedSlot {

--- a/src/bp/nlu-core/typings.ts
+++ b/src/bp/nlu-core/typings.ts
@@ -69,10 +69,6 @@ export type ListEntity = Readonly<{
   sensitive: boolean
 }>
 
-export type ListEntityWithCache = ListEntity & {
-  cache: EntityCacheDump
-}
-
 export type EntityCache = LRUCache<string, EntityExtractionResult[]>
 export type EntityCacheDump = LRUCache.Entry<string, EntityExtractionResult[]>[]
 


### PR DESCRIPTION
Tried making things cleaner... ended up making them weirder lol. I'm just getting super tired of optionnal typing, I prefer complex 
types to simple yet optionnal ones.

Behavior differs from branch dev; There's no more caching at predict time. The reasons for this change are:
1. We don't need to gain speed at predict time (theres only one utterance)
2. Appending a new utterance to the cache (seen at predict time) will bump a old one (seen at training time). This will simply make training longuer.
3. The purpose of the entity cache is to make training faster.

Also, these points are up for debate, but not implemented yet: 

1. I really don't think we should filter out empty extraction results when building cache. I feel like if there's no entity for given utterance once, there also wont be next time we extract entities.

2. Previous Cache dumps should be saved on disk, not only in memory. This way, when reloading botpress, the cache could still be used...

