### PR TITLE
Use relative URL import (#3966)

### DIFF
--- a/modules/channel-web/assets/default.css
+++ b/modules/channel-web/assets/default.css
@@ -1,4 +1,4 @@
-@import url('/assets/ui-studio/public/external/font-roboto.css');
+@import url('../../ui-studio/public/external/font-roboto.css');
 
 :root {
   --main-bg-color: #ffffff;


### PR DESCRIPTION
This PR changes the absolute import in channel-web's `default.css` to a relative one, so that it works when Botpress is deployed behind a reverse proxy.

Fixes botpress/v12#1097