### PR TITLE
fix(nlu): log error stack trace and botId in NLU

### DIFF
--- a/modules/nlu/src/backend/index.ts
+++ b/modules/nlu/src/backend/index.ts
@@ -15,7 +15,6 @@ import { NLUState } from './typings'
 
 const state: NLUState = {
   nluByBot: {},
-  logger: {} as sdk.NLU.Logger,
   sendNLUStatusEvent: async () => {}
 }
 

--- a/modules/nlu/src/backend/logger.ts
+++ b/modules/nlu/src/backend/logger.ts
@@ -1,0 +1,29 @@
+import * as sdk from 'botpress/sdk'
+
+export function makeLoggerWrapper(bp: typeof sdk, botId?: string): sdk.NLU.Logger {
+  return <sdk.NLU.Logger>{
+    info: (msg: string) => {
+      const logger = _makeLogger(bp, botId)
+      const formatedMsg = _makeMsg(msg, botId)
+      logger.info(formatedMsg)
+    },
+    warning: (msg: string, err?: Error) => {
+      const logger = _makeLogger(bp, botId)
+      const formatedMsg = _makeMsg(msg, botId)
+      err ? logger.attachError(err).warn(formatedMsg) : logger.warn(formatedMsg)
+    },
+    error: (msg: string, err?: Error) => {
+      const logger = _makeLogger(bp, botId)
+      const formatedMsg = _makeMsg(msg, botId)
+      err ? logger.attachError(err).error(formatedMsg) : logger.error(formatedMsg)
+    }
+  }
+}
+
+function _makeLogger(bp: typeof sdk, botId: string) {
+  return botId ? bp.logger.forBot(botId) : bp.logger
+}
+
+function _makeMsg(msg: string, botId: string | undefined) {
+  return botId?.length ? `[${botId}] ${msg}` : msg
+}

--- a/modules/nlu/src/backend/module-lifecycle/on-bot-mount.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-bot-mount.ts
@@ -4,6 +4,7 @@ import ms from 'ms'
 import yn from 'yn'
 
 import { createApi } from '../../api'
+import { makeLoggerWrapper } from '../logger'
 import * as ModelService from '../model-service'
 import { makeTrainingSession, makeTrainSessionKey, setTrainingSession } from '../train-session-service'
 import { NLUState } from '../typings'
@@ -23,7 +24,7 @@ export function getOnBotMount(state: NLUState) {
       bp.logger.warn(missingLangMsg(botId), { notSupported: _.difference(bot.languages, languages) })
     }
 
-    const engine = new bp.NLU.Engine(bot.id, state.logger)
+    const engine = new bp.NLU.Engine(bot.id, makeLoggerWrapper(bp, botId))
     const trainOrLoad = _.debounce(
       async (forceTrain: boolean = false) => {
         // bot got deleted

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -2,6 +2,7 @@ import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 
 import legacyElectionPipeline from '../legacy-election'
+import { makeLoggerWrapper } from '../logger'
 import { getLatestModel } from '../model-service'
 import { PredictionHandler } from '../prediction-handler'
 import { setTrainingSession } from '../train-session-service'
@@ -14,15 +15,6 @@ async function initializeReportingTool(bp: typeof sdk, state: NLUState) {
     const ev: NLUProgressEvent = { type: 'nlu', botId, trainSession: _.omit(trainSession, 'lock') }
     bp.realtime.sendPayload(bp.RealTimePayload.forAdmins('statusbar.event', ev))
   }
-}
-
-function initializeLogger(bp: typeof sdk, state: NLUState) {
-  const logger: sdk.NLU.Logger = {
-    info: (msg: string) => bp.logger.info(msg),
-    warning: (msg: string, err?: Error) => (err ? bp.logger.attachError(err).warn(msg) : bp.logger.warn(msg)),
-    error: (msg: string, err?: Error) => (err ? bp.logger.attachError(err).error(msg) : bp.logger.error(msg))
-  }
-  state.logger = logger
 }
 
 const EVENTS_TO_IGNORE = ['session_reference', 'session_reset', 'bp_dialog_timeout', 'visit', 'say_something', '']
@@ -115,9 +107,8 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
 export function getOnSeverStarted(state: NLUState) {
   return async (bp: typeof sdk) => {
     await initializeReportingTool(bp, state)
-    initializeLogger(bp, state)
     const globalConfig = await bp.config.getModuleConfig('nlu')
-    await bp.NLU.Engine.initialize(globalConfig, state.logger)
+    await bp.NLU.Engine.initialize(globalConfig, makeLoggerWrapper(bp))
     await registerMiddleware(bp, state)
   }
 }

--- a/modules/nlu/src/backend/typings.ts
+++ b/modules/nlu/src/backend/typings.ts
@@ -7,7 +7,6 @@ export interface NluMlRecommendations {
 
 export type NLUState = {
   nluByBot: _.Dictionary<BotState>
-  logger: NLU.Logger
   broadcastLoadModel?: (botId: string, hash: string, language: string) => Promise<void>
   broadcastCancelTraining?: (botId: string, language: string) => Promise<void>
   sendNLUStatusEvent: (botId: string, trainSession: NLU.TrainingSession) => Promise<void>

--- a/src/bp/ml/error-utils.ts
+++ b/src/bp/ml/error-utils.ts
@@ -1,0 +1,26 @@
+import _ from 'lodash'
+
+export type ErrorMessage = { message: string; stack?: string }
+
+export function serializeError(err: any): ErrorMessage {
+  if (err instanceof Error) {
+    const { message, stack } = err
+    return { message, stack }
+  }
+
+  if (_.isString(err)) {
+    return { message: err }
+  }
+
+  if (_.isObject(err)) {
+    return { message: JSON.stringify(err, null, 2) }
+  }
+
+  return { message: '' }
+}
+
+export function deserializeError(err: ErrorMessage): Error {
+  const newErr = new Error(err.message)
+  newErr.stack = err.stack
+  return newErr
+}

--- a/src/bp/ml/ml-thread-index.ts
+++ b/src/bp/ml/ml-thread-index.ts
@@ -8,6 +8,7 @@ import * as sdk from 'botpress/sdk'
 import { parentPort } from 'worker_threads'
 
 import { Trainer as CrfTrainer } from './crf'
+import { serializeError } from './error-utils'
 import { Message } from './ml-thread-pool'
 import { Trainer as SvmTrainer } from './svm'
 
@@ -35,7 +36,7 @@ async function messageHandler(msg: Message) {
       const response: Message = { type: 'svm_done', id: msg.id, payload: { result } }
       parentPort?.postMessage(response)
     } catch (err) {
-      const response: Message = { type: 'svm_error', id: msg.id, payload: { error: err.message } }
+      const response: Message = { type: 'svm_error', id: msg.id, payload: { error: serializeError(err) } }
       parentPort?.postMessage(response)
     }
   }
@@ -58,7 +59,7 @@ async function messageHandler(msg: Message) {
       const response: Message = { type: 'crf_done', id: msg.id, payload: { result } }
       parentPort?.postMessage(response)
     } catch (err) {
-      const response: Message = { type: 'crf_error', id: msg.id, payload: { error: err.message } }
+      const response: Message = { type: 'crf_error', id: msg.id, payload: { error: serializeError(err) } }
       parentPort?.postMessage(response)
     }
   }

--- a/src/bp/ml/ml-thread-pool.ts
+++ b/src/bp/ml/ml-thread-pool.ts
@@ -2,6 +2,7 @@ import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 import os from 'os'
 
+import { deserializeError, ErrorMessage } from './error-utils'
 import { MLThreadScheduler } from './ml-thread-scheduler'
 
 type MsgType =
@@ -17,7 +18,7 @@ type MsgType =
 type Payload = Partial<{
   progress: number
   result: string
-  error: string
+  error: ErrorMessage
   points: (sdk.MLToolkit.SVM.DataPoint | sdk.MLToolkit.CRF.DataPoint)[]
   options: sdk.MLToolkit.SVM.SVMOptions | sdk.MLToolkit.CRF.TrainerOptions | undefined
 }>
@@ -92,7 +93,7 @@ export class MLThreadPool {
       }
 
       if (msg.type === 'svm_error' || msg.type === 'crf_error') {
-        error(new Error(msg.payload.error!))
+        error(deserializeError(msg.payload.error!))
         worker.off('message', messageHandler)
       }
     }


### PR DESCRIPTION
Changes so even if error occurs inside ml-thread, inside training-worker, we keep the stack trace of the error
\+ log the botId with the message

![image](https://user-images.githubusercontent.com/25970722/92626350-c823e300-f297-11ea-9481-317e8405fb31.png)
