### PR TITLE
feat(core): aliasing

### DIFF
--- a/src/bp/core/services/aliasing.ts
+++ b/src/bp/core/services/aliasing.ts
@@ -1,0 +1,49 @@
+import * as sdk from 'botpress/sdk'
+import { KeyValueStore } from 'core/kvs'
+import { TYPES } from 'core/types'
+import { inject, injectable } from 'inversify'
+
+@injectable()
+export class AliasingService {
+  private contexts: { [context: string]: ScopedAliasing } = {}
+
+  constructor(@inject(TYPES.KeyValueStore) private kvsService: KeyValueStore) {}
+
+  public forScope(context: string): ScopedAliasing {
+    let repo = this.contexts[context]
+    if (!repo) {
+      repo = new ScopedAliasing(context, this.kvsService.global())
+      this.contexts[context] = repo
+    }
+    return repo
+  }
+}
+
+export class ScopedAliasing implements sdk.aliasing.AliasingContext {
+  constructor(private scope: string, private kvs: sdk.KvsService) {}
+
+  async make(localId: string, foreignId: string): Promise<void> {
+    await this.kvs.set(this.getForeignMapKey(foreignId), localId)
+    await this.kvs.set(this.getLocalMapKey(localId), foreignId)
+  }
+
+  async unmake(localId: string, foreignId: string): Promise<void> {
+    await this.kvs.delete(this.getForeignMapKey(foreignId))
+    await this.kvs.delete(this.getLocalMapKey(localId))
+  }
+
+  async getForeign(foreignId: string): Promise<string> {
+    return this.kvs.get(this.getForeignMapKey(foreignId))
+  }
+
+  async getLocal(localId: string): Promise<string> {
+    return this.kvs.get(this.getLocalMapKey(localId))
+  }
+
+  private getForeignMapKey(foreignId: string) {
+    return `aliasmap-foreign/${this.scope}/${foreignId}`
+  }
+  private getLocalMapKey(localId: string) {
+    return `aliasmap-local/${this.scope}/${localId}`
+  }
+}

--- a/src/bp/core/services/services.inversify.ts
+++ b/src/bp/core/services/services.inversify.ts
@@ -10,6 +10,7 @@ import { TYPES } from '../types'
 import ActionServersService from './action/action-servers-service'
 import ActionService from './action/action-service'
 import { AlertingService, CEAlertingService } from './alerting-service'
+import { AliasingService } from './aliasing'
 import { AuthStrategies, CEAuthStrategies } from './auth-strategies'
 import AuthService from './auth/auth-service'
 import { BotMonitoringService } from './bot-monitoring-service'
@@ -141,6 +142,10 @@ const ServicesContainerModule = new ContainerModule((bind: interfaces.Bind) => {
 
   bind<StatsService>(TYPES.StatsService)
     .to(StatsService)
+    .inSingletonScope()
+
+  bind<AliasingService>(TYPES.AliasingService)
+    .to(AliasingService)
     .inSingletonScope()
 })
 

--- a/src/bp/core/types.ts
+++ b/src/bp/core/types.ts
@@ -88,7 +88,8 @@ const TYPES = {
   RolesStats: Symbol.for('RolesStats'),
   SDKStats: Symbol.for('SDKStats'),
   HooksStats: Symbol.for('HooksStats'),
-  ConfigsStats: Symbol.for('ConfigsStats')
+  ConfigsStats: Symbol.for('ConfigsStats'),
+  AliasingService: Symbol.for('AliasingService')
 }
 
 export { TYPES }

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -2353,6 +2353,17 @@ declare module 'botpress/sdk' {
     export function getMessageSignature(message: string): Promise<string>
   }
 
+  export namespace aliasing {
+    export function forScope(context: string): AliasingContext
+
+    export interface AliasingContext {
+      make(localId: string, foreignId: string): Promise<void>
+      unmake(localId: string, foreignId: string): Promise<void>
+      getForeign(foreignId: string): Promise<string>
+      getLocal(localId: string): Promise<string>
+    }
+  }
+
   /**
    * These features are subject to change and should not be relied upon.
    * They will eventually be either removed or moved in another namespace


### PR DESCRIPTION
Simple feature that adds a unified way to associate between a `local` and a `foreign` id. It would need proper caching and to have its own table to scale well, but it's a start

Usage
```ts
// Context : I'm interacting with a foreign system. I have created an
//           object inside my own system that has a logical association with that foreign object

// So let's say that's our foreign id
const foreignId = 'myForeignId_439434873'
// And this is our local id for the object we created
const localId = 'myLocalId_39438943'

// Now we instruct aliasing to make an association between these two ids
// Because the foreign system I am interacting with is telegram, I'll scope this association to the telegram scope
await bp.aliasing.forScope('telegram').make(localId, foreignId)

// Now let's say somewhere I'm interacting with the foreign system and I need my local id I do
const local = await bp.aliasing.forScope('telegram').getLocal(foreignId)
// local : 'myLocalId_39438943'

// And if I need the foreign id at some point I do
const foreign = await bp.aliasing.forScope('telegram').getForeign(localId)
// foreign : 'myForeignId_439434873'

// And we I delete the local object, and can remove the association with
await bp.aliasing.forScope('telegram').unmake(localId, foreignId)
```