### PR TITLE
chore(nlu): nlu-core has its own typings hidden from rest of sdk

### DIFF
--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -1,3 +1,4 @@
+import * as NLU from 'botpress/nlu'
 import * as sdk from 'botpress/sdk'
 import Joi from 'joi'
 import _ from 'lodash'
@@ -54,7 +55,7 @@ export default async (bp: typeof sdk, state: NLUState) => {
     const modelId = botNLU.modelsByLang[predictLang]
 
     try {
-      let nlu: sdk.NLU.PredictOutput
+      let nlu: NLU.PredictOutput
 
       const spellChecked = await state.engine.spellCheck(value.text, modelId)
 

--- a/modules/nlu/src/backend/election/spellcheck-handler.ts
+++ b/modules/nlu/src/backend/election/spellcheck-handler.ts
@@ -1,24 +1,24 @@
-import * as sdk from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 import _ from 'lodash'
 
 import { NONE_INTENT, ValueOf } from './typings'
 
 const mergeSpellChecked = (
-  originalOutput: sdk.NLU.PredictOutput,
-  spellCheckedOutput: sdk.NLU.PredictOutput
-): sdk.NLU.PredictOutput => {
-  const mostConfidentContext = (preds: sdk.NLU.Predictions): ValueOf<sdk.NLU.Predictions> =>
+  originalOutput: NLU.PredictOutput,
+  spellCheckedOutput: NLU.PredictOutput
+): NLU.PredictOutput => {
+  const mostConfidentContext = (preds: NLU.Predictions): ValueOf<NLU.Predictions> =>
     _(preds)
       .values()
       .maxBy(p => p.confidence)!
 
-  const mostConfidentIntent = (preds: ValueOf<sdk.NLU.Predictions>) =>
+  const mostConfidentIntent = (preds: ValueOf<NLU.Predictions>) =>
     _(preds.intents)
       .filter(i => i.label !== NONE_INTENT)
       .maxBy(i => i.confidence)!
 
-  const originalPredictions: sdk.NLU.Predictions = originalOutput.predictions!
-  const spellCheckedPredictions: sdk.NLU.Predictions = spellCheckedOutput.predictions!
+  const originalPredictions: NLU.Predictions = originalOutput.predictions!
+  const spellCheckedPredictions: NLU.Predictions = spellCheckedOutput.predictions!
 
   const mergeContextConfidence =
     mostConfidentContext(originalPredictions).confidence < mostConfidentContext(spellCheckedPredictions).confidence

--- a/modules/nlu/src/backend/model-service.ts
+++ b/modules/nlu/src/backend/model-service.ts
@@ -1,3 +1,4 @@
+import * as NLU from 'botpress/nlu'
 import * as sdk from 'botpress/sdk'
 import fse, { WriteStream } from 'fs-extra'
 import _ from 'lodash'
@@ -29,7 +30,7 @@ const DEFAULT_LISTING_OPTIONS: ListingOptions = {
 
 export default class ModelService {
   constructor(
-    private _modelIdService: typeof sdk.NLU.modelIdService,
+    private _modelIdService: typeof NLU.modelIdService,
     private _ghost: sdk.ScopedGhostService,
     private _botId: string
   ) {}
@@ -58,7 +59,7 @@ export default class ModelService {
    * @param modelId The desired model id
    * @returns the corresponding model
    */
-  public async getModel(modelId: sdk.NLU.ModelId): Promise<sdk.NLU.Model | undefined> {
+  public async getModel(modelId: NLU.ModelId): Promise<NLU.Model | undefined> {
     const fname = this._makeFileName(this._modelIdService.toString(modelId))
     if (!(await this._ghost.fileExists(MODELS_DIR, fname))) {
       return
@@ -88,7 +89,7 @@ export default class ModelService {
    * @param query query filter
    * @returns the latest model that fits the query
    */
-  public async getLatestModel(query: Partial<sdk.NLU.ModelId>): Promise<sdk.NLU.Model | undefined> {
+  public async getLatestModel(query: Partial<NLU.ModelId>): Promise<NLU.Model | undefined> {
     debug.forBot(this._botId, `Searching for the latest model with characteristics ${JSON.stringify(query)}`)
 
     const availableModels = await this.listModels(query)
@@ -98,7 +99,7 @@ export default class ModelService {
     return this.getModel(availableModels[0])
   }
 
-  public async saveModel(model: sdk.NLU.Model): Promise<void | void[]> {
+  public async saveModel(model: NLU.Model): Promise<void | void[]> {
     const serialized = JSON.stringify(model)
     const modelName = this._makeFileName(this._modelIdService.toString(model))
     const tmpDir = tmp.dirSync({ unsafeCleanup: true })
@@ -124,15 +125,12 @@ export default class ModelService {
     return this.pruneModels(modelsOfLang, { toKeep: 2 })
   }
 
-  public async listModels(
-    query: Partial<sdk.NLU.ModelId>,
-    opt: Partial<ListingOptions> = {}
-  ): Promise<sdk.NLU.ModelId[]> {
+  public async listModels(query: Partial<NLU.ModelId>, opt: Partial<ListingOptions> = {}): Promise<NLU.ModelId[]> {
     const options = { ...DEFAULT_LISTING_OPTIONS, ...opt }
 
     const allModelsFileName = await this._listModels()
 
-    const baseFilter = (m: sdk.NLU.ModelId) => _.isMatch(m, query)
+    const baseFilter = (m: NLU.ModelId) => _.isMatch(m, query)
     const filter = options.negateFilter ? _.negate(baseFilter) : baseFilter
     const validModels = allModelsFileName
       .filter(this._modelIdService.isId)
@@ -150,7 +148,7 @@ export default class ModelService {
     return fileNames.map(this._parseFileName)
   }
 
-  public async pruneModels(models: sdk.NLU.ModelId[], opt: Partial<PruningOptions> = {}): Promise<void | void[]> {
+  public async pruneModels(models: NLU.ModelId[], opt: Partial<PruningOptions> = {}): Promise<void | void[]> {
     const options = { ...DEFAULT_PRUNING_OPTIONS, ...opt }
 
     const modelsFileNames = models.map(this._modelIdService.toString).map(this._makeFileName)

--- a/modules/nlu/src/backend/module-lifecycle/on-bot-mount.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-bot-mount.ts
@@ -1,3 +1,4 @@
+import * as NLU from 'botpress/nlu'
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 import ms from 'ms'
@@ -20,7 +21,7 @@ const KVS_TRAINING_STATUS_KEY = 'nlu:trainingStatus'
 
 async function annouceNeedsTraining(bp: typeof sdk, botId: string, state: NLUState) {
   const { engine } = state
-  const { modelIdService } = bp.NLU
+  const { modelIdService } = bp.NLU.core
 
   const api = await createApi(bp, botId)
   const intentDefs = await api.fetchIntentsWithQNAs()
@@ -49,7 +50,7 @@ async function annouceNeedsTraining(bp: typeof sdk, botId: string, state: NLUSta
   })
 }
 
-function registerNeedTrainingWatcher(bp: typeof sdk, botId: string, engine: sdk.NLU.Engine, state: NLUState) {
+function registerNeedTrainingWatcher(bp: typeof sdk, botId: string, engine: NLU.Engine, state: NLUState) {
   function hasPotentialNLUChange(filePath: string): boolean {
     return filePath.includes('/intents/') || filePath.includes('/entities/')
   }
@@ -66,7 +67,7 @@ export function getOnBotMount(state: NLUState) {
     const bot = await bp.bots.getBotById(botId)
     const ghost = bp.ghost.forBot(botId)
 
-    const { modelIdService } = bp.NLU
+    const { modelIdService } = bp.NLU.core
     const modelService = new ModelService(modelIdService, ghost, botId)
     await modelService.initialize()
 
@@ -92,7 +93,7 @@ export function getOnBotMount(state: NLUState) {
           return
         }
 
-        const trainSet: sdk.NLU.TrainingSet = {
+        const trainSet: NLU.TrainingSet = {
           intentDefs,
           entityDefs,
           languageCode,
@@ -123,7 +124,7 @@ export function getOnBotMount(state: NLUState) {
           }
 
           const previousModel = botState.modelsByLang[languageCode]
-          const options: sdk.NLU.TrainingOptions = { previousModel, progressCallback }
+          const options: NLU.TrainingOptions = { previousModel, progressCallback }
           try {
             model = await engine.train(trainSession.key, trainSet, options)
 
@@ -133,11 +134,11 @@ export function getOnBotMount(state: NLUState) {
             await engine.loadModel(model)
             await modelService.saveModel(model)
           } catch (err) {
-            if (bp.NLU.errors.isTrainingCanceled(err)) {
+            if (bp.NLU.core.errors.isTrainingCanceled(err)) {
               bp.logger.forBot(botId).info('Training cancelled')
               trainSession.status = 'needs-training'
               await state.sendNLUStatusEvent(botId, trainSession)
-            } else if (bp.NLU.errors.isTrainingAlreadyStarted(err)) {
+            } else if (bp.NLU.core.errors.isTrainingAlreadyStarted(err)) {
               bp.logger.forBot(botId).info('Training already started')
             } else {
               bp.logger

--- a/modules/nlu/src/backend/module-lifecycle/on-server-ready.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-ready.ts
@@ -1,3 +1,4 @@
+import * as NLU from 'botpress/nlu'
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 
@@ -7,7 +8,7 @@ import { NLUState } from '../typings'
 
 export function getOnServerReady(state: NLUState) {
   return async (bp: typeof sdk) => {
-    const loadModel = async (botId: string, modelId: sdk.NLU.ModelId) => {
+    const loadModel = async (botId: string, modelId: NLU.ModelId) => {
       if (!state.nluByBot[botId]) {
         return
       }

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -1,3 +1,4 @@
+import * as NLU from 'botpress/nlu'
 import * as sdk from 'botpress/sdk'
 import bytes from 'bytes'
 import _ from 'lodash'
@@ -51,7 +52,7 @@ const registerMiddleware = async (bp: typeof sdk, state: NLUState) => {
         const predictionHandler = new PredictionHandler(
           modelsByLang,
           modelService,
-          bp.NLU.modelIdService,
+          bp.NLU.core.modelIdService,
           engine,
           anticipatedLanguage,
           defaultLanguage,
@@ -114,20 +115,20 @@ export function getOnSeverStarted(state: NLUState) {
     await initializeReportingTool(bp, state)
     const globalConfig: Config = await bp.config.getModuleConfig('nlu')
 
-    const logger = <sdk.NLU.Logger>{
+    const logger = <NLU.Logger>{
       info: (msg: string) => bp.logger.info(msg),
       warning: (msg: string, err?: Error) => (err ? bp.logger.attachError(err).warn(msg) : bp.logger.warn(msg)),
       error: (msg: string, err?: Error) => (err ? bp.logger.attachError(err).error(msg) : bp.logger.error(msg))
     }
 
     const { ducklingEnabled, ducklingURL, languageSources, modelCacheSize } = globalConfig
-    const parsedConfig: sdk.NLU.Config = {
+    const parsedConfig: NLU.Config = {
       languageSources,
       ducklingEnabled,
       ducklingURL,
       modelCacheSize: bytes(modelCacheSize)
     }
-    state.engine = await bp.NLU.makeEngine(parsedConfig, logger)
+    state.engine = await bp.NLU.core.makeEngine(parsedConfig, logger)
 
     await registerMiddleware(bp, state)
   }

--- a/modules/nlu/src/backend/prediction-handler.test.ts
+++ b/modules/nlu/src/backend/prediction-handler.test.ts
@@ -1,6 +1,8 @@
 import '../../../../src/bp/sdk/botpress.d'
+import '../../../../src/bp/sdk/nlu.d'
 
-import { NLU, IO, Logger } from 'botpress/sdk'
+import { Logger } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 
 import _ from 'lodash'
 import ModelService from './model-service'

--- a/modules/nlu/src/backend/prediction-handler.ts
+++ b/modules/nlu/src/backend/prediction-handler.ts
@@ -1,3 +1,4 @@
+import * as NLU from 'botpress/nlu'
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 
@@ -9,10 +10,10 @@ type WithoutDetectedLanguage = Omit<WithoutIncludedContexts, 'detectedLanguage'>
 
 export class PredictionHandler {
   constructor(
-    private modelsByLang: _.Dictionary<sdk.NLU.ModelId>,
+    private modelsByLang: _.Dictionary<NLU.ModelId>,
     private modelService: ModelService,
-    private modelIdService: typeof sdk.NLU.modelIdService,
-    private engine: sdk.NLU.Engine,
+    private modelIdService: typeof NLU.modelIdService,
+    private engine: NLU.Engine,
     private anticipatedLanguage: string,
     private defaultLanguage: string,
     private logger: sdk.Logger
@@ -108,7 +109,7 @@ export class PredictionHandler {
     }
   }
 
-  private fetchModel(languageCode: string): Promise<sdk.NLU.Model> {
+  private fetchModel(languageCode: string): Promise<NLU.Model> {
     const modelId = this.modelsByLang[languageCode]
     if (modelId) {
       return this.modelService.getModel(modelId)

--- a/modules/nlu/src/backend/typings.ts
+++ b/modules/nlu/src/backend/typings.ts
@@ -1,4 +1,5 @@
-import { ListenHandle, NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
+import * as sdk from 'botpress/sdk'
 
 import ModelService from './model-service'
 
@@ -7,7 +8,7 @@ export interface NLUState {
   nluByBot: _.Dictionary<BotState>
   broadcastLoadModel?: (botId: string, modelId: NLU.ModelId) => Promise<void>
   broadcastCancelTraining?: (botId: string, language: string) => Promise<void>
-  sendNLUStatusEvent: (botId: string, trainSession: NLU.TrainingSession) => Promise<void>
+  sendNLUStatusEvent: (botId: string, trainSession: sdk.NLU.TrainingSession) => Promise<void>
 }
 
 export interface BotState {
@@ -18,10 +19,10 @@ export interface BotState {
 
   // TODO: we keep this DS in memory because it contains an unserializable lock,
   // but this should be abstracted by the train session service.
-  trainSessions: _.Dictionary<NLU.TrainingSession>
+  trainSessions: _.Dictionary<sdk.NLU.TrainingSession>
 
   cancelTraining: (lang: string) => Promise<void>
-  needsTrainingWatcher: ListenHandle
+  needsTrainingWatcher: sdk.ListenHandle
   modelsByLang: _.Dictionary<NLU.ModelId>
 
   modelService: ModelService
@@ -30,5 +31,5 @@ export interface BotState {
 export interface NLUProgressEvent {
   type: 'nlu'
   botId: string
-  trainSession: NLU.TrainingSession
+  trainSession: sdk.NLU.TrainingSession
 }

--- a/modules/nlu/src/config.ts
+++ b/modules/nlu/src/config.ts
@@ -1,4 +1,4 @@
-import { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 
 export interface Config {
   /**

--- a/modules/nlu/src/migrations/v12_7_1-1583507028-prune_and_compress_models.ts
+++ b/modules/nlu/src/migrations/v12_7_1-1583507028-prune_and_compress_models.ts
@@ -1,3 +1,4 @@
+import * as NLU from 'botpress/nlu'
 import * as sdk from 'botpress/sdk'
 import fse, { WriteStream } from 'fs-extra'
 import _ from 'lodash'
@@ -31,7 +32,7 @@ export async function getModel(
   ghost: sdk.ScopedGhostService,
   hash: string,
   lang: string
-): Promise<sdk.NLU.Model | undefined> {
+): Promise<NLU.Model | undefined> {
   const fname = makeFileName(hash, lang)
   if (!(await ghost.fileExists(MODELS_DIR, fname))) {
     return
@@ -56,7 +57,7 @@ export async function getModel(
   }
 }
 
-export async function getLatestModel(ghost: sdk.ScopedGhostService, lang: string): Promise<sdk.NLU.Model | undefined> {
+export async function getLatestModel(ghost: sdk.ScopedGhostService, lang: string): Promise<NLU.Model | undefined> {
   const availableModels = await listModelsForLang(ghost, lang)
   if (availableModels.length === 0) {
     return
@@ -64,11 +65,7 @@ export async function getLatestModel(ghost: sdk.ScopedGhostService, lang: string
   return getModel(ghost, availableModels[0].split('.')[0], lang)
 }
 
-export async function saveModel(
-  ghost: sdk.ScopedGhostService,
-  model: sdk.NLU.Model,
-  hash: string
-): Promise<void | void[]> {
+export async function saveModel(ghost: sdk.ScopedGhostService, model: NLU.Model, hash: string): Promise<void | void[]> {
   const serialized = JSON.stringify(model)
   const modelName = makeFileName(hash, model.languageCode)
   const tmpDir = tmp.dirSync({ unsafeCleanup: true })

--- a/modules/nlu/src/views/full/intents/FullEditor.tsx
+++ b/modules/nlu/src/views/full/intents/FullEditor.tsx
@@ -1,4 +1,3 @@
-import { AxiosInstance } from 'axios'
 import { NLU } from 'botpress/sdk'
 import { utils } from 'botpress/shared'
 import cx from 'classnames'

--- a/modules/tsconfig.shared.json
+++ b/modules/tsconfig.shared.json
@@ -16,7 +16,8 @@
     "types": ["reflect-metadata", "bluebird-global"],
     "paths": {
       "common/*": ["../../src/bp/common/*"],
-      "botpress/sdk": ["../../src/bp/sdk/botpress.d.ts"]
+      "botpress/sdk": ["../../src/bp/sdk/botpress.d.ts"],
+      "botpress/nlu": ["../../src/bp/sdk/nlu.d.ts"]
     }
   },
   "exclude": ["**/*.test.ts", "**/views/**"],

--- a/src/bp/cluster.ts
+++ b/src/bp/cluster.ts
@@ -104,7 +104,7 @@ function spawnWebWorker() {
   debug('Spawned Web Worker')
 }
 
-export async function spawnNewTrainingWorker(config: sdk.NLU.LanguageConfig, requestId: string): Promise<number> {
+export async function spawnNewTrainingWorker(config: any, requestId: string): Promise<number> {
   if (!process.TRAINING_WORKERS) {
     process.TRAINING_WORKERS = []
   }

--- a/src/bp/core/api.ts
+++ b/src/bp/core/api.ts
@@ -1,14 +1,11 @@
 import * as sdk from 'botpress/sdk'
 import { WellKnownFlags } from 'core/sdk/enums'
-import { NextFunction, Request, Response } from 'express'
 import { inject, injectable } from 'inversify'
 import Knex from 'knex'
 import _ from 'lodash'
 import { Memoize } from 'lodash-decorators'
 import MLToolkit from 'ml/toolkit'
-import Engine from 'nlu-core/engine'
-import { isTrainingAlreadyStarted, isTrainingCanceled } from 'nlu-core/errors'
-import modelIdService from 'nlu-core/model-id-service'
+import nluCore from 'nlu-core'
 
 import { container } from './app.inversify'
 import { ConfigProvider } from './config/config-loader'
@@ -319,18 +316,7 @@ export class BotpressAPIProvider {
       workspaces: this.workspaces,
       distributed: this.distributed,
       NLU: {
-        makeEngine: async (config: sdk.NLU.Config, logger: sdk.NLU.Logger) => {
-          const { ducklingEnabled, ducklingURL, languageSources, modelCacheSize } = config
-          const langConfig = { ducklingEnabled, ducklingURL, languageSources }
-          const engine = new Engine({ maxCacheSize: modelCacheSize })
-          await engine.initialize(langConfig, logger)
-          return engine
-        },
-        errors: {
-          isTrainingAlreadyStarted,
-          isTrainingCanceled
-        },
-        modelIdService
+        core: nluCore
       }
     }
   }

--- a/src/bp/nlu-core/engine.ts
+++ b/src/bp/nlu-core/engine.ts
@@ -1,4 +1,4 @@
-import { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 import bytes from 'bytes'
 import _ from 'lodash'
 import LRUCache from 'lru-cache'

--- a/src/bp/nlu-core/entities/duckling-extractor/duckling-client.ts
+++ b/src/bp/nlu-core/entities/duckling-extractor/duckling-client.ts
@@ -1,6 +1,6 @@
 import Axios, { AxiosInstance } from 'axios'
 import retry from 'bluebird-retry'
-import { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 import httpsProxyAgent from 'https-proxy-agent'
 import _ from 'lodash'
 

--- a/src/bp/nlu-core/entities/duckling-extractor/index.ts
+++ b/src/bp/nlu-core/entities/duckling-extractor/index.ts
@@ -1,4 +1,4 @@
-import { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 import _ from 'lodash'
 import { extractPattern } from '../../tools/patterns-utils'
 import { JOIN_CHAR } from '../../tools/token-utils'

--- a/src/bp/nlu-core/entities/entity-cache-manager.ts
+++ b/src/bp/nlu-core/entities/entity-cache-manager.ts
@@ -1,4 +1,4 @@
-import { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 import { ensureFile, pathExists, readJSON, writeJson } from 'fs-extra'
 import _ from 'lodash'
 import LRUCache from 'lru-cache'

--- a/src/bp/nlu-core/entities/microsoft-extractor/index.ts
+++ b/src/bp/nlu-core/entities/microsoft-extractor/index.ts
@@ -1,4 +1,4 @@
-import { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 import _ from 'lodash'
 
 import { EntityExtractionResult, SystemEntityExtractor, KeyedItem } from '../../typings'

--- a/src/bp/nlu-core/entities/microsoft-extractor/microsoft-extractor.test.ts
+++ b/src/bp/nlu-core/entities/microsoft-extractor/microsoft-extractor.test.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import { MicrosoftEntityExtractor } from '.'
 import { SystemEntityCacheManager } from '../entity-cache-manager'
 import { createSpyObject, MockObject } from 'core/misc/utils'
-import { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 import { KeyedItem } from 'nlu-core/typings'
 
 describe('Microsoft Extract Multiple', () => {

--- a/src/bp/nlu-core/index.ts
+++ b/src/bp/nlu-core/index.ts
@@ -1,0 +1,20 @@
+import * as NLU from 'botpress/nlu'
+import Engine from './engine'
+import { isTrainingAlreadyStarted, isTrainingCanceled } from './errors'
+import modelIdService from './model-id-service'
+
+const nluCore: typeof NLU = {
+  makeEngine: async (config: NLU.Config, logger: NLU.Logger) => {
+    const { ducklingEnabled, ducklingURL, languageSources, modelCacheSize } = config
+    const langConfig = { ducklingEnabled, ducklingURL, languageSources }
+    const engine = new Engine({ maxCacheSize: modelCacheSize })
+    await engine.initialize(langConfig, logger)
+    return engine
+  },
+  errors: {
+    isTrainingAlreadyStarted,
+    isTrainingCanceled
+  },
+  modelIdService
+}
+export default nluCore

--- a/src/bp/nlu-core/initialize-tools.ts
+++ b/src/bp/nlu-core/initialize-tools.ts
@@ -1,4 +1,4 @@
-import { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 import MLToolkit from 'ml/toolkit'
 import path from 'path'
 import yn from 'yn'

--- a/src/bp/nlu-core/intents/oos-intent-classfier.ts
+++ b/src/bp/nlu-core/intents/oos-intent-classfier.ts
@@ -1,6 +1,8 @@
-import { MLToolkit, NLU } from 'botpress/sdk'
-import _ from 'lodash'
+import * as NLU from 'botpress/nlu'
+import { MLToolkit } from 'botpress/sdk'
 import Joi, { validate } from 'joi'
+import _ from 'lodash'
+import { ModelLoadingError } from 'nlu-core/errors'
 import { isPOSAvailable } from 'nlu-core/language/pos-tagger'
 import {
   featurizeInScopeUtterances,
@@ -16,7 +18,6 @@ import { ExactIntenClassifier } from './exact-intent-classifier'
 import { IntentTrainInput, NoneableIntentClassifier, NoneableIntentPredictions } from './intent-classifier'
 import { getIntentFeatures } from './intent-featurizer'
 import { SvmIntentClassifier } from './svm-intent-classifier'
-import { ModelLoadingError } from 'nlu-core/errors'
 
 interface TrainInput extends IntentTrainInput {
   allUtterances: Utterance[]

--- a/src/bp/nlu-core/intents/svm-intent-classifier.ts
+++ b/src/bp/nlu-core/intents/svm-intent-classifier.ts
@@ -1,11 +1,12 @@
-import { MLToolkit, NLU } from 'botpress/sdk'
-import _ from 'lodash'
+import * as NLU from 'botpress/nlu'
+import { MLToolkit } from 'botpress/sdk'
 import Joi, { validate } from 'joi'
+import _ from 'lodash'
+import { ModelLoadingError } from 'nlu-core/errors'
 import { ListEntityModel, PatternEntity, Tools } from 'nlu-core/typings'
 import Utterance from 'nlu-core/utterance/utterance'
 
 import { IntentClassifier, IntentPredictions, IntentTrainInput } from './intent-classifier'
-import { ModelLoadingError } from 'nlu-core/errors'
 
 type Featurizer = (u: Utterance, entities: string[]) => number[]
 export interface Model {

--- a/src/bp/nlu-core/language/language-provider.ts
+++ b/src/bp/nlu-core/language/language-provider.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from 'axios'
 import retry from 'bluebird-retry'
-import { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 import crypto from 'crypto'
 import fse from 'fs-extra'
 import httpsProxyAgent from 'https-proxy-agent'

--- a/src/bp/nlu-core/model-id-service.test.ts
+++ b/src/bp/nlu-core/model-id-service.test.ts
@@ -1,4 +1,4 @@
-import { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 
 import modelIdService from './model-id-service'
 import { HALF_MD5_REG } from './tools/crypto'

--- a/src/bp/nlu-core/model-id-service.ts
+++ b/src/bp/nlu-core/model-id-service.ts
@@ -1,4 +1,4 @@
-import { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 import _ from 'lodash'
 
 import { halfmd5, HALF_MD5_REG } from './tools/crypto'

--- a/src/bp/nlu-core/model-serializer.ts
+++ b/src/bp/nlu-core/model-serializer.ts
@@ -1,19 +1,20 @@
+import * as NLU from 'botpress/nlu'
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 
 import { TrainInput, TrainOutput } from './training-pipeline'
 
-export type PredictableModel = Omit<sdk.NLU.Model, 'data'> & {
+export type PredictableModel = Omit<NLU.Model, 'data'> & {
   data: {
     input: TrainInput
     output: TrainOutput
   }
 }
 
-export function serializeModel(model: PredictableModel): sdk.NLU.Model {
+export function serializeModel(model: PredictableModel): NLU.Model {
   const { specificationHash, contentHash, languageCode: lang, startedAt, finishedAt, data, seed } = model
 
-  const serialized: sdk.NLU.Model = {
+  const serialized: NLU.Model = {
     specificationHash,
     contentHash,
     languageCode: lang,
@@ -32,7 +33,7 @@ export function serializeModel(model: PredictableModel): sdk.NLU.Model {
   return serialized
 }
 
-export function deserializeModel(serialized: sdk.NLU.Model): PredictableModel {
+export function deserializeModel(serialized: NLU.Model): PredictableModel {
   const { specificationHash, contentHash, languageCode, startedAt, finishedAt, data, seed } = serialized
 
   const model: PredictableModel = {

--- a/src/bp/nlu-core/predict-pipeline.ts
+++ b/src/bp/nlu-core/predict-pipeline.ts
@@ -1,4 +1,5 @@
-import { MLToolkit, NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
+import { MLToolkit } from 'botpress/sdk'
 import _ from 'lodash'
 
 import { extractListEntities, extractPatternEntities } from './entities/custom-entity-extractor'
@@ -172,7 +173,7 @@ function MapStepToOutput(step: SlotStep): NLU.PredictOutput {
 
   const entities = step.utterance.entities.map(entitiesMapper)
 
-  const slotsCollectionReducer = (slots: NLU.SlotCollection, s: SlotExtractionResult): NLU.SlotCollection => {
+  const slotsCollectionReducer = (slots: Dic<NLU.Slot>, s: SlotExtractionResult): Dic<NLU.Slot> => {
     if (slots[s.slot.name] && slots[s.slot.name].confidence > s.slot.confidence) {
       // we keep only the most confident slots
       return slots

--- a/src/bp/nlu-core/training-pipeline.ts
+++ b/src/bp/nlu-core/training-pipeline.ts
@@ -1,3 +1,4 @@
+import * as NLU from 'botpress/nlu'
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 
@@ -67,7 +68,7 @@ export interface TrainOutput {
 }
 
 interface Tools extends LanguageTools {
-  logger?: sdk.NLU.Logger
+  logger?: NLU.Logger
 }
 
 type progressCB = (p?: number) => void
@@ -318,7 +319,7 @@ async function TrainSlotTaggers(input: TrainStep, tools: Tools, progress: progre
 
 const NB_STEPS = 5 // change this if the training pipeline changes
 
-const makeLogger = (trainId: string, logger?: sdk.NLU.Logger) => {
+const makeLogger = (trainId: string, logger?: NLU.Logger) => {
   return <T extends (...args: any[]) => any>(fn: T) => (...args: Parameters<T>): ReturnType<T> => {
     logger?.debug(`[${trainId}] Started ${fn.name}`)
     const ret = fn(...args)

--- a/src/bp/nlu-core/training-worker-queue/communication.ts
+++ b/src/bp/nlu-core/training-worker-queue/communication.ts
@@ -1,4 +1,4 @@
-import { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 import { ErrorMessage } from 'ml/error-utils'
 
 import { TrainInput, TrainOutput } from '../training-pipeline'

--- a/src/bp/nlu-core/training-worker-queue/index.ts
+++ b/src/bp/nlu-core/training-worker-queue/index.ts
@@ -1,4 +1,4 @@
-import { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 import cluster, { Worker } from 'cluster'
 import _ from 'lodash'
 import { deserializeError, serializeError } from 'ml/error-utils'

--- a/src/bp/nlu-core/typings.ts
+++ b/src/bp/nlu-core/typings.ts
@@ -1,5 +1,6 @@
 import { AxiosInstance } from 'axios'
-import sdk, { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
+import sdk from 'botpress/sdk'
 import LRUCache from 'lru-cache'
 
 export const BIO = {
@@ -21,7 +22,7 @@ export interface LangServerInfo {
 }
 
 export interface Gateway {
-  source: sdk.NLU.LanguageSource
+  source: NLU.LanguageSource
   client: AxiosInstance
   errors: number
   disabledUntil?: Date
@@ -37,7 +38,7 @@ export interface LanguageProvider {
   vectorize(tokens: string[], lang: string): Promise<Float32Array[]>
   tokenize(utterances: string[], lang: string, vocab?: string[]): Promise<string[][]>
   generateSimilarJunkWords(subsetVocab: string[], lang: string): Promise<string[]>
-  getHealth(): Partial<sdk.NLU.Health>
+  getHealth(): Partial<NLU.Health>
 }
 
 export type TFIDF = _.Dictionary<number>
@@ -129,7 +130,7 @@ export interface Tools {
   getStopWordsForLang(lang: string): Promise<string[]>
 
   // system info
-  getHealth(): sdk.NLU.Health
+  getHealth(): NLU.Health
   getLanguages(): string[]
   getSpecifications(): NLU.Specifications
 

--- a/src/bp/nlu-server/api-mapper.ts
+++ b/src/bp/nlu-server/api-mapper.ts
@@ -1,4 +1,4 @@
-import { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 import _ from 'lodash'
 
 import {

--- a/src/bp/nlu-server/index.ts
+++ b/src/bp/nlu-server/index.ts
@@ -1,4 +1,4 @@
-import { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 import bytes from 'bytes'
 import chalk from 'chalk'
 import cluster from 'cluster'

--- a/src/bp/nlu-server/model-repo.ts
+++ b/src/bp/nlu-server/model-repo.ts
@@ -1,4 +1,4 @@
-import { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 import crypto from 'crypto'
 import fse, { WriteStream } from 'fs-extra'
 import _ from 'lodash'

--- a/src/bp/nlu-server/remove-none.ts
+++ b/src/bp/nlu-server/remove-none.ts
@@ -1,4 +1,4 @@
-import { NLU } from 'botpress/sdk'
+import * as NLU from 'botpress/nlu'
 import _ from 'lodash'
 
 import { BpPredictOutput } from './api-mapper'

--- a/src/bp/nlu-server/train-service.ts
+++ b/src/bp/nlu-server/train-service.ts
@@ -1,3 +1,4 @@
+import * as NLU from 'botpress/nlu'
 import * as sdk from 'botpress/sdk'
 import Engine from 'nlu-core/engine'
 import { isTrainingAlreadyStarted, isTrainingCanceled } from 'nlu-core/errors'
@@ -15,7 +16,7 @@ export default class TrainService {
   ) {}
 
   train = async (
-    modelId: sdk.NLU.ModelId,
+    modelId: NLU.ModelId,
     password: string,
     intents: sdk.NLU.IntentDefinition[],
     entities: sdk.NLU.EntityDefinition[],
@@ -37,7 +38,7 @@ export default class TrainService {
     }
 
     try {
-      const trainSet: sdk.NLU.TrainingSet = {
+      const trainSet: NLU.TrainingSet = {
         intentDefs: intents,
         entityDefs: entities,
         languageCode: language,

--- a/src/bp/nlu-server/train-session-service.ts
+++ b/src/bp/nlu-server/train-session-service.ts
@@ -1,3 +1,4 @@
+import * as NLU from 'botpress/nlu'
 import * as sdk from 'botpress/sdk'
 import crypto from 'crypto'
 import LRUCache from 'lru-cache'
@@ -15,14 +16,14 @@ export default class TrainSessionService {
 
   constructor() {}
 
-  makeTrainingSession = (modelId: sdk.NLU.ModelId, password: string, language: string): TrainingSession => ({
+  makeTrainingSession = (modelId: NLU.ModelId, password: string, language: string): TrainingSession => ({
     key: this._makeTrainSessionKey(modelId, password),
     status: 'training-pending',
     progress: 0,
     language
   })
 
-  getTrainingSession(modelId: sdk.NLU.ModelId, password: string): TrainingSession | undefined {
+  getTrainingSession(modelId: NLU.ModelId, password: string): TrainingSession | undefined {
     const key = this._makeTrainSessionKey(modelId, password)
     const ts = this.trainSessions[key]
     if (ts) {
@@ -31,7 +32,7 @@ export default class TrainSessionService {
     return this.releasedTrainSessions.get(key)
   }
 
-  setTrainingSession(modelId: sdk.NLU.ModelId, password: string, trainSession: TrainingSession) {
+  setTrainingSession(modelId: NLU.ModelId, password: string, trainSession: TrainingSession) {
     const key = this._makeTrainSessionKey(modelId, password)
     if (this.releasedTrainSessions.get(key)) {
       this.releasedTrainSessions.del(key)
@@ -39,14 +40,14 @@ export default class TrainSessionService {
     this.trainSessions[key] = trainSession
   }
 
-  releaseTrainingSession(modelId: sdk.NLU.ModelId, password: string): void {
+  releaseTrainingSession(modelId: NLU.ModelId, password: string): void {
     const key = this._makeTrainSessionKey(modelId, password)
     const ts = this.trainSessions[key]
     delete this.trainSessions[key]
     this.releasedTrainSessions.set(key, ts)
   }
 
-  private _makeTrainSessionKey(modelId: sdk.NLU.ModelId, password: string) {
+  private _makeTrainSessionKey(modelId: NLU.ModelId, password: string) {
     const stringId = modelIdService.toString(modelId)
     return crypto
       .createHash('md5')

--- a/src/bp/sdk/nlu.d.ts
+++ b/src/bp/sdk/nlu.d.ts
@@ -1,0 +1,195 @@
+/**
+ * This is the SDK of internal module "nlu-core".
+ * It is meant to insulate users from changes in types occuring inside our nlu.
+ */
+declare module 'botpress/nlu' {
+  export namespace errors {
+    export const isTrainingCanceled: (err: Error) => boolean
+    export const isTrainingAlreadyStarted: (err: Error) => boolean
+  }
+
+  export const makeEngine: (config: Config, logger: Logger) => Promise<Engine>
+
+  export interface Config extends LanguageConfig {
+    modelCacheSize: number
+  }
+
+  export interface LanguageConfig {
+    ducklingURL: string
+    ducklingEnabled: boolean
+    languageSources: LanguageSource[]
+  }
+
+  export interface LanguageSource {
+    endpoint: string
+    authToken?: string
+  }
+
+  export interface Logger {
+    debug: (msg: string) => void
+    info: (msg: string) => void
+    warning: (msg: string, err?: Error) => void
+    error: (msg: string, err?: Error) => void
+  }
+
+  export type EntityType = 'system' | 'pattern' | 'list'
+
+  export interface EntityDefOccurrence {
+    name: string
+    synonyms: string[]
+  }
+
+  export interface EntityDefinition {
+    id: string
+    name: string
+    type: EntityType
+    sensitive?: boolean
+    matchCase?: boolean
+    examples?: string[]
+    fuzzy?: number
+    occurrences?: EntityDefOccurrence[]
+    pattern?: string
+  }
+
+  export interface SlotDefinition {
+    id: string
+    name: string
+    entities: string[]
+    color: number
+  }
+
+  export interface IntentDefinition {
+    name: string
+    utterances: {
+      [lang: string]: string[]
+    }
+    slots: SlotDefinition[]
+    contexts: string[]
+  }
+
+  export interface Entity {
+    name: string
+    type: string
+    meta: EntityMeta
+    data: EntityBody
+  }
+
+  export interface EntityBody {
+    extras?: any
+    value: any
+    unit: string
+  }
+
+  export interface EntityMeta {
+    sensitive: boolean
+    confidence: number
+    provider?: string
+    source: string
+    start: number
+    end: number
+    raw?: any
+  }
+
+  export interface TrainingSet {
+    intentDefs: IntentDefinition[]
+    entityDefs: EntityDefinition[]
+    languageCode: string
+    seed: number // seeds random number generator in nlu training
+  }
+
+  export interface ModelIdArgs extends TrainingSet {
+    specifications: Specifications
+  }
+
+  export interface TrainingOptions {
+    progressCallback: (x: number) => void
+    previousModel: ModelId | undefined
+  }
+
+  export interface ContextPrediction {
+    confidence: number
+    oos: number
+    intents: {
+      label: string
+      confidence: number
+      slots: Dic<Slot>
+      extractor: string
+    }[]
+  }
+
+  export interface Predictions {
+    [context: string]: ContextPrediction
+  }
+
+  export interface PredictOutput {
+    entities: Entity[]
+    predictions: Predictions
+  }
+
+  export interface Slot {
+    name: string
+    value: any
+    source: any
+    entity: Entity
+    confidence: number
+    start: number
+    end: number
+  }
+
+  export interface Engine {
+    getHealth: () => Health
+    getLanguages: () => string[]
+    getSpecifications: () => Specifications
+
+    loadModel: (model: Model) => Promise<void>
+    unloadModel: (modelId: ModelId) => void
+    hasModel: (modelId: ModelId) => boolean
+
+    train: (trainSessionId: string, trainSet: TrainingSet, options?: Partial<TrainingOptions>) => Promise<Model>
+    cancelTraining: (trainSessionId: string) => Promise<void>
+
+    detectLanguage: (text: string, modelByLang: Dic<ModelId>) => Promise<string>
+    predict: (text: string, modelId: ModelId) => Promise<PredictOutput>
+    spellCheck: (sentence: string, modelId: ModelId) => Promise<string>
+  }
+
+  export const modelIdService: {
+    toString: (modelId: ModelId) => string // to use ModelId as a key
+    fromString: (stringId: string) => ModelId // to parse information from a key
+    toId: (m: Model) => ModelId // keeps only minimal information to make an id
+    isId: (m: string) => boolean
+    makeId: (factors: ModelIdArgs) => ModelId
+    briefId: (factors: Partial<ModelIdArgs>) => Partial<ModelId> // makes incomplete Id from incomplete information
+  }
+
+  export interface ModelId {
+    specificationHash: string // represents the nlu engine that was used to train the model
+    contentHash: string // represents the intent and entity definitions the model was trained with
+    seed: number // number to seed the random number generators used during nlu training
+    languageCode: string // language of the model
+  }
+
+  export interface Specifications {
+    nluVersion: string // semver string
+    languageServer: {
+      dimensions: number
+      domain: string
+      version: string // semver string
+    }
+  }
+
+  export type Model = ModelId & {
+    startedAt: Date
+    finishedAt: Date
+    data: {
+      input: string
+      output: string
+    }
+  }
+
+  export interface Health {
+    isEnabled: boolean
+    validProvidersCount: number
+    validLanguages: string[]
+  }
+}


### PR DESCRIPTION
This PR is quite simple;

I isolated all nlu-core related typings in a *hidden* sdk called "botpress/nlu".

Basic Idea:

![image](https://user-images.githubusercontent.com/25970722/109566166-7bd09780-7ab1-11eb-87fd-4c50d8c82394.png)


For now, there's no true changes between the namespace NLU of the whole Botpress SDK, but there's a lot on my mind, starting with getting rid of **contexts** in nlu-core's API.

In fact, everything in sdk.NLU namespace related to frontend, filesystem/database persistency, `EventUnderstanding`, has almost nothing to do with the core nlu algorithms. Being so different, these 2 parts of code should be representend by 2 different APIs.

This problem didn't exist before summer when Stan wasn't a thing yet. But, to make Stan, we had to move engine in the core. Doing so, I ended up exposing types that should have stayed private.  

Reasons to merge this PR:

1. NLU core typings are now in a seperate undocumented file making them more hidden. We don't need the user to be aware of the existence of `Engine` or `TrainingOptions` for now. 
2. `bp.NLU.core` is now clearly marked as experimental so users are warned not to use it.
3. I can move way faster and make the API as good-looking as I want.

**alternative design**:
I just tought of this while writing this PR's description, but nlu-core could also be a standalone npm package required by nlu-module in its package.json