### PR TITLE
fix(studio): no overwrite of output val

### DIFF
--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/PromptForm/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/PromptForm/index.tsx
@@ -43,6 +43,7 @@ const PromptForm: FC<Props> = ({
 
   useEffect(() => {
     promptType.current = formData?.type
+    currentVarName.current = formData.params.output
     setForceUpdate(!forceUpdate)
   }, [customKey])
 


### PR DESCRIPTION
switching from a prompt ot another would overwrite the output with the previous one