### PR TITLE
feat(studio): Multiple Changes

### DIFF
--- a/modules/builtin/src/bot-templates/empty-bot/flows/error.flow.json
+++ b/modules/builtin/src/bot-templates/empty-bot/flows/error.flow.json
@@ -8,7 +8,7 @@
       "name": "entry",
       "onEnter": [],
       "onReceive": null,
-      "next": []
+      "next": [{ "condition": "true", "node": "" }]
     }
   ]
 }

--- a/modules/builtin/src/bot-templates/empty-bot/flows/main.flow.json
+++ b/modules/builtin/src/bot-templates/empty-bot/flows/main.flow.json
@@ -9,7 +9,7 @@
     {
       "id": "entry",
       "name": "entry",
-      "next": [],
+      "next": [{ "condition": "true", "node": "" }],
       "onEnter": [],
       "onReceive": null
     }

--- a/src/bp/ui-studio/src/web/reducers/flows.ts
+++ b/src/bp/ui-studio/src/web/reducers/flows.ts
@@ -232,7 +232,7 @@ const doCreateNewFlow = name => {
       name: 'entry',
       onEnter: [],
       onReceive: null,
-      next: [],
+      next: [{ condition: 'true', node: '' }],
       type: 'standard',
       x: 100,
       y: 100

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/ActionSection.jsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/ActionSection.jsx
@@ -10,6 +10,9 @@ import { lang } from 'botpress/shared'
 
 const style = require('./style.scss')
 
+import { Icon, Intent, Tooltip, Position } from '@blueprintjs/core'
+import { IconNames } from '@blueprintjs/icons'
+
 export default class ActionSection extends Component {
   state = {
     showActionModalForm: false
@@ -102,9 +105,30 @@ export default class ActionSection extends Component {
       items = []
     }
 
-    const renderMoveUp = i => (i > 0 ? <a onClick={() => this.onMoveAction(i, -1)}>Up</a> : null)
-
-    const renderMoveDown = i => (i < items.length - 1 ? <a onClick={() => this.onMoveAction(i, 1)}>Down</a> : null)
+    const renderMoveUp = i => {
+      const enabled = i > 0
+      return (
+        <Tooltip position={Position.LEFT} content="Up" hoverOpenDelay="500">
+          <Icon
+            icon={IconNames.CHEVRON_UP}
+            intent={enabled ? Intent.PRIMARY : Intent.NONE}
+            onClick={() => (enabled ? this.onMoveAction(i, -1) : null)}
+          />
+        </Tooltip>
+      )
+    }
+    const renderMoveDown = i => {
+      const enabled = i < items.length - 1
+      return (
+        <Tooltip position={Position.LEFT} content="Down" hoverOpenDelay="500">
+          <Icon
+            icon={IconNames.CHEVRON_DOWN}
+            intent={enabled ? Intent.PRIMARY : Intent.NONE}
+            onClick={() => (enabled ? this.onMoveAction(i, 1) : null)}
+          />
+        </Tooltip>
+      )
+    }
 
     const handleAddAction = () => this.setState({ showActionModalForm: true })
 
@@ -116,17 +140,27 @@ export default class ActionSection extends Component {
             <ActionItem className={style.item} text={item} key={`${i}.${item}`}>
               {!readOnly && (
                 <div className={style.actions}>
-                  <a className="btn-edit" onClick={() => this.onEdit(i)}>
-                    {lang.tr('edit')}
-                  </a>
-                  <a className="btn-remove" onClick={() => this.onRemoveAction(i)}>
-                    {lang.tr('remove')}
-                  </a>
-                  <a className="btn-copy" onClick={() => this.onCopyAction(i)}>
-                    {lang.tr('copy')}
-                  </a>
-                  {renderMoveUp(i)}
-                  {renderMoveDown(i)}
+                  <div>
+                    <Tooltip
+                      style={style.tooltip}
+                      position={Position.LEFT}
+                      content={lang.tr('edit')}
+                      hoverOpenDelay="500"
+                    >
+                      <Icon icon={IconNames.EDIT} intent={Intent.PRIMARY} onClick={() => this.onEdit(i)} />
+                    </Tooltip>
+                    <Tooltip position={Position.LEFT} content={lang.tr('copy')} hoverOpenDelay="500">
+                      <Icon icon={IconNames.DUPLICATE} intent={Intent.PRIMARY} onClick={() => this.onCopyAction(i)} />
+                    </Tooltip>
+                    {renderMoveUp(i)}
+                    {renderMoveDown(i)}
+                  </div>
+
+                  <div>
+                    <Tooltip position={Position.LEFT} content={lang.tr('remove')} hoverOpenDelay="500">
+                      <Icon icon={IconNames.TRASH} intent={Intent.DANGER} onClick={() => this.onRemoveAction(i)} />
+                    </Tooltip>
+                  </div>
                 </div>
               )}
             </ActionItem>

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/TransitionSection.jsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/TransitionSection.jsx
@@ -9,6 +9,9 @@ import ConditionItem from '../common/condition'
 import ConditionModalForm from './ConditionModalForm'
 import { lang } from 'botpress/shared'
 
+import { Icon, Intent, Tooltip, Position } from '@blueprintjs/core'
+import { IconNames } from '@blueprintjs/icons'
+
 const style = require('./style.scss')
 
 export default class TransitionSection extends Component {
@@ -56,9 +59,30 @@ export default class TransitionSection extends Component {
       items = []
     }
 
-    const renderMoveUp = i => (i > 0 ? <a onClick={() => this.onMove(i, -1)}>Up</a> : null)
-
-    const renderMoveDown = i => (i < items.length - 1 ? <a onClick={() => this.onMove(i, 1)}>Down</a> : null)
+    const renderMoveUp = i => {
+      const enabled = i > 0
+      return (
+        <Tooltip position={Position.LEFT} content="Up" hoverOpenDelay="500">
+          <Icon
+            icon={IconNames.CHEVRON_UP}
+            intent={enabled ? Intent.PRIMARY : Intent.NONE}
+            onClick={() => (enabled ? this.onMoveAction(i, -1) : null)}
+          />
+        </Tooltip>
+      )
+    }
+    const renderMoveDown = i => {
+      const enabled = i < items.length - 1
+      return (
+        <Tooltip position={Position.LEFT} content="Down" hoverOpenDelay="500">
+          <Icon
+            icon={IconNames.CHEVRON_DOWN}
+            intent={enabled ? Intent.PRIMARY : Intent.NONE}
+            onClick={() => (enabled ? this.onMoveAction(i, 1) : null)}
+          />
+        </Tooltip>
+      )
+    }
 
     const handleAddAction = () => this.setState({ showConditionalModalForm: true })
 
@@ -90,11 +114,27 @@ export default class TransitionSection extends Component {
               {renderType(item)}
               {!readOnly && (
                 <div className={style.actions}>
-                  <a onClick={() => this.onEdit(i)}>{lang.tr('edit')}</a>
-                  <a onClick={() => this.onRemove(i)}>{lang.tr('remove')}</a>
-                  <a onClick={() => this.onCopyAction(i)}>{lang.tr('copy')}</a>
-                  {renderMoveUp(i)}
-                  {renderMoveDown(i)}
+                  <div>
+                    <Tooltip
+                      style={style.tooltip}
+                      position={Position.LEFT}
+                      content={lang.tr('edit')}
+                      hoverOpenDelay="500"
+                    >
+                      <Icon icon={IconNames.EDIT} intent={Intent.PRIMARY} onClick={() => this.onEdit(i)} />
+                    </Tooltip>
+                    <Tooltip position={Position.LEFT} content={lang.tr('copy')} hoverOpenDelay="500">
+                      <Icon icon={IconNames.DUPLICATE} intent={Intent.PRIMARY} onClick={() => this.onCopyAction(i)} />
+                    </Tooltip>
+                    {renderMoveUp(i)}
+                    {renderMoveDown(i)}
+                  </div>
+
+                  <div>
+                    <Tooltip position={Position.LEFT} content={lang.tr('remove')} hoverOpenDelay="500">
+                      <Icon icon={IconNames.TRASH} intent={Intent.DANGER} onClick={() => this.onRemoveAction(i)} />
+                    </Tooltip>
+                  </div>
                 </div>
               )}
             </ConditionItem>

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/style.scss
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/style.scss
@@ -67,24 +67,29 @@ h5 {
 
 .item {
   padding: 5px 0;
+  padding-left: 10px;
+  border-bottom: 1px solid #ddd;
 
   .actions {
-    display: none;
+    opacity: 0.2;
+    text-align: right;
+    font-size: 12pt;
+    color: lightgrey;
+    display: flex;
+    justify-content: space-between;
 
-    a {
+    * {
       cursor: pointer;
-      margin-right: 5px;
+      margin-right: 3px;
     }
   }
 
   &:hover {
-    background: #fefefe;
     border-left: 2px solid #999;
-    padding-left: 10px;
+    margin-left: -2px;
 
     .actions {
-      padding: 10px 0;
-      display: block;
+      opacity: 1;
     }
   }
 }
@@ -111,10 +116,21 @@ h5 {
   }
 }
 
-.actions {
-  margin-top: 10px;
-  width: 100%;
+.tooltip {
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  line-height: 1.25;
 
+  .shortcutLabel {
+    margin-left: 4px;
+  }
+}
+
+.actions {
+  margin-top: 5px;
+  margin-bottom: 5px;
+  width: 100%;
   button {
     border-radius: 3px;
   }

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/style.scss.d.ts
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/style.scss.d.ts
@@ -18,9 +18,11 @@ interface CssExports {
   'returnBloc': string;
   'returnToNodeSection': string;
   'section': string;
+  'shortcutLabel': string;
   'subflowBloc': string;
   'textFields': string;
   'tip': string;
+  'tooltip': string;
 }
 declare var cssExports: CssExports;
 export = cssExports;


### PR DESCRIPTION
Default Empty Transitions
Fixes botpress/v12#1261 
![2021-03-08_14-53-38](https://user-images.githubusercontent.com/59566773/110373984-1be07080-801e-11eb-97a8-b3dea17030ac.gif)


Side Panel Node Actions (Options always visible in fixed positions, changed labels for icons, added  separator for visibility)
Fixes botpress/v12#1224 
![newgiphy](https://user-images.githubusercontent.com/59566773/110391190-2823f800-8035-11eb-85a6-f2a66ffd2ac4.gif)
