### PR TITLE
fix(nlu): no svm training when multiple ctx but none with intents

### DIFF
--- a/src/bp/nlu-core/training-pipeline.ts
+++ b/src/bp/nlu-core/training-pipeline.ts
@@ -311,8 +311,8 @@ const TrainContextClassifier = async (input: TrainStep, tools: Tools, progress: 
       )
   }).filter(x => x.coordinates.filter(isNaN).length === 0)
 
-  const nClass = _.uniq(points.map(p => p.label)).length
-  if (points.length === 0 || nClass <= 1) {
+  const classCount = _.uniq(points.map(p => p.label)).length
+  if (points.length === 0 || classCount <= 1) {
     progress()
     debugTraining.forBot(input.botId, 'No context to train')
     return ''

--- a/src/bp/nlu-core/training-pipeline.ts
+++ b/src/bp/nlu-core/training-pipeline.ts
@@ -311,7 +311,8 @@ const TrainContextClassifier = async (input: TrainStep, tools: Tools, progress: 
       )
   }).filter(x => x.coordinates.filter(isNaN).length === 0)
 
-  if (points.length === 0 || input.contexts.length <= 1) {
+  const nClass = _.uniq(points.map(p => p.label)).length
+  if (points.length === 0 || nClass <= 1) {
     progress()
     debugTraining.forBot(input.botId, 'No context to train')
     return ''


### PR DESCRIPTION
Yeah, the bug is fairly simple. It was pointed out by @allardy.

When training context model, only contexts with defined intents are represented in training points.

However, When there's more than one context, but only one has intents, we end up having points with only one label. This is problematic.

**About the implementation**:

I tried to get rid of lodash `_.uniq` by pre-computing a datastructure that allows me to count the ammount of context with defined intents but ended up making somthing horrible :

<details>
  <summary>other implementation</summary>
  
```
  const ctxToIntents = (ctx: string): Intent<Utterance>[] =>
    input.intents.filter(intent => intent.contexts.includes(ctx) && intent.name !== NONE_INTENT)

  const ctxs = input.contexts
  const intentsByCtx: _.Dictionary<Intent<Utterance>[]> = _(ctxs)
    .zipObject(ctxs.map(ctxToIntents))
    .pickBy((intents, _ctx) => intents.length)
    .value()

  type IntentCtxPair = [string, Intent<Utterance>]
  const points = _(intentsByCtx)
    .toPairs()
    .flatMap(([ctx, intents]) => intents.map(i => [ctx, i]) as IntentCtxPair[])
    .flatMap(([ctx, intent]) =>
      intent.utterances
        .filter(u => !u.augmented) // we don't want to train on augmented utterances as it would slow down training too much
        .map(utt => ({
          label: ctx,
          coordinates: getCtxFeatures(utt, customEntities)
        }))
    )
    .filter(x => x.coordinates.filter(isNaN).length === 0)
    .value()

  if (points.length === 0 || Object.keys(intentsByCtx).length <= 1) {
    progress()
    debugTraining.forBot(input.botId, 'No context to train')
    return ''
  }
```
</details>