### PR TITLE
fix(hitl2): set correct agent attributes

### DIFF
--- a/modules/hitlnext/src/backend/repository.ts
+++ b/modules/hitlnext/src/backend/repository.ts
@@ -301,9 +301,9 @@ export default class Repository {
     })
 
     return {
-      ...data.payload,
       agentId,
-      online: await this.getAgentOnline(botId, agentId)
+      online: await this.getAgentOnline(botId, agentId),
+      attributes: data.payload
     } as IAgent
   }
 


### PR DESCRIPTION
Display agent name when set wasn't working, now it is

before 
![Screen Shot 2021-01-28 at 5 42 23 PM](https://user-images.githubusercontent.com/955524/106208469-6e15b280-6191-11eb-94a4-c4e1065760f5.png)

after
![Screen Shot 2021-01-28 at 5 50 42 PM](https://user-images.githubusercontent.com/955524/106208479-71a93980-6191-11eb-836a-ce68a7c5fc37.png)
