### PR TITLE
fix(converse): tangled messages with multiple bots

### DIFF
--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -31,7 +31,7 @@ import AuthService from './services/auth/auth-service'
 import { BotMonitoringService } from './services/bot-monitoring-service'
 import { BotService } from './services/bot-service'
 import { CMSService } from './services/cms'
-import { converseApiEvents } from './services/converse'
+import { buildUserKey, converseApiEvents } from './services/converse'
 import { DecisionEngine } from './services/dialog/decision-engine'
 import { DialogEngine } from './services/dialog/dialog-engine'
 import { ProcessingError } from './services/dialog/errors'
@@ -370,7 +370,7 @@ export class Botpress {
       await this.hookService.executeHook(new Hooks.AfterIncomingMiddleware(this.api, event))
       const sessionId = SessionIdFactory.createIdFromEvent(event)
       await this.decisionEngine.processEvent(sessionId, event)
-      await converseApiEvents.emitAsync(`done.${event.target}`, event)
+      await converseApiEvents.emitAsync(`done.${buildUserKey(event.botId, event.target)}`, event)
     }
 
     this.eventEngine.onBeforeOutgoingMiddleware = async (event: sdk.IO.IncomingEvent) => {

--- a/src/bp/core/services/dialog/dialog-engine.ts
+++ b/src/bp/core/services/dialog/dialog-engine.ts
@@ -5,7 +5,7 @@ import { TYPES } from 'core/types'
 import { inject, injectable } from 'inversify'
 import _ from 'lodash'
 
-import { converseApiEvents } from '../converse'
+import { buildUserKey, converseApiEvents } from '../converse'
 import { Hooks, HookService } from '../hook/hook-service'
 
 import { FlowError, ProcessingError, TimeoutNodeNotFound } from './errors'
@@ -83,7 +83,7 @@ export class DialogEngine {
     }
 
     try {
-      await converseApiEvents.emitAsync(`action.start.${event.target}`, event)
+      await converseApiEvents.emitAsync(`action.start.${buildUserKey(event.botId, event.target)}`, event)
       const result = await this.instructionProcessor.process(botId, instruction, event)
 
       if (result.followUpAction === 'none') {
@@ -121,7 +121,7 @@ export class DialogEngine {
     } catch (err) {
       this._reportProcessingError(botId, err, event, instruction)
     } finally {
-      await converseApiEvents.emitAsync(`action.end.${event.target}`, event)
+      await converseApiEvents.emitAsync(`action.end.${buildUserKey(event.botId, event.target)}`, event)
     }
 
     return event


### PR DESCRIPTION
Converse's message buffer was only using the userId as the key, so if you spoke with two different bots, responses could be mixed up. The key will now also include the bot ID.

Fixes https://github.com/botpress/v12/issues/1116