### PR TITLE
chore(nlu): Add routes to access and modify training repo directly

### DIFF
--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -8,7 +8,7 @@ import { NLUApplication } from './application'
 import { BotDoesntSpeakLanguageError, BotNotMountedError } from './application/errors'
 import { TrainingSession } from './application/typings'
 import legacyElectionPipeline from './election/legacy-election'
-import createRepositoryRouter from './repo-router'
+import createRepositoryRouter from './train-repo-router'
 import { NLUProgressEvent } from './typings'
 
 const ROUTER_ID = 'nlu'

--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -6,7 +6,7 @@ import yn from 'yn'
 
 import { NLUApplication } from './application'
 import { BotDoesntSpeakLanguageError, BotNotMountedError } from './application/errors'
-import { TrainingSession, TrainingState } from './application/typings'
+import { TrainingSession } from './application/typings'
 import legacyElectionPipeline from './election/legacy-election'
 import { NLUProgressEvent } from './typings'
 
@@ -122,6 +122,17 @@ export const registerRouter = async (bp: typeof sdk, app: NLUApplication) => {
   addTrainingServiceRoutes(router, app, mapError)
 }
 
+const trainingStatusSchema = Joi.object().keys({
+  status: Joi.string()
+    .valid(['idle', 'done', 'needs-training', 'training-pending', 'training', 'canceled', 'errored'])
+    .required(),
+  progress: Joi.number()
+    .default(0)
+    .min(0)
+    .max(1)
+    .required()
+})
+
 const addTrainingServiceRoutes = (
   router: sdk.http.RouterExtension,
   app: NLUApplication,
@@ -166,17 +177,6 @@ const addTrainingServiceRoutes = (
     res.status(200).send()
   })
 }
-
-const trainingStatusSchema = Joi.object().keys({
-  status: Joi.string()
-    .valid(['idle', 'done', 'needs-training', 'training-pending', 'training', 'canceled', 'errored'])
-    .required(),
-  progress: Joi.number()
-    .default(0)
-    .min(0)
-    .max(1)
-    .required()
-})
 
 export const removeRouter = (bp: typeof sdk) => {
   bp.http.deleteRouterForBot(ROUTER_ID)

--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -8,6 +8,7 @@ import { NLUApplication } from './application'
 import { BotDoesntSpeakLanguageError, BotNotMountedError } from './application/errors'
 import { TrainingSession } from './application/typings'
 import legacyElectionPipeline from './election/legacy-election'
+import createRepositoryRouter from './repo-router'
 import { NLUProgressEvent } from './typings'
 
 const ROUTER_ID = 'nlu'
@@ -119,63 +120,9 @@ export const registerRouter = async (bp: typeof sdk, app: NLUApplication) => {
     }
   })
 
-  addTrainingServiceRoutes(router, app, mapError)
-}
+  const repoRouter = createRepositoryRouter(app)
 
-const trainingStatusSchema = Joi.object().keys({
-  status: Joi.string()
-    .valid(['idle', 'done', 'needs-training', 'training-pending', 'training', 'canceled', 'errored'])
-    .required(),
-  progress: Joi.number()
-    .default(0)
-    .min(0)
-    .max(1)
-    .required()
-})
-
-const addTrainingServiceRoutes = (
-  router: sdk.http.RouterExtension,
-  app: NLUApplication,
-  errorMapper: (err: { botId: string; lang: string; error: Error }, res: Response) => Response
-) => {
-  const repo = app.trainRepository
-  const SUBROUTE_NAME = 'trainrepo'
-
-  router.get(`/${SUBROUTE_NAME}/trainings`, async (req, res) => {
-    const trainings = await repo.getAll()
-    res.status(200).json(trainings)
-  })
-
-  router.use(`/${SUBROUTE_NAME}/trainings/:botId/:lang`, async (req, res, next) => {
-    const { botId, lang } = req.params
-    try {
-      const training = await repo.get({ botId, language: lang })
-      if (!training) {
-        throw new Error('Training not found')
-      }
-      res.locals.training = training
-    } catch (error) {
-      return errorMapper({ botId, lang, error }, res)
-    }
-    next()
-  })
-
-  router.get(`/${SUBROUTE_NAME}/trainings/:botId/:lang`, async (req, res) => {
-    const trainings = res.locals.training as TrainingSession[]
-    res.status(200).json(trainings)
-  })
-
-  router.post(`/${SUBROUTE_NAME}/trainings/:botId/:lang`, async (req, res) => {
-    const { botId, lang } = req.params
-    const { error, value } = trainingStatusSchema.validate(req.body)
-
-    if (error) {
-      return res.status(400).send(`Training status body is invalid: ${error.message}`)
-    }
-
-    await repo.set({ botId, language: lang }, value)
-    res.status(200).send()
-  })
+  router.use('/trainrepo', repoRouter)
 }
 
 export const removeRouter = (bp: typeof sdk) => {

--- a/modules/nlu/src/backend/api.ts
+++ b/modules/nlu/src/backend/api.ts
@@ -138,7 +138,7 @@ const addTrainingServiceRoutes = (
   app: NLUApplication,
   errorMapper: (err: { botId: string; lang: string; error: Error }, res: Response) => Response
 ) => {
-  const repo = app.repository
+  const repo = app.trainRepository
   const SUBROUTE_NAME = 'trainrepo'
 
   router.get(`/${SUBROUTE_NAME}/trainings`, async (req, res) => {

--- a/modules/nlu/src/backend/application/index.ts
+++ b/modules/nlu/src/backend/application/index.ts
@@ -5,6 +5,7 @@ import { IBotFactory } from './bot-factory'
 import { IBotService } from './bot-service'
 import { BotNotMountedError } from './errors'
 import { ITrainingQueue } from './training-queue'
+import { ITrainingRepository } from './training-repo'
 import { Predictor, BotConfig, TrainingSession, TrainingState, TrainingId } from './typings'
 
 export class NLUApplication {
@@ -22,6 +23,10 @@ export class NLUApplication {
 
   public async initialize() {
     await this._trainingQueue.initialize()
+  }
+
+  public get repository(): ITrainingRepository {
+    return this._trainingQueue.service.repository
   }
 
   public teardown = async () => {

--- a/modules/nlu/src/backend/application/index.ts
+++ b/modules/nlu/src/backend/application/index.ts
@@ -25,7 +25,7 @@ export class NLUApplication {
     await this._trainingQueue.initialize()
   }
 
-  public get repository(): ITrainingRepository {
+  public get trainRepository(): ITrainingRepository {
     return this._trainingQueue.service.repository
   }
 

--- a/modules/nlu/src/backend/application/tests/utils/fake-training-repo.u.test.ts
+++ b/modules/nlu/src/backend/application/tests/utils/fake-training-repo.u.test.ts
@@ -37,6 +37,10 @@ export class FakeTrainingRepository implements ITrainingRepository {
       .filter(this._matchQuery(query))
   }
 
+  public async delete(id: TrainingId) {
+    delete this._trainings[this._toKey(id)]
+  }
+
   public async getAll(): Promise<TrainingSession[]> {
     return Object.entries(this._trainings).map(([k, v]) => ({
       ...this._fromKey(k),

--- a/modules/nlu/src/backend/application/training-queue.ts
+++ b/modules/nlu/src/backend/application/training-queue.ts
@@ -87,6 +87,10 @@ export class TrainingQueue implements TrainingQueue {
     return this._trainingService.initialize()
   }
 
+  public get service(): ITrainingService {
+    return this._trainingService
+  }
+
   public teardown = async () => {
     await this._trainingService.clear()
     return this._trainingService.teardown()

--- a/modules/nlu/src/backend/application/training-repo.ts
+++ b/modules/nlu/src/backend/application/training-repo.ts
@@ -59,6 +59,14 @@ export class TrainingRepository implements TrainingRepository {
       .select('*')
   }
 
+  public delete = async (trainId: TrainingId): Promise<void> => {
+    const { botId, language } = trainId
+    return this._database
+      .from(TABLE_NAME)
+      .where({ botId, language })
+      .delete()
+  }
+
   public clear = async (): Promise<void[]> => {
     return this._database.from(TABLE_NAME).delete('*')
   }

--- a/modules/nlu/src/backend/application/training-service.ts
+++ b/modules/nlu/src/backend/application/training-service.ts
@@ -40,6 +40,10 @@ export class TrainingService {
     this._taskHandle = setInterval(this._runTask, this._config.jobInterval ?? JOB_INTERVAL)
   }
 
+  public get repository(): ITrainingRepository {
+    return this._trainingRepo
+  }
+
   public async teardown(): Promise<void> {
     clearInterval(this._taskHandle)
   }

--- a/modules/nlu/src/backend/repo-router.ts
+++ b/modules/nlu/src/backend/repo-router.ts
@@ -1,0 +1,91 @@
+import express, { Router } from 'express'
+import Joi from 'joi'
+import { NLUApplication } from './application'
+import { TrainingSession } from './application/typings'
+
+const trainingStatusSchema = Joi.object().keys({
+  status: Joi.string()
+    .valid(['idle', 'done', 'needs-training', 'training-pending', 'training', 'canceled', 'errored'])
+    .required(),
+  progress: Joi.number()
+    .default(0)
+    .min(0)
+    .max(1)
+    .required()
+})
+
+/**
+ * This is the training repository router to override the training states
+ *
+ * To get all trainings for the bot:
+ * GET /mod/nlu/trainrepo/trainings
+ *
+ * To get a training's state for a specific language:
+ * GET /mod/nlu/trainrepo/trainings/:lang
+ *
+ * To modify a training's state:
+ *
+ * POST /mod/nlu/trainrepo/trainings/:lang
+ * body: {
+ *   status: <One of 'idle', 'done', 'needs-training', 'training-pending', 'training', 'canceled', 'errored'>,
+ *   progress: <value between 0.0 and 1.0>
+ * }
+ *
+ * To delete a training state:
+ * POST /mod/nlu/trainrepo/trainings/:lang/delete
+ *
+ */
+const createRepositoryRouter = (app: NLUApplication): Router => {
+  const router = express.Router()
+
+  const repo = app.trainRepository
+
+  router.get('/trainings', async (req, res) => {
+    const { botId } = req.params
+    const trainings = await repo.query({ botId })
+    res.status(200).json(trainings)
+  })
+
+  router.use('/trainings/:lang', async (req, res, next) => {
+    const { botId, lang } = req.params
+    try {
+      const training = await repo.get({ botId, language: lang })
+
+      if (!training) {
+        return res.status(404).json({ error: 'Training not found' })
+      }
+
+      res.locals.training = training
+    } catch (error) {
+      return res.status(500).json({ error: error.message })
+    }
+    next()
+  })
+
+  router.get('/trainings/:botId/:lang', async (req, res) => {
+    const trainings = res.locals.training as TrainingSession[]
+    res.status(200).json(trainings)
+  })
+
+  router.post('/trainings/:lang', async (req, res) => {
+    const { botId, lang } = req.params
+    const { error, value } = trainingStatusSchema.validate(req.body)
+
+    if (error) {
+      return res.status(400).json({ error: `Training status body is invalid: ${error.message}` })
+    }
+
+    await repo.set({ botId, language: lang }, value)
+    res.status(200).send()
+  })
+
+  router.post('/trainings/:lang/delete', async (req, res) => {
+    const { botId, lang } = req.params
+    await repo.delete({ botId, language: lang })
+    res.status(200).send()
+  })
+
+  return router
+}
+
+export default createRepositoryRouter

--- a/modules/nlu/src/backend/train-repo-router.ts
+++ b/modules/nlu/src/backend/train-repo-router.ts
@@ -36,7 +36,7 @@ const trainingStatusSchema = Joi.object().keys({
  *
  */
 const createRepositoryRouter = (app: NLUApplication): Router => {
-  const router = express.Router()
+  const router = express.Router({ mergeParams: true })
 
   const repo = app.trainRepository
 
@@ -62,7 +62,7 @@ const createRepositoryRouter = (app: NLUApplication): Router => {
     next()
   })
 
-  router.get('/trainings/:botId/:lang', async (req, res) => {
+  router.get('/trainings/:lang', async (req, res) => {
     const trainings = res.locals.training as TrainingSession[]
     res.status(200).json(trainings)
   })


### PR DESCRIPTION
To get all trainings:
`GET /mod/nlu/trainrepo/trainings`

To get a training's state:
`GET /mod/nlu/trainrepo/trainings/:botId/:lang`

To modify a training's state:

```
POST /mod/nlu/trainrepo/trainings/:botId/:lang
body: {
  status: <One of 'idle', 'done', 'needs-training', 'training-pending', 'training', 'canceled', 'errored'>,
  progress: <value between 0.0 and 1.0>
}
```

