### PR TITLE
fix(channel-messenger): added config to disable api actions

### DIFF
--- a/modules/channel-messenger/src/backend/messenger.ts
+++ b/modules/channel-messenger/src/backend/messenger.ts
@@ -298,7 +298,7 @@ export class MessengerClient {
 
   async sendAction(senderId: string, action: MessengerAction) {
     const config = await this.getConfig()
-    if (config.blacklistedActions.includes(action)) {
+    if (config.disabledActions?.length && config.disabledActions.includes(action)) {
       debugMessages('outgoing action skipped (blacklisted)', { action })
       return
     }

--- a/modules/channel-messenger/src/backend/messenger.ts
+++ b/modules/channel-messenger/src/backend/messenger.ts
@@ -1,10 +1,10 @@
-import axios, { AxiosInstance } from 'axios'
+import axios, { AxiosError, AxiosInstance } from 'axios'
 import * as sdk from 'botpress/sdk'
 import crypto from 'crypto'
 import { json as expressJson, Router } from 'express'
 import _ from 'lodash'
 
-import { Config } from '../config'
+import { Config, MessengerAction } from '../config'
 
 const debug = DEBUG('channel-messenger')
 const debugMessages = debug.sub('messages')
@@ -13,7 +13,6 @@ const debugWebhook = debugHttp.sub('webhook')
 const debugHttpOut = debugHttp.sub('out')
 
 const outgoingTypes = ['text', 'typing', 'login_prompt', 'carousel']
-type MessengerAction = 'typing_on' | 'typing_off' | 'mark_seen'
 
 interface MountedBot {
   pageId: string
@@ -298,6 +297,12 @@ export class MessengerClient {
   }
 
   async sendAction(senderId: string, action: MessengerAction) {
+    const config = await this.getConfig()
+    if (config.blacklistedActions.includes(action)) {
+      debugMessages('outgoing action skipped (blacklisted)', { action })
+      return
+    }
+
     const body = {
       recipient: {
         id: senderId

--- a/modules/channel-messenger/src/backend/messenger.ts
+++ b/modules/channel-messenger/src/backend/messenger.ts
@@ -298,7 +298,7 @@ export class MessengerClient {
 
   async sendAction(senderId: string, action: MessengerAction) {
     const config = await this.getConfig()
-    if (config.disabledActions?.length && config.disabledActions.includes(action)) {
+    if (config.disabledActions?.includes(action)) {
       debugMessages('outgoing action skipped (blacklisted)', { action })
       return
     }

--- a/modules/channel-messenger/src/config.ts
+++ b/modules/channel-messenger/src/config.ts
@@ -47,8 +47,17 @@ export interface Config {
    * @default 24h
    */
   chatUserAuthDuration: string
+
+  /**
+   * Allows to disable certain actions.
+   * Could be used to comply with some region's restrictions.
+   * Example: https://developers.facebook.com/blog/post/2020/12/04/upcoming-changes-messenger-api/
+   * @default []
+   */
+  blacklistedActions?: Array<MessengerAction>
 }
 
+export type MessengerAction = 'typing_on' | 'typing_off' | 'mark_seen'
 export interface PersistentMenuItem {
   locale: string
   composer_input_disabled?: boolean

--- a/modules/channel-messenger/src/config.ts
+++ b/modules/channel-messenger/src/config.ts
@@ -54,7 +54,7 @@ export interface Config {
    * Example: https://developers.facebook.com/blog/post/2020/12/04/upcoming-changes-messenger-api/
    * @default []
    */
-  blacklistedActions?: Array<MessengerAction>
+  disabledActions?: MessengerAction[]
 }
 
 export type MessengerAction = 'typing_on' | 'typing_off' | 'mark_seen'


### PR DESCRIPTION
This PR add the possibility for the user to disable some messenger's API sender actions (typing on/off, mark as seed). This feature makes it easier to comply with facebook's API changes like: https://developers.facebook.com/blog/post/2020/12/04/upcoming-changes-messenger-api/.

The config name is `disabledActions` and accepts a list of actions to disable.

Related to botpress/v12#1194