### PR TITLE
feat(admin): indicate if bot needs training in admin

### DIFF
--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemCompact.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemCompact.tsx
@@ -20,6 +20,8 @@ import { toastInfo } from '~/utils/toaster'
 
 import AccessControl, { isChatUser } from '../../../App/AccessControl'
 
+import { NeedsTrainingWarning } from './NeedsTrainingWarning'
+
 interface Props {
   bot: BotConfig
   hasError: boolean
@@ -136,6 +138,7 @@ const BotItemCompact: FC<Props> = ({
           </span>
         )}
         <a href={botStudioLink}>{bot.name || bot.id}</a>
+        <NeedsTrainingWarning bot={bot.id} languages={bot.languages} />
 
         {!bot.defaultLanguage && (
           <Tooltip position="right" content={lang.tr('admin.workspace.bots.item.languageIsMissing')}>

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemCompact.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemCompact.tsx
@@ -138,6 +138,11 @@ const BotItemCompact: FC<Props> = ({
           </span>
         )}
         <a href={botStudioLink}>{bot.name || bot.id}</a>
+
+        {/*
+          TODO: remove this NeedsTrainingWarning component.
+          This is a temp fix but won't be usefull after we bring back training on bot mount.
+          */}
         <NeedsTrainingWarning bot={bot.id} languages={bot.languages} />
 
         {!bot.defaultLanguage && (

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/NeedsTrainingWarning.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/NeedsTrainingWarning.tsx
@@ -1,0 +1,43 @@
+import { Classes, Icon, Intent, Position } from '@blueprintjs/core'
+import { Promise as BbPromise } from 'bluebird'
+import { ToolTip } from 'botpress/shared'
+import React, { FC, useEffect, useState } from 'react'
+import api from '~/api'
+
+interface Props {
+  bot: string
+  languages: string[]
+}
+
+export const NeedsTrainingWarning: FC<Props> = (props: Props) => {
+
+  const { bot, languages } = props
+
+  const [needsTraining, setNeedsTraining] = useState(false)
+
+  useEffect(() => {
+    const axios = api.getSecured()
+    // tslint:disable-next-line: no-floating-promises
+
+    BbPromise.map(languages, async lang => {
+      try {
+        const { data } = await axios.get(`bots/${bot}/mod/nlu/training/${lang}`)
+        return data.status === 'needs-training'
+      } catch (err) {
+        return false
+      }
+    }).then((langNeedsTraining) => {
+      setNeedsTraining(langNeedsTraining.some(Boolean))
+    })
+
+  }, [])
+
+  if (needsTraining) {
+    return (
+      <ToolTip content="Needs training..." className={Classes.TOOLTIP_INDICATOR} position={Position.TOP} intent={Intent.DANGER}>
+        <Icon icon="warning-sign" intent={Intent.DANGER} style={{ marginLeft: 10 }} />
+      </ToolTip>
+      )
+  }
+  return null
+}

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/NeedsTrainingWarning.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/NeedsTrainingWarning.tsx
@@ -17,8 +17,8 @@ export const NeedsTrainingWarning: FC<Props> = (props: Props) => {
 
   useEffect(() => {
     const axios = api.getSecured()
-    // tslint:disable-next-line: no-floating-promises
 
+    // tslint:disable-next-line: no-floating-promises
     BbPromise.map(languages, async lang => {
       try {
         const { data } = await axios.get(`bots/${bot}/mod/nlu/training/${lang}`)


### PR DESCRIPTION
Because I removed the training on bot mount, we now need to announce the user that a bots needs a training so he can go in studio and train it...

Here's what it looks like:
![image](https://user-images.githubusercontent.com/25970722/97041798-0e7a8c00-153e-11eb-8e33-4d6183b7c837.png)

(took the screenshot while on a breakpoint... thats why its kind of dark)