### PR TITLE
fix(core): perf on delete

### DIFF
--- a/src/bp/migrations/v13_0_0-1595539718-convert_events_table.ts
+++ b/src/bp/migrations/v13_0_0-1595539718-convert_events_table.ts
@@ -69,6 +69,7 @@ const migration: Migration = {
           table.boolean('success').nullable()
           table.json('event').notNullable()
           table.timestamp('createdOn').notNullable()
+          table.index('createdOn', 'ets_idx')
         })
 
         const rows = await db<sdk.IO.StoredEvent>(TABLE_NAME)


### PR DESCRIPTION
The janitor queries events' created_on to find out which to delete, based on the event collector's retention period.
Indexing events in creation order will improve this process.