### PR TITLE
chore(nlu): append one none intent per context

### DIFF
--- a/src/bp/nlu-core/initialize-tools.ts
+++ b/src/bp/nlu-core/initialize-tools.ts
@@ -7,7 +7,7 @@ import { getPOSTagger, tagSentence } from './language/pos-tagger'
 import SeededLodashProvider from './tools/seeded-lodash'
 import { LanguageProvider, NLUVersionInfo, Token2Vec, Tools } from './typings'
 
-const NLU_VERSION = '1.4.0'
+const NLU_VERSION = '1.4.1'
 
 const healthGetter = (languageProvider: LanguageProvider) => (): NLU.Health => {
   const { validProvidersCount, validLanguages } = languageProvider.getHealth()

--- a/src/bp/nlu-core/training-pipeline.ts
+++ b/src/bp/nlu-core/training-pipeline.ts
@@ -238,15 +238,17 @@ const TrainIntentClassifier = async (
   const customEntities = getCustomEntitiesNames(input)
   const svmPerCtx: _.Dictionary<string> = {}
 
-  const noneUtts = _.chain(input.intents)
-    .filter(i => i.name === NONE_INTENT) // in case use defines a none intent we want to combine utterances
-    .flatMap(i => i.utterances)
-    .filter(u => u.tokens.filter(t => t.isWord).length >= 3)
-    .value()
-
   const lo = tools.seededLodashProvider.getSeededLodash()
   for (let i = 0; i < input.ctxToTrain.length; i++) {
     const ctx = input.ctxToTrain[i]
+
+    const noneUtts = _.chain(input.intents)
+      .filter(i => i.name === NONE_INTENT) // in case use defines a none intent we want to combine utterances
+      .filter(i => i.contexts.includes(ctx))
+      .flatMap(i => i.utterances)
+      .filter(u => u.tokens.filter(t => t.isWord).length >= 3)
+      .value()
+
     const trainableIntents = input.intents.filter(
       i => i.name !== NONE_INTENT && i.contexts.includes(ctx) && i.utterances.length >= MIN_NB_UTTERANCES
     )


### PR DESCRIPTION
**What was done**

1. In oos training, use none intent that includes the current context
2. Intent classifier training only uses the none intent of his topic
3. When generating none intent:
3.1 Generate one none intent per topic
3.2 Keep augmented as they help make the oos more aggressive
3.3 Use vocab of only one topic
3.4 Sub sample the stop words before appending them to the utterances

I know the none intent is used elsewhere in the training pipeline, but I only focused on the OOS scores.

**Results**
*I've ran the same procedure twice, just to make sure. Results where the exact same each time and execution times varied in a range of 1 second*

![image](https://user-images.githubusercontent.com/25970722/96143338-00d75d80-0ed1-11eb-8679-51c693bc20c5.png)

As we can see, the oos is less agressive. Both recall and precision are lower, but accuracy is better for all seeds we've tried because the number of true negatives has increased a lot. 

Of course, these results comme from only one topic dataset in english and should be taken with a grain of salt. DM me if you want to know which dataset I used.

However, what really interest me is the training time. We can see, it drops by almost 50% in this branch. For this reason, I think this PR should be considered.

**What's left**

Test mannualy with known bots to get a feel of the performance of the new oos.