### PR TITLE
fix(gh): skip nlu gh check when PR comes from a fork + skip tslint newrules if no files change

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -41,6 +41,11 @@ jobs:
         id: filtered_files
         run: |
           echo ::set-output name=files::$(node build/tslint-filter-files.js ${{ steps.get_file_changes.outputs.files }})
-      - name: Run TSLint (new rules)
+      - name: Echo filtered files
+        run: |
+          echo "test1234"
+          echo ${{ steps.filtered_files.outputs.files }}
+      - if: steps.filtered_files.outputs.files != null
+        name: Run TSLint (new rules)
         run: |
           yarn run tslint -c tslint.newrules.json ${{ steps.filtered_files.outputs.files }}

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -41,10 +41,6 @@ jobs:
         id: filtered_files
         run: |
           echo ::set-output name=files::$(node build/tslint-filter-files.js ${{ steps.get_file_changes.outputs.files }})
-      - name: Echo filtered files
-        run: |
-          echo "test1234"
-          echo ${{ steps.filtered_files.outputs.files == null }}
       - if: steps.filtered_files.outputs.files != null
         name: Run TSLint (new rules)
         run: |

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Echo filtered files
         run: |
           echo "test1234"
-          echo ${{ steps.filtered_files.outputs.files }}
+          echo ${{ steps.filtered_files.outputs.files == null }}
       - if: steps.filtered_files.outputs.files != null
         name: Run TSLint (new rules)
         run: |

--- a/.github/workflows/nlu-regression.yml
+++ b/.github/workflows/nlu-regression.yml
@@ -1,6 +1,15 @@
 name: NLU Regression
 on: [pull_request]
 jobs:
+  nlu-warning:
+    if: github.repository != 'botpress/botpress'
+    name: Log NLU warning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo Warning Message
+        run: |
+          echo "Warning: nlu-regression check could not run because the PR comes from a fork."
+
   nlu:
     if: github.repository == 'botpress/botpress'
     name: Run regression
@@ -25,12 +34,3 @@ jobs:
       - name: Run Regression Test
         run: |
           yarn start nlu --silent & sleep 5s && node ./build/nlu-regression/index.js
-
-  nlu-warning:
-    if: github.repository != 'botpress/botpress'
-    name: Log NLU warning
-    runs-on: ubuntu-latest
-    steps:
-      - name: Echo Warning Message
-        run: |
-          echo "Warning: nlu-regression check could not run because the PR comes from a fork."

--- a/.github/workflows/nlu-regression.yml
+++ b/.github/workflows/nlu-regression.yml
@@ -6,6 +6,8 @@ jobs:
     name: Log NLU warning
     runs-on: ubuntu-latest
     steps:
+      - name: Echo github repository
+        run: echo ${{ github.repository }}
       - name: Echo Warning Message
         run: |
           echo "Warning: nlu-regression check could not run because the PR comes from a fork."
@@ -15,6 +17,8 @@ jobs:
     name: Run regression
     runs-on: ubuntu-latest
     steps:
+      - name: Echo github repository
+        run: echo ${{ github.repository }}
       - name: Checkout code
         uses: actions/checkout@master
       - uses: actions/setup-node@v1

--- a/.github/workflows/nlu-regression.yml
+++ b/.github/workflows/nlu-regression.yml
@@ -2,7 +2,7 @@ name: NLU Regression
 on: [pull_request]
 jobs:
   nlu:
-    if: github.event.pull_request.head.repo.fork = true
+    if: github.event.pull_request.head.repo.fork == true
     name: Run regression
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +27,7 @@ jobs:
           yarn start nlu --silent & sleep 5s && node ./build/nlu-regression/index.js
 
   nlu-warning:
-    if: github.event.pull_request.head.repo.fork = false
+    if: github.event.pull_request.head.repo.fork == false
     name: Log NLU warning
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nlu-regression.yml
+++ b/.github/workflows/nlu-regression.yml
@@ -19,9 +19,10 @@ jobs:
     steps:
       - name: Echo github repository
         run: |
-          echo ${{ github.repository }}
-          echo ${{ github.ref }}
-          echo ${{ github.owner }}
+          echo ${{ github.event }}
+          echo ${{ github.event.pull_request }}
+          echo ${{ github.event.pull_request.head }}  
+          echo ${{ github.event.pull_request.head.fork }}
           echo ${{ toJson(github) }}
       - name: Checkout code
         uses: actions/checkout@master

--- a/.github/workflows/nlu-regression.yml
+++ b/.github/workflows/nlu-regression.yml
@@ -2,6 +2,7 @@ name: NLU Regression
 on: [pull_request]
 jobs:
   nlu:
+    if: ${{ secrets.PAT_BITFAN != null }}
     name: Run regression
     runs-on: ubuntu-latest
     steps:
@@ -13,14 +14,23 @@ jobs:
       - name: Fetch Node Packages
         run: |
           yarn --verbose
-      - name: Build core
-        run: |
-          NODE_OPTIONS="--max-old-space-size=6000" yarn cmd build:core
-      - name: Install Bitfan
+        name: Install Bitfan
         run: |
           yarn add npm-cli-login
           ./node_modules/npm-cli-login/bin/npm-cli-login.js -r https://npm.pkg.github.com -u botpressops -p ${{ secrets.PAT_BITFAN }} -e ops@botpress.com
           yarn add @botpress/bitfan
+        name: Build core
+        run: |
+          NODE_OPTIONS="--max-old-space-size=6000" yarn cmd build:core
       - name: Run Regression Test
         run: |
           yarn start nlu --silent & sleep 5s && node ./build/nlu-regression/index.js
+  
+  nlu-warning:
+    if: ${{ secrets.PAT_BITFAN == null }}
+    name: Log NLU warning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo Warning Message
+        run: |
+          echo "Warning: nlu-regression check could not run because the PR comes from a fork."

--- a/.github/workflows/nlu-regression.yml
+++ b/.github/workflows/nlu-regression.yml
@@ -25,12 +25,3 @@ jobs:
       - name: Run Regression Test
         run: |
           yarn start nlu --silent & sleep 5s && node ./build/nlu-regression/index.js
-
-  nlu-warning:
-    if: github.event.pull_request.head.repo.fork == true
-    name: Log NLU warning
-    runs-on: ubuntu-latest
-    steps:
-      - name: Echo Warning Message
-        run: |
-          echo "Warning: nlu-regression check could not run because the PR comes from a fork."

--- a/.github/workflows/nlu-regression.yml
+++ b/.github/workflows/nlu-regression.yml
@@ -14,14 +14,14 @@ jobs:
       - name: Fetch Node Packages
         run: |
           yarn --verbose
+      - name: Build core
+        run: |
+          NODE_OPTIONS="--max-old-space-size=6000" yarn cmd build:core
       - name: Install Bitfan
         run: |
           yarn add npm-cli-login
           ./node_modules/npm-cli-login/bin/npm-cli-login.js -r https://npm.pkg.github.com -u botpressops -p ${{ secrets.PAT_BITFAN }} -e ops@botpress.com
           yarn add @botpress/bitfan
-      - name: Build core
-        run: |
-          NODE_OPTIONS="--max-old-space-size=6000" yarn cmd build:core
       - name: Run Regression Test
         run: |
           yarn start nlu --silent & sleep 5s && node ./build/nlu-regression/index.js

--- a/.github/workflows/nlu-regression.yml
+++ b/.github/workflows/nlu-regression.yml
@@ -18,7 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Echo github repository
-        run: echo ${{ github.ref }}
+        run: |
+          echo ${{ github.repository }}
+          echo ${{ github.ref }}
+          echo ${{ github.owner }}
+          echo ${{ toJson(github) }}
       - name: Checkout code
         uses: actions/checkout@master
       - uses: actions/setup-node@v1

--- a/.github/workflows/nlu-regression.yml
+++ b/.github/workflows/nlu-regression.yml
@@ -22,7 +22,8 @@ jobs:
           echo ${{ toJson(github.event) }}
           echo ${{ toJson(github.event.pull_request) }}
           echo ${{ toJson(github.event.pull_request.head) }}  
-          echo ${{ toJson(github.event.pull_request.head.fork) }}
+          echo ${{ toJson(github.event.pull_request.head.repo) }}
+          echo ${{ toJson(github.event.pull_request.head.repo.fork) }}
       - name: Checkout code
         uses: actions/checkout@master
       - uses: actions/setup-node@v1

--- a/.github/workflows/nlu-regression.yml
+++ b/.github/workflows/nlu-regression.yml
@@ -1,29 +1,11 @@
 name: NLU Regression
 on: [pull_request]
 jobs:
-  nlu-warning:
-    if: github.repository != 'botpress/botpress'
-    name: Log NLU warning
-    runs-on: ubuntu-latest
-    steps:
-      - name: Echo github repository
-        run: echo ${{ github.repository }}
-      - name: Echo Warning Message
-        run: |
-          echo "Warning: nlu-regression check could not run because the PR comes from a fork."
-
   nlu:
-    if: github.repository == 'botpress/botpress'
+    if: github.event.pull_request.head.repo.fork = true
     name: Run regression
     runs-on: ubuntu-latest
     steps:
-      - name: Echo github repository
-        run: |
-          echo ${{ toJson(github.event) }}
-          echo ${{ toJson(github.event.pull_request) }}
-          echo ${{ toJson(github.event.pull_request.head) }}  
-          echo ${{ toJson(github.event.pull_request.head.repo) }}
-          echo ${{ toJson(github.event.pull_request.head.repo.fork) }}
       - name: Checkout code
         uses: actions/checkout@master
       - uses: actions/setup-node@v1
@@ -43,3 +25,12 @@ jobs:
       - name: Run Regression Test
         run: |
           yarn start nlu --silent & sleep 5s && node ./build/nlu-regression/index.js
+
+  nlu-warning:
+    if: github.event.pull_request.head.repo.fork = false
+    name: Log NLU warning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo Warning Message
+        run: |
+          echo "Warning: nlu-regression check could not run because the PR comes from a fork."

--- a/.github/workflows/nlu-regression.yml
+++ b/.github/workflows/nlu-regression.yml
@@ -19,11 +19,10 @@ jobs:
     steps:
       - name: Echo github repository
         run: |
-          echo ${{ github.event }}
-          echo ${{ github.event.pull_request }}
-          echo ${{ github.event.pull_request.head }}  
-          echo ${{ github.event.pull_request.head.fork }}
-          echo ${{ toJson(github) }}
+          echo ${{ toJson(github.event) }}
+          echo ${{ toJson(github.event.pull_request) }}
+          echo ${{ toJson(github.event.pull_request.head) }}  
+          echo ${{ toJson(github.event.pull_request.head.fork) }}
       - name: Checkout code
         uses: actions/checkout@master
       - uses: actions/setup-node@v1

--- a/.github/workflows/nlu-regression.yml
+++ b/.github/workflows/nlu-regression.yml
@@ -2,7 +2,7 @@ name: NLU Regression
 on: [pull_request]
 jobs:
   nlu:
-    if: github.event.pull_request.head.repo.fork == true
+    if: github.event.pull_request.head.repo.fork == false
     name: Run regression
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +27,7 @@ jobs:
           yarn start nlu --silent & sleep 5s && node ./build/nlu-regression/index.js
 
   nlu-warning:
-    if: github.event.pull_request.head.repo.fork == false
+    if: github.event.pull_request.head.repo.fork == true
     name: Log NLU warning
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nlu-regression.yml
+++ b/.github/workflows/nlu-regression.yml
@@ -14,18 +14,18 @@ jobs:
       - name: Fetch Node Packages
         run: |
           yarn --verbose
-        name: Install Bitfan
+      - name: Install Bitfan
         run: |
           yarn add npm-cli-login
           ./node_modules/npm-cli-login/bin/npm-cli-login.js -r https://npm.pkg.github.com -u botpressops -p ${{ secrets.PAT_BITFAN }} -e ops@botpress.com
           yarn add @botpress/bitfan
-        name: Build core
+      - name: Build core
         run: |
           NODE_OPTIONS="--max-old-space-size=6000" yarn cmd build:core
       - name: Run Regression Test
         run: |
           yarn start nlu --silent & sleep 5s && node ./build/nlu-regression/index.js
-  
+
   nlu-warning:
     if: ${{ secrets.PAT_BITFAN == null }}
     name: Log NLU warning

--- a/.github/workflows/nlu-regression.yml
+++ b/.github/workflows/nlu-regression.yml
@@ -2,7 +2,7 @@ name: NLU Regression
 on: [pull_request]
 jobs:
   nlu:
-    if: ${{ secrets.PAT_BITFAN != null }}
+    if: github.repository == 'botpress/botpress'
     name: Run regression
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +27,7 @@ jobs:
           yarn start nlu --silent & sleep 5s && node ./build/nlu-regression/index.js
 
   nlu-warning:
-    if: ${{ secrets.PAT_BITFAN == null }}
+    if: github.repository != 'botpress/botpress'
     name: Log NLU warning
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nlu-regression.yml
+++ b/.github/workflows/nlu-regression.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Echo github repository
-        run: echo ${{ github.repository }}
+        run: echo ${{ github.ref }}
       - name: Checkout code
         uses: actions/checkout@master
       - uses: actions/setup-node@v1


### PR DESCRIPTION
Allright, this should fix our issue with the nlu check failing when the PR comes from a fork.

I tought about making a github app that automatically comments a PR when opened from a fork to warn that the nlu check could not run, but this seems like much work and I'm not sure it would be that much usefull.

I also fixed tslint gh check. Because there was no file changes, the check was running on all files. I now skip this step if no files has changed.

@spg, **I just want to take this opportunity to claim my status as "github actions master". If you are docile and attentive enough, maybe I will show you the secret of my art.**