### PR TITLE
fix(core): delete all expired sessions

### DIFF
--- a/src/bp/core/repositories/sessions.ts
+++ b/src/bp/core/repositories/sessions.ts
@@ -28,7 +28,7 @@ export interface SessionRepository {
   getOrCreateSession(sessionId: string, botId: string, trx?: Knex.Transaction): Promise<DialogSession>
   get(id: string, botId: string): Promise<DialogSession>
   getExpiredContextSessionIds(botId: string): Promise<string[]>
-  deleteExpiredSessions(botId: string)
+  deleteExpiredSessions()
   delete(id: string)
   update(session: DialogSession, trx?: Knex.Transaction)
 }
@@ -126,10 +126,9 @@ export class KnexSessionRepository implements SessionRepository {
       })) as string[]
   }
 
-  async deleteExpiredSessions(botId: string): Promise<void> {
+  async deleteExpiredSessions(): Promise<void> {
     await this.database
       .knex(this.tableName)
-      .where('botId', botId)
       .andWhere(this.database.knex.date.isBefore('session_expiry', new Date()))
       .del()
   }

--- a/src/bp/core/services/dialog/janitor.ts
+++ b/src/bp/core/services/dialog/janitor.ts
@@ -55,8 +55,9 @@ export class DialogJanitor extends Janitor {
     const botsConfigs = await this.botService.getBots()
     const botsIds = Array.from(botsConfigs.keys())
 
+    await this.sessionRepo.deleteExpiredSessions()
+
     for (const botId of botsIds) {
-      await this.sessionRepo.deleteExpiredSessions(botId)
       const sessionsIds = await this.sessionRepo.getExpiredContextSessionIds(botId)
 
       if (sessionsIds.length > 0) {


### PR DESCRIPTION
This PR fixes an issue where only sessions from active bots would be delete when expired. This means that if you made a copy of a bot and deleted the old version, or even simply promoted it to a new stage, its old sessions would never be deleted.

I think the same applies for the logs!