### PR TITLE
fix(misunderstood): empty conversation on deleted event

### DIFF
--- a/modules/misunderstood/src/backend/db.ts
+++ b/modules/misunderstood/src/backend/db.ts
@@ -92,6 +92,16 @@ export default class Db {
       .select('*')
       .then((data: DbFlaggedEvent[]) => (data && data.length ? data[0] : null))
 
+    const parentEvent = await this.knex(EVENTS_TABLE_NAME)
+      .where({ botId, incomingEventId: event.eventId, direction: 'incoming' })
+      .select('id', 'threadId', 'sessionId', 'event')
+      .limit(1)
+      .first()
+
+    if (!parentEvent) {
+      return
+    }
+
     const { threadId, sessionId, id: messageId, event: eventDetails } = await this.knex(EVENTS_TABLE_NAME)
       .where({ botId, incomingEventId: event.eventId, direction: 'incoming' })
       .select('id', 'threadId', 'sessionId', 'event')

--- a/modules/misunderstood/src/backend/db.ts
+++ b/modules/misunderstood/src/backend/db.ts
@@ -102,11 +102,7 @@ export default class Db {
       return
     }
 
-    const { threadId, sessionId, id: messageId, event: eventDetails } = await this.knex(EVENTS_TABLE_NAME)
-      .where({ botId, incomingEventId: event.eventId, direction: 'incoming' })
-      .select('id', 'threadId', 'sessionId', 'event')
-      .limit(1)
-      .first()
+    const { threadId, sessionId, id: messageId, event: eventDetails } = parentEvent
 
     const [messagesBefore, messagesAfter] = await Promise.all([
       this.knex(EVENTS_TABLE_NAME)

--- a/modules/misunderstood/src/translations/en.json
+++ b/modules/misunderstood/src/translations/en.json
@@ -39,5 +39,7 @@
   "skip": "Skip",
   "updated": "Updated",
   "waitWhileDataLoading": "Please wait while we're loading data",
-  "whatIsMessageType": "What is this message type?"
+  "whatIsMessageType": "What is this message type?",
+  "couldNotLoadConversation": "Could not load conversation",
+  "conversationDeleted": "This conversation was too old and has been deleted"
 }

--- a/modules/misunderstood/src/translations/fr.json
+++ b/modules/misunderstood/src/translations/fr.json
@@ -39,5 +39,7 @@
   "skip": "Passer",
   "updated": "Mis à jour",
   "waitWhileDataLoading": "Veuillez patienter pendant le chargement des données",
-  "whatIsMessageType": "Quel est ce type de message?"
+  "whatIsMessageType": "Quel est ce type de message?",
+  "couldNotLoadConversation": "Impossible de trouver la conversation",
+  "conversationDeleted": "La conversation était trop vieille et a été effacée"
 }

--- a/modules/misunderstood/src/views/full/MainScreen/AmendForm.tsx
+++ b/modules/misunderstood/src/views/full/MainScreen/AmendForm.tsx
@@ -13,7 +13,7 @@ import QnAPicker from './QnAPicker'
 interface Props {
   axios: AxiosStatic
   language: string
-  event: ApiFlaggedEvent
+  event: ApiFlaggedEvent | null
   mode: RESOLUTION_TYPE
   resolution: string | null
   resolutionParams: object | null

--- a/modules/misunderstood/src/views/full/MainScreen/IntentPicker.tsx
+++ b/modules/misunderstood/src/views/full/MainScreen/IntentPicker.tsx
@@ -22,7 +22,7 @@ interface Params {
 interface Props {
   axios: AxiosStatic
   language: string
-  event: ApiFlaggedEvent
+  event: ApiFlaggedEvent | null
   selected: string
   params: Params
   onSelect: (id: string | null) => void
@@ -114,7 +114,7 @@ class IntentPicker extends React.Component<Props, State> {
   renderParamsForm() {
     const { event, params, selected: selectedItemName } = this.props
 
-    const eventContexts = event.nluContexts || []
+    const eventContexts = (event && event.nluContexts) || []
     const selectedItem = this.state.intents.find(intent => intent.name === selectedItemName)
     const newContexts = without(eventContexts, ...selectedItem.contexts)
 

--- a/modules/misunderstood/src/views/full/MainScreen/IntentPicker.tsx
+++ b/modules/misunderstood/src/views/full/MainScreen/IntentPicker.tsx
@@ -114,7 +114,7 @@ class IntentPicker extends React.Component<Props, State> {
   renderParamsForm() {
     const { event, params, selected: selectedItemName } = this.props
 
-    const eventContexts = (event && event.nluContexts) || []
+    const eventContexts = event?.nluContexts || []
     const selectedItem = this.state.intents.find(intent => intent.name === selectedItemName)
     const newContexts = without(eventContexts, ...selectedItem.contexts)
 

--- a/modules/misunderstood/src/views/full/MainScreen/NewEventView.tsx
+++ b/modules/misunderstood/src/views/full/MainScreen/NewEventView.tsx
@@ -1,6 +1,7 @@
 import { Button, ButtonGroup, Intent } from '@blueprintjs/core'
 import { AxiosStatic } from 'axios'
 import { lang } from 'botpress/shared'
+import { SplashScreen } from 'botpress/ui'
 import pick from 'lodash/pick'
 import React from 'react'
 
@@ -14,7 +15,8 @@ import ChatPreview from './ChatPreview'
 interface Props {
   axios: AxiosStatic
   language: string
-  event: ApiFlaggedEvent
+  event: ApiFlaggedEvent | null
+  eventNotFound: boolean
   totalEventsCount: number
   eventIndex: number
   skipEvent: () => void
@@ -68,7 +70,7 @@ class NewEventView extends React.Component<Props, State> {
   }
 
   render() {
-    const { axios, language, event, totalEventsCount, eventIndex, skipEvent, deleteEvent } = this.props
+    const { axios, language, event, totalEventsCount, eventIndex, skipEvent, deleteEvent, eventNotFound } = this.props
     const { isAmending, resolutionType, resolution, resolutionParams } = this.state
 
     return (
@@ -77,7 +79,15 @@ class NewEventView extends React.Component<Props, State> {
 
         {!isAmending && (
           <>
-            <ChatPreview messages={event.context} />
+            {eventNotFound ? (
+              <SplashScreen
+                title={lang.tr('module.misunderstood.couldNotLoadConversation')}
+                description={lang.tr('module.misunderstood.conversationDeleted')}
+                icon="warning-sign"
+              />
+            ) : (
+              <ChatPreview messages={event.context} />
+            )}
             <StickyActionBar>
               <Button onClick={deleteEvent} icon="trash" intent={Intent.DANGER} disabled={isAmending}>
                 {lang.tr('module.misunderstood.ignore')}
@@ -97,11 +107,13 @@ class NewEventView extends React.Component<Props, State> {
           </>
         )}
 
-        <h4 className={style.newEventPreview}>
-          {lang.tr('module.misunderstood.showMisunderstoodMessage', {
-            preview: <span className={style.newEventPreviewMessage}>{event.preview}</span>
-          })}
-        </h4>
+        {event && (
+          <h4 className={style.newEventPreview}>
+            {lang.tr('module.misunderstood.showMisunderstoodMessage', {
+              preview: <span className={style.newEventPreviewMessage}>{event.preview}</span>
+            })}
+          </h4>
+        )}
 
         {isAmending && (
           <AmendForm

--- a/modules/misunderstood/src/views/full/MainScreen/index.tsx
+++ b/modules/misunderstood/src/views/full/MainScreen/index.tsx
@@ -16,6 +16,7 @@ const MainScreen = ({
   selectedStatus,
   events,
   selectedEventIndex,
+  eventNotFound,
   totalEventsCount,
   skipEvent,
   deleteEvent,
@@ -50,6 +51,7 @@ const MainScreen = ({
       language={language}
       axios={axios}
       event={selectedEvent}
+      eventNotFound={eventNotFound}
       totalEventsCount={totalEventsCount}
       eventIndex={selectedEventIndex}
       skipEvent={skipEvent}

--- a/modules/misunderstood/src/views/full/index.tsx
+++ b/modules/misunderstood/src/views/full/index.tsx
@@ -26,6 +26,7 @@ interface State {
   events: FlaggedEvent[] | null
   selectedEventIndex: number | null
   selectedEvent: FlaggedEvent | null
+  eventNotFound: boolean
 }
 
 export default class MisunderstoodMainView extends React.Component<Props, State> {
@@ -36,7 +37,8 @@ export default class MisunderstoodMainView extends React.Component<Props, State>
     selectedStatus: FLAGGED_MESSAGE_STATUS.new,
     events: null,
     selectedEventIndex: null,
-    selectedEvent: null
+    selectedEvent: null,
+    eventNotFound: false
   }
 
   apiClient: ApiClient
@@ -54,8 +56,15 @@ export default class MisunderstoodMainView extends React.Component<Props, State>
     return this.apiClient.getEvents(language, status)
   }
 
-  fetchEvent(id: string) {
-    return this.apiClient.getEvent(id)
+  async fetchEvent(id: string) {
+    try {
+      return await this.apiClient.getEvent(id)
+    } catch (e) {
+      if (e.isAxiosError && e.response.status === 404) {
+        return
+      }
+      throw e
+    }
   }
 
   async componentDidMount() {
@@ -96,7 +105,7 @@ export default class MisunderstoodMainView extends React.Component<Props, State>
     await this.setStateP({ selectedEventIndex, selectedEvent: null })
     if (events && events.length) {
       const event = await this.fetchEvent(events[selectedEventIndex].id)
-      await this.setStateP({ selectedEvent: event })
+      await this.setStateP({ selectedEvent: event, eventNotFound: !!!event })
     }
   }
 
@@ -113,7 +122,7 @@ export default class MisunderstoodMainView extends React.Component<Props, State>
 
   async alterEventsList(oldStatus: FLAGGED_MESSAGE_STATUS, newStatus: FLAGGED_MESSAGE_STATUS) {
     // do some local state patching to prevent unneeded content flash
-    const { eventCounts, selectedEventIndex, events, selectedEvent } = this.state
+    const { eventCounts, selectedEventIndex, events } = this.state
     const newEventCounts = {
       ...eventCounts,
       [oldStatus]: eventCounts[oldStatus] - 1,
@@ -122,7 +131,7 @@ export default class MisunderstoodMainView extends React.Component<Props, State>
     await this.setStateP({
       eventCounts: newEventCounts,
       selectedEvent: null,
-      events: events.filter(event => event.id !== selectedEvent.id)
+      events: events.filter(event => event.id !== events[selectedEventIndex].id)
     })
 
     // advance to the next event
@@ -133,13 +142,12 @@ export default class MisunderstoodMainView extends React.Component<Props, State>
   }
 
   deleteCurrentEvent = async () => {
-    const { selectedEvent } = this.state
+    await this.apiClient.updateStatus(
+      this.state.events[this.state.selectedEventIndex].id,
+      FLAGGED_MESSAGE_STATUS.deleted
+    )
 
-    if (selectedEvent) {
-      await this.apiClient.updateStatus(selectedEvent.id, FLAGGED_MESSAGE_STATUS.deleted)
-
-      return this.alterEventsList(FLAGGED_MESSAGE_STATUS.new, FLAGGED_MESSAGE_STATUS.deleted)
-    }
+    return this.alterEventsList(FLAGGED_MESSAGE_STATUS.new, FLAGGED_MESSAGE_STATUS.deleted)
   }
 
   undeleteEvent = async (id: string) => {
@@ -153,9 +161,11 @@ export default class MisunderstoodMainView extends React.Component<Props, State>
   }
 
   amendCurrentEvent = async (resolutionData: ResolutionData) => {
-    const { selectedEvent } = this.state
-
-    await this.apiClient.updateStatus(selectedEvent.id, FLAGGED_MESSAGE_STATUS.pending, resolutionData)
+    await this.apiClient.updateStatus(
+      this.state.events[this.state.selectedEventIndex].id,
+      FLAGGED_MESSAGE_STATUS.pending,
+      resolutionData
+    )
     return this.alterEventsList(FLAGGED_MESSAGE_STATUS.new, FLAGGED_MESSAGE_STATUS.pending)
   }
 
@@ -172,7 +182,7 @@ export default class MisunderstoodMainView extends React.Component<Props, State>
   }
 
   render() {
-    const { eventCounts, selectedStatus, events, selectedEventIndex, selectedEvent } = this.state
+    const { eventCounts, selectedStatus, events, selectedEventIndex, selectedEvent, eventNotFound } = this.state
 
     const { contentLang } = this.props
 
@@ -193,12 +203,13 @@ export default class MisunderstoodMainView extends React.Component<Props, State>
           />
         </SidePanel>
 
-        {eventCounts && dataLoaded ? (
+        {eventCounts && (dataLoaded || eventNotFound) ? (
           <div className={classnames(style.padded, style.mainView, style.withStickyActionBar)}>
             <MainScreen
               axios={this.props.bp.axios}
               language={contentLang}
               selectedEvent={selectedEvent}
+              eventNotFound={eventNotFound}
               selectedEventIndex={selectedEventIndex}
               totalEventsCount={eventCounts[selectedStatus] || 0}
               selectedStatus={selectedStatus}

--- a/modules/misunderstood/src/views/full/index.tsx
+++ b/modules/misunderstood/src/views/full/index.tsx
@@ -105,7 +105,7 @@ export default class MisunderstoodMainView extends React.Component<Props, State>
     await this.setStateP({ selectedEventIndex, selectedEvent: null })
     if (events && events.length) {
       const event = await this.fetchEvent(events[selectedEventIndex].id)
-      await this.setStateP({ selectedEvent: event, eventNotFound: !!!event })
+      await this.setStateP({ selectedEvent: event, eventNotFound: !event })
     }
   }
 


### PR DESCRIPTION
This PR adds a message when a conversation cannot be retrieved:
![2020-09-02 at 12 30 PM](https://user-images.githubusercontent.com/892367/92011589-496bfa80-ed19-11ea-8421-4f4b17a31656.png)

Note that the user can still amend the misunderstood entry even if the source conversation cannot be retrieved.

Steps to reproduce issue:
* Write some bogus messages to the bot in order to generate misunderstood entries
* Truncate the `events` table
* Click on a message in the Misunderstood module
* A "Loading" screen shows up, confusing the user

Expected behaviour:
* A more explicit message should be displayed
* Event when the conversation cannot be displayed, the User can still amend the misunderstood entry

Cause: 
 * Since the Janitor removes records in the `events` table, misunderstood entries can reference deleted `events`.
In that case, the whole conversation cannot be retrieved. 
