### PR TITLE
fix(hitlnext): incorrect bootstrap sequence

### DIFF
--- a/modules/hitlnext/src/backend/index.ts
+++ b/modules/hitlnext/src/backend/index.ts
@@ -18,8 +18,11 @@ export interface StateType {
 
 const state: StateType = { timeouts: {} }
 
-const onServerReady = async (bp: typeof sdk) => {
+const onServerStarted = async (bp: typeof sdk) => {
   await migrate(bp)
+}
+
+const onServerReady = async (bp: typeof sdk) => {
   await upsertAgentRoles(bp)
   await api(bp, state)
   await registerMiddleware(bp, state)
@@ -31,6 +34,7 @@ const onModuleUnmount = async (bp: typeof sdk) => {
 }
 
 const entryPoint: sdk.ModuleEntryPoint = {
+  onServerStarted,
   onServerReady,
   onModuleUnmount,
   translations: { en, fr },

--- a/modules/hitlnext/src/backend/index.ts
+++ b/modules/hitlnext/src/backend/index.ts
@@ -20,12 +20,12 @@ const state: StateType = { timeouts: {} }
 
 const onServerStarted = async (bp: typeof sdk) => {
   await migrate(bp)
+  await registerMiddleware(bp, state)
 }
 
 const onServerReady = async (bp: typeof sdk) => {
   await upsertAgentRoles(bp)
   await api(bp, state)
-  await registerMiddleware(bp, state)
 }
 
 const onModuleUnmount = async (bp: typeof sdk) => {


### PR DESCRIPTION
Fixes an issue in module `hitlnext` where table creation was executed too late, resulting in an error where migrations were failing because the underlying tables were not created yet.