### PR TITLE
fix(misunderstood): hide reset button on done list

### DIFF
--- a/modules/misunderstood/src/views/full/ApiClient.ts
+++ b/modules/misunderstood/src/views/full/ApiClient.ts
@@ -53,11 +53,11 @@ class ApiClient {
     })
   }
 
-  getEvent(id: string) {
+  getEvent(id: number) {
     return this.getForModule(`/events/${id}`)
   }
 
-  updateStatus(id: string, status: FLAGGED_MESSAGE_STATUS, resolutionData?: ResolutionData) {
+  updateStatus(id: number, status: FLAGGED_MESSAGE_STATUS, resolutionData?: ResolutionData) {
     return this.postForModule(`/events/${id}/status`, {
       status,
       ...resolutionData,

--- a/modules/misunderstood/src/views/full/MainScreen/DeletedList.tsx
+++ b/modules/misunderstood/src/views/full/MainScreen/DeletedList.tsx
@@ -8,7 +8,7 @@ import style from '../style.scss'
 interface Props {
   events: DbFlaggedEvent[]
   totalEventsCount: number
-  undeleteEvent: (id: string) => void
+  undeleteEvent: (id: number) => void
 }
 
 const DeletedList = ({ events, totalEventsCount, undeleteEvent }: Props) => (
@@ -29,7 +29,7 @@ const DeletedList = ({ events, totalEventsCount, undeleteEvent }: Props) => (
               <td>{event.preview}</td>
               <td>{event.updatedAt}</td>
               <td>
-                <Button onClick={() => undeleteEvent('' + event.id)} small icon="refresh" intent={Intent.PRIMARY}>
+                <Button onClick={() => undeleteEvent(event.id)} small icon="refresh" intent={Intent.PRIMARY}>
                   {lang.tr('module.misunderstood.restore')}
                 </Button>
               </td>

--- a/modules/misunderstood/src/views/full/MainScreen/PendingList.tsx
+++ b/modules/misunderstood/src/views/full/MainScreen/PendingList.tsx
@@ -12,7 +12,7 @@ interface Props {
   events: DbFlaggedEvent[]
   totalEventsCount: number
   applyAllPending: () => Promise<void>
-  resetPendingEvent: (id: string) => Promise<void>
+  resetPendingEvent: (id: number) => Promise<void>
 }
 
 const PendingList = ({ events, totalEventsCount, applyAllPending, resetPendingEvent }: Props) => (

--- a/modules/misunderstood/src/views/full/MainScreen/ResolvedEventsList.tsx
+++ b/modules/misunderstood/src/views/full/MainScreen/ResolvedEventsList.tsx
@@ -8,7 +8,7 @@ import { RESOLUTION } from '../util'
 
 interface Props {
   events: DbFlaggedEvent[]
-  resetEvent?: (id: string) => Promise<void>
+  resetEvent?: (id: number) => Promise<void>
 }
 
 const ResolvedEventsList = ({ events, resetEvent }: Props) =>
@@ -37,7 +37,7 @@ const ResolvedEventsList = ({ events, resetEvent }: Props) =>
             </td>
             <td>{event.updatedAt}</td>
             <td>
-              {resetEvent && (<Button onClick={() => resetEvent(`${event.id}`)} small icon="refresh" intent={Intent.PRIMARY}>
+              {resetEvent && (<Button onClick={() => resetEvent(event.id)} small icon="refresh" intent={Intent.PRIMARY}>
                 {lang.tr('module.misunderstood.reset')}
               </Button>)}
             </td>

--- a/modules/misunderstood/src/views/full/MainScreen/ResolvedEventsList.tsx
+++ b/modules/misunderstood/src/views/full/MainScreen/ResolvedEventsList.tsx
@@ -37,9 +37,9 @@ const ResolvedEventsList = ({ events, resetEvent }: Props) =>
             </td>
             <td>{event.updatedAt}</td>
             <td>
-              <Button onClick={() => resetEvent('' + event.id)} small icon="refresh" intent={Intent.PRIMARY}>
+              {resetEvent && (<Button onClick={() => resetEvent(`${event.id}`)} small icon="refresh" intent={Intent.PRIMARY}>
                 {lang.tr('module.misunderstood.reset')}
-              </Button>
+              </Button>)}
             </td>
           </tr>
         ))}

--- a/modules/misunderstood/src/views/full/index.tsx
+++ b/modules/misunderstood/src/views/full/index.tsx
@@ -7,7 +7,7 @@ import { Container, SidePanel, SplashScreen } from 'botpress/ui'
 import classnames from 'classnames'
 import React from 'react'
 
-import { FlaggedEvent, FLAGGED_MESSAGE_STATUS, FLAG_REASON, ResolutionData } from '../../types'
+import { DbFlaggedEvent, FLAGGED_MESSAGE_STATUS, FLAG_REASON, ResolutionData } from '../../types'
 
 import style from './style.scss'
 import ApiClient from './ApiClient'
@@ -26,9 +26,9 @@ interface State {
   language: string | null
   eventCounts: { [status: string]: number } | null
   selectedStatus: FLAGGED_MESSAGE_STATUS
-  events: FlaggedEvent[] | null
+  events: DbFlaggedEvent[] | null
   selectedEventIndex: number | null
-  selectedEvent: FlaggedEvent | null
+  selectedEvent: DbFlaggedEvent | null
   eventNotFound: boolean
   dateRange?: DateRange
   reason?: FLAG_REASON
@@ -37,7 +37,7 @@ interface State {
 const shortcuts = date.createDateRangeShortcuts()
 
 export default class MisunderstoodMainView extends React.Component<Props, State> {
-  state = {
+  state: State = {
     languages: null,
     language: null,
     eventCounts: null,
@@ -65,7 +65,7 @@ export default class MisunderstoodMainView extends React.Component<Props, State>
     return this.apiClient.getEvents(language, status, dataRange || this.state.dateRange, reason)
   }
 
-  async fetchEvent(id: string) {
+  async fetchEvent(id: number) {
     try {
       return await this.apiClient.getEvent(id)
     } catch (e) {
@@ -163,12 +163,12 @@ export default class MisunderstoodMainView extends React.Component<Props, State>
     return this.alterEventsList(FLAGGED_MESSAGE_STATUS.new, FLAGGED_MESSAGE_STATUS.deleted)
   }
 
-  undeleteEvent = async (id: string) => {
+  undeleteEvent = async (id: number) => {
     await this.apiClient.updateStatus(id, FLAGGED_MESSAGE_STATUS.new)
     return this.alterEventsList(FLAGGED_MESSAGE_STATUS.deleted, FLAGGED_MESSAGE_STATUS.new)
   }
 
-  resetPendingEvent = async (id: string) => {
+  resetPendingEvent = async (id: number) => {
     await this.apiClient.updateStatus(id, FLAGGED_MESSAGE_STATUS.new)
     return this.alterEventsList(FLAGGED_MESSAGE_STATUS.pending, FLAGGED_MESSAGE_STATUS.new)
   }


### PR DESCRIPTION
This PR hides the reset button when on the done list.

Before:

![Screenshot from 2021-01-26 15-26-32](https://user-images.githubusercontent.com/9640576/105901127-e726d580-5fea-11eb-813a-57b7147fc741.png)

After:

![Screenshot from 2021-01-26 13-49-39](https://user-images.githubusercontent.com/9640576/105900999-c3fc2600-5fea-11eb-8a73-ac399191b8e3.png)
