### PR TITLE
fix(core): auth methods with cookies

### DIFF
--- a/src/bp/ui-admin/src/routes/index.tsx
+++ b/src/bp/ui-admin/src/routes/index.tsx
@@ -53,9 +53,14 @@ export const makeMainRoutes = () => {
   setupBranding()
 
   const ExtractToken = () => {
-    const token = extractCookie('userToken')
-    if (token) {
-      authentication.setToken({ jwt: token })
+    const userToken = extractCookie('userToken')
+    const tokenExpiry = extractCookie('tokenExpiry')
+
+    if (userToken) {
+      authentication.setToken({
+        [window.USE_JWT_COOKIES ? 'csrf' : 'jwt']: userToken,
+        exp: Date.now() + Number(tokenExpiry)
+      })
     }
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises


### PR DESCRIPTION
The CSRF token with cookies was missing the expiry, so the token was considered invalid :/ 