### PR TITLE
fix(hitl2): fetchShortcuts being called infinitely

### DIFF
--- a/modules/hitlnext/src/views/lite/ShortcutComposer.tsx
+++ b/modules/hitlnext/src/views/lite/ShortcutComposer.tsx
@@ -52,7 +52,7 @@ const ShortcutComposer: FC<ComposerProps> = props => {
   useEffect(() => {
     // tslint:disable-next-line: no-floating-promises
     fetchShortcuts().finally(() => setIsLoading(false))
-  })
+  }, [])
 
   const sendMessage = async (): Promise<void> => {
     if (!canSendText()) {


### PR DESCRIPTION
This PR fixes an issue where the function `fetchShortcuts` of the `ShortcutComposer` would endlessly loop when opening an assigned an handoff

e.g.

https://user-images.githubusercontent.com/9640576/106038979-9379c200-60a6-11eb-8a9c-780d650812d6.mp4

