### PR TITLE
fix(misunderstood): remove listener on module unmount

### DIFF
--- a/modules/misunderstood/src/backend/index.ts
+++ b/modules/misunderstood/src/backend/index.ts
@@ -8,12 +8,15 @@ import { FlaggedEvent, FLAG_REASON } from '../types'
 import initApi from './api'
 import Db from './db'
 
+const EVENT_NAME: keyof BotpressCoreEvents = 'bp_core_feedback_negative'
+let listener: (arg: BotpressCoreEvents['bp_core_feedback_negative']) => void
+
 const onServerReady = async (bp: typeof sdk) => {
   const db = new Db(bp)
   await db.initialize()
   await initApi(bp, db)
 
-  process.BOTPRESS_EVENTS.on('bp_core_feedback_negative', async ({ channel, botId, type, eventId }) => {
+  listener = async ({ channel, botId, type, eventId }) => {
     const storedEvent = await bp.events.findEvents({ id: eventId })
     if (!storedEvent) {
       return
@@ -31,11 +34,18 @@ const onServerReady = async (bp: typeof sdk) => {
     }
 
     await db.addEvent(data)
-  })
+  }
+
+  process.BOTPRESS_EVENTS.on(EVENT_NAME, listener)
+}
+
+const onModuleUnmount = async (_bp: typeof sdk) => {
+  process.BOTPRESS_EVENTS.off(EVENT_NAME, listener)
 }
 
 const entryPoint: sdk.ModuleEntryPoint = {
   onServerReady,
+  onModuleUnmount,
   translations: { en, fr, es },
   definition: {
     name: 'misunderstood',


### PR DESCRIPTION
This PR fixes an issue where enabled/disabling the misunderstood module multiple times would result in the listener being setup each time and therefore, multiple duplicates of the same event  would be inserted into the database