### PR TITLE
fix(webchat): browser error on IE11

### DIFF
--- a/src/bp/ui-studio/package.json
+++ b/src/bp/ui-studio/package.json
@@ -108,6 +108,7 @@
     "babel-loader": "^7.1.2",
     "babel-plugin-root-import": "^5.1.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",

--- a/src/bp/ui-studio/webpack.web.js
+++ b/src/bp/ui-studio/webpack.web.js
@@ -124,7 +124,11 @@ const webConfig = {
       },
       {
         test: /\.jsx?$/i,
-        include: path.resolve(__dirname, 'src/web'),
+        include: [
+          path.resolve(__dirname, 'src/web'),
+          // Common files must be transpiled to avoid issues with IE11
+          path.resolve(__dirname, '../../../out/bp/common')
+        ],
         use: [
           {
             loader: 'thread-loader'
@@ -133,18 +137,21 @@ const webConfig = {
             loader: 'babel-loader',
             options: {
               presets: [
-                'stage-3',
+                require.resolve('babel-preset-stage-3'),
                 [
-                  'env',
+                  require.resolve('babel-preset-env'),
                   {
                     targets: {
                       browsers: ['last 2 versions']
                     }
                   }
                 ],
-                'react'
+                require.resolve('babel-preset-react')
               ],
-              plugins: ['transform-class-properties'],
+              plugins: [
+                require.resolve('babel-plugin-transform-class-properties'),
+                require.resolve('babel-plugin-transform-es2015-arrow-functions')
+              ],
               compact: true,
               babelrc: false,
               cacheDirectory: true

--- a/src/bp/ui-studio/yarn.lock
+++ b/src/bp/ui-studio/yarn.lock
@@ -1245,7 +1245,7 @@ babel-plugin-transform-class-properties@^6.24.1:
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
   integrity sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=
   dependencies:
     babel-runtime "^6.22.0"
@@ -8549,11 +8549,8 @@ uglifyjs-webpack-plugin@^1.2.4:
     worker-farm "^1.5.2"
 
 "ui-shared@link:../ui-shared":
-  version "0.0.1"
-  dependencies:
-    js-cookie "^2.2.1"
-    react-command-palette "^0.12.0-0"
-    react-router "4.3.1"
+  version "0.0.0"
+  uid ""
 
 uncontrollable@^7.0.2:
   version "7.1.1"


### PR DESCRIPTION
The webchat on IE11 was broken since 12.15.0 but I couldn't pinpoint the root cause. There's a script error because some files in `common` were using arrow functions, which were not transpiled correctly.

I had to use require.resolve because babel tries to load plugins relative to the folder where it's processing the files in "include", obviously when outside of the studio, those paths doesn't work anymore.

Still find it funny that nobody reported this issue which was there since start of december