### PR TITLE
fix(core): use gzip compression for responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "cerialize": "^0.1.18",
     "chalk": "^2.4.2",
     "chokidar": "^2.1.5",
+    "compression": "^1.7.4",
     "cookie-session": "^1.3.3",
     "cors": "^2.8.5",
     "debug": "^4.1.1",

--- a/src/bp/core/server.ts
+++ b/src/bp/core/server.ts
@@ -2,6 +2,7 @@ import bodyParser from 'body-parser'
 import { AxiosBotConfig, AxiosOptions, http, Logger, RouterOptions } from 'botpress/sdk'
 import LicensingService from 'common/licensing-service'
 import { RequestWithUser } from 'common/typings'
+import compression from 'compression'
 import session from 'cookie-session'
 import cors from 'cors'
 import errorHandler from 'errorhandler'
@@ -150,6 +151,10 @@ export default class HTTPServer {
     }
 
     this.app.use(debugRequestMw)
+
+    if (!yn(process.core_env.BP_HTTP_DISABLE_GZIP)) {
+      this.app.use(compression())
+    }
 
     this.modulesRouter = new ModulesRouter(
       this.logger,

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -129,6 +129,11 @@ declare interface BotpressEnvironmentVariables {
   readonly BP_PROXY?: string
 
   /**
+   * Disable the use of GZIP compression while serving assets to the end users
+   */
+  readonly BP_HTTP_DISABLE_GZIP?: boolean
+
+  /**
    * Use to set default debug namespaces
    * @example bp:dialog:*,bp:nlu:intents:*
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2320,6 +2320,26 @@ component-inherit@0.0.3:
   resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
   integrity sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=
 
+compressible@~2.0.16:
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"
+  integrity sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==
+  dependencies:
+    mime-db ">= 1.43.0 < 2"
+
+compression@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.4.tgz#95523eff170ca57c29a0ca41e6fe131f41e5bb8f"
+  integrity sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==
+  dependencies:
+    accepts "~1.3.5"
+    bytes "3.0.0"
+    compressible "~2.0.16"
+    debug "2.6.9"
+    on-headers "~1.0.2"
+    safe-buffer "5.1.2"
+    vary "~1.1.2"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -6583,6 +6603,11 @@ mime-db@1.44.0:
   version "1.44.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
+
+"mime-db@>= 1.43.0 < 2":
+  version "1.45.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.45.0.tgz#cceeda21ccd7c3a745eba2decd55d4b73e7879ea"
+  integrity sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==
 
 mime-db@~1.38.0:
   version "1.38.0"


### PR DESCRIPTION
I have no idea why we didn't enable this earlier... But by enabling gzip compression (which is supported by all modern browsers), we reduce the amount of bandwidth by 80%. There's no visible gain on a quick internet access (because of the unzipping), but it should give a major improvement on slow connections.

I've added an environment variable to disable it just in case there is some issue with that, if we see that it causes no issues at all, we may remove it in a future release.

Before
![image](https://user-images.githubusercontent.com/42552874/104927812-e00b2200-596f-11eb-9e1c-5b4c2f847449.png)

After
![image](https://user-images.githubusercontent.com/42552874/104927737-c964cb00-596f-11eb-8917-0299cebf1653.png)
