### PR TITLE
fix(studio): show turns instead of value

### DIFF
--- a/src/bp/ui-studio/src/web/components/Layout/BottomPanel/Debugger/views/Slots.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/BottomPanel/Debugger/views/Slots.tsx
@@ -38,7 +38,7 @@ const renderSlotItem = (name: string, slot: any) => {
       </td>
       <td>
         {slot.turns
-          ? lang.tr('bottomPanel.debugger.slots.turnsAgo', { x: slot.value })
+          ? lang.tr('bottomPanel.debugger.slots.turnsAgo', { x: slot.turns })
           : lang.tr('bottomPanel.debugger.slots.thisTurn')}
       </td>
     </tr>


### PR DESCRIPTION
Small fix to show the turns instead of the value in the debugger. 
## Before 
![image](https://user-images.githubusercontent.com/30974685/109834303-0929fe00-7c10-11eb-9fb4-1beb968728e1.png)


## After 
![image](https://user-images.githubusercontent.com/30974685/109834266-ffa09600-7c0f-11eb-9595-e94d6e4e7149.png)
