### PR TITLE
feat(nlu): added migrations and few routes in core

### DIFF
--- a/modules/nlu/src/views/full/intents/UtterancesEditor.tsx
+++ b/modules/nlu/src/views/full/intents/UtterancesEditor.tsx
@@ -27,7 +27,7 @@ interface Props {
   intentName: string
   utterances: string[]
   liteEditor: boolean
-  slots: NLU.SlotDefinition[]
+  slots: (NLU.SlotDefinition | NLU.LegacySlotDefinition)[]
   onChange: (x: string[]) => void
 }
 
@@ -144,7 +144,7 @@ export class UtterancesEditor extends React.Component<Props> {
     )
   }
 
-  tag = (editor: CoreEditor, slot: NLU.SlotDefinition) => {
+  tag = (editor: CoreEditor, slot: NLU.SlotDefinition | NLU.LegacySlotDefinition) => {
     const { utterance, block } = this.state.selection
     let { from, to } = this.state.selection
     const node: Node = editor.value.getIn(['document', 'nodes', utterance, 'nodes', block])

--- a/src/bp/core/routers/bots/nlu.ts
+++ b/src/bp/core/routers/bots/nlu.ts
@@ -50,6 +50,40 @@ export class NLURouter extends CustomRouter {
       })
     )
 
+    this.router.get(
+      '/intents/:intentName',
+      this._checkTokenHeader,
+      this._needPermissions('read', 'bot.content'),
+      this.asyncMiddleware(async (req, res) => {
+        const { botId } = req.params
+        const intentDefs = await this.nluService.intents.getIntents(botId)
+        const desiredIntent = intentDefs.filter(i => i.name === req.params.intentName)
+
+        if (desiredIntent.length) {
+          return res.send(desiredIntent[0])
+        }
+
+        res.sendStatus(404)
+      })
+    )
+
+    this.router.get(
+      '/contexts',
+      this._checkTokenHeader,
+      this._needPermissions('read', 'bot.content'),
+      this.asyncMiddleware(async (req, res) => {
+        const { botId } = req.params
+        const intentDefs = await this.nluService.intents.getIntents(botId)
+
+        const allTopics = _(intentDefs)
+          .flatMap(i => i.contexts)
+          .uniq()
+          .value()
+
+        res.send(allTopics)
+      })
+    )
+
     // TODO: Deprecate this
     this.router.get(
       '/entities',

--- a/src/bp/migrations/v13_0_0-1599590304030-migrate_intents.ts
+++ b/src/bp/migrations/v13_0_0-1599590304030-migrate_intents.ts
@@ -1,0 +1,48 @@
+import * as sdk from 'botpress/sdk'
+import { Migration } from 'core/services/migration'
+import _ from 'lodash'
+
+const INTENT_DIR = 'intents'
+const FLOW_DIR = 'flows'
+
+const migration: Migration = {
+  info: {
+    description: 'Migrate intents to new ".intents.qna" format',
+    target: 'bot',
+    type: 'content'
+  },
+  up: async ({ bp, metadata }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
+    try {
+      if (metadata.botId) {
+        await updateBot(bp, metadata.botId)
+      } else {
+        const bots = await bp.bots.getAllBots()
+        for (const botId of Array.from(bots.keys())) {
+          await updateBot(bp, botId)
+        }
+      }
+      return { success: true, message: 'Intents updated successfully' }
+    } catch (err) {
+      return { success: false, message: `Intent migration could not finish due to error: ${err.message}` }
+    }
+  }
+}
+export default migration
+
+async function updateBot(bp: typeof sdk, botId: string): Promise<void> {
+  const ghost = bp.ghost.forBot(botId)
+  const intentFiles = await ghost.directoryListing(INTENT_DIR, '*.json')
+  for (const file of intentFiles) {
+    // enable intent
+    const intent = await ghost.readFileAsObject<sdk.NLU.IntentDefinition>(INTENT_DIR, file)
+    intent.metadata = { ...intent.metadata, enabled: true }
+
+    // rename and move
+    const newName = file.replace(/.json$/g, '.intents.json')
+    await ghost.upsertFile(FLOW_DIR, newName, JSON.stringify(intent, null, 2))
+
+    // rm previous file
+    await ghost.deleteFile(INTENT_DIR, file)
+  }
+  // TODO: should also delete directory at the end
+}

--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -5,6 +5,7 @@ import _ from 'lodash'
 import { EntityCacheManager } from './entities/entity-cache-manager'
 import { initializeTools } from './initialize-tools'
 import DetectLanguage from './language/language-identifier'
+import { mapLegacySlots } from './legacy-slot-mapper'
 import { deserializeModel, PredictableModel, serializeModel } from './model-manager'
 import { Predict, PredictInput, Predictors, PredictOutput } from './predict-pipeline'
 import SlotTagger from './slots/slot-tagger'
@@ -80,12 +81,14 @@ export default class Engine implements NLU.Engine {
 
   async train(
     trainSessionId: string,
-    intentDefs: NLU.IntentDefinition[],
-    entityDefs: NLU.EntityDefinition[],
+    intentDefinitions: NLU.IntentDefinition[],
+    entityDefinitions: NLU.EntityDefinition[],
     languageCode: string,
     options: NLU.TrainingOptions
   ): Promise<NLU.Model | undefined> {
     trainDebug.forBot(this.botId, `Started ${languageCode} training`)
+
+    const { intentDefs, entityDefs } = mapLegacySlots(intentDefinitions, entityDefinitions)
 
     const list_entities = entityDefs
       .filter(ent => ent.type === 'list')

--- a/src/bp/nlu-core/legacy-slot-mapper.ts
+++ b/src/bp/nlu-core/legacy-slot-mapper.ts
@@ -1,0 +1,56 @@
+import { NLU } from 'botpress/sdk'
+
+type NewIntentDefinition = Omit<NLU.IntentDefinition, 'slots'> & {
+  slots: NLU.SlotDefinition[]
+}
+
+export function mapLegacySlots(intentDefs: NLU.IntentDefinition[], entityDefs: NLU.EntityDefinition[]) {
+  const patterns = entityDefs.filter(e => e.type === 'pattern')
+  const enums = entityDefs.filter(e => e.type === 'list')
+  const systems = entityDefs.filter(e => e.type === 'system')
+  const complexs: NLU.EntityDefinition[] = []
+
+  const newIntents: NewIntentDefinition[] = []
+  for (const intent of intentDefs) {
+    const newSlots: NLU.SlotDefinition[] = []
+    for (const slot of intent.slots) {
+      let newSlot: NLU.SlotDefinition
+      if (isLegacySlot(slot)) {
+        newSlot = { name: slot.name, entity: slot.name }
+
+        const pattern_entities = slot.entities.filter(e => patterns.map(p => p.name).includes(e))
+        const list_entities = slot.entities.filter(e => enums.map(p => p.name).includes(e))
+        const system_entities = slot.entities.filter(e => systems.map(p => p.name).includes(e))
+
+        complexs.push({
+          id: makeEntityId(slot.name),
+          name: slot.name,
+          type: 'complex',
+          list_entities,
+          pattern_entities,
+          system_entities,
+          examples: [] // no examples required as legacy utterances uses markdown notation
+        })
+      } else {
+        newSlot = { ...slot }
+      }
+
+      newSlots.push(newSlot)
+    }
+    newIntents.push({ ...intent, slots: newSlots })
+  }
+
+  const newEntities = [...patterns, ...enums, ...systems, ...complexs]
+  return { intentDefs: newIntents, entityDefs: newEntities }
+}
+
+function isLegacySlot(slot: NLU.SlotDefinition | NLU.LegacySlotDefinition): slot is NLU.LegacySlotDefinition {
+  return !!(slot as NLU.LegacySlotDefinition).entities
+}
+
+function makeEntityId(name: string) {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[\t\s]/g, '-')
+}

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -554,13 +554,21 @@ declare module 'botpress/sdk' {
       entity: string
     }
 
+    /**
+     * @deprecated version > 13.0.0
+     */
+    export interface LegacySlotDefinition {
+      name: string
+      entities: string[]
+    }
+
     export interface IntentDefinition {
       name: string
       utterances: {
         [lang: string]: string[]
       }
       filename: string // TODO: remove, not used anymore
-      slots: SlotDefinition[] // TODO: rename to "placeholders" when we introduce this concept (synonyms, variables)
+      slots: (SlotDefinition | LegacySlotDefinition)[] // TODO: rename to "placeholders" when we introduce this concept (synonyms, variables)
       contexts: string[] // TODO: remove contexts, now a single 'topic'
       metadata?: any
     }

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -546,6 +546,7 @@ declare module 'botpress/sdk' {
       pattern?: string
       list_entities: string[]
       pattern_entities: string[]
+      system_entities: string[]
     }
 
     export interface SlotDefinition {


### PR DESCRIPTION
Not done yet, just opening this Draft PR.

I've talk with both @allardy and @eff about this task and we still can't decide on the future of the NLU module. Currently, the only place where the NLU rooter (located in the core) is queried is in the NLU module. 

The call sequence looks like this:

```
[NLU module] -------- queries ---------> [NLU router]
                                            |
                                            |
[NLU module] <-------------------------------
[NLU module] --------train/ predict--------> [NLU core]
                                                 |
                                                 |
[NLU module] <------------------------------------
```

We really should make our mind on weither or not we keep the NLU module and what responsabilities it should have. For now, I will keep adding routes in the core to go faster.

So yeah, concerning this PR,

What is done:
1. migrate slot entities to new complexes (this was mandatory for old bot to train in Albert)
2. migrate intents from /intents directory to /flows
3. added few routes in core so that NLU GUI still works

What needs to be done:
1. Map UI array of entities to complexes (allow complexe create/update/delete while not displaying the concept of complexes to users)
