### PR TITLE
fix(nlu): duckling numbers have no unit but a value

### DIFF
--- a/src/bp/nlu-core/entities/duckling-extractor/map-duckling.test.ts
+++ b/src/bp/nlu-core/entities/duckling-extractor/map-duckling.test.ts
@@ -78,3 +78,25 @@ test('dimension time with type interval is supported', () => {
   expect(value).toBe('2020-10-08T18:00:00.000-04:00')
   expect(unit).toBe('hour')
 })
+
+test('number is supported', () => {
+  // arrange
+  const duck = {
+    body: '500',
+    start: 0,
+    value: {
+      value: 500,
+      type: 'value' as 'value'
+    },
+    end: 3,
+    dim: 'number' as DucklingDimension,
+    latent: false
+  }
+
+  // act
+  const { unit, value } = getUnitAndValue(duck)
+
+  // assert
+  expect(value).toBe(500)
+  expect(unit).toBe('')
+})

--- a/src/bp/nlu-core/entities/duckling-extractor/map-duckling.test.ts
+++ b/src/bp/nlu-core/entities/duckling-extractor/map-duckling.test.ts
@@ -100,3 +100,25 @@ test('number is supported', () => {
   expect(value).toBe(500)
   expect(unit).toBe('')
 })
+
+test('zero is supported', () => {
+  // arrange
+  const duck = {
+    body: '0',
+    start: 0,
+    value: {
+      value: 0,
+      type: 'value' as 'value'
+    },
+    end: 1,
+    dim: 'number' as DucklingDimension,
+    latent: false
+  }
+
+  // act
+  const { unit, value } = getUnitAndValue(duck)
+
+  // assert
+  expect(value).toBe(0)
+  expect(unit).toBe('')
+})

--- a/src/bp/nlu-core/entities/duckling-extractor/map-duckling.ts
+++ b/src/bp/nlu-core/entities/duckling-extractor/map-duckling.ts
@@ -1,6 +1,6 @@
 import { EntityExtractionResult } from 'nlu-core/typings'
 
-import { Duckling, DucklingDimension, DucklingReturn, DucklingType, DucklingValue, ValueUnit } from './typings'
+import { Duckling, DucklingDimension, DucklingReturn, DucklingType, DucklingValue, Value, ValueUnit } from './typings'
 
 export function mapDucklingToEntity(duck: Duckling): EntityExtractionResult {
   const dimensionData = getUnitAndValue(duck)
@@ -50,6 +50,13 @@ export function getUnitAndValue(duck: Duckling): ValueUnit {
     }
   }
 
+  if (_isValue(duck.value)) {
+    return {
+      value: duck.value.value,
+      unit: ''
+    }
+  }
+
   return {
     value: '',
     unit: ''
@@ -78,4 +85,10 @@ const _isValueUnit = (
   duckValue: DucklingValue<DucklingDimension, DucklingType>
 ): duckValue is { type: DucklingType } & ValueUnit => {
   return !!((duckValue as ValueUnit).value && (duckValue as ValueUnit).unit)
+}
+
+const _isValue = (
+  duckValue: DucklingValue<DucklingDimension, DucklingType>
+): duckValue is { type: DucklingType } & Value => {
+  return !!(duckValue as Value).value
 }

--- a/src/bp/nlu-core/entities/duckling-extractor/map-duckling.ts
+++ b/src/bp/nlu-core/entities/duckling-extractor/map-duckling.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import { EntityExtractionResult } from 'nlu-core/typings'
 
 import { Duckling, DucklingDimension, DucklingReturn, DucklingType, DucklingValue, Value, ValueUnit } from './typings'
@@ -84,11 +85,11 @@ const _isTimeValue = (duckTime: DucklingValue<'time', DucklingType>): duckTime i
 const _isValueUnit = (
   duckValue: DucklingValue<DucklingDimension, DucklingType>
 ): duckValue is { type: DucklingType } & ValueUnit => {
-  return !!((duckValue as ValueUnit).value && (duckValue as ValueUnit).unit)
+  return _isValue(duckValue) && !!(duckValue as ValueUnit).unit
 }
 
 const _isValue = (
   duckValue: DucklingValue<DucklingDimension, DucklingType>
 ): duckValue is { type: DucklingType } & Value => {
-  return !!(duckValue as Value).value
+  return _.isNumber((duckValue as Value).value) || !!(duckValue as Value).value
 }

--- a/src/bp/nlu-core/entities/duckling-extractor/typings.ts
+++ b/src/bp/nlu-core/entities/duckling-extractor/typings.ts
@@ -32,6 +32,8 @@ type DucklingValueInfo<D extends DucklingDimension, T extends DucklingType> = D 
   ? { normalized: ValueUnit }
   : D extends 'time'
   ? DucklingTimeValue<T>
+  : D extends 'number'
+  ? Value
   : ValueUnit
 
 // Not sure yet, but I feel like if property `values` is defined, then root properties are also...
@@ -44,12 +46,14 @@ export interface TimeInterval {
   to: ValueGrain
 }
 
-export interface ValueGrain {
-  value: string
+export type ValueGrain = Value & {
   grain: string
 }
 
-export interface ValueUnit {
-  value: string
+export type ValueUnit = Value & {
   unit: string
+}
+
+export interface Value {
+  value: string
 }

--- a/src/bp/nlu-core/entities/duckling-extractor/typings.ts
+++ b/src/bp/nlu-core/entities/duckling-extractor/typings.ts
@@ -55,5 +55,5 @@ export type ValueUnit = Value & {
 }
 
 export interface Value {
-  value: string
+  value: string | number
 }


### PR DESCRIPTION
Bug reported by @allardy.

In duckling, numbers have no unit, but they have a value. Slowly but surely, we'll end up handling all possible return types of duckling. Every time we see an unhandle case, we'll just add a type.

Now that it's fixed:
![Screenshot from 2020-10-14 15-24-45](https://user-images.githubusercontent.com/25970722/96035980-ccf92b00-0e31-11eb-88b2-0856a0ffe58e.png)
