### PR TITLE
chore(nlu): Make trainings start onServerReady

### DIFF
--- a/modules/nlu/src/backend/application/index.ts
+++ b/modules/nlu/src/backend/application/index.ts
@@ -20,11 +20,8 @@ export class NLUApplication {
     this._queueTrainingOnBotMount = queueTrainingOnBotMount
   }
 
-  public async initialize(autoResumeQueue: boolean = false) {
+  public async initialize() {
     await this._trainingQueue.initialize()
-    if (autoResumeQueue) {
-      await this.resumeTrainings()
-    }
   }
 
   public teardown = async () => {

--- a/modules/nlu/src/backend/application/index.ts
+++ b/modules/nlu/src/backend/application/index.ts
@@ -20,8 +20,11 @@ export class NLUApplication {
     this._queueTrainingOnBotMount = queueTrainingOnBotMount
   }
 
-  public async initialize() {
+  public async initialize(autoResumeQueue: boolean = false) {
     await this._trainingQueue.initialize()
+    if (autoResumeQueue) {
+      await this.resumeTrainings()
+    }
   }
 
   public teardown = async () => {
@@ -41,6 +44,14 @@ export class NLUApplication {
 
   async getAllTrainings(): Promise<TrainingSession[]> {
     return this._trainingQueue.getAllTrainings()
+  }
+
+  async pauseTrainings() {
+    return this._trainingQueue.pause()
+  }
+
+  async resumeTrainings(): Promise<void> {
+    await this._trainingQueue.resume()
   }
 
   public hasBot = (botId: string) => {

--- a/modules/nlu/src/backend/application/tests/app-integration.test.ts
+++ b/modules/nlu/src/backend/application/tests/app-integration.test.ts
@@ -814,7 +814,9 @@ describe('NLU API integration tests', () => {
     await sleep(10)
     await app.resumeTrainings()
 
-    expect(engineTrainSpy).not.toHaveBeenCalled()
-    expect(dependencies.socket).not.toHaveBeenCalledWith(expectTs({ botId, status: 'training' }))
+    await waitForTrainingsToBeDone(app)
+    expect(engineTrainSpy).toHaveBeenCalled()
+
+    expectTrainingToStartAndComplete(dependencies.socket, dependencies.trainingRepo, { botId, language: lang })
   })
 })

--- a/modules/nlu/src/backend/application/tests/app-integration.test.ts
+++ b/modules/nlu/src/backend/application/tests/app-integration.test.ts
@@ -59,7 +59,8 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies)
 
     // act
-    await app.initialize(true)
+    await app.initialize()
+    await app.resumeTrainings()
     await app.mountBot({
       id: botId,
       defaultLanguage: lang,
@@ -109,7 +110,8 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies, trainingQueueOptions)
 
     // act
-    await app.initialize(true)
+    await app.initialize()
+    await app.resumeTrainings()
     await app.mountBot({
       id: botId,
       defaultLanguage: 'en',
@@ -163,7 +165,8 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies, trainingQueueOptions)
 
     // act
-    await app.initialize(true)
+    await app.initialize()
+    await app.resumeTrainings()
     await app.mountBot({
       id: botId,
       defaultLanguage: 'en',
@@ -253,7 +256,8 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies, trainingQueueOptions)
 
     // act
-    await app.initialize(true)
+    await app.initialize()
+    await app.resumeTrainings()
     await app.mountBot(bot1)
     await app.mountBot(bot2)
     await app.mountBot(bot3)
@@ -317,7 +321,8 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies)
 
     // act
-    await app.initialize(true)
+    await app.initialize()
+    await app.resumeTrainings()
     await app.mountBot({
       id: botId,
       defaultLanguage: lang,
@@ -370,7 +375,8 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies)
 
     // act
-    await app.initialize(true)
+    await app.initialize()
+    await app.resumeTrainings()
     await app.mountBot({
       id: botId,
       defaultLanguage: 'en',
@@ -426,7 +432,8 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies)
 
     // act
-    await app.initialize(true)
+    await app.initialize()
+    await app.resumeTrainings()
 
     await app.mountBot({
       id: botId,
@@ -467,7 +474,8 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies)
 
     // act
-    await app.initialize(true)
+    await app.initialize()
+    await app.resumeTrainings()
     await app.mountBot({
       id: botId,
       defaultLanguage: 'en',
@@ -515,7 +523,8 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies)
 
     // act
-    await app.initialize(true)
+    await app.initialize()
+    await app.resumeTrainings()
     await app.mountBot({
       id: botId,
       defaultLanguage: lang,
@@ -560,7 +569,8 @@ describe('NLU API integration tests', () => {
     const app = makeApp({ ...dependencies, errors })
 
     // act
-    await app.initialize(true)
+    await app.initialize()
+    await app.resumeTrainings()
     await app.mountBot({
       id: botId,
       defaultLanguage: lang,
@@ -603,7 +613,8 @@ describe('NLU API integration tests', () => {
     const app = makeApp({ ...dependencies, socket })
 
     // act
-    await app.initialize(true)
+    await app.initialize()
+    await app.resumeTrainings()
     await app.mountBot({
       id: botId,
       defaultLanguage: 'en',
@@ -647,7 +658,8 @@ describe('NLU API integration tests', () => {
     const app = makeApp({ ...dependencies, socket })
 
     // act
-    await app.initialize(true)
+    await app.initialize()
+    await app.resumeTrainings()
     await app.mountBot({
       id: botId,
       defaultLanguage: lang,
@@ -704,7 +716,8 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies)
 
     // act
-    await app.initialize(true)
+    await app.initialize()
+    await app.resumeTrainings()
     await app.mountBot({
       id: botId,
       defaultLanguage: lang,
@@ -749,7 +762,8 @@ describe('NLU API integration tests', () => {
     const engineTrainSpy = jest.spyOn(dependencies.engine, 'train')
 
     // act
-    await app.initialize(true)
+    await app.initialize()
+    await app.resumeTrainings()
     await app.mountBot({
       id: botId,
       defaultLanguage: lang,

--- a/modules/nlu/src/backend/application/tests/app-integration.test.ts
+++ b/modules/nlu/src/backend/application/tests/app-integration.test.ts
@@ -59,7 +59,7 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies)
 
     // act
-    await app.initialize()
+    await app.initialize(true)
     await app.mountBot({
       id: botId,
       defaultLanguage: lang,
@@ -109,7 +109,7 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies, trainingQueueOptions)
 
     // act
-    await app.initialize()
+    await app.initialize(true)
     await app.mountBot({
       id: botId,
       defaultLanguage: 'en',
@@ -163,7 +163,7 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies, trainingQueueOptions)
 
     // act
-    await app.initialize()
+    await app.initialize(true)
     await app.mountBot({
       id: botId,
       defaultLanguage: 'en',
@@ -253,7 +253,7 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies, trainingQueueOptions)
 
     // act
-    await app.initialize()
+    await app.initialize(true)
     await app.mountBot(bot1)
     await app.mountBot(bot2)
     await app.mountBot(bot3)
@@ -317,7 +317,7 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies)
 
     // act
-    await app.initialize()
+    await app.initialize(true)
     await app.mountBot({
       id: botId,
       defaultLanguage: lang,
@@ -370,7 +370,7 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies)
 
     // act
-    await app.initialize()
+    await app.initialize(true)
     await app.mountBot({
       id: botId,
       defaultLanguage: 'en',
@@ -426,7 +426,7 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies)
 
     // act
-    await app.initialize()
+    await app.initialize(true)
 
     await app.mountBot({
       id: botId,
@@ -467,7 +467,7 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies)
 
     // act
-    await app.initialize()
+    await app.initialize(true)
     await app.mountBot({
       id: botId,
       defaultLanguage: 'en',
@@ -515,7 +515,7 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies)
 
     // act
-    await app.initialize()
+    await app.initialize(true)
     await app.mountBot({
       id: botId,
       defaultLanguage: lang,
@@ -560,7 +560,7 @@ describe('NLU API integration tests', () => {
     const app = makeApp({ ...dependencies, errors })
 
     // act
-    await app.initialize()
+    await app.initialize(true)
     await app.mountBot({
       id: botId,
       defaultLanguage: lang,
@@ -603,7 +603,7 @@ describe('NLU API integration tests', () => {
     const app = makeApp({ ...dependencies, socket })
 
     // act
-    await app.initialize()
+    await app.initialize(true)
     await app.mountBot({
       id: botId,
       defaultLanguage: 'en',
@@ -647,7 +647,7 @@ describe('NLU API integration tests', () => {
     const app = makeApp({ ...dependencies, socket })
 
     // act
-    await app.initialize()
+    await app.initialize(true)
     await app.mountBot({
       id: botId,
       defaultLanguage: lang,
@@ -704,7 +704,7 @@ describe('NLU API integration tests', () => {
     const app = makeApp(dependencies)
 
     // act
-    await app.initialize()
+    await app.initialize(true)
     await app.mountBot({
       id: botId,
       defaultLanguage: lang,
@@ -749,7 +749,7 @@ describe('NLU API integration tests', () => {
     const engineTrainSpy = jest.spyOn(dependencies.engine, 'train')
 
     // act
-    await app.initialize()
+    await app.initialize(true)
     await app.mountBot({
       id: botId,
       defaultLanguage: lang,

--- a/modules/nlu/src/backend/application/tests/app-integration.test.ts
+++ b/modules/nlu/src/backend/application/tests/app-integration.test.ts
@@ -774,7 +774,10 @@ describe('NLU API integration tests', () => {
     expect(engineTrainSpy).toHaveBeenCalledTimes(0)
     expect(dependencies.socket).toHaveBeenCalledWith(expectTs({ botId, status: 'needs-training' }))
     expect(dependencies.socket).not.toHaveBeenCalledWith(expectTs({ botId, status: 'training-pending' }))
+
+    await app.teardown()
   })
+
   test('Training queue starts out paused and does not start any training', async () => {
     // arrange
     const lang = 'en'
@@ -809,14 +812,16 @@ describe('NLU API integration tests', () => {
       defaultLanguage: lang,
       languages: [lang]
     })
+    await sleep(30) // ms
 
     expect(engineTrainSpy).not.toHaveBeenCalled()
-    await sleep(10)
     await app.resumeTrainings()
 
     await waitForTrainingsToBeDone(app)
     expect(engineTrainSpy).toHaveBeenCalled()
 
     expectTrainingToStartAndComplete(dependencies.socket, dependencies.trainingRepo, { botId, language: lang })
+
+    await app.teardown()
   })
 })

--- a/modules/nlu/src/backend/application/tests/cluster-integration.test.ts
+++ b/modules/nlu/src/backend/application/tests/cluster-integration.test.ts
@@ -86,7 +86,8 @@ describe('NLU API integration tests with cluster enabled', () => {
     const nNodes = 2
 
     // act
-    await Promise.all([node1.initialize(true), node2.initialize(true)])
+    await Promise.all([node1.initialize(), node2.initialize()])
+    await Promise.all([node1.resumeTrainings(), node2.resumeTrainings()])
     await Promise.all([node1.mountBot(bot1), node2.mountBot(bot1)])
     await Promise.all([node1.mountBot(bot2), node2.mountBot(bot2)])
     await Promise.all([node1.mountBot(bot3), node2.mountBot(bot3)])

--- a/modules/nlu/src/backend/application/tests/cluster-integration.test.ts
+++ b/modules/nlu/src/backend/application/tests/cluster-integration.test.ts
@@ -86,7 +86,7 @@ describe('NLU API integration tests with cluster enabled', () => {
     const nNodes = 2
 
     // act
-    await Promise.all([node1.initialize(), node2.initialize()])
+    await Promise.all([node1.initialize(true), node2.initialize(true)])
     await Promise.all([node1.mountBot(bot1), node2.mountBot(bot1)])
     await Promise.all([node1.mountBot(bot2), node2.mountBot(bot2)])
     await Promise.all([node1.mountBot(bot3), node2.mountBot(bot3)])

--- a/modules/nlu/src/backend/application/training-queue.ts
+++ b/modules/nlu/src/backend/application/training-queue.ts
@@ -54,11 +54,10 @@ class LocalTrainingContainer {
 
 export class TrainingQueue implements TrainingQueue {
   private _options: TrainingQueueOptions
-
+  private _paused: boolean = true
   private _broadcastCancelTraining: (id: TrainingId) => Promise<void>
   private _broadcastLoadModel: (botId: string, modelId: sdk.NLU.ModelId) => Promise<void>
   private _broadcastRunTask: () => Promise<void>
-
   private _localTrainings = new LocalTrainingContainer()
 
   constructor(
@@ -125,9 +124,21 @@ export class TrainingQueue implements TrainingQueue {
       return update(trainId, { status: 'training-pending', progress: 0 })
     })
 
+    if (this._paused) {
+      return
+    }
+
     return this._broadcastRunTask()
   }
 
+  public pause = () => {
+    this._paused = true
+  }
+
+  public resume = async () => {
+    this._paused = false
+    await this._broadcastRunTask()
+  }
   public cancelTraining = async (trainId: TrainingId): Promise<void> => {
     return this._broadcastCancelTraining(trainId)
   }

--- a/modules/nlu/src/backend/index.ts
+++ b/modules/nlu/src/backend/index.ts
@@ -31,6 +31,7 @@ const onServerReady = async (bp: typeof sdk) => {
     throw new AppNotInitializedError()
   }
   await registerRouter(bp, app)
+  await app.resumeTrainings()
 }
 
 const onBotMount = async (bp: typeof sdk, botId: string) => {


### PR DESCRIPTION
Training queue starts out paused by default, you must call `await app.resumeTrainings()` or `await trainingQueue.resume()` you can also pass a boolean to the initializer`app.initialize(true)` to start out resumed (useful for testing)