### PR TITLE
fix(studio): emulator push content to the left when open

### DIFF
--- a/modules/misunderstood/src/views/full/style.scss
+++ b/modules/misunderstood/src/views/full/style.scss
@@ -164,6 +164,7 @@
   padding: 10px 15px;
   position: absolute;
   right: 0;
+  text-align: right;
   z-index: 9;
 
   button {

--- a/src/bp/ui-shared/src/MainLayout/RightSidebar/style.scss
+++ b/src/bp/ui-shared/src/MainLayout/RightSidebar/style.scss
@@ -3,8 +3,6 @@
 }
 
 :global(.emulator-open) {
-  padding-right: calc(var(--spacing-x-large) + var(--emulator-width)) !important;
-
   &.wRightSidebar {
     padding-right: calc(var(--spacing-x-large) + var(--right-sidebar-width) + var(--emulator-width)) !important;
   }

--- a/src/bp/ui-studio/src/web/components/Layout/BottomPanel/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/BottomPanel/index.tsx
@@ -99,7 +99,7 @@ const BottomPanel = props => {
         {props.inspectorEnabled && <Tab id="inspector" title={lang.tr('inspector')} />}
       </Tabs>
 
-      <div className={cx(style.padded, style.fullWidth, { 'emulator-open': props.emulatorOpen })}>
+      <div className={cx(style.padded, style.fullWidth)}>
         <Logs commonButtons={commonButtons} hidden={tab !== 'logs'} />
 
         <Debugger

--- a/src/bp/ui-studio/src/web/components/Layout/Layout.scss
+++ b/src/bp/ui-studio/src/web/components/Layout/Layout.scss
@@ -22,6 +22,10 @@
   top: 50px !important;
 }
 
+:global(.emulator-open) {
+  padding-right: var(--emulator-width) !important;
+}
+
 .aside {
   background-color: var(--c-background--dark-3);
   overflow-x: hidden;

--- a/src/bp/ui-studio/src/web/components/Layout/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/index.tsx
@@ -1,5 +1,6 @@
 import { NLU } from 'botpress/sdk'
 import { lang, utils } from 'botpress/shared'
+import cx from 'classnames'
 import React, { FC, Fragment, useEffect, useRef, useState } from 'react'
 import { HotKeys } from 'react-hotkeys'
 import { connect } from 'react-redux'
@@ -203,7 +204,9 @@ const Layout: FC<Props> = (props: Props) => {
             onChange={size => size > 100 && localStorage.setItem(splitPanelLastSizeKey, size.toString())}
             size={bottomBarSize}
             maxSize={-100}
-            className={layout.mainSplitPaneWToolbar}
+            className={cx(layout.mainSplitPaneWToolbar, {
+              'emulator-open': props.emulatorOpen
+            })}
           >
             <main ref={mainElRef} className={layout.main} id="main" tabIndex={9999}>
               <Switch>
@@ -248,7 +251,8 @@ const mapStateToProps = state => ({
   bottomPanel: state.ui.bottomPanel,
   bottomPanelExpanded: state.ui.bottomPanelExpanded,
   translations: state.language.translations,
-  contentLang: state.language.contentLang
+  contentLang: state.language.contentLang,
+  emulatorOpen: state.ui.emulatorOpen
 })
 
 const mapDispatchToProps = {

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
@@ -667,11 +667,7 @@ class Diagram extends Component<Props> {
     const canAdd = !this.props.defaultLang || this.props.defaultLang === this.props.currentLang
 
     return (
-      <MainLayout.Wrapper
-        className={cx({
-          'emulator-open': this.props.emulatorOpen
-        })}
-      >
+      <MainLayout.Wrapper>
         <WorkflowToolbar />
 
         <div className={style.searchWrapper}>

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/style.scss
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/style.scss
@@ -6,10 +6,6 @@
   }
 }
 
-:global(.emulator-open) {
-  padding-right: calc(var(--spacing-x-large) + var(--emulator-width)) !important;
-}
-
 .floatingInfo {
   position: absolute;
   left: 10px;


### PR DESCRIPTION
This PR fixes botpress/v12#1231 


https://user-images.githubusercontent.com/9640576/107097021-020efc00-67da-11eb-92a5-d24c63668c57.mp4

