### PR TITLE
fix(studio): enhance unclosed brackets, respect order and exact length

### DIFF
--- a/src/bp/ui-studio/src/web/components/Util/form.util.ts
+++ b/src/bp/ui-studio/src/web/components/Util/form.util.ts
@@ -3,12 +3,10 @@ export const isMissingCurlyBraceClosure = (text: string): boolean => {
 
   return brackets && !(brackets.length % 2 === 0 &&
     new Array(brackets.length / 2)
-      .fill([])
-      .map( () => brackets.splice(0, 2))
-      .map( bracket =>
-        bracket[0].match(/{{{?/g) &&
-        bracket[1].match(/}}}?/g) &&
-        bracket[0].length === bracket[1].length
-      )
+      .fill('')
+      .map( () => {
+        const [leftBracket, rightBracket] = brackets.splice(0, 2)
+        return leftBracket.match(/{{{?/g) && rightBracket.match(/}}}?/g) && leftBracket.length === rightBracket.length
+      })
       .reduce((a, c) => c && a))
 }

--- a/src/bp/ui-studio/src/web/components/Util/form.util.ts
+++ b/src/bp/ui-studio/src/web/components/Util/form.util.ts
@@ -1,2 +1,14 @@
-export const isMissingCurlyBraceClosure = (text: string): boolean =>
-  (text?.match(/{{/g) || []).length !== (text?.match(/}}/g) || []).length
+export const isMissingCurlyBraceClosure = (text: string): boolean => {
+  const brackets = text?.match(/{{{?|}}}?/g)
+
+  return brackets && !(brackets.length % 2 === 0 &&
+    new Array(brackets.length / 2)
+      .fill([])
+      .map( () => brackets.splice(0, 2))
+      .map( bracket =>
+        bracket[0].match(/{{{?/g) &&
+        bracket[1].match(/}}}?/g) &&
+        bracket[0].length === bracket[1].length
+      )
+      .reduce((a, c) => c && a))
+}


### PR DESCRIPTION
Hello,

This is an enhancement of @MaxCloutier 's fix  [4106](https://github.com/botpress/botpress/pull/4106) for the bug [3678](https://github.com/botpress/v12/issues/1069) , referring to @allardy 's comment:

> Actually, the bracket matching is a bit too simplistic. Templates will always start with {{ or {{{ , then it must end with the proper ending. Not sure we want to prevent usage of brackets exclusively for template rendering

The bug still exists with current implementation if we don't respect brackets order or if we did this example: `"{{{ test }}"`
![image](https://s8.gifyu.com/images/studio-crash.gif)


Thanks.