### PR TITLE
feat(qna): display count when expanding

### DIFF
--- a/modules/qna/src/views/full/Components/QnA.tsx
+++ b/modules/qna/src/views/full/Components/QnA.tsx
@@ -193,11 +193,10 @@ const QnA: FC<Props> = props => {
                 <span className={cx(style.tag)}>{lang.tr('module.qna.form.incomplete')}</span>
               </Tooltip>
             )}
-            {!expanded && (
-              <span className={style.tag}>{`${questions?.filter(q => q.trim()).length || 0} ${lang.tr(
-                'module.qna.form.q'
-              )} · ${answers?.filter(a => a.trim()).length || 0}  ${lang.tr('module.qna.form.a')}`}</span>
-            )}
+            <span className={style.tag}>
+              {`${questions?.filter(q => q.trim()).length || 0} ${lang.tr('module.qna.form.q')}
+               · ${answers?.filter(a => a.trim()).length || 0}  ${lang.tr('module.qna.form.a')}`}
+            </span>
           </div>
         </Button>
         <MoreOptions show={showOption} onToggle={() => setShowOption(!showOption)} items={moreOptionsItems} />


### PR DESCRIPTION
Closes botpress/v12#1193

Before: 

![image](https://user-images.githubusercontent.com/59566773/104240803-a21b7480-542a-11eb-907b-d45f6f8e84f6.png)

After: 

![Screenshot from 2021-01-12 15-06-47](https://user-images.githubusercontent.com/9640576/104367166-6b0b9880-54e8-11eb-84fb-b592adc8b5d2.png)
