### PR TITLE
fix(emulator): cover pic responsive

### DIFF
--- a/modules/channel-web/assets/default.css
+++ b/modules/channel-web/assets/default.css
@@ -853,8 +853,11 @@ body {
 }
 
 .bpw-botinfo-cover-picture-wrapper {
-  height: 50%;
   overflow: hidden;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 50%;
+}
 }
 
 .bpw-botinfo-cover-picture {


### PR DESCRIPTION
Before
![before](https://user-images.githubusercontent.com/74312982/110483684-a4304580-80f2-11eb-862a-13b111d31915.PNG)
After
![after](https://user-images.githubusercontent.com/74312982/110483724-abefea00-80f2-11eb-9ac1-cff5d9efa442.PNG)
