### PR TITLE
fix(tooltip): fix tooltip never dissapearing when element was deleted

### DIFF
--- a/src/bp/ui-shared-lite/ToolTip/index.tsx
+++ b/src/bp/ui-shared-lite/ToolTip/index.tsx
@@ -185,9 +185,16 @@ const ToolTip: FC<ToolTipProps> = ({ children, content, position = 'top', hoverO
   }
 
   const show = e => {
+    document.addEventListener('mousemove', mouseMove)
     clearTimeout(timeout.current)
     handleHtmlRendering()
     pastShow(e.currentTarget)
+  }
+
+  const mouseMove = e => {
+    if (!e.target?.closest(`#${id.current}-trigger`)) {
+      hide()
+    }
   }
 
   const handleHtmlRendering = (classNames = '', inlineStyle = {}, tipPos = {}) => {
@@ -213,6 +220,7 @@ const ToolTip: FC<ToolTipProps> = ({ children, content, position = 'top', hoverO
   }
 
   const hide = () => {
+    document.removeEventListener('mousemove', mouseMove)
     tooltipRef.current.classList.remove(style.visible)
     const body = document.getElementsByTagName('body')[0]
 
@@ -226,6 +234,7 @@ const ToolTip: FC<ToolTipProps> = ({ children, content, position = 'top', hoverO
   }
 
   return cloneElement(Children.only(children), {
+    id: `${id.current}-trigger`,
     onMouseEnter: show,
     onMouseLeave: hide
   })

--- a/src/bp/ui-shared/src/Contents/Components/Fields/Upload.tsx
+++ b/src/bp/ui-shared/src/Contents/Components/Fields/Upload.tsx
@@ -1,5 +1,6 @@
-import { Button, FileInput, Icon, Intent, Position, Tooltip } from '@blueprintjs/core'
+import { Button, FileInput, Icon, Intent } from '@blueprintjs/core'
 import React, { FC, Fragment, useReducer } from 'react'
+import ToolTip from '../../../../../ui-shared-lite/ToolTip'
 
 import { lang } from '../../../translations'
 import wrapperStyle from '../../../FormFields/FieldWrapper/style.scss'
@@ -83,7 +84,7 @@ const Upload: FC<UploadFieldProps> = props => {
       {value && (
         <div style={{ backgroundImage: `url('${value}')` }} className={style.imgWrapper}>
           <div className={style.imgWrapperActions}>
-            <Tooltip content={lang('deleteImage')} position={Position.TOP}>
+            <ToolTip content={lang('deleteImage')}>
               <Button
                 className={style.deleteImg}
                 minimal
@@ -92,7 +93,7 @@ const Upload: FC<UploadFieldProps> = props => {
                 icon="trash"
                 onClick={deleteFile}
               ></Button>
-            </Tooltip>
+            </ToolTip>
           </div>
         </div>
       )}


### PR DESCRIPTION
https://trello.com/c/O3t4Gugm/335-tooltips-always-stay-there-this-happens-when-an-element-is-removed-from-the-dom