### PR TITLE
fix(analytics): Overlapped text in graph & active users

### DIFF
--- a/modules/analytics/src/backend/db.ts
+++ b/modules/analytics/src/backend/db.ts
@@ -145,6 +145,12 @@ export default class Database {
       .andWhere(this.knex.date.isBetween('createdOn', startDate, endDate))
       .groupBy(['createdOn', 'channel'])
 
+    let queryReturningUsers = this.knex('bot_chat_users')
+      .where({ botId })
+      .andWhere(this.knex.date.isBetween('lastSeenOn', startDate, endDate))
+      .groupBy(['lastSeenOn', 'channel'])
+      .andWhereRaw('lastSeenOn <> createdOn')
+
     let queryActiveUsers = this.knex('bot_chat_users')
       .where({ botId })
       .andWhere(this.knex.date.isBetween('lastSeenOn', startDate, endDate))
@@ -154,6 +160,7 @@ export default class Database {
       queryMetrics = queryMetrics.andWhere({ channel: options.channel })
       queryNewUsers = queryNewUsers.andWhere({ channel: options.channel })
       queryActiveUsers = queryActiveUsers.andWhere({ channel: options.channel })
+      queryReturningUsers = queryReturningUsers.andWhere({ channel: options.channel })
     }
 
     try {
@@ -168,11 +175,17 @@ export default class Database {
         'channel',
         this.knex.raw('count(*) as value')
       )
+      const returningUsersCount = await queryReturningUsers.select(
+        'lastSeenOn as date',
+        'channel',
+        this.knex.raw('count(*) as value')
+      )
 
       return [
         ...metrics,
         ...newUsersCount.map(x => ({ ...x, value: Number(x.value), metric: 'new_users_count' })),
-        ...activeUsersCount.map(x => ({ ...x, value: Number(x.value), metric: 'active_users_count' }))
+        ...activeUsersCount.map(x => ({ ...x, value: Number(x.value), metric: 'active_users_count' })),
+        ...returningUsersCount.map(x => ({ ...x, value: Number(x.value), metric: 'returning_users_count' }))
       ].map(x => ({ ...x, created_on: x.date, date: moment(x.date).format('YYYY-MM-DD') }))
     } catch (err) {
       this.bp.logger.attachError(err).warn('Could not retrieve analytics')

--- a/modules/analytics/src/views/full/TimeSeriesChart.tsx
+++ b/modules/analytics/src/views/full/TimeSeriesChart.tsx
@@ -19,8 +19,9 @@ interface Props extends Extras {
   channels: Channel[]
 }
 
-const formatTick = timestamp => moment.unix(timestamp).format('D')
+const formatTick = timestamp => moment.unix(timestamp).format('D/M')
 const formatTootilTick = timestamp => moment.unix(timestamp).format('dddd, MMMM Do YYYY')
+
 
 const TimeSeriesChart: FC<Props> = props => {
   const { data, name, className, channels } = props
@@ -48,12 +49,13 @@ const TimeSeriesChart: FC<Props> = props => {
                   ))}
               </defs>
               <Tooltip labelFormatter={formatTootilTick} />
+              {console.log("dataLen: ",Math.floor(data.length/12))}
               <XAxis
                 tickMargin={10}
                 height={28}
                 dataKey="time"
                 minTickGap={0}
-                interval={0}
+                interval={Math.floor(data.length/12)}
                 axisLine={false}
                 tickLine={false}
                 tickFormatter={formatTick}

--- a/modules/analytics/src/views/full/TimeSeriesChart.tsx
+++ b/modules/analytics/src/views/full/TimeSeriesChart.tsx
@@ -49,7 +49,6 @@ const TimeSeriesChart: FC<Props> = props => {
                   ))}
               </defs>
               <Tooltip labelFormatter={formatTootilTick} />
-              {console.log("dataLen: ",Math.floor(data.length/12))}
               <XAxis
                 tickMargin={10}
                 height={28}

--- a/modules/analytics/src/views/full/index.tsx
+++ b/modules/analytics/src/views/full/index.tsx
@@ -310,9 +310,9 @@ const Analytics: FC<any> = ({ bp }) => {
   }
 
   const getReturningUsers = () => {
-    const activeUsersCount = getMetricCount('active_users_count')
+    const returningUsersCount = getMetricCount('returning_users_count')
     const newUsersCount = getMetricCount('new_users_count')
-    const percent = Math.round((activeUsersCount / (newUsersCount + activeUsersCount)) * 100)
+    const percent = Math.round((returningUsersCount / (newUsersCount + returningUsersCount)) * 100)
 
     return getNotNaN(percent, '%')
   }
@@ -362,7 +362,7 @@ const Analytics: FC<any> = ({ bp }) => {
 
   const renderEngagement = () => {
     const newUserCountDiff = getMetricCount('new_users_count') - getPreviousRangeMetricCount('new_users_count')
-    const activeUserCountDiff = getMetricCount('active_users_count') - getPreviousRangeMetricCount('active_users_count')
+    const returningUserCountDiff = getMetricCount('returning_users_count') - getPreviousRangeMetricCount('returning_users_count')
     const activeUsers = fillMissingValues(getMetric('active_users_count'), state.dateRange[0], state.dateRange[1])
 
     return (
@@ -376,9 +376,9 @@ const Analytics: FC<any> = ({ bp }) => {
         />
         <NumberMetric
           className={style.half}
-          diffFromPreviousRange={activeUserCountDiff}
+          diffFromPreviousRange={returningUserCountDiff}
           previousDateRange={state.previousDateRange}
-          name={lang.tr('module.analytics.returningUsers', { nb: getMetricCount('active_users_count') })}
+          name={lang.tr('module.analytics.returningUsers', { nb: getMetricCount('returning_users_count') })}
           value={getReturningUsers()}
         />
         <TimeSeriesChart


### PR DESCRIPTION
- Fixed overlapped text on the Xaxis of the graph when a lot of data is in the graph.
- Added a returning users concept to differentiate with the active users.

In this example, there are 7 users in the database, and 1 was created before the displayed range.
Before:
![Screen Shot 2021-03-08 at 3 21 36 PM](https://user-images.githubusercontent.com/16272318/110377125-05d4af00-8022-11eb-9f7f-71c5ee081890.png)

After:
![Screen Shot 2021-03-08 at 3 20 47 PM](https://user-images.githubusercontent.com/16272318/110377146-0b31f980-8022-11eb-9228-41b4c57dbd7a.png)


Before:
![Screen Shot 2021-03-08 at 3 14 58 PM](https://user-images.githubusercontent.com/16272318/110377609-9e6b2f00-8022-11eb-9a59-4e4727a4ba33.png)

After:
![Screen Shot 2021-03-08 at 3 14 10 PM](https://user-images.githubusercontent.com/16272318/110377628-a4611000-8022-11eb-9212-6499a4ed60f5.png)







