### PR TITLE
Standardize module name usage

### DIFF
--- a/examples/chat-3rd-party-OAuth/src/botpress.d.ts
+++ b/examples/chat-3rd-party-OAuth/src/botpress.d.ts
@@ -99,7 +99,6 @@ declare module 'botpress/sdk' {
     /** Gives a short description of your module, which is displayed once the template is selected */
     desc: string
     /** These are used internally by Botpress when they are registered on startup */
-    readonly moduleId?: string
     readonly moduleName?: string
   }
 
@@ -952,14 +951,14 @@ declare module 'botpress/sdk' {
   }
 
   export namespace config {
-    export function getModuleConfig(moduleId: string): Promise<any>
+    export function getModuleConfig(moduleName: string): Promise<any>
 
     /**
      * Returns the configuration values for the specified module and bot.
-     * @param moduleId
+     * @param moduleName
      * @param botId
      */
-    export function getModuleConfigForBot(moduleId: string, botId: string): Promise<any>
+    export function getModuleConfigForBot(moduleName: string, botId: string): Promise<any>
 
     /**
      * Returns the configuration options of Botpress

--- a/src/bp/core/api.ts
+++ b/src/bp/core/api.ts
@@ -328,9 +328,11 @@ export class BotpressAPIProvider {
   }
 }
 
-export function createForModule(moduleId: string): Promise<typeof sdk> {
+export function createForModule(moduleName: string): Promise<typeof sdk> {
   // return Promise.resolve(<typeof sdk>{})
-  return container.get<BotpressAPIProvider>(TYPES.BotpressAPIProvider).create(`Mod[${moduleId}]`, `module.${moduleId}`)
+  return container
+    .get<BotpressAPIProvider>(TYPES.BotpressAPIProvider)
+    .create(`Mod[${moduleName}]`, `module.${moduleName}`)
 }
 
 export function createForGlobalHooks(): Promise<typeof sdk> {

--- a/src/bp/core/module-loader.ts
+++ b/src/bp/core/module-loader.ts
@@ -330,7 +330,7 @@ export class ModuleLoader {
       .filter(module => module.botTemplates)
       .map(module => {
         return module.botTemplates!.map(template => {
-          return { ...template, moduleName: module.definition.name }
+          return { ...template, moduleName: module.definition.name, moduleFullName: module.definition.fullName }
         })
       })
 

--- a/src/bp/core/module-loader.ts
+++ b/src/bp/core/module-loader.ts
@@ -330,7 +330,7 @@ export class ModuleLoader {
       .filter(module => module.botTemplates)
       .map(module => {
         return module.botTemplates!.map(template => {
-          return { ...template, moduleId: module.definition.name, moduleName: module.definition.fullName }
+          return { ...template, moduleName: module.definition.name }
         })
       })
 

--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -520,15 +520,15 @@ export class BotService {
     this._invalidateBotIds()
   }
 
-  public async getBotTemplate(moduleId: string, templateId: string): Promise<FileContent[]> {
-    const resourceLoader = new ModuleResourceLoader(this.logger, moduleId, this.ghostService)
+  public async getBotTemplate(moduleName: string, templateId: string): Promise<FileContent[]> {
+    const resourceLoader = new ModuleResourceLoader(this.logger, moduleName, this.ghostService)
     const templatePath = await resourceLoader.getBotTemplatePath(templateId)
 
     return this._loadBotTemplateFiles(templatePath)
   }
 
   private async _createBotFromTemplate(botConfig: BotConfig, template: BotTemplate): Promise<BotConfig | undefined> {
-    const resourceLoader = new ModuleResourceLoader(this.logger, template.moduleId!, this.ghostService)
+    const resourceLoader = new ModuleResourceLoader(this.logger, template.moduleName!, this.ghostService)
     const templatePath = await resourceLoader.getBotTemplatePath(template.id)
     const templateConfigPath = path.resolve(templatePath, BOT_CONFIG_FILENAME)
 

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -194,7 +194,6 @@ declare module 'botpress/sdk' {
     /** Gives a short description of your module, which is displayed once the template is selected */
     desc: string
     /** These are used internally by Botpress when they are registered on startup */
-    readonly moduleId?: string
     readonly moduleName?: string
   }
 
@@ -1975,15 +1974,15 @@ declare module 'botpress/sdk' {
   }
 
   export namespace config {
-    export function getModuleConfig(moduleId: string): Promise<any>
+    export function getModuleConfig(moduleName: string): Promise<any>
 
     /**
      * Returns the configuration values for the specified module and bot.
-     * @param moduleId
+     * @param moduleName
      * @param botId
      * @param ignoreGlobal Enable this when you want only bot-specific configuration to be possible
      */
-    export function getModuleConfigForBot(moduleId: string, botId: string, ignoreGlobal?: boolean): Promise<any>
+    export function getModuleConfigForBot(moduleName: string, botId: string, ignoreGlobal?: boolean): Promise<any>
 
     /**
      * Returns the configuration options of Botpress

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -195,6 +195,7 @@ declare module 'botpress/sdk' {
     desc: string
     /** These are used internally by Botpress when they are registered on startup */
     readonly moduleName?: string
+    readonly moduleFullName?: string
   }
 
   export interface ModuleDefinition {

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/CreateBotModal.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/CreateBotModal.tsx
@@ -104,7 +104,7 @@ class CreateBotModal extends Component<Props, State> {
       return this.props.fetchBotTemplates()
     }
 
-    const templatesByModule = _.groupBy(this.props.botTemplates, 'moduleName')
+    const templatesByModule = _.groupBy(this.props.botTemplates, 'moduleFullName')
     const groupedOptions = _.toPairs(templatesByModule).map(g => ({ label: g[0], options: g[1] }))
 
     this.setState({ templates: groupedOptions, selectedTemplate: undefined })
@@ -127,7 +127,7 @@ class CreateBotModal extends Component<Props, State> {
     const newBot = {
       id: this.state.botId,
       name: this.state.botName,
-      template: _.pick(this.state.selectedTemplate, ['id', 'moduleName']),
+      template: _.pick(this.state.selectedTemplate, ['id', 'moduleFullName']),
       category: this.state.selectedCategory && this.state.selectedCategory.value
     }
 

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/CreateBotModal.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/CreateBotModal.tsx
@@ -127,7 +127,7 @@ class CreateBotModal extends Component<Props, State> {
     const newBot = {
       id: this.state.botId,
       name: this.state.botName,
-      template: _.pick(this.state.selectedTemplate, ['id', 'moduleId']),
+      template: _.pick(this.state.selectedTemplate, ['id', 'moduleName']),
       category: this.state.selectedCategory && this.state.selectedCategory.value
     }
 


### PR DESCRIPTION
I've observed throughout the codebase that `moduleName` & `moduleId` local variables are used interchangeably. I get that most of the time the module's name is used as an Id but it is confusing.

None of the module-related types have the concept of `id`, so I've renamed all `moduleId` instances to `moduleName`. I don't expect this to break anything, but it might, and a thorough review would be great.