### PR TITLE
fix(channel-web): revert minimum user id length

### DIFF
--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -246,7 +246,7 @@ export default async (bp: typeof sdk, db: Database) => {
   })
 
   function validateUserId(userId: string) {
-    if (!userId || userId.length > USER_ID_MAX_LENGTH) {
+    if (!userId || userId.length > USER_ID_MAX_LENGTH || userId.toLowerCase() === 'undefined') {
       return false
     }
 

--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -19,7 +19,6 @@ const ERR_CONV_ID_REQ = '`conversationId` is required and must be valid'
 const ERR_BAD_LANGUAGE = '`language` is required and must be valid'
 
 const USER_ID_MAX_LENGTH = 40
-const USER_ID_MIN_LENGTH = 18
 const SUPPORTED_MESSAGES = [
   'text',
   'quick_reply',
@@ -247,7 +246,7 @@ export default async (bp: typeof sdk, db: Database) => {
   })
 
   function validateUserId(userId: string) {
-    if (!userId || userId.length > USER_ID_MAX_LENGTH || userId.length < USER_ID_MIN_LENGTH) {
+    if (!userId || userId.length > USER_ID_MAX_LENGTH) {
       return false
     }
 


### PR DESCRIPTION
Reverts breaking change introduced by https://github.com/botpress/botpress/pull/4211 that restricts custom user IDs to be 18 characters in length minimum.

This is breaking for bots that already have custom user IDs of length < 18 chars. Since the 18 chars minimal length is arbitrary, I suggest we simply remove it.