### PR TITLE
fix(misunderstood): display convo on date range change

### DIFF
--- a/modules/misunderstood/src/views/full/index.tsx
+++ b/modules/misunderstood/src/views/full/index.tsx
@@ -207,23 +207,23 @@ export default class MisunderstoodMainView extends React.Component<Props, State>
       reason !== undefined ? reason : this.state.reason
     )
 
-    const event = null
+    let firstEvent = null
     if (events && events.length) {
-      const event = await this.fetchEvent(events[0].id)
+      firstEvent = await this.fetchEvent(events[0].id)
     }
 
-    return { eventCounts, events, event }
+    return { eventCounts, events, firstEvent }
   }
 
   handleDateChange = async (dateRange: DateRange) => {
-    const { eventCounts, events, event } = await this.fetchEventsAndCounts(this.state.language, dateRange)
+    const { eventCounts, events, firstEvent } = await this.fetchEventsAndCounts(this.state.language, dateRange)
 
     await this.setStateP({
       dateRange,
       events,
       selectedEventIndex: 0,
-      selectedEvent: event,
-      eventNotFound: !event,
+      selectedEvent: firstEvent,
+      eventNotFound: !firstEvent,
       eventCounts
     })
   }
@@ -231,7 +231,7 @@ export default class MisunderstoodMainView extends React.Component<Props, State>
   handleReasonChange = async (reason: FLAG_REASON) => {
     reason = this.state.reason !== reason ? reason : null
 
-    const { eventCounts, events, event } = await this.fetchEventsAndCounts(
+    const { eventCounts, events, firstEvent } = await this.fetchEventsAndCounts(
       this.state.language,
       this.state.dateRange,
       reason
@@ -240,8 +240,8 @@ export default class MisunderstoodMainView extends React.Component<Props, State>
     await this.setStateP({
       events,
       selectedEventIndex: 0,
-      selectedEvent: event,
-      eventNotFound: !event,
+      selectedEvent: firstEvent,
+      eventNotFound: !firstEvent,
       eventCounts,
       reason
     })


### PR DESCRIPTION
This PR fixes an issue where selecting a date range with no misunderstood and then adding one that contains some would result in this error:

![Screenshot from 2021-01-26 15-30-16](https://user-images.githubusercontent.com/9640576/105901557-88ae2700-5feb-11eb-83f4-d163bb6c4b4d.png)


https://user-images.githubusercontent.com/9640576/105901692-bb581f80-5feb-11eb-94e3-328851f19841.mp4

