### PR TITLE
fix(core): api.rest fix

### DIFF
--- a/api.rest
+++ b/api.rest
@@ -7,6 +7,7 @@ Content-Type: application/x-www-form-urlencoded
 
 email={{email}}&password={{password}}
 
+###
 @authToken = {{login.response.body.payload.token}}
 
 ### List All Bots (need to login first)

--- a/api.rest
+++ b/api.rest
@@ -15,8 +15,11 @@ GET {{baseUrl}}/api/v1/admin/bots
 Authorization: Bearer {{authToken}}
 X-BP-Workspace: default
 
+### 
+@botId = YOUR_BOT_ID
+
 ### Send a request using Converse
-POST {{baseUrl}}/api/v1/bots/welcome-bot/converse/benchmarkUser
+POST {{baseUrl}}/api/v1/bots/{{botId}}/converse/benchmarkUser
 Content-Type: application/json
 
 {


### PR DESCRIPTION
I suppose something changed about the Rest Client extension because the api.rest wasn't working for me.

- @authtoken was intepreted as being in the payload so I put a ### before
-  I changed _welcome-bot_ to be a variable to make things a bit clearer