### PR TITLE
fix(channel-web): delete conversation button wrong action

### DIFF
--- a/modules/channel-web/src/views/lite/components/Header.tsx
+++ b/modules/channel-web/src/views/lite/components/Header.tsx
@@ -266,7 +266,7 @@ class Header extends React.Component<HeaderProps> {
     if (this.props.showDeleteConversationButton) {
       optionsItems.push({
         label: 'Delete conversation',
-        action: this.renderDeleteConversationButton
+        action: this.props.deleteConversation
       })
     }
 


### PR DESCRIPTION
This PR fixes an issue where deleting the conversation from the emulator raises an exception.

Note that I decided to bypass the confirmation dialog (`handleDeleteConversation`) when the web channel config `isEmulator` is set to `true` and directly call the prop function `deleteConversation`.