### PR TITLE
fix(nlu): bring back debugging during training

### DIFF
--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -85,13 +85,9 @@ export default class Engine implements NLU.Engine {
     return !!this.modelsById.get(stringId)
   }
 
-  async train(
-    trainSessionId: string,
-    trainSet: NLU.TrainingSet,
-    opt: Partial<NLU.TrainingOptions> = {}
-  ): Promise<NLU.Model> {
+  async train(trainId: string, trainSet: NLU.TrainingSet, opt: Partial<NLU.TrainingOptions> = {}): Promise<NLU.Model> {
     const { languageCode, seed, entityDefs, intentDefs } = trainSet
-    trainDebug(`Started ${languageCode} training`)
+    trainDebug(`[${trainId}] Started ${languageCode} training`)
 
     const options = { ...DEFAULT_TRAINING_OPTIONS, ...opt }
 
@@ -147,10 +143,10 @@ export default class Engine implements NLU.Engine {
     const debugMsg = previousModel
       ? `Retraining only contexts: [${ctxToTrain}] for language: ${languageCode}`
       : `Training all contexts for language: ${languageCode}`
-    trainDebug(debugMsg)
+    trainDebug(`[${trainId}] ${debugMsg}`)
 
     const input: TrainInput = {
-      trainId: trainSessionId,
+      trainId,
       nluSeed: seed,
       languageCode,
       list_entities,
@@ -182,7 +178,7 @@ export default class Engine implements NLU.Engine {
       model.data.output = mergeModelOutputs(model.data.output, previousModel.model.data.output, contexts)
     }
 
-    trainDebug(`Successfully finished ${languageCode} training`)
+    trainDebug(`[${trainId}] Successfully finished ${languageCode} training`)
 
     return serializeModel(model)
   }

--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -150,6 +150,7 @@ export default class Engine implements NLU.Engine {
     trainDebug(debugMsg)
 
     const input: TrainInput = {
+      trainId: trainSessionId,
       nluSeed: seed,
       languageCode,
       list_entities,
@@ -160,7 +161,7 @@ export default class Engine implements NLU.Engine {
     }
 
     const startedAt = new Date()
-    const output = await this._trainingWorkerQueue.startTraining(trainSessionId, input, progressCallback)
+    const output = await this._trainingWorkerQueue.startTraining(input, progressCallback)
 
     const modelId = modelIdService.makeId({
       ...trainSet,

--- a/src/bp/nlu-core/intents/exact-matcher.test.ts
+++ b/src/bp/nlu-core/intents/exact-matcher.test.ts
@@ -34,7 +34,7 @@ describe('Exact match', () => {
     intents: [intent1, intent2, noneIntent]
   } as TrainStep
 
-  const exactMatchIndex = BuildExactMatchIndex(input, {} as Tools)
+  const exactMatchIndex = BuildExactMatchIndex(input)
   describe('Build exact match index', () => {
     test('none intent not added', () => {
       Object.values(exactMatchIndex).forEach(entry => {

--- a/src/bp/nlu-core/intents/exact-matcher.test.ts
+++ b/src/bp/nlu-core/intents/exact-matcher.test.ts
@@ -1,7 +1,7 @@
 import { findExactIntentForCtx } from '../predict-pipeline'
 import { SPECIAL_CHARSET } from '../tools/chars'
 import { BuildExactMatchIndex, TrainStep } from '../training-pipeline'
-import { Intent } from '../typings'
+import { Intent, Tools } from '../typings'
 import Utterance, { makeTestUtterance } from '../utterance/utterance'
 
 const u1 = 'Hi my name is Alex W and I try to make NLU for a living'
@@ -34,7 +34,7 @@ describe('Exact match', () => {
     intents: [intent1, intent2, noneIntent]
   } as TrainStep
 
-  const exactMatchIndex = BuildExactMatchIndex(input)
+  const exactMatchIndex = BuildExactMatchIndex(input, {} as Tools)
   describe('Build exact match index', () => {
     test('none intent not added', () => {
       Object.values(exactMatchIndex).forEach(entry => {

--- a/src/bp/nlu-core/training-pipeline.test.ts
+++ b/src/bp/nlu-core/training-pipeline.test.ts
@@ -35,7 +35,7 @@ test('tfidf has a value for all tokens of the training set', async () => {
   const intents: Intent<Utterance>[] = [installBpIntent, reportBugIntent]
 
   // act
-  const { tfIdf } = await TfidfTokens({ intents } as TrainStep, {} as Tools)
+  const { tfIdf } = await TfidfTokens({ intents } as TrainStep)
 
   // assert
   const botpressToken = 'botpress'

--- a/src/bp/nlu-core/training-pipeline.test.ts
+++ b/src/bp/nlu-core/training-pipeline.test.ts
@@ -2,7 +2,7 @@ import _ from 'lodash'
 
 import { tokenizeLatinTextForTests } from './tools/token-utils'
 import { TfidfTokens, TrainStep } from './training-pipeline'
-import { Intent } from './typings'
+import { Intent, Tools } from './typings'
 import Utterance from './utterance/utterance'
 
 test('tfidf has a value for all tokens of the training set', async () => {
@@ -35,7 +35,7 @@ test('tfidf has a value for all tokens of the training set', async () => {
   const intents: Intent<Utterance>[] = [installBpIntent, reportBugIntent]
 
   // act
-  const { tfIdf } = await TfidfTokens({ intents } as TrainStep)
+  const { tfIdf } = await TfidfTokens({ intents } as TrainStep, {} as Tools)
 
   // assert
   const botpressToken = 'botpress'

--- a/src/bp/nlu-core/training-pipeline.ts
+++ b/src/bp/nlu-core/training-pipeline.ts
@@ -521,6 +521,8 @@ const makeLogDecorator = (trainId: string, logger?: sdk.NLU.Logger) => {
 }
 
 export const Trainer = async (input: TrainInput, tools: Tools, progress: (x: number) => void): Promise<TrainOutput> => {
+  tools.logger?.debug(`[${input.trainId}] Started running training pipeline.`)
+
   let totalProgress = 0
   let normalizedProgress = 0
 
@@ -559,7 +561,6 @@ export const Trainer = async (input: TrainInput, tools: Tools, progress: (x: num
   ])
 
   debouncedProgress.flush()
-  tools.logger?.debug(`[${input.trainId}] Done training.`)
 
   const [oos_model, ctx_model, intent_model_by_ctx, slots_model] = models
 
@@ -581,5 +582,6 @@ export const Trainer = async (input: TrainInput, tools: Tools, progress: (x: num
     contexts: input.contexts
   }
 
+  tools.logger?.debug(`[${input.trainId}] Done running training pipeline.`)
   return output
 }

--- a/src/bp/nlu-core/training-worker-queue/communication.ts
+++ b/src/bp/nlu-core/training-worker-queue/communication.ts
@@ -16,7 +16,7 @@ export interface OutgoingMessage<T extends OutgoingMessageType> {
   destWorkerId: number
 }
 
-export type Log = Partial<{ info: string; warning: string; error: string }>
+export type Log = Partial<{ info: string; warning: string; error: string; debug: string }>
 export type IncomingPayload<T extends IncomingMessageType> = T extends 'log'
   ? { log: Log; requestId: string }
   : T extends 'worker_ready'

--- a/src/bp/nlu-core/training-worker-queue/index.ts
+++ b/src/bp/nlu-core/training-worker-queue/index.ts
@@ -25,8 +25,6 @@ import {
 
 const debugTraining = DEBUG('nlu').sub('training')
 
-const MASTER_WORKER_ID: number = NaN
-
 export class TrainingWorkerQueue {
   private readyWorkers: number[] = []
   private activeWorkers: { [trainSessionId: string]: number } = {}
@@ -180,7 +178,7 @@ if (cluster.isMaster) {
     const log: IncomingMessage<'log'> = {
       type: 'log',
       payload: { log: { debug: msg }, requestId },
-      srcWorkerId: MASTER_WORKER_ID
+      srcWorkerId: 0
     }
     sendToWebWorker(log)
   }

--- a/src/bp/nlu-core/training-worker-queue/index.ts
+++ b/src/bp/nlu-core/training-worker-queue/index.ts
@@ -66,7 +66,7 @@ export class TrainingWorkerQueue {
     if (!this.readyWorkers.length) {
       debugTraining(`[${input.trainId}] About to make new training worker`)
       const newWorker = await this._createNewWorker(trainId)
-      debugTraining(`[${input.trainId}] Creation of training worker done. Worker id is ${newWorker}`)
+      debugTraining(`[${input.trainId}] Creation of training worker ${newWorker} done.`)
       this.readyWorkers.push(newWorker)
     }
 
@@ -214,9 +214,9 @@ if (cluster.isMaster) {
   }
 
   registerMsgHandler('make_new_worker', async (msg: OutgoingMessage<'make_new_worker'>) => {
-    debugLog('About to spawn new process.', msg.payload.requestId)
+    debugLog('About to spawn new training process.', msg.payload.requestId)
     await spawnNewTrainingWorker(msg.payload.config, msg.payload.requestId)
-    debugLog('Done spawning new process.', msg.payload.requestId)
+    debugLog('Done spawning new training process.', msg.payload.requestId)
   })
   registerMsgHandler('cancel_training', killTrainingWorker)
   registerMsgHandler('start_training', sendToTrainingWorker)

--- a/src/bp/nlu-core/training-worker-queue/index.ts
+++ b/src/bp/nlu-core/training-worker-queue/index.ts
@@ -217,7 +217,7 @@ if (cluster.isMaster) {
 
   registerMsgHandler('make_new_worker', async (msg: OutgoingMessage<'make_new_worker'>) => {
     debugLog('About to spawn new process.', msg.payload.requestId)
-    spawnNewTrainingWorker(msg.payload.config, msg.payload.requestId)
+    await spawnNewTrainingWorker(msg.payload.config, msg.payload.requestId)
     debugLog('Done spawning new process.', msg.payload.requestId)
   })
   registerMsgHandler('cancel_training', killTrainingWorker)

--- a/src/bp/nlu-server/index.ts
+++ b/src/bp/nlu-server/index.ts
@@ -55,7 +55,8 @@ export default async function(options: ArgV) {
 
   options.modelDir = options.modelDir || path.join(process.APP_DATA_PATH, 'models')
 
-  const loggerWrapper = <NLU.Logger>{
+  const loggerWrapper: NLU.Logger = {
+    debug: (msg: string) => logger.debug(msg),
     info: (msg: string) => logger.info(msg),
     warning: (msg: string, err?: Error) => (err ? logger.attachError(err).warn(msg) : logger.warn(msg)),
     error: (msg: string, err?: Error) => (err ? logger.attachError(err).error(msg) : logger.error(msg))

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -455,6 +455,7 @@ declare module 'botpress/sdk' {
     }
 
     export interface Logger {
+      debug: (msg: string) => void
       info: (msg: string) => void
       warning: (msg: string, err?: Error) => void
       error: (msg: string, err?: Error) => void


### PR DESCRIPTION
I should have done this earlier... This took me less than an hour to figure out and its really usefull.

The previous `DEBUG` instance had no access on the enabled scopes (in training process).

The first solution I tought of was to pass the enabled debug scopes when creating the process, but this meant these scopes could not change for the whole life of the process.

By wiring up the logs to the web process, we can use the usual `DEBUG` mecanic we use everywhere.  