### PR TITLE
fix(channel-web): wrong intl id

### DIFF
--- a/modules/channel-web/src/views/lite/components/Composer.tsx
+++ b/modules/channel-web/src/views/lite/components/Composer.tsx
@@ -68,7 +68,7 @@ class Composer extends React.Component<ComposerProps> {
     const placeholder =
       this.props.composerPlaceholder ||
       this.props.intl.formatMessage({
-        id: this.isLastMessageFromBot() ? 'placeholder' : 'composer.placeholderInit' }, { name: this.props.botName })
+        id: this.isLastMessageFromBot() ? 'composer.placeholder' : 'composer.placeholderInit' }, { name: this.props.botName })
 
     return (
       <div role="region" className={'bpw-composer'}>


### PR DESCRIPTION
This PR fixes an issue where the wrong id was used to reference some translation raising these errors:

![Screenshot from 2021-01-12 18-17-17](https://user-images.githubusercontent.com/9640576/104386209-adda6a00-5502-11eb-9e43-5ddc5e28e644.png)
