### PR TITLE
feat(core): added new hook to highjack nlu election

### DIFF
--- a/modules/code-editor/src/typings/hooks.ts
+++ b/modules/code-editor/src/typings/hooks.ts
@@ -1,5 +1,6 @@
 export const HOOK_SIGNATURES = {
   before_incoming_middleware: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
+  after_nlu_election: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
   after_incoming_middleware: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
   before_outgoing_middleware: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
   after_event_processed: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
@@ -32,6 +33,7 @@ export const HOOK_SIGNATURES = {
 export const BOT_SCOPED_HOOKS = [
   'before_incoming_middleware',
   'after_incoming_middleware',
+  'after_nlu_election',
   'before_outgoing_middleware',
   'after_event_processed',
   'before_suggestions_election',

--- a/modules/code-editor/src/views/full/SidePanel.tsx
+++ b/modules/code-editor/src/views/full/SidePanel.tsx
@@ -264,6 +264,7 @@ class PanelContent extends React.Component<Props> {
         items: hooks.filter(x =>
           [
             'before_incoming_middleware',
+            'after_nlu_election',
             'after_incoming_middleware',
             'before_outgoing_middleware',
             'after_event_processed',

--- a/modules/examples/src/examples/hooks/after_nlu_election/00_highjack_nlu.js
+++ b/modules/examples/src/examples/hooks/after_nlu_election/00_highjack_nlu.js
@@ -1,0 +1,9 @@
+/**
+ * This hook executes rigth after nlu election, before all incoming middlewares.
+ *
+ * Use it to modify election logic and force any result you want.
+ *
+ * Here, let's force the none intent to be elected
+ */
+event.nlu.intent.name = 'none'
+event.nlu.intent.confidence = 1

--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -3,7 +3,7 @@ import Joi from 'joi'
 import _ from 'lodash'
 import yn from 'yn'
 
-import legacyElectionPipeline from './election/legacy-election'
+import simpleElection from './election/simple-election'
 import mergeSpellChecked from './election/spellcheck-handler'
 import { getTrainingSession } from './train-session-service'
 import { NLUState } from './typings'
@@ -77,7 +77,7 @@ export default async (bp: typeof sdk, state: NLUState) => {
         ms,
         spellChecked
       }
-      res.send({ nlu: legacyElectionPipeline(event) })
+      res.send({ nlu: simpleElection(event) })
     } catch (err) {
       res.status(500).send('Could not extract nlu data')
     }

--- a/modules/nlu/src/backend/election/simple-election.ts
+++ b/modules/nlu/src/backend/election/simple-election.ts
@@ -1,0 +1,99 @@
+import * as sdk from 'botpress/sdk'
+import _ from 'lodash'
+
+const NONE_INTENT = 'none'
+
+function detectAmbiguity(intents: sdk.NLU.Intent[]): boolean {
+  // +- 10% away from perfect median leads to ambiguity
+  const preds = intents
+  const perfectConfusion = 1 / preds.length
+  const low = perfectConfusion - 0.1
+  const up = perfectConfusion + 0.1
+  const confidenceVec = preds.map(p => p.confidence)
+
+  const allInRange = (vec: number[], lower: number, upper: number) =>
+    vec.map(v => _.inRange(v, lower, upper)).every(_.identity)
+
+  const ambiguous =
+    preds.length > 1 &&
+    (allInRange(confidenceVec, low, up) ||
+      (preds[0].name === NONE_INTENT && allInRange(confidenceVec.slice(1), low, up)))
+
+  return ambiguous
+}
+
+/**
+ * @description confidence of none intent becomes Math.max(none, oos)
+ * @param oos confidence of OOS
+ */
+const replaceNone = (oos: number) => (i: sdk.NLU.Intent): sdk.NLU.Intent => {
+  if (i.name !== NONE_INTENT) {
+    return i
+  }
+  return { ...i, confidence: Math.max(i.confidence, oos) }
+}
+
+const toNLUIntent = (context: string) => (intent: sdk.NLU.ContextPrediction['intents'][number]): sdk.NLU.Intent => {
+  return {
+    name: intent.label,
+    confidence: intent.confidence,
+    context
+  }
+}
+
+/**
+ * @description make probabilities sum up to 1 (because, oos classifier is different from intent classifier, probabilities don't sum up to 1)
+ * @param oos confidence of OOS
+ */
+const makeTotalConfidenceOne = (intents: sdk.NLU.Intent[]): sdk.NLU.Intent[] => {
+  const totalConfidence = intents.reduce(
+    (totalConfidence: number, currentIntent: sdk.NLU.Intent) => totalConfidence + currentIntent.confidence,
+    0
+  )
+  return intents.map(i => ({ ...i, confidence: i.confidence / totalConfidence }))
+}
+
+export default function simpleElection(nlu: sdk.IO.EventUnderstanding): sdk.IO.EventUnderstanding {
+  const { predictions, includedContexts } = nlu
+  if (!includedContexts.length || !predictions) {
+    return nlu
+  }
+
+  const ctxPredictions = _(predictions)
+    .toPairs()
+    .filter(([ctx, pred]) => includedContexts.includes(ctx))
+    .value()
+
+  if (!ctxPredictions.length) {
+    const noneIntent: sdk.NLU.Intent = { name: NONE_INTENT, confidence: 1, context: includedContexts[0] }
+    return {
+      ...nlu,
+      intent: noneIntent,
+      intents: [noneIntent],
+      slots: {},
+      ambiguous: false
+    }
+  }
+
+  const [electedContext, contextPrediction] = _.maxBy(ctxPredictions, ([ctx, pred]) => pred.confidence)
+
+  const topTwoIntents = _(contextPrediction.intents)
+    .map(toNLUIntent(electedContext))
+    .map(replaceNone(contextPrediction.oos))
+    .orderBy(i => i.confidence, 'desc')
+    .take(2)
+    .value()
+  const ambiguous = detectAmbiguity(topTwoIntents)
+
+  const intents = makeTotalConfidenceOne(topTwoIntents)
+  const [electedIntent] = intents
+  const slots = predictions[electedContext].intents.find(i => i.label === electedIntent.name).slots
+
+  return {
+    ...nlu,
+    intent: electedIntent,
+    intents,
+    slots,
+    ambiguous
+  }
+}

--- a/modules/nlu/src/backend/election/spellcheck-handler.ts
+++ b/modules/nlu/src/backend/election/spellcheck-handler.ts
@@ -1,7 +1,9 @@
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 
-import { NONE_INTENT, ValueOf } from './typings'
+export const NONE_INTENT = 'none'
+
+export type ValueOf<T> = T[keyof T]
 
 const mergeSpellChecked = (
   originalOutput: sdk.NLU.PredictOutput,

--- a/modules/nlu/src/backend/election/typings.ts
+++ b/modules/nlu/src/backend/election/typings.ts
@@ -1,3 +1,0 @@
-export const NONE_INTENT = 'none' // should extract in comon code
-
-export type ValueOf<T> = T[keyof T]

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -31,7 +31,7 @@ const ignoreEvent = (bp: typeof sdk, state: NLUState, event: sdk.IO.IncomingEven
 }
 
 const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
-  bp.events.registerMiddleware({
+  const predictMw: sdk.IO.MiddlewareDefinition = {
     name: 'nlu-predict.incoming',
     direction: 'incoming',
     order: 100,
@@ -68,7 +68,7 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
         next()
       }
     }
-  })
+  }
 
   function removeSensitiveText(event: sdk.IO.IncomingEvent) {
     if (!event.nlu.entities || !event.payload.text) {
@@ -86,7 +86,7 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
     }
   }
 
-  bp.events.registerMiddleware({
+  const electMw: sdk.IO.MiddlewareDefinition = {
     name: 'nlu-elect.incoming',
     direction: 'incoming',
     order: 120,
@@ -106,6 +106,12 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
         next()
       }
     }
+  }
+
+  process.BOTPRESS_EVENTS.on('NLU_PREDICT_REQUEST', async (event: sdk.IO.Event) => {
+    await predictMw.handler(event, () => {})
+    await electMw.handler(event, () => {})
+    process.BOTPRESS_EVENTS.emit('NLU_PREDICT_RESPONSE', event.id)
   })
 }
 

--- a/modules/nlu/src/hooks/after_nlu_election/00_legacy-election.js
+++ b/modules/nlu/src/hooks/after_nlu_election/00_legacy-election.js
@@ -1,0 +1,1 @@
+bp.logger.info('This is legacy election.')

--- a/modules/nlu/src/hooks/after_nlu_election/00_legacy-election.js
+++ b/modules/nlu/src/hooks/after_nlu_election/00_legacy-election.js
@@ -1,1 +1,0 @@
-bp.logger.info('This is legacy election.')

--- a/src/bp/core/botpress.ts
+++ b/src/bp/core/botpress.ts
@@ -357,6 +357,10 @@ export class Botpress {
       await this.hookService.executeHook(new Hooks.BeforeIncomingMiddleware(this.api, event))
     }
 
+    this.eventEngine.onAfterNluElection = async (event: sdk.IO.IncomingEvent) => {
+      await this.hookService.executeHook(new Hooks.AfterNluElectionMiddleware(this.api, event))
+    }
+
     this.eventEngine.onAfterIncomingMiddleware = async (event: sdk.IO.IncomingEvent) => {
       if (event.isPause) {
         this.eventCollector.storeEvent(event)

--- a/src/bp/core/services/hook/hook-service.ts
+++ b/src/bp/core/services/hook/hook-service.ts
@@ -62,6 +62,12 @@ export namespace Hooks {
     }
   }
 
+  export class AfterNluElectionMiddleware extends BaseHook {
+    constructor(bp: typeof sdk, event: sdk.IO.Event) {
+      super('after_nlu_election', { bp, event })
+    }
+  }
+
   export class AfterIncomingMiddleware extends BaseHook {
     constructor(bp: typeof sdk, event: sdk.IO.Event) {
       super('after_incoming_middleware', { bp, event })

--- a/src/bp/core/services/middleware/event-engine.ts
+++ b/src/bp/core/services/middleware/event-engine.ts
@@ -89,6 +89,7 @@ export class EventEngine {
   public onBeforeIncomingMiddleware?: (event) => Promise<void>
   public onAfterIncomingMiddleware?: (event) => Promise<void>
   public onBeforeOutgoingMiddleware?: (event) => Promise<void>
+  public onAfterNluElection?: (event) => Promise<void>
 
   private readonly _incomingPerf = new TimedPerfCounter('mw_incoming')
   private readonly _outgoingPerf = new TimedPerfCounter('mw_outgoing')
@@ -110,6 +111,7 @@ export class EventEngine {
       this.onBeforeIncomingMiddleware && (await this.onBeforeIncomingMiddleware(event))
 
       await this.nluEngine.processEvent(event)
+      this.onAfterNluElection && (await this.onAfterNluElection(event))
 
       const { incoming } = await this.getBotMiddlewareChains(event.botId)
       await incoming.run(event)

--- a/src/bp/core/services/nlu/nlu-engine.ts
+++ b/src/bp/core/services/nlu/nlu-engine.ts
@@ -1,0 +1,26 @@
+import { IO } from 'botpress/sdk'
+import { injectable } from 'inversify'
+
+@injectable()
+export class NLUEngine {
+  constructor() {}
+
+  public processEvent(event: IO.Event): Promise<IO.Event> {
+    return new Promise((resolve, reject) => {
+      try {
+        process.BOTPRESS_EVENTS.emit('NLU_PREDICT_REQUEST', event)
+
+        const listener = (eventId: string) => {
+          if (event.id === eventId) {
+            process.BOTPRESS_EVENTS.removeListener('NLU_PREDICT_RESPONSE', listener)
+            resolve(event)
+          }
+        }
+
+        process.BOTPRESS_EVENTS.on('NLU_PREDICT_RESPONSE', listener)
+      } catch (err) {
+        reject(err)
+      }
+    })
+  }
+}

--- a/src/bp/core/services/services.inversify.ts
+++ b/src/bp/core/services/services.inversify.ts
@@ -25,6 +25,7 @@ import { LogsService } from './logs/service'
 import MediaService from './media'
 import { EventEngine } from './middleware/event-engine'
 import { CEMonitoringService, MonitoringService } from './monitoring'
+import { NLUEngine } from './nlu/nlu-engine'
 import { NLUService } from './nlu/nlu-service'
 import { NotificationsService } from './notification/service'
 import { Queue } from './queue'
@@ -39,6 +40,10 @@ const ServicesContainerModule = new ContainerModule((bind: interfaces.Bind) => {
 
   bind<NLUService>(TYPES.NLUService)
     .to(NLUService)
+    .inSingletonScope()
+
+  bind<NLUEngine>(TYPES.NLUEngine)
+    .to(NLUEngine)
     .inSingletonScope()
 
   bind<MediaService>(TYPES.MediaService)

--- a/src/bp/core/types.ts
+++ b/src/bp/core/types.ts
@@ -81,6 +81,7 @@ const TYPES = {
   WorkspaceInviteCodesRepository: Symbol.for('WorkspaceInviteCodesRepository'),
   LocalActionServer: Symbol.for('LocalActionServer'),
   NLUService: Symbol.for('NLUService'),
+  NLUEngine: Symbol.for('NLUEngine'),
   TelemetryRepository: Symbol.for('TelemetryRepository'),
   ActionStats: Symbol.for('ActionStats'),
   LegacyStats: Symbol.for('LegacyStats'),


### PR DESCRIPTION
Allright, this is a really early draft of a solution to hijack nlu election before every other middlewares.

Of course, in the actual solution, the nlu middleware wouldn't be called by emitting an event, but rather by moving it into the core. This was only to draft quicker.

This picture gives a rough estimate of the PR:

![image](https://user-images.githubusercontent.com/25970722/104491728-a6699e00-55a0-11eb-94f2-6687da943941.png)

I named this new hook the `after_nlu_election` hook, which is kind of weird, because now the `before_incoming_middlewares` hooks are not directly before the incoming middlewares...

TBH, I don't even think this solution is that much nice... The legacy election needs information to compute that shouldn't even be available outside of nlu-core implementation...
\+ we will need to update the legacy-election if we modify sdk typings.