### PR TITLE
fix(misunderstood): emulator overlapping misunderstood buttons

### DIFF
--- a/modules/misunderstood/src/views/full/style.scss
+++ b/modules/misunderstood/src/views/full/style.scss
@@ -164,7 +164,6 @@
   padding: 10px 15px;
   position: absolute;
   right: 0;
-  text-align: right;
   z-index: 9;
 
   button {


### PR DESCRIPTION
Fix botpress/v12#1174 by aligning buttons to the left

![image](https://user-images.githubusercontent.com/13484138/106898658-39df4c00-66d3-11eb-97f9-b14ff6a411a6.png)
