### PR TITLE
fix(hitl2): stringify tags with postgresql

### DIFF
--- a/modules/hitlnext/src/backend/repository.ts
+++ b/modules/hitlnext/src/backend/repository.ts
@@ -70,7 +70,7 @@ export default class Repository {
     const result = _.clone(object)
 
     paths.map(path => {
-      _.has(object, path) && _.set(result, path, this.bp.database.json.set(_.get(object, path)))
+      _.has(object, path) && _.set(result, path, JSON.stringify(_.get(object, path)))
     })
 
     return result


### PR DESCRIPTION
This PR fixes an issue where HITLNext tags could not be inserted into a PostgesQL database.

This issue was related to the fact that JSON arrays need to be stringified before being inserted into a pg DB. 

> For PostgreSQL, due to incompatibility between native array and json types, when setting an array (or a value that could be an array) as the value of a json or jsonb column, you should use JSON.stringify() to convert your value to a string prior to passing it to the query builder.

See: http://knexjs.org/#Schema-json

`this.bp.database.json.set()` only _JSON.stringify_ payload for SQLite so directly calling this function will work for both databases. 

Fixes: botpress/v12#1197