### PR TITLE
fix(channel-web): fix userId generation and assignment

### DIFF
--- a/modules/channel-web/assets/examples/embedded-webchat.html
+++ b/modules/channel-web/assets/examples/embedded-webchat.html
@@ -66,7 +66,8 @@
 
       let lastConfig = {
         host: window.location.origin || 'http://localhost:3000',
-        botId: botId
+        botId: botId,
+        lazySocket: false
         /*
         To change the styling of the webchat, you can either edit directly default.css, or use the extraStylesheet property.
         This allows you to customize the chat on a per-bot basis.
@@ -156,7 +157,7 @@
           botId: botId,
           userId: Math.random()
             .toString()
-            .slice(-4),
+            .slice(-25),
           showConversationsButton: false,
           botName: 'Chat window #2',
           className: 'chat2',

--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -19,6 +19,7 @@ const ERR_CONV_ID_REQ = '`conversationId` is required and must be valid'
 const ERR_BAD_LANGUAGE = '`language` is required and must be valid'
 
 const USER_ID_MAX_LENGTH = 40
+const USER_ID_MIN_LENGTH = 18
 const SUPPORTED_MESSAGES = [
   'text',
   'quick_reply',
@@ -246,7 +247,7 @@ export default async (bp: typeof sdk, db: Database) => {
   })
 
   function validateUserId(userId: string) {
-    if (!userId || userId.length > USER_ID_MAX_LENGTH) {
+    if (!userId || userId.length > USER_ID_MAX_LENGTH || userId.length < USER_ID_MIN_LENGTH) {
       return false
     }
 

--- a/modules/channel-web/src/views/lite/core/socket.tsx
+++ b/modules/channel-web/src/views/lite/core/socket.tsx
@@ -39,14 +39,16 @@ export default class BpSocket {
   }
 
   public changeUserId(newId: string) {
-    this.events.updateVisitorId(newId, this.userIdScope)
+    if (typeof newId === 'string' && newId !== 'undefined') {
+      this.events.updateVisitorId(newId, this.userIdScope)
+    }
   }
 
   /** Waits until the VISITOR ID is set  */
   public waitForUserId(): Promise<void> {
     return new Promise((resolve, reject) => {
       const interval = setInterval(() => {
-        if (window.__BP_VISITOR_ID) {
+        if (typeof window.__BP_VISITOR_ID === 'string' && window.__BP_VISITOR_ID !== 'undefined') {
           clearInterval(interval)
 
           this.userId = window.__BP_VISITOR_ID

--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -74,10 +74,11 @@ class Web extends React.Component<MainProps> {
     if (this.props.activeView === 'side' || this.props.isFullscreen) {
       this.hasBeenInitialized = true
 
-      if (this.isLazySocket()) {
+      if (this.isLazySocket() || !this.socket) {
         await this.initializeSocket()
       }
 
+      await this.socket.waitForUserId()
       await this.props.initializeChat()
     }
   }

--- a/modules/extensions/src/views/lite/components/debugger/index.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/index.tsx
@@ -24,7 +24,7 @@ import Unauthorized from './Unauthorized'
 
 export const updater = { callback: undefined }
 
-const WEBCHAT_WIDTH = 240
+const WEBCHAT_WIDTH = 300
 const DEV_TOOLS_WIDTH = 240
 const RETRY_PERIOD = 500 // Delay (ms) between each call to the backend to fetch a desired event
 const RETRY_SECURITY_FACTOR = 3

--- a/src/bp/ui-studio/src/web/util/Auth.ts
+++ b/src/bp/ui-studio/src/web/util/Auth.ts
@@ -66,16 +66,18 @@ export const login = (email, password) => {
 }
 
 export const setVisitorId = (userId: string, userIdScope?: string) => {
-  storage.set(userIdScope ? `bp/socket/${userIdScope}/user` : 'bp/socket/user', userId)
-  window.__BP_VISITOR_ID = userId
+  if (typeof userId === 'string' && userId !== 'undefined') {
+    storage.set(userIdScope ? `bp/socket/${userIdScope}/user` : 'bp/socket/user', userId)
+    window.__BP_VISITOR_ID = userId
+  }
 }
 
 export const getUniqueVisitorId = (userIdScope?: string): string => {
   const key = userIdScope ? `bp/socket/${userIdScope}/user` : 'bp/socket/user'
 
   let userId = storage.get(key)
-  if (!userId) {
-    userId = nanoid()
+  if (typeof userId !== 'string' || userId === 'undefined') {
+    userId = nanoid(24)
     storage.set(key, userId)
   }
 


### PR DESCRIPTION
There was a bug since v12.9.0 on the userId generation logic.  There was a race condition that made some userId's equal "undefined".

I also added some logic to prevent undefined (or short/unsecure) userIds from being passed to the backend.

Manual tests:
- lazy socket ON (embedded)
- lazy socket ON (full-screen)
- lazy socket OFF (full-screen)
- lazy socket OFF (embedded)
- on-the-fly userId regeneration

Also tested everything on slow 3g network mode to prevent race conditions