### PR TITLE
fix(admin): render needs training only if nlu module is enabled

### DIFF
--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemCompact.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/BotItemCompact.tsx
@@ -16,7 +16,6 @@ import { lang } from 'botpress/shared'
 import React, { FC } from 'react'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import history from '~/history'
-import { toastInfo } from '~/utils/toaster'
 
 import AccessControl, { isChatUser } from '../../../App/AccessControl'
 
@@ -25,6 +24,7 @@ import { NeedsTrainingWarning } from './NeedsTrainingWarning'
 interface Props {
   bot: BotConfig
   hasError: boolean
+  nluModuleEnabled: boolean | undefined
   deleteBot?: () => void
   exportBot?: () => void
   createRevision?: () => void
@@ -36,6 +36,7 @@ interface Props {
 const BotItemCompact: FC<Props> = ({
   bot,
   hasError,
+  nluModuleEnabled,
   deleteBot,
   exportBot,
   createRevision,
@@ -143,7 +144,7 @@ const BotItemCompact: FC<Props> = ({
           TODO: remove this NeedsTrainingWarning component.
           This is a temp fix but won't be usefull after we bring back training on bot mount.
           */}
-        <NeedsTrainingWarning bot={bot.id} languages={bot.languages} />
+        {nluModuleEnabled && <NeedsTrainingWarning bot={bot.id} languages={bot.languages} />}
 
         {!bot.defaultLanguage && (
           <Tooltip position="right" content={lang.tr('admin.workspace.bots.item.languageIsMissing')}>

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/index.tsx
@@ -73,7 +73,10 @@ class Bots extends Component<Props> {
   componentDidMount() {
     this.props.fetchBots()
     this.props.fetchBotHealth()
-    this.props.profile && this.props.profile.isSuperAdmin && this.props.fetchModules()
+
+    if (!this.props.modules.length && this.props.profile && this.props.profile.isSuperAdmin) {
+      this.props.fetchModules()
+    }
 
     if (!this.props.licensing) {
       this.props.fetchLicensing()

--- a/src/bp/ui-admin/src/Pages/Workspace/Bots/index.tsx
+++ b/src/bp/ui-admin/src/Pages/Workspace/Bots/index.tsx
@@ -13,7 +13,7 @@ import {
 } from '@blueprintjs/core'
 import { BotConfig } from 'botpress/sdk'
 import { confirmDialog, lang, telemetry } from 'botpress/shared'
-import { ServerHealth, UserProfile } from 'common/typings'
+import { ModuleInfo, ServerHealth, UserProfile } from 'common/typings'
 import _ from 'lodash'
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
@@ -29,6 +29,7 @@ import { Downloader } from '~/Pages/Components/Downloader'
 import api from '../../../api'
 import { fetchBotHealth, fetchBots } from '../../../reducers/bots'
 import { fetchLicensing } from '../../../reducers/license'
+import { fetchModules } from '../../../reducers/modules'
 import AccessControl from '../../../App/AccessControl'
 import LoadingSection from '../../Components/LoadingSection'
 
@@ -42,12 +43,14 @@ import RollbackBotModal from './RollbackBotModal'
 const botFilterFields = ['name', 'id', 'description']
 
 interface Props extends RouteComponentProps {
+  modules: ModuleInfo[]
   bots: BotConfig[]
   health: ServerHealth[]
   workspace: any
   fetchBots: () => void
   fetchLicensing: () => void
   fetchBotHealth: () => void
+  fetchModules: () => void
   licensing: any
   profile: UserProfile
 }
@@ -70,6 +73,7 @@ class Bots extends Component<Props> {
   componentDidMount() {
     this.props.fetchBots()
     this.props.fetchBotHealth()
+    this.props.profile && this.props.profile.isSuperAdmin && this.props.fetchModules()
 
     if (!this.props.licensing) {
       this.props.fetchLicensing()
@@ -222,12 +226,15 @@ class Bots extends Component<Props> {
       return null
     }
 
+    const nluModule = this.props.modules.find(m => m.name === 'nlu')
+
     return (
       <div className="bp_table bot_views compact_view">
         {bots.map(bot => (
           <Fragment key={bot.id}>
             <BotItemCompact
               bot={bot}
+              nluModuleEnabled={nluModule && nluModule.enabled}
               hasError={this.findBotError(bot.id)}
               deleteBot={this.deleteBot.bind(this, bot.id)}
               exportBot={this.exportBot.bind(this, bot.id)}
@@ -418,6 +425,7 @@ class Bots extends Component<Props> {
 }
 
 const mapStateToProps = state => ({
+  modules: state.modules.modules,
   bots: state.bots.bots,
   health: state.bots.health,
   workspace: state.bots.workspace,
@@ -429,7 +437,8 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = {
   fetchBots,
   fetchLicensing,
-  fetchBotHealth
+  fetchBotHealth,
+  fetchModules
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Bots)

--- a/src/bp/ui-admin/src/reducers/modules.ts
+++ b/src/bp/ui-admin/src/reducers/modules.ts
@@ -1,11 +1,14 @@
+import { ModuleDefinition } from 'botpress/sdk'
+import { ModuleInfo } from 'common/typings'
+
 import api from '../api'
 
 export const FETCH_MODULES_RECEIVED = 'bots/FETCH_MODULES_RECEIVED'
 export const FETCH_LOADED_MODULES_RECEIVED = 'bots/FETCH_LOADED_MODULES_RECEIVED'
 
 export interface ModulesState {
-  loadedModules: []
-  modules: []
+  loadedModules: ModuleDefinition[]
+  modules: ModuleInfo[]
 }
 const initialState: ModulesState = {
   loadedModules: [],


### PR DESCRIPTION
This PR fixes a red popup in admin reporting a 404 when nlu module is disabled (It is a shitty fix I know).

I check if user is superAdmin before calling backend to know if nlu module is enabled.

I then check if nlu module is enabled before calling nlu module to know if bot needs training.