### PR TITLE
fix(core): conflict between session ids

### DIFF
--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -375,7 +375,7 @@ export default async (bp: typeof sdk, db: Database) => {
       await sendNewMessage(botId, userId, conversationId, payload, req.credentials)
 
       const sessionId = await bp.dialog.createId({ botId, target: userId, threadId: conversationId, channel: 'web' })
-      await bp.dialog.deleteSession(sessionId)
+      await bp.dialog.deleteSession(sessionId, botId)
       res.sendStatus(200)
     })
   )

--- a/src/bp/core/services/dialog/session/id-factory.ts
+++ b/src/bp/core/services/dialog/session/id-factory.ts
@@ -2,12 +2,14 @@ import { IO } from 'botpress/sdk'
 
 export class SessionIdFactory {
   static createIdFromEvent(eventDestination: IO.EventDestination) {
-    const { channel, target, threadId } = eventDestination
-    return `${channel}::${target}${threadId ? `::${threadId}` : ''}`
+    const { botId, channel, target, threadId } = eventDestination
+    return `${channel}::${target}::${botId}${threadId ? `::${threadId}` : ''}`
   }
 
-  static extractDestinationFromId(sessionId: string): Pick<IO.EventDestination, 'channel' | 'target' | 'threadId'> {
-    const [channel, target, threadId] = sessionId.split('::')
-    return { channel, target, threadId }
+  static extractDestinationFromId(
+    sessionId: string
+  ): Pick<IO.EventDestination, 'channel' | 'target' | 'botId' | 'threadId'> {
+    const [channel, target, botId, threadId] = sessionId.split('::')
+    return { channel, target, botId, threadId }
   }
 }

--- a/src/bp/core/services/dialog/session/id-factory.ts
+++ b/src/bp/core/services/dialog/session/id-factory.ts
@@ -2,14 +2,12 @@ import { IO } from 'botpress/sdk'
 
 export class SessionIdFactory {
   static createIdFromEvent(eventDestination: IO.EventDestination) {
-    const { botId, channel, target, threadId } = eventDestination
-    return `${channel}::${target}::${botId}${threadId ? `::${threadId}` : ''}`
+    const { channel, target, threadId } = eventDestination
+    return `${channel}::${target}${threadId ? `::${threadId}` : ''}`
   }
 
-  static extractDestinationFromId(
-    sessionId: string
-  ): Pick<IO.EventDestination, 'channel' | 'target' | 'botId' | 'threadId'> {
-    const [channel, target, botId, threadId] = sessionId.split('::')
-    return { channel, target, botId, threadId }
+  static extractDestinationFromId(sessionId: string): Pick<IO.EventDestination, 'channel' | 'target' | 'threadId'> {
+    const [channel, target, threadId] = sessionId.split('::')
+    return { channel, target, threadId }
   }
 }

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -2026,8 +2026,9 @@ declare module 'botpress/sdk' {
     /**
      * Deletes a session
      * @param sessionId The Id of the session to delete
+     * @param botId The Id of the bot to which the session is tied
      */
-    export function deleteSession(sessionId: string): Promise<void>
+    export function deleteSession(sessionId: string, botId: string): Promise<void>
 
     /**
      * Jumps to a specific flow and optionally a specific node. This is useful when the default flow behavior needs to be bypassed.


### PR DESCRIPTION
This PR (related to botpress/botpress#4085) fixes an issue (#4030) where, in some cases, the same user having two conversations with different bots could result in one message being sent to the wrong convo and result in an exception being raised (Node not found). 

e.g.
![Screenshot from 2021-01-14 08-31-30](https://user-images.githubusercontent.com/9640576/104601226-f8b1ca00-5647-11eb-9f99-204c1c019bc2.png)


This is caused by the fact that the session ID was constructed from the `sessionstate_(channel + userID + threadID (convoID))` and could sometimes conflict with one another.

To resolve this issue, the bot ID is added to redis's session ID (`sessionstate_(botId + channel + userID + threadID)`) making it more resilient to multi-bot communication for the same channel.