### PR TITLE
doc: release notes and getting started

### DIFF
--- a/docs/guide/website/sidebars.json
+++ b/docs/guide/website/sidebars.json
@@ -1,7 +1,7 @@
 {
   "docs": {
-    "Release Notes": ["releases/migrate", "releases/release-notes", "releases/v12_10_0"],
-    "Getting Started": ["introduction", "installation", "quickstart", "updating", "troubleshoot"],
+    "Release Notes": ["releases/migrate", "updating"],
+    "Getting Started": ["introduction", "installation", "quickstart"],
     "Main Concepts": [
       "main/overview",
       "main/glossary",


### PR DESCRIPTION
Merged releases/migrate, releases/release-notes and releases/v12_10_0 to one topic releases/migrate

Moved updating.md from Getting Started to Release Notes

Removed troubleshoot from Getting Started. Will add that error under nlu