### PR TITLE
fix(mig): ensure strategy table exist before alter

### DIFF
--- a/src/bp/migrations/v12_17_1-1611946378-implement_token_version.ts
+++ b/src/bp/migrations/v12_17_1-1611946378-implement_token_version.ts
@@ -12,8 +12,13 @@ const migration: Migration = {
     const config = await configProvider.getBotpressConfig()
 
     for (const strategy of Object.keys(config.authStrategies)) {
-      if (!(await bp.database.schema.hasColumn(`strategy_${strategy}`, 'tokenVersion'))) {
-        await bp.database.schema.alterTable(`strategy_${strategy}`, table => {
+      const tableName = `strategy_${strategy}`
+
+      if (
+        (await bp.database.schema.hasTable(tableName)) &&
+        !(await bp.database.schema.hasColumn(tableName, 'tokenVersion'))
+      ) {
+        await bp.database.schema.alterTable(tableName, table => {
           table
             .integer('tokenVersion')
             .notNullable()


### PR DESCRIPTION
If the following conditions are met:
- Config version is < 12.17.1
- Current version is ≥ 12.17.1
- Table strategy_{strategy} does not exist 

The migration `v12_17_1-1611946378-implement_token_version.ts` will fail with `error: relation strategy_default does not exist`

It is safer to check for the existence (`bp.database.schema.hasTable(tableName))`) of table `strategy_{strategy}` before attempting the migration.

