### PR TITLE
feat(core): base for shared libraries

### DIFF
--- a/src/bp/core/services/action/action-service.ts
+++ b/src/bp/core/services/action/action-service.ts
@@ -93,7 +93,7 @@ export default class ActionService {
 
   private _listenForCacheInvalidation() {
     this.cache.events.on('invalidation', key => {
-      if (key.toLowerCase().indexOf('/actions') > -1) {
+      if (key.toLowerCase().indexOf('/actions') > -1 || key.toLowerCase().indexOf('/libraries') > -1) {
         this._invalidateDebounce(key)
       }
     })
@@ -102,7 +102,7 @@ export default class ActionService {
   // Debouncing invalidate since we get a lot of events when it happens
   private _invalidateRequire() {
     Object.keys(require.cache)
-      .filter(r => r.match(/(\\|\/)actions(\\|\/)/g))
+      .filter(r => r.match(/(\\|\/)actions(\\|\/)/g) || r.match(/(\\|\/)shared_libs(\\|\/)/g))
       .map(file => delete require.cache[file])
 
     clearRequireCache()
@@ -356,7 +356,7 @@ export class ScopedActionService {
 
     const botFolder = action.scope === 'global' ? 'global' : `bots/${this.botId}`
     const dirPath = path.resolve(path.join(process.PROJECT_LOCATION, `/data/${botFolder}/actions/${actionName}.js`))
-    const lookups = getBaseLookupPaths(dirPath)
+    const lookups = getBaseLookupPaths(dirPath, 'actions')
 
     return { code, dirPath, lookups, action }
   }

--- a/src/bp/core/services/action/utils.ts
+++ b/src/bp/core/services/action/utils.ts
@@ -3,16 +3,16 @@ import { ActionScope } from 'common/typings'
 import { requireAtPaths } from 'core/modules/require'
 import path from 'path'
 
-export const getBaseLookupPaths = (fullPath: string) => {
+export const getBaseLookupPaths = (fullPath: string, lastPathPart: string) => {
   const actionLocation = path.dirname(fullPath)
 
   let parts = path.relative(process.PROJECT_LOCATION, actionLocation).split(path.sep)
-  parts = parts.slice(parts.indexOf('actions') + 1) // We only keep the parts after /actions/...
+  parts = parts.slice(parts.indexOf(lastPathPart) + 1) // We only keep the parts after /actions/...
 
-  const lookups: string[] = [actionLocation]
+  const lookups: string[] = [actionLocation, path.join(process.PROJECT_LOCATION, 'shared_libs')]
 
   if (parts[0] in process.LOADED_MODULES) {
-    // the action is in a directory by the same name as a module
+    // the hook/action is in a directory by the same name as a module
     lookups.unshift(process.LOADED_MODULES[parts[0]])
   }
 


### PR DESCRIPTION
This is a minor modification of the core in prevision of the shared libraries module which will be shipped later.

It adds a lookup to actions and hooks in the folder `shared_libs` , so any file or library in this folder can be called seamlessly by hooks and actions

Basically, changes in the ghost in the `libraries` folder triggers a sync which copies the files locally in the `shared_libs` folder