### PR TITLE
feat(studio): enable multi-point connectors

### DIFF
--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
@@ -82,6 +82,7 @@ type ExtendedDiagramEngine = {
 } & DiagramEngine
 
 const EXPANDED_NODES_KEY = `bp::${window.BOT_ID}::expandedNodes`
+export const MAX_NUMBER_OF_POINTS_PER_LINK = 3
 
 const getExpandedNodes = () => {
   try {
@@ -709,7 +710,7 @@ class Diagram extends Component<Props> {
             ref={w => (this.diagramWidget = w)}
             deleteKeys={[]}
             diagramEngine={this.diagramEngine}
-            maxNumberPointsPerLink={3}
+            maxNumberPointsPerLink={MAX_NUMBER_OF_POINTS_PER_LINK}
             inverseZoom
           />
           <ZoomToolbar />

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
@@ -507,18 +507,18 @@ class Diagram extends Component<Props> {
 
   onDiagramClick = (event: MouseEvent) => {
     const selectedNode = this.manager.getSelectedNode() as BlockModel
-
     const currentNode = this.props.currentFlowNode
     const target = this.diagramWidget.getMouseElement(event)
 
     this.manager.sanitizeLinks()
     this.manager.cleanPortLinks()
 
+    // skip when a link is selected
     if (selectedNode && selectedNode instanceof DefaultLinkModel) {
       return
     }
 
-    // Only when creating a link
+    // only when creating a link
     if (selectedNode && selectedNode instanceof PointModel && selectedNode.parent.points.length <= 2) {
       this.dragPortSource = selectedNode
       this.handleContextMenu(event as any)

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
@@ -18,7 +18,7 @@ import _ from 'lodash'
 import React, { Component, Fragment } from 'react'
 import ReactDOM from 'react-dom'
 import { connect } from 'react-redux'
-import { DefaultPortModel, DiagramEngine, DiagramWidget, NodeModel, PointModel } from 'storm-react-diagrams'
+import { DefaultLinkModel, DefaultPortModel, DiagramEngine, DiagramWidget, NodeModel, PointModel } from 'storm-react-diagrams'
 import {
   buildNewSkill,
   closeFlowNodeProps,
@@ -507,13 +507,19 @@ class Diagram extends Component<Props> {
 
   onDiagramClick = (event: MouseEvent) => {
     const selectedNode = this.manager.getSelectedNode() as BlockModel
+
     const currentNode = this.props.currentFlowNode
     const target = this.diagramWidget.getMouseElement(event)
 
     this.manager.sanitizeLinks()
     this.manager.cleanPortLinks()
 
-    if (selectedNode && selectedNode instanceof PointModel) {
+    if (selectedNode && selectedNode instanceof DefaultLinkModel) {
+      return
+    }
+
+    // Only when creating a link
+    if (selectedNode && selectedNode instanceof PointModel && selectedNode.parent.points.length <= 2) {
       this.dragPortSource = selectedNode
       this.handleContextMenu(event as any)
     }
@@ -703,7 +709,7 @@ class Diagram extends Component<Props> {
             ref={w => (this.diagramWidget = w)}
             deleteKeys={[]}
             diagramEngine={this.diagramEngine}
-            maxNumberPointsPerLink={0}
+            maxNumberPointsPerLink={3}
             inverseZoom
           />
           <ZoomToolbar />

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/LinkWidget.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/LinkWidget.tsx
@@ -209,11 +209,7 @@ class DeletableLinkWidget extends DefaultLinkWidget {
           this.generateLink(
             Toolkit.generateCurvePath(pointLeft, pointRight, this.props.link.curvyness),
             {
-              onMouseDown: (event: MouseEvent) => {
-                console.log('onMouseDown called')
-                this.addPointToLink(event, 1)
-              }
-            },
+              onMouseDown: (event: MouseEvent) => this.addPointToLink(event, 1)},
             '0'
           )
         )
@@ -231,11 +227,7 @@ class DeletableLinkWidget extends DefaultLinkWidget {
               {
                 'data-linkid': this.props.link.id,
                 'data-point': j,
-                onMouseDown: (event: MouseEvent) => {
-                  console.log('onMouseDown called')
-                  this.addPointToLink(event, j + 1)
-                }
-              },
+                onMouseDown: (event: MouseEvent) => this.addPointToLink(event, j + 1)},
               j
             )
           )

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/LinkWidget.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/LinkWidget.tsx
@@ -4,18 +4,19 @@ import { AbstractLinkFactory, DefaultLinkModel, DefaultLinkWidget, DiagramEngine
 
 import style from './style.scss'
 
+// the end and beginning of a link counts as two points
+export const LINK_DEFAULT_NUMBER_OF_POINTS = 2
+
 class DeletableLinkWidget extends DefaultLinkWidget {
   private currentLink: string
 
   generatePoint(pointIndex: number): JSX.Element {
     const { link } = this.props
     const point = link.points[pointIndex]
-    const x = point.x
-    const y = point.y
-    const id = point.id
+    const { x, y, id } = link.points[pointIndex]
 
     // When adding a new link
-    if (link.points.length <= 2) {
+    if (link.points.length <= LINK_DEFAULT_NUMBER_OF_POINTS) {
       this.currentLink = link.getID()
     }
 
@@ -184,7 +185,7 @@ class DeletableLinkWidget extends DefaultLinkWidget {
     // true when smart routing was skipped or not enabled.
     // See @link{#isSmartRoutingApplicable()}.
     if (paths.length === 0) {
-      if (points.length === 2) {
+      if (points.length === LINK_DEFAULT_NUMBER_OF_POINTS) {
         const isHorizontal = Math.abs(points[0].x - points[1].x) > Math.abs(points[0].y - points[1].y)
         const xOrY = isHorizontal ? 'x' : 'y'
 


### PR DESCRIPTION
This PR adds the possibility of adding multiple points to a link/connector in the flow editor.

**Left click** on a link adds a new point.
**Right click** removes the point.
**Shift + left click** to select the link/connector without adding a point.

The number of points per link is currently limited to 3.

_Note: this is more of a proof of concept than anything. Feel free to comment!_

https://user-images.githubusercontent.com/9640576/104931921-11d2b780-5975-11eb-8daa-aa13412f4ac6.mp4

