### PR TITLE
fix(nlu): no more weird debounce that override other intents

### DIFF
--- a/modules/nlu/src/api.ts
+++ b/modules/nlu/src/api.ts
@@ -5,26 +5,29 @@ import * as sdk from 'botpress/sdk'
 export type NLUApi = ReturnType<typeof makeApi>
 
 export const makeApi = (bp: { axios: AxiosInstance }) => ({
-  fetchContexts: () => bp.axios.get('/nlu/contexts').then(res => res.data),
-  fetchIntentsWithQNAs: () => bp.axios.get('/nlu/intents').then(res => res.data),
-  fetchIntents: async () => {
+  fetchContexts: (): Promise<string[]> => bp.axios.get('/nlu/contexts').then(res => res.data),
+  fetchIntentsWithQNAs: (): Promise<NLU.IntentDefinition[]> => bp.axios.get('/nlu/intents').then(res => res.data),
+  fetchIntents: async (): Promise<NLU.IntentDefinition[]> => {
     const { data } = await bp.axios.get('/nlu/intents')
     return data.filter(x => !x.name.startsWith('__qna__'))
   },
-  fetchIntent: (intentName: string) => bp.axios.get(`/nlu/intents/${intentName}`).then(res => res.data),
+  fetchIntent: (intentName: string): Promise<NLU.IntentDefinition> =>
+    bp.axios.get(`/nlu/intents/${intentName}`).then(res => res.data),
   createIntent: (intent: Partial<NLU.IntentDefinition>) => bp.axios.post('/nlu/intents', intent),
-  updateIntent: (targetIntent: string, intent: Partial<NLU.IntentDefinition>) =>
+  updateIntent: (targetIntent: string, intent: Partial<NLU.IntentDefinition>): Promise<void> =>
     bp.axios.post(`/nlu/intents/${targetIntent}`, intent),
-  deleteIntent: (name: string) => bp.axios.post(`/nlu/intents/${name}/delete`),
-  syncIntentTopics: (intentNames?: string[]) => bp.axios.post('/nlu/sync/intents/topics', { intentNames }),
-  fetchEntities: () => bp.axios.get('/nlu/entities').then(res => res.data),
-  fetchEntity: (entityName: string) => bp.axios.get(`/nlu/entities/${entityName}`).then(res => res.data),
-  createEntity: (entity: NLU.EntityDefinition) => bp.axios.post('/nlu/entities/', entity),
-  updateEntity: (targetEntityId: string, entity: NLU.EntityDefinition) =>
+  deleteIntent: (name: string): Promise<void> => bp.axios.post(`/nlu/intents/${name}/delete`),
+  syncIntentTopics: (intentNames?: string[]): Promise<void> =>
+    bp.axios.post('/nlu/sync/intents/topics', { intentNames }),
+  fetchEntities: (): Promise<NLU.EntityDefinition[]> => bp.axios.get('/nlu/entities').then(res => res.data),
+  fetchEntity: (entityName: string): Promise<NLU.EntityDefinition> =>
+    bp.axios.get(`/nlu/entities/${entityName}`).then(res => res.data),
+  createEntity: (entity: NLU.EntityDefinition): Promise<void> => bp.axios.post('/nlu/entities/', entity),
+  updateEntity: (targetEntityId: string, entity: NLU.EntityDefinition): Promise<void> =>
     bp.axios.post(`/nlu/entities/${targetEntityId}`, entity),
-  deleteEntity: (entityId: string) => bp.axios.post(`/nlu/entities/${entityId}/delete`),
-  train: () => bp.axios.post('/mod/nlu/train'),
-  cancelTraining: () => bp.axios.post('/mod/nlu/train/delete')
+  deleteEntity: (entityId: string): Promise<void> => bp.axios.post(`/nlu/entities/${entityId}/delete`),
+  train: (): Promise<void> => bp.axios.post('/mod/nlu/train'),
+  cancelTraining: (): Promise<void> => bp.axios.post('/mod/nlu/train/delete')
 })
 
 export const createApi = async (bp: typeof sdk, botId: string) => {

--- a/modules/nlu/src/api.ts
+++ b/modules/nlu/src/api.ts
@@ -2,25 +2,9 @@ import axios, { AxiosInstance } from 'axios'
 import { NLU } from 'botpress/sdk'
 import * as sdk from 'botpress/sdk'
 
-export interface NLUApi {
-  fetchContexts: () => Promise<string[]>
-  fetchIntentsWithQNAs: () => Promise<NLU.IntentDefinition[]>
-  fetchIntents: () => Promise<NLU.IntentDefinition[]>
-  fetchIntent: (x: string) => Promise<NLU.IntentDefinition>
-  createIntent: (x: Partial<NLU.IntentDefinition>) => Promise<any>
-  updateIntent: (targetIntent: string, intent: Partial<NLU.IntentDefinition>, updateTopics?: boolean) => Promise<any>
-  syncIntentTopics: (intentNames?: string[]) => Promise<void>
-  deleteIntent: (x: string) => Promise<any>
-  fetchEntities: () => Promise<NLU.EntityDefinition[]>
-  fetchEntity: (x: string) => Promise<NLU.EntityDefinition>
-  createEntity: (x: NLU.EntityDefinition) => Promise<any>
-  updateEntity: (targetEntityId: string, x: NLU.EntityDefinition) => Promise<any>
-  deleteEntity: (x: string) => Promise<any>
-  train: () => Promise<void>
-  cancelTraining: () => Promise<void>
-}
+export type NLUApi = ReturnType<typeof makeApi>
 
-export const makeApi = (bp: { axios: AxiosInstance }): NLUApi => ({
+export const makeApi = (bp: { axios: AxiosInstance }) => ({
   fetchContexts: () => bp.axios.get('/nlu/contexts').then(res => res.data),
   fetchIntentsWithQNAs: () => bp.axios.get('/nlu/intents').then(res => res.data),
   fetchIntents: async () => {

--- a/modules/nlu/src/views/full/index.tsx
+++ b/modules/nlu/src/views/full/index.tsx
@@ -146,13 +146,7 @@ const NLU: FC<Props> = props => {
           />
         )}
         {!!intents.length && currentItem && currentItem.type === 'intent' && (
-          <IntentEditor
-            intent={currentItem.name}
-            api={api}
-            contentLang={props.contentLang}
-            showSlotPanel
-            axios={props.bp.axios} // to be removed for api, requires a lot of refactoring
-          />
+          <IntentEditor intent={currentItem.name} api={api} contentLang={props.contentLang} showSlotPanel />
         )}
         {currentItem && currentItem.type === 'entity' && (
           <EntityEditor

--- a/modules/nlu/src/views/full/intents/FullEditor.tsx
+++ b/modules/nlu/src/views/full/intents/FullEditor.tsx
@@ -47,7 +47,7 @@ export const IntentEditor: FC<Props> = props => {
   const saveIntent = (newIntent: NLU.IntentDefinition) => {
     setIntent(newIntent)
     // tslint:disable-next-line: no-floating-promises
-    props.api.updateIntent(newIntent.name, newIntent)
+    props.api.createIntent(newIntent)
   }
 
   const handleUtterancesChange = (newUtterances: string[]) => {

--- a/modules/nlu/src/views/full/intents/FullEditor.tsx
+++ b/modules/nlu/src/views/full/intents/FullEditor.tsx
@@ -35,6 +35,8 @@ export const IntentEditor: FC<Props> = props => {
       setIntent(intent)
       utils.inspect(intent)
     })
+
+    return () => debouncedApiSaveIntent.current.flush()
   }, [props.intent])
 
   if (!intent) {

--- a/modules/nlu/src/views/full/intents/FullEditor.tsx
+++ b/modules/nlu/src/views/full/intents/FullEditor.tsx
@@ -19,7 +19,6 @@ interface Props {
   api: NLUApi
   contentLang: string
   showSlotPanel?: boolean
-  axios: AxiosInstance
   liteEditor?: boolean
 }
 
@@ -80,12 +79,7 @@ export const IntentEditor: FC<Props> = props => {
               api={props.api}
             />
           )}
-          <IntentHint
-            intent={intent}
-            liteEditor={props.liteEditor}
-            contentLang={props.contentLang}
-            axios={props.axios}
-          />
+          <IntentHint intent={intent} liteEditor={props.liteEditor} contentLang={props.contentLang} />
         </div>
         <UtterancesEditor
           intentName={intent.name}
@@ -94,9 +88,7 @@ export const IntentEditor: FC<Props> = props => {
           slots={intent.slots}
         />
       </div>
-      {props.showSlotPanel && (
-        <Slots slots={intent.slots} api={props.api} axios={props.axios} onSlotsChanged={handleSlotsChange} />
-      )}
+      {props.showSlotPanel && <Slots slots={intent.slots} api={props.api} onSlotsChanged={handleSlotsChange} />}
     </div>
   )
 }

--- a/modules/nlu/src/views/full/intents/IntentHint.tsx
+++ b/modules/nlu/src/views/full/intents/IntentHint.tsx
@@ -13,7 +13,6 @@ import style from './style.scss'
 interface Props {
   intent: sdk.NLU.IntentDefinition
   contentLang: string
-  axios: AxiosInstance
   liteEditor: boolean
 }
 

--- a/modules/nlu/src/views/full/intents/LiteEditor.tsx
+++ b/modules/nlu/src/views/full/intents/LiteEditor.tsx
@@ -92,15 +92,7 @@ export const LiteEditor: FC<Props> = props => {
         onSubmit={createIntent}
         title={lang.tr('module.nlu.intents.createLabel')}
       />
-      {currentIntent && (
-        <IntentEditor
-          liteEditor
-          intent={currentIntent}
-          api={api}
-          contentLang={props.contentLang}
-          axios={props.bp.axios} // to be removed for api, requires a lot of refactoring
-        />
-      )}
+      {currentIntent && <IntentEditor liteEditor intent={currentIntent} api={api} contentLang={props.contentLang} />}
 
       <div className={style.chooseContainer}>
         <ControlGroup>

--- a/modules/nlu/src/views/full/intents/slots/EntitySelector.tsx
+++ b/modules/nlu/src/views/full/intents/slots/EntitySelector.tsx
@@ -10,7 +10,6 @@ interface EntityOption {
   type: string
   name: string
 }
-
 interface Props {
   entities: string[]
   api: NLUApi

--- a/modules/nlu/src/views/full/intents/slots/SlotItem.tsx
+++ b/modules/nlu/src/views/full/intents/slots/SlotItem.tsx
@@ -1,9 +1,19 @@
-import React from 'react'
-import style from '../style.scss'
 import { Tag } from '@blueprintjs/core'
+import { NLU } from 'botpress/sdk'
 import { confirmDialog, lang } from 'botpress/shared'
+import React from 'react'
 
-export default class SlotItem extends React.Component {
+import style from '../style.scss'
+
+interface State {}
+interface Props {
+  key: string
+  slot: NLU.SlotDefinition
+  onDelete: (slot: NLU.SlotDefinition) => void
+  onEdit: (slot: NLU.SlotDefinition) => void
+}
+
+export default class SlotItem extends React.Component<Props, State> {
   handleDeleteClicked = async e => {
     e.preventDefault()
 

--- a/modules/nlu/src/views/full/intents/slots/SlotModal.tsx
+++ b/modules/nlu/src/views/full/intents/slots/SlotModal.tsx
@@ -1,21 +1,43 @@
-import React from 'react'
-import nanoid from 'nanoid'
-import random from 'lodash/random'
-
-import { Dialog, Button, Classes, FormGroup, Intent } from '@blueprintjs/core'
-import { EntitySelector } from './EntitySelector'
+import { Button, Classes, Dialog, FormGroup, Intent } from '@blueprintjs/core'
+import { NLU } from 'botpress/sdk'
 import { lang } from 'botpress/shared'
+import _ from 'lodash'
+import random from 'lodash/random'
+import nanoid from 'nanoid'
+import React from 'react'
+
+import { NLUApi } from '../../../../api'
+
+import { SlotOperation } from './typings'
+import { EntitySelector } from './EntitySelector'
 
 const N_COLORS = 12
-const INITIAL_STATE = {
+const INITIAL_STATE: State = {
   id: null,
   name: '',
   entities: [],
   editing: false,
-  color: false
+  color: 0
 }
 
-export default class SlotModal extends React.Component {
+interface State extends NLU.SlotDefinition {
+  id: null | string
+  name: string
+  entities: string[]
+  editing: boolean
+  color: number
+}
+
+interface Props {
+  api: NLUApi
+  slot: NLU.SlotDefinition
+  slots: NLU.SlotDefinition[]
+  show: boolean
+  onSlotSave: (slot: NLU.SlotDefinition, operation: SlotOperation) => void
+  onHide: () => void
+}
+
+export default class SlotModal extends React.Component<Props, State> {
   nameInput = null
   state = { ...INITIAL_STATE }
 
@@ -40,7 +62,9 @@ export default class SlotModal extends React.Component {
   initializeFromProps = () => {
     if (this.props.slot) {
       this.setState({ ...this.props.slot, editing: true })
-    } else this.resetState()
+    } else {
+      this.resetState()
+    }
   }
 
   resetState = () => this.setState({ ...INITIAL_STATE })
@@ -48,7 +72,7 @@ export default class SlotModal extends React.Component {
   getNextAvailableColor = () => {
     const maxColor = _.get(_.maxBy(this.props.slots, 'color'), 'color') || 0
 
-    //if no more colors available, we return a random color
+    // if no more colors available, we return a random color
     return maxColor <= N_COLORS ? maxColor + 1 : random(1, N_COLORS)
   }
 
@@ -84,7 +108,7 @@ export default class SlotModal extends React.Component {
         <div className={Classes.DIALOG_BODY}>
           <FormGroup label={lang.tr('name')}>
             <input
-              tabIndex="1"
+              tabIndex={1}
               ref={el => (this.nameInput = el)}
               className={`${Classes.INPUT} ${Classes.FILL}`}
               value={this.state.name}

--- a/modules/nlu/src/views/full/intents/slots/SlotPopover.tsx
+++ b/modules/nlu/src/views/full/intents/slots/SlotPopover.tsx
@@ -1,4 +1,5 @@
 import { Tag } from '@blueprintjs/core'
+import { NLU } from 'botpress/sdk'
 import { lang } from 'botpress/shared'
 import classnames from 'classnames'
 import React from 'react'
@@ -8,7 +9,13 @@ import style from '../style.scss'
 
 const MENU_WIDTH = 300
 
-export const TagSlotPopover = props => {
+interface Props {
+  show: boolean
+  slots: NLU.SlotDefinition[]
+  onSlotClicked: (s: NLU.SlotDefinition) => void
+}
+
+export const TagSlotPopover = (props: Props) => {
   if (!props.show || !window.getSelection().rangeCount) {
     return null
   }

--- a/modules/nlu/src/views/full/intents/slots/Slots.tsx
+++ b/modules/nlu/src/views/full/intents/slots/Slots.tsx
@@ -1,14 +1,26 @@
-import React from 'react'
+import { Button, NonIdealState } from '@blueprintjs/core'
+import { AxiosInstance } from 'axios'
+import { NLU } from 'botpress/sdk'
+import { lang } from 'botpress/shared'
 import _ from 'lodash'
+import React from 'react'
 
+import { NLUApi } from '../../../../api'
+import style from '../style.scss'
+
+import { SlotModification } from './typings'
+import SlotItem from './SlotItem'
 import SlotModal from './SlotModal'
 
-import style from '../style.scss'
-import SlotItem from './SlotItem'
-import { NonIdealState, Button } from '@blueprintjs/core'
-import { lang } from 'botpress/shared'
+interface State {}
 
-export default class Slots extends React.Component {
+interface Props {
+  api: NLUApi
+  slots: NLU.SlotDefinition[]
+  onSlotsChanged: (slot: NLU.SlotDefinition[], mod: SlotModification) => void
+}
+
+export default class Slots extends React.Component<Props, State> {
   state = {
     slotModalVisible: false,
     editingSlotIdx: null
@@ -32,12 +44,12 @@ export default class Slots extends React.Component {
     this.props.onSlotsChanged && this.props.onSlotsChanged(slots, { operation, oldName, name: slot.name })
   }
 
-  onSlotDeleted = slot => {
+  onSlotDeleted = (slot: NLU.SlotDefinition) => {
     const slots = [...this.getSlots().filter(s => s.id !== slot.id)]
     this.props.onSlotsChanged && this.props.onSlotsChanged(slots, { operation: 'deleted', name: slot.name })
   }
 
-  showSlotModal = idx => {
+  showSlotModal = (idx: number) => {
     this.setState({
       slotModalVisible: true,
       editingSlotIdx: idx
@@ -88,7 +100,6 @@ export default class Slots extends React.Component {
       <div className={style.slotSidePanel}>
         <SlotModal
           api={this.props.api}
-          axios={this.props.axios}
           show={this.state.slotModalVisible}
           slot={this.props.slots[this.state.editingSlotIdx]}
           onSlotSave={this.onSlotSave}

--- a/modules/nlu/src/views/full/intents/slots/typings.ts
+++ b/modules/nlu/src/views/full/intents/slots/typings.ts
@@ -1,0 +1,7 @@
+export type SlotOperation = 'deleted' | 'created' | 'modified'
+
+export interface SlotModification {
+  operation: SlotOperation
+  name: string
+  oldName?: string
+}

--- a/modules/nlu/src/views/full/intents/utterances-state-utils.ts
+++ b/modules/nlu/src/views/full/intents/utterances-state-utils.ts
@@ -35,7 +35,7 @@ export const textNodesFromUtterance = (rawUtterance: string, idx: number = 0): T
     .value() as TextJSON[]
 }
 
-export const utterancesToValue = (utterances: string[], selection = undefined) => {
+export const utterancesToValue = (utterances: string[], selection = undefined): Value => {
   const summary = utterances[0] || ''
   const rest = utterances.length > 1 ? utterances.slice(1) : ['']
 
@@ -65,7 +65,7 @@ export const utterancesToValue = (utterances: string[], selection = undefined) =
   return Value.fromJS(value)
 }
 
-export const valueToUtterances = value => {
+export const valueToUtterances = (value: Value): string[] => {
   return value
     .getIn(['document', 'nodes'])
     .map(block =>

--- a/src/bp/nlu-server/utils.ts
+++ b/src/bp/nlu-server/utils.ts
@@ -14,6 +14,7 @@ interface BpTrainInput {
 const mapVariable = (variable: Variable): NLU.SlotDefinition => {
   const { name, types } = variable
   return {
+    id: name,
     entities: types,
     name,
     color: 0

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -577,6 +577,7 @@ declare module 'botpress/sdk' {
     }
 
     export interface SlotDefinition {
+      id: string
       name: string
       entities: string[]
       color: number


### PR DESCRIPTION
Attempt at fixing botpress/v12#1185 \+ added few typings while I was there.

I'm not sure I actually solved the problem described in the issue, but I solved another one for sure:

when swicthing between intents (in the left pannel), if you switch before 2.5 seconds of deboucing, you override the current intent.

this is fixed now.