### PR TITLE
fix(nlu): speedup intent retrieval

### DIFF
--- a/src/bp/core/services/nlu/intent-service.ts
+++ b/src/bp/core/services/nlu/intent-service.ts
@@ -18,7 +18,7 @@ export class IntentService {
 
   public async getIntents(botId: string): Promise<sdk.NLU.IntentDefinition[]> {
     const intentNames = await this.ghostService.forBot(botId).directoryListing(INTENTS_DIR, '*.json')
-    return Promise.mapSeries(intentNames, n => this.getIntent(botId, n))
+    return Promise.map(intentNames, n => this.getIntent(botId, n))
   }
 
   public async getIntent(botId: string, intentName: string): Promise<sdk.NLU.IntentDefinition> {


### PR DESCRIPTION
For bots with a few thousand intents, mounting took ages.
Loading the intents in parallel speeds things up a lot.