### PR TITLE
fix(hitl): missing column thread_id for new tables

### DIFF
--- a/modules/hitl/src/backend/db.ts
+++ b/modules/hitl/src/backend/db.ts
@@ -71,11 +71,9 @@ export default class HitlDb {
 
   createUserSession = async (event: sdk.IO.Event) => {
     let profileUrl = undefined
-    let displayName =
-      '#' +
-      Math.random()
-        .toString()
-        .substr(2)
+    let displayName = `# ${Math.random()
+      .toString()
+      .substr(2)}`
 
     const user: sdk.User = (await this.bp.users.getOrCreateUser(event.channel, event.target, event.botId)).result
 
@@ -83,7 +81,7 @@ export default class HitlDb {
       const { first_name, last_name, full_name, profile_pic, picture_url } = user.attributes
 
       profileUrl = profile_pic || picture_url
-      displayName = full_name || (first_name && last_name && first_name + ' ' + last_name) || displayName
+      displayName = full_name || (first_name && last_name && `${first_name} ${last_name}`) || displayName
     }
 
     const session = {
@@ -289,7 +287,7 @@ export default class HitlDb {
       .where({ botId })
 
     if (onlyPaused) {
-      query = query.whereRaw('hitl_sessions.paused = ' + this.knex.bool.true())
+      query = query.whereRaw(`hitl_sessions.paused = ${this.knex.bool.true()}`)
     }
 
     if (sessionIds) {

--- a/modules/hitl/src/backend/db.ts
+++ b/modules/hitl/src/backend/db.ts
@@ -37,6 +37,7 @@ export default class HitlDb {
         table.timestamp('last_heard_on')
         table.boolean('paused')
         table.string('paused_trigger')
+        table.string('thread_id')
       })
       .then(() => {
         return this.knex.createTableIfNotExists('hitl_messages', function(table) {

--- a/modules/hitl/src/migrations/v12_10_8-1600900478-add_thread_id_column_to_session_table.ts
+++ b/modules/hitl/src/migrations/v12_10_8-1600900478-add_thread_id_column_to_session_table.ts
@@ -17,7 +17,7 @@ const migration: sdk.ModuleMigration = {
 
       return {
         success: true,
-        message: exists ? 'thread_id column created.' : 'thread_id column already exists, skipping...'
+        message: exists ? 'thread_id column already exists, skipping...' : 'thread_id column created.'
       }
     } catch (err) {
       return { success: false, message: err.message }

--- a/modules/hitl/src/migrations/v12_13_0-1605201510-add_thread_id_column_to_session_table.ts
+++ b/modules/hitl/src/migrations/v12_13_0-1605201510-add_thread_id_column_to_session_table.ts
@@ -1,0 +1,28 @@
+import * as sdk from 'botpress/sdk'
+
+const migration: sdk.ModuleMigration = {
+  info: {
+    description: 'Add thread_id column to hitl_sessions',
+    type: 'database'
+  },
+  up: async ({ bp }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
+    try {
+      const tableName = 'hitl_sessions'
+      const column = 'thread_id'
+      const exists = await bp.database.schema.hasColumn(tableName, column)
+
+      if (!exists) {
+        await bp.database.schema.alterTable(tableName, table => table.string(column))
+      }
+
+      return {
+        success: true,
+        message: exists ? 'thread_id column already exists, skipping...' : 'thread_id column created.'
+      }
+    } catch (err) {
+      return { success: false, message: err.message }
+    }
+  }
+}
+
+export default migration

--- a/modules/hitl/src/migrations/v12_13_0-1605201510-add_thread_id_column_to_session_table.ts
+++ b/modules/hitl/src/migrations/v12_13_0-1605201510-add_thread_id_column_to_session_table.ts
@@ -1,28 +1,5 @@
-import * as sdk from 'botpress/sdk'
-
-const migration: sdk.ModuleMigration = {
-  info: {
-    description: 'Add thread_id column to hitl_sessions',
-    type: 'database'
-  },
-  up: async ({ bp }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
-    try {
-      const tableName = 'hitl_sessions'
-      const column = 'thread_id'
-      const exists = await bp.database.schema.hasColumn(tableName, column)
-
-      if (!exists) {
-        await bp.database.schema.alterTable(tableName, table => table.string(column))
-      }
-
-      return {
-        success: true,
-        message: exists ? 'thread_id column already exists, skipping...' : 'thread_id column created.'
-      }
-    } catch (err) {
-      return { success: false, message: err.message }
-    }
-  }
-}
-
-export default migration
+import previousMigration from './v12_10_8-1600900478-add_thread_id_column_to_session_table'
+// This is the exact same migration as modules/hitl/src/migrations/v12_10_8-1600900478-add_thread_id_column_to_session_table.ts.
+// This will be useful for clients that upgrade to 12.13.0 and are missing the thread_id column, but don't want to add the column manually by connecting to their database.
+// See https://github.com/botpress/botpress/pull/4181 for more information
+export default previousMigration


### PR DESCRIPTION
If users where using Botpress > 12.10.8 and activated the HITL module for the first time, the newly created `hitl_sessions` table was missing the `thread_id` column. 

This column was only added through a migration (`modules/hitl/src/migrations/v12_10_8-1600900478-add_thread_id_column_to_session_table.ts`) for already existing tables.

For Botpress installations experiencing errors like:
```
Launcher Unhandled Rejection [error, select * from "hitl_sessions" where "botId" = $1 and "channel" = $2 and "userId" = $3 and "thread_id" = $4 limit $5 - the column «thread_id»] do not exists
```
here are the workarounds:

1. Make sure to launch Botpress with either the `--auto-migrate` flag or the `AUTO_MIGRATE=true` environment variable
2. If the issue still persists, upgrade to Botpress 12.13.0
2. If the issue still persists and you don't want to upgrade to 12.13.0, create the column manually by executing the following command on your database: 
```
alter table hitl_sessions add column "thread_id" character varying(255);
```