### PR TITLE
fix(build) Exit on webpack errors

### DIFF
--- a/src/bp/ui-shared/package.json
+++ b/src/bp/ui-shared/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "node ./webpack.config.js --watch",
-    "build": "cross-env NODE_ENV=production node ./webpack.config.js --compile --nomap & yarn scss",
+    "build": "cross-env NODE_ENV=production node ./webpack.config.js --compile --nomap && yarn scss",
     "scss": "node-sass src/theme/main.scss dist/theme.css --importer=node_modules/node-sass-tilde-importer"
   },
   "devDependencies": {

--- a/src/bp/ui-shared/webpack.config.js
+++ b/src/bp/ui-shared/webpack.config.js
@@ -68,8 +68,9 @@ if (process.argv.find(x => x.toLowerCase() === '--analyze')) {
 const compiler = webpack(config)
 
 compiler.hooks.done.tap('ExitCodePlugin', stats => {
-  if (stats.compilation.errors && stats.compilation.errors.length && process.argv.indexOf('--watch') == -1) {
-    for (const e of stats.compilation.errors) {
+  const errors = stats.compilation.errors
+  if (errors && errors.length && process.argv.indexOf('--watch') == -1) {
+    for (const e of errors) {
       console.log(e.message)
     }
     console.log('Webpack build failed')

--- a/src/bp/ui-shared/webpack.config.js
+++ b/src/bp/ui-shared/webpack.config.js
@@ -66,6 +66,17 @@ if (process.argv.find(x => x.toLowerCase() === '--analyze')) {
 }
 
 const compiler = webpack(config)
+
+compiler.hooks.done.tap('ExitCodePlugin', stats => {
+  if (stats.compilation.errors && stats.compilation.errors.length && process.argv.indexOf('--watch') == -1) {
+    for (const e of stats.compilation.errors) {
+      console.log(e.message)
+    }
+    console.log('Webpack build failed')
+    process.exit(1)
+  }
+})
+
 const postProcess = (err, stats) => {
   if (err) {
     throw err

--- a/src/bp/ui-shared/webpack.config.js
+++ b/src/bp/ui-shared/webpack.config.js
@@ -69,11 +69,11 @@ const compiler = webpack(config)
 
 compiler.hooks.done.tap('ExitCodePlugin', stats => {
   const errors = stats.compilation.errors
-  if (errors && errors.length && process.argv.indexOf('--watch') == -1) {
+  if (errors && errors.length && process.argv.indexOf('--watch') === -1) {
     for (const e of errors) {
-      console.log(e.message)
+      console.error(e.message)
     }
-    console.log('Webpack build failed')
+    console.error('Webpack build failed')
     process.exit(1)
   }
 })

--- a/src/bp/ui-studio/webpack.web.js
+++ b/src/bp/ui-studio/webpack.web.js
@@ -249,8 +249,9 @@ const showNodeEnvWarning = () => {
 const compiler = webpack(webConfig)
 
 compiler.hooks.done.tap('ExitCodePlugin', stats => {
-  if (stats.compilation.errors && stats.compilation.errors.length && process.argv.indexOf('--watch') == -1) {
-    for (const e of stats.compilation.errors) {
+  const errors = stats.compilation.errors
+  if (errors && errors.length && process.argv.indexOf('--watch') == -1) {
+    for (const e of errors) {
       console.log(e.message)
     }
     console.log('Webpack build failed')

--- a/src/bp/ui-studio/webpack.web.js
+++ b/src/bp/ui-studio/webpack.web.js
@@ -250,11 +250,11 @@ const compiler = webpack(webConfig)
 
 compiler.hooks.done.tap('ExitCodePlugin', stats => {
   const errors = stats.compilation.errors
-  if (errors && errors.length && process.argv.indexOf('--watch') == -1) {
+  if (errors && errors.length && process.argv.indexOf('--watch') === -1) {
     for (const e of errors) {
-      console.log(e.message)
+      console.error(e.message)
     }
-    console.log('Webpack build failed')
+    console.error('Webpack build failed')
     process.exit(1)
   }
 })

--- a/src/bp/ui-studio/webpack.web.js
+++ b/src/bp/ui-studio/webpack.web.js
@@ -247,6 +247,17 @@ const showNodeEnvWarning = () => {
 }
 
 const compiler = webpack(webConfig)
+
+compiler.hooks.done.tap('ExitCodePlugin', stats => {
+  if (stats.compilation.errors && stats.compilation.errors.length && process.argv.indexOf('--watch') == -1) {
+    for (const e of stats.compilation.errors) {
+      console.log(e.message)
+    }
+    console.log('Webpack build failed')
+    process.exit(1)
+  }
+})
+
 const postProcess = (err, stats) => {
   if (err) {
     throw err


### PR DESCRIPTION
Forces webpack (`ui-studio`, `ui-shared`) to exit with non-zero status code when a compilation error happens.
See https://github.com/webpack/webpack/issues/708

webpack already exits with non-zero status code in `ui-admin` and `modules`.