### PR TITLE
fix(builtin): ResetSession - Dont remove workflows

### DIFF
--- a/modules/builtin/src/actions/resetSession.js
+++ b/modules/builtin/src/actions/resetSession.js
@@ -8,7 +8,7 @@
  * @author Botpress, Inc.
  */
 const _ = require('lodash')
-const PROPERTIES_TO_KEEP = ['lastMessages', 'nluContexts']
+const PROPERTIES_TO_KEEP = ['lastMessages', 'nluContexts', 'workflows']
 
 async function resetSession() {
   bp.logger.debug('inside reset')


### PR DESCRIPTION
Removing the `workflows` from the session causes an error in [the StateManager](https://github.com/botpress/botpress/blob/998d30d7d9e630d0acbf1f4745531d37965c1460/src/bp/core/services/middleware/state-manager.ts#L99):

```
01/12/2021 16:04:58.152 ActionService An error occurred while executing the action "builtin/resetSession [TypeError, Cannot read property 'undefined' of undefined]
STACK TRACE
TypeError: Cannot read property 'undefined' of undefined
    at Object.get (/Users/spg/botpress/out/bp/core/services/middleware/state-manager.js:133:55)
    at Object.exports.extractEventCommonArgs (/Users/spg/botpress/out/bp/common/action.js:37:457)
    at ScopedActionService.<anonymous> (/Users/spg/botpress/out/bp/core/services/action/action-service.js:262:35)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/spg/botpress/out/bp/core/services/action/action-service.js:17:58)
From previous event:
    at __awaiter (/Users/spg/botpress/out/bp/core/services/action/action-service.js:16:12)
    at ScopedActionService.runAction (/Users/spg/botpress/out/bp/core/services/action/action-service.js:157:16)
    at ActionStrategy.<anonymous> (/Users/spg/botpress/out/bp/core/services/dialog/instruction/strategy.js:144:31)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/spg/botpress/out/bp/core/services/dialog/instruction/strategy.js:17:58)
```

Fixes https://github.com/botpress/v12/issues/1187