### PR TITLE
fix(nlu): retrain only modified ctx merge fix

### DIFF
--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -142,7 +142,7 @@ export default class Engine implements NLU.Engine {
       const ctxHasChanged = this._ctxHasChanged(previousIntents, intents)
       const modifiedCtx = contexts.filter(ctxHasChanged)
 
-      trainAllCtx = modifiedCtx.length === contexts.length
+      trainAllCtx = modifiedCtx.length >= contexts.length
       ctxToTrain = trainAllCtx ? contexts : modifiedCtx
     }
 

--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -171,7 +171,7 @@ export default class Engine implements NLU.Engine {
     }
 
     if (!trainAllCtx) {
-      model.data.output = this._mergeModelOutputs(model.data.output, previousModel.data.output)
+      model.data.output = this._mergeModelOutputs(model.data.output, previousModel.data.output, contexts)
     }
 
     trainDebug.forBot(this.botId, `Successfully finished ${languageCode} training`)
@@ -183,10 +183,18 @@ export default class Engine implements NLU.Engine {
     return Engine._trainingWorkerQueue.cancelTraining(trainSessionId)
   }
 
-  private _mergeModelOutputs(currentOutput: TrainOutput, previousOutput: TrainOutput): TrainOutput {
+  private _mergeModelOutputs(
+    currentOutput: TrainOutput,
+    previousOutput: TrainOutput,
+    allContexts: string[]
+  ): TrainOutput {
     const output = { ...currentOutput }
-    output.intent_model_by_ctx = { ...previousOutput.intent_model_by_ctx, ...currentOutput.intent_model_by_ctx }
-    output.oos_model = { ...previousOutput.oos_model, ...currentOutput.oos_model }
+
+    const previousIntents = _.pick(previousOutput.intent_model_by_ctx, allContexts)
+    const previousOOS = _.pick(previousOutput.oos_model, allContexts)
+
+    output.intent_model_by_ctx = { ...previousIntents, ...currentOutput.intent_model_by_ctx }
+    output.oos_model = { ...previousOOS, ...currentOutput.oos_model }
     return output
   }
 

--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -171,8 +171,7 @@ export default class Engine implements NLU.Engine {
     }
 
     if (!trainAllCtx) {
-      model.data.output = _.merge({}, previousModel.data.output, model.data.output)
-      model.data.output.slots_model = new Buffer(model.data.output.slots_model) // lodash merge messes up buffers
+      model.data.output = this._mergeModelOutputs(model.data.output, previousModel.data.output)
     }
 
     trainDebug.forBot(this.botId, `Successfully finished ${languageCode} training`)
@@ -182,6 +181,13 @@ export default class Engine implements NLU.Engine {
 
   cancelTraining(trainSessionId: string): Promise<void> {
     return Engine._trainingWorkerQueue.cancelTraining(trainSessionId)
+  }
+
+  private _mergeModelOutputs(currentOutput: TrainOutput, previousOutput: TrainOutput): TrainOutput {
+    const output = { ...currentOutput }
+    output.intent_model_by_ctx = { ...previousOutput.intent_model_by_ctx, ...currentOutput.intent_model_by_ctx }
+    output.oos_model = { ...previousOutput.oos_model, ...currentOutput.oos_model }
+    return output
   }
 
   private async _trainAndMakeModel(

--- a/src/bp/nlu-core/entities/custom-entity-extractor.ts
+++ b/src/bp/nlu-core/entities/custom-entity-extractor.ts
@@ -191,7 +191,7 @@ export const extractListEntitiesWithCache = (
   utterance: Utterance,
   list_entities: WarmedListEntityModel[]
 ): EntityExtractionResult[] => {
-  const cacheKey = utterance.toString({ lowerCase: true })
+  const cacheKey = utterance.toString({ lowerCase: true, entities: 'keep-value' })
   const { withCacheHit, withCacheMiss } = splitModelsByCacheHitOrMiss(list_entities, cacheKey)
 
   const cachedMatches: EntityExtractionResult[] = _.flatMap(withCacheHit, listModel => listModel.cache.get(cacheKey)!)

--- a/src/bp/nlu-core/entities/custom-entity-extractor.ts
+++ b/src/bp/nlu-core/entities/custom-entity-extractor.ts
@@ -191,7 +191,8 @@ export const extractListEntitiesWithCache = (
   utterance: Utterance,
   list_entities: WarmedListEntityModel[]
 ): EntityExtractionResult[] => {
-  const cacheKey = utterance.toString({ lowerCase: true, entities: 'keep-value' })
+  // no need to "keep-value" of entities as this function's purpose is precisly to extract entities before tagging them in the utterance.
+  const cacheKey = utterance.toString({ lowerCase: true })
   const { withCacheHit, withCacheMiss } = splitModelsByCacheHitOrMiss(list_entities, cacheKey)
 
   const cachedMatches: EntityExtractionResult[] = _.flatMap(withCacheHit, listModel => listModel.cache.get(cacheKey)!)


### PR DESCRIPTION
This PR solves two separate bugs related to the same lines of code.

Here's how to current training caching works:

When a model is trained for the first time we train all contexts in the training pipeline. When however, we then modify few utterances of given contexts, we only retrain models for modified contexts. What this means it that we still run the training pipeline like we did the first time, but we only train an **Intent classifier** and an **oos classifier** for modified contexts. All other steps of training pipeline stay the same. After the training pipeline we then merge the previous model with the newly trained one.

The bugs where the following:

1. If we had an entity cache, the merge steps was offsetting a given cache key with other extracted entities.
2. Deleted topics where still present in the model because of the merge. This bug is the one pointed out by @allardy.