### PR TITLE
fix(docker): Use UTC time zone

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN apt update && \
 	chgrp -R 0 /botpress && \
 	chmod -R g=u /botpress && \
 	apt install -y tzdata && \
-	ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && \
+	ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
 	dpkg-reconfigure --frontend noninteractive tzdata && \
 	./bp extract
 


### PR DESCRIPTION
There does not seem to be a good reason to default to the New-York timezone

So far, the only difference in Botpress' behaviour (apart from the timestamp changes in the logs) is Duckling is extracting timestamps in UTC (instead of America/New_York) time zone when dates are found in sentences. For example, create a bot using the Welcome Bot template, make sure to train your chatbot (bottome right corner of the Studio), and ask the bot "book me a table in 2 hours". Now, in the debugger, you will see that the time entity's normalized goes from "2021-03-01T10:54:00.000-05:00 minute" (America/New_York) to "2021-03-01T18:04:00.000+00:00 minute" (UTC). 

⚠️This may be a breaking change if users rely on the time entities extracted by Duckling