### PR TITLE
chore(nlu): engine now only returns prediction results + rm included contexts from nlu prediction

### DIFF
--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -5,7 +5,6 @@ import yn from 'yn'
 
 import legacyElectionPipeline from './election/legacy-election'
 import mergeSpellChecked from './election/spellcheck-handler'
-import { PredictOutput } from './election/typings'
 import { getTrainingSession } from './train-session-service'
 import { NLUState } from './typings'
 
@@ -51,27 +50,36 @@ export default async (bp: typeof sdk, state: NLUState) => {
       return res.status(404).send(`Bot ${botId} doesn't exist`)
     }
 
-    const modelId = botNLU.modelsByLang[botNLU.defaultLanguage]
+    const predictionLanguage = botNLU.defaultLanguage
+    const modelId = botNLU.modelsByLang[predictionLanguage]
 
     try {
       // TODO: language should be a path param of route
 
-      let nlu: sdk.IO.EventUnderstanding
+      let nlu: sdk.NLU.PredictOutput
 
       const spellChecked = await state.engine.spellCheck(value.text, modelId)
+
+      const t0 = Date.now()
       if (spellChecked !== value.text) {
-        const originalPrediction = (await state.engine.predict(value.text, value.contexts, modelId)) as PredictOutput
-        const spellCheckedPrediction = (await state.engine.predict(
-          spellChecked,
-          value.contexts,
-          modelId
-        )) as PredictOutput
+        const originalPrediction = await state.engine.predict(value.text, value.contexts, modelId)
+        const spellCheckedPrediction = await state.engine.predict(spellChecked, value.contexts, modelId)
         nlu = mergeSpellChecked(originalPrediction, spellCheckedPrediction)
       } else {
         nlu = await state.engine.predict(value.text, value.contexts, modelId)
       }
-      nlu = legacyElectionPipeline(nlu)
-      res.send({ nlu })
+      const ms = Date.now() - t0
+
+      const event: sdk.IO.EventUnderstanding = {
+        ...nlu,
+        includedContexts: value.contexts,
+        language: predictionLanguage,
+        detectedLanguage: undefined,
+        errored: false,
+        ms,
+        spellChecked
+      }
+      res.send({ nlu: legacyElectionPipeline(event) })
     } catch (err) {
       res.status(500).send('Could not extract nlu data')
     }

--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -62,11 +62,11 @@ export default async (bp: typeof sdk, state: NLUState) => {
 
       const t0 = Date.now()
       if (spellChecked !== value.text) {
-        const originalPrediction = await state.engine.predict(value.text, value.contexts, modelId)
-        const spellCheckedPrediction = await state.engine.predict(spellChecked, value.contexts, modelId)
+        const originalPrediction = await state.engine.predict(value.text, modelId)
+        const spellCheckedPrediction = await state.engine.predict(spellChecked, modelId)
         nlu = mergeSpellChecked(originalPrediction, spellCheckedPrediction)
       } else {
-        nlu = await state.engine.predict(value.text, value.contexts, modelId)
+        nlu = await state.engine.predict(value.text, modelId)
       }
       const ms = Date.now() - t0
 

--- a/modules/nlu/src/backend/election/legacy-election.ts
+++ b/modules/nlu/src/backend/election/legacy-election.ts
@@ -3,7 +3,7 @@ import _ from 'lodash'
 
 import { allInRange, GetZPercent, std } from '../tools/math'
 
-import { NONE_INTENT, PredictOutput } from './typings'
+import { NONE_INTENT } from './typings'
 
 const OOS_AS_NONE_TRESH = 0.4
 const LOW_INTENT_CONFIDENCE_TRESH = 0.4
@@ -13,14 +13,13 @@ export default function legacyElectionPipeline(input: sdk.IO.EventUnderstanding)
   if (!input.predictions) {
     return input
   }
-  let step: PredictOutput = input as PredictOutput
-  step = electIntent(step)
+  let step = electIntent(input)
   step = detectAmbiguity(step)
   step = extractElectedIntentSlot(step)
   return step
 }
 
-function electIntent(input: PredictOutput): PredictOutput {
+function electIntent(input: sdk.IO.EventUnderstanding): sdk.IO.EventUnderstanding {
   const allCtx = Object.keys(input.predictions)
 
   const ctx_predictions = allCtx.map(label => {
@@ -122,7 +121,7 @@ function electIntent(input: PredictOutput): PredictOutput {
   }
 }
 
-function detectAmbiguity(input: PredictOutput): PredictOutput {
+function detectAmbiguity(input: sdk.IO.EventUnderstanding): sdk.IO.EventUnderstanding {
   // +- 10% away from perfect median leads to ambiguity
   const preds = input.intents!
   const perfectConfusion = 1 / preds.length
@@ -138,7 +137,7 @@ function detectAmbiguity(input: PredictOutput): PredictOutput {
   return { ...input, ambiguous }
 }
 
-function extractElectedIntentSlot(input: PredictOutput): PredictOutput {
+function extractElectedIntentSlot(input: sdk.IO.EventUnderstanding): sdk.IO.EventUnderstanding {
   const intentWasElectedWithoutAmbiguity = input?.intent?.name && !_.isEmpty(input.predictions) && !input.ambiguous
   const intentIsNone = input?.intent?.name === NONE_INTENT
   if (!intentWasElectedWithoutAmbiguity || intentIsNone) {

--- a/modules/nlu/src/backend/election/spellcheck-handler.ts
+++ b/modules/nlu/src/backend/election/spellcheck-handler.ts
@@ -1,9 +1,12 @@
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 
-import { NONE_INTENT, PredictOutput, ValueOf } from './typings'
+import { NONE_INTENT, ValueOf } from './typings'
 
-const mergeSpellChecked = (originalOutput: PredictOutput, spellCheckedOutput: PredictOutput): PredictOutput => {
+const mergeSpellChecked = (
+  originalOutput: sdk.NLU.PredictOutput,
+  spellCheckedOutput: sdk.NLU.PredictOutput
+): sdk.NLU.PredictOutput => {
   const mostConfidentContext = (preds: sdk.NLU.Predictions): ValueOf<sdk.NLU.Predictions> =>
     _(preds)
       .values()

--- a/modules/nlu/src/backend/election/typings.ts
+++ b/modules/nlu/src/backend/election/typings.ts
@@ -1,9 +1,3 @@
-import * as sdk from 'botpress/sdk'
-
-export type PredictOutput = Omit<sdk.IO.EventUnderstanding, 'predictions'> & {
-  predictions: sdk.NLU.Predictions
-}
-
 export const NONE_INTENT = 'none' // should extract in comon code
 
 export type ValueOf<T> = T[keyof T]

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -43,7 +43,7 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
       }
 
       try {
-        const { botId, preview, nlu } = event
+        const { botId, preview } = event
         const { engine, nluByBot } = state
         const { defaultLanguage, modelsByLang, modelService } = nluByBot[botId]
 
@@ -57,9 +57,10 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
           defaultLanguage,
           bp.logger.forBot(botId)
         )
-        const nluResults = await predictionHandler.predict(preview, nlu?.includedContexts)
+        const nluResults = await predictionHandler.predict(preview)
 
-        _.merge(event, { nlu: nluResults ?? {} })
+        const nlu = { ...nluResults, includedContexts: event.nlu?.includedContexts ?? [] }
+        _.merge(event, { nlu })
         removeSensitiveText(event)
       } catch (err) {
         bp.logger.warn(`Error extracting metadata for incoming text: ${err.message}`)

--- a/modules/nlu/src/backend/prediction-handler.test.ts
+++ b/modules/nlu/src/backend/prediction-handler.test.ts
@@ -15,7 +15,13 @@ const fr = 'fr'
 const en = 'en'
 const de = 'de'
 
-const loggerMock = (<Partial<Logger>>{ warn: (msg: string) => {} }) as Logger
+const loggerMock = (<Partial<Logger>>{
+  attachError: (err: Error) => {
+    return loggerMock
+  },
+  warn: (msg: string) => {},
+  error: (msg: string) => {}
+}) as Logger
 
 const makeModelsByLang = (langs: string[]) => {
   const models: NLU.ModelId[] = (<Partial<NLU.ModelId>[]>langs.map(l => ({ languageCode: l }))) as NLU.ModelId[]
@@ -59,17 +65,14 @@ function makeEngineMock(loadedLanguages: string[]): NLU.Engine {
 
     hasModel: (modelId: NLU.ModelId) => loadedModels.map(m => m.languageCode).includes(modelId.languageCode),
 
-    predict: jest.fn(async (textInput: string, ctx: string[], modelId: NLU.ModelId) => {
+    predict: jest.fn(async (textInput: string, modelId: NLU.ModelId) => {
       if (loadedModels.map(m => m.languageCode).includes(modelId.languageCode)) {
-        return <IO.EventUnderstanding>{
+        return <NLU.PredictOutput>{
           entities: [],
-          predictions: {},
-          includedContexts: ctx,
-          language: modelId.languageCode,
-          ms: Date.now()
+          predictions: {}
         }
       }
-      return <IO.EventUnderstanding>{ errored: true }
+      throw new Error('model not loaded')
     })
   }) as NLU.Engine
 }
@@ -120,7 +123,7 @@ const assertModelLoaded = (modelGetterMock: jest.Mock, langs: string[]) => {
 const assertPredictCalled = (enginePredictMock: jest.Mock, langs: string[]) => {
   expect(enginePredictMock.mock.calls.length).toBe(langs.length)
   for (let i = 0; i < langs.length; i++) {
-    expect(enginePredictMock.mock.calls[i][2].languageCode).toBe(langs[i])
+    expect(enginePredictMock.mock.calls[i][1].languageCode).toBe(langs[i])
   }
 }
 
@@ -155,7 +158,7 @@ describe('predict', () => {
       defaultLang,
       loggerMock
     )
-    const result = await predictionHandler.predict(germanUtt, ['global'])
+    const result = await predictionHandler.predict(germanUtt)
 
     // assert
     expect(result).toBeDefined()
@@ -183,7 +186,7 @@ describe('predict', () => {
       defaultLang,
       loggerMock
     )
-    const result = await predictionHandler.predict(germanUtt, ['global'])
+    const result = await predictionHandler.predict(germanUtt)
 
     // assert
     expect(result).toBeDefined()
@@ -211,7 +214,7 @@ describe('predict', () => {
       defaultLang,
       loggerMock
     )
-    const result = await predictionHandler.predict(germanUtt, ['global'])
+    const result = await predictionHandler.predict(germanUtt)
 
     // assert
     expect(result).toBeDefined()
@@ -239,7 +242,7 @@ describe('predict', () => {
       defaultLang,
       loggerMock
     )
-    const result = await predictionHandler.predict(germanUtt, ['global'])
+    const result = await predictionHandler.predict(germanUtt)
 
     // assert
     expect(result).toBeDefined()
@@ -267,7 +270,7 @@ describe('predict', () => {
       defaultLang,
       loggerMock
     )
-    const result = await predictionHandler.predict(germanUtt, ['global'])
+    const result = await predictionHandler.predict(germanUtt)
 
     // assert
     expect(result).toBeDefined()
@@ -295,7 +298,7 @@ describe('predict', () => {
       defaultLang,
       loggerMock
     )
-    const result = await predictionHandler.predict(germanUtt, ['global'])
+    const result = await predictionHandler.predict(germanUtt)
 
     // assert
     expect(result).toBeDefined()
@@ -323,7 +326,7 @@ describe('predict', () => {
       defaultLang,
       loggerMock
     )
-    await assertThrows(() => predictionHandler.predict(germanUtt, ['global']))
+    await assertThrows(() => predictionHandler.predict(germanUtt))
     assertPredictCalled(engine.predict as jest.Mock, [])
     assertModelLoaded(modelProvider.getLatestModel as jest.Mock, [de, fr, en])
   })

--- a/modules/nlu/src/backend/prediction-handler.test.ts
+++ b/modules/nlu/src/backend/prediction-handler.test.ts
@@ -99,12 +99,12 @@ function makeModelProviderMock(langsOnFs: string[]): ModelService {
   }) as ModelService
 }
 
-const modelIdService = (<Partial<typeof NLU.modelId>>{
+const modelIdService = (<Partial<typeof NLU.modelIdService>>{
   toId: (m: NLU.ModelId) => m,
   briefId: (q: { specifications: any; languageCode: string }) => ({
     languageCode: q.languageCode
   })
-}) as typeof NLU.modelId
+}) as typeof NLU.modelIdService
 
 const assertNoModelLoaded = (modelGetterMock: jest.Mock) => {
   assertModelLoaded(modelGetterMock, [])

--- a/modules/nlu/src/backend/prediction-handler.ts
+++ b/modules/nlu/src/backend/prediction-handler.ts
@@ -42,8 +42,8 @@ export class PredictionHandler {
     try {
       detectedLanguage = await this.engine.detectLanguage(textInput, loadedModels)
     } catch (err) {
-      let msg = `An error occured when detecting language for input ${textInput}\n`
-      msg += `Falling back on default language ${this.defaultLanguage}.`
+      let msg = `An error occured when detecting language for input "${textInput}"\n`
+      msg += `Falling back on default language: ${this.defaultLanguage}.`
       this.logger.attachError(err).error(msg)
     }
 
@@ -82,7 +82,7 @@ export class PredictionHandler {
     try {
       spellChecked = await this.engine.spellCheck(textInput, this.modelsByLang[language])
     } catch (err) {
-      let msg = `An error occured when spell checking input ${textInput}\n`
+      let msg = `An error occured when spell checking input "${textInput}"\n`
       msg += 'Falling back on original input.'
       this.logger.attachError(err).error(msg)
     }
@@ -99,7 +99,8 @@ export class PredictionHandler {
       }
       return { ...originalOutput, spellChecked, errored: false, language, ms }
     } catch (err) {
-      const msg = `An error occured when predicting for input ${textInput} with model ${this.modelsByLang[language]}`
+      const stringId = this.modelIdService.toString(this.modelsByLang[language])
+      const msg = `An error occured when predicting for input "${textInput}" with model ${stringId}`
       this.logger.attachError(err).error(msg)
 
       const ms = Date.now() - t0

--- a/src/bp/core/sdk/impl.ts
+++ b/src/bp/core/sdk/impl.ts
@@ -76,7 +76,8 @@ export class IOEvent implements sdk.IO.Event {
     this.nlu = {
       entities: [],
       language: 'n/a',
-      detectedLanguage: 'n/a',
+      detectedLanguage: undefined,
+      spellChecked: undefined,
       ambiguous: false,
       slots: {},
       intent: { name: 'none', confidence: 1, context: 'global' },

--- a/src/bp/core/services/middleware/event-engine.ts
+++ b/src/bp/core/services/middleware/event-engine.ts
@@ -60,7 +60,8 @@ const eventSchema = {
         .array()
         .items(joi.string())
         .optional(),
-      ms: joi.number().optional()
+      ms: joi.number().optional(),
+      spellChecked: joi.string().optional()
     })
     .optional()
     .default({})

--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -294,7 +294,7 @@ export default class Engine implements NLU.Engine {
     }
   }
 
-  async predict(text: string, includedContexts: string[], modelId: NLU.ModelId): Promise<NLU.PredictOutput> {
+  async predict(text: string, modelId: NLU.ModelId): Promise<NLU.PredictOutput> {
     debugPredict(`Predict for input: "${text}"`)
 
     const stringId = modelIdService.toString(modelId)
@@ -304,13 +304,14 @@ export default class Engine implements NLU.Engine {
     }
 
     const language = loaded.model.languageCode
-    const input: PredictInput = {
-      language,
-      sentence: text,
-      includedContexts
-    }
-
-    return Predict(input, this._tools, loaded.predictors)
+    return Predict(
+      {
+        language,
+        text
+      },
+      this._tools,
+      loaded.predictors
+    )
   }
 
   async spellCheck(sentence: string, modelId: NLU.ModelId) {

--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -11,7 +11,7 @@ import DetectLanguage from './language/language-identifier'
 import makeSpellChecker from './language/spell-checker'
 import modelIdService from './model-id-service'
 import { deserializeModel, PredictableModel, serializeModel } from './model-serializer'
-import { Predict, PredictInput, Predictors, PredictOutput } from './predict-pipeline'
+import { Predict, PredictInput, Predictors } from './predict-pipeline'
 import SlotTagger from './slots/slot-tagger'
 import { isPatternValid } from './tools/patterns-utils'
 import { ProcessIntents, TrainInput, TrainOutput } from './training-pipeline'
@@ -294,7 +294,7 @@ export default class Engine implements NLU.Engine {
     }
   }
 
-  async predict(text: string, includedContexts: string[], modelId: NLU.ModelId): Promise<PredictOutput> {
+  async predict(text: string, includedContexts: string[], modelId: NLU.ModelId): Promise<NLU.PredictOutput> {
     debugPredict(`Predict for input: "${text}"`)
 
     const stringId = modelIdService.toString(modelId)

--- a/src/bp/nlu-core/predict-pipeline.test.ts
+++ b/src/bp/nlu-core/predict-pipeline.test.ts
@@ -1,0 +1,77 @@
+import { predictContext, predictIntent, Predictors } from './predict-pipeline'
+import Utterance from './utterance/utterance'
+
+describe('predict pipeline', () => {
+  test('predict with no ctx classifier and no ctxs returns empty array', async () => {
+    // arrange
+    const languageCode = 'en'
+    const contexts: string[] = []
+
+    // act
+    const { ctx_predictions } = await predictContext(
+      {
+        rawText: "hello, I love you won't you tell me your name",
+        languageCode,
+        utterance: new Utterance([], [], [], languageCode),
+        oos_predictions: {}
+      },
+      <Predictors>{ contexts, ctx_classifier: undefined }
+    )
+
+    // assert
+    expect(ctx_predictions.length).toEqual(0)
+  })
+
+  test('predict with no ctx classifier returns equi-confident ctx with none intent in each', async () => {
+    // arrange
+    const languageCode = 'en'
+    const contexts = ['A', 'B', 'C', 'D']
+
+    // act
+    const { ctx_predictions } = await predictContext(
+      {
+        rawText: "hello, I love you won't you tell me your name",
+        languageCode,
+        utterance: new Utterance([], [], [], languageCode),
+        oos_predictions: {}
+      },
+      <Predictors>{ contexts, ctx_classifier: undefined }
+    )
+
+    // assert
+    const labels = ctx_predictions.map(ctx => ctx.label)
+    const confs = ctx_predictions.map(ctx => ctx.confidence)
+    expect(labels).toEqual(contexts)
+    expect(confs).toEqual([0.25, 0.25, 0.25, 0.25])
+  })
+
+  test('predict with no intent classifier returns only none intent for each ctx', async () => {
+    // arrange
+    const languageCode = 'en'
+    const contexts = ['A', 'B', 'C', 'D']
+
+    // act
+    const step = await predictContext(
+      {
+        rawText: "hello, I love you won't you tell me your name",
+        languageCode,
+        utterance: new Utterance([], [], [], languageCode),
+        oos_predictions: {}
+      },
+      <Predictors>{ contexts, ctx_classifier: undefined }
+    )
+    const { intent_predictions } = await predictIntent(step, <Predictors>{
+      contexts,
+      ctx_classifier: undefined,
+      intent_classifier_per_ctx: {}
+    })
+
+    // assert
+    const ctxs = Object.keys(intent_predictions)
+    const intents = Object.values(intent_predictions)
+    expect(ctxs).toEqual(contexts)
+    for (const i of intents) {
+      expect(i).toEqual([{ label: 'none', confidence: 1 }])
+    }
+  })
+})

--- a/src/bp/nlu-core/predict-pipeline.ts
+++ b/src/bp/nlu-core/predict-pipeline.ts
@@ -1,4 +1,4 @@
-import * as sdk from 'botpress/sdk'
+import { MLToolkit, NLU } from 'botpress/sdk'
 import _ from 'lodash'
 
 import { extractListEntities, extractPatternEntities } from './entities/custom-entity-extractor'
@@ -21,7 +21,7 @@ import {
 } from './typings'
 import Utterance, { buildUtteranceBatch, preprocessRawUtterance, UtteranceEntity } from './utterance/utterance'
 
-export type ExactMatchResult = (sdk.MLToolkit.SVM.Prediction & { extractor: 'exact-matcher' }) | undefined
+export type ExactMatchResult = (MLToolkit.SVM.Prediction & { extractor: 'exact-matcher' }) | undefined
 
 export type Predictors = {
   lang: string
@@ -33,10 +33,10 @@ export type Predictors = {
   pattern_entities: PatternEntity[]
   intents: Intent<Utterance>[]
 } & Partial<{
-  ctx_classifier: sdk.MLToolkit.SVM.Predictor
-  intent_classifier_per_ctx: _.Dictionary<sdk.MLToolkit.SVM.Predictor>
-  oos_classifier_per_ctx: _.Dictionary<sdk.MLToolkit.SVM.Predictor>
-  kmeans: sdk.MLToolkit.KMeans.KmeansResult
+  ctx_classifier: MLToolkit.SVM.Predictor
+  intent_classifier_per_ctx: _.Dictionary<MLToolkit.SVM.Predictor>
+  oos_classifier_per_ctx: _.Dictionary<MLToolkit.SVM.Predictor>
+  kmeans: MLToolkit.KMeans.KmeansResult
   slot_tagger: SlotTagger // TODO replace this by MlToolkit.CRF.Tagger
 }>
 
@@ -53,11 +53,9 @@ interface InitialStep {
 }
 type PredictStep = InitialStep & { utterance: Utterance }
 type OutOfScopeStep = PredictStep & { oos_predictions: _.Dictionary<number> }
-type ContextStep = OutOfScopeStep & { ctx_predictions: sdk.MLToolkit.SVM.Prediction[] }
-type IntentStep = ContextStep & { intent_predictions: _.Dictionary<sdk.MLToolkit.SVM.Prediction[]> }
+type ContextStep = OutOfScopeStep & { ctx_predictions: MLToolkit.SVM.Prediction[] }
+type IntentStep = ContextStep & { intent_predictions: _.Dictionary<MLToolkit.SVM.Prediction[]> }
 type SlotStep = IntentStep & { slot_predictions_per_intent: _.Dictionary<SlotExtractionResult[]> }
-
-export type PredictOutput = sdk.IO.EventUnderstanding
 
 const DEFAULT_CTX = 'global'
 const NONE_INTENT = 'none'
@@ -157,7 +155,7 @@ async function predictIntent(input: ContextStep, predictors: Predictors): Promis
   const ctxToPredict = input.ctx_predictions.map(p => p.label)
   const predictions = (
     await Promise.map(ctxToPredict, async ctx => {
-      const preds: sdk.MLToolkit.SVM.Prediction[] = []
+      const preds: MLToolkit.SVM.Prediction[] = []
 
       const predictor = predictors.intent_classifier_per_ctx?.[ctx]
       if (predictor) {
@@ -230,8 +228,8 @@ async function extractSlots(input: IntentStep, predictors: Predictors): Promise<
   return { ...input, slot_predictions_per_intent: slots_per_intent }
 }
 
-function MapStepToOutput(step: SlotStep, startTime: number): PredictOutput {
-  const entitiesMapper = (e?: EntityExtractionResult | UtteranceEntity): sdk.NLU.Entity => {
+function MapStepToOutput(step: SlotStep): NLU.PredictOutput {
+  const entitiesMapper = (e?: EntityExtractionResult | UtteranceEntity): NLU.Entity => {
     if (!e) {
       return eval('null')
     }
@@ -256,23 +254,7 @@ function MapStepToOutput(step: SlotStep, startTime: number): PredictOutput {
   // legacy pre-ndu
   const entities = step.utterance.entities.map(entitiesMapper)
 
-  // legacy pre-ndu
-  const slots = step.utterance.slots.reduce((slots, s) => {
-    return {
-      ...slots,
-      [s.name]: {
-        start: s.startPos,
-        end: s.endPos,
-        confidence: s.confidence,
-        name: s.name,
-        source: s.source,
-        value: s.value,
-        entity: entitiesMapper(s.entity) // TODO: add this mapper to the legacy election pipeline
-      }
-    }
-  }, {} as sdk.NLU.SlotCollection)
-
-  const slotsCollectionReducer = (slots: sdk.NLU.SlotCollection, s: SlotExtractionResult): sdk.NLU.SlotCollection => {
+  const slotsCollectionReducer = (slots: NLU.SlotCollection, s: SlotExtractionResult): NLU.SlotCollection => {
     if (slots[s.slot.name] && slots[s.slot.name].confidence > s.slot.confidence) {
       // we keep only the most confident slots
       return slots
@@ -292,7 +274,7 @@ function MapStepToOutput(step: SlotStep, startTime: number): PredictOutput {
     }
   }
 
-  const predictions: sdk.NLU.Predictions = step.ctx_predictions!.reduce((preds, current) => {
+  const predictions: NLU.Predictions = step.ctx_predictions!.reduce((preds, current) => {
     const { label, confidence } = current
 
     const intentPred = step.intent_predictions[label]
@@ -316,17 +298,13 @@ function MapStepToOutput(step: SlotStep, startTime: number): PredictOutput {
     }
   }, {})
 
-  return {
+  return <NLU.PredictOutput>{
     entities,
-    errored: false,
     predictions: _.chain(predictions) // orders all predictions by confidence
       .entries()
       .orderBy(x => x[1].confidence, 'desc')
       .fromPairs()
-      .value(),
-    includedContexts: step.includedContexts, // legacy pre-ndu
-    language: step.languageCode,
-    ms: Date.now() - startTime
+      .value()
   }
 }
 
@@ -344,26 +322,19 @@ export function findExactIntentForCtx(
   }
 }
 
-export const Predict = async (input: PredictInput, tools: Tools, predictors: Predictors): Promise<PredictOutput> => {
-  try {
-    const { includedContexts, language, sentence } = input
-
-    const t0 = Date.now()
-
-    // tslint:disable-next-line
-    let { step } = await preprocessInput({ includedContexts, language, sentence: sentence }, tools, predictors)
-
-    const initialStep = await makePredictionUtterance(step, predictors, tools)
-    const entitesStep = await extractEntities(initialStep, predictors, tools)
-    const oosStep = await predictOutOfScope(entitesStep, predictors)
-    const ctxStep = await predictContext(oosStep, predictors)
-    const intentStep = await predictIntent(ctxStep, predictors)
-    const slotStep = await extractSlots(intentStep, predictors)
-    const output = MapStepToOutput(slotStep, t0)
-    return output
-  } catch (err) {
-    // tslint:disable-next-line: no-console
-    console.log('Could not perform predict data', err)
-    return { errored: true } as sdk.IO.EventUnderstanding
-  }
+export const Predict = async (
+  input: PredictInput,
+  tools: Tools,
+  predictors: Predictors
+): Promise<NLU.PredictOutput> => {
+  const { includedContexts, language, sentence } = input
+  const { step } = await preprocessInput({ includedContexts, language, sentence }, tools, predictors)
+  const initialStep = await makePredictionUtterance(step, predictors, tools)
+  const entitesStep = await extractEntities(initialStep, predictors, tools)
+  const oosStep = await predictOutOfScope(entitesStep, predictors)
+  const ctxStep = await predictContext(oosStep, predictors)
+  const intentStep = await predictIntent(ctxStep, predictors)
+  const slotStep = await extractSlots(intentStep, predictors)
+  const output = MapStepToOutput(slotStep)
+  return output
 }

--- a/src/bp/nlu-core/predict-pipeline.ts
+++ b/src/bp/nlu-core/predict-pipeline.ts
@@ -125,7 +125,7 @@ async function predictContext(input: OutOfScopeStep, predictors: Predictors): Pr
       ...input,
       ctx_predictions: [
         {
-          label: DEFAULT_CTX,
+          label: predictors.contexts[0] ?? DEFAULT_CTX,
           confidence: 1
         }
       ]
@@ -143,7 +143,8 @@ async function predictContext(input: OutOfScopeStep, predictors: Predictors): Pr
 
 async function predictIntent(input: ContextStep, predictors: Predictors): Promise<IntentStep> {
   if (_.flatMap(predictors.intents, i => i.utterances).length <= 0) {
-    return { ...input, intent_predictions: { [DEFAULT_CTX]: [{ label: NONE_INTENT, confidence: 1 }] } }
+    const defaultCtx = predictors.contexts[0] ?? DEFAULT_CTX
+    return { ...input, intent_predictions: { [defaultCtx]: [{ label: NONE_INTENT, confidence: 1 }] } }
   }
 
   const customEntities = getCustomEntitiesNames(predictors)

--- a/src/bp/nlu-core/predict-pipeline.ts
+++ b/src/bp/nlu-core/predict-pipeline.ts
@@ -42,13 +42,11 @@ export type Predictors = {
 
 export interface PredictInput {
   language: string
-  includedContexts: string[]
-  sentence: string
+  text: string
 }
 
 interface InitialStep {
-  readonly rawText: string
-  includedContexts: string[]
+  rawText: string
   languageCode: string
 }
 type PredictStep = InitialStep & { utterance: Utterance }
@@ -72,10 +70,8 @@ async function preprocessInput(
     throw new Error(`Predictor for language: ${usedLanguage} is not valid`)
   }
 
-  const contexts = input.includedContexts.filter(x => predictors.contexts.includes(x))
   const step: InitialStep = {
-    includedContexts: _.isEmpty(contexts) ? predictors.contexts : contexts,
-    rawText: input.sentence,
+    rawText: input.text,
     languageCode: usedLanguage
   }
 
@@ -129,7 +125,7 @@ async function predictContext(input: OutOfScopeStep, predictors: Predictors): Pr
       ...input,
       ctx_predictions: [
         {
-          label: input.includedContexts.length ? input.includedContexts[0] : DEFAULT_CTX,
+          label: DEFAULT_CTX,
           confidence: 1
         }
       ]
@@ -327,8 +323,7 @@ export const Predict = async (
   tools: Tools,
   predictors: Predictors
 ): Promise<NLU.PredictOutput> => {
-  const { includedContexts, language, sentence } = input
-  const { step } = await preprocessInput({ includedContexts, language, sentence }, tools, predictors)
+  const { step } = await preprocessInput(input, tools, predictors)
   const initialStep = await makePredictionUtterance(step, predictors, tools)
   const entitesStep = await extractEntities(initialStep, predictors, tools)
   const oosStep = await predictOutOfScope(entitesStep, predictors)

--- a/src/bp/nlu-server/api.ts
+++ b/src/bp/nlu-server/api.ts
@@ -187,7 +187,7 @@ export default async function(options: APIOptions, engine: Engine) {
 
       const rawPredictions = await Promise.map(texts as string[], async t => {
         const spellChecked = await engine.spellCheck(t, modelId)
-        const output = await engine.predict(t, [], modelId)
+        const output = await engine.predict(t, modelId)
         return { ...output, spellChecked }
       })
       const withoutNone = rawPredictions.map(removeNoneIntent)

--- a/src/bp/nlu-server/remove-none.test.ts
+++ b/src/bp/nlu-server/remove-none.test.ts
@@ -1,17 +1,11 @@
-import { IO } from 'botpress/sdk'
+import { NLU } from 'botpress/sdk'
 
 import removeNoneIntent from './remove-none'
 
 test('remove none intent', () => {
   // arrange
-  const nlu: IO.EventUnderstanding = {
-    errored: false,
-    language: 'en',
-    detectedLanguage: 'en',
-    spellChecked: 'ok',
+  const nlu: NLU.PredictOutput = {
     entities: [],
-    includedContexts: ['global', 'someTopic'],
-    ms: 0,
     predictions: {
       global: {
         confidence: 0.5,

--- a/src/bp/nlu-server/remove-none.ts
+++ b/src/bp/nlu-server/remove-none.ts
@@ -1,11 +1,11 @@
-import { IO } from 'botpress/sdk'
+import { NLU } from 'botpress/sdk'
 import _ from 'lodash'
 
 /**
  * TODO: move this inside the actual NLU code
  * and find the best possible decision function to merge both none intent and oos.
  */
-export default function removeNoneIntent(nlu: IO.EventUnderstanding) {
+export default function removeNoneIntent(nlu: NLU.PredictOutput): NLU.PredictOutput {
   const predictions = _.mapValues(nlu.predictions, t => {
     const topic = { ...t }
     const noneIdx = topic.intents.findIndex(i => i.label === 'none')

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -486,7 +486,7 @@ declare module 'botpress/sdk' {
       train: (trainSessionId: string, trainSet: TrainingSet, options?: Partial<TrainingOptions>) => Promise<Model>
       cancelTraining: (trainSessionId: string) => Promise<void>
       detectLanguage: (text: string, modelByLang: Dic<ModelId>) => Promise<string>
-      predict: (text: string, ctx: string[], modelId: ModelId) => Promise<IO.EventUnderstanding>
+      predict: (text: string, ctx: string[], modelId: ModelId) => Promise<PredictOutput>
       spellCheck: (sentence: string, modelId: ModelId) => Promise<string>
     }
 
@@ -646,6 +646,11 @@ declare module 'botpress/sdk' {
         }[]
       }
     }
+
+    export interface PredictOutput {
+      readonly entities: Entity[]
+      readonly predictions: Predictions
+    }
   }
 
   export namespace NDU {
@@ -792,23 +797,27 @@ declare module 'botpress/sdk' {
       readonly threadId?: string
     }
 
-    export interface EventUnderstanding {
-      intent?: NLU.Intent
-      /** Predicted intents needs disambiguation */
-      readonly ambiguous?: boolean
-      intents?: NLU.Intent[]
-      /** The language used for prediction. Will be equal to detected language when its part of supported languages, falls back to default language otherwise */
-      readonly language: string
-      /** Language detected from users input. */
-      readonly detectedLanguage?: string
-      readonly spellChecked?: string
-      readonly entities: NLU.Entity[]
-      readonly slots?: NLU.SlotCollection
+    export type EventUnderstanding = {
       readonly errored: boolean
+
+      // election
+      readonly intent?: NLU.Intent
+      readonly intents?: NLU.Intent[]
+      readonly ambiguous?: boolean /** Predicted intents needs disambiguation */
+      readonly slots?: NLU.SlotCollection
+
+      // pre-prediction
+      readonly detectedLanguage:
+        | string
+        | undefined /** Language detected from users input. If undefined, detection failed. */
+      readonly spellChecked:
+        | string
+        | undefined /** Result of spell checking on users input. If undefined, spell check failed. */
+
+      readonly language: string /** The language used for prediction */
       readonly includedContexts: string[]
-      readonly predictions?: NLU.Predictions
       readonly ms: number
-    }
+    } & Partial<NLU.PredictOutput>
 
     export interface IncomingEvent extends Event {
       /** Array of possible suggestions that the Decision Engine can take  */

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -486,7 +486,7 @@ declare module 'botpress/sdk' {
       train: (trainSessionId: string, trainSet: TrainingSet, options?: Partial<TrainingOptions>) => Promise<Model>
       cancelTraining: (trainSessionId: string) => Promise<void>
       detectLanguage: (text: string, modelByLang: Dic<ModelId>) => Promise<string>
-      predict: (text: string, ctx: string[], modelId: ModelId) => Promise<PredictOutput>
+      predict: (text: string, modelId: ModelId) => Promise<PredictOutput>
       spellCheck: (sentence: string, modelId: ModelId) => Promise<string>
     }
 


### PR DESCRIPTION
Was about to make changes to Stan's API, when I noticed how weird it is that `engine` is so thightly coupled with `IO` namespace and event typings. 

In a effort to make `engine` as simple as possible with one well-defined mission, I changed the return type of `predict()` for something simpler.

I also, removed `includedContexts` from `predict()` args as the contexts wheren't even used for prediction... They are only used for the election (given an "understanding" data structure) and the election occurs in the nlu module.

We've chosen in the past that the only reason that `engine` is not responsible for election is that it is a stateless machine and it is unaware of the current conversation state. 

I know this type of work is not a priority, but what is done is done. I've already took some time to make this refactor so why not merge it? 

What do you guys think?