### PR TITLE
fix(channel-web): unlock composer on conversation/session reset

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/renderer/QuickReplies.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/renderer/QuickReplies.tsx
@@ -19,6 +19,10 @@ export class QuickReplies extends Component<Renderer.QuickReply> {
     this.props.store.composer.setLocked(this.props.disableFreeText)
   }
 
+  componentWillUnmount() {
+    this.props.store.composer.setLocked(false)
+  }
+
   handleButtonClicked = (title, payload) => {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.props.onSendData?.({

--- a/modules/channel-web/src/views/lite/store/index.ts
+++ b/modules/channel-web/src/views/lite/store/index.ts
@@ -304,6 +304,8 @@ class RootStore {
 
   @action.bound
   async resetSession(): Promise<void> {
+    this.composer.setLocked(false)
+
     return this.api.resetSession(this.currentConversationId)
   }
 


### PR DESCRIPTION
This PR fixes an issue where resetting the session/conversation would not unlock composer.

_Note: related to #3576_

Example:

https://user-images.githubusercontent.com/9640576/109860476-371d3b80-7c2c-11eb-825f-509a3b69656a.mp4

