### PR TITLE
feat(misunderstood): skip already seen utterances

### DIFF
--- a/modules/misunderstood/src/backend/db.ts
+++ b/modules/misunderstood/src/backend/db.ts
@@ -44,7 +44,19 @@ export default class Db {
   }
 
   async addEvent(event: FlaggedEvent) {
-    await this.knex(TABLE_NAME).insert(event)
+    const lookup = { botId: event.botId, language: event.language, preview: event.preview }
+    const treatedEvents = await this.knex(TABLE_NAME)
+      .count('id')
+      .where(lookup)
+      .andWhereNot({ status: FLAGGED_MESSAGE_STATUS.new })
+
+    if (treatedEvents[0].count > 0) {
+      this.bp.logger.info(
+        `Not inserting event with properies ${JSON.stringify(lookup)} as it has already been treated before`
+      )
+    } else {
+      await this.knex(TABLE_NAME).insert(event)
+    }
   }
 
   async updateStatuses(botId: string, ids: string[], status: FLAGGED_MESSAGE_STATUS, resolutionData?: ResolutionData) {


### PR DESCRIPTION
If a phrase has already been dealt with (moved to pending, done or ignored) then do not show it in the NEW list again

![Mar-09-2021 10-07-44](https://user-images.githubusercontent.com/892367/110491503-59e1a100-80bf-11eb-9e0f-3bd1d3f60bd6.gif)


