### PR TITLE
fix(telemetry): negative limit not supported in pg

### DIFF
--- a/src/bp/core/repositories/telemetry.ts
+++ b/src/bp/core/repositories/telemetry.ts
@@ -51,13 +51,13 @@ export class TelemetryRepository {
 
   async pruneEntries(): Promise<void> {
     const config = await this.config.getBotpressConfig()
-    const limit = config.telemetry?.entriesLimit ?? DEFAULT_ENTRIES_LIMIT
+    const offset = config.telemetry?.entriesLimit ?? DEFAULT_ENTRIES_LIMIT
 
     const uuIds = await this.database.knex
       .from(this.tableName)
       .select('uuid')
       .orderBy('creationDate', 'desc')
-      .offset(limit)
+      .offset(offset)
       .then(rows => rows.map(entry => entry.uuid))
 
     return this.removeMany(uuIds)

--- a/src/bp/core/repositories/telemetry.ts
+++ b/src/bp/core/repositories/telemetry.ts
@@ -57,7 +57,6 @@ export class TelemetryRepository {
       .from(this.tableName)
       .select('uuid')
       .orderBy('creationDate', 'desc')
-      .limit(-1)
       .offset(limit)
       .then(rows => rows.map(entry => entry.uuid))
 


### PR DESCRIPTION
I ended up having the following issue while conducting load tests:

`error, select "uuid" from "telemetry" order by "creationDate" desc limit $1 offset $2- LIMIT mus not be negative`

**2 ways to interpret the original author wanted (which is not me contrary to what git history says) :**

1- is that the original author used sqlite -1  as described [here](https://sqlite.org/lang_select.html#limitoffset) ` If the LIMIT expression evaluates to a negative value, then there is no upper bound on the number of rows returned`

2- the author wanted to reverse the query order which is supported by some sql engine but not pg.

If I think logically what we want is to insert new rows, then prune all the entries over an offset ==> `config.telemetry?.entriesLimit ?? DEFAULT_ENTRIES_LIMIT`. Thus, 1