### PR TITLE
fix(hitl2): scrollable HandoffList

### DIFF
--- a/modules/hitlnext/src/views/full/app/components/HandoffList.tsx
+++ b/modules/hitlnext/src/views/full/app/components/HandoffList.tsx
@@ -10,7 +10,6 @@ import { Context } from '../Store'
 import HandoffItem from './HandoffItem'
 import HandoffListHeader, { FilterType, SortType } from './HandoffListHeader'
 
-import cx from 'classnames'
 import style from '../../style.scss'
 
 

--- a/modules/hitlnext/src/views/full/app/components/HandoffList.tsx
+++ b/modules/hitlnext/src/views/full/app/components/HandoffList.tsx
@@ -11,8 +11,6 @@ import HandoffItem from './HandoffItem'
 import HandoffListHeader, { FilterType, SortType } from './HandoffListHeader'
 
 import style from '../../style.scss'
-
-
 interface Props {
   handoffs: object
   loading: boolean

--- a/modules/hitlnext/src/views/full/app/components/HandoffList.tsx
+++ b/modules/hitlnext/src/views/full/app/components/HandoffList.tsx
@@ -10,6 +10,10 @@ import { Context } from '../Store'
 import HandoffItem from './HandoffItem'
 import HandoffListHeader, { FilterType, SortType } from './HandoffListHeader'
 
+import cx from 'classnames'
+import style from '../../style.scss'
+
+
 interface Props {
   handoffs: object
   loading: boolean
@@ -63,6 +67,16 @@ const HandoffList: FC<Props> = ({ handoffs, loading }) => {
     setItems(filtered)
   }, [filterOptions, sortOption, handoffs, loading])
 
+  const displayHandoffList = () => {
+    return (
+      <div className={style.handoffList}>
+        {items.map(handoff => (
+          <HandoffItem key={handoff.id} {...handoff}></HandoffItem>
+        ))}
+      </div>
+    )
+  }
+
   return (
     <Fragment>
       <HandoffListHeader
@@ -79,7 +93,7 @@ const HandoffList: FC<Props> = ({ handoffs, loading }) => {
         <EmptyState icon={<CasesIcon />} text={lang.tr('module.hitlnext.handoffs.empty')}></EmptyState>
       )}
 
-      {!loading && !_.isEmpty(items) && items.map(handoff => <HandoffItem key={handoff.id} {...handoff}></HandoffItem>)}
+      {!loading && !_.isEmpty(items) && displayHandoffList()}
     </Fragment>
   )
 }

--- a/modules/hitlnext/src/views/full/style.scss
+++ b/modules/hitlnext/src/views/full/style.scss
@@ -300,7 +300,7 @@
 
   .handoffList {
     background-color: var(--bg);
-    display: flex;
+    overflow-y: scroll;
     flex-direction: column;
     flex-grow: 1;
     height: 100%;


### PR DESCRIPTION
Fix bug where handoffs would stack on each other when multiple handoffs are present by adding a scrollbar

Before:
![Screen Shot 2021-03-08 at 3 51 17 PM](https://user-images.githubusercontent.com/16272318/110381063-fd32a780-8026-11eb-9925-80b18c4e8b3e.png)

After:
![Screen Shot 2021-03-08 at 3 51 52 PM](https://user-images.githubusercontent.com/16272318/110381078-002d9800-8027-11eb-8bfc-fcc702ccee3a.png)

