### PR TITLE
feat(qna) add sorting of contexts list

### DIFF
--- a/modules/qna/src/views/full/Components/ContextSelector.tsx
+++ b/modules/qna/src/views/full/Components/ContextSelector.tsx
@@ -16,17 +16,19 @@ const ContextSelector: FC<Props> = props => {
   const [availableContexts, setContexts] = useState([])
   const contexts = props.contexts || []
 
+  const updateContexts = (contexts: string[]) => setContexts(contexts.sort())
+
   useEffect(() => {
-    props.bp.axios.get('/nlu/contexts').then(({ data }) => setContexts(data.sort()))
+    props.bp.axios.get('/nlu/contexts').then(({ data }) => updateContexts(data))
   }, [])
 
-  const removeCtx = (_, idx: number) => {
+  const removeCtx = (_value: string, idx: number) => {
     props.saveContexts([...contexts.slice(0, idx), ...contexts.slice(idx + 1)])
   }
 
   const addCtx = (ctx: string) => {
     if (availableContexts.indexOf(ctx) === -1) {
-      setContexts([...availableContexts, ctx].sort())
+      updateContexts([...availableContexts, ctx])
     }
     props.saveContexts([...contexts, ctx])
   }

--- a/modules/qna/src/views/full/Components/ContextSelector.tsx
+++ b/modules/qna/src/views/full/Components/ContextSelector.tsx
@@ -17,7 +17,7 @@ const ContextSelector: FC<Props> = props => {
   const contexts = props.contexts || []
 
   useEffect(() => {
-    props.bp.axios.get('/nlu/contexts').then(({ data }) => setContexts(data))
+    props.bp.axios.get('/nlu/contexts').then(({ data }) => setContexts(data.sort()))
   }, [])
 
   const removeCtx = (_, idx: number) => {
@@ -26,7 +26,7 @@ const ContextSelector: FC<Props> = props => {
 
   const addCtx = (ctx: string) => {
     if (availableContexts.indexOf(ctx) === -1) {
-      setContexts([...availableContexts, ctx])
+      setContexts([...availableContexts, ctx].sort())
     }
     props.saveContexts([...contexts, ctx])
   }


### PR DESCRIPTION
This PR adds sorting (alphabetical order) on the contexts list making it a little bit easier/intuitive to find the proper context when there is a good quantity available.

![Screenshot from 2021-01-04 17-07-06](https://user-images.githubusercontent.com/9640576/103584444-52c7c800-4eaf-11eb-8fca-293551540c3c.png)
