### PR TITLE
feat(channel-web): allow dropdown css customization

### DIFF
--- a/modules/channel-web/assets/default.css
+++ b/modules/channel-web/assets/default.css
@@ -61,6 +61,10 @@ body {
   text-decoration: underline;
 }
 
+.bpw-keyboard-quick_reply-dropdown-select > * {
+  background: white;
+}
+
 .bpw-widget-btn:focus,
 .bpw-widget-btn:hover {
   background-color: #333;

--- a/modules/extensions/src/views/lite/components/Dropdown.jsx
+++ b/modules/extensions/src/views/lite/components/Dropdown.jsx
@@ -61,6 +61,7 @@ export class Dropdown extends React.Component {
             />
           ) : (
             <Select
+              className={'bpw-keyboard-quick_reply-dropdown-select'}
               value={this.state.selectedOption}
               onChange={this.handleChange}
               options={this.state.options}


### PR DESCRIPTION
This css class allows to customize the dropdown item in web channel.

Here's an example where I made it red:

![image](https://user-images.githubusercontent.com/25970722/101391073-d337e080-3891-11eb-887a-5f2861e30cf3.png)

Because the dropdown is actually made using react-select, the user still has to reference the component's childs using `> *` css operator. 

It's only a quick fix, the real solution would be to get rid of react-select and implement a fully customizable dropdown with plain old html tags.

what do you guys think?