### PR TITLE
chore(stan): make sure intent confidence sums up to one

### DIFF
--- a/build/nlu-regression/current_scores/bpds-intent.json
+++ b/build/nlu-regression/current_scores/bpds-intent.json
@@ -1,23 +1,23 @@
 {
-  "generatedOn": "2021-01-04T21:36:12.110Z",
+  "generatedOn": "2021-01-13T22:05:41.971Z",
   "scores": [
     {
       "metric": "accuracy",
       "problem": "bpsd A-en",
       "seed": 42,
-      "score": 0.6863636363636364
+      "score": 0.7045454545454546
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpsd A-en",
       "seed": 42,
-      "score": 0.7818181818181819
+      "score": 0.8045454545454546
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A-en",
       "seed": 42,
-      "score": 0.7888888888888889
+      "score": 0.8352941176470589
     },
     {
       "metric": "oosRecall",
@@ -29,25 +29,25 @@
       "metric": "oosF1",
       "problem": "bpsd A-en",
       "seed": 42,
-      "score": 0.7473684210526317
+      "score": 0.7675675675675675
     },
     {
       "metric": "accuracy",
       "problem": "bpsd A-en",
       "seed": 69,
-      "score": 0.6909090909090909
+      "score": 0.7045454545454546
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpsd A-en",
       "seed": 69,
-      "score": 0.7954545454545454
+      "score": 0.8090909090909091
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A-en",
       "seed": 69,
-      "score": 0.8313253012048193
+      "score": 0.8625
     },
     {
       "metric": "oosRecall",
@@ -59,25 +59,25 @@
       "metric": "oosF1",
       "problem": "bpsd A-en",
       "seed": 69,
-      "score": 0.7540983606557377
+      "score": 0.7666666666666667
     },
     {
       "metric": "accuracy",
       "problem": "bpsd A-en",
       "seed": 666,
-      "score": 0.6954545454545454
+      "score": 0.7136363636363636
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpsd A-en",
       "seed": 666,
-      "score": 0.7863636363636364
+      "score": 0.8045454545454546
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A-en",
       "seed": 666,
-      "score": 0.7912087912087912
+      "score": 0.8275862068965517
     },
     {
       "metric": "oosRecall",
@@ -89,247 +89,247 @@
       "metric": "oosF1",
       "problem": "bpsd A-en",
       "seed": 666,
-      "score": 0.7539267015706805
+      "score": 0.7700534759358287
     },
     {
       "metric": "accuracy",
       "problem": "bpds A imbalanced-en",
       "seed": 42,
-      "score": 0.4772727272727273
+      "score": 0.5
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A imbalanced-en",
       "seed": 42,
-      "score": 0.6363636363636364
+      "score": 0.6636363636363637
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced-en",
       "seed": 42,
-      "score": 0.5961538461538461
+      "score": 0.6444444444444445
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A imbalanced-en",
       "seed": 42,
-      "score": 0.62
+      "score": 0.58
     },
     {
       "metric": "oosF1",
       "problem": "bpds A imbalanced-en",
       "seed": 42,
-      "score": 0.607843137254902
+      "score": 0.6105263157894737
     },
     {
       "metric": "accuracy",
       "problem": "bpds A imbalanced-en",
       "seed": 69,
-      "score": 0.5909090909090909
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds A imbalanced-en",
-      "seed": 69,
-      "score": 0.7
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds A imbalanced-en",
-      "seed": 69,
-      "score": 0.7428571428571429
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds A imbalanced-en",
-      "seed": 69,
-      "score": 0.52
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds A imbalanced-en",
-      "seed": 69,
-      "score": 0.6117647058823529
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpds A imbalanced-en",
-      "seed": 666,
-      "score": 0.5636363636363636
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds A imbalanced-en",
-      "seed": 666,
-      "score": 0.6909090909090909
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds A imbalanced-en",
-      "seed": 666,
-      "score": 0.75
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds A imbalanced-en",
-      "seed": 666,
-      "score": 0.48
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds A imbalanced-en",
-      "seed": 666,
-      "score": 0.5853658536585366
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpds A fewshot-en",
-      "seed": 42,
       "score": 0.6
     },
     {
       "metric": "oosAccuracy",
-      "problem": "bpds A fewshot-en",
-      "seed": 42,
-      "score": 0.6909090909090909
+      "problem": "bpds A imbalanced-en",
+      "seed": 69,
+      "score": 0.7136363636363636
     },
     {
       "metric": "oosPrecision",
-      "problem": "bpds A fewshot-en",
-      "seed": 42,
-      "score": 0.6509433962264151
+      "problem": "bpds A imbalanced-en",
+      "seed": 69,
+      "score": 0.7936507936507936
     },
     {
       "metric": "oosRecall",
-      "problem": "bpds A fewshot-en",
-      "seed": 42,
-      "score": 0.69
+      "problem": "bpds A imbalanced-en",
+      "seed": 69,
+      "score": 0.5
     },
     {
       "metric": "oosF1",
-      "problem": "bpds A fewshot-en",
-      "seed": 42,
-      "score": 0.6699029126213591
+      "problem": "bpds A imbalanced-en",
+      "seed": 69,
+      "score": 0.6134969325153374
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpds A imbalanced-en",
+      "seed": 666,
+      "score": 0.5772727272727273
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpds A imbalanced-en",
+      "seed": 666,
+      "score": 0.7090909090909091
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds A imbalanced-en",
+      "seed": 666,
+      "score": 0.8214285714285714
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpds A imbalanced-en",
+      "seed": 666,
+      "score": 0.46
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds A imbalanced-en",
+      "seed": 666,
+      "score": 0.5897435897435898
     },
     {
       "metric": "accuracy",
       "problem": "bpds A fewshot-en",
-      "seed": 69,
-      "score": 0.5227272727272727
+      "seed": 42,
+      "score": 0.6318181818181818
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot-en",
-      "seed": 69,
-      "score": 0.6454545454545455
+      "seed": 42,
+      "score": 0.7272727272727273
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot-en",
-      "seed": 69,
-      "score": 0.6666666666666666
+      "seed": 42,
+      "score": 0.7127659574468085
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A fewshot-en",
-      "seed": 69,
-      "score": 0.44
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds A fewshot-en",
-      "seed": 69,
-      "score": 0.5301204819277109
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpds A fewshot-en",
-      "seed": 666,
-      "score": 0.6
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds A fewshot-en",
-      "seed": 666,
-      "score": 0.7
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds A fewshot-en",
-      "seed": 666,
-      "score": 0.6808510638297872
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds A fewshot-en",
-      "seed": 666,
-      "score": 0.64
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds A fewshot-en",
-      "seed": 666,
-      "score": 0.6597938144329897
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpds B",
-      "seed": 42,
-      "score": 0.7
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds B",
-      "seed": 42,
-      "score": 0.8136363636363636
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds B",
-      "seed": 42,
-      "score": 0.8933333333333333
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds B",
       "seed": 42,
       "score": 0.67
     },
     {
       "metric": "oosF1",
+      "problem": "bpds A fewshot-en",
+      "seed": 42,
+      "score": 0.6907216494845361
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpds A fewshot-en",
+      "seed": 69,
+      "score": 0.5454545454545454
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpds A fewshot-en",
+      "seed": 69,
+      "score": 0.6954545454545454
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds A fewshot-en",
+      "seed": 69,
+      "score": 0.8367346938775511
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpds A fewshot-en",
+      "seed": 69,
+      "score": 0.41
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds A fewshot-en",
+      "seed": 69,
+      "score": 0.5503355704697986
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpds A fewshot-en",
+      "seed": 666,
+      "score": 0.6227272727272727
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpds A fewshot-en",
+      "seed": 666,
+      "score": 0.7363636363636363
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds A fewshot-en",
+      "seed": 666,
+      "score": 0.75
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpds A fewshot-en",
+      "seed": 666,
+      "score": 0.63
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds A fewshot-en",
+      "seed": 666,
+      "score": 0.6847826086956522
+    },
+    {
+      "metric": "accuracy",
       "problem": "bpds B",
       "seed": 42,
-      "score": 0.7657142857142857
+      "score": 0.6954545454545454
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpds B",
+      "seed": 42,
+      "score": 0.8090909090909091
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds B",
+      "seed": 42,
+      "score": 0.9027777777777778
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpds B",
+      "seed": 42,
+      "score": 0.65
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds B",
+      "seed": 42,
+      "score": 0.7558139534883721
     },
     {
       "metric": "accuracy",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.6545454545454545
+      "score": 0.6409090909090909
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.7954545454545454
+      "score": 0.7863636363636364
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.9365079365079365
+      "score": 0.9491525423728814
     },
     {
       "metric": "oosRecall",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.59
+      "score": 0.56
     },
     {
       "metric": "oosF1",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.7239263803680981
+      "score": 0.7044025157232704
     },
     {
       "metric": "accuracy",
@@ -341,205 +341,205 @@
       "metric": "oosAccuracy",
       "problem": "bpds B",
       "seed": 666,
-      "score": 0.7909090909090909
+      "score": 0.7954545454545454
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds B",
       "seed": 666,
-      "score": 0.8970588235294118
+      "score": 0.9230769230769231
     },
     {
       "metric": "oosRecall",
       "problem": "bpds B",
       "seed": 666,
-      "score": 0.61
+      "score": 0.6
     },
     {
       "metric": "oosF1",
       "problem": "bpds B",
       "seed": 666,
-      "score": 0.7261904761904763
+      "score": 0.7272727272727274
     },
     {
       "metric": "accuracy",
       "problem": "bpsd A-fr",
       "seed": 42,
-      "score": 0.6545454545454545
+      "score": 0.6727272727272727
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpsd A-fr",
       "seed": 42,
-      "score": 0.7136363636363636
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpsd A-fr",
-      "seed": 42,
-      "score": 0.6831683168316832
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpsd A-fr",
-      "seed": 42,
-      "score": 0.69
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpsd A-fr",
-      "seed": 42,
-      "score": 0.6865671641791044
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpsd A-fr",
-      "seed": 69,
-      "score": 0.6636363636363637
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpsd A-fr",
-      "seed": 69,
-      "score": 0.7318181818181818
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpsd A-fr",
-      "seed": 69,
-      "score": 0.7029702970297029
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpsd A-fr",
-      "seed": 69,
-      "score": 0.71
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpsd A-fr",
-      "seed": 69,
-      "score": 0.7064676616915423
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpsd A-fr",
-      "seed": 666,
-      "score": 0.6590909090909091
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpsd A-fr",
-      "seed": 666,
       "score": 0.7363636363636363
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A-fr",
-      "seed": 666,
-      "score": 0.723404255319149
+      "seed": 42,
+      "score": 0.7386363636363636
     },
     {
       "metric": "oosRecall",
       "problem": "bpsd A-fr",
-      "seed": 666,
-      "score": 0.68
+      "seed": 42,
+      "score": 0.65
     },
     {
       "metric": "oosF1",
       "problem": "bpsd A-fr",
-      "seed": 666,
-      "score": 0.7010309278350516
+      "seed": 42,
+      "score": 0.6914893617021277
     },
     {
       "metric": "accuracy",
-      "problem": "bpds A imbalanced-fr",
-      "seed": 42,
-      "score": 0.45454545454545453
+      "problem": "bpsd A-fr",
+      "seed": 69,
+      "score": 0.6681818181818182
     },
     {
       "metric": "oosAccuracy",
-      "problem": "bpds A imbalanced-fr",
-      "seed": 42,
+      "problem": "bpsd A-fr",
+      "seed": 69,
+      "score": 0.75
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpsd A-fr",
+      "seed": 69,
+      "score": 0.7586206896551724
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpsd A-fr",
+      "seed": 69,
+      "score": 0.66
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpsd A-fr",
+      "seed": 69,
+      "score": 0.7058823529411765
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpsd A-fr",
+      "seed": 666,
       "score": 0.6636363636363637
     },
     {
+      "metric": "oosAccuracy",
+      "problem": "bpsd A-fr",
+      "seed": 666,
+      "score": 0.759090909090909
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpsd A-fr",
+      "seed": 666,
+      "score": 0.7831325301204819
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpsd A-fr",
+      "seed": 666,
+      "score": 0.65
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpsd A-fr",
+      "seed": 666,
+      "score": 0.7103825136612022
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpds A imbalanced-fr",
+      "seed": 42,
+      "score": 0.45
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpds A imbalanced-fr",
+      "seed": 42,
+      "score": 0.6863636363636364
+    },
+    {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced-fr",
       "seed": 42,
-      "score": 0.6444444444444445
+      "score": 0.6962025316455697
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A imbalanced-fr",
       "seed": 42,
-      "score": 0.58
+      "score": 0.55
     },
     {
       "metric": "oosF1",
       "problem": "bpds A imbalanced-fr",
       "seed": 42,
-      "score": 0.6105263157894737
+      "score": 0.6145251396648046
     },
     {
       "metric": "accuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 69,
-      "score": 0.5545454545454546
+      "score": 0.5409090909090909
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 69,
-      "score": 0.6909090909090909
+      "score": 0.7045454545454546
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced-fr",
       "seed": 69,
-      "score": 0.6777777777777778
+      "score": 0.7397260273972602
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A imbalanced-fr",
       "seed": 69,
-      "score": 0.61
+      "score": 0.54
     },
     {
       "metric": "oosF1",
       "problem": "bpds A imbalanced-fr",
       "seed": 69,
-      "score": 0.6421052631578946
+      "score": 0.624277456647399
     },
     {
       "metric": "accuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 666,
-      "score": 0.5
+      "score": 0.5181818181818182
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 666,
-      "score": 0.6818181818181818
+      "score": 0.7272727272727273
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced-fr",
       "seed": 666,
-      "score": 0.7027027027027027
+      "score": 0.8225806451612904
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A imbalanced-fr",
       "seed": 666,
-      "score": 0.52
+      "score": 0.51
     },
     {
       "metric": "oosF1",
       "problem": "bpds A imbalanced-fr",
       "seed": 666,
-      "score": 0.5977011494252874
+      "score": 0.6296296296296298
     },
     {
       "metric": "accuracy",
@@ -551,43 +551,43 @@
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 42,
-      "score": 0.7136363636363636
+      "score": 0.7181818181818181
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot-fr",
       "seed": 42,
-      "score": 0.6608695652173913
+      "score": 0.6727272727272727
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A fewshot-fr",
       "seed": 42,
-      "score": 0.76
+      "score": 0.74
     },
     {
       "metric": "oosF1",
       "problem": "bpds A fewshot-fr",
       "seed": 42,
-      "score": 0.7069767441860464
+      "score": 0.7047619047619048
     },
     {
       "metric": "accuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.5318181818181819
+      "score": 0.5363636363636364
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.759090909090909
+      "score": 0.7818181818181819
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.7901234567901234
+      "score": 0.8421052631578947
     },
     {
       "metric": "oosRecall",
@@ -599,37 +599,37 @@
       "metric": "oosF1",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.7071823204419889
+      "score": 0.7272727272727272
     },
     {
       "metric": "accuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.45454545454545453
+      "score": 0.41818181818181815
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.7045454545454546
+      "score": 0.7136363636363636
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.7397260273972602
+      "score": 0.9111111111111111
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.54
+      "score": 0.41
     },
     {
       "metric": "oosF1",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.624277456647399
+      "score": 0.5655172413793103
     }
   ]
 }

--- a/build/nlu-regression/current_scores/bpds-intent.json
+++ b/build/nlu-regression/current_scores/bpds-intent.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-13T22:05:41.971Z",
+  "generatedOn": "2021-01-15T14:43:33.734Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-intent.json
+++ b/build/nlu-regression/current_scores/bpds-intent.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-15T15:09:06.379Z",
+  "generatedOn": "2021-01-15T16:58:22.593Z",
   "scores": [
     {
       "metric": "accuracy",
@@ -431,13 +431,13 @@
       "metric": "oosAccuracy",
       "problem": "bpsd A-fr",
       "seed": 666,
-      "score": 0.7363636363636363
+      "score": 0.740909090909091
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A-fr",
       "seed": 666,
-      "score": 0.723404255319149
+      "score": 0.7311827956989247
     },
     {
       "metric": "oosRecall",
@@ -449,7 +449,7 @@
       "metric": "oosF1",
       "problem": "bpsd A-fr",
       "seed": 666,
-      "score": 0.7010309278350516
+      "score": 0.7046632124352332
     },
     {
       "metric": "accuracy",
@@ -545,31 +545,31 @@
       "metric": "accuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 42,
-      "score": 0.5772727272727273
+      "score": 0.5727272727272728
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 42,
-      "score": 0.7136363636363636
+      "score": 0.7090909090909091
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot-fr",
       "seed": 42,
-      "score": 0.6608695652173913
+      "score": 0.6578947368421053
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A fewshot-fr",
       "seed": 42,
-      "score": 0.76
+      "score": 0.75
     },
     {
       "metric": "oosF1",
       "problem": "bpds A fewshot-fr",
       "seed": 42,
-      "score": 0.7069767441860464
+      "score": 0.7009345794392524
     },
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-intent.json
+++ b/build/nlu-regression/current_scores/bpds-intent.json
@@ -1,23 +1,23 @@
 {
-  "generatedOn": "2021-01-15T14:43:33.734Z",
+  "generatedOn": "2021-01-15T15:09:06.379Z",
   "scores": [
     {
       "metric": "accuracy",
       "problem": "bpsd A-en",
       "seed": 42,
-      "score": 0.7045454545454546
+      "score": 0.6863636363636364
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpsd A-en",
       "seed": 42,
-      "score": 0.8045454545454546
+      "score": 0.7818181818181819
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A-en",
       "seed": 42,
-      "score": 0.8352941176470589
+      "score": 0.7888888888888889
     },
     {
       "metric": "oosRecall",
@@ -29,25 +29,25 @@
       "metric": "oosF1",
       "problem": "bpsd A-en",
       "seed": 42,
-      "score": 0.7675675675675675
+      "score": 0.7473684210526317
     },
     {
       "metric": "accuracy",
       "problem": "bpsd A-en",
       "seed": 69,
-      "score": 0.7045454545454546
+      "score": 0.6909090909090909
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpsd A-en",
       "seed": 69,
-      "score": 0.8090909090909091
+      "score": 0.7954545454545454
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A-en",
       "seed": 69,
-      "score": 0.8625
+      "score": 0.8313253012048193
     },
     {
       "metric": "oosRecall",
@@ -59,25 +59,25 @@
       "metric": "oosF1",
       "problem": "bpsd A-en",
       "seed": 69,
-      "score": 0.7666666666666667
+      "score": 0.7540983606557377
     },
     {
       "metric": "accuracy",
       "problem": "bpsd A-en",
       "seed": 666,
-      "score": 0.7136363636363636
+      "score": 0.6954545454545454
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpsd A-en",
       "seed": 666,
-      "score": 0.8045454545454546
+      "score": 0.7863636363636364
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A-en",
       "seed": 666,
-      "score": 0.8275862068965517
+      "score": 0.7912087912087912
     },
     {
       "metric": "oosRecall",
@@ -89,457 +89,457 @@
       "metric": "oosF1",
       "problem": "bpsd A-en",
       "seed": 666,
-      "score": 0.7700534759358287
+      "score": 0.7539267015706805
     },
     {
       "metric": "accuracy",
       "problem": "bpds A imbalanced-en",
       "seed": 42,
-      "score": 0.5
+      "score": 0.4772727272727273
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A imbalanced-en",
       "seed": 42,
-      "score": 0.6636363636363637
+      "score": 0.6363636363636364
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced-en",
       "seed": 42,
-      "score": 0.6444444444444445
+      "score": 0.5961538461538461
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A imbalanced-en",
       "seed": 42,
-      "score": 0.58
+      "score": 0.62
     },
     {
       "metric": "oosF1",
       "problem": "bpds A imbalanced-en",
       "seed": 42,
-      "score": 0.6105263157894737
+      "score": 0.607843137254902
     },
     {
       "metric": "accuracy",
       "problem": "bpds A imbalanced-en",
       "seed": 69,
+      "score": 0.5909090909090909
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpds A imbalanced-en",
+      "seed": 69,
+      "score": 0.7
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds A imbalanced-en",
+      "seed": 69,
+      "score": 0.7428571428571429
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpds A imbalanced-en",
+      "seed": 69,
+      "score": 0.52
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds A imbalanced-en",
+      "seed": 69,
+      "score": 0.6117647058823529
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpds A imbalanced-en",
+      "seed": 666,
+      "score": 0.5636363636363636
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpds A imbalanced-en",
+      "seed": 666,
+      "score": 0.6909090909090909
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds A imbalanced-en",
+      "seed": 666,
+      "score": 0.75
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpds A imbalanced-en",
+      "seed": 666,
+      "score": 0.48
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds A imbalanced-en",
+      "seed": 666,
+      "score": 0.5853658536585366
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpds A fewshot-en",
+      "seed": 42,
       "score": 0.6
     },
     {
       "metric": "oosAccuracy",
-      "problem": "bpds A imbalanced-en",
-      "seed": 69,
-      "score": 0.7136363636363636
+      "problem": "bpds A fewshot-en",
+      "seed": 42,
+      "score": 0.6909090909090909
     },
     {
       "metric": "oosPrecision",
-      "problem": "bpds A imbalanced-en",
-      "seed": 69,
-      "score": 0.7936507936507936
+      "problem": "bpds A fewshot-en",
+      "seed": 42,
+      "score": 0.6509433962264151
     },
     {
       "metric": "oosRecall",
-      "problem": "bpds A imbalanced-en",
-      "seed": 69,
-      "score": 0.5
+      "problem": "bpds A fewshot-en",
+      "seed": 42,
+      "score": 0.69
     },
     {
       "metric": "oosF1",
-      "problem": "bpds A imbalanced-en",
-      "seed": 69,
-      "score": 0.6134969325153374
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpds A imbalanced-en",
-      "seed": 666,
-      "score": 0.5772727272727273
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds A imbalanced-en",
-      "seed": 666,
-      "score": 0.7090909090909091
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds A imbalanced-en",
-      "seed": 666,
-      "score": 0.8214285714285714
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds A imbalanced-en",
-      "seed": 666,
-      "score": 0.46
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds A imbalanced-en",
-      "seed": 666,
-      "score": 0.5897435897435898
+      "problem": "bpds A fewshot-en",
+      "seed": 42,
+      "score": 0.6699029126213591
     },
     {
       "metric": "accuracy",
       "problem": "bpds A fewshot-en",
-      "seed": 42,
-      "score": 0.6318181818181818
+      "seed": 69,
+      "score": 0.5227272727272727
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot-en",
-      "seed": 42,
-      "score": 0.7272727272727273
+      "seed": 69,
+      "score": 0.6454545454545455
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot-en",
-      "seed": 42,
-      "score": 0.7127659574468085
+      "seed": 69,
+      "score": 0.6666666666666666
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A fewshot-en",
+      "seed": 69,
+      "score": 0.44
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds A fewshot-en",
+      "seed": 69,
+      "score": 0.5301204819277109
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpds A fewshot-en",
+      "seed": 666,
+      "score": 0.6
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpds A fewshot-en",
+      "seed": 666,
+      "score": 0.7
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds A fewshot-en",
+      "seed": 666,
+      "score": 0.6808510638297872
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpds A fewshot-en",
+      "seed": 666,
+      "score": 0.64
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds A fewshot-en",
+      "seed": 666,
+      "score": 0.6597938144329897
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpds B",
+      "seed": 42,
+      "score": 0.7
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpds B",
+      "seed": 42,
+      "score": 0.8136363636363636
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds B",
+      "seed": 42,
+      "score": 0.8933333333333333
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpds B",
       "seed": 42,
       "score": 0.67
     },
     {
       "metric": "oosF1",
-      "problem": "bpds A fewshot-en",
-      "seed": 42,
-      "score": 0.6907216494845361
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpds A fewshot-en",
-      "seed": 69,
-      "score": 0.5454545454545454
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds A fewshot-en",
-      "seed": 69,
-      "score": 0.6954545454545454
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds A fewshot-en",
-      "seed": 69,
-      "score": 0.8367346938775511
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds A fewshot-en",
-      "seed": 69,
-      "score": 0.41
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds A fewshot-en",
-      "seed": 69,
-      "score": 0.5503355704697986
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpds A fewshot-en",
-      "seed": 666,
-      "score": 0.6227272727272727
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds A fewshot-en",
-      "seed": 666,
-      "score": 0.7363636363636363
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds A fewshot-en",
-      "seed": 666,
-      "score": 0.75
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds A fewshot-en",
-      "seed": 666,
-      "score": 0.63
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds A fewshot-en",
-      "seed": 666,
-      "score": 0.6847826086956522
-    },
-    {
-      "metric": "accuracy",
       "problem": "bpds B",
       "seed": 42,
-      "score": 0.6954545454545454
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds B",
-      "seed": 42,
-      "score": 0.8090909090909091
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds B",
-      "seed": 42,
-      "score": 0.9027777777777778
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds B",
-      "seed": 42,
-      "score": 0.65
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds B",
-      "seed": 42,
-      "score": 0.7558139534883721
+      "score": 0.7657142857142857
     },
     {
       "metric": "accuracy",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.6409090909090909
+      "score": 0.6545454545454545
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds B",
       "seed": 69,
-      "score": 0.7863636363636364
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds B",
-      "seed": 69,
-      "score": 0.9491525423728814
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds B",
-      "seed": 69,
-      "score": 0.56
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds B",
-      "seed": 69,
-      "score": 0.7044025157232704
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpds B",
-      "seed": 666,
-      "score": 0.6727272727272727
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds B",
-      "seed": 666,
       "score": 0.7954545454545454
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds B",
-      "seed": 666,
-      "score": 0.9230769230769231
+      "seed": 69,
+      "score": 0.9365079365079365
     },
     {
       "metric": "oosRecall",
       "problem": "bpds B",
-      "seed": 666,
-      "score": 0.6
+      "seed": 69,
+      "score": 0.59
     },
     {
       "metric": "oosF1",
       "problem": "bpds B",
-      "seed": 666,
-      "score": 0.7272727272727274
+      "seed": 69,
+      "score": 0.7239263803680981
     },
     {
       "metric": "accuracy",
-      "problem": "bpsd A-fr",
-      "seed": 42,
+      "problem": "bpds B",
+      "seed": 666,
       "score": 0.6727272727272727
     },
     {
       "metric": "oosAccuracy",
-      "problem": "bpsd A-fr",
-      "seed": 42,
-      "score": 0.7363636363636363
+      "problem": "bpds B",
+      "seed": 666,
+      "score": 0.7909090909090909
     },
     {
       "metric": "oosPrecision",
-      "problem": "bpsd A-fr",
-      "seed": 42,
-      "score": 0.7386363636363636
+      "problem": "bpds B",
+      "seed": 666,
+      "score": 0.8970588235294118
     },
     {
       "metric": "oosRecall",
-      "problem": "bpsd A-fr",
-      "seed": 42,
-      "score": 0.65
+      "problem": "bpds B",
+      "seed": 666,
+      "score": 0.61
     },
     {
       "metric": "oosF1",
-      "problem": "bpsd A-fr",
-      "seed": 42,
-      "score": 0.6914893617021277
+      "problem": "bpds B",
+      "seed": 666,
+      "score": 0.7261904761904763
     },
     {
       "metric": "accuracy",
       "problem": "bpsd A-fr",
-      "seed": 69,
-      "score": 0.6681818181818182
+      "seed": 42,
+      "score": 0.6545454545454545
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpsd A-fr",
-      "seed": 69,
-      "score": 0.75
+      "seed": 42,
+      "score": 0.7136363636363636
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A-fr",
-      "seed": 69,
-      "score": 0.7586206896551724
+      "seed": 42,
+      "score": 0.6831683168316832
     },
     {
       "metric": "oosRecall",
       "problem": "bpsd A-fr",
-      "seed": 69,
-      "score": 0.66
+      "seed": 42,
+      "score": 0.69
     },
     {
       "metric": "oosF1",
       "problem": "bpsd A-fr",
-      "seed": 69,
-      "score": 0.7058823529411765
+      "seed": 42,
+      "score": 0.6865671641791044
     },
     {
       "metric": "accuracy",
       "problem": "bpsd A-fr",
-      "seed": 666,
+      "seed": 69,
       "score": 0.6636363636363637
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpsd A-fr",
+      "seed": 69,
+      "score": 0.7318181818181818
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpsd A-fr",
+      "seed": 69,
+      "score": 0.7029702970297029
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpsd A-fr",
+      "seed": 69,
+      "score": 0.71
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpsd A-fr",
+      "seed": 69,
+      "score": 0.7064676616915423
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpsd A-fr",
       "seed": 666,
-      "score": 0.759090909090909
+      "score": 0.6590909090909091
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpsd A-fr",
+      "seed": 666,
+      "score": 0.7363636363636363
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A-fr",
       "seed": 666,
-      "score": 0.7831325301204819
+      "score": 0.723404255319149
     },
     {
       "metric": "oosRecall",
       "problem": "bpsd A-fr",
       "seed": 666,
-      "score": 0.65
+      "score": 0.68
     },
     {
       "metric": "oosF1",
       "problem": "bpsd A-fr",
       "seed": 666,
-      "score": 0.7103825136612022
+      "score": 0.7010309278350516
     },
     {
       "metric": "accuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 42,
-      "score": 0.45
+      "score": 0.45454545454545453
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 42,
-      "score": 0.6863636363636364
+      "score": 0.6636363636363637
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced-fr",
       "seed": 42,
-      "score": 0.6962025316455697
+      "score": 0.6444444444444445
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A imbalanced-fr",
       "seed": 42,
-      "score": 0.55
+      "score": 0.58
     },
     {
       "metric": "oosF1",
       "problem": "bpds A imbalanced-fr",
       "seed": 42,
-      "score": 0.6145251396648046
+      "score": 0.6105263157894737
     },
     {
       "metric": "accuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 69,
-      "score": 0.5409090909090909
+      "score": 0.5545454545454546
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 69,
-      "score": 0.7045454545454546
+      "score": 0.6909090909090909
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced-fr",
       "seed": 69,
-      "score": 0.7397260273972602
+      "score": 0.6777777777777778
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A imbalanced-fr",
       "seed": 69,
-      "score": 0.54
+      "score": 0.61
     },
     {
       "metric": "oosF1",
       "problem": "bpds A imbalanced-fr",
       "seed": 69,
-      "score": 0.624277456647399
+      "score": 0.6421052631578946
     },
     {
       "metric": "accuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 666,
-      "score": 0.5181818181818182
+      "score": 0.5
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 666,
-      "score": 0.7272727272727273
+      "score": 0.6818181818181818
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced-fr",
       "seed": 666,
-      "score": 0.8225806451612904
+      "score": 0.7027027027027027
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A imbalanced-fr",
       "seed": 666,
-      "score": 0.51
+      "score": 0.52
     },
     {
       "metric": "oosF1",
       "problem": "bpds A imbalanced-fr",
       "seed": 666,
-      "score": 0.6296296296296298
+      "score": 0.5977011494252874
     },
     {
       "metric": "accuracy",
@@ -551,43 +551,43 @@
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 42,
-      "score": 0.7181818181818181
+      "score": 0.7136363636363636
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot-fr",
       "seed": 42,
-      "score": 0.6727272727272727
+      "score": 0.6608695652173913
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A fewshot-fr",
       "seed": 42,
-      "score": 0.74
+      "score": 0.76
     },
     {
       "metric": "oosF1",
       "problem": "bpds A fewshot-fr",
       "seed": 42,
-      "score": 0.7047619047619048
+      "score": 0.7069767441860464
     },
     {
       "metric": "accuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.5363636363636364
+      "score": 0.5318181818181819
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.7818181818181819
+      "score": 0.759090909090909
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.8421052631578947
+      "score": 0.7901234567901234
     },
     {
       "metric": "oosRecall",
@@ -599,37 +599,37 @@
       "metric": "oosF1",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.7272727272727272
+      "score": 0.7071823204419889
     },
     {
       "metric": "accuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.41818181818181815
+      "score": 0.45454545454545453
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.7136363636363636
+      "score": 0.7045454545454546
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.9111111111111111
+      "score": 0.7397260273972602
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.41
+      "score": 0.54
     },
     {
       "metric": "oosF1",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.5655172413793103
+      "score": 0.624277456647399
     }
   ]
 }

--- a/build/nlu-regression/current_scores/bpds-slots.json
+++ b/build/nlu-regression/current_scores/bpds-slots.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-13T22:05:53.875Z",
+  "generatedOn": "2021-01-15T14:43:47.079Z",
   "scores": [
     {
       "metric": "avgScore:slotsAre",

--- a/build/nlu-regression/current_scores/bpds-slots.json
+++ b/build/nlu-regression/current_scores/bpds-slots.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-15T15:09:19.839Z",
+  "generatedOn": "2021-01-15T16:58:34.923Z",
   "scores": [
     {
       "metric": "avgScore:slotsAre",

--- a/build/nlu-regression/current_scores/bpds-slots.json
+++ b/build/nlu-regression/current_scores/bpds-slots.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-15T14:43:47.079Z",
+  "generatedOn": "2021-01-15T15:09:19.839Z",
   "scores": [
     {
       "metric": "avgScore:slotsAre",

--- a/build/nlu-regression/current_scores/bpds-slots.json
+++ b/build/nlu-regression/current_scores/bpds-slots.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-04T21:28:31.874Z",
+  "generatedOn": "2021-01-13T22:05:53.875Z",
   "scores": [
     {
       "metric": "avgScore:slotsAre",

--- a/build/nlu-regression/current_scores/bpds-spell.json
+++ b/build/nlu-regression/current_scores/bpds-spell.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-15T14:43:51.529Z",
+  "generatedOn": "2021-01-15T15:09:23.132Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-spell.json
+++ b/build/nlu-regression/current_scores/bpds-spell.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-04T21:28:34.797Z",
+  "generatedOn": "2021-01-13T22:05:58.170Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-spell.json
+++ b/build/nlu-regression/current_scores/bpds-spell.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-15T15:09:23.132Z",
+  "generatedOn": "2021-01-15T16:58:38.162Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-spell.json
+++ b/build/nlu-regression/current_scores/bpds-spell.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-13T22:05:58.170Z",
+  "generatedOn": "2021-01-15T14:43:51.529Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/clinc150.json
+++ b/build/nlu-regression/current_scores/clinc150.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-13T22:13:02.778Z",
+  "generatedOn": "2021-01-15T14:50:29.121Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/clinc150.json
+++ b/build/nlu-regression/current_scores/clinc150.json
@@ -1,11 +1,11 @@
 {
-  "generatedOn": "2021-01-15T15:15:29.366Z",
+  "generatedOn": "2021-01-15T17:04:26.067Z",
   "scores": [
     {
       "metric": "accuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.7253488372093023
+      "score": 0.7252325581395349
     },
     {
       "metric": "oosAccuracy",
@@ -17,19 +17,19 @@
       "metric": "oosPrecision",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.294478527607362
+      "score": 0.290625
     },
     {
       "metric": "oosRecall",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.08727272727272728
+      "score": 0.08454545454545455
     },
     {
       "metric": "oosF1",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.13464235624123425
+      "score": 0.13098591549295777
     }
   ]
 }

--- a/build/nlu-regression/current_scores/clinc150.json
+++ b/build/nlu-regression/current_scores/clinc150.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-04T21:32:08.422Z",
+  "generatedOn": "2021-01-13T22:13:02.778Z",
   "scores": [
     {
       "metric": "accuracy",
@@ -11,25 +11,25 @@
       "metric": "oosAccuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.8565116279069768
+      "score": 0.8575581395348837
     },
     {
       "metric": "oosPrecision",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.294478527607362
+      "score": 0.2977346278317152
     },
     {
       "metric": "oosRecall",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.08727272727272728
+      "score": 0.08363636363636363
     },
     {
       "metric": "oosF1",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.13464235624123425
+      "score": 0.13058907026259758
     }
   ]
 }

--- a/build/nlu-regression/current_scores/clinc150.json
+++ b/build/nlu-regression/current_scores/clinc150.json
@@ -1,35 +1,35 @@
 {
-  "generatedOn": "2021-01-15T14:50:29.121Z",
+  "generatedOn": "2021-01-15T15:15:29.366Z",
   "scores": [
     {
       "metric": "accuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.7255813953488373
+      "score": 0.7253488372093023
     },
     {
       "metric": "oosAccuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.8575581395348837
+      "score": 0.8565116279069768
     },
     {
       "metric": "oosPrecision",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.2977346278317152
+      "score": 0.294478527607362
     },
     {
       "metric": "oosRecall",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.08363636363636363
+      "score": 0.08727272727272728
     },
     {
       "metric": "oosF1",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.13058907026259758
+      "score": 0.13464235624123425
     }
   ]
 }

--- a/src/bp/nlu-server/api-mapper.ts
+++ b/src/bp/nlu-server/api-mapper.ts
@@ -169,14 +169,30 @@ function mapContext(context: NLU.ContextPrediction, name: string): ContextPredic
   }
 }
 
+const N_DIGITS = 3
+
+const _roundConfidencesTo3Digits = (output: PredictOutput): PredictOutput => {
+  const contexts = output.contexts.map(context => {
+    context.confidence = _.round(context.confidence, N_DIGITS)
+    context.oos = _.round(context.oos, N_DIGITS)
+    context.intents = context.intents.map(i => {
+      const slots = i.slots.map(s => ({ ...s, confidence: _.round(s.confidence, N_DIGITS) }))
+      return { ...i, confidence: _.round(i.confidence, N_DIGITS), slots }
+    })
+    return context
+  })
+  return { ...output, contexts }
+}
+
 export function mapPredictOutput(output: BpPredictOutput): PredictOutput {
   const { entities, contexts, utterance, detectedLanguage, spellChecked } = output
 
-  return {
+  const ret = {
     entities: entities.map(mapEntity),
     contexts: Object.entries(contexts).map(([name, ctx]) => mapContext(ctx, name)),
     detectedLanguage,
     spellChecked,
     utterance
   }
+  return _roundConfidencesTo3Digits(ret)
 }

--- a/src/bp/nlu-server/index.ts
+++ b/src/bp/nlu-server/index.ts
@@ -124,6 +124,7 @@ ${_.repeat(' ', 9)}========================================`)
   logger.info(`lang server: url=${options.languageURL}`)
 
   logger.info(`body size: allowing HTTP resquests body of size ${options.bodySize}`)
+  logger.info(`models stored at "${options.modelDir}"`)
 
   if (options.batchSize > 0) {
     logger.info(`batch size: allowing up to ${options.batchSize} predictions in one call to POST /predict`)

--- a/src/bp/nlu-server/remove-none.test.ts
+++ b/src/bp/nlu-server/remove-none.test.ts
@@ -72,7 +72,7 @@ test('ajdust to 100', () => {
   const withoutNone = removeNoneIntent(nlu)
 
   // assert
-  const expectedOOS = 0.99 / (0.99 + 0.98) // 0.502
+  const expectedOOS = 0.99 / (0.99 + 0.98) // 0.503
   expect(withoutNone.contexts.global.oos).toBe(expectedOOS)
   expect(withoutNone.contexts.global.intents.some(i => i.label === 'none')).toBe(false)
 })

--- a/src/bp/nlu-server/remove-none.test.ts
+++ b/src/bp/nlu-server/remove-none.test.ts
@@ -1,5 +1,3 @@
-import { NLU } from 'botpress/sdk'
-
 import { BpPredictOutput } from './api-mapper'
 import removeNoneIntent from './remove-none'
 
@@ -12,7 +10,7 @@ test('remove none intent', () => {
         confidence: 0.5,
         oos: 0.666,
         intents: [
-          { label: 'A', confidence: 0.5, extractor: 'classifier', slots: {} },
+          { label: 'A', confidence: 0.58, extractor: 'classifier', slots: {} },
           { label: 'none', confidence: 0.42, extractor: 'classifier', slots: {} }
         ]
       },
@@ -20,7 +18,7 @@ test('remove none intent', () => {
         confidence: 0.5,
         oos: 0.123,
         intents: [
-          { label: 'B', confidence: 0.5, extractor: 'classifier', slots: {} },
+          { label: 'B', confidence: 0.01, extractor: 'classifier', slots: {} },
           { label: 'none', confidence: 0.99, extractor: 'classifier', slots: {} }
         ]
       }
@@ -34,7 +32,8 @@ test('remove none intent', () => {
   const withoutNone = removeNoneIntent(nlu)
 
   // assert
-  expect(withoutNone.contexts.global.oos).toBe(0.666)
+  const expectedGlobalOOS = 0.666 / (0.666 + 0.58) // 0.53
+  expect(withoutNone.contexts.global.oos).toBe(expectedGlobalOOS)
   expect(withoutNone.contexts.someTopic.oos).toBe(0.99)
   expect(withoutNone.contexts.global.intents.some(i => i.label === 'none')).toBe(false)
   expect(withoutNone.contexts.someTopic.intents.some(i => i.label === 'none')).toBe(false)

--- a/src/bp/nlu-server/remove-none.test.ts
+++ b/src/bp/nlu-server/remove-none.test.ts
@@ -1,3 +1,5 @@
+import _ from 'lodash'
+
 import { BpPredictOutput } from './api-mapper'
 import removeNoneIntent from './remove-none'
 
@@ -34,7 +36,43 @@ test('remove none intent', () => {
   // assert
   const expectedGlobalOOS = 0.666 / (0.666 + 0.58) // 0.53
   expect(withoutNone.contexts.global.oos).toBe(expectedGlobalOOS)
-  expect(withoutNone.contexts.someTopic.oos).toBe(0.99)
+
+  const totalGlobalConf =
+    withoutNone.contexts.global.oos + _.sum(withoutNone.contexts.global.intents.map(i => i.confidence))
+  expect(totalGlobalConf).toBe(1)
   expect(withoutNone.contexts.global.intents.some(i => i.label === 'none')).toBe(false)
+
+  expect(withoutNone.contexts.someTopic.oos).toBe(0.99)
+  const totalSomeTopicConf =
+    withoutNone.contexts.someTopic.oos + _.sum(withoutNone.contexts.someTopic.intents.map(i => i.confidence))
+  expect(totalSomeTopicConf).toBe(1)
   expect(withoutNone.contexts.someTopic.intents.some(i => i.label === 'none')).toBe(false)
+})
+
+test('ajdust to 100', () => {
+  // arrange
+  const nlu: BpPredictOutput = {
+    entities: [],
+    contexts: {
+      global: {
+        confidence: 1.0,
+        oos: 0.99,
+        intents: [
+          { label: 'A', confidence: 0.98, extractor: 'classifier', slots: {} },
+          { label: 'none', confidence: 0.02, extractor: 'classifier', slots: {} }
+        ]
+      }
+    },
+    detectedLanguage: 'en',
+    spellChecked: 'heyheyheyhey',
+    utterance: 'heyheyheyhey'
+  }
+
+  // act
+  const withoutNone = removeNoneIntent(nlu)
+
+  // assert
+  const expectedOOS = 0.99 / (0.99 + 0.98) // 0.502
+  expect(withoutNone.contexts.global.oos).toBe(expectedOOS)
+  expect(withoutNone.contexts.global.intents.some(i => i.label === 'none')).toBe(false)
 })

--- a/src/bp/nlu-server/remove-none.ts
+++ b/src/bp/nlu-server/remove-none.ts
@@ -1,22 +1,31 @@
+import { NLU } from 'botpress/sdk'
 import _ from 'lodash'
 
 import { BpPredictOutput } from './api-mapper'
+
+export const adjustTotalConfidenceTo100 = (context: NLU.ContextPrediction): NLU.ContextPrediction => {
+  const totalConfidence = context.oos + _.sum(context.intents.map(i => i.confidence))
+  context.oos = context.oos / totalConfidence
+  context.intents.map(i => ({ ...i, confidence: i.confidence / totalConfidence }))
+  return context
+}
 
 /**
  * TODO: move this inside the actual NLU code
  * and find the best possible decision function to merge both none intent and oos.
  */
 export default function removeNoneIntent(nlu: BpPredictOutput): BpPredictOutput {
-  const contexts = _.mapValues(nlu.contexts, t => {
-    const topic = { ...t }
-    const noneIdx = topic.intents.findIndex(i => i.label === 'none')
+  const contexts = _.mapValues(nlu.contexts, ctx => {
+    const context = { ...ctx }
+    const noneIdx = context.intents.findIndex(i => i.label === 'none')
     if (noneIdx < 0) {
-      return topic
+      return context
     }
-    const none = topic.intents[noneIdx]
-    topic.intents.splice(noneIdx, 1)
-    topic.oos = Math.max(none.confidence, topic.oos)
-    return topic
+    const none = context.intents[noneIdx]
+    context.intents.splice(noneIdx, 1)
+    context.oos = Math.max(none.confidence, context.oos)
+
+    return adjustTotalConfidenceTo100(context)
   })
 
   return { ...nlu, contexts }

--- a/src/bp/nlu-server/remove-none.ts
+++ b/src/bp/nlu-server/remove-none.ts
@@ -3,10 +3,10 @@ import _ from 'lodash'
 
 import { BpPredictOutput } from './api-mapper'
 
-export const adjustTotalConfidenceTo100 = (context: NLU.ContextPrediction): NLU.ContextPrediction => {
+const _adjustTotalConfidenceTo100 = (context: NLU.ContextPrediction): NLU.ContextPrediction => {
   const totalConfidence = context.oos + _.sum(context.intents.map(i => i.confidence))
   context.oos = context.oos / totalConfidence
-  context.intents.map(i => ({ ...i, confidence: i.confidence / totalConfidence }))
+  context.intents = context.intents.map(i => ({ ...i, confidence: i.confidence / totalConfidence }))
   return context
 }
 
@@ -25,7 +25,7 @@ export default function removeNoneIntent(nlu: BpPredictOutput): BpPredictOutput 
     context.intents.splice(noneIdx, 1)
     context.oos = Math.max(none.confidence, context.oos)
 
-    return adjustTotalConfidenceTo100(context)
+    return _adjustTotalConfidenceTo100(context)
   })
 
   return { ...nlu, contexts }


### PR DESCRIPTION
In Stan, the confidence of OOS for a given context is `Math.max(none, oos)`. This is problematic because OOS confidence is not result of the same classifier as intents. This means that confidence might not sum up to 1.

This PR contains:
1. Scale intent confidences so their sum is 1
2. Log the location of model directory
3. Round up every confidence to 3 digits for output

The scalling confidence to a sum of 1 part has not changed results, but the rounding up does a little. Still, results are pretty much the same.