### PR TITLE
feat(webchat): lazy socket

### DIFF
--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -114,7 +114,8 @@ export default async (bp: typeof sdk, db: Database) => {
         details: botInfo.details,
         languages: botInfo.languages,
         extraStylesheet: config.extraStylesheet,
-        security
+        security,
+        lazySocket: config.lazySocket
       })
     })
   )

--- a/modules/channel-web/src/config.ts
+++ b/modules/channel-web/src/config.ts
@@ -76,4 +76,10 @@ export interface Config {
    * Path to an additional stylesheet. It will be applied on top of the default style
    */
   extraStylesheet: string
+
+  /**
+   * If true, Websocket is created when the Webchat is opened. Bot cannot be proactive.
+   * @default false
+   */
+  lazySocket: boolean
 }

--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -243,7 +243,10 @@ class Web extends React.Component<MainProps> {
   }
 
   isLazySocket() {
-    return this.config.lazySocket === true || this.props.botInfo?.lazySocket
+    if (this.config.lazySocket !== undefined) {
+      return this.config.lazySocket
+    }
+    return this.props.botInfo?.lazySocket
   }
 
   handleResetUnreadCount = () => {

--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -10,13 +10,13 @@ import constants from './core/constants'
 import BpSocket from './core/socket'
 import ChatIcon from './icons/Chat'
 import { RootStore, StoreDef } from './store'
-import { Message } from './typings'
+import { Config, Message } from './typings'
 import { checkLocationOrigin, initializeAnalytics, trackMessage, trackWebchatState } from './utils'
 
 const _values = obj => Object.keys(obj).map(x => obj[x])
 
 class Web extends React.Component<MainProps> {
-  private config: any
+  private config: Config
   private socket: BpSocket
   private parentClass: string
   private hasBeenInitialized: boolean = false
@@ -67,7 +67,7 @@ class Web extends React.Component<MainProps> {
     if (this.props.activeView === 'side' || this.props.isFullscreen) {
       this.hasBeenInitialized = true
 
-      if (this.config.lazySocket) {
+      if (this.isLazySocket()) {
         await this.initializeSocket()
       }
 
@@ -90,10 +90,9 @@ class Web extends React.Component<MainProps> {
 
     this.config.reference && this.props.setReference()
 
-    // tslint:disable-next-line: no-floating-promises
-    this.props.fetchBotInfo()
+    await this.props.fetchBotInfo()
 
-    if (!this.config.lazySocket) {
+    if (!this.isLazySocket()) {
       await this.initializeSocket()
     }
   }
@@ -243,6 +242,10 @@ class Web extends React.Component<MainProps> {
     }, constants.MIN_TIME_BETWEEN_SOUNDS)
   }
 
+  isLazySocket() {
+    return this.config.lazySocket || this.props.botInfo?.lazySocket
+  }
+
   handleResetUnreadCount = () => {
     if (document.hasFocus?.() && this.props.activeView === 'side') {
       this.props.resetUnread()
@@ -305,6 +308,7 @@ export default inject(({ store }: { store: RootStore }) => ({
   config: store.config,
   sendData: store.sendData,
   initializeChat: store.initializeChat,
+  botInfo: store.botInfo,
   fetchBotInfo: store.fetchBotInfo,
   updateConfig: store.updateConfig,
   mergeConfig: store.mergeConfig,
@@ -337,6 +341,7 @@ type MainProps = { store: RootStore } & Pick<
   | 'bp'
   | 'config'
   | 'initializeChat'
+  | 'botInfo'
   | 'fetchBotInfo'
   | 'sendMessage'
   | 'setUserId'

--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -243,7 +243,7 @@ class Web extends React.Component<MainProps> {
   }
 
   isLazySocket() {
-    return this.config.lazySocket || this.props.botInfo?.lazySocket
+    return this.config.lazySocket === true || this.props.botInfo?.lazySocket
   }
 
   handleResetUnreadCount = () => {

--- a/modules/channel-web/src/views/lite/typings.d.ts
+++ b/modules/channel-web/src/views/lite/typings.d.ts
@@ -175,7 +175,7 @@ export type Config = {
   /** Reference ensures that a specific value and its signature are valid */
   reference: string
   /** If true, Websocket is created when the Webchat is opened. Bot cannot be proactive. */
-  lazySocket: boolean
+  lazySocket?: boolean
 }
 
 type OverridableComponents = 'below_conversation' | 'before_container' | 'composer'

--- a/modules/channel-web/src/views/lite/typings.d.ts
+++ b/modules/channel-web/src/views/lite/typings.d.ts
@@ -174,6 +174,7 @@ export type Config = {
   exposeStore: boolean
   /** Reference ensures that a specific value and its signature are valid */
   reference: string
+  lazySocket: boolean
 }
 
 type OverridableComponents = 'below_conversation' | 'before_container' | 'composer'
@@ -205,6 +206,7 @@ export interface BotInfo {
   security: {
     escapeHTML: boolean
   }
+  lazySocket: boolean
 }
 
 interface Conversation {

--- a/modules/channel-web/src/views/lite/typings.d.ts
+++ b/modules/channel-web/src/views/lite/typings.d.ts
@@ -174,6 +174,7 @@ export type Config = {
   exposeStore: boolean
   /** Reference ensures that a specific value and its signature are valid */
   reference: string
+  /** If true, Websocket is created when the Webchat is opened. Bot cannot be proactive. */
   lazySocket: boolean
 }
 


### PR DESCRIPTION
This PR adds a `lazySocket: boolean` flag to the Webchat config. This allows delaying the websocket initialization until the webchat is opened. 

As of now, the websocket is always created, even though the webchat is not opened by the user. This can create a lot of load on a Botpress server if the host page is being loaded by many simultaneous users. For example, if 1000 users load the host page and only 100 of them open the webchat, then 900 websockets are created unnecessarily.  

Ideally, we would want to delay the websocket initialization until the webchat is opened by the user. However, setting the the `lazySocket: true` will make it impossible for the bot to be proactive.

In sum:
`lazySocket: false` - Current default. Websocket is eargerly created. Bot can be proactive.
`lazySocket: true` - Websocket is created when the webchat is opened. Bot cannot be proactive.