### PR TITLE
fix(analytics): fix duplicate language stats

### DIFF
--- a/modules/analytics/src/views/full/index.tsx
+++ b/modules/analytics/src/views/full/index.tsx
@@ -420,7 +420,7 @@ const Analytics: FC<any> = ({ bp }) => {
   }
 
   const renderInteractions = () => {
-    return(
+    return (
       <div className={cx(style.metricsContainer, style.fullWidth)}>
         <ItemsList
           name={lang.tr('module.analytics.mostUsedWorkflows')}
@@ -445,7 +445,16 @@ const Analytics: FC<any> = ({ bp }) => {
     `[${lang.tr('module.analytics.deletedQna')}, ID: ${id.replace('__qna__', '')}]`
 
   const getLanguagesData = () => {
-    const metrics = state.metrics.filter(m => m.metric === 'msg_nlu_language')
+    const metricsByDay = state.metrics.filter(m => m.metric === 'msg_nlu_language')
+
+    const metrics = _(metricsByDay)
+      .groupBy('subMetric')
+      .map((objs, key) => ({
+        language: key,
+        value: _.sumBy(objs, 'value')
+      }))
+      .value()
+
     if (metrics.length === 0) {
       return []
     }
@@ -454,7 +463,7 @@ const Analytics: FC<any> = ({ bp }) => {
 
     return _.sortBy(metrics, m => m.value)
       .reverse()
-      .map(m => ({ value: getNotNaN((m.value / total) * 100, '%'), language: m.subMetric }))
+      .map(m => ({ value: getNotNaN((m.value / total) * 100, '%'), language: m.language }))
   }
 
   const renderHandlingUnderstanding = () => {


### PR DESCRIPTION
This bug sometime appeared in analytics
![unnamed](https://user-images.githubusercontent.com/59894025/110366542-6bba3a00-8014-11eb-84db-b9d5b3adee55.png)

I didn't fully check why this happened, but I'm pretty sure it was because the statistics were stored by day. So now I merge everything by language to avoid these duplicates
