### PR TITLE
chore(gh): increment bitfan version

### DIFF
--- a/.github/workflows/nlu-regression.yml
+++ b/.github/workflows/nlu-regression.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           yarn add npm-cli-login
           ./node_modules/npm-cli-login/bin/npm-cli-login.js -r https://npm.pkg.github.com -u botpressops -p ${{ secrets.PAT_BITFAN }} -e ops@botpress.com
-          yarn add @botpress/bitfan@0.3.0
+          yarn add @botpress/bitfan@0.3.1
       - name: Run Regression Test
         run: |
           yarn start nlu --silent --ducklingEnabled=false & 


### PR DESCRIPTION
In version 0.3.0, bitfan was not throwing when one or more tests where failing. Version 0.3.1 is fixed.