### PR TITLE
chore(nlu): few refactors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -91,6 +91,19 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Debug Jest Current File",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${fileBasenameNoExtension}", "--config", "jest.config.js"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Debug Jest Integration Tests",
       "cwd": "${workspaceFolder}",
       "env": {

--- a/src/bp/core/services/nlu/entities-service.ts
+++ b/src/bp/core/services/nlu/entities-service.ts
@@ -1,6 +1,6 @@
 import * as sdk from 'botpress/sdk'
 import { sanitizeFileName } from 'core/misc/utils'
-import { DUCKLING_ENTITIES } from 'nlu-core/entities/duckling-extractor/typings'
+import { DUCKLING_ENTITIES } from 'nlu-core/entities/duckling-extractor/enums'
 import { GhostService } from '..'
 import * as CacheManager from './cache-manager'
 import { NLUService } from './nlu-service'

--- a/src/bp/nlu-core/entities/duckling-extractor/enums.ts
+++ b/src/bp/nlu-core/entities/duckling-extractor/enums.ts
@@ -1,0 +1,16 @@
+import { DucklingDimension } from './typings'
+
+export const DUCKLING_ENTITIES: DucklingDimension[] = [
+  'amountOfMoney',
+  'distance',
+  'duration',
+  'email',
+  'number',
+  'ordinal',
+  'phoneNumber',
+  'quantity',
+  'temperature',
+  'time',
+  'url',
+  'volume'
+]

--- a/src/bp/nlu-core/entities/duckling-extractor/index.ts
+++ b/src/bp/nlu-core/entities/duckling-extractor/index.ts
@@ -5,8 +5,8 @@ import { JOIN_CHAR } from '../../tools/token-utils'
 import { EntityExtractionResult, KeyedItem, SystemEntityExtractor } from '../../typings'
 import { SystemEntityCacheManager } from '../entity-cache-manager'
 import { DucklingClient, DucklingParams } from './duckling-client'
+import { DUCKLING_ENTITIES } from './enums'
 import { mapDucklingToEntity } from './map-duckling'
-import { DUCKLING_ENTITIES } from './typings'
 
 const BATCH_SIZE = 10
 

--- a/src/bp/nlu-core/entities/duckling-extractor/typings.ts
+++ b/src/bp/nlu-core/entities/duckling-extractor/typings.ts
@@ -22,21 +22,6 @@ export type DucklingDimension =
   | 'url'
   | 'volume'
 
-export const DUCKLING_ENTITIES: DucklingDimension[] = [
-  'amountOfMoney',
-  'distance',
-  'duration',
-  'email',
-  'number',
-  'ordinal',
-  'phoneNumber',
-  'quantity',
-  'temperature',
-  'time',
-  'url',
-  'volume'
-]
-
 export type DucklingType = 'value' | 'interval'
 
 export type DucklingValue<D extends DucklingDimension, T extends DucklingType> = {

--- a/src/bp/nlu-core/entities/entity-cache-manager.ts
+++ b/src/bp/nlu-core/entities/entity-cache-manager.ts
@@ -91,7 +91,7 @@ export class SystemEntityCacheManager {
     }
   }
 
-  public async dumpCache() {
+  private async _dumpCache() {
     await ensureFile(this._path)
     await writeJson(this._path, this._cache.dump())
   }
@@ -99,7 +99,7 @@ export class SystemEntityCacheManager {
   private _onCacheChanged = _.debounce(async () => {
     if (this._dumpEnabled) {
       try {
-        await this.dumpCache()
+        await this._dumpCache()
       } catch (err) {
         this._logger?.error(`Could not persist system entities cache, error ${err.message}`, err)
         this._dumpEnabled = false

--- a/src/bp/nlu-core/entities/microsoft-extractor/enums.ts
+++ b/src/bp/nlu-core/entities/microsoft-extractor/enums.ts
@@ -1,42 +1,12 @@
-import { ModelResult } from '@microsoft/recognizers-text'
 import Recognizers from '@microsoft/recognizers-text-suite'
+import { MicrosoftSupportedLanguage } from './typings'
 
-export interface MicrosoftValue {
-  value: string
-  unit?: string
-  type?: string
-  score?: number
-  otherResults?: any[]
+export const supportedLangsList: MicrosoftSupportedLanguage[] = ['zh', 'nl', 'en', 'fr', 'de', 'it', 'ja', 'pt', 'es']
+export const isSupportedLanguage = (lang: string): lang is MicrosoftSupportedLanguage => {
+  return supportedLangsList.includes(lang as MicrosoftSupportedLanguage)
 }
 
-export interface MicrosoftTimeValues {
-  timex: string
-  type: string
-  start?: string
-  end?: string
-  value?: string
-  Mod?: string
-  sourceEntity?: string
-}
-
-export interface MicrosoftValues {
-  values: MicrosoftTimeValues[]
-}
-
-export type MicrosoftResolution = MicrosoftValue | MicrosoftValues
-
-export interface MicrosoftEntity extends ModelResult {
-  start: number
-  end: number
-  resolution: MicrosoftResolution
-  text: string
-  typeName: string
-}
-
-export type SupportedLangs = 'zh' | 'nl' | 'en' | 'fr' | 'de' | 'it' | 'ja' | 'pt' | 'es'
-export const SupportedLangsList = ['zh', 'nl', 'en', 'fr', 'de', 'it', 'ja', 'pt', 'es']
-
-export const langToCulture = (lang: SupportedLangs): string | undefined => {
+export const langToCulture = (lang: MicrosoftSupportedLanguage): string | undefined => {
   switch (lang) {
     case 'zh':
       return Recognizers.Culture.Chinese

--- a/src/bp/nlu-core/entities/microsoft-extractor/typings.ts
+++ b/src/bp/nlu-core/entities/microsoft-extractor/typings.ts
@@ -1,0 +1,35 @@
+import { ModelResult } from '@microsoft/recognizers-text'
+
+export interface MicrosoftValue {
+  value: string
+  unit?: string
+  type?: string
+  score?: number
+  otherResults?: any[]
+}
+
+export interface MicrosoftTimeValues {
+  timex: string
+  type: string
+  start?: string
+  end?: string
+  value?: string
+  Mod?: string
+  sourceEntity?: string
+}
+
+export interface MicrosoftValues {
+  values: MicrosoftTimeValues[]
+}
+
+export type MicrosoftResolution = MicrosoftValue | MicrosoftValues
+
+export interface MicrosoftEntity extends ModelResult {
+  start: number
+  end: number
+  resolution: MicrosoftResolution
+  text: string
+  typeName: string
+}
+
+export type MicrosoftSupportedLanguage = 'zh' | 'nl' | 'en' | 'fr' | 'de' | 'it' | 'ja' | 'pt' | 'es'

--- a/src/bp/nlu-core/initialize-tools.ts
+++ b/src/bp/nlu-core/initialize-tools.ts
@@ -65,26 +65,19 @@ const makeSystemEntityExtractor = async (
   config: NLU.LanguageConfig,
   logger: NLU.Logger
 ): Promise<SystemEntityExtractor> => {
-  let extractor: SystemEntityExtractor
+  const makeCacheManager = (cacheFileName: string) =>
+    new SystemEntityCacheManager(path.join(process.APP_DATA_PATH, 'cache', cacheFileName), true, logger)
 
   if (yn(process.env.BP_MICROSOFT_RECOGNIZER)) {
-    const msCache = new SystemEntityCacheManager(
-      path.join(process.APP_DATA_PATH, 'cache', 'microsoft_sys_entities.json'),
-      true,
-      logger
-    )
-    extractor = new MicrosoftEntityExtractor(msCache, logger)
+    const msCache = makeCacheManager('microsoft_sys_entities.json')
+    const extractor = new MicrosoftEntityExtractor(msCache, logger)
     await extractor.configure()
-  } else {
-    const duckCache = new SystemEntityCacheManager(
-      path.join(process.APP_DATA_PATH, 'cache', 'duckling_sys_entities.json'),
-      true,
-      logger
-    )
-    extractor = new DucklingEntityExtractor(duckCache, logger)
-    await extractor.configure(config.ducklingEnabled, config.ducklingURL)
+    return extractor
   }
 
+  const duckCache = makeCacheManager('duckling_sys_entities.json')
+  const extractor = new DucklingEntityExtractor(duckCache, logger)
+  await extractor.configure(config.ducklingEnabled, config.ducklingURL)
   return extractor
 }
 

--- a/src/bp/nlu-core/test-utils/fake-tools.ts
+++ b/src/bp/nlu-core/test-utils/fake-tools.ts
@@ -82,8 +82,7 @@ export const makeFakeTools = (dim: number, languages: string[]): Tools => {
 
   const fakeSystemEntityExtractor: SystemEntityExtractor = {
     extractMultiple: async (input: string[], lang: string, useCache?: Boolean) => [],
-    extract: async (input: string, lang: string) => [],
-    configure: async (enabled?: boolean, url?: string) => {}
+    extract: async (input: string, lang: string) => []
   }
 
   const fakeMlToolkit: Partial<typeof MLToolkit> = {

--- a/src/bp/nlu-core/typings.ts
+++ b/src/bp/nlu-core/typings.ts
@@ -141,7 +141,6 @@ export interface Tools {
 export interface SystemEntityExtractor {
   extractMultiple(input: string[], lang: string, useCache?: Boolean): Promise<EntityExtractionResult[][]>
   extract(input: string, lang: string): Promise<EntityExtractionResult[]>
-  configure(enabled?: boolean, url?: string): Promise<void>
 }
 
 export type Intent<T> = Readonly<{

--- a/src/bp/nlu-server/validation/validate.ts
+++ b/src/bp/nlu-server/validation/validate.ts
@@ -1,5 +1,5 @@
 import { validate } from 'joi'
-import { DUCKLING_ENTITIES } from 'nlu-core/entities/duckling-extractor/typings'
+import { DUCKLING_ENTITIES } from 'nlu-core/entities/duckling-extractor/enums'
 import { isListEntity, isPatternEntity } from 'nlu-server/api-mapper'
 
 import {


### PR DESCRIPTION
few things before merging in master:

1. Split typings.ts from enums.ts (typings should only contain typings).
2. No need for `configure()` method in `SystemEntityExtractor` interface.
3. Got rid of some copy/paste in `initialize-tools`.
4. Method `_dumpCache` should be private.
5. Rm unused code `_getTz `. There's no need to keep unused code in codebase. We will code it back if we need it.
6. Added unit tests to make sure cache is used correctly by microsoft extractor