### PR TITLE
chore(nlu): replaced alternate utterance by spell-checker

### DIFF
--- a/build/nlu-regression/current_scores/bpds-intent.json
+++ b/build/nlu-regression/current_scores/bpds-intent.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2020-11-26T22:38:49.729Z",
+  "generatedOn": "2020-11-27T19:30:08.495Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-intent.json
+++ b/build/nlu-regression/current_scores/bpds-intent.json
@@ -1,35 +1,35 @@
 {
-  "generatedOn": "2020-11-26T21:55:33.751Z",
+  "generatedOn": "2020-11-26T22:38:49.729Z",
   "scores": [
     {
       "metric": "accuracy",
       "problem": "bpsd A",
       "seed": 42,
-      "score": 0.6727272727272727
+      "score": 0.6772727272727272
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpsd A",
       "seed": 42,
-      "score": 0.7772727272727272
+      "score": 0.7818181818181819
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A",
       "seed": 42,
-      "score": 0.7931034482758621
+      "score": 0.7954545454545454
     },
     {
       "metric": "oosRecall",
       "problem": "bpsd A",
       "seed": 42,
-      "score": 0.69
+      "score": 0.7
     },
     {
       "metric": "oosF1",
       "problem": "bpsd A",
       "seed": 42,
-      "score": 0.7379679144385026
+      "score": 0.7446808510638298
     },
     {
       "metric": "accuracy",
@@ -65,109 +65,109 @@
       "metric": "accuracy",
       "problem": "bpsd A",
       "seed": 666,
-      "score": 0.6863636363636364
+      "score": 0.6954545454545454
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpsd A",
       "seed": 666,
-      "score": 0.7818181818181819
+      "score": 0.7863636363636364
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A",
       "seed": 666,
-      "score": 0.7888888888888889
+      "score": 0.7912087912087912
     },
     {
       "metric": "oosRecall",
       "problem": "bpsd A",
       "seed": 666,
-      "score": 0.71
+      "score": 0.72
     },
     {
       "metric": "oosF1",
       "problem": "bpsd A",
       "seed": 666,
-      "score": 0.7473684210526317
+      "score": 0.7539267015706805
     },
     {
       "metric": "accuracy",
       "problem": "bpds A imbalanced",
       "seed": 42,
-      "score": 0.45454545454545453
+      "score": 0.45
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A imbalanced",
       "seed": 42,
-      "score": 0.6181818181818182
+      "score": 0.6090909090909091
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced",
       "seed": 42,
-      "score": 0.5754716981132075
+      "score": 0.5660377358490566
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A imbalanced",
       "seed": 42,
-      "score": 0.61
+      "score": 0.6
     },
     {
       "metric": "oosF1",
       "problem": "bpds A imbalanced",
       "seed": 42,
-      "score": 0.5922330097087378
+      "score": 0.5825242718446602
     },
     {
       "metric": "accuracy",
       "problem": "bpds A imbalanced",
       "seed": 69,
-      "score": 0.6181818181818182
+      "score": 0.6090909090909091
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A imbalanced",
       "seed": 69,
-      "score": 0.740909090909091
+      "score": 0.7272727272727273
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced",
       "seed": 69,
-      "score": 0.7945205479452054
+      "score": 0.7702702702702703
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A imbalanced",
       "seed": 69,
-      "score": 0.58
+      "score": 0.57
     },
     {
       "metric": "oosF1",
       "problem": "bpds A imbalanced",
       "seed": 69,
-      "score": 0.6705202312138728
+      "score": 0.6551724137931034
     },
     {
       "metric": "accuracy",
       "problem": "bpds A imbalanced",
       "seed": 666,
-      "score": 0.5636363636363636
+      "score": 0.5545454545454546
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A imbalanced",
       "seed": 666,
-      "score": 0.6909090909090909
+      "score": 0.6818181818181818
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced",
       "seed": 666,
-      "score": 0.7666666666666667
+      "score": 0.7419354838709677
     },
     {
       "metric": "oosRecall",
@@ -179,7 +179,7 @@
       "metric": "oosF1",
       "problem": "bpds A imbalanced",
       "seed": 666,
-      "score": 0.575
+      "score": 0.5679012345679013
     },
     {
       "metric": "accuracy",
@@ -191,13 +191,13 @@
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot",
       "seed": 42,
-      "score": 0.7136363636363636
+      "score": 0.7090909090909091
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot",
       "seed": 42,
-      "score": 0.6907216494845361
+      "score": 0.6836734693877551
     },
     {
       "metric": "oosRecall",
@@ -209,13 +209,13 @@
       "metric": "oosF1",
       "problem": "bpds A fewshot",
       "seed": 42,
-      "score": 0.6802030456852791
+      "score": 0.6767676767676768
     },
     {
       "metric": "accuracy",
       "problem": "bpds A fewshot",
       "seed": 69,
-      "score": 0.5227272727272727
+      "score": 0.5272727272727272
     },
     {
       "metric": "oosAccuracy",
@@ -227,19 +227,19 @@
       "metric": "oosPrecision",
       "problem": "bpds A fewshot",
       "seed": 69,
-      "score": 0.676923076923077
+      "score": 0.6716417910447762
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A fewshot",
       "seed": 69,
-      "score": 0.44
+      "score": 0.45
     },
     {
       "metric": "oosF1",
       "problem": "bpds A fewshot",
       "seed": 69,
-      "score": 0.5333333333333334
+      "score": 0.5389221556886228
     },
     {
       "metric": "accuracy",
@@ -251,13 +251,13 @@
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot",
       "seed": 666,
-      "score": 0.7318181818181818
+      "score": 0.7227272727272728
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot",
       "seed": 666,
-      "score": 0.7469879518072289
+      "score": 0.7294117647058823
     },
     {
       "metric": "oosRecall",
@@ -269,13 +269,13 @@
       "metric": "oosF1",
       "problem": "bpds A fewshot",
       "seed": 666,
-      "score": 0.6775956284153004
+      "score": 0.6702702702702702
     },
     {
       "metric": "accuracy",
       "problem": "bpds B",
       "seed": 42,
-      "score": 0.7
+      "score": 0.6954545454545454
     },
     {
       "metric": "oosAccuracy",
@@ -305,61 +305,61 @@
       "metric": "accuracy",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.6545454545454545
+      "score": 0.6590909090909091
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.7863636363636364
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds B",
-      "seed": 69,
-      "score": 0.9344262295081968
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds B",
-      "seed": 69,
-      "score": 0.57
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds B",
-      "seed": 69,
-      "score": 0.7080745341614907
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpds B",
-      "seed": 666,
-      "score": 0.6772727272727272
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds B",
-      "seed": 666,
       "score": 0.7954545454545454
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds B",
+      "seed": 69,
+      "score": 0.9365079365079365
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpds B",
+      "seed": 69,
+      "score": 0.59
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds B",
+      "seed": 69,
+      "score": 0.7239263803680981
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpds B",
       "seed": 666,
-      "score": 0.8985507246376812
+      "score": 0.6818181818181818
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpds B",
+      "seed": 666,
+      "score": 0.8
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds B",
+      "seed": 666,
+      "score": 0.8888888888888888
     },
     {
       "metric": "oosRecall",
       "problem": "bpds B",
       "seed": 666,
-      "score": 0.62
+      "score": 0.64
     },
     {
       "metric": "oosF1",
       "problem": "bpds B",
       "seed": 666,
-      "score": 0.7337278106508875
+      "score": 0.7441860465116279
     }
   ]
 }

--- a/build/nlu-regression/current_scores/bpds-intent.json
+++ b/build/nlu-regression/current_scores/bpds-intent.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2020-11-26T15:02:40.071Z",
+  "generatedOn": "2020-11-26T20:32:52.938Z",
   "scores": [
     {
       "metric": "accuracy",
@@ -11,13 +11,13 @@
       "metric": "oosAccuracy",
       "problem": "bpsd A",
       "seed": 42,
-      "score": 0.7772727272727272
+      "score": 0.7818181818181819
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A",
       "seed": 42,
-      "score": 0.7865168539325843
+      "score": 0.7954545454545454
     },
     {
       "metric": "oosRecall",
@@ -29,7 +29,7 @@
       "metric": "oosF1",
       "problem": "bpsd A",
       "seed": 42,
-      "score": 0.7407407407407408
+      "score": 0.7446808510638298
     },
     {
       "metric": "accuracy",
@@ -41,115 +41,115 @@
       "metric": "oosAccuracy",
       "problem": "bpsd A",
       "seed": 69,
+      "score": 0.7863636363636364
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpsd A",
+      "seed": 69,
+      "score": 0.797752808988764
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpsd A",
+      "seed": 69,
+      "score": 0.71
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpsd A",
+      "seed": 69,
+      "score": 0.7513227513227513
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpsd A",
+      "seed": 666,
+      "score": 0.6863636363636364
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpsd A",
+      "seed": 666,
       "score": 0.7818181818181819
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A",
-      "seed": 69,
+      "seed": 666,
       "score": 0.7888888888888889
     },
     {
       "metric": "oosRecall",
       "problem": "bpsd A",
-      "seed": 69,
+      "seed": 666,
       "score": 0.71
     },
     {
       "metric": "oosF1",
       "problem": "bpsd A",
-      "seed": 69,
+      "seed": 666,
       "score": 0.7473684210526317
     },
     {
       "metric": "accuracy",
-      "problem": "bpsd A",
-      "seed": 666,
-      "score": 0.6863636363636364
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpsd A",
-      "seed": 666,
-      "score": 0.7772727272727272
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpsd A",
-      "seed": 666,
-      "score": 0.7802197802197802
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpsd A",
-      "seed": 666,
-      "score": 0.71
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpsd A",
-      "seed": 666,
-      "score": 0.743455497382199
-    },
-    {
-      "metric": "accuracy",
       "problem": "bpds A imbalanced",
       "seed": 42,
-      "score": 0.45
+      "score": 0.45454545454545453
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A imbalanced",
       "seed": 42,
-      "score": 0.6136363636363636
+      "score": 0.6181818181818182
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced",
       "seed": 42,
-      "score": 0.5714285714285714
+      "score": 0.5754716981132075
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A imbalanced",
       "seed": 42,
-      "score": 0.6
+      "score": 0.61
     },
     {
       "metric": "oosF1",
       "problem": "bpds A imbalanced",
       "seed": 42,
-      "score": 0.5853658536585366
+      "score": 0.5922330097087378
     },
     {
       "metric": "accuracy",
       "problem": "bpds A imbalanced",
       "seed": 69,
-      "score": 0.6136363636363636
+      "score": 0.6181818181818182
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A imbalanced",
       "seed": 69,
-      "score": 0.7363636363636363
+      "score": 0.740909090909091
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced",
       "seed": 69,
-      "score": 0.7916666666666666
+      "score": 0.7945205479452054
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A imbalanced",
       "seed": 69,
-      "score": 0.57
+      "score": 0.58
     },
     {
       "metric": "oosF1",
       "problem": "bpds A imbalanced",
       "seed": 69,
-      "score": 0.6627906976744186
+      "score": 0.6705202312138728
     },
     {
       "metric": "accuracy",
@@ -305,31 +305,31 @@
       "metric": "accuracy",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.6727272727272727
+      "score": 0.6636363636363637
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.8045454545454546
+      "score": 0.7954545454545454
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.9384615384615385
+      "score": 0.9365079365079365
     },
     {
       "metric": "oosRecall",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.61
+      "score": 0.59
     },
     {
       "metric": "oosF1",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.7393939393939394
+      "score": 0.7239263803680981
     },
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-intent.json
+++ b/build/nlu-regression/current_scores/bpds-intent.json
@@ -1,35 +1,35 @@
 {
-  "generatedOn": "2020-11-26T20:32:52.938Z",
+  "generatedOn": "2020-11-26T21:55:33.751Z",
   "scores": [
     {
       "metric": "accuracy",
       "problem": "bpsd A",
       "seed": 42,
-      "score": 0.6772727272727272
+      "score": 0.6727272727272727
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpsd A",
       "seed": 42,
-      "score": 0.7818181818181819
+      "score": 0.7772727272727272
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A",
       "seed": 42,
-      "score": 0.7954545454545454
+      "score": 0.7931034482758621
     },
     {
       "metric": "oosRecall",
       "problem": "bpsd A",
       "seed": 42,
-      "score": 0.7
+      "score": 0.69
     },
     {
       "metric": "oosF1",
       "problem": "bpsd A",
       "seed": 42,
-      "score": 0.7446808510638298
+      "score": 0.7379679144385026
     },
     {
       "metric": "accuracy",
@@ -215,31 +215,31 @@
       "metric": "accuracy",
       "problem": "bpds A fewshot",
       "seed": 69,
-      "score": 0.5272727272727272
+      "score": 0.5227272727272727
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot",
       "seed": 69,
-      "score": 0.6545454545454545
+      "score": 0.65
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot",
       "seed": 69,
-      "score": 0.6818181818181818
+      "score": 0.676923076923077
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A fewshot",
       "seed": 69,
-      "score": 0.45
+      "score": 0.44
     },
     {
       "metric": "oosF1",
       "problem": "bpds A fewshot",
       "seed": 69,
-      "score": 0.5421686746987951
+      "score": 0.5333333333333334
     },
     {
       "metric": "accuracy",
@@ -275,61 +275,61 @@
       "metric": "accuracy",
       "problem": "bpds B",
       "seed": 42,
-      "score": 0.7045454545454546
+      "score": 0.7
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds B",
       "seed": 42,
-      "score": 0.8181818181818182
+      "score": 0.8136363636363636
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds B",
       "seed": 42,
-      "score": 0.8947368421052632
+      "score": 0.8933333333333333
     },
     {
       "metric": "oosRecall",
       "problem": "bpds B",
       "seed": 42,
-      "score": 0.68
+      "score": 0.67
     },
     {
       "metric": "oosF1",
       "problem": "bpds B",
       "seed": 42,
-      "score": 0.7727272727272727
+      "score": 0.7657142857142857
     },
     {
       "metric": "accuracy",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.6636363636363637
+      "score": 0.6545454545454545
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.7954545454545454
+      "score": 0.7863636363636364
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.9365079365079365
+      "score": 0.9344262295081968
     },
     {
       "metric": "oosRecall",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.59
+      "score": 0.57
     },
     {
       "metric": "oosF1",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.7239263803680981
+      "score": 0.7080745341614907
     },
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-slots.json
+++ b/build/nlu-regression/current_scores/bpds-slots.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2020-11-26T21:55:45.855Z",
+  "generatedOn": "2020-11-26T22:39:01.741Z",
   "scores": [
     {
       "metric": "avgScore:slotsAre",

--- a/build/nlu-regression/current_scores/bpds-slots.json
+++ b/build/nlu-regression/current_scores/bpds-slots.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2020-11-26T20:33:04.251Z",
+  "generatedOn": "2020-11-26T21:55:45.855Z",
   "scores": [
     {
       "metric": "avgScore:slotsAre",

--- a/build/nlu-regression/current_scores/bpds-slots.json
+++ b/build/nlu-regression/current_scores/bpds-slots.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2020-11-26T22:39:01.741Z",
+  "generatedOn": "2020-11-27T19:30:19.842Z",
   "scores": [
     {
       "metric": "avgScore:slotsAre",

--- a/build/nlu-regression/current_scores/bpds-slots.json
+++ b/build/nlu-regression/current_scores/bpds-slots.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2020-11-26T15:02:52.371Z",
+  "generatedOn": "2020-11-26T20:33:04.251Z",
   "scores": [
     {
       "metric": "avgScore:slotsAre",

--- a/build/nlu-regression/current_scores/bpds-spell.json
+++ b/build/nlu-regression/current_scores/bpds-spell.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2020-11-26T22:39:04.841Z",
+  "generatedOn": "2020-11-27T19:30:23.386Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-spell.json
+++ b/build/nlu-regression/current_scores/bpds-spell.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2020-11-26T15:02:55.567Z",
+  "generatedOn": "2020-11-26T20:33:07.288Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-spell.json
+++ b/build/nlu-regression/current_scores/bpds-spell.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2020-11-26T20:33:07.288Z",
+  "generatedOn": "2020-11-26T21:55:49.206Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-spell.json
+++ b/build/nlu-regression/current_scores/bpds-spell.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2020-11-26T21:55:49.206Z",
+  "generatedOn": "2020-11-26T22:39:04.841Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/clinc150.json
+++ b/build/nlu-regression/current_scores/clinc150.json
@@ -1,35 +1,35 @@
 {
-  "generatedOn": "2020-11-26T15:08:37.729Z",
+  "generatedOn": "2020-11-26T20:38:41.962Z",
   "scores": [
     {
       "metric": "accuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.7248837209302326
+      "score": 0.7247674418604652
     },
     {
       "metric": "oosAccuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.856046511627907
+      "score": 0.8555813953488373
     },
     {
       "metric": "oosPrecision",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.275974025974026
+      "score": 0.27388535031847133
     },
     {
       "metric": "oosRecall",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.07727272727272727
+      "score": 0.07818181818181819
     },
     {
       "metric": "oosF1",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.12073863636363637
+      "score": 0.12164073550212164
     }
   ]
 }

--- a/build/nlu-regression/current_scores/clinc150.json
+++ b/build/nlu-regression/current_scores/clinc150.json
@@ -1,35 +1,35 @@
 {
-  "generatedOn": "2020-11-26T20:38:41.962Z",
+  "generatedOn": "2020-11-26T22:01:53.413Z",
   "scores": [
     {
       "metric": "accuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.7247674418604652
+      "score": 0.7243023255813954
     },
     {
       "metric": "oosAccuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.8555813953488373
+      "score": 0.8552325581395349
     },
     {
       "metric": "oosPrecision",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.27388535031847133
+      "score": 0.26537216828478966
     },
     {
       "metric": "oosRecall",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.07818181818181819
+      "score": 0.07454545454545454
     },
     {
       "metric": "oosF1",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.12164073550212164
+      "score": 0.1163946061036196
     }
   ]
 }

--- a/build/nlu-regression/current_scores/clinc150.json
+++ b/build/nlu-regression/current_scores/clinc150.json
@@ -1,35 +1,35 @@
 {
-  "generatedOn": "2020-11-26T22:01:53.413Z",
+  "generatedOn": "2020-11-26T22:44:36.765Z",
   "scores": [
     {
       "metric": "accuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.7243023255813954
+      "score": 0.7248837209302326
     },
     {
       "metric": "oosAccuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.8552325581395349
+      "score": 0.8563953488372092
     },
     {
       "metric": "oosPrecision",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.26537216828478966
+      "score": 0.29357798165137616
     },
     {
       "metric": "oosRecall",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.07454545454545454
+      "score": 0.08727272727272728
     },
     {
       "metric": "oosF1",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.1163946061036196
+      "score": 0.1345480028030834
     }
   ]
 }

--- a/build/nlu-regression/current_scores/clinc150.json
+++ b/build/nlu-regression/current_scores/clinc150.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2020-11-26T22:44:36.765Z",
+  "generatedOn": "2020-11-27T19:35:25.227Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/modules/nlu-testing/src/bot-templates/bp-nlu-regression-testing/latest-results.csv
+++ b/modules/nlu-testing/src/bot-templates/bp-nlu-regression-testing/latest-results.csv
@@ -1,4 +1,4 @@
-utterance,context,conditions,status,date: 10/21/2020,summary: 68.95,nlu seed: 42
+utterance,context,conditions,status,date: 11/27/2020,summary: 69.8,nlu seed: 42
 What is the contact number?,A,"-intent,is,a-contact-details",pass
 WHAT IS THE CONTACT NUMBER?,A,"-intent,is,a-contact-details",pass
 WHAT is THE contact NUMBER,A,"-intent,is,a-contact-details",pass
@@ -13,11 +13,11 @@ Where can I find your ladnline?,C,"-intent,is,c-contact-details",pass
 Where can I find your ladnline?,D,"-intent,is,d-contact-details",pass
 Where can I find your ladnline?,E,"-intent,is,e-contact-details",fail
 Where can I find your ladnline?,F,"-intent,is,f-contact-details",pass
-Please help with technical isseu,A,"-intent,is,a-problem",fail
-Please help with technical isseu,C,"-intent,is,c-problem",fail
+Please help with technical isseu,A,"-intent,is,a-problem",pass
+Please help with technical isseu,C,"-intent,is,c-problem",pass
 Please help with technical isseu,D,"-intent,is,d-problem",pass
-Please help with technical isseu,E,"-intent,is,e-problem",fail
-Please help with technical isseu,F,"-intent,is,f-problem",fail
+Please help with technical isseu,E,"-intent,is,e-problem",pass
+Please help with technical isseu,F,"-intent,is,f-problem",pass
 I want to amend my staetment,A,"-intent,is,a-bill-inquiry",pass
 I want to amend my staetment,C,"-intent,is,c-bill-inquiry",fail
 I want to amend my staetment,D,"-intent,is,d-bill-inquiry",fail
@@ -42,14 +42,14 @@ hellpine please!,C,"-intent,is,c-contact-details",fail
 hellpine please!,D,"-intent,is,d-contact-details",fail
 hellpine please!,E,"-intent,is,e-contact-details",fail
 hellpine please!,F,"-intent,is,f-contact-details",fail
-hellpine,A,"-intent,is,a-contact-details",fail
+hellpine,A,"-intent,is,a-contact-details",pass
 hellpine,C,"-intent,is,c-contact-details",fail
 hellpine,D,"-intent,is,d-contact-details",fail
-hellpine,E,"-intent,is,e-contact-details",fail
+hellpine,E,"-intent,is,e-contact-details",pass
 hellpine,F,"-intent,is,f-contact-details",fail
 isseu,A,"-intent,is,a-problem",fail
 isseu,C,"-intent,is,c-problem",fail
-isseu,D,"-intent,is,d-problem",fail
+isseu,D,"-intent,is,d-problem",pass
 isseu,E,"-intent,is,e-problem",fail
 isseu,F,"-intent,is,f-problem",fail
 teck isseu,A,"-intent,is,a-problem",fail
@@ -130,7 +130,7 @@ Why is my screen lcked?,C,"-intent,is,c-none",pass
 Why is my screen lcked?,D,"-intent,is,d-none",pass
 Why is my screen lcked?,E,"-intent,is,e-none",pass
 Why is my screen lcked?,F,"-intent,is,f-none",pass
-lgin problm,A,"-intent,is,a-problem",fail
+lgin problm,A,"-intent,is,a-problem",pass
 lgin problm,C,"-intent,is,c-problem",pass
 lgin problm,D,"-intent,is,d-problem",fail
 lgin problm,E,"-intent,is,e-problem",fail
@@ -188,7 +188,7 @@ Whats the contactnumer,F,"-intent,is,f-contact-details",pass
 How can Icanncel,A,"-intent,is,a-cancellation",pass
 How can Icanncel,C,"-intent,is,c-cancellation",pass
 How can Icanncel,D,"-intent,is,d-cancellation",pass
-How can Icanncel,E,"-intent,is,e-cancellation",fail
+How can Icanncel,E,"-intent,is,e-cancellation",pass
 How can Icanncel,F,"-intent,is,f-cancellation",pass
 How can Icancerl,A,"-intent,is,a-cancellation",pass
 How can Icancerl,C,"-intent,is,c-cancellation",pass
@@ -347,11 +347,11 @@ Where can I fidn your ladnline?,C,"-intent,is,c-contact-details",pass
 Where can I fidn your ladnline?,D,"-intent,is,d-contact-details",pass
 Where can I fidn your ladnline?,E,"-intent,is,e-contact-details",fail
 Where can I fidn your ladnline?,F,"-intent,is,f-contact-details",pass
-Please help with techniqual isseu,A,"-intent,is,a-problem",fail
-Please help with techniqual isseu,C,"-intent,is,c-problem",fail
+Please help with techniqual isseu,A,"-intent,is,a-problem",pass
+Please help with techniqual isseu,C,"-intent,is,c-problem",pass
 Please help with techniqual isseu,D,"-intent,is,d-problem",pass
-Please help with techniqual isseu,E,"-intent,is,e-problem",fail
-Please help with techniqual isseu,F,"-intent,is,f-problem",fail
+Please help with techniqual isseu,E,"-intent,is,e-problem",pass
+Please help with techniqual isseu,F,"-intent,is,f-problem",pass
 I want to ammend my staetment,A,"-intent,is,a-bill-inquiry",pass
 I want to ammend my staetment,C,"-intent,is,c-bill-inquiry",pass
 I want to ammend my staetment,D,"-intent,is,d-bill-inquiry",fail
@@ -621,11 +621,11 @@ I have bugs,C,"-intent,is,c-problem",pass
 I have bugs,D,"-intent,is,d-problem",fail
 I have bugs,E,"-intent,is,e-problem",fail
 I have bugs,F,"-intent,is,f-problem",fail
-I want to solve some bugs,A,"-intent,is,a-problem",pass
-I want to solve some bugs,C,"-intent,is,c-problem",pass
+I want to solve some bugs,A,"-intent,is,a-problem",fail
+I want to solve some bugs,C,"-intent,is,c-problem",fail
 I want to solve some bugs,D,"-intent,is,d-problem",fail
-I want to solve some bugs,E,"-intent,is,e-problem",pass
-I want to solve some bugs,F,"-intent,is,f-problem",pass
+I want to solve some bugs,E,"-intent,is,e-problem",fail
+I want to solve some bugs,F,"-intent,is,f-problem",fail
 I am facing several bugs,A,"-intent,is,a-problem",pass
 I am facing several bugs,C,"-intent,is,c-problem",pass
 I am facing several bugs,D,"-intent,is,d-problem",fail
@@ -729,7 +729,7 @@ IT issue,D,"-intent,is,d-problem",pass
 IT issue,E,"-intent,is,e-problem",pass
 IT problem,A,"-intent,is,a-problem",pass
 IT problem,C,"-intent,is,c-problem",pass
-IT problem,D,"-intent,is,d-problem",fail
+IT problem,D,"-intent,is,d-problem",pass
 IT problem,E,"-intent,is,e-problem",pass
 help with bill,A,"-intent,is,a-bill-inquiry",fail
 help with bill,C,"-intent,is,c-bill-inquiry",fail
@@ -803,7 +803,7 @@ hello,A,"-intent,is,a-none",pass
 hello,B,"-intent,is,b-none",pass
 hello,C,"-intent,is,c-none",fail
 hello,D,"-intent,is,d-none",fail
-hello,E,"-intent,is,e-none",pass
+hello,E,"-intent,is,e-none",fail
 hello,F,"-intent,is,f-none",fail
 hello how are you going,A,"-intent,is,a-none",fail
 hello how are you going,B,"-intent,is,b-none",pass
@@ -1039,7 +1039,7 @@ are you available near me,C,"-intent,is,c-none",pass
 are you available near me,D,"-intent,is,d-none",pass
 are you available near me,E,"-intent,is,e-none",pass
 are you available near me,F,"-intent,is,f-none",pass
-is there a location near me,A,"-intent,is,a-none",fail
+is there a location near me,A,"-intent,is,a-none",pass
 is there a location near me,B,"-intent,is,b-none",pass
 is there a location near me,C,"-intent,is,c-none",fail
 is there a location near me,D,"-intent,is,d-none",pass

--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -3,7 +3,7 @@ import Joi from 'joi'
 import _ from 'lodash'
 import yn from 'yn'
 
-import legacyElectionPipeline from './legacy-election'
+import legacyElectionPipeline from './election/legacy-election'
 import { getTrainingSession } from './train-session-service'
 import { NLUState } from './typings'
 

--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -4,7 +4,7 @@ import _ from 'lodash'
 import yn from 'yn'
 
 import legacyElectionPipeline from './election/legacy-election'
-import mergeOutputs from './election/spellcheck-handler'
+import mergeSpellChecked from './election/spellcheck-handler'
 import { PredictOutput } from './election/typings'
 import { getTrainingSession } from './train-session-service'
 import { NLUState } from './typings'
@@ -60,9 +60,13 @@ export default async (bp: typeof sdk, state: NLUState) => {
 
       const spellChecked = await state.engine.spellCheck(value.text, modelId)
       if (spellChecked !== value.text) {
-        const originalPrediction = await state.engine.predict(value.text, value.contexts, modelId) as PredictOutput
-        const spellCheckedPrediction = await state.engine.predict(spellChecked, value.contexts, modelId) as PredictOutput
-        nlu = mergeOutputs(originalPrediction, spellCheckedPrediction)
+        const originalPrediction = (await state.engine.predict(value.text, value.contexts, modelId)) as PredictOutput
+        const spellCheckedPrediction = (await state.engine.predict(
+          spellChecked,
+          value.contexts,
+          modelId
+        )) as PredictOutput
+        nlu = mergeSpellChecked(originalPrediction, spellCheckedPrediction)
       } else {
         nlu = await state.engine.predict(value.text, value.contexts, modelId)
       }

--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -4,6 +4,8 @@ import _ from 'lodash'
 import yn from 'yn'
 
 import legacyElectionPipeline from './election/legacy-election'
+import mergeOutputs from './election/spellcheck-handler'
+import { PredictOutput } from './election/typings'
 import { getTrainingSession } from './train-session-service'
 import { NLUState } from './typings'
 
@@ -53,7 +55,17 @@ export default async (bp: typeof sdk, state: NLUState) => {
 
     try {
       // TODO: language should be a path param of route
-      let nlu = await state.engine.predict(value.text, value.contexts, modelId)
+
+      let nlu: sdk.IO.EventUnderstanding
+
+      const spellChecked = await state.engine.spellCheck(value.text, modelId)
+      if (spellChecked !== value.text) {
+        const originalPrediction = await state.engine.predict(value.text, value.contexts, modelId) as PredictOutput
+        const spellCheckedPrediction = await state.engine.predict(spellChecked, value.contexts, modelId) as PredictOutput
+        nlu = mergeOutputs(originalPrediction, spellCheckedPrediction)
+      } else {
+        nlu = await state.engine.predict(value.text, value.contexts, modelId)
+      }
       nlu = legacyElectionPipeline(nlu)
       res.send({ nlu })
     } catch (err) {

--- a/modules/nlu/src/backend/election/legacy-election.ts
+++ b/modules/nlu/src/backend/election/legacy-election.ts
@@ -1,15 +1,12 @@
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 
-import { allInRange, GetZPercent, std } from './tools/math'
+import { allInRange, GetZPercent, std } from '../tools/math'
 
-type PredictOutput = Omit<sdk.IO.EventUnderstanding, 'predictions'> & {
-  predictions: sdk.NLU.Predictions
-}
+import { NONE_INTENT, PredictOutput } from './typings'
 
 const OOS_AS_NONE_TRESH = 0.4
 const LOW_INTENT_CONFIDENCE_TRESH = 0.4
-const NONE_INTENT = 'none' // should extract in comon code
 
 // @deprecated > 13
 export default function legacyElectionPipeline(input: sdk.IO.EventUnderstanding) {

--- a/modules/nlu/src/backend/election/spellcheck-handler.ts
+++ b/modules/nlu/src/backend/election/spellcheck-handler.ts
@@ -1,0 +1,49 @@
+import * as sdk from 'botpress/sdk'
+import _ from 'lodash'
+
+import { NONE_INTENT, PredictOutput, ValueOf } from './typings'
+
+const mergeOutputs = (originalOutput: PredictOutput, spellCheckedOutput: PredictOutput): PredictOutput => {
+  const mostConfidentContext = (preds: sdk.NLU.Predictions): ValueOf<sdk.NLU.Predictions> =>
+    _(preds)
+      .values()
+      .maxBy(p => p.confidence)!
+
+  const mostConfidentIntent = (preds: ValueOf<sdk.NLU.Predictions>) =>
+    _(preds.intents)
+      .filter(i => i.label !== NONE_INTENT)
+      .maxBy(i => i.confidence)!
+
+  const originalPredictions: sdk.NLU.Predictions = originalOutput.predictions!
+  const spellCheckedPredictions: sdk.NLU.Predictions = spellCheckedOutput.predictions!
+
+  const mergedPredictions = _.cloneDeep(originalPredictions)
+
+  const mergeContextConfidence =
+    mostConfidentContext(originalPredictions).confidence < mostConfidentContext(spellCheckedPredictions).confidence
+
+  for (const ctx of Object.keys(mergedPredictions)) {
+    const originalPred = originalPredictions[ctx]
+    const spellCheckedPred = spellCheckedPredictions[ctx]
+
+    if (mergeContextConfidence) {
+      mergedPredictions[ctx].confidence = _.mean([originalPred.confidence, spellCheckedPred.confidence])
+    }
+
+    if (
+      originalPred.intents.length &&
+      mostConfidentIntent(originalPred).confidence <= mostConfidentIntent(spellCheckedPred).confidence
+    ) {
+      for (const intent of mergedPredictions[ctx].intents) {
+        const originalIntent = originalPred.intents.find(i => i.label === intent.label)!
+        const spellCheckedIntent = spellCheckedPred.intents.find(i => i.label === intent.label)!
+        intent.confidence = _.max([originalIntent.confidence, spellCheckedIntent.confidence])!
+      }
+    }
+
+    mergedPredictions[ctx].oos = spellCheckedPred.oos
+  }
+
+  return { ...originalOutput, predictions: mergedPredictions }
+}
+export default mergeOutputs

--- a/modules/nlu/src/backend/election/spellcheck-handler.ts
+++ b/modules/nlu/src/backend/election/spellcheck-handler.ts
@@ -3,7 +3,7 @@ import _ from 'lodash'
 
 import { NONE_INTENT, PredictOutput, ValueOf } from './typings'
 
-const mergeOutputs = (originalOutput: PredictOutput, spellCheckedOutput: PredictOutput): PredictOutput => {
+const mergeSpellChecked = (originalOutput: PredictOutput, spellCheckedOutput: PredictOutput): PredictOutput => {
   const mostConfidentContext = (preds: sdk.NLU.Predictions): ValueOf<sdk.NLU.Predictions> =>
     _(preds)
       .values()
@@ -17,33 +17,31 @@ const mergeOutputs = (originalOutput: PredictOutput, spellCheckedOutput: Predict
   const originalPredictions: sdk.NLU.Predictions = originalOutput.predictions!
   const spellCheckedPredictions: sdk.NLU.Predictions = spellCheckedOutput.predictions!
 
-  const mergedPredictions = _.cloneDeep(originalPredictions)
-
   const mergeContextConfidence =
     mostConfidentContext(originalPredictions).confidence < mostConfidentContext(spellCheckedPredictions).confidence
 
-  for (const ctx of Object.keys(mergedPredictions)) {
+  for (const ctx of Object.keys(originalPredictions)) {
     const originalPred = originalPredictions[ctx]
     const spellCheckedPred = spellCheckedPredictions[ctx]
 
     if (mergeContextConfidence) {
-      mergedPredictions[ctx].confidence = _.mean([originalPred.confidence, spellCheckedPred.confidence])
+      originalPred.confidence = _.mean([originalPred.confidence, spellCheckedPred.confidence])
     }
 
     if (
       originalPred.intents.length &&
       mostConfidentIntent(originalPred).confidence <= mostConfidentIntent(spellCheckedPred).confidence
     ) {
-      for (const intent of mergedPredictions[ctx].intents) {
+      for (const intent of originalPred.intents) {
         const originalIntent = originalPred.intents.find(i => i.label === intent.label)!
         const spellCheckedIntent = spellCheckedPred.intents.find(i => i.label === intent.label)!
         intent.confidence = _.max([originalIntent.confidence, spellCheckedIntent.confidence])!
       }
     }
 
-    mergedPredictions[ctx].oos = spellCheckedPred.oos
+    originalPred.oos = spellCheckedPred.oos
   }
 
-  return { ...originalOutput, predictions: mergedPredictions }
+  return { ...originalOutput, predictions: originalPredictions }
 }
-export default mergeOutputs
+export default mergeSpellChecked

--- a/modules/nlu/src/backend/election/typings.ts
+++ b/modules/nlu/src/backend/election/typings.ts
@@ -1,0 +1,9 @@
+import * as sdk from 'botpress/sdk'
+
+export type PredictOutput = Omit<sdk.IO.EventUnderstanding, 'predictions'> & {
+  predictions: sdk.NLU.Predictions
+}
+
+export const NONE_INTENT = 'none' // should extract in comon code
+
+export type ValueOf<T> = T[keyof T]

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -3,7 +3,7 @@ import bytes from 'bytes'
 import _ from 'lodash'
 
 import { Config } from '../../config'
-import legacyElectionPipeline from '../legacy-election'
+import legacyElectionPipeline from '../election/legacy-election'
 import { getLatestModel } from '../model-service'
 import { PredictionHandler } from '../prediction-handler'
 import { setTrainingSession } from '../train-session-service'

--- a/modules/nlu/src/backend/prediction-handler.test.ts
+++ b/modules/nlu/src/backend/prediction-handler.test.ts
@@ -1,7 +1,7 @@
 import '../../../../src/bp/sdk/botpress.d'
 
 // tslint:disable-next-line: ordered-imports
-import { NLU, IO } from 'botpress/sdk'
+import { NLU, IO, Logger } from 'botpress/sdk'
 
 import _ from 'lodash'
 import { ModelProvider, PredictionHandler } from './prediction-handler'
@@ -14,10 +14,14 @@ const fr = 'fr'
 const en = 'en'
 const de = 'de'
 
+const loggerMock = (<Partial<Logger>>{ warn: (msg: string) => {} }) as Logger
+
 const makeModelsByLang = (langs: string[]) => _.zipObject(langs, langs)
 
 function makeEngineMock(loadedModels: string[]): NLU.Engine {
   return (<Partial<NLU.Engine>>{
+    spellCheck: async (text: string, modelId: string) => text,
+
     loadModel: async (m: NLU.Model) => {
       loadedModels.push(m.languageCode)
     },
@@ -115,7 +119,8 @@ describe('predict', () => {
       modelProvider,
       engine,
       anticipatedLang,
-      defaultLang
+      defaultLang,
+      loggerMock
     )
     const result = await predictionHandler.predict(germanUtt, ['global'])
 
@@ -141,7 +146,8 @@ describe('predict', () => {
       modelProvider,
       engine,
       anticipatedLang,
-      defaultLang
+      defaultLang,
+      loggerMock
     )
     const result = await predictionHandler.predict(germanUtt, ['global'])
 
@@ -167,7 +173,8 @@ describe('predict', () => {
       modelProvider,
       engine,
       anticipatedLang,
-      defaultLang
+      defaultLang,
+      loggerMock
     )
     const result = await predictionHandler.predict(germanUtt, ['global'])
 
@@ -193,7 +200,8 @@ describe('predict', () => {
       modelProvider,
       engine,
       anticipatedLang,
-      defaultLang
+      defaultLang,
+      loggerMock
     )
     const result = await predictionHandler.predict(germanUtt, ['global'])
 
@@ -219,7 +227,8 @@ describe('predict', () => {
       modelProvider,
       engine,
       anticipatedLang,
-      defaultLang
+      defaultLang,
+      loggerMock
     )
     const result = await predictionHandler.predict(germanUtt, ['global'])
 
@@ -245,7 +254,8 @@ describe('predict', () => {
       modelProvider,
       engine,
       anticipatedLang,
-      defaultLang
+      defaultLang,
+      loggerMock
     )
     const result = await predictionHandler.predict(germanUtt, ['global'])
 
@@ -271,7 +281,8 @@ describe('predict', () => {
       modelProvider,
       engine,
       anticipatedLang,
-      defaultLang
+      defaultLang,
+      loggerMock
     )
     await assertThrows(() => predictionHandler.predict(germanUtt, ['global']))
     assertPredictCalled(engine.predict as jest.Mock, [])

--- a/modules/nlu/src/backend/prediction-handler.ts
+++ b/modules/nlu/src/backend/prediction-handler.ts
@@ -1,6 +1,9 @@
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 
+import mergeSpellChecked from './election/spellcheck-handler'
+import { PredictOutput } from './election/typings'
+
 export interface ModelProvider {
   getLatestModel: (lang: string) => Promise<sdk.NLU.Model | undefined>
 }
@@ -68,7 +71,16 @@ export class PredictionHandler {
       this.modelsByLang[lang] = model.hash
       await this.engine.loadModel(model, model.hash)
     }
-    return this.engine.predict(textInput, includedContexts, this.modelsByLang[lang])
+
+    const spellChecked = await this.engine.spellCheck(textInput, this.modelsByLang[lang])
+    if (spellChecked !== textInput) {
+      const originalOutput = await this.engine.predict(textInput, includedContexts, this.modelsByLang[lang])
+      const spellCheckedOutput = await this.engine.predict(spellChecked, includedContexts, this.modelsByLang[lang])
+      const merged = mergeSpellChecked(originalOutput as PredictOutput, spellCheckedOutput as PredictOutput)
+      return { ...merged, spellChecked }
+    }
+    const output = this.engine.predict(textInput, includedContexts, this.modelsByLang[lang])
+    return { ...output, spellChecked }
   }
 
   private isEmptyOrError(nluResults: sdk.IO.EventUnderstanding | undefined) {

--- a/modules/nlu/src/backend/prediction-handler.ts
+++ b/modules/nlu/src/backend/prediction-handler.ts
@@ -16,7 +16,7 @@ export class PredictionHandler {
     private anticipatedLanguage: string,
     private defaultLanguage: string,
     private logger: sdk.Logger
-  ) {}
+  ) { }
 
   async predict(textInput: string, includedContexts: string[]) {
     const modelCacheState = _.mapValues(this.modelsByLang, model => ({ model, loaded: this.engine.hasModel(model) }))

--- a/modules/nlu/src/backend/prediction-handler.ts
+++ b/modules/nlu/src/backend/prediction-handler.ts
@@ -16,7 +16,7 @@ export class PredictionHandler {
     private anticipatedLanguage: string,
     private defaultLanguage: string,
     private logger: sdk.Logger
-  ) { }
+  ) {}
 
   async predict(textInput: string, includedContexts: string[]) {
     const modelCacheState = _.mapValues(this.modelsByLang, model => ({ model, loaded: this.engine.hasModel(model) }))

--- a/modules/nlu/src/backend/prediction-handler.ts
+++ b/modules/nlu/src/backend/prediction-handler.ts
@@ -79,7 +79,7 @@ export class PredictionHandler {
       const merged = mergeSpellChecked(originalOutput as PredictOutput, spellCheckedOutput as PredictOutput)
       return { ...merged, spellChecked }
     }
-    const output = this.engine.predict(textInput, includedContexts, this.modelsByLang[lang])
+    const output = await this.engine.predict(textInput, includedContexts, this.modelsByLang[lang])
     return { ...output, spellChecked }
   }
 

--- a/src/bp/nlu-core/initialize-tools.ts
+++ b/src/bp/nlu-core/initialize-tools.ts
@@ -65,7 +65,7 @@ export async function initializeTools(config: NLU.LanguageConfig, logger: NLU.Lo
       const tagger = getPOSTagger(lang, MLToolkit)
       return tokenUtterances.map(u => tagSentence(tagger, u))
     },
-    tokenize_utterances: (utterances: string[], lang: string, vocab?: Token2Vec) =>
+    tokenize_utterances: (utterances: string[], lang: string, vocab?: string[]) =>
       languageProvider.tokenize(utterances, lang, vocab),
     vectorize_tokens: async (tokens, lang) => {
       const a = await languageProvider.vectorize(tokens, lang)

--- a/src/bp/nlu-core/language/language-provider.ts
+++ b/src/bp/nlu-core/language/language-provider.ts
@@ -465,7 +465,7 @@ export class RemoteLanguageProvider implements LanguageProvider {
     return vectors
   }
 
-  async tokenize(utterances: string[], lang: string, vocab: Token2Vec = {}): Promise<string[][]> {
+  async tokenize(utterances: string[], lang: string, vocab: string[] = []): Promise<string[][]> {
     if (!utterances.length) {
       return []
     }

--- a/src/bp/nlu-core/language/spell-checker.ts
+++ b/src/bp/nlu-core/language/spell-checker.ts
@@ -1,0 +1,29 @@
+import { convertToRealSpaces, isWord } from 'nlu-core/tools/token-utils'
+import { getClosestSpellingToken } from 'nlu-core/tools/vocab'
+import { Tools } from 'nlu-core/typings'
+
+function isClosestTokenValid(originalToken: string, closestToken: string): boolean {
+  return isWord(closestToken) && originalToken.length > 3 && closestToken.length > 3
+}
+
+const makeSpellChecker = (vocab: string[], lang: string, tools: Tools) => async (text: string) => {
+  const [raw_tokens] = await tools.tokenize_utterances([text], lang, vocab)
+
+  return raw_tokens
+    .map(convertToRealSpaces)
+    .map(token => {
+      const strTok = token.toLowerCase()
+      if (!isWord(token) || vocab.includes(strTok)) {
+        return token
+      }
+
+      const closestToken = getClosestSpellingToken(strTok, vocab)
+      if (isClosestTokenValid(token, closestToken)) {
+        return closestToken
+      }
+
+      return token
+    })
+    .join('')
+}
+export default makeSpellChecker

--- a/src/bp/nlu-core/predict-pipeline.ts
+++ b/src/bp/nlu-core/predict-pipeline.ts
@@ -5,7 +5,6 @@ import { extractListEntities, extractPatternEntities } from './entities/custom-e
 import { getCtxFeatures } from './intents/context-featurizer'
 import { getIntentFeatures } from './intents/intent-featurizer'
 import { isPOSAvailable } from './language/pos-tagger'
-import makeSpellChecker from './language/spell-checker'
 import { getUtteranceFeatures } from './out-of-scope-featurizer'
 import SlotTagger from './slots/slot-tagger'
 import { ExactMatchIndex, EXACT_MATCH_STR_OPTIONS } from './training-pipeline'
@@ -300,10 +299,10 @@ function MapStepToOutput(step: SlotStep, startTime: number): PredictOutput {
     const intents = !intentPred
       ? []
       : intentPred.map(i => ({
-          extractor: 'classifier', // exact-matcher overwrites this field in line below
-          ...i,
-          slots: (step.slot_predictions_per_intent?.[i.label] || []).reduce(slotsCollectionReducer, {})
-        }))
+        extractor: 'classifier', // exact-matcher overwrites this field in line below
+        ...i,
+        slots: (step.slot_predictions_per_intent?.[i.label] || []).reduce(slotsCollectionReducer, {})
+      }))
 
     const includeOOS = !intents.filter(x => x.extractor === 'exact-matcher').length
 

--- a/src/bp/nlu-core/predict-pipeline.ts
+++ b/src/bp/nlu-core/predict-pipeline.ts
@@ -299,10 +299,10 @@ function MapStepToOutput(step: SlotStep, startTime: number): PredictOutput {
     const intents = !intentPred
       ? []
       : intentPred.map(i => ({
-        extractor: 'classifier', // exact-matcher overwrites this field in line below
-        ...i,
-        slots: (step.slot_predictions_per_intent?.[i.label] || []).reduce(slotsCollectionReducer, {})
-      }))
+          extractor: 'classifier', // exact-matcher overwrites this field in line below
+          ...i,
+          slots: (step.slot_predictions_per_intent?.[i.label] || []).reduce(slotsCollectionReducer, {})
+        }))
 
     const includeOOS = !intents.filter(x => x.extractor === 'exact-matcher').length
 

--- a/src/bp/nlu-core/tools/math.ts
+++ b/src/bp/nlu-core/tools/math.ts
@@ -7,7 +7,7 @@ import { log, mean, std } from 'mathjs'
  * Vectorial distance between two N-dimentional points
  * a[] and b[] must be of same dimention
  */
-export function ndistance(a: number[], b: number[]): number {
+export function euclideanDistance(a: number[], b: number[]): number {
   if (a.length !== b.length) {
     throw new Error(`Can't calculate distance between vectors of different length (${a.length} vs ${b.length})`)
   }

--- a/src/bp/nlu-core/tools/token-utils.test.ts
+++ b/src/bp/nlu-core/tools/token-utils.test.ts
@@ -98,12 +98,8 @@ describe('Raw token processing', () => {
 
   test('processUtteranceTokens with vocab should help tokenization', () => {
     const toks = [`${SPACE}i`, "'", 'm', `${SPACE}having`, `${SPACE}some`, `${SPACE}trouble`, `${SPACE}tol`, 'ogin']
-    const vocab = {
-      to: [1, 2, 3, 4],
-      login: [1, 2, 3, 4]
-    }
 
-    expect(processUtteranceTokens(toks, vocab)).toEqual([
+    expect(processUtteranceTokens(toks, ['to', 'login'])).toEqual([
       'i',
       "'",
       'm',

--- a/src/bp/nlu-core/tools/token-utils.ts
+++ b/src/bp/nlu-core/tools/token-utils.ts
@@ -58,19 +58,19 @@ export const mergeSimilarCharsetTokens = (
 const mergeSpaces = (tokens: string[]): string[] => mergeSimilarCharsetTokens(tokens, [SPACE])
 const mergeNumeral = (tokens: string[]): string[] => mergeSimilarCharsetTokens(tokens, ['[0-9]'])
 const mergeSpecialChars = (tokens: string[]): string[] => mergeSimilarCharsetTokens(tokens, SPECIAL_CHARSET)
-const mergeLatin = (tokens: string[], vocab: Token2Vec): string[] => {
+const mergeLatin = (tokens: string[], vocab: string[]): string[] => {
   const oovMatcher = (token: string) => {
-    return !!token && !vocab[token.toLowerCase()]
+    return !!token && !vocab.includes(token.toLowerCase())
   }
 
-  const vocabTokenizer = getVocabTokenizer(Object.keys(vocab))
+  const vocabTokenizer = getVocabTokenizer(vocab)
   const vocabTransformer = (prev: string, next: string) => {
     return vocabTokenizer(`${prev}${next}`)
   }
   return mergeSimilarCharsetTokens(tokens, LATIN_CHARSET, oovMatcher, vocabTransformer)
 }
 
-export const processUtteranceTokens = (tokens: string[], vocab: Token2Vec = {}): string[] => {
+export const processUtteranceTokens = (tokens: string[], vocab: string[] = []): string[] => {
   return _.chain(tokens)
     .flatMap(splitSpaceToken)
     .thru(mergeSpaces)

--- a/src/bp/nlu-core/typings.ts
+++ b/src/bp/nlu-core/typings.ts
@@ -40,7 +40,7 @@ export interface LanguageProvider {
   languages: string[]
   langServerInfo: LangServerInfo
   vectorize(tokens: string[], lang: string): Promise<Float32Array[]>
-  tokenize(utterances: string[], lang: string, vocab?: Token2Vec): Promise<string[][]>
+  tokenize(utterances: string[], lang: string, vocab?: string[]): Promise<string[][]>
   generateSimilarJunkWords(subsetVocab: string[], lang: string): Promise<string[]>
   getHealth(): Partial<sdk.NLU.Health>
 }
@@ -120,7 +120,7 @@ export interface SeededLodashProvider {
 }
 
 export interface Tools {
-  tokenize_utterances(utterances: string[], languageCode: string, vocab?: Token2Vec): Promise<string[][]>
+  tokenize_utterances(utterances: string[], languageCode: string, vocab?: string[]): Promise<string[][]>
   vectorize_tokens(tokens: string[], languageCode: string): Promise<number[][]>
   partOfSpeechUtterances(utterances: string[][], languageCode: string): string[][]
   generateSimilarJunkWords(vocabulary: string[], languageCode: string): Promise<string[]>

--- a/src/bp/nlu-core/typings.ts
+++ b/src/bp/nlu-core/typings.ts
@@ -150,5 +150,3 @@ type SlotDefinition = Readonly<{
   name: string
   entities: string[]
 }>
-
-export type ValueOf<T> = T[keyof T]

--- a/src/bp/nlu-core/typings.ts
+++ b/src/bp/nlu-core/typings.ts
@@ -150,3 +150,5 @@ type SlotDefinition = Readonly<{
   name: string
   entities: string[]
 }>
+
+export type ValueOf<T> = T[keyof T]

--- a/src/bp/nlu-core/utterance/utterance.ts
+++ b/src/bp/nlu-core/utterance/utterance.ts
@@ -271,7 +271,7 @@ export default class Utterance {
   }
 }
 
-export const preprocessRawUtterance = _.flow([replaceConsecutiveSpaces, replaceEllipsis])
+export const preprocessRawUtterance: (raw: string) => string = _.flow([replaceConsecutiveSpaces, replaceEllipsis])
 
 export async function buildUtteranceBatch(
   raw_utterances: string[],

--- a/src/bp/nlu-core/utterance/utterance.ts
+++ b/src/bp/nlu-core/utterance/utterance.ts
@@ -6,7 +6,6 @@ import { SPECIAL_CHARSET } from '../tools/chars'
 import { computeNorm, scalarDivide, scalarMultiply, vectorAdd, zeroes } from '../tools/math'
 import { replaceConsecutiveSpaces, replaceEllipsis } from '../tools/strings'
 import { convertToRealSpaces, isSpace, isWord, SPACE } from '../tools/token-utils'
-import { getClosestToken } from '../tools/vocab'
 import { ExtractedEntity, ExtractedSlot, TFIDF, Token2Vec, Tools } from '../typings'
 
 import { parseUtterance } from './utterance-parser'
@@ -285,7 +284,7 @@ export async function buildUtteranceBatch(
   const tokenUtterances = await tools.tokenize_utterances(
     parsed.map(p => p.utterance),
     language,
-    vocab
+    vocab ? Object.keys(vocab) : []
   )
   const POSUtterances = tools.partOfSpeechUtterances(tokenUtterances, language) as POSClass[][]
   const uniqTokens = _.uniq(_.flatten(tokenUtterances))
@@ -314,64 +313,6 @@ export async function buildUtteranceBatch(
 
       return utterance
     })
-}
-
-interface AlternateToken {
-  value: string
-  vector: number[] | ReadonlyArray<number>
-  POS: POSClass
-  isAlter?: boolean
-}
-
-function uttTok2altTok(token: UtteranceToken): AlternateToken {
-  return {
-    ..._.pick(token, ['vector', 'POS']),
-    value: token.toString(),
-    isAlter: false
-  }
-}
-
-function isClosestTokenValid(originalToken: UtteranceToken, closestToken: string): boolean {
-  return isWord(closestToken) && originalToken.value.length > 3 && closestToken.length > 3
-}
-
-/**
- * @description Returns slightly different version of the given utterance, replacing OOV tokens with their closest IV syntaxical neighbour
- * @param utterance the original utterance
- * @param vocabVectors Bot wide vocabulary
- */
-export function getAlternateUtterance(utterance: Utterance, vocabVectors: Token2Vec): Utterance | undefined {
-  return _.chain(utterance.tokens)
-    .map(token => {
-      const strTok = token.toString({ lowerCase: true })
-      if (!token.isWord || vocabVectors[strTok] || !_.isEmpty(token.entities)) {
-        return uttTok2altTok(token)
-      }
-
-      const closestToken = getClosestToken(strTok, token.vector, vocabVectors, false)
-      if (isClosestTokenValid(token, closestToken)) {
-        return {
-          value: closestToken,
-          vector: vocabVectors[closestToken],
-          POS: token.POS,
-          isAlter: true
-        } as AlternateToken
-      } else {
-        return uttTok2altTok(token)
-      }
-    })
-    .thru((altToks: AlternateToken[]) => {
-      const hasAlternate = altToks.length === utterance.tokens.length && altToks.some(t => t.isAlter)
-      if (hasAlternate) {
-        return new Utterance(
-          altToks.map(t => t.value),
-          altToks.map(t => <number[]>t.vector),
-          altToks.map(t => t.POS),
-          utterance.languageCode
-        )
-      }
-    })
-    .value()
 }
 
 /**

--- a/src/bp/nlu-server/api.ts
+++ b/src/bp/nlu-server/api.ts
@@ -169,7 +169,11 @@ export default async function(options: APIOptions, engine: Engine) {
         await engine.loadModel(model, modelId)
       }
 
-      const rawPredictions = await Promise.map(texts as string[], t => engine.predict(t, [], modelId))
+      const rawPredictions = await Promise.map(texts as string[], async t => {
+        const spellChecked = await engine.spellCheck(t, modelId)
+        const output = await engine.predict(t, [], modelId)
+        return { ...output, spellChecked }
+      })
       const withoutNone = rawPredictions.map(removeNoneIntent)
 
       return res.send({ success: true, predictions: withoutNone })

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -455,6 +455,7 @@ declare module 'botpress/sdk' {
       cancelTraining: (trainSessionId: string) => Promise<void>
       detectLanguage: (text: string, modelByLang: Dic<string>) => Promise<string>
       predict: (text: string, ctx: string[], modelId: string) => Promise<IO.EventUnderstanding>
+      spellCheck(sentence: string, modelId: string): Promise<string>
     }
 
     export interface Config extends LanguageConfig {


### PR DESCRIPTION
Resons to merge this: 
1. Intent classification benchmarks are fully independent of the implementation of the spellChecker. This mean you could replace the whole spellChecker by something that returns "My name is Jeff" and you would get the exact same results in intent classification tests.
2. The interface of the spell checker is way simpler, and it will be way easier to control its outputs and change the algorithm. **That's actually the first reason I started working on this.**
3. Almost all (if not all) test results have gone up, because intent classification train and test sets do not contain any spelling mistake. The spell checker, was only interfering with the samples.
4. This just looks better

**However,**
It was expected that the intent classification results would change, **BUT** If you look closely at each commit, you'll see that intent results started changing even before they where supposed too. I never could figure out why and this was really driving me nuts. I feel like my new `mergeSpellChecked` logic is the exact same that used to happend inside the prediciton pipeline, but I'll have to double check that.

These weird varying results are the reason it took me so long to open this PR. I feel like this is mergable anyway as results are still good, but let's just keep an eye open.

This PR is related to botpress/v12#1140 , but does not fully close the issue. To do so, extracted slot of spell-checked utterance should be considered when merging predictions. 

\*\* Also (this is really hypothetical), if the spell-checking took list entities into considerations, we could completely get rid of fuzzy-matching in list entity extractor.

**QA**

Made sure there was no regression in Botpress election:
![Screen Shot 2020-11-27 at 12 49 22 PM](https://user-images.githubusercontent.com/25970722/100475199-7fb6dd00-30b0-11eb-9ddb-32b46ed7861f.png)

On master, score is `69.1`...