### PR TITLE
fix(hitlnext): Infinite loading of the agent live chat 

### DIFF
--- a/modules/hitlnext/src/views/full/app/components/LiveChat.tsx
+++ b/modules/hitlnext/src/views/full/app/components/LiveChat.tsx
@@ -38,7 +38,7 @@ const LiveChat: React.FC<Props> = ({ handoff, currentAgent }) => {
 
   useEffect(() => {
     const webchatConfig = {
-      host: window.location.origin,
+      host: window.ROOT_PATH,
       botId: window.BOT_ID,
       userId: currentAgent.agentId,
       conversationId: handoff.agentThreadId, // parseint ?


### PR DESCRIPTION
Livechat was stuck in a loading loop when the EXTERNAL_URL was set with a subdir at the end.

Before:
<img width="1377" alt="Screen Shot 2021-02-25 at 3 29 23 PM" src="https://user-images.githubusercontent.com/16272318/109216374-722df380-7782-11eb-997f-27e74c03115f.png">

After:
<img width="1381" alt="Screen Shot 2021-02-25 at 3 31 45 PM" src="https://user-images.githubusercontent.com/16272318/109216400-78bc6b00-7782-11eb-8b97-33c1865cc152.png">

***This issue could also be resolved by removing completely the line I edited***
