### PR TITLE
fix(channel-twillio): mediaUrl on card element

### DIFF
--- a/modules/channel-twilio/src/backend/client.ts
+++ b/modules/channel-twilio/src/backend/client.ts
@@ -149,7 +149,7 @@ export class TwilioClient {
         }
       }
 
-      const args = { mediaUrl: picture }
+      const args = { mediaUrl: picture ? picture : undefined }
       await this.sendOptions(event, body, args, options)
     }
   }


### PR DESCRIPTION
this fixes an error thrown when the mediaUrl is not defined in a card/carrusel element