### PR TITLE
chore(nlu): isolate oos classification in class

### DIFF
--- a/build/nlu-regression/current_scores/bpds-intent.json
+++ b/build/nlu-regression/current_scores/bpds-intent.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-27T17:50:52.917Z",
+  "generatedOn": "2021-01-27T18:28:44.759Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-intent.json
+++ b/build/nlu-regression/current_scores/bpds-intent.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-27T14:02:25.400Z",
+  "generatedOn": "2021-01-27T14:43:18.032Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-intent.json
+++ b/build/nlu-regression/current_scores/bpds-intent.json
@@ -1,41 +1,41 @@
 {
-  "generatedOn": "2021-01-27T17:19:52.754Z",
+  "generatedOn": "2021-01-27T17:50:52.917Z",
   "scores": [
     {
       "metric": "accuracy",
       "problem": "bpsd A-en",
       "seed": 42,
-      "score": 0.6818181818181818
+      "score": 0.6909090909090909
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpsd A-en",
       "seed": 42,
-      "score": 0.7818181818181819
+      "score": 0.7863636363636364
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A-en",
       "seed": 42,
-      "score": 0.8170731707317073
+      "score": 0.8117647058823529
     },
     {
       "metric": "oosRecall",
       "problem": "bpsd A-en",
       "seed": 42,
-      "score": 0.67
+      "score": 0.69
     },
     {
       "metric": "oosF1",
       "problem": "bpsd A-en",
       "seed": 42,
-      "score": 0.7362637362637363
+      "score": 0.7459459459459459
     },
     {
       "metric": "accuracy",
       "problem": "bpsd A-en",
       "seed": 69,
-      "score": 0.6863636363636364
+      "score": 0.6818181818181818
     },
     {
       "metric": "oosAccuracy",
@@ -71,25 +71,25 @@
       "metric": "oosAccuracy",
       "problem": "bpsd A-en",
       "seed": 666,
-      "score": 0.7863636363636364
+      "score": 0.7818181818181819
     },
     {
       "metric": "oosPrecision",
       "problem": "bpsd A-en",
       "seed": 666,
-      "score": 0.797752808988764
+      "score": 0.7954545454545454
     },
     {
       "metric": "oosRecall",
       "problem": "bpsd A-en",
       "seed": 666,
-      "score": 0.71
+      "score": 0.7
     },
     {
       "metric": "oosF1",
       "problem": "bpsd A-en",
       "seed": 666,
-      "score": 0.7513227513227513
+      "score": 0.7446808510638298
     },
     {
       "metric": "accuracy",
@@ -125,31 +125,31 @@
       "metric": "accuracy",
       "problem": "bpds A imbalanced-en",
       "seed": 69,
-      "score": 0.5863636363636363
+      "score": 0.5681818181818182
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A imbalanced-en",
       "seed": 69,
-      "score": 0.7090909090909091
+      "score": 0.6909090909090909
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced-en",
       "seed": 69,
-      "score": 0.7571428571428571
+      "score": 0.7352941176470589
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A imbalanced-en",
       "seed": 69,
-      "score": 0.53
+      "score": 0.5
     },
     {
       "metric": "oosF1",
       "problem": "bpds A imbalanced-en",
       "seed": 69,
-      "score": 0.6235294117647059
+      "score": 0.5952380952380952
     },
     {
       "metric": "accuracy",
@@ -275,121 +275,121 @@
       "metric": "accuracy",
       "problem": "bpds B",
       "seed": 42,
-      "score": 0.7045454545454546
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds B",
-      "seed": 42,
-      "score": 0.8
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds B",
-      "seed": 42,
-      "score": 0.868421052631579
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds B",
-      "seed": 42,
-      "score": 0.66
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds B",
-      "seed": 42,
-      "score": 0.7500000000000001
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpds B",
-      "seed": 69,
-      "score": 0.6636363636363637
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds B",
-      "seed": 69,
-      "score": 0.7681818181818182
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds B",
-      "seed": 69,
-      "score": 0.8769230769230769
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds B",
-      "seed": 69,
-      "score": 0.57
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds B",
-      "seed": 69,
-      "score": 0.6909090909090909
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpds B",
-      "seed": 666,
-      "score": 0.6454545454545455
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds B",
-      "seed": 666,
-      "score": 0.7636363636363637
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds B",
-      "seed": 666,
-      "score": 0.8636363636363636
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds B",
-      "seed": 666,
-      "score": 0.57
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds B",
-      "seed": 666,
-      "score": 0.6867469879518072
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpsd A-fr",
-      "seed": 42,
-      "score": 0.6636363636363637
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpsd A-fr",
-      "seed": 42,
-      "score": 0.7363636363636363
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpsd A-fr",
-      "seed": 42,
-      "score": 0.7142857142857143
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpsd A-fr",
-      "seed": 42,
       "score": 0.7
     },
     {
+      "metric": "oosAccuracy",
+      "problem": "bpds B",
+      "seed": 42,
+      "score": 0.7909090909090909
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds B",
+      "seed": 42,
+      "score": 0.8552631578947368
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpds B",
+      "seed": 42,
+      "score": 0.65
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds B",
+      "seed": 42,
+      "score": 0.7386363636363636
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpds B",
+      "seed": 69,
+      "score": 0.6772727272727272
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpds B",
+      "seed": 69,
+      "score": 0.7909090909090909
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds B",
+      "seed": 69,
+      "score": 0.8857142857142857
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpds B",
+      "seed": 69,
+      "score": 0.62
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds B",
+      "seed": 69,
+      "score": 0.7294117647058823
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpds B",
+      "seed": 666,
+      "score": 0.6409090909090909
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpds B",
+      "seed": 666,
+      "score": 0.759090909090909
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds B",
+      "seed": 666,
+      "score": 0.8615384615384616
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpds B",
+      "seed": 666,
+      "score": 0.56
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds B",
+      "seed": 666,
+      "score": 0.6787878787878788
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpsd A-fr",
+      "seed": 42,
+      "score": 0.65
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpsd A-fr",
+      "seed": 42,
+      "score": 0.7136363636363636
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpsd A-fr",
+      "seed": 42,
+      "score": 0.6831683168316832
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpsd A-fr",
+      "seed": 42,
+      "score": 0.69
+    },
+    {
       "metric": "oosF1",
       "problem": "bpsd A-fr",
       "seed": 42,
-      "score": 0.7070707070707072
+      "score": 0.6865671641791044
     },
     {
       "metric": "accuracy",
@@ -407,25 +407,25 @@
       "metric": "oosPrecision",
       "problem": "bpsd A-fr",
       "seed": 69,
-      "score": 0.71
+      "score": 0.7019230769230769
     },
     {
       "metric": "oosRecall",
       "problem": "bpsd A-fr",
       "seed": 69,
-      "score": 0.71
+      "score": 0.73
     },
     {
       "metric": "oosF1",
       "problem": "bpsd A-fr",
       "seed": 69,
-      "score": 0.7100000000000001
+      "score": 0.7156862745098039
     },
     {
       "metric": "accuracy",
       "problem": "bpsd A-fr",
       "seed": 666,
-      "score": 0.6590909090909091
+      "score": 0.6636363636363637
     },
     {
       "metric": "oosAccuracy",
@@ -455,181 +455,181 @@
       "metric": "accuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 42,
-      "score": 0.5
+      "score": 0.5181818181818182
     },
     {
       "metric": "oosAccuracy",
+      "problem": "bpds A imbalanced-fr",
+      "seed": 42,
+      "score": 0.6772727272727272
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds A imbalanced-fr",
+      "seed": 42,
+      "score": 0.6435643564356436
+    },
+    {
+      "metric": "oosRecall",
       "problem": "bpds A imbalanced-fr",
       "seed": 42,
       "score": 0.65
     },
     {
-      "metric": "oosPrecision",
-      "problem": "bpds A imbalanced-fr",
-      "seed": 42,
-      "score": 0.6138613861386139
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds A imbalanced-fr",
-      "seed": 42,
-      "score": 0.62
-    },
-    {
       "metric": "oosF1",
       "problem": "bpds A imbalanced-fr",
       "seed": 42,
-      "score": 0.6169154228855721
+      "score": 0.6467661691542289
     },
     {
       "metric": "accuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 69,
-      "score": 0.5590909090909091
+      "score": 0.5636363636363636
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A imbalanced-fr",
       "seed": 69,
-      "score": 0.6909090909090909
+      "score": 0.7
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A imbalanced-fr",
       "seed": 69,
-      "score": 0.6777777777777778
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds A imbalanced-fr",
-      "seed": 69,
-      "score": 0.61
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds A imbalanced-fr",
-      "seed": 69,
-      "score": 0.6421052631578946
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpds A imbalanced-fr",
-      "seed": 666,
-      "score": 0.55
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds A imbalanced-fr",
-      "seed": 666,
-      "score": 0.6954545454545454
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds A imbalanced-fr",
-      "seed": 666,
-      "score": 0.7088607594936709
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds A imbalanced-fr",
-      "seed": 666,
-      "score": 0.56
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds A imbalanced-fr",
-      "seed": 666,
-      "score": 0.6256983240223464
-    },
-    {
-      "metric": "accuracy",
-      "problem": "bpds A fewshot-fr",
-      "seed": 42,
-      "score": 0.5772727272727273
-    },
-    {
-      "metric": "oosAccuracy",
-      "problem": "bpds A fewshot-fr",
-      "seed": 42,
-      "score": 0.7045454545454546
-    },
-    {
-      "metric": "oosPrecision",
-      "problem": "bpds A fewshot-fr",
-      "seed": 42,
-      "score": 0.6521739130434783
-    },
-    {
-      "metric": "oosRecall",
-      "problem": "bpds A fewshot-fr",
-      "seed": 42,
-      "score": 0.75
-    },
-    {
-      "metric": "oosF1",
-      "problem": "bpds A fewshot-fr",
-      "seed": 42,
       "score": 0.6976744186046512
     },
     {
+      "metric": "oosRecall",
+      "problem": "bpds A imbalanced-fr",
+      "seed": 69,
+      "score": 0.6
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds A imbalanced-fr",
+      "seed": 69,
+      "score": 0.6451612903225806
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpds A imbalanced-fr",
+      "seed": 666,
+      "score": 0.5318181818181819
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpds A imbalanced-fr",
+      "seed": 666,
+      "score": 0.6772727272727272
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds A imbalanced-fr",
+      "seed": 666,
+      "score": 0.6835443037974683
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpds A imbalanced-fr",
+      "seed": 666,
+      "score": 0.54
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds A imbalanced-fr",
+      "seed": 666,
+      "score": 0.6033519553072625
+    },
+    {
+      "metric": "accuracy",
+      "problem": "bpds A fewshot-fr",
+      "seed": 42,
+      "score": 0.5818181818181818
+    },
+    {
+      "metric": "oosAccuracy",
+      "problem": "bpds A fewshot-fr",
+      "seed": 42,
+      "score": 0.7090909090909091
+    },
+    {
+      "metric": "oosPrecision",
+      "problem": "bpds A fewshot-fr",
+      "seed": 42,
+      "score": 0.6551724137931034
+    },
+    {
+      "metric": "oosRecall",
+      "problem": "bpds A fewshot-fr",
+      "seed": 42,
+      "score": 0.76
+    },
+    {
+      "metric": "oosF1",
+      "problem": "bpds A fewshot-fr",
+      "seed": 42,
+      "score": 0.7037037037037037
+    },
+    {
       "metric": "accuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.55
+      "score": 0.5363636363636364
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.7727272727272727
+      "score": 0.7681818181818182
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.8289473684210527
+      "score": 0.7951807228915663
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.63
+      "score": 0.66
     },
     {
       "metric": "oosF1",
       "problem": "bpds A fewshot-fr",
       "seed": 69,
-      "score": 0.715909090909091
+      "score": 0.7213114754098361
     },
     {
       "metric": "accuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.45454545454545453
+      "score": 0.45
     },
     {
       "metric": "oosAccuracy",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.7045454545454546
+      "score": 0.7
     },
     {
       "metric": "oosPrecision",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.7536231884057971
+      "score": 0.75
     },
     {
       "metric": "oosRecall",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.52
+      "score": 0.51
     },
     {
       "metric": "oosF1",
       "problem": "bpds A fewshot-fr",
       "seed": 666,
-      "score": 0.6153846153846154
+      "score": 0.6071428571428571
     }
   ]
 }

--- a/build/nlu-regression/current_scores/bpds-intent.json
+++ b/build/nlu-regression/current_scores/bpds-intent.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-27T14:43:18.032Z",
+  "generatedOn": "2021-01-27T17:19:52.754Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-slots.json
+++ b/build/nlu-regression/current_scores/bpds-slots.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-27T17:51:06.446Z",
+  "generatedOn": "2021-01-27T18:28:57.738Z",
   "scores": [
     {
       "metric": "avgScore:slotsAre",

--- a/build/nlu-regression/current_scores/bpds-slots.json
+++ b/build/nlu-regression/current_scores/bpds-slots.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-27T17:20:05.870Z",
+  "generatedOn": "2021-01-27T17:51:06.446Z",
   "scores": [
     {
       "metric": "avgScore:slotsAre",

--- a/build/nlu-regression/current_scores/bpds-slots.json
+++ b/build/nlu-regression/current_scores/bpds-slots.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-27T14:43:36.242Z",
+  "generatedOn": "2021-01-27T17:20:05.870Z",
   "scores": [
     {
       "metric": "avgScore:slotsAre",

--- a/build/nlu-regression/current_scores/bpds-slots.json
+++ b/build/nlu-regression/current_scores/bpds-slots.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-27T14:02:38.031Z",
+  "generatedOn": "2021-01-27T14:43:36.242Z",
   "scores": [
     {
       "metric": "avgScore:slotsAre",

--- a/build/nlu-regression/current_scores/bpds-spell.json
+++ b/build/nlu-regression/current_scores/bpds-spell.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-27T14:02:42.125Z",
+  "generatedOn": "2021-01-27T14:43:41.638Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-spell.json
+++ b/build/nlu-regression/current_scores/bpds-spell.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-27T17:51:10.550Z",
+  "generatedOn": "2021-01-27T18:29:01.289Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-spell.json
+++ b/build/nlu-regression/current_scores/bpds-spell.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-27T14:43:41.638Z",
+  "generatedOn": "2021-01-27T17:20:09.378Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-spell.json
+++ b/build/nlu-regression/current_scores/bpds-spell.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-27T17:20:09.378Z",
+  "generatedOn": "2021-01-27T17:51:10.550Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/clinc150.json
+++ b/build/nlu-regression/current_scores/clinc150.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-27T14:08:48.631Z",
+  "generatedOn": "2021-01-27T14:51:17.134Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/clinc150.json
+++ b/build/nlu-regression/current_scores/clinc150.json
@@ -1,23 +1,23 @@
 {
-  "generatedOn": "2021-01-27T17:57:57.231Z",
+  "generatedOn": "2021-01-27T18:35:47.658Z",
   "scores": [
     {
       "metric": "accuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.7244186046511628
+      "score": 0.7245348837209302
     },
     {
       "metric": "oosAccuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.8559302325581395
+      "score": 0.8554651162790697
     },
     {
       "metric": "oosPrecision",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.2848297213622291
+      "score": 0.28134556574923547
     },
     {
       "metric": "oosRecall",
@@ -29,7 +29,7 @@
       "metric": "oosF1",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.129304286718201
+      "score": 0.1289418360196216
     }
   ]
 }

--- a/build/nlu-regression/current_scores/clinc150.json
+++ b/build/nlu-regression/current_scores/clinc150.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-01-27T14:51:17.134Z",
+  "generatedOn": "2021-01-27T17:27:10.979Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/clinc150.json
+++ b/build/nlu-regression/current_scores/clinc150.json
@@ -1,35 +1,35 @@
 {
-  "generatedOn": "2021-01-27T17:27:10.979Z",
+  "generatedOn": "2021-01-27T17:57:57.231Z",
   "scores": [
     {
       "metric": "accuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.7246511627906976
+      "score": 0.7244186046511628
     },
     {
       "metric": "oosAccuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.8561627906976744
+      "score": 0.8559302325581395
     },
     {
       "metric": "oosPrecision",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.28792569659442724
+      "score": 0.2848297213622291
     },
     {
       "metric": "oosRecall",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.08454545454545455
+      "score": 0.08363636363636363
     },
     {
       "metric": "oosF1",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.13070976809557275
+      "score": 0.129304286718201
     }
   ]
 }

--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -7,7 +7,7 @@ import sizeof from 'object-sizeof'
 import { deserializeKmeans } from './clustering'
 import { EntityCacheManager } from './entities/entity-cache-manager'
 import { initializeTools } from './initialize-tools'
-import { BaseIntentClassifier } from './intents/base-intent-classifier'
+import { OOSIntentClassifier } from './intents/oos-intent-classfier'
 import DetectLanguage from './language/language-identifier'
 import makeSpellChecker from './language/spell-checker'
 import modelIdService from './model-id-service'
@@ -256,8 +256,8 @@ export default class Engine implements NLU.Engine {
 
     const warmKmeans = kmeans && deserializeKmeans(kmeans)
 
-    const intent_classifier_per_ctx: Dic<BaseIntentClassifier> = _.mapValues(intent_model_by_ctx, model => {
-      const intentClf = new BaseIntentClassifier(tools)
+    const intent_classifier_per_ctx: Dic<OOSIntentClassifier> = _.mapValues(intent_model_by_ctx, model => {
+      const intentClf = new OOSIntentClassifier(tools)
       intentClf.load(model)
       return intentClf
     })

--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -246,7 +246,7 @@ export default class Engine implements NLU.Engine {
   private async _makePredictors(input: TrainInput, output: TrainOutput): Promise<Predictors> {
     const tools = this._tools
 
-    const { ctx_model, intent_model_by_ctx, oos_model, kmeans } = output
+    const { ctx_model, intent_model_by_ctx, kmeans } = output
 
     /**
      * TODO: extract this function some place else,
@@ -278,10 +278,6 @@ export default class Engine implements NLU.Engine {
     }
 
     const ctx_classifier = ctx_model ? new tools.mlToolkit.SVM.Predictor(ctx_model) : undefined
-    const oos_classifier = _.toPairs(oos_model).reduce(
-      (c, [ctx, mod]) => ({ ...c, [ctx]: new tools.mlToolkit.SVM.Predictor(mod) }),
-      {} as _.Dictionary<MLToolkit.SVM.Predictor>
-    )
 
     let slot_tagger: SlotTagger | undefined
     if (output.slots_model.length) {
@@ -292,7 +288,6 @@ export default class Engine implements NLU.Engine {
     return {
       ...basePredictors,
       ctx_classifier,
-      oos_classifier_per_ctx: oos_classifier,
       slot_tagger
     }
   }

--- a/src/bp/nlu-core/intents/exact-matcher.ts
+++ b/src/bp/nlu-core/intents/exact-matcher.ts
@@ -1,8 +1,9 @@
 import { MLToolkit } from 'botpress/sdk'
 import _ from 'lodash'
-import { NONE_INTENT } from 'nlu-core/training-pipeline'
 import { Intent } from 'nlu-core/typings'
 import Utterance, { UtteranceToStringOptions } from 'nlu-core/utterance/utterance'
+
+import { NONE_INTENT } from './oos-intent-classfier'
 
 export const EXACT_MATCH_STR_OPTIONS: UtteranceToStringOptions = {
   lowerCase: true,

--- a/src/bp/nlu-core/intents/intent-classifier.d.ts
+++ b/src/bp/nlu-core/intents/intent-classifier.d.ts
@@ -2,6 +2,7 @@ import { Intent, ListEntityModel, PatternEntity } from 'nlu-core/typings'
 import Utterance from 'nlu-core/utterance/utterance'
 
 export interface IntentTrainInput {
+  languageCode: string
   list_entities: ListEntityModel[]
   pattern_entities: PatternEntity[]
   intents: Intent<Utterance>[]

--- a/src/bp/nlu-core/intents/intent-classifier.d.ts
+++ b/src/bp/nlu-core/intents/intent-classifier.d.ts
@@ -1,8 +1,6 @@
 import { Intent, ListEntityModel, PatternEntity } from 'nlu-core/typings'
 import Utterance from 'nlu-core/utterance/utterance'
 
-import { ExactMatchIndex } from './exact-matcher'
-
 export interface IntentTrainInput {
   list_entities: ListEntityModel[]
   pattern_entities: PatternEntity[]

--- a/src/bp/nlu-core/intents/oos-intent-classfier.ts
+++ b/src/bp/nlu-core/intents/oos-intent-classfier.ts
@@ -1,0 +1,174 @@
+import { MLToolkit } from 'botpress/sdk'
+import _ from 'lodash'
+import { isPOSAvailable } from 'nlu-core/language/pos-tagger'
+import {
+  featurizeInScopeUtterances,
+  featurizeOOSUtterances,
+  getUtteranceFeatures
+} from 'nlu-core/out-of-scope-featurizer'
+import { NONE_INTENT } from 'nlu-core/training-pipeline'
+import { Intent, Tools } from 'nlu-core/typings'
+import Utterance from 'nlu-core/utterance/utterance'
+
+import { BaseIntentClassifier, MIN_NB_UTTERANCES } from './base-intent-classifier'
+import { IntentTrainInput, NoneableIntentClassifier, NoneableIntentPredictions } from './intent-classifier'
+
+interface TrainInput extends IntentTrainInput {
+  allUtterances: Utterance[]
+  noneIntent: Intent<Utterance>
+}
+
+interface Model {
+  trainingVocab: string[]
+  baseIntentClfModel: string
+  oosSvmModel: string | undefined
+}
+
+interface Predictors {
+  baseIntentClf: BaseIntentClassifier
+  oosSvm: MLToolkit.SVM.Predictor | undefined
+  trainingVocab: string[]
+}
+
+export class OOSIntentClassifier implements NoneableIntentClassifier {
+  private model: Model | undefined
+  private predictors: Predictors | undefined
+
+  constructor(private tools: Tools) {}
+
+  public async train(trainInput: TrainInput, progress: (p: number) => void): Promise<void> {
+    const { noneIntent } = trainInput
+
+    const [ooScopeModel, inScopeModel] = await Promise.all([
+      this._trainOOScopeSvm(trainInput, noneIntent, (p: number) => progress(p / 2)),
+      this._trainInScopeSvm(trainInput, noneIntent, (p: number) => progress(p / 2))
+    ])
+
+    this.model = {
+      oosSvmModel: ooScopeModel,
+      baseIntentClfModel: inScopeModel,
+      trainingVocab: this.getVocab(trainInput.allUtterances)
+    }
+  }
+
+  private async _trainOOScopeSvm(
+    trainInput: TrainInput,
+    noneIntent: Omit<Intent<Utterance>, 'contexts'>,
+    progress: (p: number) => void
+  ): Promise<string | undefined> {
+    const { allUtterances, nluSeed, intents } = trainInput
+    const { languageCode } = allUtterances[0]
+
+    const trainingOptions: MLToolkit.SVM.SVMOptions = {
+      c: [10], // so there's no grid search
+      kernel: 'LINEAR',
+      classifier: 'C_SVC',
+      seed: nluSeed
+    }
+
+    const noneUtts = noneIntent.utterances
+
+    if (!isPOSAvailable(languageCode) || noneUtts.length === 0) {
+      progress(1)
+      return
+    }
+
+    const vocab = this.getVocab(allUtterances)
+    const oos_points = featurizeOOSUtterances(noneUtts, vocab, this.tools)
+
+    const in_ctx_scope_points = _.chain(intents)
+      .filter(i => i.name !== NONE_INTENT)
+      .flatMap(i => featurizeInScopeUtterances(i.utterances, i.name))
+      .value()
+
+    const svm = new this.tools.mlToolkit.SVM.Trainer()
+
+    const model = await svm.train([...in_ctx_scope_points, ...oos_points], trainingOptions, progress)
+    return model
+  }
+
+  private async _trainInScopeSvm(
+    trainInput: TrainInput,
+    noneIntent: Omit<Intent<Utterance>, 'contexts'>,
+    progress: (p: number) => void
+  ): Promise<string> {
+    const baseIntentClf = new BaseIntentClassifier(this.tools)
+    const noneUtts = noneIntent.utterances.filter(u => u.tokens.filter(t => t.isWord).length >= 3)
+    const trainableIntents = trainInput.intents.filter(
+      i => i.name !== NONE_INTENT && i.utterances.length >= MIN_NB_UTTERANCES
+    )
+    const nAvgUtts = Math.ceil(_.meanBy(trainableIntents, i => i.utterances.length))
+
+    const lo = this.tools.seededLodashProvider.getSeededLodash()
+
+    trainInput.intents.push({
+      name: NONE_INTENT,
+      utterances: lo
+        .chain(noneUtts)
+        .shuffle()
+        .take(nAvgUtts * 2.5) // undescriptible magic n, no sens to extract constant
+        .value(),
+      contexts: [...trainInput.intents[0].contexts],
+      slot_definitions: []
+    })
+
+    await baseIntentClf.train(trainInput, progress)
+    return baseIntentClf.serialize()
+  }
+
+  private getVocab(utts: Utterance[]) {
+    return _.flatMap(utts, u => u.tokens.map(t => t.toString({ lowerCase: true })))
+  }
+
+  public serialize(): string {
+    if (!this.model) {
+      throw new Error('Intent classifier must be trained before calling serialize')
+    }
+    return JSON.stringify(this.model)
+  }
+
+  public load(serialized: string): void {
+    const model: Model = JSON.parse(serialized) // TODO: validate input
+
+    const { oosSvmModel, baseIntentClfModel, trainingVocab } = model
+
+    const baseIntentClf = new BaseIntentClassifier(this.tools)
+    baseIntentClf.load(baseIntentClfModel)
+
+    this.predictors = {
+      oosSvm: oosSvmModel ? new this.tools.mlToolkit.SVM.Predictor(oosSvmModel) : undefined,
+      baseIntentClf,
+      trainingVocab
+    }
+  }
+
+  public async predict(utterance: Utterance): Promise<NoneableIntentPredictions> {
+    if (!this.predictors) {
+      throw new Error('Intent classifier must be either trained or a model must be loaded before calling predict')
+    }
+
+    const { oosSvm, baseIntentClf, trainingVocab } = this.predictors
+
+    const intentPredictions = await baseIntentClf.predict(utterance)
+
+    let oosPrediction = 0
+    if (oosSvm) {
+      const feats = getUtteranceFeatures(utterance, trainingVocab)
+      try {
+        const preds = await oosSvm.predict(feats)
+        oosPrediction =
+          _.chain(preds)
+            .filter(p => p.label.startsWith('out'))
+            .maxBy(p => p.confidence)
+            .value()?.confidence || 0
+      } catch (err) {}
+    }
+
+    // TODO: proceed to election between none intent and oos, remove none intent and make sure confidences sum to 1.
+
+    return {
+      ...intentPredictions,
+      oos: oosPrediction
+    }
+  }
+}

--- a/src/bp/nlu-core/predict-pipeline.test.ts
+++ b/src/bp/nlu-core/predict-pipeline.test.ts
@@ -12,8 +12,7 @@ describe('predict pipeline', () => {
       {
         rawText: "hello, I love you won't you tell me your name",
         languageCode,
-        utterance: new Utterance([], [], [], languageCode),
-        oos_predictions: {}
+        utterance: new Utterance([], [], [], languageCode)
       },
       <Predictors>{ contexts, ctx_classifier: undefined }
     )
@@ -32,8 +31,7 @@ describe('predict pipeline', () => {
       {
         rawText: "hello, I love you won't you tell me your name",
         languageCode,
-        utterance: new Utterance([], [], [], languageCode),
-        oos_predictions: {}
+        utterance: new Utterance([], [], [], languageCode)
       },
       <Predictors>{ contexts, ctx_classifier: undefined }
     )
@@ -55,8 +53,7 @@ describe('predict pipeline', () => {
       {
         rawText: "hello, I love you won't you tell me your name",
         languageCode,
-        utterance: new Utterance([], [], [], languageCode),
-        oos_predictions: {}
+        utterance: new Utterance([], [], [], languageCode)
       },
       <Predictors>{ contexts, ctx_classifier: undefined }
     )

--- a/src/bp/nlu-core/predict-pipeline.test.ts
+++ b/src/bp/nlu-core/predict-pipeline.test.ts
@@ -68,7 +68,7 @@ describe('predict pipeline', () => {
     const intents = Object.values(intent_predictions)
     expect(ctxs).toEqual(contexts)
     for (const i of intents) {
-      expect(i).toEqual([{ label: 'none', confidence: 1 }])
+      expect(i).toEqual({ oos: 1, intents: [{ name: 'none', confidence: 1 }] })
     }
   })
 })

--- a/src/bp/nlu-core/predict-pipeline.ts
+++ b/src/bp/nlu-core/predict-pipeline.ts
@@ -2,8 +2,8 @@ import { MLToolkit, NLU } from 'botpress/sdk'
 import _ from 'lodash'
 
 import { extractListEntities, extractPatternEntities } from './entities/custom-entity-extractor'
-import { BaseIntentClassifier } from './intents/base-intent-classifier'
 import { getCtxFeatures } from './intents/context-featurizer'
+import { OOSIntentClassifier } from './intents/oos-intent-classfier'
 import { isPOSAvailable } from './language/pos-tagger'
 import { getUtteranceFeatures } from './out-of-scope-featurizer'
 import SlotTagger from './slots/slot-tagger'
@@ -28,7 +28,7 @@ export type Predictors = {
   contexts: string[]
   pattern_entities: PatternEntity[]
   intents: Intent<Utterance>[]
-  intent_classifier_per_ctx: _.Dictionary<BaseIntentClassifier>
+  intent_classifier_per_ctx: _.Dictionary<OOSIntentClassifier>
 } & Partial<{
   ctx_classifier: MLToolkit.SVM.Predictor
   oos_classifier_per_ctx: _.Dictionary<MLToolkit.SVM.Predictor>

--- a/src/bp/nlu-core/training-pipeline.ts
+++ b/src/bp/nlu-core/training-pipeline.ts
@@ -317,7 +317,9 @@ export const AppendNoneIntent = async (input: TrainStep, tools: Tools): Promise<
     .chain(input.tfIdf)
     .toPairs()
     .filter(([word, tfidf]) => tfidf <= SMALL_TFIDF)
-    .map('0')
+    .map(p => p[0])
+    .uniq()
+    .orderBy(t => t)
     .value()
 
   // If 30% in utterances is a space, language is probably space-separated so we'll join tokens using spaces

--- a/src/bp/nlu-core/warm-training-handler.test.ts
+++ b/src/bp/nlu-core/warm-training-handler.test.ts
@@ -30,10 +30,6 @@ const _makeTrainOuput = (
       .map(i => [i.ctx, i.model])
       .fromPairs()
       .value(),
-    oos_model: _(oosModels)
-      .map(i => [i.ctx, i.model])
-      .fromPairs()
-      .value(),
     kmeans: {
       centroids: [],
       clusters: [],
@@ -197,7 +193,6 @@ describe('mergeModelsOutputs', () => {
     expect(output.contexts.length).toBe(1)
     expect(output.contexts[0]).toBe('A')
 
-    expect(output.oos_model['A']).toBe('oos model for A')
     expect(output.intent_model_by_ctx['A']).toBe('intent model for A')
   })
 
@@ -233,8 +228,6 @@ describe('mergeModelsOutputs', () => {
     expect(output.contexts.sort()[0]).toBe('A')
     expect(output.contexts.sort()[1]).toBe('B')
 
-    expect(output.oos_model['A']).toBe('oos model for A')
-    expect(output.oos_model['B']).toBe('modified oos model for B')
     expect(output.intent_model_by_ctx['A']).toBe('intent model for A')
     expect(output.intent_model_by_ctx['B']).toBe('modified intent model for B')
   })
@@ -265,8 +258,6 @@ describe('mergeModelsOutputs', () => {
     expect(output.contexts.sort()[0]).toBe('A')
     expect(output.contexts.sort()[1]).toBe('B')
 
-    expect(output.oos_model['A']).toBe('oos model for A')
-    expect(output.oos_model['B']).toBe('created oos model for B')
     expect(output.intent_model_by_ctx['A']).toBe('intent model for A')
     expect(output.intent_model_by_ctx['B']).toBe('created intent model for B')
   })
@@ -306,9 +297,6 @@ describe('mergeModelsOutputs', () => {
     expect(output.contexts.sort()[1]).toBe('B')
     expect(output.contexts.sort()[2]).toBe('C')
 
-    expect(output.oos_model['A']).toBe('modified oos model for A')
-    expect(output.oos_model['B']).toBe('modified oos model for B')
-    expect(output.oos_model['C']).toBe('created oos model for C')
     expect(output.intent_model_by_ctx['A']).toBe('modified intent model for A')
     expect(output.intent_model_by_ctx['B']).toBe('modified intent model for B')
     expect(output.intent_model_by_ctx['C']).toBe('created intent model for C')

--- a/src/bp/nlu-core/warm-training-handler.ts
+++ b/src/bp/nlu-core/warm-training-handler.ts
@@ -63,9 +63,7 @@ export const mergeModelOutputs = (
   const output = { ...currentOutput }
 
   const previousIntents = _.pick(previousOutput.intent_model_by_ctx, contexts)
-  const previousOOS = _.pick(previousOutput.oos_model, contexts)
 
   output.intent_model_by_ctx = { ...previousIntents, ...currentOutput.intent_model_by_ctx }
-  output.oos_model = { ...previousOOS, ...currentOutput.oos_model }
   return output
 }


### PR DESCRIPTION
There is now an "noneable" intent classifier. Its noneable, because it allowed to add a label called "oos" to the existing labels.

This clf is reponsible for creating the none intent and managing the "base" intent classifier.

Results have change, but only in commit 909065654f8669f34412e55ccd9a6c93228f3565. This commit changes one line where I reorder the vocab words used to generate none intent. Fair to say, results have not changed except for some random ordering reason.