### PR TITLE
fix(analytics): fix count returning users

### DIFF
--- a/modules/analytics/src/backend/db.ts
+++ b/modules/analytics/src/backend/db.ts
@@ -148,6 +148,7 @@ export default class Database {
     let queryActiveUsers = this.knex('bot_chat_users')
       .where({ botId })
       .andWhere(this.knex.date.isBetween('lastSeenOn', startDate, endDate))
+      .andWhereRaw('lastSeenOn <> createdOn')
       .groupBy(['lastSeenOn', 'channel'])
 
     if (options?.channel !== 'all') {


### PR DESCRIPTION
Fixed a bug where returning and new users could be counted twice when a new user is created.