### PR TITLE
fix(channel-web): display spinner when webchat is loading

### DIFF
--- a/modules/channel-web/assets/default.css
+++ b/modules/channel-web/assets/default.css
@@ -233,6 +233,30 @@ body {
   align-items: flex-end;
 }
 
+.bpw-msg-list-loading {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: 50px;
+  height: 50px;
+  border: 3px solid rgba(0, 0, 0, 0.3);
+  border-radius: 50%;
+  border-top-color: rgb(0, 0, 0);
+  animation: spin 1s ease-in-out infinite;
+  -webkit-animation: spin 1s ease-in-out infinite;
+}
+
+@keyframes spin {
+  to {
+    -webkit-transform: rotate(360deg);
+  }
+}
+@-webkit-keyframes spin {
+  to {
+    -webkit-transform: rotate(360deg);
+  }
+}
+
 /* */
 .bpw-msg-list-container {
   -webkit-box-flex: 1;

--- a/modules/channel-web/assets/default.css
+++ b/modules/channel-web/assets/default.css
@@ -249,11 +249,13 @@ body {
 @keyframes spin {
   to {
     -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
   }
 }
 @-webkit-keyframes spin {
   to {
     -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
   }
 }
 

--- a/modules/channel-web/src/views/lite/components/Container.tsx
+++ b/modules/channel-web/src/views/lite/components/Container.tsx
@@ -17,7 +17,7 @@ import OverridableComponent from './OverridableComponent'
 class Container extends React.Component<ContainerProps> {
   renderBody() {
     if (!this.props.isInitialized) {
-      return (<div className="bpw-msg-list-container" />)
+      return (<div className="bpw-msg-list-container"><div className="bpw-msg-list-loading" /></div>)
     }
 
     if (this.props.isConversationsDisplayed) {

--- a/modules/channel-web/src/views/lite/components/Container.tsx
+++ b/modules/channel-web/src/views/lite/components/Container.tsx
@@ -17,7 +17,7 @@ import OverridableComponent from './OverridableComponent'
 class Container extends React.Component<ContainerProps> {
   renderBody() {
     if (!this.props.isInitialized) {
-      return null
+      return (<div className="bpw-msg-list-container" />)
     }
 
     if (this.props.isConversationsDisplayed) {

--- a/modules/channel-web/src/views/lite/components/Container.tsx
+++ b/modules/channel-web/src/views/lite/components/Container.tsx
@@ -17,7 +17,7 @@ import OverridableComponent from './OverridableComponent'
 class Container extends React.Component<ContainerProps> {
   renderBody() {
     if (!this.props.isInitialized) {
-      return (<div className="bpw-msg-list-container"><div className="bpw-msg-list-loading" /></div>)
+      return (<div className="bpw-msg-list-container bpw-msg-list-container-loading"><div className="bpw-msg-list-loading" /></div>)
     }
 
     if (this.props.isConversationsDisplayed) {


### PR DESCRIPTION
Fixes: botpress/v12#1186 and added a spinner for when the container is loading.

Before: 

https://user-images.githubusercontent.com/9640576/103910361-be3daf80-50d2-11eb-8c52-40878310d0db.mp4

After:


https://user-images.githubusercontent.com/9640576/103920079-dadfe480-50de-11eb-9134-7eac696382c3.mp4



