### PR TITLE
fix(core): logs panel no longer cleared

### DIFF
--- a/src/bp/ui-studio/src/web/components/Layout/BottomPanel/Debugger/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/BottomPanel/Debugger/index.tsx
@@ -34,6 +34,7 @@ interface Props {
   setAutoFocus: (newValue: boolean) => void
   commonButtons: any
   setDebuggerEvent: any
+  hidden: boolean
 }
 
 interface State {
@@ -196,6 +197,10 @@ export class Debugger extends React.Component<Props, State> {
   }
 
   render() {
+    if (this.props.hidden) {
+      return null
+    }
+
     const hasEvent = !!this.state.event
     const ndu = _.get(this.state, 'event.ndu')
 

--- a/src/bp/ui-studio/src/web/components/Layout/BottomPanel/Logs/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/BottomPanel/Logs/index.tsx
@@ -62,7 +62,7 @@ class BottomPanel extends React.Component<Props, State> {
 
   setupListener = () => {
     // @ts-ignore
-    EventBus.default.on('logs::' + window.BOT_ID, ({ id, level, message, args }) => {
+    EventBus.default.on(`logs::${window.BOT_ID}`, ({ id, level, message, args }) => {
       this.logs.push({
         ts: new Date(),
         id: nanoid(10),
@@ -105,7 +105,7 @@ class BottomPanel extends React.Component<Props, State> {
   renderEntry(log: LogEntry): JSX.Element {
     const time = moment(new Date(log.ts)).format('YYYY-MM-DD HH:mm:ss')
     return (
-      <li className={cn(logStyle.entry, logStyle[`level-${log.level}`])} key={'log-entry-' + log.id}>
+      <li className={cn(logStyle.entry, logStyle[`level-${log.level}`])} key={`log-entry-${log.id}`}>
         <span className={logStyle.time}>{time}</span>
         <span className={logStyle.level}>{log.level}</span>
         <span className={logStyle.message} dangerouslySetInnerHTML={{ __html: log.message }} />

--- a/src/bp/ui-studio/src/web/components/Layout/BottomPanel/Logs/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/BottomPanel/Logs/index.tsx
@@ -25,6 +25,7 @@ interface Props {
   toggleBottomPanel: () => void
   emulatorOpen: boolean
   commonButtons: any
+  hidden: boolean
 }
 
 interface State {
@@ -160,6 +161,9 @@ class BottomPanel extends React.Component<Props, State> {
   }
 
   render() {
+    if (this.props.hidden) {
+      return null
+    }
     const allLogs = [...this.state.initialLogs, ...this.logs]
     const LogsPanel = (
       <ul

--- a/src/bp/ui-studio/src/web/components/Layout/BottomPanel/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/BottomPanel/index.tsx
@@ -81,15 +81,15 @@ const BottomPanel = props => {
       </Tabs>
 
       <div className={cx(style.padded, style.fullWidth, { 'emulator-open': props.emulatorOpen })}>
-        {tab === 'logs' && <Logs commonButtons={commonButtons} />}
-        {tab === 'debugger' && (
-          <Debugger
-            eventId={eventId}
-            autoFocus={autoFocusDebugger}
-            setAutoFocus={handleAutoFocus}
-            commonButtons={commonButtons}
-          />
-        )}
+        <Logs commonButtons={commonButtons} hidden={tab !== 'logs'} />
+
+        <Debugger
+          eventId={eventId}
+          autoFocus={autoFocusDebugger}
+          setAutoFocus={handleAutoFocus}
+          commonButtons={commonButtons}
+          hidden={tab !== 'debugger'}
+        />
       </div>
     </div>
   )

--- a/src/bp/ui-studio/src/web/components/Layout/BottomPanel/style.scss
+++ b/src/bp/ui-studio/src/web/components/Layout/BottomPanel/style.scss
@@ -87,3 +87,7 @@
 .flex {
   display: flex;
 }
+
+.hidden {
+  display: none;
+}

--- a/src/bp/ui-studio/src/web/components/Layout/BottomPanel/style.scss.d.ts
+++ b/src/bp/ui-studio/src/web/components/Layout/BottomPanel/style.scss.d.ts
@@ -6,6 +6,7 @@ interface CssExports {
   'divide': string;
   'flex': string;
   'fullWidth': string;
+  'hidden': string;
   'inspectorMenu': string;
   'item': string;
   'menu': string;


### PR DESCRIPTION
When the debugger autofocus on a new message and the focus is lost on the logs panel, it is unmounted so messages are lost. Since logs are streamed (only errors are persisted), when you focus again on the logs panel it has been cleared and messages are lost.

I tried to use the tabs panel directly instead of the hidden prop, but after a lot of time lost on the css, I went with an easy solution.