### PR TITLE
fix(analytics): wrong count of misunderstood messages

### DIFF
--- a/modules/analytics/src/backend/setup.ts
+++ b/modules/analytics/src/backend/setup.ts
@@ -73,6 +73,11 @@ export default async (bp: typeof sdk, db: Database, interactionsToTrack: string[
 
     db.incrementMetric(event.botId, event.channel, 'msg_received_count')
 
+    // quick replies aren't counted as misunderstood
+    if (event.type === 'quick_reply') {
+      return next()
+    }
+
     // misunderstood messages
     const intentName = event?.nlu?.intent?.name
     if (intentName === 'none' || event?.nlu?.ambiguous) {


### PR DESCRIPTION
The reported number of misunderstood messages is almost never the same a the listed misunderstood messages in the misunderstood menu.

This small fix prevents the `quick_reply` messages for counting in the statistics so the numbers should be the same now.