### PR TITLE
fix(webchat): added condition to query

### DIFF
--- a/modules/channel-web/src/backend/db.ts
+++ b/modules/channel-web/src/backend/db.ts
@@ -286,6 +286,7 @@ export default class WebchatDb {
           'ON ("conversationId") message_type, message_text, full_name, avatar_url, sent_on, "conversationId"'
         )
       )
+      .whereIn('conversationId', conversationIds)
       .orderBy('conversationId')
       .orderBy('sent_on', 'desc')
 


### PR DESCRIPTION
The query was fetching the last messages of every conversations, so if there was a lot of them, it could slow it down considerably