### PR TITLE
fix: repaired debugger by fixing outFiles

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,10 +19,10 @@
       },
       "smartStep": true,
       "outFiles": [
-        "${workspaceFolder}/out",
-        "${workspaceFolder}/modules/*/dist",
-        "${workspaceFolder}/private-modules/*/dist",
-        "!${workspaceFolder}/**/node_modules"
+        "${workspaceFolder}/out/**/*.js",
+        "${workspaceFolder}/modules/**/dist/**/*.js",
+        "${workspaceFolder}/private-modules/**/dist/**/*.js",
+        "!${workspaceFolder}/**/node_modules/**/*.js"
       ],
       "console": "integratedTerminal",
       "sourceMaps": true,
@@ -45,10 +45,10 @@
       },
       "smartStep": true,
       "outFiles": [
-        "${workspaceFolder}/out",
-        "${workspaceFolder}/modules/*/dist",
-        "${workspaceFolder}/private-modules/*/dist",
-        "!${workspaceFolder}/**/node_modules"
+        "${workspaceFolder}/out/**/*.js",
+        "${workspaceFolder}/modules/**/dist/**/*.js",
+        "${workspaceFolder}/private-modules/**/dist/**/*.js",
+        "!${workspaceFolder}/**/node_modules/**/*.js"
       ],
       "console": "integratedTerminal",
       "sourceMaps": true,
@@ -78,7 +78,6 @@
           "-c=${workspaceFolder}/jest.config.js"
         ]
       },
-      "outFiles": ["${workspaceFolder}/out/"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
       "sourceMaps": true,


### PR DESCRIPTION
Got tired of debugging with console.log... LOL

The problem exists since the release of vscode 1.49.

The solutions comes from this [issue](https://github.com/microsoft/vscode/issues/106787).

I tested on Ubuntu 18.04, both unit tests and actual code, inside modules and inside core. All breakpoints seem to work.

Ideally, I need somebody to assert this fix works on all plateforms (Windows, MacOS, Arch)...