### PR TITLE
fix(qna) - Fix new ID generation on batch import

### DIFF
--- a/modules/qna/src/backend/transfer.ts
+++ b/modules/qna/src/backend/transfer.ts
@@ -50,8 +50,6 @@ export const importQuestions = async (data: ImportData, storage, bp, statusCallb
     }
   }
 
-  const existingQnaIds = (await (storage as Storage).fetchQNAs()).map(item => item.id)
-
   for (const qnaItem of questions) {
     qnaItem.data.enabled = true
   }

--- a/modules/qna/src/backend/transfer.ts
+++ b/modules/qna/src/backend/transfer.ts
@@ -64,11 +64,7 @@ export const importQuestions = async (data: ImportData, storage, bp, statusCallb
       delete qnaItem.data.category
     }
 
-    if (existingQnaIds.includes(qnaItem.id)) {
-      await (storage as Storage).update(qnaItem.data, qnaItem.id)
-    } else {
-      await (storage as Storage).insertItem(qnaItem)
-    }
+    await (storage as Storage).upsertItem(qnaItem)
 
     questionsSavedCount += 1
     statusCallback(

--- a/modules/qna/src/backend/transfer.ts
+++ b/modules/qna/src/backend/transfer.ts
@@ -58,18 +58,16 @@ export const importQuestions = async (data: ImportData, storage, bp, statusCallb
 
   let questionsSavedCount = 0
   return Promise.each(questions, async (qnaItem: QnaItem & { data: { category?: string } }) => {
-    const { data, id } = qnaItem
-
     // Support for previous QnA
-    if (data.category) {
-      data.contexts = [data.category]
-      delete data.category
+    if (qnaItem.data.category) {
+      qnaItem.data.contexts = [qnaItem.data.category]
+      delete qnaItem.data.category
     }
 
-    if (existingQnaIds.includes(id)) {
-      await (storage as Storage).update(data, id)
+    if (existingQnaIds.includes(qnaItem.id)) {
+      await (storage as Storage).update(qnaItem.data, qnaItem.id)
     } else {
-      await (storage as Storage).insert(data)
+      await (storage as Storage).insertItem(qnaItem)
     }
 
     questionsSavedCount += 1

--- a/modules/qna/src/translations/en.json
+++ b/modules/qna/src/translations/en.json
@@ -83,6 +83,7 @@
     "analysis": "Analysis",
     "botContains": "The bot contains {qnaCount} questions and {cmsCount} content elements.",
     "clearQuestionsThenInsert": "Clear existing questions, then insert my new questions and create/update content elements",
+    "clearQuestionsAnalyticsWarning": "Clearing questions will make them unavailable in the analytics report",
     "fileContains": "Your file contains {fileQnaCount} questions and {fileCmsCount} content elements.",
     "insertNewQuestions": "Insert the new questions from my file and create/update associated content elements",
     "notAbleToExtract": "We were not able to extract any data from your file. Either the file is empty, or it doesn't match any known format.",

--- a/modules/qna/src/translations/es.json
+++ b/modules/qna/src/translations/es.json
@@ -83,6 +83,7 @@
     "analysis": "Análisis",
     "botContains": "El bot contiene preguntas {qnaCount} y elementos de contenido {cmsCount}.",
     "clearQuestionsThenInsert": "Borrar preguntas existentes, luego insertar mis nuevas preguntas y crear/actualizar elementos de contenido",
+    "clearQuestionsAnalyticsWarning": "Si se aclaran las preguntas, no estarán disponibles en el informe de análisis",
     "fileContains": "Su archivo contiene preguntas {fileQnaCount} y elementos de contenido {fileCmsCount}.",
     "insertNewQuestions": "Insertar las nuevas preguntas de mi archivo y crear/actualizar elementos de contenido asociados",
     "notAbleToExtract": "No hemos podido extraer ningún dato de su archivo. O el archivo está vacío o no coincide con ningún formato conocido.",

--- a/modules/qna/src/translations/fr.json
+++ b/modules/qna/src/translations/fr.json
@@ -83,6 +83,7 @@
     "analysis": "Analyse",
     "botContains": "Le bot contient {qnaCount} questions et {cmsCount} éléments de contenu.",
     "clearQuestionsThenInsert": "Effacer les questions existantes, puis insérer mes nouvelles questions et créer / mettre à jour des éléments de contenu",
+    "clearQuestionsAnalyticsWarning": "Effacer des questions les rendront indisponibles dans le rapport d'analytique",
     "fileContains": "Votre dossier contient {fileQnaCount} questions et {fileCmsCount} éléments de contenu.",
     "insertNewQuestions": "Insérer les nouvelles questions de mon fichier et créer / mettre à jour les éléments de contenu associés",
     "notAbleToExtract": "Nous n'avons pas pu extraire de données de votre fichier. Soit le fichier est vide, soit il ne correspond à aucun format connu.",

--- a/modules/qna/src/views/full/Components/ImportModal.tsx
+++ b/modules/qna/src/views/full/Components/ImportModal.tsx
@@ -190,6 +190,9 @@ export const ImportModal: FC<Props> = props => {
                   label={lang.tr('module.qna.import.clearQuestionsThenInsert')}
                   value="clear_insert"
                 />
+                <Callout intent="warning">
+                  {lang.tr('module.qna.import.clearQuestionsAnalyticsWarning')}
+                </Callout>
               </RadioGroup>
             </p>
           </div>


### PR DESCRIPTION
Batch imports of qnas currently generate new IDs on update & insert causing [Deleted IDs] to appear in the analytics report. 

If the uploaded json file has QnAs with IDs that already exist on the server, the ones in the json will squash the ones on the server.

Made the "insert new QnAs and add new ones" import function use existing IDs from the uploaded json file.

Added a warning in the import modal that using the "clear all QnAs and import from file" option will cause deleted QnAs to be unavailable in the analytics report.



