### PR TITLE
fix(studio): update flow on link deletion

### DIFF
--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
@@ -76,9 +76,9 @@ type DispatchProps = typeof mapDispatchToProps
 
 type Props = DispatchProps & StateProps & OwnProps
 
-type ExtendedDiagramEngine = {
+export type ExtendedDiagramEngine = {
   enableLinkPoints?: boolean
-  flowBuilder?: any
+  flowBuilder?: Diagram
 } & DiagramEngine
 
 const EXPANDED_NODES_KEY = `bp::${window.BOT_ID}::expandedNodes`
@@ -97,7 +97,7 @@ class Diagram extends Component<Props> {
   private diagramWidget: DiagramWidget
   private diagramContainer: HTMLDivElement
   private searchRef: React.RefObject<HTMLInputElement>
-  private manager: DiagramManager
+  public manager: DiagramManager
   /** Represents the source port clicked when the user is connecting a node */
   private dragPortSource: any
 

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/LinkWidget.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/LinkWidget.tsx
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 import React from 'react'
 import { AbstractLinkFactory, DefaultLinkModel, DefaultLinkWidget, DiagramEngine, Toolkit } from 'storm-react-diagrams'
+
 import { ExtendedDiagramEngine } from '..'
 
 import style from './style.scss'
@@ -23,12 +24,7 @@ class DeletableLinkWidget extends DefaultLinkWidget {
 
     return (
       <g key={`point-${id}`}>
-        <circle
-          cx={x}
-          cy={y}
-          r={5}
-          fill={point.isSelected() ?  'var(--ocean)' : 'var(--gray)'}
-        />
+        <circle cx={x} cy={y} r={5} fill={point.isSelected() ? 'var(--ocean)' : 'var(--gray)'} />
         <circle
           onContextMenu={() => point.remove()}
           onMouseLeave={() => {
@@ -107,9 +103,11 @@ class DeletableLinkWidget extends DefaultLinkWidget {
         onMouseLeave={() => this.setState({ selected: false })}
         onMouseEnter={() => this.setState({ selected: true })}
         onClick={() => {
+          const diagramEngine = this.props.diagramEngine as ExtendedDiagramEngine
+
           link.remove()
 
-          const diagramEngine = (this.props.diagramEngine as ExtendedDiagramEngine)
+          diagramEngine.repaintCanvas()
           diagramEngine.flowBuilder.checkForLinksUpdate()
         }}
       >
@@ -212,7 +210,8 @@ class DeletableLinkWidget extends DefaultLinkWidget {
           this.generateLink(
             Toolkit.generateCurvePath(pointLeft, pointRight, this.props.link.curvyness),
             {
-              onMouseDown: (event: MouseEvent) => this.addPointToLink(event, 1)},
+              onMouseDown: (event: MouseEvent) => this.addPointToLink(event, 1)
+            },
             '0'
           )
         )
@@ -230,7 +229,8 @@ class DeletableLinkWidget extends DefaultLinkWidget {
               {
                 'data-linkid': this.props.link.id,
                 'data-point': j,
-                onMouseDown: (event: MouseEvent) => this.addPointToLink(event, j + 1)},
+                onMouseDown: (event: MouseEvent) => this.addPointToLink(event, j + 1)
+              },
               j
             )
           )

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/LinkWidget.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/LinkWidget.tsx
@@ -172,7 +172,7 @@ class DeletableLinkWidget extends DefaultLinkWidget {
           this.generateLink(
             Toolkit.generateDynamicPath(simplifiedPath),
             {
-              onMouseDown: event => {
+              onMouseDown: (event: MouseEvent) => {
                 this.addPointToLink(event, 1)
               }
             },

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/LinkWidget.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/nodes/LinkWidget.tsx
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 import React from 'react'
 import { AbstractLinkFactory, DefaultLinkModel, DefaultLinkWidget, DiagramEngine, Toolkit } from 'storm-react-diagrams'
+import { ExtendedDiagramEngine } from '..'
 
 import style from './style.scss'
 
@@ -54,8 +55,7 @@ class DeletableLinkWidget extends DefaultLinkWidget {
     const { link, diagramEngine } = this.props
     let { color, width } = this.props
 
-    // @ts-ignore
-    const flowManager = diagramEngine.flowBuilder.manager
+    const flowManager = (diagramEngine as ExtendedDiagramEngine).flowBuilder.manager
     if (flowManager.shouldHighlightLink(link.getID())) {
       color = 'var(--ocean)'
       width = 4
@@ -108,7 +108,9 @@ class DeletableLinkWidget extends DefaultLinkWidget {
         onMouseEnter={() => this.setState({ selected: true })}
         onClick={() => {
           link.remove()
-          this.props.diagramEngine.repaintCanvas()
+
+          const diagramEngine = (this.props.diagramEngine as ExtendedDiagramEngine)
+          diagramEngine.flowBuilder.checkForLinksUpdate()
         }}
       >
         <rect


### PR DESCRIPTION
This PR fixes an issue where deleting a link between two nodes did not update the flow until the user clicked somewhere on the flow editor.

Note: this affect roughlt Botpress v12.14 to v12.17

Before:

https://user-images.githubusercontent.com/9640576/107444861-68ad5600-6b09-11eb-90cb-ec68a4e8a20c.mp4

 
After: 

https://user-images.githubusercontent.com/9640576/107444887-7662db80-6b09-11eb-82c4-d7f37cb951e0.mp4

