### PR TITLE
fix(nlu): warn of duplication on synonym removal

### DIFF
--- a/modules/nlu/src/views/full/entities/ListEntity.tsx
+++ b/modules/nlu/src/views/full/entities/ListEntity.tsx
@@ -90,9 +90,16 @@ export const ListEntityEditor: React.FC<Props> = props => {
   }
 
   const editOccurrence = (idx: number, occurrence: NLU.EntityDefOccurrence) => {
-    const newSynonym = _.last(occurrence.synonyms)
-    if (!isUnique(newSynonym)) {
-      return toastFailure('Synonyms duplication is not allowed')
+    const synonymAdded = () => {
+      const oldOccurence = state.occurrences[idx]
+      return oldOccurence.synonyms.length < occurrence.synonyms.length
+    }
+
+    if (synonymAdded()) {
+      const newSynonym = _.last(occurrence.synonyms)
+      if (!isUnique(newSynonym)) {
+        return toastFailure('Synonyms duplication is not allowed')
+      }
     }
 
     const occurrences = [...state.occurrences.slice(0, idx), occurrence, ...state.occurrences.slice(idx + 1)]


### PR DESCRIPTION
Fixes a bug in the List Entities editor where removing a synonym always displays an error message: "Synonyms duplication is not allowed"

To reproduce:
1- Try deleting a synonym
![2021-01-18 at 4 01 PM](https://user-images.githubusercontent.com/892367/104962485-807c3900-59a6-11eb-9af0-77c88756441a.png)
2- Witness error message
![2021-01-18 at 4 04 PM](https://user-images.githubusercontent.com/892367/104962662-e5d02a00-59a6-11eb-89d1-afb41a559768.png)
3- Cry

