### PR TITLE
fix(nlu): intent clf picks exact match over svm

### DIFF
--- a/build/nlu-regression/current_scores/bpds-intent.json
+++ b/build/nlu-regression/current_scores/bpds-intent.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-02-12T17:52:30.479Z",
+  "generatedOn": "2021-03-03T15:38:00.296Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-slots.json
+++ b/build/nlu-regression/current_scores/bpds-slots.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-02-12T17:52:43.604Z",
+  "generatedOn": "2021-03-03T15:38:14.032Z",
   "scores": [
     {
       "metric": "avgScore:slotsAre",

--- a/build/nlu-regression/current_scores/bpds-spell.json
+++ b/build/nlu-regression/current_scores/bpds-spell.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-02-12T17:52:48.107Z",
+  "generatedOn": "2021-03-03T15:38:18.350Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/clinc150.json
+++ b/build/nlu-regression/current_scores/clinc150.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-02-12T17:59:21.966Z",
+  "generatedOn": "2021-03-03T15:44:39.518Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/src/bp/nlu-core/intents/exact-intent-classifier.ts
+++ b/src/bp/nlu-core/intents/exact-intent-classifier.ts
@@ -1,10 +1,10 @@
-import _ from 'lodash'
 import Joi, { validate } from 'joi'
+import _ from 'lodash'
+import { ModelLoadingError } from 'nlu-core/errors'
 import { Intent } from 'nlu-core/typings'
 import Utterance, { UtteranceToStringOptions } from 'nlu-core/utterance/utterance'
 
-import { IntentClassifier, IntentPredictions, IntentTrainInput } from './intent-classifier'
-import { ModelLoadingError } from 'nlu-core/errors'
+import { IntentTrainInput, NoneableIntentClassifier, NoneableIntentPredictions } from './intent-classifier'
 
 export interface Model {
   intents: string[]
@@ -32,9 +32,15 @@ export const modelSchema = Joi.object()
   .keys(schemaKeys)
   .required()
 
-export class ExactIntenClassifier implements IntentClassifier {
-  private static _name = 'Exact Intent Classifier'
+export class ExactIntenClassifier implements NoneableIntentClassifier {
+  private static _displayName = 'Exact Intent Classifier'
+  private static _name = 'exact-matcher'
+
   private model: Model | undefined
+
+  get name() {
+    return ExactIntenClassifier._name
+  }
 
   async train(trainInput: IntentTrainInput, progress: (p: number) => void) {
     const { intents } = trainInput
@@ -66,7 +72,7 @@ export class ExactIntenClassifier implements IntentClassifier {
 
   serialize() {
     if (!this.model) {
-      throw new Error(`${ExactIntenClassifier._name} must be trained before calling serialize.`)
+      throw new Error(`${ExactIntenClassifier._displayName} must be trained before calling serialize.`)
     }
     return JSON.stringify(this.model)
   }
@@ -77,25 +83,33 @@ export class ExactIntenClassifier implements IntentClassifier {
       const model: Model = await validate(raw, modelSchema)
       this.model = model
     } catch (err) {
-      throw new ModelLoadingError(ExactIntenClassifier._name, err)
+      throw new ModelLoadingError(ExactIntenClassifier._displayName, err)
     }
   }
 
-  async predict(utterance: Utterance): Promise<IntentPredictions> {
+  async predict(utterance: Utterance): Promise<NoneableIntentPredictions> {
     if (!this.model) {
-      throw new Error(`${ExactIntenClassifier._name} must be trained before calling predict.`)
+      throw new Error(`${ExactIntenClassifier._displayName} must be trained before calling predict.`)
     }
 
+    const { _name: extractor } = ExactIntenClassifier
+
     const { exact_match_index, intents: intentNames } = this.model
+
     const exactPred = this._findExactIntent(exact_match_index, utterance)
 
     if (exactPred) {
+      const oneHot = intentNames.map(name => ({ name, confidence: name === exactPred ? 1 : 0, extractor }))
       return {
-        intents: [{ name: exactPred, confidence: 1, extractor: 'exact-matcher' }]
+        oos: 0,
+        intents: oneHot
       }
     }
+
+    const zeros = intentNames.map(name => ({ name, confidence: 0, extractor }))
     return {
-      intents: []
+      oos: 1,
+      intents: zeros
     }
   }
 

--- a/src/bp/nlu-core/intents/exact-intent-classifier.ts
+++ b/src/bp/nlu-core/intents/exact-intent-classifier.ts
@@ -92,21 +92,19 @@ export class ExactIntenClassifier implements NoneableIntentClassifier {
       throw new Error(`${ExactIntenClassifier._displayName} must be trained before calling predict.`)
     }
 
-    const { _name: extractor } = ExactIntenClassifier
-
     const { exact_match_index, intents: intentNames } = this.model
 
     const exactPred = this._findExactIntent(exact_match_index, utterance)
 
     if (exactPred) {
-      const oneHot = intentNames.map(name => ({ name, confidence: name === exactPred ? 1 : 0, extractor }))
+      const oneHot = intentNames.map(name => ({ name, confidence: name === exactPred ? 1 : 0, extractor: this.name }))
       return {
         oos: 0,
         intents: oneHot
       }
     }
 
-    const zeros = intentNames.map(name => ({ name, confidence: 0, extractor }))
+    const zeros = intentNames.map(name => ({ name, confidence: 0, extractor: this.name }))
     return {
       oos: 1,
       intents: zeros

--- a/src/bp/nlu-core/intents/svm-intent-classifier.ts
+++ b/src/bp/nlu-core/intents/svm-intent-classifier.ts
@@ -1,11 +1,11 @@
 import { MLToolkit, NLU } from 'botpress/sdk'
-import _ from 'lodash'
 import Joi, { validate } from 'joi'
+import _ from 'lodash'
+import { ModelLoadingError } from 'nlu-core/errors'
 import { ListEntityModel, PatternEntity, Tools } from 'nlu-core/typings'
 import Utterance from 'nlu-core/utterance/utterance'
 
 import { IntentClassifier, IntentPredictions, IntentTrainInput } from './intent-classifier'
-import { ModelLoadingError } from 'nlu-core/errors'
 
 type Featurizer = (u: Utterance, entities: string[]) => number[]
 export interface Model {
@@ -36,12 +36,17 @@ export const modelSchema = Joi.object()
   .required()
 
 export class SvmIntentClassifier implements IntentClassifier {
-  private static _name = 'SVM Intent Classifier'
+  private static _displayName = 'SVM Intent Classifier'
+  private static _name = 'svm-classifier'
 
   private model: Model | undefined
   private predictors: Predictors | undefined
 
   constructor(private tools: Tools, private featurizer: Featurizer, private logger?: NLU.Logger) {}
+
+  get name() {
+    return SvmIntentClassifier._name
+  }
 
   async train(input: IntentTrainInput, progress: (p: number) => void): Promise<void> {
     const { intents, nluSeed, list_entities, pattern_entities } = input
@@ -86,7 +91,7 @@ export class SvmIntentClassifier implements IntentClassifier {
 
   serialize(): string {
     if (!this.model) {
-      throw new Error(`${SvmIntentClassifier._name} must be trained before calling serialize.`)
+      throw new Error(`${SvmIntentClassifier._displayName} must be trained before calling serialize.`)
     }
     return JSON.stringify(this.model)
   }
@@ -98,7 +103,7 @@ export class SvmIntentClassifier implements IntentClassifier {
       this.predictors = this._makePredictors(model)
       this.model = model
     } catch (err) {
-      throw new ModelLoadingError(SvmIntentClassifier._name, err)
+      throw new ModelLoadingError(SvmIntentClassifier._displayName, err)
     }
   }
 
@@ -114,7 +119,7 @@ export class SvmIntentClassifier implements IntentClassifier {
   async predict(utterance: Utterance): Promise<IntentPredictions> {
     if (!this.predictors) {
       if (!this.model) {
-        throw new Error(`${SvmIntentClassifier._name} must be trained before calling predict.`)
+        throw new Error(`${SvmIntentClassifier._displayName} must be trained before calling predict.`)
       }
 
       this.predictors = this._makePredictors(this.model)


### PR DESCRIPTION
fixes [this](https://forum.botpress.com/t/intent-worked-in-12-17-2-but-doest-in-12-18-0/4718).

Small regression introduced by this PR #4421

There was one intent of 2 utterances named **k**. This means there was not enough utterances for the intent to be part of the SVM train set.

Both the intent **k** and the none intent had confidence 1 so for some reason the none intent was picked.

This PR makes sure if an exact match occurs, svm predictions are fully ignored.