### PR TITLE
fix(nlu): train now button is more responsive

### DIFF
--- a/modules/nlu/src/backend/module-lifecycle/on-bot-mount.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-bot-mount.ts
@@ -65,76 +65,73 @@ export function getOnBotMount(state: NLUState) {
     }
 
     const engine = new bp.NLU.Engine(bot.id, makeLoggerWrapper(bp, botId))
-    const trainOrLoad = _.debounce(
-      async (disableTraining: boolean) => {
-        // bot got deleted
-        if (!state.nluByBot[botId]) {
-          return
-        }
+    const trainOrLoad = async (disableTraining: boolean) => {
+      // bot got deleted
+      if (!state.nluByBot[botId]) {
+        return
+      }
 
-        const api = await createApi(bp, botId)
-        const intentDefs = await api.fetchIntentsWithQNAs()
-        const entityDefs = await api.fetchEntities()
+      const api = await createApi(bp, botId)
+      const intentDefs = await api.fetchIntentsWithQNAs()
+      const entityDefs = await api.fetchEntities()
 
-        const kvs = bp.kvs.forBot(botId)
-        await kvs.set(KVS_TRAINING_STATUS_KEY, 'training')
+      const kvs = bp.kvs.forBot(botId)
+      await kvs.set(KVS_TRAINING_STATUS_KEY, 'training')
 
-        try {
-          await Promise.mapSeries(languages, async languageCode => {
-            // shorter lock and extend in training steps
-            const lock = await bp.distributed.acquireLock(makeTrainSessionKey(botId, languageCode), ms('5m'))
-            if (!lock) {
-              return
-            }
+      try {
+        await Promise.mapSeries(languages, async languageCode => {
+          // shorter lock and extend in training steps
+          const lock = await bp.distributed.acquireLock(makeTrainSessionKey(botId, languageCode), ms('5m'))
+          if (!lock) {
+            return
+          }
 
-            const hash = engine.computeModelHash(intentDefs, entityDefs, languageCode)
-            await ModelService.pruneModels(ghost, languageCode)
-            let model = await ModelService.getModel(ghost, hash, languageCode)
+          const hash = engine.computeModelHash(intentDefs, entityDefs, languageCode)
+          await ModelService.pruneModels(ghost, languageCode)
+          let model = await ModelService.getModel(ghost, hash, languageCode)
 
-            const trainSession = makeTrainingSession(botId, languageCode, lock)
-            state.nluByBot[botId].trainSessions[languageCode] = trainSession
-            if (!model && !disableTraining) {
-              await setTrainingSession(bp, botId, trainSession)
+          const trainSession = makeTrainingSession(botId, languageCode, lock)
+          state.nluByBot[botId].trainSessions[languageCode] = trainSession
+          if (!model && !disableTraining) {
+            await state.sendNLUStatusEvent(botId, trainSession)
 
-              const progressCallback = async (progress: number) => {
-                trainSession.progress = progress
-                await state.sendNLUStatusEvent(botId, trainSession)
-              }
-
-              const rand = () => Math.round(Math.random() * 10000)
-              const nluSeed = parseInt(process.env.NLU_SEED) || rand()
-
-              const options: sdk.NLU.TrainingOptions = { forceTrain: false, nluSeed, progressCallback }
-              model = await engine.train(trainSession.key, intentDefs, entityDefs, languageCode, options)
-              if (model) {
-                trainSession.status = 'done'
-                await state.sendNLUStatusEvent(botId, trainSession)
-                await engine.loadModel(model)
-                await ModelService.saveModel(ghost, model, hash)
-              } else {
-                trainSession.status = 'needs-training'
-                await state.sendNLUStatusEvent(botId, trainSession)
-              }
-            } else {
-              trainSession.progress = 1
-              trainSession.status = 'done'
+            const progressCallback = async (progress: number) => {
+              trainSession.status = 'training'
+              trainSession.progress = progress
               await state.sendNLUStatusEvent(botId, trainSession)
             }
-            try {
-              if (model) {
-                await state.broadcastLoadModel(botId, hash, languageCode)
-              }
-            } finally {
-              await lock.unlock()
+
+            const rand = () => Math.round(Math.random() * 10000)
+            const nluSeed = parseInt(process.env.NLU_SEED) || rand()
+
+            const options: sdk.NLU.TrainingOptions = { forceTrain: false, nluSeed, progressCallback }
+            model = await engine.train(trainSession.key, intentDefs, entityDefs, languageCode, options)
+            if (model) {
+              trainSession.status = 'done'
+              await state.sendNLUStatusEvent(botId, trainSession)
+              await engine.loadModel(model)
+              await ModelService.saveModel(ghost, model, hash)
+            } else {
+              trainSession.status = 'needs-training'
+              await state.sendNLUStatusEvent(botId, trainSession)
             }
-          })
-        } finally {
-          await kvs.delete(KVS_TRAINING_STATUS_KEY)
-        }
-      },
-      10000,
-      { leading: true }
-    )
+          } else {
+            trainSession.progress = 1
+            trainSession.status = 'done'
+            await state.sendNLUStatusEvent(botId, trainSession)
+          }
+          try {
+            if (model) {
+              await state.broadcastLoadModel(botId, hash, languageCode)
+            }
+          } finally {
+            await lock.unlock()
+          }
+        })
+      } finally {
+        await kvs.delete(KVS_TRAINING_STATUS_KEY)
+      }
+    }
 
     const cancelTraining = async () => {
       await Promise.map(languages, async lang => {

--- a/modules/nlu/src/backend/train-session-service.ts
+++ b/modules/nlu/src/backend/train-session-service.ts
@@ -10,7 +10,7 @@ export const makeTrainSessionKey = (botId: string, language: string): string => 
 
 export const makeTrainingSession = (botId: string, language: string, lock: sdk.RedisLock): sdk.NLU.TrainingSession => ({
   key: makeTrainSessionKey(botId, language),
-  status: 'training',
+  status: 'training-pending',
   progress: 0,
   language,
   lock

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -498,11 +498,20 @@ declare module 'botpress/sdk' {
      * idle : occures when there are no training sessions for a bot
      * done : when a training is complete
      * needs-training : when current chatbot model differs from training data
+     * training-pending : when a training was launched, but the training process is not started yet
      * training: when a chatbot is currently training
-     * canceled: when a training has been canceled by the user
+     * canceled: when a user cancels a training and the training is being canceled
      * errored: when a chatbot failed to train
      */
-    export type TrainingStatus = 'idle' | 'done' | 'needs-training' | 'training' | 'canceled' | 'errored' | null
+    export type TrainingStatus =
+      | 'idle'
+      | 'done'
+      | 'needs-training'
+      | 'training-pending'
+      | 'training'
+      | 'canceled'
+      | 'errored'
+      | null
 
     export interface TrainingSession {
       key: string

--- a/src/bp/ui-studio/src/web/components/Layout/StatusBar/TrainingStatus.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/StatusBar/TrainingStatus.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@blueprintjs/core'
+import { Button, Spinner } from '@blueprintjs/core'
 import axios from 'axios'
 import { NLU } from 'botpress/sdk'
 import { lang } from 'botpress/shared'
@@ -83,12 +83,18 @@ const TrainingStatusComponent: FC<Props> = (props: Props) => {
             {lang.tr('statusBar.trainChatbot')}
           </Button>
         )}
+        {status === 'training-pending' && (
+          <div className={style.pending}>
+            <span className={cx(style.pending, style.text)}>{lang.tr('statusBar.trainingPending')}</span>
+            <Spinner size={5}/>
+          </div>
+        )}
         {status === 'training' && (
           <Button minimal className={cx(style.button, style.danger)} onClick={onCancelClicked} disabled={loading}>
             {lang.tr('statusBar.cancelTraining')}
           </Button>
         )}
-      </div>
+      </div >
     )
   }
 }

--- a/src/bp/ui-studio/src/web/components/Layout/StatusBar/style.scss
+++ b/src/bp/ui-studio/src/web/components/Layout/StatusBar/style.scss
@@ -22,6 +22,15 @@
     }
   }
 
+  .pending {
+    background-color: var(--c-background--dark-2);
+    display: flex;
+
+    &.text {
+      margin-right: 1em;
+    }
+  }
+
   .botName {
     color: var(--c-text--light);
   }

--- a/src/bp/ui-studio/src/web/components/Layout/StatusBar/style.scss.d.ts
+++ b/src/bp/ui-studio/src/web/components/Layout/StatusBar/style.scss.d.ts
@@ -10,7 +10,9 @@ interface CssExports {
   'langItem': string;
   'langSwitherMenu': string;
   'message': string;
+  'pending': string;
   'statusBar': string;
+  'text': string;
 }
 declare var cssExports: CssExports;
 export = cssExports;

--- a/src/bp/ui-studio/src/web/translations/en.json
+++ b/src/bp/ui-studio/src/web/translations/en.json
@@ -49,6 +49,7 @@
     "training": "Training",
     "ready": "Ready",
     "cancelTraining": "Cancel Training",
+    "trainingPending": "Training Pending",
     "canceling": "Canceling",
     "trainingError": "Cannot train Chatbot"
   },

--- a/src/bp/ui-studio/src/web/translations/fr.json
+++ b/src/bp/ui-studio/src/web/translations/fr.json
@@ -49,6 +49,7 @@
     "training": "Entraînement en cours",
     "ready": "Prêt",
     "cancelTraining": "Annuler l'entraînement",
+    "trainingPending": "Entraînement en attente",
     "canceling": "Annulation en cours",
     "trainingError": "L'agent ne peut pas être entraîné"
   },


### PR DESCRIPTION
I added status 'training-pending' and I removed the debounce from 'trainOrLoad' (we dont really need it anymore now that trainings can be canceled).

UI looks like this:
![image](https://user-images.githubusercontent.com/25970722/98269469-c3a83d80-1f5b-11eb-91e5-b1e11d9539a1.png)


Make sure to hide white space when reviewing this PR:
![image](https://user-images.githubusercontent.com/25970722/98269002-34028f00-1f5b-11eb-975f-744ae2f22311.png)
