### PR TITLE
fix(studio): various small fixes

### DIFF
--- a/modules/extensions/src/views/lite/components/debugger/index.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/index.tsx
@@ -191,7 +191,11 @@ export class Debugger extends React.Component<Props, State> {
       this.props.store.view.setHighlightedMessages(eventId)
 
       if (this.state.updateDiagram) {
-        this.showEventOnDiagram(event)
+        try {
+          this.showEventOnDiagram(event)
+        } catch (err) {
+          console.error("Couldn't load event on workflow", err)
+        }
       }
 
       if (!event.processing?.['completed']) {

--- a/modules/ndu/src/backend/ndu-engine.ts
+++ b/modules/ndu/src/backend/ndu-engine.ts
@@ -223,6 +223,11 @@ export class UnderstandingEngine {
 
     await this.trainIfNot()
 
+    // This can happen if one request acquired the lock and is waiting a training or loading the model
+    if (!this.predictor) {
+      return
+    }
+
     const predict = async (input: Features): Promise<ActionPredictions> => {
       const vec = this.featToVec(input)
       const preds = await this.predictor.predict(vec)

--- a/src/bp/ui-studio/src/web/translations/en.json
+++ b/src/bp/ui-studio/src/web/translations/en.json
@@ -163,6 +163,7 @@
       "mustHaveOutcomes": "Workflows must have at least one success and one failure outcome",
       "referenceCount": "{count} {count, plural, one {reference} other {references}}",
       "noReferences": "Not used",
+      "cannotAddContent": "Adding new content is disabled when not in the default language",
       "emptyWorkflow": "Right-click or drag and drop blocks to start designing your workflow.",
       "chips": "Chips",
       "condition": {

--- a/src/bp/ui-studio/src/web/translations/fr.json
+++ b/src/bp/ui-studio/src/web/translations/fr.json
@@ -162,6 +162,7 @@
       "mustHaveOutcomes": "Les flux de travail doivent avoir au moins un succès et un échec",
       "referenceCount": "{count} {count, plural, one {référence} other {références}}",
       "noReferences": "Non utilisé",
+      "cannotAddContent": "L'ajout de contenu n'est disponible que sur la langue par défaut",
       "emptyWorkflow": "Utilisez le clic droit ou glissez et déplacez des bloques pour commencer a designer votre workflow.",
       "chips": "Chips",
       "condition": {

--- a/src/bp/ui-studio/src/web/translations/fr.json
+++ b/src/bp/ui-studio/src/web/translations/fr.json
@@ -162,7 +162,7 @@
       "mustHaveOutcomes": "Les flux de travail doivent avoir au moins un succès et un échec",
       "referenceCount": "{count} {count, plural, one {référence} other {références}}",
       "noReferences": "Non utilisé",
-      "cannotAddContent": "L'ajout de contenu n'est disponible que sur la langue par défaut",
+      "cannotAddContent": "L'ajout de contenu est seulement disponible sur la langue par défaut",
       "emptyWorkflow": "Utilisez le clic droit ou glissez et déplacez des bloques pour commencer a designer votre workflow.",
       "chips": "Chips",
       "condition": {

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/manager.ts
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/manager.ts
@@ -235,7 +235,7 @@ export class DiagramManager {
       const targetPort = link.getSourcePort().name.startsWith('out') ? link.getTargetPort() : link.getSourcePort()
 
       const output = outPort.getParent()['name']
-      const input = targetPort.getParent()['name']
+      const input = targetPort?.getParent()['name']
 
       if (nodeNames.includes(output) && nodeNames.includes(input)) {
         this.highlightedLinks.push(link.getID())

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/debugger.ts
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/debugger.ts
@@ -123,9 +123,9 @@ const processStackTrace = (
   traces: sdk.IO.JumpPoint[],
   context: sdk.IO.DialogContext,
   getNode: (flow: string, node: string) => NodeDebugInfo
-) => {
+): FlowNode[] => {
   if (!traces?.length) {
-    return
+    return []
   }
 
   const lastNode = _.last(traces)

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/index.tsx
@@ -446,10 +446,6 @@ class Diagram extends Component<Props> {
   }
 
   handleContextMenuNoElement = (event: React.MouseEvent) => {
-    if (this.props.defaultLang && this.props.defaultLang !== this.props.currentLang) {
-      return
-    }
-
     const point = this.manager.getRealPosition(event)
     const originatesFromOutPort = _.get(this.dragPortSource, 'parent.sourcePort.name', '').startsWith('out')
 
@@ -529,6 +525,11 @@ class Diagram extends Component<Props> {
 
   handleContextMenu = (event: React.MouseEvent) => {
     event.preventDefault()
+
+    if (this.props.defaultLang && this.props.defaultLang !== this.props.currentLang) {
+      toast.info('studio.flow.cannotAddContent')
+      return
+    }
 
     const target = this.diagramWidget.getMouseElement(event)
     if (!target && !this.props.readOnly) {

--- a/src/bp/ui-studio/src/web/views/OneFlow/diagram/nodes/Block/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/diagram/nodes/Block/index.tsx
@@ -1,6 +1,6 @@
 import { Intent, Menu, MenuItem } from '@blueprintjs/core'
 import { DecisionTriggerCondition, FormData, SubWorkflowNode } from 'botpress/sdk'
-import { contextMenu, lang, ShortcutLabel } from 'botpress/shared'
+import { contextMenu, lang, ShortcutLabel, toast } from 'botpress/shared'
 import { FlowView } from 'common/typings'
 import React, { FC, useState } from 'react'
 import { AbstractNodeFactory, DiagramEngine } from 'storm-react-diagrams'
@@ -67,10 +67,17 @@ const BlockWidget: FC<Props> = ({
   getDebugInfo
 }) => {
   const { nodeType } = node
+  const { currentLang, defaultLang } = getLanguage()
 
   const handleContextMenu = e => {
     e.stopPropagation()
     e.preventDefault()
+
+    if (defaultLang && defaultLang !== currentLang) {
+      toast.info('studio.flow.cannotAddContent')
+      return
+    }
+
     switchFlowNode(node.id)
     contextMenu(
       e,
@@ -109,7 +116,7 @@ const BlockWidget: FC<Props> = ({
   const outPortInHeader = !['failure', 'prompt', 'router', 'success', 'sub-workflow'].includes(nodeType)
   const canCollapse = !['failure', 'prompt', 'router', 'success', 'sub-workflow'].includes(nodeType)
   const hasContextMenu = !['failure', 'success'].includes(nodeType)
-  const { currentLang, defaultLang } = getLanguage()
+
   const debugInfo = getDebugInfo(node.name)
 
   const renderContents = () => {

--- a/src/bp/ui-studio/src/web/views/OneFlow/index.tsx
+++ b/src/bp/ui-studio/src/web/views/OneFlow/index.tsx
@@ -51,11 +51,16 @@ const SEARCH_TAG = '#search:'
 const FlowBuilder = (props: Props) => {
   const { flow } = props.match.params as any
 
+  const getLang = () => {
+    const lang = localStorage.getItem(CMS_LANG_KEY)
+    return lang && props.languages.includes(lang) ? lang : props.contentLang
+  }
+
   const diagram: any = useRef(null)
   const [showSearch, setShowSearch] = useState(false)
   const [readOnly, setReadOnly] = useState(false)
   const [flowPreview, setFlowPreview] = useState(true)
-  const [currentLang, setCurrentLang] = useState(localStorage.getItem(CMS_LANG_KEY) || props.contentLang)
+  const [currentLang, setCurrentLang] = useState(getLang())
   const [mutex, setMutex] = useState(null)
   const [actions, setActions] = useState(allActions)
   const [highlightFilter, setHighlightFilter] = useState('')


### PR DESCRIPTION
Couple of fixes while playing around:
- The debugger was trying to retry loading an event if there was no stacktrace (there was an exception on the diagram). Fixed the issue & added failsafe
- Patch work on the ndu where if a ton of requests were sent and no model is loaded, it would display a ton of error messages (best solution would be to await until lock is released, but not implemented)
- Fixed random issue where playing with links would crash the studio
- Added a small toast info when you right click on the diagram or when you try to drag&drop to create a new node when not on the default language. That damn thing pissed me off too often today and I never look at the orange message below. Need something that pops out

![image](https://user-images.githubusercontent.com/42552874/92647870-9ec67f80-f2b6-11ea-8b8f-c77079dfd621.png)

Edit:
- Also added a check to ensure the language stored in local storage is part of the list of languages supported by the bot. Otherwise it's read only and it can't be changed

