### PR TITLE
fix(nlu): allow entity extraction even if no utterance at predict time

### DIFF
--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -298,8 +298,12 @@ export default class Engine implements NLU.Engine {
       (c, [ctx, mod]) => ({ ...c, [ctx]: new tools.mlToolkit.SVM.Predictor(mod) }),
       {} as _.Dictionary<MLToolkit.SVM.Predictor>
     )
-    const slot_tagger = new SlotTagger(tools.mlToolkit)
-    slot_tagger.load(output.slots_model)
+
+    let slot_tagger: SlotTagger | undefined
+    if (output.slots_model.length) {
+      slot_tagger = new SlotTagger(tools.mlToolkit)
+      slot_tagger.load(output.slots_model)
+    }
 
     const kmeans = computeKmeans(intents!, tools) // TODO load from artefacts when persisted
 

--- a/src/bp/nlu-core/predict-pipeline.ts
+++ b/src/bp/nlu-core/predict-pipeline.ts
@@ -51,20 +51,18 @@ interface InitialStep {
   includedContexts: string[]
   languageCode: string
 }
-
-export type PredictStep = InitialStep & {
-  utterance: Utterance
-  alternateUtterance?: Utterance
-  ctx_predictions?: sdk.MLToolkit.SVM.Prediction[]
-  intent_predictions?: {
+type PredictStep = InitialStep & { utterance: Utterance; alternateUtterance?: Utterance }
+type OutOfScopeStep = PredictStep & { oos_predictions: _.Dictionary<number> }
+type ContextStep = OutOfScopeStep & { ctx_predictions: sdk.MLToolkit.SVM.Prediction[] }
+type IntentStep = ContextStep & {
+  intent_predictions: {
     per_ctx?: _.Dictionary<sdk.MLToolkit.SVM.Prediction[]>
     combined?: E1IntentPred[] // only to comply with E1
     elected?: E1IntentPred // only to comply with E1
     ambiguous?: boolean
   }
-  oos_predictions?: _.Dictionary<number>
-  slot_predictions_per_intent?: _.Dictionary<SlotExtractionResult[]>
 }
+type SlotStep = IntentStep & { slot_predictions_per_intent: _.Dictionary<SlotExtractionResult[]> }
 
 export type PredictOutput = sdk.IO.EventUnderstanding
 
@@ -158,7 +156,7 @@ const getCustomEntitiesNames = (predictors: Predictors): string[] => [
   ...predictors.pattern_entities.map(e => e.name)
 ]
 
-async function predictContext(input: PredictStep, predictors: Predictors): Promise<PredictStep> {
+async function predictContext(input: OutOfScopeStep, predictors: Predictors): Promise<ContextStep> {
   const customEntities = getCustomEntitiesNames(predictors)
 
   const classifier = predictors.ctx_classifier
@@ -199,23 +197,19 @@ async function predictContext(input: PredictStep, predictors: Predictors): Promi
   }
 }
 
-async function predictIntent(input: PredictStep, predictors: Predictors): Promise<PredictStep> {
+async function predictIntent(input: ContextStep, predictors: Predictors): Promise<IntentStep> {
   if (_.flatMap(predictors.intents, i => i.utterances).length <= 0) {
     return { ...input, intent_predictions: { per_ctx: { [DEFAULT_CTX]: [{ label: NONE_INTENT, confidence: 1 }] } } }
   }
 
   const customEntities = getCustomEntitiesNames(predictors)
 
-  const predictableContext = Object.keys(predictors.intent_classifier_per_ctx ?? {}).filter(_.identity)
-  const ctxToPredict = _.intersection(
-    input.ctx_predictions!.map(p => p.label),
-    predictableContext
-  )
+  const ctxToPredict = input.ctx_predictions.map(p => p.label)
   const predictions = (
     await Promise.map(ctxToPredict, async ctx => {
       let preds: sdk.MLToolkit.SVM.Prediction[] = []
 
-      const predictor = predictors.intent_classifier_per_ctx![ctx]
+      const predictor = predictors.intent_classifier_per_ctx?.[ctx]
       if (predictor) {
         const features = getIntentFeatures(input.utterance, customEntities)
         const prediction = await predictor.predict(features)
@@ -265,9 +259,13 @@ async function predictIntent(input: PredictStep, predictors: Predictors): Promis
   }
 }
 
-async function predictOutOfScope(input: PredictStep, predictors: Predictors): Promise<PredictStep> {
+async function predictOutOfScope(input: PredictStep, predictors: Predictors): Promise<OutOfScopeStep> {
   const oos_predictions = {} as _.Dictionary<number>
-  if (!isPOSAvailable(input.languageCode) || _.isEmpty(predictors.oos_classifier_per_ctx)) {
+  if (
+    !isPOSAvailable(input.languageCode) ||
+    !predictors.oos_classifier_per_ctx ||
+    _.isEmpty(predictors.oos_classifier_per_ctx)
+  ) {
     return {
       ...input,
       oos_predictions: Object.keys(predictors.contexts).reduce((preds, ctx) => ({ ...preds, [ctx]: 0 }), {})
@@ -278,7 +276,7 @@ async function predictOutOfScope(input: PredictStep, predictors: Predictors): Pr
   const feats = getUtteranceFeatures(utt, predictors.vocabVectors)
   for (const ctx of predictors.contexts) {
     try {
-      const preds = await predictors.oos_classifier_per_ctx![ctx].predict(feats)
+      const preds = await predictors.oos_classifier_per_ctx[ctx].predict(feats)
       oos_predictions[ctx] = _.chain(preds)
         .filter(p => p.label.startsWith('out'))
         .maxBy('confidence')
@@ -295,21 +293,21 @@ async function predictOutOfScope(input: PredictStep, predictors: Predictors): Pr
   }
 }
 
-async function extractSlots(input: PredictStep, predictors: Predictors): Promise<PredictStep> {
+async function extractSlots(input: IntentStep, predictors: Predictors): Promise<SlotStep> {
   if (!predictors.slot_tagger) {
-    return input
+    return { ...input, slot_predictions_per_intent: {} }
   }
 
-  const slots_per_intent: typeof input.slot_predictions_per_intent = {}
+  const slots_per_intent: _.Dictionary<SlotExtractionResult[]> = {}
   for (const intent of predictors.intents.filter(x => x.slot_definitions.length > 0)) {
-    const slots = await predictors.slot_tagger!.extract(input.utterance, intent)
+    const slots = await predictors.slot_tagger.extract(input.utterance, intent)
     slots_per_intent[intent.name] = slots
   }
 
   return { ...input, slot_predictions_per_intent: slots_per_intent }
 }
 
-function MapStepToOutput(step: PredictStep, startTime: number): PredictOutput {
+function MapStepToOutput(step: SlotStep, startTime: number): PredictOutput {
   const entitiesMapper = (e?: EntityExtractionResult | UtteranceEntity): sdk.NLU.Entity => {
     if (!e) {
       return eval('null')
@@ -357,7 +355,7 @@ function MapStepToOutput(step: PredictStep, startTime: number): PredictOutput {
   const predictions: sdk.NLU.Predictions = step.ctx_predictions!.reduce((preds, current) => {
     const { label, confidence } = current
 
-    const intentPred = step.intent_predictions!.per_ctx![label]
+    const intentPred = step.intent_predictions.per_ctx![label]
     const intents = !intentPred
       ? []
       : intentPred.map(i => ({
@@ -372,7 +370,7 @@ function MapStepToOutput(step: PredictStep, startTime: number): PredictOutput {
       ...preds,
       [label]: {
         confidence,
-        oos: includeOOS ? step.oos_predictions![label] || 0 : 0,
+        oos: includeOOS ? step.oos_predictions[label] || 0 : 0,
         intents
       }
     }
@@ -416,15 +414,14 @@ export const Predict = async (
     // tslint:disable-next-line
     let { step, predictors } = await preprocessInput(input, tools, predictorsByLang)
 
-    let stepOutput: PredictStep
-    stepOutput = await makePredictionUtterance(step, predictors, tools)
-    stepOutput = await extractEntities(stepOutput, predictors, tools)
-    stepOutput = await predictOutOfScope(stepOutput, predictors)
-    stepOutput = await predictContext(stepOutput, predictors)
-    stepOutput = await predictIntent(stepOutput, predictors)
-    stepOutput = await extractSlots(stepOutput, predictors)
+    const initialStep = await makePredictionUtterance(step, predictors, tools)
+    const entitesStep = await extractEntities(initialStep, predictors, tools)
+    const oosStep = await predictOutOfScope(entitesStep, predictors)
+    const ctxStep = await predictContext(oosStep, predictors)
+    const intentStep = await predictIntent(ctxStep, predictors)
+    const slotStep = await extractSlots(intentStep, predictors)
 
-    return MapStepToOutput(stepOutput, t0)
+    return MapStepToOutput(slotStep, t0)
   } catch (err) {
     // tslint:disable-next-line: no-console
     console.log('Could not perform predict data', err)

--- a/src/bp/nlu-core/predict-pipeline.ts
+++ b/src/bp/nlu-core/predict-pipeline.ts
@@ -56,22 +56,12 @@ type OutOfScopeStep = PredictStep & { oos_predictions: _.Dictionary<number> }
 type ContextStep = OutOfScopeStep & { ctx_predictions: sdk.MLToolkit.SVM.Prediction[] }
 type IntentStep = ContextStep & {
   intent_predictions: {
-    per_ctx?: _.Dictionary<sdk.MLToolkit.SVM.Prediction[]>
-    combined?: E1IntentPred[] // only to comply with E1
-    elected?: E1IntentPred // only to comply with E1
-    ambiguous?: boolean
+    per_ctx: _.Dictionary<sdk.MLToolkit.SVM.Prediction[]>
   }
 }
 type SlotStep = IntentStep & { slot_predictions_per_intent: _.Dictionary<SlotExtractionResult[]> }
 
 export type PredictOutput = sdk.IO.EventUnderstanding
-
-// only to comply with E1
-interface E1IntentPred {
-  name: string
-  context: string
-  confidence: number
-}
 
 const DEFAULT_CTX = 'global'
 const NONE_INTENT = 'none'
@@ -199,7 +189,10 @@ async function predictContext(input: OutOfScopeStep, predictors: Predictors): Pr
 
 async function predictIntent(input: ContextStep, predictors: Predictors): Promise<IntentStep> {
   if (_.flatMap(predictors.intents, i => i.utterances).length <= 0) {
-    return { ...input, intent_predictions: { per_ctx: { [DEFAULT_CTX]: [{ label: NONE_INTENT, confidence: 1 }] } } }
+    return {
+      ...input,
+      intent_predictions: { per_ctx: { [DEFAULT_CTX]: [{ label: NONE_INTENT, confidence: 1 }] } }
+    }
   }
 
   const customEntities = getCustomEntitiesNames(predictors)

--- a/src/bp/nlu-core/predict-pipeline.ts
+++ b/src/bp/nlu-core/predict-pipeline.ts
@@ -189,10 +189,7 @@ async function predictContext(input: OutOfScopeStep, predictors: Predictors): Pr
 
 async function predictIntent(input: ContextStep, predictors: Predictors): Promise<IntentStep> {
   if (_.flatMap(predictors.intents, i => i.utterances).length <= 0) {
-    return {
-      ...input,
-      intent_predictions: { per_ctx: { [DEFAULT_CTX]: [{ label: NONE_INTENT, confidence: 1 }] } }
-    }
+    return { ...input, intent_predictions: { per_ctx: { [DEFAULT_CTX]: [{ label: NONE_INTENT, confidence: 1 }] } } }
   }
 
   const customEntities = getCustomEntitiesNames(predictors)


### PR DESCRIPTION
Got rid of unecesseray optionnal types in predict pipeline + handle true optionnals better then just with a `!`
\+ do not try to predict slots if there's no model for it (this just throws a C++ exception that can't be catched)

@EFF This PR includes lots of little changes, I added comments to help you out while reviewing.