### PR TITLE
feat(studio): controls for actions always showing

### DIFF
--- a/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/style.scss
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/nodeProps/style.scss
@@ -67,23 +67,15 @@ h5 {
 
 .item {
   padding: 5px 0;
-
   .actions {
-    display: none;
-
     a {
-      cursor: pointer;
       margin-right: 5px;
     }
   }
 
   &:hover {
-    background: #fefefe;
-    border-left: 2px solid #999;
-    padding-left: 10px;
-
+    background: rgb(245, 245, 245);
     .actions {
-      padding: 10px 0;
       display: block;
     }
   }


### PR DESCRIPTION
Fixed this https://github.com/botpress/v12/issues/1224

On over the background of the action will change to light gray to add a bit more interaction with the application.
![2021-03-08 18 15 33](https://user-images.githubusercontent.com/16272318/110394418-6a9c0380-803a-11eb-98ed-8d371dba1636.gif)



