### PR TITLE
chore(nlu): serialize kmeans output

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "mathjs": "^5.9.0",
     "mime-types": "^2.1.27",
     "ml-kmeans": "^5.0.0",
+    "ml-nearest-vector": "^2.0.1",
     "moment": "^2.24.0",
     "ms": "^2.1.1",
     "multer": "^1.4.1",

--- a/src/bp/nlu-core/clustering.ts
+++ b/src/bp/nlu-core/clustering.ts
@@ -1,0 +1,67 @@
+import * as sdk from 'botpress/sdk'
+import _ from 'lodash'
+import nearestVector from 'ml-nearest-vector'
+
+import { euclideanDistanceSquared } from './tools/math'
+import { Intent, SerializedKmeansResult, Tools } from './typings'
+import Utterance, { UtteranceToken } from './utterance/utterance'
+
+const NUM_CLUSTERS = 8
+const KMEANS_OPTIONS = <sdk.MLToolkit.KMeans.KMeansOptions>{
+  iterations: 250,
+  initialization: 'random',
+  seed: 666, // so training is consistent
+  distanceFunction: euclideanDistanceSquared
+}
+
+const NONE_INTENT = 'none'
+
+export const computeKmeans = (
+  intents: Intent<Utterance>[],
+  tools: Tools
+): sdk.MLToolkit.KMeans.KmeansResult | undefined => {
+  const data = _.chain(intents)
+    .filter(i => i.name !== NONE_INTENT)
+    .flatMap(i => i.utterances)
+    .flatMap(u => u.tokens)
+    .uniqBy((t: UtteranceToken) => t.value)
+    .map((t: UtteranceToken) => t.vector)
+    .value() as number[][]
+
+  if (data.length < 2) {
+    return
+  }
+
+  const k = data.length > NUM_CLUSTERS ? NUM_CLUSTERS : 2
+
+  return tools.mlToolkit.KMeans.kmeans(data, k, KMEANS_OPTIONS)
+}
+
+export const serializeKmeans = (kmeans: sdk.MLToolkit.KMeans.KmeansResult): SerializedKmeansResult => {
+  const { centroids, clusters, iterations } = kmeans
+  return { centroids, clusters, iterations }
+}
+
+export const deserializeKmeans = (kmeans: SerializedKmeansResult): sdk.MLToolkit.KMeans.KmeansResult => {
+  const { centroids, clusters, iterations } = kmeans
+  const thisNearest = (data: sdk.MLToolkit.KMeans.DataPoint[]) => {
+    return nearest(kmeans, data)
+  }
+  return { centroids, clusters, iterations, nearest: thisNearest }
+}
+
+/**
+ * Copied from https://github.com/mljs/kmeans/blob/master/src/utils.js
+ */
+export const nearest = (kmeans: SerializedKmeansResult, data: sdk.MLToolkit.KMeans.DataPoint[]) => {
+  const clusterID: number[] = new Array(data.length)
+  const centroids = kmeans.centroids.map(c => c.centroid)
+
+  for (let i = 0; i < data.length; i++) {
+    clusterID[i] = nearestVector(centroids, data[i], {
+      distanceFunction: euclideanDistanceSquared
+    })
+  }
+
+  return clusterID
+}

--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -5,6 +5,7 @@ import _ from 'lodash'
 import LRUCache from 'lru-cache'
 import sizeof from 'object-sizeof'
 
+import { deserializeKmeans } from './clustering'
 import { EntityCacheManager } from './entities/entity-cache-manager'
 import { initializeTools } from './initialize-tools'
 import DetectLanguage from './language/language-identifier'
@@ -13,7 +14,7 @@ import { deserializeModel, PredictableModel, serializeModel } from './model-seri
 import { Predict, PredictInput, Predictors, PredictOutput } from './predict-pipeline'
 import SlotTagger from './slots/slot-tagger'
 import { isPatternValid } from './tools/patterns-utils'
-import { computeKmeans, ProcessIntents, TrainInput, TrainOutput } from './training-pipeline'
+import { ProcessIntents, TrainInput, TrainOutput } from './training-pipeline'
 import { TrainingWorkerQueue } from './training-worker-queue'
 import { EntityCacheDump, ListEntity, PatternEntity, Tools } from './typings'
 import { preprocessRawUtterance } from './utterance/utterance'
@@ -229,17 +230,22 @@ export default class Engine implements NLU.Engine {
   private async _makePredictors(input: TrainInput, output: TrainOutput): Promise<Predictors> {
     const tools = this._tools
 
+    const { ctx_model, intent_model_by_ctx, oos_model, list_entities, kmeans } = output
+
     /**
      * TODO: extract this function some place else,
      * Engine's predict() shouldn't be dependant of training pipeline...
      */
-    const intents = await ProcessIntents(input.intents, input.languageCode, output.list_entities, this._tools)
+    const intents = await ProcessIntents(input.intents, input.languageCode, list_entities, this._tools)
+
+    const warmKmeans = kmeans && deserializeKmeans(kmeans)
 
     const basePredictors: Predictors = {
       ...output,
       lang: input.languageCode,
       intents,
-      pattern_entities: input.pattern_entities
+      pattern_entities: input.pattern_entities,
+      kmeans: warmKmeans
     }
 
     if (_.flatMap(input.intents, i => i.utterances).length <= 0) {
@@ -248,7 +254,6 @@ export default class Engine implements NLU.Engine {
       return basePredictors
     }
 
-    const { ctx_model, intent_model_by_ctx, oos_model } = output
     const ctx_classifier = ctx_model ? new tools.mlToolkit.SVM.Predictor(ctx_model) : undefined
     const intent_classifier_per_ctx = _.toPairs(intent_model_by_ctx).reduce(
       (c, [ctx, intentModel]) => ({ ...c, [ctx]: new tools.mlToolkit.SVM.Predictor(intentModel as string) }),
@@ -265,15 +270,12 @@ export default class Engine implements NLU.Engine {
       slot_tagger.load(output.slots_model)
     }
 
-    const kmeans = computeKmeans(intents!, tools) // TODO load from artefacts when persisted
-
     return {
       ...basePredictors,
       ctx_classifier,
       oos_classifier_per_ctx: oos_classifier,
       intent_classifier_per_ctx,
-      slot_tagger,
-      kmeans
+      slot_tagger
     }
   }
 

--- a/src/bp/nlu-core/initialize-tools.ts
+++ b/src/bp/nlu-core/initialize-tools.ts
@@ -5,9 +5,9 @@ import { DucklingEntityExtractor } from './entities/duckling-extractor'
 import LangProvider from './language/language-provider'
 import { getPOSTagger, tagSentence } from './language/pos-tagger'
 import SeededLodashProvider from './tools/seeded-lodash'
-import { LanguageProvider, NLUVersionInfo, Token2Vec, Tools } from './typings'
+import { LanguageProvider, NLUVersionInfo, Tools } from './typings'
 
-const NLU_VERSION = '1.4.1'
+const NLU_VERSION = '1.5.0'
 
 const healthGetter = (languageProvider: LanguageProvider) => (): NLU.Health => {
   const { validProvidersCount, validLanguages } = languageProvider.getHealth()

--- a/src/bp/nlu-core/tools/math.ts
+++ b/src/bp/nlu-core/tools/math.ts
@@ -3,11 +3,7 @@ import { log, mean, std } from 'mathjs'
 
 // TODO: remove all theses functions and use mathjs instead
 
-/**
- * Vectorial distance between two N-dimentional points
- * a[] and b[] must be of same dimention
- */
-export function euclideanDistance(a: number[], b: number[]): number {
+export function euclideanDistanceSquared(a: number[], b: number[]): number {
   if (a.length !== b.length) {
     throw new Error(`Can't calculate distance between vectors of different length (${a.length} vs ${b.length})`)
   }
@@ -17,7 +13,15 @@ export function euclideanDistance(a: number[], b: number[]): number {
     const diff = b[i] - a[i]
     total += diff * diff
   }
-  return Math.sqrt(total)
+  return total
+}
+
+/**
+ * Vectorial distance between two N-dimentional points
+ * a[] and b[] must be of same dimention
+ */
+export function euclideanDistance(a: number[], b: number[]): number {
+  return Math.sqrt(euclideanDistanceSquared(a, b))
 }
 
 export function computeNorm(vec: number[]): number {

--- a/src/bp/nlu-core/training-pipeline.ts
+++ b/src/bp/nlu-core/training-pipeline.ts
@@ -1,6 +1,7 @@
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 
+import { serializeKmeans } from './clustering'
 import { extractListEntitiesWithCache, extractPatternEntities } from './entities/custom-entity-extractor'
 import { warmEntityCache } from './entities/entity-cache-manager'
 import { getCtxFeatures } from './intents/context-featurizer'
@@ -20,6 +21,7 @@ import {
   ListEntity,
   ListEntityModel,
   PatternEntity,
+  SerializedKmeansResult,
   TFIDF,
   Token2Vec,
   Tools,
@@ -59,7 +61,7 @@ export interface TrainOutput {
   list_entities: ColdListEntityModel[]
   tfidf: TFIDF
   vocabVectors: Token2Vec
-  // kmeans: KmeansResult
+  kmeans: SerializedKmeansResult | undefined
   contexts: string[]
   ctx_model: string
   intent_model_by_ctx: Dic<string>
@@ -567,7 +569,7 @@ export const Trainer = async (
     slots_model: slots_model!,
     vocabVectors: step.vocabVectors,
     exact_match_index,
-    // kmeans: {} add this when mlKmeans supports loading from serialized data,
+    kmeans: step.kmeans && serializeKmeans(step.kmeans),
     contexts: input.contexts
   }
 

--- a/src/bp/nlu-core/typings.ts
+++ b/src/bp/nlu-core/typings.ts
@@ -150,3 +150,5 @@ type SlotDefinition = Readonly<{
   name: string
   entities: string[]
 }>
+
+export type SerializedKmeansResult = Omit<sdk.MLToolkit.KMeans.KmeansResult, 'nearest'>

--- a/src/bp/nlu-core/warm-training-handler.test.ts
+++ b/src/bp/nlu-core/warm-training-handler.test.ts
@@ -34,7 +34,12 @@ const _makeTrainOuput = (
     oos_model: _(oosModels)
       .map(i => [i.ctx, i.model])
       .fromPairs()
-      .value()
+      .value(),
+    kmeans: {
+      centroids: [],
+      clusters: [],
+      iterations: 0
+    }
   }
 }
 


### PR DESCRIPTION
I know this is not a priority, but I kind of wanted to start an easy task friday afternoon and code a little so I started addressing this [issue](https://github.com/botpress/v12/issues/1143) botpress/v12#1143.  (tbh, I wanted to get used to my new macbook keyboard and get a reason to type some code)

This ended up being not as easy as I thought for the following reasons; 
1. For our biggest known bot (let's call it **Gerry**), the added weight of processed intents in training output was at least ~500mb... (I say at least because I tried few configurations)
2. Adding too much information in training output ends up taking more time to move around the data than to recreate it when loading.
3. There is a risk that too much data won't make it from the training worker to the web worker (I actually experienced this bug on **Gerry** in a particular circumstances)

So yeah, I decided to scope down the PR and only to address the kmeans part. 

This PR is small, mergeable and improves load time in **Gerry** from 9538ms to 8040ms