### PR TITLE
feat(nlu): draft out nlu hooks

### DIFF
--- a/src/bp/nlu-core/intents/exact-matcher.test.ts
+++ b/src/bp/nlu-core/intents/exact-matcher.test.ts
@@ -1,6 +1,6 @@
 import { findExactIntentForCtx } from '../predict-pipeline'
 import { SPECIAL_CHARSET } from '../tools/chars'
-import { BuildExactMatchIndex, TrainStep } from '../training-pipeline'
+import { BuildExactMatchIndex, TrainStepDS } from '../training-pipeline'
 import { Intent } from '../typings'
 import Utterance, { makeTestUtterance } from '../utterance/utterance'
 
@@ -32,7 +32,7 @@ const noneIntent: Intent<Utterance> = {
 describe('Exact match', () => {
   const input = {
     intents: [intent1, intent2, noneIntent]
-  } as TrainStep
+  } as TrainStepDS
 
   const exactMatchIndex = BuildExactMatchIndex(input)
   describe('Build exact match index', () => {

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -652,7 +652,7 @@ declare module 'botpress/sdk' {
 
     export interface PredictOutput {
       readonly entities: Entity[]
-      readonly predictions: Predictions
+      readonly contexts: ContextPrediction[]
     }
   }
 


### PR DESCRIPTION
# NLU HOOKS

## Needs

- Few injection points during training to customize the current training data structure and train other engines
- Few injection points during prediction to customize the current prediction with a handle on every artefact of training
- One injection point to highjack the election result so the user can make his bot work fast and so we can change election logic without breaking old clients

## Design Ideas

First, let's distinguish the election hook from the other two.

The election hook has:
1 - a much more stable interface (EventUnderstanding)
2 - a very well defined mission (electing an intent and its slots)
3 - gives a lot of value to the user
4 - gives us the freedom to move around better (by ditching the legacy-election)

The training and prediction hooks have:
1 - an interface that varies (the stages of pipelines change or disappear just like the data structure that links the stages together)
2 - gives a little value to our success team, but very little to our users

For these reasons, I believe the election hook is more urgent and needs to be implemented with more care than the other two.

### Election hook

We could design a whole hook system that takes a `PredictOutput` as parameter and return something like `{ intent: Intent, entities: Entity[], slots: Slot[] }`, but I believe there's no point of doing so as current traditional hooks already allow this.

The only problem we're currently facing in letting the user highjack the election is that other middlewares (like analytics for instance) use the result of the election.

This is why, IMO, the best approach for this hook it simply to extract the nlu module in the core and create a new category of hooks called `before_nlu_prediction`.

This would have the benefit of using already known concepts + be as robust as current hooks already are. This would look something like this:

![event_enginev2 2](https://user-images.githubusercontent.com/25970722/104239547-aba3dd00-5428-11eb-99e6-f74690493d5a.png)
*where point (1) represents `before_nlu_prediction` hook and point (2) represents `after_nlu_prediction`* 

### Training and Prediction hooks

As previously stated, both hooks have a very precarious interface. I don't see myself coding a `before_context_classifier_training` hook anytime soon, as this step might disapear / change name / etc...

What I feel is the best approach, is to define suchs things as `TrainingStep` and `TrainingHook` and call all hooks after each training steps. To make it work, we would pass the current trianing step **name** to the hook so it can decide weither or not to act or to do nothing on this particular step. 

This would look something like this:

```ts
interface TrainingDS { // this is currently named TrainStep
 ... requiredProperties
 ... optionnalProperties (that are truely optional, or are set through the pipeline)
 hook_memory: Object // Which will be available at predict time (in predict hooks) as long as its serializable
}

interface TrainStep {
    name: string,
    eval: (ds: TrainingDS) => Promise<TrainingDS>
}

interface TrainHook {
    name: string,
    eval: (step: name, ds: TrainingDS) => Promise<void>
}

const someTrainingHook = {
    name: 'keep kmeans',
    eval: async (step: name, ds: TrainingDS) => {
        if (step !== 'ClusterTokens') {
            return // this hook is made to be run after kmeans
        }
        ds.hook_memory.kmeans = ds.kmeans // will use later at predict time
    }
}
```

The user of this feature would then read the actual training-pipeline code and based on his reading, would inject his code at the correct place.

Because, this is a very very advanced feature, I feel like:
1 - there should be a warning saying that the feature is meant for hardcore botpress users.
2 - there's no need for any sort of VM running the code as its already really dangerous to inject anything at this point.
3 - the solution should add as less execution time as possible to the current pipelines (nlu execution time is quite critical).
4 - there's no need for preconditions and exeption throwing. Maybe just log a warning if a hooks fails. 

## Planning

I personally believe that the election hook is more urgent than others for previously mentionned reasons. This is why, I would start by bringing the nlu module into the core. 

This, however, will break some users: 

- lot of botpress users from the comunity forum who calls a the `/mod/nlu` http router directly. 
- some users have fully disabled the nlu module. The same feature will be possible, but will require different steps (setting an env variable for instance).
- all configurable elements of the nlu (located in the nlu config file) will be migrated to another config file.
- while we are at it, I think this would be a perfect opportunity to refactor the NLU typings (`EventUnderstanding` in the sdk). Let's be honnest, those typings are getting a little bit old.

Would these breaking changes justify bumping the botpress version up by a major? I'm thinking of a botpress 13 with a builtin unchangeable nlu system.

What do you guys think?



