### PR TITLE
fix(misunderstood): train all modified languages

### DIFF
--- a/modules/misunderstood/src/backend/api.ts
+++ b/modules/misunderstood/src/backend/api.ts
@@ -101,11 +101,11 @@ export default async (bp: typeof sdk, db: Db) => {
       const { botId } = req.params
 
       try {
-        await db.applyChanges(botId)
+        const modifiedLanguages = await db.applyChanges(botId)
         const axiosConfig = await bp.http.getAxiosConfigForBot(botId, { localUrl: true })
         setTimeout(() => {
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          axios.post('/mod/nlu/train', {}, axiosConfig)
+          Promise.map(modifiedLanguages, lang => axios.post(`/mod/nlu/train/${lang}`, {}, axiosConfig))
         }, 1000)
         res.sendStatus(200)
       } catch (err) {

--- a/modules/misunderstood/src/backend/applyChanges.ts
+++ b/modules/misunderstood/src/backend/applyChanges.ts
@@ -1,6 +1,6 @@
-import axios from 'axios'
 import Bluebird from 'bluebird'
 import * as sdk from 'botpress/sdk'
+import _ from 'lodash'
 import memoize from 'lodash/memoize'
 import uniq from 'lodash/uniq'
 
@@ -75,6 +75,11 @@ const applyChanges = (bp: typeof sdk, botId: string, tableName: string) => {
         'id',
         events.map(({ id }) => id)
       )
+
+    return _(events)
+      .map(e => e.language)
+      .uniq()
+      .value()
   })
 }
 

--- a/modules/nlu/src/api.ts
+++ b/modules/nlu/src/api.ts
@@ -24,9 +24,7 @@ export const makeApi = (bp: { axios: AxiosInstance }) => ({
   createEntity: (entity: sdk.NLU.EntityDefinition): Promise<void> => bp.axios.post('/nlu/entities/', entity),
   updateEntity: (targetEntityId: string, entity: sdk.NLU.EntityDefinition): Promise<void> =>
     bp.axios.post(`/nlu/entities/${targetEntityId}`, entity),
-  deleteEntity: (entityId: string): Promise<void> => bp.axios.post(`/nlu/entities/${entityId}/delete`),
-  train: (): Promise<void> => bp.axios.post('/mod/nlu/train'),
-  cancelTraining: (): Promise<void> => bp.axios.post('/mod/nlu/train/delete')
+  deleteEntity: (entityId: string): Promise<void> => bp.axios.post(`/nlu/entities/${entityId}/delete`)
 })
 
 export const createApi = async (bp: typeof sdk, botId: string) => {


### PR DESCRIPTION
fixes: https://github.com/botpress/v12/issues/1269

The misunderstood was calling `mod/nlu/train` but the API should be `mod/nlu/train/:lang` so we need to train all modified languages.

This PR takes modified languages in events and trains for these languages.