### PR TITLE
chore(nlu): few refactors

### DIFF
--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -245,13 +245,13 @@ export default class Engine implements NLU.Engine {
   private async _makePredictors(input: TrainInput, output: TrainOutput): Promise<Predictors> {
     const tools = this._tools
 
-    const { ctx_model, intent_model_by_ctx, oos_model, list_entities, kmeans } = output
+    const { ctx_model, intent_model_by_ctx, oos_model, kmeans } = output
 
     /**
      * TODO: extract this function some place else,
      * Engine's predict() shouldn't be dependant of training pipeline...
      */
-    const intents = await ProcessIntents(input.intents, input.languageCode, list_entities, this._tools)
+    const intents = await ProcessIntents(input.intents, input.languageCode, this._tools)
 
     const warmKmeans = kmeans && deserializeKmeans(kmeans)
 
@@ -282,7 +282,7 @@ export default class Engine implements NLU.Engine {
     let slot_tagger: SlotTagger | undefined
     if (output.slots_model.length) {
       slot_tagger = new SlotTagger(tools.mlToolkit)
-      slot_tagger.load(output.slots_model)
+      slot_tagger.load(output.slots_model, intents, output.list_entities)
     }
 
     return {

--- a/src/bp/nlu-core/intents/intent-vocab.test.ts
+++ b/src/bp/nlu-core/intents/intent-vocab.test.ts
@@ -1,8 +1,9 @@
 import { POSClass } from '../language/pos-tagger'
 import { SPACE } from '../tools/token-utils'
-import { buildIntentVocab } from '../training-pipeline'
 import { ExtractedSlot, ListEntityModel } from '../typings'
 import Utterance from '../utterance/utterance'
+
+import { buildIntentVocab } from './intent-vocab'
 
 const LIST_ENTITIES: ListEntityModel[] = [
   {

--- a/src/bp/nlu-core/intents/intent-vocab.ts
+++ b/src/bp/nlu-core/intents/intent-vocab.ts
@@ -1,0 +1,45 @@
+import _ from 'lodash'
+import { IntentSlotFeatures } from 'nlu-core/slots/slot-tagger'
+import { SPACE } from 'nlu-core/tools/token-utils'
+import { Intent, ListEntityModel } from 'nlu-core/typings'
+import Utterance from 'nlu-core/utterance/utterance'
+
+type IntentWithSlotFeatures = Intent<Utterance> & IntentSlotFeatures
+
+export const buildIntentVocab = (utterances: Utterance[], intentEntities: ListEntityModel[]): Dic<boolean> => {
+  // @ts-ignore
+  const entitiesTokens: string[] = _.chain(intentEntities)
+    .flatMapDeep(e => Object.values(e.mappingsTokens))
+    .map((t: string) => t.toLowerCase().replace(SPACE, ' '))
+    .value()
+
+  return _.chain(utterances)
+    .flatMap(u => u.tokens.filter(t => _.isEmpty(t.slots)).map(t => t.toString({ lowerCase: true })))
+    .concat(entitiesTokens)
+    .reduce((vocab: Dic<boolean>, tok: string) => ({ ...vocab, [tok]: true }), {})
+    .value()
+}
+
+export const getEntitiesAndVocabOfIntent = (
+  intents: Intent<Utterance>[],
+  entities: ListEntityModel[]
+): IntentWithSlotFeatures[] => {
+  return intents.map(intent => {
+    const allowedEntities = _.chain(intent.slot_definitions)
+      .flatMap(s => s.entities)
+      .filter(e => e !== 'any')
+      .uniq()
+      .value() as string[]
+
+    const entityModels = _.intersectionWith(entities, allowedEntities, (entity, name) => {
+      return entity.entityName === name
+    })
+
+    const vocab = Object.keys(buildIntentVocab(intent.utterances, entityModels))
+    return {
+      ...intent,
+      vocab,
+      slot_entities: allowedEntities
+    }
+  })
+}

--- a/src/bp/nlu-core/model-id-service.test.ts
+++ b/src/bp/nlu-core/model-id-service.test.ts
@@ -6,7 +6,6 @@ import { HALF_MD5_REG } from './tools/crypto'
 const intentDefs: NLU.IntentDefinition[] = [
   {
     contexts: ['global'],
-    filename: 'Frodo',
     name: 'Frodo',
     slots: [],
     utterances: {

--- a/src/bp/nlu-core/slots/slot-featurizer.test.ts
+++ b/src/bp/nlu-core/slots/slot-featurizer.test.ts
@@ -3,6 +3,7 @@ import { Intent } from '../typings'
 import Utterance, { UtteranceEntity, UtteranceToken } from '../utterance/utterance'
 
 import * as featurizer from './slot-featurizer'
+import { IntentSlotFeatures } from './slot-tagger'
 
 describe('CRF Featurizer 2', () => {
   test('featToCRFsuiteAttr', () => {
@@ -136,25 +137,14 @@ describe('CRF Featurizer 2', () => {
       Object.defineProperty(tok, 'toString', { value: () => tok.value, enumerable: true })
     )
 
-    const anIntent: Partial<Intent<Utterance>> = {
-      name: 'find flight',
-      vocab: {
-        fly: true
-      }
-    }
+    const vocab = ['fly']
 
-    expect(
-      featurizer.getInVocabFeat({ ...tokens[0], slots: ['lol.A.W'] }, anIntent as Intent<Utterance>).value
-    ).toBeTruthy()
-    expect(featurizer.getInVocabFeat(tokens[0], anIntent as Intent<Utterance>).value).toBeTruthy()
-    expect(
-      featurizer.getInVocabFeat({ ...tokens[1], slots: ['lol.A.W'] }, anIntent as Intent<Utterance>).value
-    ).toBeFalsy()
-    expect(featurizer.getInVocabFeat(tokens[1], anIntent as Intent<Utterance>).value).toBeFalsy()
-    expect(
-      featurizer.getInVocabFeat({ ...tokens[2], slots: ['lol.A.W'] }, anIntent as Intent<Utterance>).value
-    ).toBeFalsy()
-    expect(featurizer.getInVocabFeat(tokens[2], anIntent as Intent<Utterance>).value).toBeFalsy()
+    expect(featurizer.getInVocabFeat({ ...tokens[0], slots: ['lol.A.W'] }, vocab).value).toBeTruthy()
+    expect(featurizer.getInVocabFeat(tokens[0], vocab).value).toBeTruthy()
+    expect(featurizer.getInVocabFeat({ ...tokens[1], slots: ['lol.A.W'] }, vocab).value).toBeFalsy()
+    expect(featurizer.getInVocabFeat(tokens[1], vocab).value).toBeFalsy()
+    expect(featurizer.getInVocabFeat({ ...tokens[2], slots: ['lol.A.W'] }, vocab).value).toBeFalsy()
+    expect(featurizer.getInVocabFeat(tokens[2], vocab).value).toBeFalsy()
   })
 
   test('getEntitiesFeats', () => {
@@ -199,10 +189,10 @@ describe('CRF Featurizer 2', () => {
   })
 
   test('getIntentFeature', () => {
-    const anIntent: Partial<Intent<Utterance>> = {
+    const anIntent = {
       name: 'give-me-money'
     }
-    const feat = featurizer.getIntentFeature(anIntent as Intent<Utterance>)
+    const feat = featurizer.getIntentFeature(anIntent.name)
 
     expect(feat.value).toEqual(anIntent.name)
     expect(feat.boost).toEqual(100)

--- a/src/bp/nlu-core/slots/slot-featurizer.ts
+++ b/src/bp/nlu-core/slots/slot-featurizer.ts
@@ -4,7 +4,6 @@ import { sanitize } from '../language/sanitizer'
 import { computeQuantile } from '../tools/math'
 import { countAlpha, countNum, countSpecial } from '../tools/strings'
 import { MAX_TFIDF, MIN_TFIDF } from '../tools/tfidf'
-import { Intent } from '../typings'
 import Utterance, { UtteranceToken } from '../utterance/utterance'
 
 type FeatureValue = string | number | boolean
@@ -72,11 +71,9 @@ export function getWordFeat(token: UtteranceToken, isPredict: boolean): CRFFeatu
   }
 }
 
-export function getInVocabFeat(token: UtteranceToken, intent: Intent<Utterance>): CRFFeature {
-  if (!intent.vocab) {
-    throw new Error('getInVocabFeat requires a vocab')
-  }
-  const inVocab = !!intent.vocab[token.toString({ lowerCase: true })]
+export function getInVocabFeat(token: UtteranceToken, vocab: string[]): CRFFeature {
+  const stringToken = token.toString({ lowerCase: true })
+  const inVocab = vocab.includes(stringToken)
   return {
     name: 'inVocab',
     value: inVocab
@@ -126,10 +123,10 @@ export function getSpecialChars(token: UtteranceToken): CRFFeature {
   }
 }
 
-export function getIntentFeature(intent: Intent<Utterance>): CRFFeature {
+export function getIntentFeature(intentName: string): CRFFeature {
   return {
     name: 'intent',
-    value: sanitize(intent.name.replace(/\s/g, '')),
+    value: sanitize(intentName.replace(/\s/g, '')),
     boost: 100
   }
 }

--- a/src/bp/nlu-core/slots/slot-tagger.test.ts
+++ b/src/bp/nlu-core/slots/slot-tagger.test.ts
@@ -47,9 +47,7 @@ describe('makeExtractedSlots', () => {
   let u: Utterance
   const out: TagResult = { name: '', tag: BIO.OUT, probability: 1 }
   let tagResults: TagResult[]
-  const testIntent = {
-    slot_entities: ['CS_Field']
-  } as Intent<Utterance>
+  const slot_entities = ['CS_Field']
 
   beforeEach(() => {
     u = makeTestUtterance('No one is safe big AI is watching')
@@ -65,7 +63,7 @@ describe('makeExtractedSlots', () => {
       { name: 'threath', probability: 1, tag: BIO.INSIDE }
     )
 
-    const extractedSlots = makeExtractedSlots(testIntent, u, tagResults)
+    const extractedSlots = makeExtractedSlots(slot_entities, u, tagResults)
 
     expect(extractedSlots.length).toEqual(1)
     expect(extractedSlots[0].slot.source).toEqual('big AI')
@@ -84,7 +82,7 @@ describe('makeExtractedSlots', () => {
       { name: 'action', probability: 1, tag: BIO.INSIDE }
     )
 
-    const extractedSlots = makeExtractedSlots(testIntent, u, tagResults)
+    const extractedSlots = makeExtractedSlots(slot_entities, u, tagResults)
 
     expect(extractedSlots.length).toEqual(2)
     expect(extractedSlots[0].slot.source).toEqual('big AI')
@@ -108,7 +106,7 @@ describe('makeExtractedSlots', () => {
     const entity = { type: 'CS_Field', value, confidence: 0.42, sensitive: false, metadata: {} } as ExtractedEntity
     u.tagEntity(entity, 19, 21)
 
-    const extractedSlots = makeExtractedSlots(testIntent, u, tagResults)
+    const extractedSlots = makeExtractedSlots(slot_entities, u, tagResults)
 
     expect(extractedSlots.length).toEqual(1)
     expect(extractedSlots[0].slot.source).toEqual('big AI')
@@ -127,7 +125,7 @@ describe('makeExtractedSlots', () => {
     )
     u.tagEntity({ type: 'verb', value: 'to watch' } as ExtractedEntity, 25, 33)
 
-    const extractedSlots = makeExtractedSlots(testIntent, u, tagResults)
+    const extractedSlots = makeExtractedSlots(slot_entities, u, tagResults)
 
     expect(extractedSlots.length).toEqual(1)
     expect(extractedSlots[0].slot.entity).toBeUndefined()

--- a/src/bp/nlu-core/training-pipeline.ts
+++ b/src/bp/nlu-core/training-pipeline.ts
@@ -102,12 +102,17 @@ const PreprocessInput = async (input: TrainInput, tools: Tools): Promise<TrainSt
   const intents = await ProcessIntents(input.intents, input.languageCode, tools)
   const vocabVectors = buildVectorsVocab(intents)
 
+  const { nluSeed, languageCode, pattern_entities, contexts, ctxToTrain } = input
   return {
-    ..._.omit(input, 'list_entities', 'intents'),
+    nluSeed,
+    languageCode,
+    pattern_entities,
+    contexts,
+    ctxToTrain,
     list_entities,
     intents,
     vocabVectors
-  } as TrainStep
+  }
 }
 
 const makeListEntityModel = async (entity: ListEntityWithCache, languageCode: string, tools: Tools) => {

--- a/src/bp/nlu-core/typings.ts
+++ b/src/bp/nlu-core/typings.ts
@@ -137,8 +137,6 @@ export type Intent<T> = Readonly<{
   contexts: string[]
   slot_definitions: SlotDefinition[]
   utterances: T[]
-  vocab?: _.Dictionary<boolean>
-  slot_entities?: string[]
 }>
 
 type SlotDefinition = Readonly<{

--- a/src/bp/nlu-core/warm-training-handler.ts
+++ b/src/bp/nlu-core/warm-training-handler.ts
@@ -46,9 +46,7 @@ const _computeCtxHash = (intents: Intent<string>[], ctx: string) => {
   const informationToTrack = intentsOfCtx.map(i => ({
     name: i.name,
     slot_definitions: i.slot_definitions,
-    utterances: i.utterances,
-    vocab: i.vocab,
-    slot_entities: i.slot_entities
+    utterances: i.utterances
   }))
 
   return crypto

--- a/src/bp/nlu-server/api-mapper.ts
+++ b/src/bp/nlu-server/api-mapper.ts
@@ -62,7 +62,6 @@ const makeIntentMapper = (ctx: string, lang: string) => (intent: IntentDefinitio
 
   return {
     contexts: [ctx],
-    filename: '',
     name,
     utterances: {
       [lang]: utterances

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -588,7 +588,6 @@ declare module 'botpress/sdk' {
       utterances: {
         [lang: string]: string[]
       }
-      filename: string
       slots: SlotDefinition[]
       contexts: string[]
     }

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -596,7 +596,6 @@ declare module 'botpress/sdk' {
       name: string
       confidence: number
       context: string
-      matches?: (intentPattern: string) => boolean
     }
 
     export interface Entity {


### PR DESCRIPTION
Allright, I was working in the NLU on another job and I ended up making few refactors that had nothing to do with my job so I felt like I should open another independant PR.

This PR should be reviewed by commit:

commit 1: The field `fileName` in intent definition was not used
commit 2: I removed fields `vocab` and `slot_entities` from intent deifnition
commit 3: I removed any notion of `botId` in training pipeline
commit 4: No more type assertion in preprocess input
commit 5: I removed field `matches` from IntentDefinition in sdk as it was unused

Why did I removed fields `vocab` and `slot_entities`? 

reason1: Those fields where optionnal in typings, but truth is they where required by the slot tagger (this is misleading).
reason2: Slot Tagger is really dependent on entities, but this dependency was barely exposed anywhere.
reason3: As it was, if you tried tagging a slot without calling the exact function `ProcessIntents()` it was throwing. I think its better if Slot Tagger's depencies are more explicit and it resolve itself the feature it needs.

This PR adds no value, just refactoring.