### PR TITLE
feat(stan): get stan ready for launch

### DIFF
--- a/.github/workflows/nlu-regression.yml
+++ b/.github/workflows/nlu-regression.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           yarn add npm-cli-login
           ./node_modules/npm-cli-login/bin/npm-cli-login.js -r https://npm.pkg.github.com -u botpressops -p ${{ secrets.PAT_BITFAN }} -e ops@botpress.com
-          yarn add @botpress/bitfan@0.3.2
+          yarn add @botpress/bitfan@0.3.3
       - name: Run Regression Test
         run: |
           yarn start nlu --silent --ducklingEnabled=false & 

--- a/src/bp/nlu-server/api-mapper.ts
+++ b/src/bp/nlu-server/api-mapper.ts
@@ -151,7 +151,7 @@ function mapOutputSlot(slot: NLU.Slot): SlotPrediction {
     confidence,
     start,
     end,
-    entity: entity && mapEntity(entity),
+    entity: entity ? mapEntity(entity) : null,
     name,
     source,
     value

--- a/src/bp/nlu-server/api-mapper.ts
+++ b/src/bp/nlu-server/api-mapper.ts
@@ -123,7 +123,7 @@ function mapEntity(entity: NLU.Entity): EntityPrediction {
 
   return {
     name,
-    type: type.split('.')[0] as EntityType,
+    type,
     start,
     end,
     confidence,

--- a/src/bp/nlu-server/api.rest
+++ b/src/bp/nlu-server/api.rest
@@ -12,81 +12,82 @@ Content-Type: application/json
 
 {
   "language": "en",
-  "topics": [
+  "intents": [
     {
-      "name": "global",
-      "intents": [
+      "name": "fruit-is-moldy",
+      "contexts": ["grocery"],
+      "utterances": [
+        "fruit is moldy",
+        "this fruit is moldy",
+        "this [banana](fruit) is not good to eat",
+        "theses [oranges](fruit) have passed",
+        "theses [grapes](fruit) look bad",
+        "theses [apples](fruit) look soo moldy"
+      ],
+      "slots": [
         {
-          "name": "fruit-is-moldy",
-          "examples": [
-            "fruit is moldy",
-            "this fruit is moldy",
-            "this [banana](fruit) is not good to eat",
-            "theses [oranges](fruit) have passed",
-            "theses [grapes](fruit) look bad",
-            "theses [apples](fruit) look soo moldy"
-          ],
-          "variables": [
-            {
-              "name": "moldy_fruit",
-              "types": ["fruits"]
-            }
-          ]
-        },
+          "name": "moldy_fruit",
+          "entities": ["fruits"]
+        }
+      ]
+    },
+    {
+      "name": "hello",
+      "contexts": ["global", "grocery"],
+      "slots": [],
+      "utterances": [
+        "good day!",
+        "good morning",
+        "holla",
+        "bonjour",
+        "hey there",
+        "hi bot",
+        "hey bot",
+        "hey robot",
+        "hey!",
+        "hi",
+        "hello"
+      ]
+    },
+    {
+      "name": "talk-to-manager",
+      "contexts": ["grocery"],
+      "utterances": [
+        "talk to manager",
+        "I want to talk to the manager",
+        "Who's your boss?",
+        "Can talk to the person in charge?",
+        "I'd like to speak to your manager",
+        "Can I talk to your boss? plz",
+        "I wanna speak to manager please",
+        "let me speak to your boss or someone"
+      ],
+      "slots": []
+    },
+    {
+      "name": "where-is",
+      "contexts": ["grocery"],
+      "utterances": [
+        "where is [milk](thing_to_search) ?",
+        "where are [apples](thing_to_search) ?",
+        "can you help me find [apples](thing_to_search) ?",
+        "I'm searching for [pie](thing_to_search) ?",
+        "where is the [milk](thing_to_search) ?",
+        "where are the [milk](thing_to_search) ?"
+      ],
+      "slots": [
         {
-          "name": "hello",
-          "variables": [],
-          "examples": [
-            "good day!",
-            "good morning",
-            "holla",
-            "bonjour",
-            "hey there",
-            "hi bot",
-            "hey bot",
-            "hey robot",
-            "hey!",
-            "hi",
-            "hello"
-          ]
-        },
-        {
-          "name": "talk-to-manager",
-          "examples": [
-            "talk to manager",
-            "I want to talk to the manager",
-            "Who's your boss?",
-            "Can talk to the person in charge?",
-            "I'd like to speak to your manager",
-            "Can I talk to your boss? plz",
-            "I wanna speak to manager please",
-            "let me speak to your boss or someone"
-          ],
-          "variables": []
-        },
-        {
-          "name": "where-is",
-          "examples": [
-            "where is [milk](thing_to_search) ?",
-            "where are [apples](thing_to_search) ?",
-            "can you help me find [apples](thing_to_search) ?",
-            "I'm searching for [pie](thing_to_search) ?",
-            "where is the [milk](thing_to_search) ?",
-            "where are the [milk](thing_to_search) ?"
-          ],
-          "variables": [
-            {
-              "name": "thing_to_search",
-              "types": ["fruits", "any"]
-            }
-          ]
+          "name": "thing_to_search",
+          "entities": ["fruits", "any"]
         }
       ]
     }
   ],
-  "enums": [
+  "contexts": ["grocery", "global"],
+  "entities": [
     {
       "name": "fruits",
+      "type": "list",
       "fuzzy": 0.9,
       "values": [
         { "name": "banana", "synonyms": ["bananas"] },

--- a/src/bp/nlu-server/api.rest
+++ b/src/bp/nlu-server/api.rest
@@ -125,6 +125,10 @@ POST {{api}}/predict/{{modelId}}
 Content-Type: application/json
 
 {
-  "texts" : ["These grapes look moldy", "Can I talk with the person in charge?"],
+  "utterances" : [
+    "These grapes look moldy",
+    "Can I talk with the person in charge?",
+    "My flight is at 9 pm"
+  ],
   "password": "123456"
 }

--- a/src/bp/nlu-server/api.ts
+++ b/src/bp/nlu-server/api.ts
@@ -44,7 +44,7 @@ const createExpressApp = (options: APIOptions): Application => {
   app.use(bodyParser.json({ limit: options.bodySize }))
 
   app.use((req, res, next) => {
-    res.header('X-Powered-By', 'Botpress')
+    res.header('X-Powered-By', 'Botpress NLU')
     debugRequest(`incoming ${req.path}`, { ip: req.ip })
     next()
   })
@@ -126,9 +126,10 @@ export default async function(options: APIOptions, engine: Engine) {
         const model = await modelRepo.getModel(modelId, password ?? '')
 
         if (!model) {
-          return res
-            .status(404)
-            .send({ success: false, error: `no model or training could be found for modelId: ${stringId}` })
+          return res.status(404).send({
+            success: false,
+            error: `no model or training could be found for modelId: ${stringId}`
+          })
         }
 
         session = {
@@ -159,7 +160,7 @@ export default async function(options: APIOptions, engine: Engine) {
         return res.send({ success: true })
       }
 
-      res.status(404).send({ success: true, error: `no current training for model id: ${stringId}` })
+      res.status(404).send({ success: false, error: `no current training for model id: ${stringId}` })
     } catch (err) {
       res.status(500).send({ success: false, error: err.message })
     }
@@ -177,6 +178,7 @@ export default async function(options: APIOptions, engine: Engine) {
       }
 
       const modelId = modelIdService.fromString(stringId)
+      // once the model is loaded, there's no more password check
       if (!engine.hasModel(modelId)) {
         const model = await modelRepo.getModel(modelId, password)
         if (!model) {

--- a/src/bp/nlu-server/api.ts
+++ b/src/bp/nlu-server/api.ts
@@ -74,7 +74,7 @@ const createExpressApp = (options: APIOptions): Application => {
 
 export default async function(options: APIOptions, engine: Engine) {
   const app = createExpressApp(options)
-  const logger = new Logger('API', options.silent)
+  const logger = new Logger('API')
 
   const modelRepo = new ModelRepository(options.modelDir)
   await modelRepo.init()
@@ -214,4 +214,5 @@ export default async function(options: APIOptions, engine: Engine) {
   })
 
   logger.info(`NLU Server is ready at http://${options.host}:${options.port}/`)
+  options.silent && logger.silence()
 }

--- a/src/bp/nlu-server/index.ts
+++ b/src/bp/nlu-server/index.ts
@@ -22,6 +22,7 @@ import API, { APIOptions } from './api'
 const debug = DEBUG('api')
 
 const GH_TYPINGS_FILE = 'https://github.com/botpress/botpress/blob/master/src/bp/nlu-server/typings_v1.d.ts'
+const GH_TRAIN_INPUT_EXAMPLE = 'https://github.com/botpress/botpress/blob/master/src/bp/nlu-server/train-example.json'
 
 type ArgV = APIOptions & {
   languageURL: string
@@ -181,6 +182,9 @@ ${_.repeat(' ', 9)}========================================`)
 
 {bold For more detailed information on typings, see
 ${GH_TYPINGS_FILE}}.
+
+{bold For a complete example on training input, see
+${GH_TRAIN_INPUT_EXAMPLE}}.
 
     `)
   }

--- a/src/bp/nlu-server/index.ts
+++ b/src/bp/nlu-server/index.ts
@@ -92,7 +92,7 @@ export default async function(options: ArgV) {
   const { nluVersion } = engine.getSpecifications()
 
   logger.info(chalk`========================================
-{bold ${center('Botpress NLU Server', 40, 9)}}
+{bold ${center('Botpress Standalone NLU', 40, 9)}}
 {dim ${center(`Version ${nluVersion}`, 40, 9)}}
 {dim ${center(`OS ${process.distro}`, 40, 9)}}
 ${_.repeat(' ', 9)}========================================`)
@@ -124,6 +124,24 @@ ${_.repeat(' ', 9)}========================================`)
 
   if (options.batchSize > 0) {
     logger.info(`batch size: allowing up to ${options.batchSize} predictions in one call to POST /predict`)
+  }
+
+  if (!options.silent) {
+    const { host, port } = options
+
+    const baseUrl = `http://${host}:${port}/v1`
+
+    logger.info(chalk`
+
+{bold Available Routes:}
+
+{bold GET ${baseUrl}/info} {dim // to get current version of botpress standalone NLU and test if your installation is working}
+{bold POST ${baseUrl}/train} {dim // to start a training; returns a model id}
+{bold GET ${baseUrl}/train/:modelId} {dim // to get the training progress status of a model}
+{bold POST ${baseUrl}/train/:modelId/cancel} {dim // to cancel the training of a model}
+{bold POST ${baseUrl}/predict/:modelId} {dim // to predict with a previously trained model}
+
+    `)
   }
 
   await API(options, engine)

--- a/src/bp/nlu-server/index.ts
+++ b/src/bp/nlu-server/index.ts
@@ -21,6 +21,8 @@ import API, { APIOptions } from './api'
 
 const debug = DEBUG('api')
 
+const GH_TYPINGS_FILE = 'https://github.com/botpress/botpress/blob/master/src/bp/nlu-server/typings_v1.d.ts'
+
 type ArgV = APIOptions & {
   languageURL: string
   languageAuthToken?: string
@@ -133,13 +135,52 @@ ${_.repeat(' ', 9)}========================================`)
 
     logger.info(chalk`
 
-{bold Available Routes:}
+{bold {underline Available Routes}}
 
-{bold GET ${baseUrl}/info} {dim // to get current version of botpress standalone NLU and test if your installation is working}
-{bold POST ${baseUrl}/train} {dim // to start a training; returns a model id}
-{bold GET ${baseUrl}/train/:modelId} {dim // to get the training progress status of a model}
-{bold POST ${baseUrl}/train/:modelId/cancel} {dim // to cancel the training of a model}
-{bold POST ${baseUrl}/predict/:modelId} {dim // to predict with a previously trained model}
+{green /**
+ * Gets the current version of botpress core NLU. Usefull to test if your installation is working.
+ * @returns version: botpress core NLU version number.
+*/}
+{bold GET ${baseUrl}/info}
+
+{green /**
+  * Starts a training.
+  * @body_parameter {bold language} Language to use for training.
+  * @body_parameter {bold intents} Intents definitions.
+  * @body_parameter {bold contexts} All available contexts.
+  * @body_parameter {bold entities} Entities definitions.
+  * @body_parameter {bold password} Password to protect your model. {yellow ** Optionnal **}
+  * @body_parameter {bold seed} Number to seed random number generators used during training (beta feature). {yellow ** Optionnal **}
+  * @returns {bold modelId} A model id for futur API calls
+ */}
+{bold POST ${baseUrl}/train}
+
+{green /**
+  * Gets a training progress status.
+  * @path_parameter {bold modelId} The model id for which you seek the training progress.
+  * @body_parameter {bold password} The password protecting your model.
+  * @returns {bold session} A training session data structure with information on desired model.
+ */}
+{bold GET ${baseUrl}/train/:modelId}
+
+{green /**
+  * Cancels a training.
+  * @path_parameter {bold modelId} The model id for which you want to cancel the training.
+  * @body_parameter {bold password} The password protecting your model.
+ */}
+{bold POST ${baseUrl}/train/:modelId/cancel}
+
+{green /**
+  * Perform prediction for a text input.
+  * @path_parameter {bold modelId} The model id you want to use for prediction.
+  * @body_parameter {bold password} The password protecting your model.
+  * @body_parameter {bold texts} Array of text for which you want a prediction.
+  * @returns {bold predictions} Array of predictions; Each prediction is a data structure reprensenting our understanding of the text.
+ */}
+{bold POST ${baseUrl}/predict/:modelId}
+
+{bold For more detailed information on typings, see
+${GH_TYPINGS_FILE}}.
 
     `)
   }

--- a/src/bp/nlu-server/index.ts
+++ b/src/bp/nlu-server/index.ts
@@ -140,7 +140,7 @@ ${_.repeat(' ', 9)}========================================`)
 
 {green /**
  * Gets the current version of botpress core NLU. Usefull to test if your installation is working.
- * @returns version: botpress core NLU version number.
+ * @returns {bold version}: botpress core NLU version number.
 */}
 {bold GET ${baseUrl}/info}
 

--- a/src/bp/nlu-server/index.ts
+++ b/src/bp/nlu-server/index.ts
@@ -159,10 +159,10 @@ ${_.repeat(' ', 9)}========================================`)
 {green /**
   * Gets a training progress status.
   * @path_parameter {bold modelId} The model id for which you seek the training progress.
-  * @body_parameter {bold password} The password protecting your model.
+  * @query_parameter {bold password} The password protecting your model.
   * @returns {bold session} A training session data structure with information on desired model.
  */}
-{bold GET ${baseUrl}/train/:modelId}
+{bold GET ${baseUrl}/train/:modelId?password=XXXXXX}
 
 {green /**
   * Cancels a training.
@@ -175,7 +175,7 @@ ${_.repeat(' ', 9)}========================================`)
   * Perform prediction for a text input.
   * @path_parameter {bold modelId} The model id you want to use for prediction.
   * @body_parameter {bold password} The password protecting your model.
-  * @body_parameter {bold texts} Array of text for which you want a prediction.
+  * @body_parameter {bold utterances} Array of text for which you want a prediction.
   * @returns {bold predictions} Array of predictions; Each prediction is a data structure reprensenting our understanding of the text.
  */}
 {bold POST ${baseUrl}/predict/:modelId}

--- a/src/bp/nlu-server/train-example.json
+++ b/src/bp/nlu-server/train-example.json
@@ -1,0 +1,90 @@
+{
+  "language": "en",
+  "intents": [
+    {
+      "name": "fruit-is-moldy",
+      "contexts": ["grocery"],
+      "utterances": [
+        "fruit is moldy",
+        "this fruit is moldy",
+        "this [banana](fruit) is not good to eat",
+        "theses [oranges](fruit) have passed",
+        "theses [grapes](fruit) look bad",
+        "theses [apples](fruit) look so moldy"
+      ],
+      "slots": [
+        {
+          "name": "moldy_fruit",
+          "entities": ["fruits"]
+        }
+      ]
+    },
+    {
+      "name": "hello",
+      "contexts": ["global", "grocery"],
+      "slots": [],
+      "utterances": [
+        "good day!",
+        "good morning",
+        "holla",
+        "bonjour",
+        "hey there",
+        "hi bot",
+        "hey bot",
+        "hey robot",
+        "hey!",
+        "hi",
+        "hello"
+      ]
+    },
+    {
+      "name": "talk-to-manager",
+      "contexts": ["grocery"],
+      "utterances": [
+        "talk to manager",
+        "I want to talk to the manager",
+        "Who's your boss?",
+        "Can I talk to the person in charge?",
+        "I'd like to speak to your manager",
+        "Can I talk to your boss? plz",
+        "I wanna speak to manager please",
+        "let me speak to your boss or someone"
+      ],
+      "slots": []
+    },
+    {
+      "name": "where-is",
+      "contexts": ["grocery"],
+      "utterances": [
+        "where is [milk](thing_to_search) ?",
+        "where are [apples](thing_to_search) ?",
+        "can you help me find [apples](thing_to_search) ?",
+        "I'm searching for [pie](thing_to_search) ?",
+        "where is the [milk](thing_to_search) ?",
+        "where are the [milk](thing_to_search) ?"
+      ],
+      "slots": [
+        {
+          "name": "thing_to_search",
+          "entities": ["fruits", "any"]
+        }
+      ]
+    }
+  ],
+  "contexts": ["grocery", "global"],
+  "entities": [
+    {
+      "name": "fruits",
+      "type": "list",
+      "fuzzy": 0.9,
+      "values": [
+        { "name": "banana", "synonyms": ["bananas"] },
+        { "name": "apple", "synonyms": ["apples"] },
+        { "name": "grape", "synonyms": ["grapes"] },
+        { "name": "orange", "synonyms": ["oranges"] }
+      ]
+    }
+  ],
+  "password": "123456",
+  "seed": 42
+}

--- a/src/bp/nlu-server/train-service.ts
+++ b/src/bp/nlu-server/train-service.ts
@@ -1,8 +1,7 @@
 import * as sdk from 'botpress/sdk'
 import Engine from 'nlu-core/engine'
-import { isTrainingAlreadyStarted } from 'nlu-core/errors'
+import { isTrainingAlreadyStarted, isTrainingCanceled } from 'nlu-core/errors'
 import modelIdService from 'nlu-core/model-id-service'
-import { isTrainingCanceled } from 'nlu-core/training-worker-queue/communication'
 
 import ModelRepository from './model-repo'
 import TrainSessionService from './train-session-service'
@@ -30,6 +29,9 @@ export default class TrainService {
     this.trainSessionService.setTrainingSession(modelId, password, ts)
 
     const progressCallback = (progress: number) => {
+      if (ts.status === 'training-pending') {
+        ts.status = 'training'
+      }
       ts.progress = progress
       this.trainSessionService.setTrainingSession(modelId, password, ts)
     }

--- a/src/bp/nlu-server/train-session-service.ts
+++ b/src/bp/nlu-server/train-session-service.ts
@@ -3,24 +3,26 @@ import crypto from 'crypto'
 import LRUCache from 'lru-cache'
 import modelIdService from 'nlu-core/model-id-service'
 
+import { TrainingSession } from './typings_v1'
+
 export default class TrainSessionService {
   private trainSessions: {
-    [key: string]: sdk.NLU.TrainingSession
+    [key: string]: TrainingSession
   } = {}
 
   // training sessions of this cache will eventually be kicked out so there's no memory leak
-  private releasedTrainSessions = new LRUCache<string, sdk.NLU.TrainingSession>(1000)
+  private releasedTrainSessions = new LRUCache<string, TrainingSession>(1000)
 
   constructor() {}
 
-  makeTrainingSession = (modelId: sdk.NLU.ModelId, password: string, language: string): sdk.NLU.TrainingSession => ({
+  makeTrainingSession = (modelId: sdk.NLU.ModelId, password: string, language: string): TrainingSession => ({
     key: this._makeTrainSessionKey(modelId, password),
-    status: 'training',
+    status: 'training-pending',
     progress: 0,
     language
   })
 
-  getTrainingSession(modelId: sdk.NLU.ModelId, password: string): sdk.NLU.TrainingSession | undefined {
+  getTrainingSession(modelId: sdk.NLU.ModelId, password: string): TrainingSession | undefined {
     const key = this._makeTrainSessionKey(modelId, password)
     const ts = this.trainSessions[key]
     if (ts) {
@@ -29,7 +31,7 @@ export default class TrainSessionService {
     return this.releasedTrainSessions.get(key)
   }
 
-  setTrainingSession(modelId: sdk.NLU.ModelId, password: string, trainSession: sdk.NLU.TrainingSession) {
+  setTrainingSession(modelId: sdk.NLU.ModelId, password: string, trainSession: TrainingSession) {
     const key = this._makeTrainSessionKey(modelId, password)
     if (this.releasedTrainSessions.get(key)) {
       this.releasedTrainSessions.del(key)

--- a/src/bp/nlu-server/typings_v1.d.ts
+++ b/src/bp/nlu-server/typings_v1.d.ts
@@ -93,7 +93,7 @@ export interface SlotPrediction {
   source: string
   start: number
   end: number
-  entity: EntityPrediction | undefined
+  entity: EntityPrediction | null
 }
 
 /**

--- a/src/bp/nlu-server/typings_v1.d.ts
+++ b/src/bp/nlu-server/typings_v1.d.ts
@@ -95,3 +95,25 @@ export interface SlotPrediction {
   end: number
   entity: EntityPrediction | undefined
 }
+
+/**
+ * ################################
+ * ############ OTHERS ############
+ * ################################
+ */
+
+/**
+ * done : when a training is complete
+ * training-pending : when a training was launched, but the training process is not started yet
+ * training: when a chatbot is currently training
+ * canceled: when a training was canceled
+ * errored: when a chatbot failed to train
+ */
+export type TrainingStatus = 'done' | 'training-pending' | 'training' | 'canceled' | 'errored'
+
+export interface TrainingSession {
+  key: string
+  status: TrainingStatus
+  language: string
+  progress: number
+}

--- a/src/bp/nlu-server/typings_v1.d.ts
+++ b/src/bp/nlu-server/typings_v1.d.ts
@@ -63,7 +63,7 @@ export type EntityType = 'pattern' | 'list' | 'system'
 
 export interface EntityPrediction {
   name: string
-  type: EntityType
+  type: string // ex: ['custom.list.fruits', 'system.time']
   value: string
   confidence: number
   source: string
@@ -95,12 +95,6 @@ export interface SlotPrediction {
   end: number
   entity: EntityPrediction | undefined
 }
-
-/**
- * ################################
- * ############ OTHERS ############
- * ################################
- */
 
 /**
  * done : when a training is complete

--- a/src/bp/nlu-server/validation/schemas.ts
+++ b/src/bp/nlu-server/validation/schemas.ts
@@ -76,3 +76,21 @@ export const TrainInputSchema = Joi.object().keys({
     .default(''),
   seed: Joi.number().optional()
 })
+
+export const CancelInputSchema = Joi.object().keys({
+  password: Joi.string()
+    .allow('')
+    .optional()
+    .default('')
+})
+
+export const PredictInputSchema = Joi.object().keys({
+  password: Joi.string()
+    .allow('')
+    .optional()
+    .default(''),
+  utterances: Joi.array()
+    .items(Joi.string())
+    .required()
+    .min(1)
+})

--- a/src/bp/nlu-server/validation/validate.test.ts
+++ b/src/bp/nlu-server/validation/validate.test.ts
@@ -6,7 +6,7 @@ import {
   TrainInput
 } from '../typings_v1'
 
-import validateInput from './validate'
+import { validateTrainInput } from './validate'
 
 /**
  * These unit tests don't cover all possible scenarios of training input, but they to more good than bad.
@@ -78,7 +78,7 @@ test('validate with correct format should pass', async () => {
   }
 
   // act
-  const validated = await validateInput(trainInput)
+  const validated = await validateTrainInput(trainInput)
 
   // assert
   expect(validated).toStrictEqual(trainInput)
@@ -95,7 +95,7 @@ test('validate without pw should set pw as empty string', async () => {
   }
 
   // act
-  const validated = await validateInput(trainInput)
+  const validated = await validateTrainInput(trainInput)
 
   // assert
   expect(validated.password).toBe('')
@@ -113,7 +113,7 @@ test('validate with empty string pw should be allowed', async () => {
   }
 
   // act
-  const validated = await validateInput(trainInput)
+  const validated = await validateTrainInput(trainInput)
 
   // assert
   expect(validated.password).toBe('')
@@ -130,7 +130,7 @@ test('validate input without enums and patterns should pass', async () => {
   }
 
   // act
-  const validated = await validateInput(trainInput)
+  const validated = await validateTrainInput(trainInput)
 
   // assert
   const expected: TrainInput = { ...trainInput, entities: [] }
@@ -153,8 +153,8 @@ test('validate input without topics or language should throw', async () => {
   }
 
   // act & assert
-  await expect(validateInput(withoutContexts)).rejects.toThrow()
-  await expect(validateInput(withoutLang)).rejects.toThrow()
+  await expect(validateTrainInput(withoutContexts)).rejects.toThrow()
+  await expect(validateTrainInput(withoutLang)).rejects.toThrow()
 })
 
 test('validate without intent should fail', async () => {
@@ -171,7 +171,7 @@ test('validate without intent should fail', async () => {
   }
 
   // act & assert
-  await expect(validateInput(trainInput)).rejects.toThrow()
+  await expect(validateTrainInput(trainInput)).rejects.toThrow()
 })
 
 test('validate intent with unexisting context should fail', async () => {
@@ -186,7 +186,7 @@ test('validate intent with unexisting context should fail', async () => {
   }
 
   // act & assert
-  await expect(validateInput(trainInput)).rejects.toThrow()
+  await expect(validateTrainInput(trainInput)).rejects.toThrow()
 })
 
 test('validate enum without values or patterns without regexes should fail', async () => {
@@ -214,8 +214,8 @@ test('validate enum without values or patterns without regexes should fail', asy
   }
 
   // act & assert
-  await expect(validateInput(withoutValues)).rejects.toThrow()
-  await expect(validateInput(withoutRegexes)).rejects.toThrow()
+  await expect(validateTrainInput(withoutValues)).rejects.toThrow()
+  await expect(validateTrainInput(withoutRegexes)).rejects.toThrow()
 })
 
 test('validate with an unexisting referenced enum should throw', async () => {
@@ -230,7 +230,7 @@ test('validate with an unexisting referenced enum should throw', async () => {
   }
 
   // act & assert
-  await expect(validateInput(trainInput)).rejects.toThrow()
+  await expect(validateTrainInput(trainInput)).rejects.toThrow()
 })
 
 test('validate with an unexisting referenced pattern should throw', async () => {
@@ -245,7 +245,7 @@ test('validate with an unexisting referenced pattern should throw', async () => 
   }
 
   // act & assert
-  await expect(validateInput(trainInput)).rejects.toThrow()
+  await expect(validateTrainInput(trainInput)).rejects.toThrow()
 })
 
 test('validate with an unexisting referenced complex should throw', async () => {
@@ -260,7 +260,7 @@ test('validate with an unexisting referenced complex should throw', async () => 
   }
 
   // act & assert
-  await expect(validateInput(trainInput)).rejects.toThrow()
+  await expect(validateTrainInput(trainInput)).rejects.toThrow()
 })
 
 test('validate with correct format but unexpected property should fail', async () => {
@@ -276,5 +276,5 @@ test('validate with correct format but unexpected property should fail', async (
   }
 
   // act & assert
-  await expect(validateInput(trainInput)).rejects.toThrow()
+  await expect(validateTrainInput(trainInput)).rejects.toThrow()
 })

--- a/src/bp/nlu-server/validation/validate.ts
+++ b/src/bp/nlu-server/validation/validate.ts
@@ -6,20 +6,26 @@ import {
   IntentDefinition,
   ListEntityDefinition,
   PatternEntityDefinition,
+  PredictInput,
   SlotDefinition,
   TrainInput
 } from '../typings_v1'
 
-import { TrainInputSchema } from './schemas'
+import { CancelInputSchema, PredictInputSchema, TrainInputSchema } from './schemas'
 
 const SLOT_ANY = 'any'
 
-const makeVariableChecker = (enums: ListEntityDefinition[], patterns: PatternEntityDefinition[]) => (
+const makeSlotChecker = (listEntities: ListEntityDefinition[], patternEntities: PatternEntityDefinition[]) => (
   variable: SlotDefinition
 ) => {
   const { entities, name } = variable
 
-  const supportedTypes = [...enums.map(e => e.name), ...patterns.map(p => p.name), ...DUCKLING_ENTITIES, SLOT_ANY]
+  const supportedTypes = [
+    ...listEntities.map(e => e.name),
+    ...patternEntities.map(p => p.name),
+    ...DUCKLING_ENTITIES,
+    SLOT_ANY
+  ]
   for (const entity of entities) {
     if (!supportedTypes.includes(entity)) {
       throw new Error(`Slot ${name} references entity ${entity}, but it does not exist.`)
@@ -37,11 +43,11 @@ const makeIntentChecker = (contexts: string[]) => (
       throw new Error(`Context ${ctx} of Intent ${intent.name} does not seem to appear in all contexts`)
     }
   }
-  const variableChecker = makeVariableChecker(enums, patterns)
+  const variableChecker = makeSlotChecker(enums, patterns)
   intent.slots.forEach(variableChecker)
 }
 
-async function validateInput(rawInput: any): Promise<TrainInput> {
+export async function validateTrainInput(rawInput: any): Promise<TrainInput> {
   const validatedInput: TrainInput = await validate(rawInput, TrainInputSchema, {})
 
   const { entities, contexts } = validatedInput
@@ -58,4 +64,12 @@ async function validateInput(rawInput: any): Promise<TrainInput> {
   return validatedInput
 }
 
-export default validateInput
+export async function validateCancelRequestInput(rawInput: any): Promise<{ password: string }> {
+  const validated: { password: string } = await validate(rawInput, CancelInputSchema, {})
+  return validated
+}
+
+export async function validatePredictInput(rawInput: any): Promise<PredictInput> {
+  const validated: PredictInput = await validate(rawInput, PredictInputSchema, {})
+  return validated
+}

--- a/src/bp/simple-logger.ts
+++ b/src/bp/simple-logger.ts
@@ -25,9 +25,14 @@ export default class Logger implements sdk.Logger {
   private attachedError: Error | undefined
   public readonly displayLevel: number
   private currentMessageLevel: LogLevel | undefined
+  private silent = false
 
-  constructor(private name: string, private silent = false) {
+  constructor(private name: string) {
     this.displayLevel = process.VERBOSITY_LEVEL || 0
+  }
+
+  public silence(): void {
+    this.silent = true
   }
 
   forBot(botId: string): this {


### PR DESCRIPTION
Get Stan ready for launch with some makeup. Did a bunch of little small things:

**What was done**
- [x] Return `success: false` if no training found
- [x] HTTP header `X-Powered-By: Botpress NLU`
- [x] Print HTTP documentation on start (won't print if --silent=true)
- [x] Add `example.json` for training input
- [x] Add validation on all routes (only `POST /train` is validated)
- [x] Maybe change param `texts` at `POST /predict` route for `utterances` which is conform to current botpress vocab  

When no `--silent=true` argument is passed, terminal looks like this:

![Screen Shot 2021-01-06 at 1 34 27 PM](https://user-images.githubusercontent.com/25970722/103808622-3e5a0b80-5026-11eb-8837-483405052e49.png)
