### PR TITLE
chore(nlu): make sure tfidf dictionnary is not case sensitive

### DIFF
--- a/build/nlu-regression/current_scores/bpds-intent.json
+++ b/build/nlu-regression/current_scores/bpds-intent.json
@@ -1,11 +1,11 @@
 {
-  "generatedOn": "2021-01-15T16:58:22.593Z",
+  "generatedOn": "2021-01-26T16:51:29.713Z",
   "scores": [
     {
       "metric": "accuracy",
       "problem": "bpsd A-en",
       "seed": 42,
-      "score": 0.6863636363636364
+      "score": 0.6818181818181818
     },
     {
       "metric": "oosAccuracy",
@@ -17,25 +17,25 @@
       "metric": "oosPrecision",
       "problem": "bpsd A-en",
       "seed": 42,
-      "score": 0.7888888888888889
+      "score": 0.8170731707317073
     },
     {
       "metric": "oosRecall",
       "problem": "bpsd A-en",
       "seed": 42,
-      "score": 0.71
+      "score": 0.67
     },
     {
       "metric": "oosF1",
       "problem": "bpsd A-en",
       "seed": 42,
-      "score": 0.7473684210526317
+      "score": 0.7362637362637363
     },
     {
       "metric": "accuracy",
       "problem": "bpsd A-en",
       "seed": 69,
-      "score": 0.6909090909090909
+      "score": 0.6863636363636364
     },
     {
       "metric": "oosAccuracy",
@@ -47,25 +47,25 @@
       "metric": "oosPrecision",
       "problem": "bpsd A-en",
       "seed": 69,
-      "score": 0.8313253012048193
+      "score": 0.8395061728395061
     },
     {
       "metric": "oosRecall",
       "problem": "bpsd A-en",
       "seed": 69,
-      "score": 0.69
+      "score": 0.68
     },
     {
       "metric": "oosF1",
       "problem": "bpsd A-en",
       "seed": 69,
-      "score": 0.7540983606557377
+      "score": 0.7513812154696133
     },
     {
       "metric": "accuracy",
       "problem": "bpsd A-en",
       "seed": 666,
-      "score": 0.6954545454545454
+      "score": 0.6818181818181818
     },
     {
       "metric": "oosAccuracy",
@@ -77,25 +77,25 @@
       "metric": "oosPrecision",
       "problem": "bpsd A-en",
       "seed": 666,
-      "score": 0.7912087912087912
+      "score": 0.797752808988764
     },
     {
       "metric": "oosRecall",
       "problem": "bpsd A-en",
       "seed": 666,
-      "score": 0.72
+      "score": 0.71
     },
     {
       "metric": "oosF1",
       "problem": "bpsd A-en",
       "seed": 666,
-      "score": 0.7539267015706805
+      "score": 0.7513227513227513
     },
     {
       "metric": "accuracy",
       "problem": "bpds A imbalanced-en",
       "seed": 42,
-      "score": 0.4772727272727273
+      "score": 0.4681818181818182
     },
     {
       "metric": "oosAccuracy",
@@ -107,49 +107,49 @@
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced-en",
       "seed": 42,
-      "score": 0.5961538461538461
+      "score": 0.5943396226415094
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A imbalanced-en",
       "seed": 42,
-      "score": 0.62
+      "score": 0.63
     },
     {
       "metric": "oosF1",
       "problem": "bpds A imbalanced-en",
       "seed": 42,
-      "score": 0.607843137254902
+      "score": 0.6116504854368932
     },
     {
       "metric": "accuracy",
       "problem": "bpds A imbalanced-en",
       "seed": 69,
-      "score": 0.5909090909090909
+      "score": 0.5863636363636363
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A imbalanced-en",
       "seed": 69,
-      "score": 0.7
+      "score": 0.7090909090909091
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced-en",
       "seed": 69,
-      "score": 0.7428571428571429
+      "score": 0.7571428571428571
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A imbalanced-en",
       "seed": 69,
-      "score": 0.52
+      "score": 0.53
     },
     {
       "metric": "oosF1",
       "problem": "bpds A imbalanced-en",
       "seed": 69,
-      "score": 0.6117647058823529
+      "score": 0.6235294117647059
     },
     {
       "metric": "accuracy",
@@ -185,19 +185,19 @@
       "metric": "accuracy",
       "problem": "bpds A fewshot-en",
       "seed": 42,
-      "score": 0.6
+      "score": 0.6318181818181818
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot-en",
       "seed": 42,
-      "score": 0.6909090909090909
+      "score": 0.7
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot-en",
       "seed": 42,
-      "score": 0.6509433962264151
+      "score": 0.6634615384615384
     },
     {
       "metric": "oosRecall",
@@ -209,205 +209,205 @@
       "metric": "oosF1",
       "problem": "bpds A fewshot-en",
       "seed": 42,
-      "score": 0.6699029126213591
+      "score": 0.6764705882352942
     },
     {
       "metric": "accuracy",
       "problem": "bpds A fewshot-en",
       "seed": 69,
-      "score": 0.5227272727272727
+      "score": 0.5409090909090909
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot-en",
       "seed": 69,
-      "score": 0.6454545454545455
+      "score": 0.6409090909090909
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot-en",
       "seed": 69,
-      "score": 0.6666666666666666
+      "score": 0.6721311475409836
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A fewshot-en",
       "seed": 69,
-      "score": 0.44
+      "score": 0.41
     },
     {
       "metric": "oosF1",
       "problem": "bpds A fewshot-en",
       "seed": 69,
-      "score": 0.5301204819277109
+      "score": 0.5093167701863354
     },
     {
       "metric": "accuracy",
       "problem": "bpds A fewshot-en",
       "seed": 666,
-      "score": 0.6
+      "score": 0.6363636363636364
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot-en",
       "seed": 666,
-      "score": 0.7
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds A fewshot-en",
-      "seed": 666,
-      "score": 0.6808510638297872
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds A fewshot-en",
-      "seed": 666,
-      "score": 0.64
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds A fewshot-en",
-      "seed": 666,
-      "score": 0.6597938144329897
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpds B",
-      "seed": 42,
-      "score": 0.7
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds B",
-      "seed": 42,
-      "score": 0.8136363636363636
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds B",
-      "seed": 42,
-      "score": 0.8933333333333333
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds B",
-      "seed": 42,
-      "score": 0.67
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds B",
-      "seed": 42,
-      "score": 0.7657142857142857
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpds B",
-      "seed": 69,
-      "score": 0.6545454545454545
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds B",
-      "seed": 69,
-      "score": 0.7954545454545454
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds B",
-      "seed": 69,
-      "score": 0.9365079365079365
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds B",
-      "seed": 69,
-      "score": 0.59
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds B",
-      "seed": 69,
-      "score": 0.7239263803680981
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpds B",
-      "seed": 666,
-      "score": 0.6727272727272727
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds B",
-      "seed": 666,
-      "score": 0.7909090909090909
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds B",
-      "seed": 666,
-      "score": 0.8970588235294118
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds B",
-      "seed": 666,
-      "score": 0.61
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds B",
-      "seed": 666,
-      "score": 0.7261904761904763
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpsd A-fr",
-      "seed": 42,
-      "score": 0.6545454545454545
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpsd A-fr",
-      "seed": 42,
       "score": 0.7136363636363636
     },
     {
       "metric": "oosPrecision",
-      "problem": "bpsd A-fr",
-      "seed": 42,
-      "score": 0.6831683168316832
+      "problem": "bpds A fewshot-en",
+      "seed": 666,
+      "score": 0.7078651685393258
     },
     {
       "metric": "oosRecall",
-      "problem": "bpsd A-fr",
-      "seed": 42,
-      "score": 0.69
+      "problem": "bpds A fewshot-en",
+      "seed": 666,
+      "score": 0.63
     },
     {
       "metric": "oosF1",
-      "problem": "bpsd A-fr",
-      "seed": 42,
-      "score": 0.6865671641791044
+      "problem": "bpds A fewshot-en",
+      "seed": 666,
+      "score": 0.6666666666666666
     },
     {
       "metric": "accuracy",
-      "problem": "bpsd A-fr",
+      "problem": "bpds B",
+      "seed": 42,
+      "score": 0.7045454545454546
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpds B",
+      "seed": 42,
+      "score": 0.8
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds B",
+      "seed": 42,
+      "score": 0.868421052631579
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpds B",
+      "seed": 42,
+      "score": 0.66
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds B",
+      "seed": 42,
+      "score": 0.7500000000000001
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpds B",
       "seed": 69,
       "score": 0.6636363636363637
     },
     {
       "metric": "oosAccuracy",
+      "problem": "bpds B",
+      "seed": 69,
+      "score": 0.7681818181818182
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds B",
+      "seed": 69,
+      "score": 0.8769230769230769
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpds B",
+      "seed": 69,
+      "score": 0.57
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds B",
+      "seed": 69,
+      "score": 0.6909090909090909
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpds B",
+      "seed": 666,
+      "score": 0.6454545454545455
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpds B",
+      "seed": 666,
+      "score": 0.7636363636363637
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds B",
+      "seed": 666,
+      "score": 0.8636363636363636
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpds B",
+      "seed": 666,
+      "score": 0.57
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds B",
+      "seed": 666,
+      "score": 0.6867469879518072
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpsd A-fr",
+      "seed": 42,
+      "score": 0.6636363636363637
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpsd A-fr",
+      "seed": 42,
+      "score": 0.7363636363636363
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpsd A-fr",
+      "seed": 42,
+      "score": 0.7142857142857143
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpsd A-fr",
+      "seed": 42,
+      "score": 0.7
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpsd A-fr",
+      "seed": 42,
+      "score": 0.7070707070707072
+    },
+    {
+      "metric": "accuracy",
       "problem": "bpsd A-fr",
       "seed": 69,
-      "score": 0.7318181818181818
+      "score": 0.6681818181818182
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpsd A-fr",
+      "seed": 69,
+      "score": 0.7363636363636363
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A-fr",
       "seed": 69,
-      "score": 0.7029702970297029
+      "score": 0.71
     },
     {
       "metric": "oosRecall",
@@ -419,7 +419,7 @@
       "metric": "oosF1",
       "problem": "bpsd A-fr",
       "seed": 69,
-      "score": 0.7064676616915423
+      "score": 0.7100000000000001
     },
     {
       "metric": "accuracy",
@@ -455,37 +455,37 @@
       "metric": "accuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 42,
-      "score": 0.45454545454545453
+      "score": 0.5
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 42,
-      "score": 0.6636363636363637
+      "score": 0.65
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced-fr",
       "seed": 42,
-      "score": 0.6444444444444445
+      "score": 0.6138613861386139
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A imbalanced-fr",
       "seed": 42,
-      "score": 0.58
+      "score": 0.62
     },
     {
       "metric": "oosF1",
       "problem": "bpds A imbalanced-fr",
       "seed": 42,
-      "score": 0.6105263157894737
+      "score": 0.6169154228855721
     },
     {
       "metric": "accuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 69,
-      "score": 0.5545454545454546
+      "score": 0.5590909090909091
     },
     {
       "metric": "oosAccuracy",
@@ -515,49 +515,49 @@
       "metric": "accuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 666,
-      "score": 0.5
+      "score": 0.55
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 666,
-      "score": 0.6818181818181818
+      "score": 0.6954545454545454
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced-fr",
       "seed": 666,
-      "score": 0.7027027027027027
+      "score": 0.7088607594936709
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A imbalanced-fr",
       "seed": 666,
-      "score": 0.52
+      "score": 0.56
     },
     {
       "metric": "oosF1",
       "problem": "bpds A imbalanced-fr",
       "seed": 666,
-      "score": 0.5977011494252874
+      "score": 0.6256983240223464
     },
     {
       "metric": "accuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 42,
-      "score": 0.5727272727272728
+      "score": 0.5772727272727273
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 42,
-      "score": 0.7090909090909091
+      "score": 0.7045454545454546
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot-fr",
       "seed": 42,
-      "score": 0.6578947368421053
+      "score": 0.6521739130434783
     },
     {
       "metric": "oosRecall",
@@ -569,37 +569,37 @@
       "metric": "oosF1",
       "problem": "bpds A fewshot-fr",
       "seed": 42,
-      "score": 0.7009345794392524
+      "score": 0.6976744186046512
     },
     {
       "metric": "accuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.5318181818181819
+      "score": 0.55
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.759090909090909
+      "score": 0.7727272727272727
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.7901234567901234
+      "score": 0.8289473684210527
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.64
+      "score": 0.63
     },
     {
       "metric": "oosF1",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.7071823204419889
+      "score": 0.715909090909091
     },
     {
       "metric": "accuracy",
@@ -617,19 +617,19 @@
       "metric": "oosPrecision",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.7397260273972602
+      "score": 0.7536231884057971
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.54
+      "score": 0.52
     },
     {
       "metric": "oosF1",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.624277456647399
+      "score": 0.6153846153846154
     }
   ]
 }

--- a/build/nlu-regression/current_scores/bpds-slots.json
+++ b/build/nlu-regression/current_scores/bpds-slots.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-15T16:58:34.923Z",
+  "generatedOn": "2021-01-26T16:51:47.469Z",
   "scores": [
     {
       "metric": "avgScore:slotsAre",

--- a/build/nlu-regression/current_scores/bpds-spell.json
+++ b/build/nlu-regression/current_scores/bpds-spell.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-15T16:58:38.162Z",
+  "generatedOn": "2021-01-26T16:51:51.902Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/clinc150.json
+++ b/build/nlu-regression/current_scores/clinc150.json
@@ -1,23 +1,23 @@
 {
-  "generatedOn": "2021-01-15T17:04:26.067Z",
+  "generatedOn": "2021-01-26T16:58:25.537Z",
   "scores": [
     {
       "metric": "accuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.7252325581395349
+      "score": 0.7246511627906976
     },
     {
       "metric": "oosAccuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.8565116279069768
+      "score": 0.8561627906976744
     },
     {
       "metric": "oosPrecision",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.290625
+      "score": 0.28792569659442724
     },
     {
       "metric": "oosRecall",
@@ -29,7 +29,7 @@
       "metric": "oosF1",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.13098591549295777
+      "score": 0.13070976809557275
     }
   ]
 }

--- a/src/bp/nlu-core/training-pipeline.test.ts
+++ b/src/bp/nlu-core/training-pipeline.test.ts
@@ -1,0 +1,50 @@
+import _ from 'lodash'
+
+import { tokenizeLatinTextForTests } from './tools/token-utils'
+import { TfidfTokens, TrainStep } from './training-pipeline'
+import { Intent } from './typings'
+import Utterance from './utterance/utterance'
+
+test('tfidf has a value for all tokens of the training set', async () => {
+  // arrange
+  const makeUtterance = (utt: string) => {
+    const tokens = tokenizeLatinTextForTests(utt)
+    return new Utterance(
+      tokens,
+      tokens.map(t => Array(300).fill(0)),
+      tokens.map(t => 'NOUN'),
+      'en'
+    )
+  }
+
+  const makeIntent = (name: string, utterances: string[]) => {
+    return <Intent<Utterance>>{
+      name,
+      contexts: ['global'],
+      slot_definitions: [],
+      utterances: utterances.map(makeUtterance)
+    }
+  }
+
+  const installBpIntent = makeIntent('install-bp', [
+    'How can I install Botpress?',
+    'Can you help me with Botpress install?'
+  ])
+  const reportBugIntent = makeIntent('report-bug', ['There seems to be a bug with Botpress...', 'I have a problem'])
+
+  const intents: Intent<Utterance>[] = [installBpIntent, reportBugIntent]
+
+  // act
+  const { tfIdf } = await TfidfTokens({ intents } as TrainStep)
+
+  // assert
+  const botpressToken = 'botpress'
+
+  const utterances = _.flatMap(intents, i => i.utterances)
+  const tokens = _.flatMap(utterances, u => u.tokens)
+  const desiredToken = tokens.find(t => t.toString({ lowerCase: true }) === botpressToken)
+
+  expect(tfIdf).toBeDefined()
+  expect(_.round(tfIdf![botpressToken], 2)).toBe(0.54)
+  expect(_.round(desiredToken!.tfidf, 2)).toBe(0.54)
+})

--- a/src/bp/nlu-core/utterance/utterance.ts
+++ b/src/bp/nlu-core/utterance/utterance.ts
@@ -163,7 +163,7 @@ export default class Utterance {
   }
 
   setGlobalTfidf(tfidf: TFIDF) {
-    this._globalTfidf = tfidf
+    this._globalTfidf = _.mapKeys(tfidf, (tfidf, token) => token.toLowerCase())
   }
 
   setKmeans(kmeans?: sdk.MLToolkit.KMeans.KmeansResult) {

--- a/src/bp/nlu-core/utterance/utterance.ts
+++ b/src/bp/nlu-core/utterance/utterance.ts
@@ -83,7 +83,8 @@ export default class Utterance {
             return that.entities.filter(x => x.startTokenIdx <= i && x.endTokenIdx >= i)
           },
           get tfidf(): number {
-            return (that._globalTfidf && that._globalTfidf[value]) || 1
+            const lowerCased = this.toString({ lowerCase: true }) // global tfidf is built with lowercased vocab
+            return (that._globalTfidf && that._globalTfidf[lowerCased]) || 1
           },
           get cluster(): number {
             const wordVec = vectors[i]


### PR DESCRIPTION
Ok, this doesnt seem like much but its actually critical...

The global dictionnary of tfidf is lower-cased, but when accessing a token's tfidf we don't call `toLowerCase()`. The consequences are:

1 -  Whenever you have a token with a cap case in your trianing data, its tfidf is 1
2 - At predict time, if you have the same token with a cap case its tfidf is again 1

There are two options to solve the problem:

1 - Make the dictionnary case-sensitive.
2 - Make the retreival of tfidf insensitive.

I went with option 2 because if we see "botpress" in train set and "Botpress" at predict time, I want both token to have the same tfidf.

What do you think?