### PR TITLE
fix(studio): width of emulator

### DIFF
--- a/modules/channel-web/assets/default-emulator.css
+++ b/modules/channel-web/assets/default-emulator.css
@@ -33,8 +33,7 @@
     --spacing-xxxx-large: 28px;
 
     --right-sidebar-width: 240px;
-    --emulator-width: 240px;
-    --debugger-width: 240px;
+    --emulator-width: 300px;
   }
 
   body {

--- a/src/bp/ui-shared/src/style/variables.scss
+++ b/src/bp/ui-shared/src/style/variables.scss
@@ -36,6 +36,5 @@
   --spacing-xxxx-large: 28px;
 
   --right-sidebar-width: 240px;
-  --emulator-width: 240px;
-  --debugger-width: 240px;
+  --emulator-width: 300px;
 }


### PR DESCRIPTION
The PR https://github.com/botpress/botpress/pull/4256 didn't change the css width so the bottom panel was partially hidden

![image](https://user-images.githubusercontent.com/42552874/101051262-45878880-3553-11eb-8b3c-21221c3f81aa.png)
