### PR TITLE
chore(core): add support for hooks to throw on error

### DIFF
--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -440,7 +440,10 @@ export class BotService {
       actions: [currentStage.action]
     }
 
-    await this.hookService.executeHook(new Hooks.OnStageChangeRequest(api, alteredBot, users, pipeline, hookResult))
+    await this.hookService.executeHook(
+      new Hooks.OnStageChangeRequest(api, alteredBot, users, pipeline, hookResult),
+      true
+    )
     if (_.isArray(hookResult.actions)) {
       await Promise.map(hookResult.actions, async action => {
         if (bpConfig.autoRevision && (await this.botExists(alteredBot.id))) {

--- a/src/bp/core/services/bot-service.ts
+++ b/src/bp/core/services/bot-service.ts
@@ -440,10 +440,7 @@ export class BotService {
       actions: [currentStage.action]
     }
 
-    await this.hookService.executeHook(
-      new Hooks.OnStageChangeRequest(api, alteredBot, users, pipeline, hookResult),
-      true
-    )
+    await this.hookService.executeHook(new Hooks.OnStageChangeRequest(api, alteredBot, users, pipeline, hookResult))
     if (_.isArray(hookResult.actions)) {
       await Promise.map(hookResult.actions, async action => {
         if (bpConfig.autoRevision && (await this.botExists(alteredBot.id))) {


### PR DESCRIPTION
This PR adds the possibility to tell the HookService to throw an error when a hook execution fails.