### PR TITLE
fix(channel-web): refactor of the webchat API

### DIFF
--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -109,8 +109,7 @@ export default async (bp: typeof sdk, db: Database) => {
 
   const assertUserInfo = (options: { convoIdRequired?: boolean } = {}) => async (req: ChatRequest, _res, next) => {
     const { botId } = req.params
-    const { userId } = req.body || {}
-    const conversationId = req.params.conversationId || req.query.conversationId
+    const { userId, conversationId } = req.body || {}
 
     if (!validateUserId(userId)) {
       return next(ERR_USER_ID_REQ)
@@ -161,7 +160,6 @@ export default async (bp: typeof sdk, db: Database) => {
     })
   )
 
-  // ?conversationId=xxx (optional)
   router.post(
     '/messages',
     bp.http.extractExternalToken,
@@ -171,7 +169,7 @@ export default async (bp: typeof sdk, db: Database) => {
       let { conversationId } = req
 
       const user = await bp.users.getOrCreateUser('web', userId, botId)
-      const payload = req.body || {}
+      const payload = req.body.payload || {}
 
       if (!SUPPORTED_MESSAGES.includes(payload.type)) {
         // TODO: Support files
@@ -211,7 +209,6 @@ export default async (bp: typeof sdk, db: Database) => {
     })
   )
 
-  // ?conversationId=xxx (required)
   router.post(
     '/messages/files',
     upload.single('file'),
@@ -240,7 +237,7 @@ export default async (bp: typeof sdk, db: Database) => {
   )
 
   router.post(
-    '/conversations/get/:conversationId',
+    '/conversations/get',
     assertUserInfo({ convoIdRequired: true }),
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
       const { userId, conversationId, botId } = req
@@ -252,7 +249,7 @@ export default async (bp: typeof sdk, db: Database) => {
   )
 
   router.post(
-    '/conversations/get',
+    '/conversations/list',
     assertUserInfo(),
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
       const { userId, botId } = req
@@ -323,7 +320,7 @@ export default async (bp: typeof sdk, db: Database) => {
       const { userId, botId } = req
       let { conversationId } = req
 
-      const payload = req.body || {}
+      const payload = req.body.payload || {}
 
       await bp.users.getOrCreateUser('web', userId, botId)
 
@@ -381,7 +378,7 @@ export default async (bp: typeof sdk, db: Database) => {
   )
 
   router.post(
-    '/conversations/:conversationId/reset',
+    '/conversations/reset',
     bp.http.extractExternalToken,
     assertUserInfo({ convoIdRequired: true }),
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
@@ -419,7 +416,7 @@ export default async (bp: typeof sdk, db: Database) => {
   )
 
   router.post(
-    '/conversations/:conversationId/reference',
+    '/conversations/reference',
     assertUserInfo(),
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
       try {
@@ -536,7 +533,7 @@ export default async (bp: typeof sdk, db: Database) => {
   }
 
   router.post(
-    '/conversations/:conversationId/download/txt',
+    '/conversations/download/txt',
     assertUserInfo({ convoIdRequired: true }),
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
       const { userId, conversationId, botId } = req
@@ -549,7 +546,7 @@ export default async (bp: typeof sdk, db: Database) => {
   )
 
   router.post(
-    '/conversations/:conversationId/messages/delete',
+    '/conversations/messages/delete',
     assertUserInfo({ convoIdRequired: true }),
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
       const { userId, conversationId } = req

--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -108,7 +108,8 @@ export default async (bp: typeof sdk, db: Database) => {
   }).middleware
 
   const assertUserInfo = (options: { convoIdRequired?: boolean } = {}) => async (req: ChatRequest, _res, next) => {
-    const { botId, userId } = req.params
+    const { botId } = req.params
+    const { userId } = req.body || {}
     const conversationId = req.params.conversationId || req.query.conversationId
 
     if (!validateUserId(userId)) {
@@ -162,7 +163,7 @@ export default async (bp: typeof sdk, db: Database) => {
 
   // ?conversationId=xxx (optional)
   router.post(
-    '/messages/:userId',
+    '/messages',
     bp.http.extractExternalToken,
     assertUserInfo(),
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
@@ -212,7 +213,7 @@ export default async (bp: typeof sdk, db: Database) => {
 
   // ?conversationId=xxx (required)
   router.post(
-    '/messages/:userId/files',
+    '/messages/files',
     upload.single('file'),
     bp.http.extractExternalToken,
     assertUserInfo({ convoIdRequired: true }),
@@ -238,8 +239,8 @@ export default async (bp: typeof sdk, db: Database) => {
     })
   )
 
-  router.get(
-    '/conversations/:userId/:conversationId',
+  router.post(
+    '/conversations/get/:conversationId',
     assertUserInfo({ convoIdRequired: true }),
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
       const { userId, conversationId, botId } = req
@@ -250,8 +251,8 @@ export default async (bp: typeof sdk, db: Database) => {
     })
   )
 
-  router.get(
-    '/conversations/:userId',
+  router.post(
+    '/conversations/get',
     assertUserInfo(),
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
       const { userId, botId } = req
@@ -315,7 +316,7 @@ export default async (bp: typeof sdk, db: Database) => {
   }
 
   router.post(
-    '/events/:userId',
+    '/events',
     bp.http.extractExternalToken,
     assertUserInfo(),
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
@@ -380,7 +381,7 @@ export default async (bp: typeof sdk, db: Database) => {
   )
 
   router.post(
-    '/conversations/:userId/:conversationId/reset',
+    '/conversations/:conversationId/reset',
     bp.http.extractExternalToken,
     assertUserInfo({ convoIdRequired: true }),
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
@@ -407,7 +408,7 @@ export default async (bp: typeof sdk, db: Database) => {
   )
 
   router.post(
-    '/conversations/:userId/new',
+    '/conversations/new',
     assertUserInfo(),
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
       const { botId, userId } = req
@@ -418,12 +419,12 @@ export default async (bp: typeof sdk, db: Database) => {
   )
 
   router.post(
-    '/conversations/:userId/:conversationId/reference/:reference',
+    '/conversations/:conversationId/reference',
     assertUserInfo(),
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
       try {
         const { botId, userId } = req
-        const { reference } = req.params
+        const { reference } = req.body
         let { conversationId } = req
 
         await bp.users.getOrCreateUser('web', userId, botId)
@@ -469,8 +470,8 @@ export default async (bp: typeof sdk, db: Database) => {
     })
   )
 
-  router.get(
-    '/preferences/:userId',
+  router.post(
+    '/preferences/get',
     assertUserInfo(),
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
       const { userId, botId } = req
@@ -481,7 +482,7 @@ export default async (bp: typeof sdk, db: Database) => {
   )
 
   router.post(
-    '/preferences/:userId',
+    '/preferences',
     assertUserInfo(),
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
       const { userId, botId } = req
@@ -534,8 +535,8 @@ export default async (bp: typeof sdk, db: Database) => {
     return [metadata, ...messagesAsTxt].join('')
   }
 
-  router.get(
-    '/conversations/:userId/:conversationId/download/txt',
+  router.post(
+    '/conversations/:conversationId/download/txt',
     assertUserInfo({ convoIdRequired: true }),
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
       const { userId, conversationId, botId } = req
@@ -548,7 +549,7 @@ export default async (bp: typeof sdk, db: Database) => {
   )
 
   router.post(
-    '/conversations/:userId/:conversationId/messages/delete',
+    '/conversations/:conversationId/messages/delete',
     assertUserInfo({ convoIdRequired: true }),
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
       const { userId, conversationId } = req

--- a/modules/channel-web/src/views/lite/core/api.tsx
+++ b/modules/channel-web/src/views/lite/core/api.tsx
@@ -75,25 +75,29 @@ export default class WebchatApi {
 
   async fetchConversations() {
     try {
-      const { data } = await this.axios.post('/conversations/get', { userId: this.userId }, this.axiosConfig)
+      const { data } = await this.axios.post('/conversations/list', { userId: this.userId }, this.axiosConfig)
       return data
     } catch (err) {
       console.error('Error while fetching convos', err)
     }
   }
 
-  async fetchConversation(convoId: number) {
+  async fetchConversation(conversationId: number) {
     try {
-      const { data } = await this.axios.post(`/conversations/get/${convoId}`, { userId: this.userId }, this.axiosConfig)
+      const { data } = await this.axios.post(
+        '/conversations/get',
+        { userId: this.userId, conversationId },
+        this.axiosConfig
+      )
       return data
     } catch (err) {
       await this.handleApiError(err)
     }
   }
 
-  async resetSession(convoId: number) {
+  async resetSession(conversationId: number) {
     try {
-      this.axios.post(`/conversations/${convoId}/reset`, { userId: this.userId }, this.axiosConfig)
+      this.axios.post('/conversations/reset', { userId: this.userId, conversationId }, this.axiosConfig)
     } catch (err) {
       console.error('Error while resetting convo', err)
     }
@@ -102,17 +106,17 @@ export default class WebchatApi {
   async createConversation(): Promise<number> {
     try {
       const { data } = await this.axios.post('/conversations/new', { userId: this.userId }, this.axiosConfig)
-      return data.convoId
+      return data.conversationId
     } catch (err) {
       console.error('Error in create conversation', err)
     }
   }
 
-  async downloadConversation(convoId: number): Promise<any> {
+  async downloadConversation(conversationId: number): Promise<any> {
     try {
       const { data } = await this.axios.post(
-        `/conversations/${convoId}/download/txt`,
-        { userId: this.userId },
+        '/conversations/download/txt',
+        { userId: this.userId, conversationId },
         this.axiosConfig
       )
       return { name: data.name, txt: data.txt }
@@ -121,27 +125,25 @@ export default class WebchatApi {
     }
   }
 
-  async sendEvent(data: any, convoId: number): Promise<void> {
+  async sendEvent(payload: any, conversationId: number): Promise<void> {
     try {
-      const config = { params: { conversationId: convoId }, ...this.axiosConfig }
-      return this.axios.post('/events', { userId: this.userId, ...data }, config)
+      return this.axios.post('/events', { userId: this.userId, conversationId, payload }, this.axiosConfig)
     } catch (err) {
       await this.handleApiError(err)
     }
   }
 
-  async sendMessage(data: any, convoId: number): Promise<void> {
+  async sendMessage(payload: any, conversationId: number): Promise<void> {
     try {
-      const config = { params: { conversationId: convoId }, ...this.axiosConfig }
-      return this.axios.post('/messages', { userId: this.userId, ...data }, config)
+      return this.axios.post('/messages', { userId: this.userId, conversationId, payload }, this.axiosConfig)
     } catch (err) {
       await this.handleApiError(err)
     }
   }
 
-  async deleteMessages(convoId: number) {
+  async deleteMessages(conversationId: number) {
     try {
-      await this.axios.post(`/conversations/${convoId}/messages/delete`, { userId: this.userId }, this.axiosConfig)
+      await this.axios.post('/conversations/messages/delete', { userId: this.userId, conversationId }, this.axiosConfig)
     } catch (err) {
       await this.handleApiError(err)
     }
@@ -164,20 +166,19 @@ export default class WebchatApi {
     }
   }
 
-  async uploadFile(data: any, convoId: number): Promise<void> {
+  async uploadFile(data: any, conversationId: number): Promise<void> {
     try {
-      const config = { params: { conversationId: convoId }, ...this.axiosConfig }
-      return this.axios.post('/messages/files', { userId: this.userId, ...data }, config)
+      return this.axios.post('/messages/files', { userId: this.userId, conversationId, ...data }, this.axiosConfig)
     } catch (err) {
       await this.handleApiError(err)
     }
   }
 
-  async setReference(reference: string, convoId: number): Promise<void> {
+  async setReference(reference: string, conversationId: number): Promise<void> {
     try {
       return this.axios.post(
-        `/conversations/${convoId}/reference`,
-        { userId: this.userId, reference },
+        '/conversations/reference',
+        { userId: this.userId, conversationId, reference },
         this.axiosConfig
       )
     } catch (err) {

--- a/modules/channel-web/src/views/lite/core/api.tsx
+++ b/modules/channel-web/src/views/lite/core/api.tsx
@@ -14,7 +14,7 @@ export default class WebchatApi {
       config => {
         if (!config.url.includes('/botInfo')) {
           const prefix = config.url.indexOf('?') > 0 ? '&' : '?'
-          config.url =  `${config.url}${prefix}__ts=${new Date().getTime()}`
+          config.url = `${config.url}${prefix}__ts=${new Date().getTime()}`
         }
         return config
       },
@@ -58,7 +58,7 @@ export default class WebchatApi {
 
   async fetchPreferences() {
     try {
-      const { data } = await this.axios.get(`/preferences/${this.userId}`, this.axiosConfig)
+      const { data } = await this.axios.post('/preferences/get', { userId: this.userId }, this.axiosConfig)
       return data
     } catch (err) {
       console.error('Error while fetching preferences', err)
@@ -67,7 +67,7 @@ export default class WebchatApi {
 
   async updateUserPreferredLanguage(language: string) {
     try {
-      await this.axios.post(`/preferences/${this.userId}`, { language }, this.axiosConfig)
+      await this.axios.post('/preferences', { userId: this.userId, language }, this.axiosConfig)
     } catch (err) {
       console.error('Error in updating user preferred language', err)
     }
@@ -75,7 +75,7 @@ export default class WebchatApi {
 
   async fetchConversations() {
     try {
-      const { data } = await this.axios.get(`/conversations/${this.userId}`, this.axiosConfig)
+      const { data } = await this.axios.post('/conversations/get', { userId: this.userId }, this.axiosConfig)
       return data
     } catch (err) {
       console.error('Error while fetching convos', err)
@@ -84,7 +84,7 @@ export default class WebchatApi {
 
   async fetchConversation(convoId: number) {
     try {
-      const { data } = await this.axios.get(`/conversations/${this.userId}/${convoId}`, this.axiosConfig)
+      const { data } = await this.axios.post(`/conversations/get/${convoId}`, { userId: this.userId }, this.axiosConfig)
       return data
     } catch (err) {
       await this.handleApiError(err)
@@ -93,7 +93,7 @@ export default class WebchatApi {
 
   async resetSession(convoId: number) {
     try {
-      this.axios.post(`/conversations/${this.userId}/${convoId}/reset`, {}, this.axiosConfig)
+      this.axios.post(`/conversations/${convoId}/reset`, { userId: this.userId }, this.axiosConfig)
     } catch (err) {
       console.error('Error while resetting convo', err)
     }
@@ -101,7 +101,7 @@ export default class WebchatApi {
 
   async createConversation(): Promise<number> {
     try {
-      const { data } = await this.axios.post(`/conversations/${this.userId}/new`, {}, this.axiosConfig)
+      const { data } = await this.axios.post('/conversations/new', { userId: this.userId }, this.axiosConfig)
       return data.convoId
     } catch (err) {
       console.error('Error in create conversation', err)
@@ -110,7 +110,11 @@ export default class WebchatApi {
 
   async downloadConversation(convoId: number): Promise<any> {
     try {
-      const { data } = await this.axios.get(`/conversations/${this.userId}/${convoId}/download/txt`, this.axiosConfig)
+      const { data } = await this.axios.post(
+        `/conversations/${convoId}/download/txt`,
+        { userId: this.userId },
+        this.axiosConfig
+      )
       return { name: data.name, txt: data.txt }
     } catch (err) {
       console.error('Error in download convo', err)
@@ -120,7 +124,7 @@ export default class WebchatApi {
   async sendEvent(data: any, convoId: number): Promise<void> {
     try {
       const config = { params: { conversationId: convoId }, ...this.axiosConfig }
-      return this.axios.post(`/events/${this.userId}`, data, config)
+      return this.axios.post('/events', { userId: this.userId, ...data }, config)
     } catch (err) {
       await this.handleApiError(err)
     }
@@ -129,7 +133,7 @@ export default class WebchatApi {
   async sendMessage(data: any, convoId: number): Promise<void> {
     try {
       const config = { params: { conversationId: convoId }, ...this.axiosConfig }
-      return this.axios.post(`/messages/${this.userId}`, data, config)
+      return this.axios.post('/messages', { userId: this.userId, ...data }, config)
     } catch (err) {
       await this.handleApiError(err)
     }
@@ -137,7 +141,7 @@ export default class WebchatApi {
 
   async deleteMessages(convoId: number) {
     try {
-      await this.axios.post(`/conversations/${this.userId}/${convoId}/messages/delete`, {}, this.axiosConfig)
+      await this.axios.post(`/conversations/${convoId}/messages/delete`, { userId: this.userId }, this.axiosConfig)
     } catch (err) {
       await this.handleApiError(err)
     }
@@ -163,7 +167,7 @@ export default class WebchatApi {
   async uploadFile(data: any, convoId: number): Promise<void> {
     try {
       const config = { params: { conversationId: convoId }, ...this.axiosConfig }
-      return this.axios.post(`/messages/${this.userId}/files`, data, config)
+      return this.axios.post('/messages/files', { userId: this.userId, ...data }, config)
     } catch (err) {
       await this.handleApiError(err)
     }
@@ -171,7 +175,11 @@ export default class WebchatApi {
 
   async setReference(reference: string, convoId: number): Promise<void> {
     try {
-      return this.axios.post(`/conversations/${this.userId}/${convoId}/reference/${reference}`, {}, this.axiosConfig)
+      return this.axios.post(
+        `/conversations/${convoId}/reference`,
+        { userId: this.userId, reference },
+        this.axiosConfig
+      )
     } catch (err) {
       await this.handleApiError(err)
     }

--- a/src/e2e/studio/ui.test.ts
+++ b/src/e2e/studio/ui.test.ts
@@ -12,7 +12,7 @@ describe('Studio - UI', () => {
     await page.focus('#mainLayout')
     await page.type('#mainLayout', 'e')
     await page.keyboard.type('Much automated!')
-    await Promise.all([expectBotApiCallSuccess('mod/channel-web/messages/'), page.keyboard.press('Enter')])
+    await Promise.all([expectBotApiCallSuccess('mod/channel-web/messages'), page.keyboard.press('Enter')])
     await page.keyboard.press('Escape')
   })
 


### PR DESCRIPTION
The userId and convoId was removed from the URL and is now sent as POST data instead. 

This will prevents web servers from logging any user data and requests will be anonymous.
When combined with the rate limiting, this should prevent an attacker to brute force user IDs

In a future PR, once the initial handshake is completed, the ID sent in the post data will be temporary