### PR TITLE
fix(hitl2): hidden reply box on livechat render

### DIFF
--- a/modules/hitlnext/src/views/full/style.scss
+++ b/modules/hitlnext/src/views/full/style.scss
@@ -280,6 +280,8 @@
     flex-grow: 1;
     .webchatWrapper {
       height: 100%;
+      display: flex;
+      flex-direction: column;
       > div {
         height: 100%;
       }


### PR DESCRIPTION
FIx bug where the LiveChat textbox would render behind the emulator.

Before:
![Screen Shot 2021-03-08 at 5 12 01 PM](https://user-images.githubusercontent.com/16272318/110388679-6fa88500-8031-11eb-827a-bc9097ce667a.png)

After:
![Screen Shot 2021-03-08 at 5 11 26 PM](https://user-images.githubusercontent.com/16272318/110388690-72a37580-8031-11eb-90e8-1b8aaaa96cc6.png)
