### PR TITLE
chore(studio): move node filter to toolbar

### DIFF
--- a/src/bp/ui-shared/src/MainLayout/Toolbar/index.tsx
+++ b/src/bp/ui-shared/src/MainLayout/Toolbar/index.tsx
@@ -18,6 +18,7 @@ const Toolbar: FC<ToolbarProps> = props => {
       )}
       {!!props.buttons?.length && (
         <NavbarGroup className={cx(style.buttons, 'toolbar-buttons')} align={Alignment.RIGHT}>
+          {props.rightContent}
           {props.buttons.map((button, index) => (
             <div key={index} className={style.btnWrapper}>
               <Fragment>

--- a/src/bp/ui-shared/src/MainLayout/Toolbar/typings.d.ts
+++ b/src/bp/ui-shared/src/MainLayout/Toolbar/typings.d.ts
@@ -8,6 +8,7 @@ export interface ToolbarProps {
   tabChange?: (tab: string) => void
   currentTab?: string
   buttons?: ToolbarButtonProps[]
+  rightContent?: Jsx
   className?: string
 }
 

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/WorkflowToolbar/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/WorkflowToolbar/index.tsx
@@ -3,11 +3,21 @@ import _ from 'lodash'
 import React from 'react'
 import { connect } from 'react-redux'
 import { flowEditorRedo, flowEditorUndo } from '~/actions'
+import { SearchBar } from '~/components/Shared/Interface'
 import { canFlowRedo, canFlowUndo } from '~/reducers'
 
 import style from './style.scss'
 
-const WorkflowToolbar = ({ canRedo, canUndo, currentTab, redo, tabChange, undo }) => {
+const WorkflowToolbar = ({
+  canRedo,
+  canUndo,
+  currentTab,
+  redo,
+  tabChange,
+  undo,
+  highlightFilter,
+  handleFilterChanged
+}) => {
   const tabs = [
     {
       id: 'workflow',
@@ -30,6 +40,16 @@ const WorkflowToolbar = ({ canRedo, canUndo, currentTab, redo, tabChange, undo }
     }
   ]
 
+  const searchBar = (
+    <SearchBar
+      id="input-highlight-name"
+      className={style.noPadding}
+      value={highlightFilter}
+      placeholder={lang.tr('studio.flow.filterNodes')}
+      onChange={handleFilterChanged}
+    />
+  )
+
   return (
     <MainLayout.Toolbar
       className={style.header}
@@ -37,6 +57,7 @@ const WorkflowToolbar = ({ canRedo, canUndo, currentTab, redo, tabChange, undo }
       buttons={flowButtons}
       currentTab={currentTab}
       tabChange={tabChange}
+      rightContent={searchBar}
     />
   )
 }

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/WorkflowToolbar/style.scss
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/WorkflowToolbar/style.scss
@@ -9,3 +9,7 @@
     fill: var(--shark) !important;
   }
 }
+
+.noPadding {
+  padding: 0 !important;
+}

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/WorkflowToolbar/style.scss.d.ts
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/WorkflowToolbar/style.scss.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'header': string;
+  'noPadding': string;
 }
 declare var cssExports: CssExports;
 export = cssExports;

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/index.tsx
@@ -103,7 +103,6 @@ class Diagram extends Component<Props> {
   private diagramEngine: ExtendedDiagramEngine
   private diagramWidget: DiagramWidget
   private diagramContainer: HTMLDivElement
-  private searchRef: React.RefObject<HTMLInputElement>
   public manager: DiagramManager
   /** Represents the source port clicked when the user is connecting a node */
   private dragPortSource: any
@@ -226,8 +225,6 @@ class Diagram extends Component<Props> {
         this.props.switchFlow(firstFlow)
       }
     }
-
-    this.searchRef = React.createRef()
   }
 
   componentDidMount() {
@@ -536,7 +533,7 @@ class Diagram extends Component<Props> {
       this.handleContextMenu(event as any)
     }
 
-    if(this.canTargetOpenInspector(target)) {
+    if (this.canTargetOpenInspector(target)) {
       this.props.openFlowNodeProps()
     }
 
@@ -678,19 +675,10 @@ class Diagram extends Component<Props> {
 
     return (
       <MainLayout.Wrapper>
-        <WorkflowToolbar />
-
-        <div className={style.searchWrapper}>
-          <SearchBar
-            id="input-highlight-name"
-            className={style.noPadding}
-            ref={this.searchRef}
-            onBlur={this.props.hideSearch}
-            value={this.props.highlightFilter}
-            placeholder={lang.tr('studio.flow.filterNodes')}
-            onChange={value => this.props.handleFilterChanged({ target: { value } })}
-          />
-        </div>
+        <WorkflowToolbar
+          highlightFilter={this.props.highlightFilter}
+          handleFilterChanged={value => this.props.handleFilterChanged({ target: { value } })}
+        />
         <div
           id="diagramContainer"
           ref={ref => (this.diagramContainer = ref)}

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/style.scss
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/style.scss
@@ -17,20 +17,6 @@
   }
 }
 
-.noPadding {
-  padding: 0 !important;
-}
-
-.searchWrapper {
-  position: relative;
-  z-index: 9;
-  align-items: flex-start;
-  display: flex;
-  justify-content: flex-end;
-  margin-top: var(--spacing-large);
-  margin-bottom: -38px;
-}
-
 :global {
   .bp3-tab {
     text-transform: uppercase;

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/style.scss.d.ts
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/diagram/style.scss.d.ts
@@ -4,8 +4,6 @@ interface CssExports {
   'floatingInfo': string;
   'insertMode': string;
   'insertNode': string;
-  'noPadding': string;
-  'searchWrapper': string;
 }
 declare var cssExports: CssExports;
 export = cssExports;


### PR DESCRIPTION
Simply move the filter input to the toolbar

![filter-toolbar](https://user-images.githubusercontent.com/955524/110482203-67def400-80b6-11eb-9fbb-5b9c42c82341.gif)
