### PR TITLE
feat(core): add generic bot data cache

### DIFF
--- a/src/bp/common/bot-data-cache.test.ts
+++ b/src/bp/common/bot-data-cache.test.ts
@@ -1,0 +1,244 @@
+import 'jest-extended'
+
+import _ from 'lodash'
+
+import { FlowView } from 'common/typings'
+import { BotDataCache } from './bot-data-cache'
+
+const FLOW = () => ({
+  name: RANDOM_STRING(),
+  startNode: RANDOM_STRING(),
+  nodes: [
+    {
+      name: RANDOM_STRING(),
+      x: RANDOM_NUMBER(),
+      y: RANDOM_NUMBER()
+    }
+  ],
+  links: [
+    {
+      source: RANDOM_STRING(),
+      target: RANDOM_STRING(),
+      points: [
+        {
+          x: RANDOM_NUMBER(),
+          y: RANDOM_NUMBER()
+        }
+      ]
+    }
+  ]
+})
+const BOT_ID = 'bot_123'
+const OTHER_BOT_ID = 'bot_321'
+const RANDOM_NUMBER = () => Math.random() * 1000
+const RANDOM_STRING = () =>
+  Math.random()
+    .toString(36)
+    .substring(7)
+
+describe('FlowCache', () => {
+  let cache: BotDataCache<FlowView>
+  let flows: FlowView[]
+
+  beforeEach(() => {
+    cache = new BotDataCache<FlowView>('name')
+    flows = Array.from(new Array(10), _ => FLOW())
+  })
+
+  describe('Get', () => {
+    it("Returns all the bot's flows from the cache", () => {
+      cache.set(BOT_ID, flows)
+
+      const cacheFlows = cache['_cache']
+
+      expect(cache.get(BOT_ID)).not.toBeUndefined()
+      expect(cache.get(BOT_ID)).toEqual(flows)
+      expect(Array.from(cacheFlows.get(BOT_ID)!.values())).toEqual(flows)
+    })
+
+    it('Returns a particular flow for a given bot from the cache', () => {
+      cache.set(BOT_ID, flows)
+
+      const singleFlow = flows[0]
+      const cacheFlows = cache['_cache']
+
+      expect(cache.get(BOT_ID)).not.toBeUndefined()
+      expect(cache.get(BOT_ID)).toEqual(flows)
+      expect(cache.get(BOT_ID, singleFlow.name)).toEqual(singleFlow)
+      expect(cacheFlows.get(BOT_ID)!.get(singleFlow.name)).toEqual(singleFlow)
+    })
+
+    it('Returns undefined if the bot is not found in the cache', () => {
+      expect(OTHER_BOT_ID).not.toEqual(BOT_ID)
+
+      cache.set(OTHER_BOT_ID, flows)
+
+      const randomName = RANDOM_STRING()
+      const cacheFlows = cache['_cache']
+
+      expect(cache.get(BOT_ID)).toBeUndefined()
+      expect(cache.get(BOT_ID, randomName)).toBeUndefined()
+      expect(cacheFlows.get(BOT_ID)).toBeUndefined()
+    })
+
+    it('Returns undefined if the flow cannot be found', () => {
+      cache.set(BOT_ID, flows)
+
+      const randomName = RANDOM_STRING()
+
+      expect(cache.get(BOT_ID)).not.toBeUndefined()
+      expect(cache.get(BOT_ID, randomName)).toBeUndefined()
+    })
+  })
+
+  describe('Set', () => {
+    it('Sets the bot with its flows in the cache', () => {
+      cache.set(BOT_ID, flows)
+
+      expect(cache.get(BOT_ID)).not.toBeUndefined()
+      expect(cache.get(BOT_ID)).toEqual(flows)
+    })
+
+    it('Sets the bot with its one flow in the cache', () => {
+      const singleFlow = flows[0]
+      cache.set(BOT_ID, singleFlow)
+
+      expect(cache.get(BOT_ID)).not.toBeUndefined()
+      expect(cache.get(BOT_ID, singleFlow.name)).toEqual(singleFlow)
+    })
+
+    it('Overrides the bot flow when its already present in the cache', () => {
+      cache.set(BOT_ID, flows)
+
+      const singleFlow = _.cloneDeep(flows[0])
+      singleFlow.description = 'a new description'
+
+      cache.set(BOT_ID, singleFlow)
+
+      expect(cache.get(BOT_ID)).not.toBeUndefined()
+      expect(cache.get(BOT_ID, singleFlow.name)).toEqual(singleFlow)
+    })
+  })
+
+  describe('Remove', () => {
+    it('Removes a particular flow for a given bot', () => {
+      expect(OTHER_BOT_ID).not.toEqual(BOT_ID)
+
+      const singleFlow = flows[0]
+
+      cache.set(BOT_ID, flows)
+      cache.set(OTHER_BOT_ID, flows)
+
+      cache.remove(BOT_ID, singleFlow.name)
+
+      expect(cache.get(OTHER_BOT_ID)).not.toBeUndefined()
+      expect(cache.get(OTHER_BOT_ID)).toEqual(flows)
+      expect(cache.get(BOT_ID)).not.toBeUndefined()
+      expect(cache.get(BOT_ID, singleFlow.name)).toBeUndefined()
+    })
+
+    it("Does not remove a particular flow if it is not part of the bot's flows", () => {
+      const singleFlow = FLOW()
+
+      cache.set(BOT_ID, flows)
+      cache.remove(BOT_ID, singleFlow.name)
+
+      expect(cache.get(BOT_ID)).not.toBeUndefined()
+      expect(cache.get(BOT_ID)).toEqual(flows)
+      expect(cache.get(BOT_ID, singleFlow.name)).toBeUndefined()
+    })
+
+    it('Removes a particular bot from the cache', () => {
+      expect(OTHER_BOT_ID).not.toEqual(BOT_ID)
+
+      cache.set(BOT_ID, flows)
+      cache.set(OTHER_BOT_ID, flows)
+
+      cache.remove(BOT_ID)
+
+      expect(cache.get(OTHER_BOT_ID)).not.toBeUndefined()
+      expect(cache.get(OTHER_BOT_ID)).toEqual(flows)
+      expect(cache.get(BOT_ID)).toBeUndefined()
+    })
+
+    it('Does nothing if the bot is not in the cache', () => {
+      try {
+        cache.remove(BOT_ID)
+        expect(cache.get(BOT_ID)).toBeUndefined()
+      } catch (e) {
+        fail(e)
+      }
+    })
+  })
+
+  describe('Has', () => {
+    it('Returns true if the bot is found in the cache', () => {
+      cache.set(BOT_ID, flows)
+
+      expect(cache.has(BOT_ID)).toBeTrue()
+    })
+
+    it('Returns false if the bot is not found in the cache', () => {
+      expect(OTHER_BOT_ID).not.toEqual(BOT_ID)
+
+      cache.set(BOT_ID, flows)
+
+      expect(cache.has(OTHER_BOT_ID)).toBeFalse()
+    })
+
+    it("Returns true if the flow is found in the bot's cache", () => {
+      const flow = flows[0]
+      cache.set(BOT_ID, flows)
+
+      expect(cache.has(BOT_ID)).toBeTrue()
+      expect(cache.has(BOT_ID, flow.name)).toBeTrue()
+    })
+
+    it("Returns false if the flow is not found in the bot's cache", () => {
+      expect(OTHER_BOT_ID).not.toEqual(BOT_ID)
+
+      const flow = flows[0]
+      cache.set(BOT_ID, flows)
+
+      const randomName = RANDOM_STRING()
+
+      expect(cache.has(OTHER_BOT_ID)).toBeFalse()
+      expect(cache.has(OTHER_BOT_ID, flow.name)).toBeFalse()
+      expect(cache.has(BOT_ID, randomName)).toBeFalse()
+    })
+  })
+
+  describe('IsEmpty', () => {
+    it('Returns true if the cache is empty', () => {
+      const cacheFlows = cache['_cache']
+
+      expect(cache.isEmpty()).toBeTrue()
+      expect(cache.isEmpty(BOT_ID)).toBeTrue()
+      expect(cacheFlows.size === 0).toBeTrue()
+    })
+
+    it('Returns false if the cache is not empty', () => {
+      cache.set(BOT_ID, [])
+      const cacheFlows = cache['_cache']
+
+      expect(cache.isEmpty()).toBeFalse()
+      expect(cacheFlows.size === 0).toBeFalse()
+    })
+
+    it('Returns true if the bot has no flow', () => {
+      cache.set(BOT_ID, [])
+      const cacheFlows = cache['_cache']
+
+      expect(cache.isEmpty(BOT_ID)).toBeTrue()
+      expect(cacheFlows.get(BOT_ID)!.size === 0).toBeTrue()
+    })
+
+    it('Returns false if the bot has some flows', () => {
+      cache.set(BOT_ID, flows)
+      const cacheFlows = cache['_cache']
+
+      expect(cache.isEmpty(BOT_ID)).toBeFalse()
+      expect(cacheFlows.get(BOT_ID)!.size === 0).toBeFalse()
+    })
+  })
+})

--- a/src/bp/common/bot-data-cache.ts
+++ b/src/bp/common/bot-data-cache.ts
@@ -1,0 +1,130 @@
+type IndexableValues = string | number
+// Only keep keys of T were its correspond value is mandatory and either of type string or number
+type NonOptionalKeys<T> = {
+  [k in keyof T]-?: undefined extends T[k] ? never : T[k] extends IndexableValues ? k : never
+}[keyof T]
+
+/**
+ * A generic cache used to store any king of bot data.
+ *
+ * _Note: `V` must be a key/value object with a minimum of one key being **non optional** and of type **string or number**_
+ */
+export class BotDataCache<V extends {}> {
+  private _key: NonOptionalKeys<V>
+  private _cache: Map<string, Map<any, V>>
+
+  /**
+   *
+   * @param key The key used to store and retrieve the data of type `T`
+   */
+  constructor(key: NonOptionalKeys<V>) {
+    this._key = key
+    this._cache = new Map<string, Map<V[NonOptionalKeys<V>], V>>()
+  }
+
+  /**
+   * Caches data or update a currently cached data
+   * @param botId The id of the bot used to store the data
+   * @param data Either an object or an array of objects to cache
+   */
+  public set(botId: string, data: V | V[]): void {
+    if (Array.isArray(data)) {
+      const map = new Map(data.map(f => [f[this._key], f]))
+      this._cache.set(botId, map)
+    } else {
+      if (this._cache.has(botId)) {
+        this._cache.get(botId)!.set(data[this._key], data)
+      } else {
+        this.set(botId, [data])
+      }
+    }
+  }
+
+  /**
+   * Removes a bot from the cache
+   * @param botId The id of the bot to be removed from the cache
+   */
+  public remove(botId: string): void
+  /**
+   * Removes cached data for a given bot
+   * @param botId The id of the bot used to remove the data
+   * @param key The key corresponding to the data to remove
+   */
+  public remove(botId: string, key: V[NonOptionalKeys<V>]): void
+  public remove(botId: string, key?: V[NonOptionalKeys<V>]): void {
+    if (key) {
+      if (this._cache.has(botId)) {
+        this._cache.get(botId)!.delete(key)
+      }
+    } else {
+      this._cache.delete(botId)
+    }
+  }
+
+  /**
+   * Retrieves all cached data for a given bot
+   * @param botId The id of the bot used to retrieve the data
+   */
+  public get(botId: string): V[]
+  /**
+   * Retrieves a single data from the cache
+   * @param botId The id of the bot used to retrieve the data
+   * @param key The key corresponding to the data to retrieve
+   */
+  public get(botId: string, key: V[NonOptionalKeys<V>]): V | undefined
+  public get(botId: string, key: V[NonOptionalKeys<V>] = null as any): V | undefined | V[] {
+    if (!this._cache.has(botId)) {
+      return undefined
+    }
+
+    if (key) {
+      return this._cache.get(botId)!.get(key)
+    }
+
+    return Array.from(this._cache.get(botId)!.values())
+  }
+
+  /**
+   * Checks whether or not the bot exists in the cache
+   * @param botId The id used to see if the bot exists in the cache
+   */
+  public has(botId: string): boolean
+  /**
+   * Checks whether or not a data exists the in the bot's cache
+   * @param botId The id of the bot used to retrieve the data
+   * @param key The key used to see if the data exists in the cache
+   */
+  public has(botId: string, key: V[NonOptionalKeys<V>]): boolean
+  public has(botId: string, key: V[NonOptionalKeys<V>] = null as any): boolean {
+    if (key) {
+      if (!this._cache.has(botId)) {
+        return false
+      } else {
+        return this._cache.get(botId)!.has(key)
+      }
+    }
+
+    return this._cache.has(botId)
+  }
+
+  /**
+   * Checks whether or not the cache is empty
+   */
+  public isEmpty(): boolean
+  /**
+   * Checks whether or not a bot's cache is empty
+   * @param botId The id of the bot used to retrieve the data
+   */
+  public isEmpty(botId: string): boolean
+  public isEmpty(botId?: string): boolean {
+    if (botId) {
+      if (!this._cache.has(botId)) {
+        return true
+      } else {
+        return this._cache.get(botId)!.size === 0
+      }
+    }
+
+    return this._cache.size === 0
+  }
+}

--- a/src/bp/core/services/dialog/flow/service.ts
+++ b/src/bp/core/services/dialog/flow/service.ts
@@ -1,4 +1,5 @@
 import { Flow, Logger } from 'botpress/sdk'
+import { BotDataCache } from 'common/bot-data-cache'
 import { ObjectCache } from 'common/object-cache'
 import { TreeSearch, PATH_SEPARATOR } from 'common/treeSearch'
 import { FlowMutex, FlowView, NodeView } from 'common/typings'
@@ -49,58 +50,9 @@ export class MutexError extends Error {
   type = MutexError.name
 }
 
-class FlowCache {
-  private _flows: Map<string, Map<string, FlowView>> = new Map()
-
-  public set(botId: string, flowViews: FlowView[]): void {
-    const flows = new Map(flowViews.map(f => [f.name, f]))
-    this._flows.set(botId, flows)
-  }
-
-  public get(botId: string): FlowView[] {
-    if (this._flows.has(botId)) {
-      return Array.from(this._flows.get(botId)!.values())
-    } else {
-      return []
-    }
-  }
-
-  public has(botId: string): boolean {
-    return this._flows.has(botId)
-  }
-
-  public isEmpty(): boolean {
-    return this._flows.size === 0
-  }
-
-  public upsertFlow(botId: string, flow: FlowView): void {
-    if (this._flows.has(botId)) {
-      this._flows.get(botId)!.set(flow.name, flow)
-    } else {
-      this.set(botId, [flow])
-    }
-  }
-
-  public deleteFlow(botId: string, flowName: string): void {
-    if (this._flows.has(botId)) {
-      this._flows.get(botId)!.delete(flowName)
-    }
-  }
-
-  public renameFlow(botId: string, oldName: string, newName: string): void {
-    if (this._flows.has(botId) && this._flows.get(botId)!.has(oldName)) {
-      const flow = this._flows.get(botId)!.get(oldName)!
-      flow.name = newName
-
-      this.upsertFlow(botId, flow)
-      this.deleteFlow(botId, oldName)
-    }
-  }
-}
-
 @injectable()
 export class FlowService {
-  private _flowCache: FlowCache = new FlowCache()
+  private _flowCache = new BotDataCache<FlowView>('name')
 
   constructor(
     @inject(TYPES.Logger)
@@ -130,9 +82,14 @@ export class FlowService {
         if (await this.ghost.forBot(botId).fileExists(FLOW_DIR, flowPath)) {
           const flow = await this.parseFlow(botId, flowPath)
 
-          this._flowCache.upsertFlow(botId, flow)
+          this._flowCache.set(botId, flow)
         } else {
-          this._flowCache.deleteFlow(botId, flowPath)
+          this._flowCache.remove(botId, flowPath)
+
+          // Remove the bot if doesn't have any flows
+          if (this._flowCache.get(botId).length === 0) {
+            this._flowCache.remove(botId)
+          }
         }
 
         // parent flows are only used by the NDU
@@ -301,8 +258,6 @@ export class FlowService {
       ghost.upsertFile(FLOW_DIR, flowPath!, JSON.stringify(flowContent, undefined, 2)),
       ghost.upsertFile(FLOW_DIR, uiPath, JSON.stringify(uiContent, undefined, 2))
     ])
-
-    this._flowCache.upsertFlow(botId, flow)
   }
 
   async deleteFlow(botId: string, flowName: string, userEmail: string) {
@@ -318,8 +273,6 @@ export class FlowService {
 
     const uiPath = this.toUiPath(fileToDelete)
     await Promise.all([ghost.deleteFile(FLOW_DIR, fileToDelete!), ghost.deleteFile(FLOW_DIR, uiPath)])
-
-    this._flowCache.deleteFlow(botId, flowName)
 
     this.notifyChanges({
       name: flowName,
@@ -346,8 +299,6 @@ export class FlowService {
       ghost.renameFile(FLOW_DIR, fileToRename!, newName),
       ghost.renameFile(FLOW_DIR, previousUiName, newUiName)
     ])
-
-    this._flowCache.renameFlow(botId, previousName, newName)
 
     await this.moduleLoader.onFlowRenamed(botId, previousName, newName)
 


### PR DESCRIPTION
This PR adds:

 1. A new generic class (FlowCache class) allowing to cache any kind of data related to a bot.
 2. Unit tests for this class
 3. Small improvements in the flow service in relation to the cache handling 