### PR TITLE
fix(channel-web): remove custom action on component unmount

### DIFF
--- a/modules/extensions/src/views/lite/components/debugger/index.tsx
+++ b/modules/extensions/src/views/lite/components/debugger/index.tsx
@@ -25,6 +25,7 @@ interface State {
 
 export class Debugger extends React.Component<Props, State> {
   lastMessage = undefined
+  readonly customActionId = 'actionDebug'
 
   async componentDidMount() {
     updater.callback = this.loadEvent
@@ -32,7 +33,7 @@ export class Debugger extends React.Component<Props, State> {
     this.props.store.setMessageWrapper({ module: 'extensions', component: 'Wrapper' })
 
     this.props.store.view.addCustomAction({
-      id: 'actionDebug',
+      id: this.customActionId,
       label: 'Inspect in Debugger',
       onClick: this.handleSelect
     })
@@ -53,6 +54,8 @@ export class Debugger extends React.Component<Props, State> {
 
   componentWillUnmount() {
     this.props.store.bp.events.off('guest.webchat.message', this.handleNewMessage)
+
+    this.props.store.view.removeCustomAction(this.customActionId)
   }
 
   handleNewMessage = async ({ payload, incomingEventId }) => {


### PR DESCRIPTION
This PR fixes an "issue" where displaying and hiding the emulator multiple time would result in a console "error".

Since the debugger register a new custom action when the component is mounting and never removes it, a console error is displayed on the next component rendering.

`Can't add another action with the same ID.`