### PR TITLE
@allardy fix(core): display correct version

### DIFF
--- a/build/package.pkg.json
+++ b/build/package.pkg.json
@@ -1,6 +1,6 @@
 {
   "name": "botpress",
-  "version": "11.0.0",
+  "version": "12.11.0",
   "description": "The world's most powerful conversational engine",
   "main": "index.js",
   "bin": "index.js",

--- a/build/update_pkg_version.js
+++ b/build/update_pkg_version.js
@@ -1,0 +1,7 @@
+const fs = require('fs')
+const os = require('os')
+
+const content = JSON.parse(fs.readFileSync('./package.pkg.json').toString())
+content.version = require('../package.json').version
+
+fs.writeFileSync('./package.pkg.json', `${JSON.stringify(content, undefined, 2)}${os.EOL}`, 'UTF-8')

--- a/build/update_pkg_version.js
+++ b/build/update_pkg_version.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const os = require('os')
 
-const content = JSON.parse(fs.readFileSync('./package.pkg.json').toString())
+const content = JSON.parse(fs.readFileSync('build/package.pkg.json').toString())
 content.version = require('../package.json').version
 
-fs.writeFileSync('./package.pkg.json', `${JSON.stringify(content, undefined, 2)}${os.EOL}`, 'UTF-8')
+fs.writeFileSync('build/package.pkg.json', `${JSON.stringify(content, undefined, 2)}${os.EOL}`, 'UTF-8')

--- a/release-version.sh
+++ b/release-version.sh
@@ -30,6 +30,8 @@ select VERSION in patch minor major "Specific Version"
         yarn cmd changelog
         node build/remove_changelog_dupes.js
 
+        node build/update_pkg_version.js
+
         # Create commit
         git add -A
         git commit -m "v$NEW_VERSION"


### PR DESCRIPTION
Typing `bp --version` would always display 11.0 (because there are two different places where the version had to be updated).

Fix https://github.com/botpress/v12/issues/1020