### PR TITLE
fix(basic-skills): choice: kw strict equality comparison

### DIFF
--- a/modules/basic-skills/src/actions/choice_parse_answer.js
+++ b/modules/basic-skills/src/actions/choice_parse_answer.js
@@ -38,9 +38,17 @@ const validateChoice = async data => {
     choice = _.findKey(data.keywords, keywords =>
       _.some(keywords || [], k => {
         const keyword = lcstr(k)
-        return preview.includes(keyword) || userText.includes(keyword) || choiceValue.includes(keyword)
+        return preview === keyword || userText === keyword || choiceValue === keyword
       })
     )
+    if (!choice) {
+      choice = _.findKey(data.keywords, keywords =>
+        _.some(keywords || [], k => {
+          const keyword = lcstr(k)
+          return preview.includes(keyword) || userText.includes(keyword) || choiceValue.includes(keyword)
+        })
+      )
+    }
   }
 
   const keySuffix = args.randomId ? `-${args.randomId}` : ''


### PR DESCRIPTION
Fixes a bug in the Choice Skill where similar choices do not behave properly.

For example, if your 2 choices are `Like` and `Dislike`, the `Like` option will always be chosen (even if the user clicks on Dislike)