### PR TITLE
fix(studio): fix warning messages so they don't display on each other

### DIFF
--- a/src/bp/ui-studio/src/web/components/Layout/WarningMessage/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/WarningMessage/index.tsx
@@ -1,12 +1,31 @@
 import { Icon } from '@blueprintjs/core'
-import { FC } from 'react'
+import _uniqueId from 'lodash/uniqueId'
+import { FC, useEffect, useRef, useState } from 'react'
 import React from 'react'
 
 import style from './style.scss'
 
+let instances = []
+
 const WarningMessage: FC<{ message: string }> = ({ message }) => {
+  const uniqId = useRef('')
+  const [currentNumber, setCurrentNumber] = useState(0)
+
+  useEffect(() => {
+    uniqId.current = _uniqueId()
+    instances.push(uniqId.current)
+
+    return () => {
+      instances = instances.filter(id => id !== uniqId.current)
+    }
+  }, [])
+
+  useEffect(() => {
+    setCurrentNumber(instances.indexOf(uniqId.current))
+  }, [instances])
+
   return (
-    <div className={style.warning_container}>
+    <div className="warning-container" style={{ marginBottom: `${currentNumber * 60}px` }}>
       <div className={style.warning}>
         <Icon icon="warning-sign" iconSize={20} className={style.warning_icon} />
         <div className={style.warning_text}>{message}</div>

--- a/src/bp/ui-studio/src/web/components/Layout/WarningMessage/style.scss
+++ b/src/bp/ui-studio/src/web/components/Layout/WarningMessage/style.scss
@@ -1,3 +1,11 @@
+:global(.warning-container) {
+  position: fixed;
+  right: 50%;
+  bottom: calc(var(--spacing-medium) + 28px);
+  transform: translate(50%, 0);
+  z-index: 9;
+}
+
 .warning {
   position: relative;
   background: var(--hover-lighthouse-30);
@@ -5,14 +13,6 @@
   border-radius: 5px;
   display: flex;
   align-items: center;
-
-  &_container {
-    position: fixed;
-    right: 50%;
-    bottom: calc(var(--spacing-medium) + 28px);
-    transform: translate(50%, 0);
-    z-index: 9;
-  }
 
   &_icon {
     color: var(--lighthouse);
@@ -26,7 +26,7 @@
   }
 }
 
-:global(.layout-emulator-open) + .warning_container,
-:global(.emulator-open) + .warning_container {
+:global(.layout-emulator-open) + :global(.warning-container),
+:global(.emulator-open) + :global(.warning-container) {
   margin-right: 100px;
 }

--- a/src/bp/ui-studio/src/web/components/Layout/WarningMessage/style.scss.d.ts
+++ b/src/bp/ui-studio/src/web/components/Layout/WarningMessage/style.scss.d.ts
@@ -2,7 +2,6 @@
 // Please do not change this file!
 interface CssExports {
   'warning': string;
-  'warning_container': string;
   'warning_icon': string;
   'warning_text': string;
 }

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/style.scss
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/style.scss
@@ -45,7 +45,7 @@
 
 .searchWrapper {
   position: relative;
-  z-index: 9999;
+  z-index: 9;
   align-items: flex-start;
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
There sometimes is a delay before the top one moves to the bottom after the bottom one disappears, but for now it works, could spend more time on it at some point

![Screen Shot 2020-09-09 at 3 26 00 PM](https://user-images.githubusercontent.com/3555826/92645033-3bd2e980-f2b2-11ea-8fcd-ac0e9e72e941.png)
