### PR TITLE
fix(core): deprecate set attributes

### DIFF
--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -1935,11 +1935,13 @@ declare module 'botpress/sdk' {
 
     /**
      * Merge the specified attributes to the existing attributes of the user
+     * @deprecated Please mutate `event.state.user` directly instead
      */
     export function updateAttributes(channel: string, userId: string, attributes: any): Promise<void>
 
     /**
      * Overwrite all the attributes of the user with the specified payload
+     * @deprecated Please mutate `event.state.user` directly instead
      */
     export function setAttributes(channel: string, userId: string, attributes: any): Promise<void>
     export function getAllUsers(paging?: Paging): Promise<any>


### PR DESCRIPTION
The methods setAttributes and updateAttributes cannot be used while in the event loop (ex: in a middleware, action or hook) because we persist the user's attributes which are stored in the event when we store it. Therefore, anytime this method is used, attributes are saved, but they are overwritten at the end.

Since I can't think of a proper usage for these methods, we'll just deprecate them for now so users have a warning when they use them, without affecting those which rely on them. Will need to document use cases...

![image](https://user-images.githubusercontent.com/42552874/100917061-a2783580-34a4-11eb-9ff5-4a70d9a527a9.png)
