### PR TITLE
fix(misunderstood): order events based on createdOn

### DIFF
--- a/modules/misunderstood/src/backend/db.ts
+++ b/modules/misunderstood/src/backend/db.ts
@@ -1,6 +1,7 @@
 import * as sdk from 'botpress/sdk'
 import Knex from 'knex'
-import { get, pick } from 'lodash'
+import _, { get, pick } from 'lodash'
+import moment from 'moment'
 
 import {
   DbFlaggedEvent,
@@ -92,29 +93,40 @@ export default class Db {
       .select('*')
       .then((data: DbFlaggedEvent[]) => (data && data.length ? data[0] : null))
 
-    const { threadId, sessionId, id: messageId, event: eventDetails } = await this.knex(EVENTS_TABLE_NAME)
+    const { threadId, sessionId, id: messageId, event: eventDetails, createdOn: messageCreatedOn } = await this.knex(
+      EVENTS_TABLE_NAME
+    )
       .where({ botId, incomingEventId: event.eventId, direction: 'incoming' })
-      .select('id', 'threadId', 'sessionId', 'event')
+      .select('id', 'threadId', 'sessionId', 'event', 'createdOn')
       .limit(1)
       .first()
+
+    // SQLite will return dates as strings.
+    // Since this.knex.date.[isAfter() | isBeforeOrOn()] expect strings to be colum names,
+    // I wrap the timestamp string to a Date
+    const messageCreatedOnAsDate = moment(messageCreatedOn).toDate()
 
     const [messagesBefore, messagesAfter] = await Promise.all([
       this.knex(EVENTS_TABLE_NAME)
         .where({ botId, threadId, sessionId })
-        .andWhere('id', '<=', messageId)
-        .orderBy('id', 'desc')
-        .limit(3)
+        .andWhere(this.knex.date.isBeforeOrOn('createdOn', messageCreatedOnAsDate))
+        // Two events with different id can have same createdOn
+        .orderBy([
+          { column: 'createdOn', order: 'desc' },
+          { column: 'id', order: 'desc' }
+        ])
+        .limit(6) // More messages displayed before can help user understand conversation better
         .select('id', 'event', 'createdOn'),
       this.knex(EVENTS_TABLE_NAME)
         .where({ botId, threadId, sessionId })
-        .andWhere('id', '>', messageId)
-        .orderBy('id', 'asc')
+        .andWhere(this.knex.date.isAfter('createdOn', messageCreatedOnAsDate))
+        .orderBy(['createdOn', 'id'])
         .limit(3)
         .select('id', 'event', 'createdOn')
     ])
 
-    const context = [...messagesBefore, ...messagesAfter]
-      .sort((e1, e2) => e1.createdOn.localeCompare(e2.createdOn))
+    const context = _.chain([...messagesBefore, ...messagesAfter])
+      .sortBy(['createdOn', 'id'])
       .map(({ id, event }) => {
         const eventObj = typeof event === 'string' ? JSON.parse(event) : event
         return {
@@ -124,6 +136,7 @@ export default class Db {
           isCurrent: id === messageId
         }
       })
+      .value()
 
     const parsedEventDetails =
       eventDetails && typeof eventDetails !== 'object' ? JSON.parse(eventDetails) : eventDetails

--- a/modules/misunderstood/src/backend/db.ts
+++ b/modules/misunderstood/src/backend/db.ts
@@ -104,17 +104,17 @@ export default class Db {
         .andWhere('id', '<=', messageId)
         .orderBy('id', 'desc')
         .limit(3)
-        .select('id', 'event'),
+        .select('id', 'event', 'createdOn'),
       this.knex(EVENTS_TABLE_NAME)
         .where({ botId, threadId, sessionId })
         .andWhere('id', '>', messageId)
         .orderBy('id', 'asc')
         .limit(3)
-        .select('id', 'event')
+        .select('id', 'event', 'createdOn')
     ])
 
     const context = [...messagesBefore, ...messagesAfter]
-      .sort((e1, e2) => e1.id - e2.id)
+      .sort((e1, e2) => e1.createdOn.localeCompare(e2.createdOn))
       .map(({ id, event }) => {
         const eventObj = typeof event === 'string' ? JSON.parse(event) : event
         return {

--- a/modules/misunderstood/src/backend/db.ts
+++ b/modules/misunderstood/src/backend/db.ts
@@ -93,7 +93,6 @@ export default class Db {
       .select('*')
       .then((data: DbFlaggedEvent[]) => (data && data.length ? data[0] : null))
 
-    )
     const parentEvent = await this.knex(EVENTS_TABLE_NAME)
       .where({ botId, incomingEventId: event.eventId, direction: 'incoming' })
       .select('id', 'threadId', 'sessionId', 'event', 'createdOn')

--- a/src/bp/core/database/helpers.ts
+++ b/src/bp/core/database/helpers.ts
@@ -116,10 +116,22 @@ export const patchKnex = (knex: Knex): KnexExtended => {
       return knex.raw(exp1 + ' < ' + exp2)
     },
 
+    isBeforeOrOn: (d1: Knex.ColumnOrDate, d2: Knex.ColumnOrDate): Knex.Raw => {
+      const exp1 = columnOrDateFormat(d1)
+      const exp2 = columnOrDateFormat(d2)
+      return knex.raw(exp1 + ' <= ' + exp2)
+    },
+
     isAfter: (d1: Knex.ColumnOrDate, d2: Knex.ColumnOrDate): Knex.Raw => {
       const exp1 = columnOrDateFormat(d1)
       const exp2 = columnOrDateFormat(d2)
       return knex.raw(exp1 + ' > ' + exp2)
+    },
+
+    isAfterOrOn: (d1: Knex.ColumnOrDate, d2: Knex.ColumnOrDate): Knex.Raw => {
+      const exp1 = columnOrDateFormat(d1)
+      const exp2 = columnOrDateFormat(d2)
+      return knex.raw(exp1 + ' >= ' + exp2)
     },
 
     isBetween: (date: Knex.ColumnOrDate, betweenA: Knex.ColumnOrDate, betweenB: Knex.ColumnOrDate): Knex.Raw => {

--- a/src/typings/knex.d.ts
+++ b/src/typings/knex.d.ts
@@ -14,7 +14,9 @@ declare module 'knex' {
     now(): Raw
     today(): Raw
     isBefore(d1: ColumnOrDate, d2: ColumnOrDate): Raw
+    isBeforeOrOn(d1: ColumnOrDate, d2: ColumnOrDate): Raw
     isAfter(d1: ColumnOrDate, d2: ColumnOrDate): Raw
+    isAfterOrOn(d1: ColumnOrDate, d2: ColumnOrDate): Raw
     isBetween(date: ColumnOrDate, betweenA: ColumnOrDate, betweenB: ColumnOrDate): Raw
     isSameDay(d1: ColumnOrDate, d2: ColumnOrDate): Raw
     hourOfDay(date: ColumnOrDate): Raw


### PR DESCRIPTION
Fixes a bug where messages were appearing in incorrect order in the Misunderstood screen.

Since records in table `events` are inserted in batch by the `EventCollector`, it seems like their `id` is not reliable to sort them in chronological order. 