### PR TITLE
feat(channel-web): conversationId

### DIFF
--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -176,7 +176,7 @@ class Web extends React.Component<MainProps> {
       return
     }
 
-    if (Number(this.props.config.conversationId) !== Number(event.conversationId)) {
+    if (this.props.config.conversationId && Number(this.props.config.conversationId) !== Number(event.conversationId)) {
       // don't do anything, it's a message from another conversation
       return
     }
@@ -194,7 +194,7 @@ class Web extends React.Component<MainProps> {
   }
 
   handleTyping = async (event: Message) => {
-    if (Number(this.props.config.conversationId) !== Number(event.conversationId)) {
+    if (this.props.config.conversationId && Number(this.props.config.conversationId) !== Number(event.conversationId)) {
       // don't do anything, it's a message from another conversation
       return
     }

--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -10,6 +10,7 @@ import constants from './core/constants'
 import BpSocket from './core/socket'
 import ChatIcon from './icons/Chat'
 import { RootStore, StoreDef } from './store'
+import { Message } from './typings'
 import { checkLocationOrigin, initializeAnalytics, trackMessage, trackWebchatState } from './utils'
 
 const _values = obj => Object.keys(obj).map(x => obj[x])
@@ -78,7 +79,7 @@ class Web extends React.Component<MainProps> {
 
     this.socket = new BpSocket(this.props.bp, config)
     this.socket.onMessage = this.handleNewMessage
-    this.socket.onTyping = this.props.updateTyping
+    this.socket.onTyping = this.handleTyping
     this.socket.onData = this.handleDataMessage
     this.socket.onUserIdChanged = this.props.setUserId
     this.socket.setup()
@@ -175,6 +176,11 @@ class Web extends React.Component<MainProps> {
       return
     }
 
+    if (Number(this.props.config.conversationId) !== Number(event.conversationId)) {
+      // don't do anything, it's a message from another conversation
+      return
+    }
+
     trackMessage('received')
     await this.props.addEventToConversation(event)
 
@@ -185,6 +191,15 @@ class Web extends React.Component<MainProps> {
     }
 
     this.handleResetUnreadCount()
+  }
+
+  handleTyping = async (event: Message) => {
+    if (Number(this.props.config.conversationId) !== Number(event.conversationId)) {
+      // don't do anything, it's a message from another conversation
+      return
+    }
+
+    await this.props.updateTyping(event)
   }
 
   handleDataMessage = event => {

--- a/modules/channel-web/src/views/lite/store/index.ts
+++ b/modules/channel-web/src/views/lite/store/index.ts
@@ -158,7 +158,7 @@ class RootStore {
   async initializeChat(): Promise<void> {
     try {
       await this.fetchConversations()
-      await this.fetchConversation()
+      await this.fetchConversation(this.config.conversationId)
       runInAction('-> setInitialized', () => {
         this.isInitialized = true
       })

--- a/modules/channel-web/src/views/lite/store/view.ts
+++ b/modules/channel-web/src/views/lite/store/view.ts
@@ -66,7 +66,7 @@ class ViewStore {
 
   @computed
   get showConversationsButton() {
-    return this.rootStore.config?.showConversationsButton
+    return !this.rootStore.config?.conversationId && this.rootStore.config?.showConversationsButton
   }
 
   @computed

--- a/modules/channel-web/src/views/lite/typings.d.ts
+++ b/modules/channel-web/src/views/lite/typings.d.ts
@@ -131,6 +131,7 @@ export type Config = {
   botId?: string
   externalAuthToken?: string
   userId?: string
+  conversationId?: number
   /** Allows to set a different user id for different windows (eg: studio, specific bot, etc) */
   userIdScope?: string
   enableReset: boolean


### PR DESCRIPTION
Adds a `conversationId` parameter in the Webchat config.
When specified, the Webchat will load the specified conversation. The Conversations list will be disabled.
If an unknown conversationId is specified, a stacktrace will be displayed in the browser console. Maybe you guys have a better UX for that case.
