### PR TITLE
fix(telemetry): Fix infinite loop when telemetry server out of reach

### DIFF
--- a/src/bp/ui-shared/src/telemetry/index.ts
+++ b/src/bp/ui-shared/src/telemetry/index.ts
@@ -29,7 +29,9 @@ const sendSavedEvents = async (api: AxiosInstance) => {
   const success = await sendTelemetry(events)
   await sendFeedback(api, events, success)
 
-  await sendSavedEvents(api)
+  if (success) {
+    await sendSavedEvents(api)
+  }
 }
 
 const getSavedEvents = async (api: AxiosInstance): Promise<TelemetryEvent[]> => {


### PR DESCRIPTION
A simple fix to address this issue that happens when Botpress can't reach the telemetry server.

<img width="785" alt="TelemetryBug" src="https://user-images.githubusercontent.com/16272318/109527232-6cd1f100-7a81-11eb-8a32-95fb83c5adb8.png">

Thanks, SP and Frank L for your help on this.
