### PR TITLE
feat(code-editor): add sorting of code editor files list

### DIFF
--- a/modules/code-editor/src/views/full/SidePanel.tsx
+++ b/modules/code-editor/src/views/full/SidePanel.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@blueprintjs/core'
 import { lang } from 'botpress/shared'
 import { SearchBar, SectionAction, SidePanel, SidePanelSection } from 'botpress/ui'
+import _ from 'lodash'
 import { inject, observer } from 'mobx-react'
 import React from 'react'
 
@@ -48,9 +49,8 @@ class PanelContent extends React.Component<Props> {
     const files = this.props.files[fileType]
 
     if (files && files.length) {
-      const sorted_files = files.slice().sort((a, b) => a.location.localeCompare(b.location))
-
-      fileList.push({ label, files: sorted_files })
+      const sortedFiles = _.sortBy(files, 'location')
+      fileList.push({ label, files: sortedFiles })
     }
   }
 

--- a/modules/code-editor/src/views/full/SidePanel.tsx
+++ b/modules/code-editor/src/views/full/SidePanel.tsx
@@ -48,7 +48,9 @@ class PanelContent extends React.Component<Props> {
     const files = this.props.files[fileType]
 
     if (files && files.length) {
-      fileList.push({ label, files })
+      const sorted_files = files.slice().sort((a, b) => a.location.localeCompare(b.location))
+
+      fileList.push({ label, files: sorted_files })
     }
   }
 


### PR DESCRIPTION
This PR adds sorting (alphabetical order) on the code editor's files list making it a little bit easier/intuitive to find the proper file when there is a good quantity available.

![Screenshot from 2021-01-05 09-30-04](https://user-images.githubusercontent.com/9640576/103657978-9c102a00-4f38-11eb-8e21-782fc37f36cd.png)
