### PR TITLE
fix(nlu): lang id is still executed even if some models are out of cache

### DIFF
--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -59,7 +59,8 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
           modelProvider,
           engine,
           anticipatedLanguage,
-          defaultLanguage
+          defaultLanguage,
+          bp.logger.forBot(botId)
         )
         const nluResults = await predictionHandler.predict(preview, nlu?.includedContexts)
 

--- a/modules/nlu/src/backend/prediction-handler.ts
+++ b/modules/nlu/src/backend/prediction-handler.ts
@@ -19,9 +19,7 @@ export class PredictionHandler {
     const modelCacheState = _.mapValues(this.modelsByLang, model => ({ model, loaded: this.engine.hasModel(model) }))
 
     const missingModels = _(modelCacheState)
-      .toPairs()
-      .filter(([lang, mod]) => !mod.loaded)
-      .fromPairs()
+      .pickBy(mod => !mod.loaded)
       .mapValues(({ model }) => model)
       .value()
 
@@ -33,9 +31,7 @@ export class PredictionHandler {
     }
 
     const loadedModels = _(modelCacheState)
-      .toPairs()
-      .filter(([lang, mod]) => mod.loaded)
-      .fromPairs()
+      .pickBy(mod => mod.loaded)
       .mapValues(({ model }) => model)
       .value()
 

--- a/modules/nlu/src/backend/prediction-handler.ts
+++ b/modules/nlu/src/backend/prediction-handler.ts
@@ -11,11 +11,35 @@ export class PredictionHandler {
     private modelProvider: ModelProvider,
     private engine: sdk.NLU.Engine,
     private anticipatedLanguage: string,
-    private defaultLanguage: string
+    private defaultLanguage: string,
+    private logger: sdk.Logger
   ) {}
 
   async predict(textInput: string, includedContexts: string[]) {
-    const detectedLanguage = await this.engine.detectLanguage(textInput, this.modelsByLang)
+    const modelCacheState = _.mapValues(this.modelsByLang, model => ({ model, loaded: this.engine.hasModel(model) }))
+
+    const missingModels = _(modelCacheState)
+      .toPairs()
+      .filter(([lang, mod]) => !mod.loaded)
+      .fromPairs()
+      .mapValues(({ model }) => model)
+      .value()
+
+    if (Object.keys(missingModels).length) {
+      const formattedMissingModels = JSON.stringify(missingModels, undefined, 2)
+      this.logger.warn(
+        `About to detect language, but the following models are not loaded: \n${formattedMissingModels}\nMake sure you have enough cache space to fit all models for your bot.`
+      )
+    }
+
+    const loadedModels = _(modelCacheState)
+      .toPairs()
+      .filter(([lang, mod]) => mod.loaded)
+      .fromPairs()
+      .mapValues(({ model }) => model)
+      .value()
+
+    const detectedLanguage = await this.engine.detectLanguage(textInput, loadedModels)
 
     let nluResults: sdk.IO.EventUnderstanding | undefined
 

--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -213,7 +213,7 @@ export default class Engine implements NLU.Engine {
     }
 
     this.modelsById.set(modelId, modelCacheItem)
-    trainDebug('Model loaded with succes.')
+    trainDebug('Model loaded with success')
     trainDebug(`Model cache entries are: [${this.modelsById.keys().join(', ')}]`)
   }
 
@@ -292,9 +292,17 @@ export default class Engine implements NLU.Engine {
   }
 
   async detectLanguage(text: string, modelsByLang: _.Dictionary<string>): Promise<string> {
+    trainDebug(`Detecting language for input: "${text}"`)
+
     const predictorsByLang = _.mapValues(modelsByLang, id => this.modelsById.get(id)?.predictors)
     if (!this._dictionnaryIsFilled(predictorsByLang)) {
-      throw new Error(`one of models is not loaded: ${modelsByLang}`)
+      const missingLangs = _(predictorsByLang)
+        .toPairs()
+        .filter(([lang, pred]) => _.isUndefined(pred))
+        .fromPairs()
+        .keys()
+        .value()
+      throw new Error(`No models loaded for the following languages: [${missingLangs.join(', ')}]`)
     }
     return DetectLanguage(text, predictorsByLang, this._tools)
   }

--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -297,9 +297,7 @@ export default class Engine implements NLU.Engine {
     const predictorsByLang = _.mapValues(modelsByLang, id => this.modelsById.get(id)?.predictors)
     if (!this._dictionnaryIsFilled(predictorsByLang)) {
       const missingLangs = _(predictorsByLang)
-        .toPairs()
-        .filter(([lang, pred]) => _.isUndefined(pred))
-        .fromPairs()
+        .pickBy(pred => _.isUndefined(pred))
         .keys()
         .value()
       throw new Error(`No models loaded for the following languages: [${missingLangs.join(', ')}]`)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25970722/99848262-7628f480-2b47-11eb-81a4-2344ec22f293.png)
