### PR TITLE
feat: enforce comon variable naming rules across all app

### DIFF
--- a/src/bp/common/variable-naming.test.ts
+++ b/src/bp/common/variable-naming.test.ts
@@ -1,0 +1,21 @@
+import { extractVariables, validateVariableName } from './variable-naming'
+
+test('variables extraction', () => {
+  expect(extractVariables('give me a $fruit and a gatorade')[0]).toBe('fruit')
+  expect(extractVariables('give me a $fruit水果 or a gatorade')[0]).toBe('fruit')
+
+  expect(extractVariables('give me a 5 \\$ or a gatorade').length).toBe(0)
+
+  expect(() => extractVariables('give me a 5 $ or a gatorade')).toThrow()
+})
+
+test('variables name validation', () => {
+  expect(validateVariableName('fruit')).toBe(true)
+  expect(validateVariableName('fruit_5')).toBe(true)
+  expect(validateVariableName('fruit-5')).toBe(true)
+  expect(validateVariableName('fruit5fruit')).toBe(true)
+
+  expect(validateVariableName('5fruit5fruit')).toBe(false)
+  expect(validateVariableName('水果')).toBe(false)
+  expect(validateVariableName('fruit水果')).toBe(false)
+})

--- a/src/bp/common/variable-naming.ts
+++ b/src/bp/common/variable-naming.ts
@@ -1,0 +1,38 @@
+const DOLLAR_SIGNS_REGEX = /(?<!\\)\$/gm // unescaped dollar sign
+const VARIABLE_NAME_REGEX = /^[A-Za-z][\w-]*/ // letter followed by letters, numbers, underscore and dash
+
+export function extractVariables(text: string) {
+  const variables: string[] = []
+
+  let match: RegExpExecArray | null
+  do {
+    match = DOLLAR_SIGNS_REGEX.exec(text)
+    if (match) {
+      variables.push(_extractVariableName(text, match))
+    }
+  } while (match)
+
+  return variables
+}
+
+export const validateVariableName = (text: string): boolean => {
+  const variableNameMatch = VARIABLE_NAME_REGEX.exec(text)
+  return !!(variableNameMatch && variableNameMatch[0].length === text.length)
+}
+
+const _extractVariableName = (text: string, dollarSignMatch: RegExpExecArray) => {
+  const stripped = text.substring(dollarSignMatch.index + 1)
+  const variableNameMatch = VARIABLE_NAME_REGEX.exec(stripped)
+
+  if (!variableNameMatch) {
+    const errorMsg = `Error while extracting variable from "${text}". \n\
+      Rules for variable naming are the following ones: \n\
+                      1. Variables names must start with an ascii letter.\n\
+                      2. Variables names must contain only letters, numbers, underscores and dashes.\n\
+                      3. Variables names are case sensitives.\n\
+      If you where not trying to reference a variable, escape any dollar symbol ($) with a back slash (\\).`
+    throw new Error(errorMsg)
+  }
+
+  return variableNameMatch[0]
+}


### PR DESCRIPTION
**This is a proposal.** I only wrote some code to better expose my ideas.

I'm currently having a challenge in Stan (botpress standalone NLU) to extract referenced variable names from a given input. What I'm trying to do convert this `"I love $fruit and $thing"` to this `["fruit", "thing"]`. I want to extract these to notify a user if his text references a variable that does not exist.

The problem is, we still have no rules for variable naming. 

**I could define variable naming rules for Stan only, but I feel like these buisness rules should be shared with botpress. Maybe you guys won't agree, that's why I'm opening a proposal.**

What I suggest:

Suggestion 1) Rules for variable naming are the following ones:
1. Variables names must start with an ascii letter.
2. Variables names must contain only letters, numbers, underscores and dashes.
3. Variables names are case sensitives.

Suggestion 2) If a user wants to write an example with a dollar sign he should escape it. Else the dollar sign is considered an anchor for a variable name.

What do you guys think about this? Should theses rules only be applied in Stan? 
