### PR TITLE
fix(core): bad data type for migration

### DIFF
--- a/src/bp/core/database/tables/server-wide/migrations.ts
+++ b/src/bp/core/database/tables/server-wide/migrations.ts
@@ -9,7 +9,7 @@ export class MigrationsTable extends Table {
       table.increments('id')
       table.string('initialVersion')
       table.string('targetVersion')
-      table.string('details')
+      table.text('details')
       table.timestamps(true, true)
       created = true
     })

--- a/src/bp/core/services/migration/index.ts
+++ b/src/bp/core/services/migration/index.ts
@@ -117,9 +117,13 @@ export class MigrationService {
       targetVersion: this.currentVersion
     }
 
-    await this.database
-      .knex('srv_migrations')
-      .insert({ ...entry, details: logs.join('\n'), created_at: this.database.knex.date.now() })
+    try {
+      await this.database
+        .knex('srv_migrations')
+        .insert({ ...entry, details: logs.join('\n'), created_at: this.database.knex.date.now() })
+    } catch (err) {
+      this.logger.error('Error persisting migrations')
+    }
 
     const hasBotMigrations = !!missingMigrations.find(x => this.loadedMigrations[x.filename].info.target === 'bot')
     if (hasBotMigrations) {

--- a/src/bp/migrations/v12_17_1-1611947414-fix_migration_table.ts
+++ b/src/bp/migrations/v12_17_1-1611947414-fix_migration_table.ts
@@ -1,0 +1,63 @@
+import * as sdk from 'botpress/sdk'
+import { Migration } from 'core/services/migration'
+
+const TABLE_NAME = 'srv_migrations'
+const TEMP_TABLE_NAME = 'srv_migrations_temp'
+
+const migration: Migration = {
+  info: {
+    description: 'Fix migration table field type',
+    target: 'core',
+    type: 'database'
+  },
+  up: async ({ database }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
+    const db = database.knex as sdk.KnexExtended
+
+    const { client } = db.client.config
+    let columnType
+
+    if (db.isLite) {
+      const tableInfo = await db.raw(`PRAGMA table_info([${TABLE_NAME}])`)
+      columnType = tableInfo[3].type
+    } else {
+      const query = await db('information_schema.columns')
+        .select('data_type')
+        .where({ table_name: TABLE_NAME, column_name: 'details' })
+        .first()
+
+      columnType = query.data_type
+    }
+
+    if (columnType === 'text') {
+      return { success: true, message: 'Field already fixed' }
+    }
+
+    if (!db.isLite) {
+      await db.raw('ALTER TABLE srv_migrations ALTER COLUMN details TYPE text')
+    } else {
+      await db.transaction(async trx => {
+        await db.schema.transacting(trx).createTableIfNotExists('srv_migrations_temp', table => {
+          table.increments('id')
+          table.string('initialVersion')
+          table.string('targetVersion')
+          table.text('details')
+          table.timestamps(true, true)
+        })
+
+        await trx.raw(`
+          INSERT OR IGNORE INTO
+            ${TEMP_TABLE_NAME} (id, initialVersion, targetVersion, details, created_at, updated_at)
+          SELECT
+            *
+          FROM ${TABLE_NAME}`)
+
+        await database.knex.schema.transacting(trx).dropTable(TABLE_NAME)
+        await database.knex.schema.transacting(trx).renameTable(TEMP_TABLE_NAME, TABLE_NAME)
+      })
+    }
+
+    return { success: true, message: 'Field type changed successfully' }
+  }
+}
+
+export default migration

--- a/src/bp/migrations/v12_17_1-1611947414-fix_migration_table.ts
+++ b/src/bp/migrations/v12_17_1-1611947414-fix_migration_table.ts
@@ -36,7 +36,7 @@ const migration: Migration = {
       await db.raw('ALTER TABLE srv_migrations ALTER COLUMN details TYPE text')
     } else {
       await db.transaction(async trx => {
-        await db.schema.transacting(trx).createTableIfNotExists('srv_migrations_temp', table => {
+        await db.schema.transacting(trx).createTableIfNotExists(TEMP_TABLE_NAME, table => {
           table.increments('id')
           table.string('initialVersion')
           table.string('targetVersion')


### PR DESCRIPTION
The default type for migration details in the database is varchar 255, so migration fails if the log is bigger... This changes the type from varchar to text. Added a try/catch on the database step otherwise it may prevent the migration from being executed...