### PR TITLE
fix(nlu): repair vocab words when generating none utts

### DIFF
--- a/modules/nlu-testing/src/bot-templates/bp-nlu-slot-extraction/latest-results.csv
+++ b/modules/nlu-testing/src/bot-templates/bp-nlu-slot-extraction/latest-results.csv
@@ -1,5 +1,5 @@
-utterance,context,conditions,status,date: 9/17/2020,summary: 43.8,nlu seed: 42
-A MP34 I WHAT I WISH FOR LOL,patterns,"-intent,is,buy-guns-slot:gun_to_buy,is,MP34",pass
+utterance,context,conditions,status,date: 9/17/2020,summary: 41.6,nlu seed: 42
+A MP34 I WHAT I WISH FOR LOL,patterns,"-intent,is,buy-guns-slot:gun_to_buy,is,MP34",fail
 I wanto by a AKP447,patterns,"-intent,is,buy-guns-slot:gun_to_buy,is,AKP447",fail
 I wish to get my hands on a Ak-47,patterns,"-intent,is,buy-guns-slot:gun_to_buy,is,Ak-47",pass
 I really want an m16 right now,patterns,"-intent,is,buy-guns-slot:gun_to_buy,is,m16",pass
@@ -84,7 +84,7 @@ I WANT A g36 RIGHT NOW,patterns,"-intent,is,buy-guns-slot:gun_to_buy,is,g36",fai
 Bring a WD-40 on my trip to tokyo HG-45,2-entities-close,"-intent,is,flight-gun-slot:flight,is,HG-45-slot:gun,is,WD-40",pass
 I want to carry my PP-90 on my air canada RE-9856 flight ,2-entities-close,"-intent,is,flight-gun-slot:flight,is,RE-9856-slot:gun,is,PP-90",fail
 I want to carry my PP-90 on my air canada PP-90 flight ,2-entities-close,"-intent,is,flight-gun-slot:gun,is,PP-90-slot:flight,is, PP-90",fail
-Is it possible to board the TR7856 flight with an UT-22 ? ,2-entities-close,"-intent,is,flight-gun-slot:flight,is,TR7856-slot:gun,is,UT-22",pass
+Is it possible to board the TR7856 flight with an UT-22 ? ,2-entities-close,"-intent,is,flight-gun-slot:flight,is,TR7856-slot:gun,is,UT-22",fail
 I want to bring my DF-78 on the air france FR8956 flight to Tokyo,2-entities-close,"-intent,is,flight-gun-slot:flight,is,FR8956-slot:gun,is,DF-78",pass
 I can't go on KH-4571 with a JH-03,2-entities-close,"-intent,is,flight-gun-slot:gun,is,JH-03-slot:flight,is,KH-4571",fail
 I have one TY-89 that I want to take on the flight AF-879,2-entities-close,"-intent,is,flight-gun-slot:gun,is,TY-89-slot:flight,is,AF-879",pass

--- a/modules/nlu-testing/src/bot-templates/bp-nlu-slot-extraction/latest-results.csv
+++ b/modules/nlu-testing/src/bot-templates/bp-nlu-slot-extraction/latest-results.csv
@@ -1,4 +1,4 @@
-utterance,context,conditions,status,date: 9/15/2020,summary: 46.1,nlu seed: 42
+utterance,context,conditions,status,date: 9/17/2020,summary: 43.8,nlu seed: 42
 A MP34 I WHAT I WISH FOR LOL,patterns,"-intent,is,buy-guns-slot:gun_to_buy,is,MP34",pass
 I wanto by a AKP447,patterns,"-intent,is,buy-guns-slot:gun_to_buy,is,AKP447",fail
 I wish to get my hands on a Ak-47,patterns,"-intent,is,buy-guns-slot:gun_to_buy,is,Ak-47",pass
@@ -17,7 +17,7 @@ Can I purchase a galia melon ?,list,"-intent,is,buy-fruits-slot:fruit-to-buy,is,
 info BK-8754 to tataouine,2-entities,"-intent,is,flight-info-slot:flight-number,is,BK-8754-slot:arrival-city,is,tataouine",pass
 Could you give me informations about the AT-8886 flight ?,2-entities,"-intent,is,flight-info-slot:flight-number,is,AT-8886",pass
 I want informations about the TK-89 flight to Chaï,2-entities,"-intent,is,flight-info-slot:flight-number,is,TK-89-slot:arrival-city,is,Chaï",pass
-I think QW6621 is delayed ,2-entities,"-intent,is,flight-info-slot:flight-number,is,QW6621",pass
+I think QW6621 is delayed ,2-entities,"-intent,is,flight-info-slot:flight-number,is,QW6621",fail
 Details about my trip to Tataouine,2-entities,"-intent,is,flight-info-slot:arrival-city,is,Tataouine",pass
 info AB008 incoming in Quebec,2-entities,"-intent,is,flight-info-slot:flight-number,is,AB008-slot:arrival-city,is,Quebec",pass
 Could I have a fruit,list,"-intent,is,buy-fruits",pass
@@ -43,7 +43,7 @@ about to eat my lemon at the big apple right now,no-slot,"-intent,is,eat-fruit-s
 I want a flight which leaves Prague and land in Tataouine,1-entity,"-intent,is,book-flight-slot:to_city,is,Tataouine-slot:from_city,is,Prague",pass
 Sofia to Tokyo,1-entity,"-intent,is,book-flight-slot:to_city,is,Tokyo-slot:from_city,is,Sofia",fail
 flight to Tokyo,1-entity,"-intent,is,book-flight-slot:to_city,is,Tokyo",pass
-flight from Vaduz,1-entity,"-intent,is,book-flight-slot:from_city,is,Vaduz",pass
+flight from Vaduz,1-entity,"-intent,is,book-flight-slot:from_city,is,Vaduz",fail
 register a flight to Stockholm leaving Tripolis,1-entity,"-intent,is,book-flight-slot:to_city,is,Stockholm-slot:from_city,is,Tripolis",pass
 I want to fly high and reach Teheran by leaving Tallinn,1-entity,"-intent,is,book-flight-slot:to_city,is,Teheran-slot:from_city,is,Tallinn",fail
 I'm heading to montreal to fire cherries on buildings,multi-slot-multi-entity,"-intent,is,fire-something-slot:thing_to_fire,is,cherries-slot:time_or_place,is,montreal",fail

--- a/src/bp/nlu-core/tools/tfidf.ts
+++ b/src/bp/nlu-core/tools/tfidf.ts
@@ -2,6 +2,7 @@ import _ from 'lodash'
 
 export const MAX_TFIDF = 2
 export const MIN_TFIDF = 0.5
+export const SMALL_TFIDF = (MAX_TFIDF - MIN_TFIDF) * 0.2 + MIN_TFIDF
 
 const MIN_IDF = 0.25 // term appears in 78.5% of documents
 

--- a/src/bp/nlu-core/tools/tfidf.ts
+++ b/src/bp/nlu-core/tools/tfidf.ts
@@ -3,6 +3,8 @@ import _ from 'lodash'
 export const MAX_TFIDF = 2
 export const MIN_TFIDF = 0.5
 
+const MIN_IDF = 0.25 // term appears in 78.5% of documents
+
 export type TfidfInput = _.Dictionary<string[]>
 export type TfidfOutput = _.Dictionary<_.Dictionary<number>>
 
@@ -18,18 +20,19 @@ export default function tfidf(docs: TfidfInput): TfidfOutput {
     const termsCount = _.countBy(tokens, _.identity)
     const meanTf = _.mean(_.values(termsCount))!
 
-    const tfidf: _.Dictionary<number> = _.mapValues(termsCount, (_v, key) => {
-      const docFreq = _.values(docs).filter(x => x.includes(key)).length
+    const tfidf: _.Dictionary<number> = _.mapValues(termsCount, (_v, term) => {
+      const docFreq = _.values(docs).filter(x => x.includes(term)).length
 
       // Double-normalization TF with K=0.5
       // See https://en.wikipedia.org/wiki/Tf%E2%80%93idf
-      const tf = 0.5 + (0.5 * termsCount[key]) / meanTf
+      // TODO: wikipedia recommends to divide by tf of mostly represented term in doc, not the meanTf
+      const tf = 0.5 + (0.5 * termsCount[term]) / meanTf
 
       // Smooth IDF
-      const idf = Math.max(0.25, -Math.log(docFreq / Object.keys(docs).length))
+      const idf = Math.max(MIN_IDF, Math.log(Object.keys(docs).length / docFreq))
       const tfidf = Math.max(MIN_TFIDF, Math.min(MAX_TFIDF, tf * idf))
-      _avgSum[key] = (_avgSum[key] || 0) + tfidf
-      _avgCount[key] = (_avgCount[key] || 0) + 1
+      _avgSum[term] = (_avgSum[term] || 0) + tfidf
+      _avgCount[term] = (_avgCount[term] || 0) + 1
       return tfidf
     })
 

--- a/src/bp/nlu-core/training-pipeline.ts
+++ b/src/bp/nlu-core/training-pipeline.ts
@@ -12,7 +12,7 @@ import { featurizeInScopeUtterances, featurizeOOSUtterances } from './out-of-sco
 import SlotTagger from './slots/slot-tagger'
 import { getSeededLodash, resetSeed } from './tools/seeded-lodash'
 import { replaceConsecutiveSpaces } from './tools/strings'
-import tfidf from './tools/tfidf'
+import tfidf, { SMALL_TFIDF } from './tools/tfidf'
 import { convertToRealSpaces, isSpace, SPACE } from './tools/token-utils'
 import {
   ColdListEntityModel,
@@ -449,7 +449,7 @@ export const AppendNoneIntent = async (input: TrainStep, tools: Tools): Promise<
   const vocabWords = lo
     .chain(input.tfIdf)
     .toPairs()
-    .filter(([word, tfidf]) => tfidf <= 0.3) // TODO: 0.3 is smaller than the minimum allowed tfidf...
+    .filter(([word, tfidf]) => tfidf <= SMALL_TFIDF)
     .map('0')
     .value()
 

--- a/src/bp/nlu-core/training-pipeline.ts
+++ b/src/bp/nlu-core/training-pipeline.ts
@@ -430,6 +430,7 @@ export const AppendNoneIntent = async (input: TrainStep, tools: Tools): Promise<
 
   const lo = getSeededLodash(input.nluSeed)
 
+  // TODO: we should filter out augmented + we should create none utterances by context
   const allUtterances = lo.flatten(input.intents.map(x => x.utterances))
   const vocabWithDupes = lo
     .chain(allUtterances)
@@ -448,7 +449,7 @@ export const AppendNoneIntent = async (input: TrainStep, tools: Tools): Promise<
   const vocabWords = lo
     .chain(input.tfIdf)
     .toPairs()
-    .filter(([word, tfidf]) => tfidf <= 0.3)
+    .filter(([word, tfidf]) => tfidf <= 0.3) // TODO: 0.3 is smaller than the minimum allowed tfidf...
     .map('0')
     .value()
 

--- a/src/bp/nlu-core/utterance/utterance.ts
+++ b/src/bp/nlu-core/utterance/utterance.ts
@@ -3,7 +3,7 @@ import _ from 'lodash'
 
 import { POSClass } from '../language/pos-tagger'
 import { SPECIAL_CHARSET } from '../tools/chars'
-import { computeNorm, scalarDivide, vectorAdd } from '../tools/math'
+import { computeNorm, scalarDivide, scalarMultiply, vectorAdd } from '../tools/math'
 import { replaceConsecutiveSpaces } from '../tools/strings'
 import { convertToRealSpaces, isSpace, isWord, SPACE } from '../tools/token-utils'
 import { getClosestToken } from '../tools/vocab'
@@ -129,6 +129,7 @@ export default class Utterance {
     const dims = this._tokens[0].vector.length
     let sentenceEmbedding = new Array(dims).fill(0)
 
+    // Algorithm strongly inspired by Fasttext classifier (see method FastText::getSentenceVector)
     for (const token of this.tokens) {
       const norm = computeNorm(token.vector as number[])
       if (norm <= 0 || !token.isWord) {
@@ -136,10 +137,9 @@ export default class Utterance {
         continue
       }
 
-      // hard limit on TFIDF of (we don't want to over scale the features)
-      const weight = Math.min(1, token.tfidf)
+      const weight = Math.min(1, token.tfidf) // TODO: there's already an upper limit on TFIDF
       totalWeight += weight
-      const weightedVec = scalarDivide(token.vector as number[], norm / weight)
+      const weightedVec = scalarMultiply(token.vector as number[], weight / norm) // TODO: experiment without dividing by norm
       sentenceEmbedding = vectorAdd(sentenceEmbedding, weightedVec)
     }
 


### PR DESCRIPTION
Added few comments and notes, refactored some variable names here and there.

There's only one true change, its the threshold of small TFIDF which as passed from 0.3 to 0.8.

0.3 was actually less than the minimum allowed TFIDF, so theres was no vocab words in none utterances.

|----------|--------------------|--------------------------------------------------------------------|
0&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;min(0.5)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;small (20% of range = 0.8)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;max (2)

0.8 = (2 - 0.5) * 0.2 + 0.5

\
\
**On BPDS Regression's Bot:**

we used to have no vocab words at all in non utts, now we have:
![image](https://user-images.githubusercontent.com/25970722/93493853-5886a700-f8da-11ea-862a-19e9bd135423.png)
