### PR TITLE
fix(nlu): handle unexpected process exit

### DIFF
--- a/src/bp/cluster.ts
+++ b/src/bp/cluster.ts
@@ -111,7 +111,8 @@ export async function spawnNewTrainingWorker(config: sdk.NLU.LanguageConfig, req
   const worker = cluster.fork({
     WORKER_TYPE: WORKER_TYPES.TRAINING,
     NLU_CONFIG: JSON.stringify(config),
-    REQUEST_ID: requestId
+    REQUEST_ID: requestId,
+    BP_FAILSAFE: false // training workers are allowed to fail and exit
   })
   const workerId = worker.id
   process.TRAINING_WORKERS.push(workerId)

--- a/src/bp/cluster.ts
+++ b/src/bp/cluster.ts
@@ -56,9 +56,6 @@ export const setupMasterNode = (logger: sdk.Logger) => {
     const { exitedAfterDisconnect, id } = worker
 
     if (process.TRAINING_WORKERS?.includes(id)) {
-      if (signal !== 'SIGKILL') {
-        logger.error(`Training worker ${id} exited. Exit code is ${code}. Signal is ${signal}.`)
-      }
       process.TRAINING_WORKERS = process.TRAINING_WORKERS.filter(w => w !== id)
       return
     }

--- a/src/bp/index.ts
+++ b/src/bp/index.ts
@@ -59,6 +59,9 @@ process.stderr.write = stripDeprecationWrite
 
 process.on('unhandledRejection', err => {
   global.printErrorDefault(err)
+  if (!process.IS_FAILSAFE) {
+    process.exit(1)
+  }
 })
 
 process.on('uncaughtException', err => {

--- a/src/bp/nlu-core/errors/index.ts
+++ b/src/bp/nlu-core/errors/index.ts
@@ -1,10 +1,16 @@
 export class TrainingCanceled extends Error {}
-export class TrainingAlreadyStarted extends Error {}
-
 export function isTrainingCanceled(err: Error): err is TrainingCanceled {
   return err instanceof TrainingCanceled
 }
 
+export class TrainingAlreadyStarted extends Error {}
 export function isTrainingAlreadyStarted(err: Error): err is TrainingAlreadyStarted {
   return err instanceof TrainingAlreadyStarted
+}
+
+export class TrainingExitedUnexpectedly extends Error {
+  constructor(srcWorkerId: number, info: { exitCode: number; signal: string }) {
+    const { exitCode, signal } = info
+    super(`Training worker ${srcWorkerId} exited with exit code ${exitCode} and signal ${signal}.`)
+  }
 }

--- a/src/bp/nlu-core/training-worker-queue/communication.ts
+++ b/src/bp/nlu-core/training-worker-queue/communication.ts
@@ -29,12 +29,15 @@ export type IncomingPayload<T extends IncomingMessageType> = T extends 'log'
   ? { progress: number }
   : T extends 'training_error'
   ? { error: ErrorMessage }
+  : T extends 'training_exited'
+  ? { exitCode: number; signal: string }
   : {}
 
 export type IncomingMessageType =
   | 'log'
   | 'worker_ready'
   | 'training_canceled'
+  | 'training_exited'
   | 'training_done'
   | 'training_progress'
   | 'training_error'
@@ -60,6 +63,8 @@ export const isWorkerReady = (msg: AllIncomingMessages): msg is IncomingMessage<
   msg.type === 'worker_ready'
 export const isTrainingCanceled = (msg: AllIncomingMessages): msg is IncomingMessage<'training_canceled'> =>
   msg.type === 'training_canceled'
+export const isTrainingExited = (msg: AllIncomingMessages): msg is IncomingMessage<'training_exited'> =>
+  msg.type === 'training_exited'
 export const isTrainingDone = (msg: AllIncomingMessages): msg is IncomingMessage<'training_done'> =>
   msg.type === 'training_done'
 export const isTrainingProgress = (msg: AllIncomingMessages): msg is IncomingMessage<'training_progress'> =>

--- a/src/bp/nlu-core/training-worker-queue/index.ts
+++ b/src/bp/nlu-core/training-worker-queue/index.ts
@@ -18,12 +18,15 @@ import {
   isTrainingCanceled,
   isTrainingDone,
   isTrainingError,
+  isTrainingExited,
   isTrainingProgress,
   isWorkerReady,
   OutgoingMessage
 } from './communication'
 
 const debugTraining = DEBUG('nlu').sub('training')
+
+const SIG_KILL = 'SIGKILL'
 
 export class TrainingWorkerQueue {
   private readyWorkers: number[] = []
@@ -123,6 +126,12 @@ export class TrainingWorkerQueue {
           process.off('message', handler)
           reject(new TrainingCanceled())
         }
+        if (isTrainingExited(msg)) {
+          process.off('message', handler)
+          const { exitCode, signal } = msg.payload
+          const errorMsg = `Training process exited with exit code ${exitCode} and signal ${signal}.`
+          reject(new Error(errorMsg))
+        }
         if (isTrainingProgress(msg)) {
           progress(msg.payload.progress)
         }
@@ -143,7 +152,7 @@ export class TrainingWorkerQueue {
       destWorkerId: NaN
     }
 
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       const handler = (msg: AllIncomingMessages) => {
         if (isLog(msg) && msg.payload.requestId === requestId) {
           this._logMessage(msg)
@@ -152,6 +161,13 @@ export class TrainingWorkerQueue {
         if (isWorkerReady(msg) && msg.payload.requestId === requestId) {
           process.off('message', handler)
           resolve(msg.srcWorkerId)
+        }
+
+        if (isTrainingExited(msg)) {
+          process.off('message', handler)
+          const { exitCode, signal } = msg.payload
+          const errorMsg = `Training process exited with exit code ${exitCode} and signal ${signal}.`
+          reject(new Error(errorMsg))
         }
       }
       process.send!(msg)
@@ -199,25 +215,42 @@ if (cluster.isMaster) {
       }
       return sendToWebWorker(response)
     }
+    worker.process.kill(SIG_KILL)
+  }
 
-    const exitHandler = (worker: Worker, _exitCode: number, _signal: string) => {
-      const response: IncomingMessage<'training_canceled'> = {
-        type: 'training_canceled',
-        payload: {},
+  async function makeNewWorker(msg: OutgoingMessage<'make_new_worker'>) {
+    debugLog('About to spawn new training process.', msg.payload.requestId)
+    const workerId = await spawnNewTrainingWorker(msg.payload.config, msg.payload.requestId)
+    debugLog('Done spawning new training process.', msg.payload.requestId)
+
+    const exitHandler = (worker: Worker, exitCode: number, signal: string) => {
+      if (worker.id !== workerId) {
+        return
+      }
+
+      cluster.removeListener('exit', exitHandler)
+
+      if (signal === SIG_KILL) {
+        const response: IncomingMessage<'training_canceled'> = {
+          type: 'training_canceled',
+          payload: {},
+          srcWorkerId: worker.id
+        }
+        sendToWebWorker(response)
+        return
+      }
+
+      const response: IncomingMessage<'training_exited'> = {
+        type: 'training_exited',
+        payload: { exitCode, signal },
         srcWorkerId: worker.id
       }
       sendToWebWorker(response)
     }
-    cluster.once('exit', exitHandler)
-
-    worker.process.kill('SIGKILL')
+    cluster.on('exit', exitHandler)
   }
 
-  registerMsgHandler('make_new_worker', async (msg: OutgoingMessage<'make_new_worker'>) => {
-    debugLog('About to spawn new training process.', msg.payload.requestId)
-    await spawnNewTrainingWorker(msg.payload.config, msg.payload.requestId)
-    debugLog('Done spawning new training process.', msg.payload.requestId)
-  })
+  registerMsgHandler('make_new_worker', makeNewWorker)
   registerMsgHandler('cancel_training', killTrainingWorker)
   registerMsgHandler('start_training', sendToTrainingWorker)
 


### PR DESCRIPTION
This PR is related to a problem observed by @spg. 

Sometimes, training doesn't event seem to start and stays pending forever. 

I previously added a log line to at least give some explanation on what's happening, but in this PR I added a true error handling rather than simply logging.

To check that this PR works, append this code 
```ts
if (cluster.isWorker && process.env.WORKER_TYPE === 'TRAINING') {
  throw new Error('some random error')
}
```
at the end of `src/bp/index.ts` file.

This what it looks like:

![image](https://user-images.githubusercontent.com/25970722/107252356-4204f780-6a03-11eb-9dd6-8cc97cc59fdb.png)


