### PR TITLE
fix(nlu): race condition on import ml toolkit

### DIFF
--- a/src/bp/nlu-server/index.ts
+++ b/src/bp/nlu-server/index.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line import/order
+import rewire from '../sdk/rewire'
+// eslint-disable-next-line import/order
 import { NLU } from 'botpress/sdk'
 import bytes from 'bytes'
 import chalk from 'chalk'
@@ -10,10 +13,6 @@ import path from 'path'
 import { setupMasterNode, WORKER_TYPES } from '../cluster'
 import center from '../core/logger/center'
 import { LogLevel } from '../core/sdk/enums'
-
-// eslint-disable-next-line import/order
-import rewire from '../sdk/rewire'
-// eslint-disable-next-line import/order
 
 global.rewire = rewire as any
 


### PR DESCRIPTION
This is a small fix to hide/remove the race condition on imports for the ml toolkit in the standalone NLU. 

This crashed when trying to import nlu-server which imported API -> engine -> ML toolkit and thus the crf node binding. 

However, loading it too fast didn't allow rewire.ts to find it and a Module not found was raised. 

Moving the line up allow for a longer time to load everything and worked fined. 

Note : I was the only one to experience this bug but it needed to be fixed. 