### PR TITLE
fix(nlu): vocab tokenizer should not return empty string

### DIFF
--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -145,8 +145,8 @@ export default class Engine implements NLU.Engine {
     }
 
     const debugMsg = previousModel
-      ? `Training all contexts for language: ${languageCode}`
-      : `Retraining only contexts: [${ctxToTrain}] for language: ${languageCode}`
+      ? `Retraining only contexts: [${ctxToTrain}] for language: ${languageCode}`
+      : `Training all contexts for language: ${languageCode}`
     trainDebug(debugMsg)
 
     const input: TrainInput = {

--- a/src/bp/nlu-core/tools/vocab-tokenizer.test.ts
+++ b/src/bp/nlu-core/tools/vocab-tokenizer.test.ts
@@ -57,3 +57,16 @@ test('vocab tokenizer should not split', () => {
   expect(actual).toHaveLength(1)
   expect(actual[0]).toBe('arthur')
 })
+
+test('vocab tokenizer should never return empty string', () => {
+  // arange
+  const sentencepieceToken = 'covid'
+  const vocabTokenizer = getVocabTokenizer(['covid', '$'])
+
+  // act
+  const actual = vocabTokenizer(sentencepieceToken)
+
+  // assert
+  expect(actual).toHaveLength(1)
+  expect(actual[0]).toBe('covid')
+})

--- a/src/bp/nlu-core/tools/vocab-tokenizer.ts
+++ b/src/bp/nlu-core/tools/vocab-tokenizer.ts
@@ -8,30 +8,30 @@ interface VocabMatch {
 }
 
 export default (vocab: string[]) => (token: string) => {
-  const matchingVocabTokens = _(vocab)
+  let matchingVocabTokens: VocabMatch[] = vocab
     .map(t => {
       try {
         const regexp = new RegExp(t, 'i')
-        return token.match(regexp)
+        const match: RegExpMatchArray | null = token.match(regexp)
+        return match
       } catch {
         return undefined
       }
     })
-    .filter(x => !!x)
+    .filter(x => !!x && x.length && x[0].length)
     .map(match => {
       const start = match!.index
       const src = match![0]
       const length = src.length
       const end = start! + length
-      return {
+      return <VocabMatch>{
         start,
         end,
         length,
         src
-      } as VocabMatch
+      }
     })
-    .orderBy(match => match.length, 'desc')
-    .value()
+  matchingVocabTokens = _.orderBy(matchingVocabTokens, (match: VocabMatch) => match.length, 'desc')
 
   const coverAllToken = matchesCoverAllToken(token)
 


### PR DESCRIPTION
Fixes a case where vocab tokenizer tokenize "covid" to ["covid", ""]