### PR TITLE
fix(webchat): typo in createConversation

### DIFF
--- a/modules/channel-web/src/views/lite/core/api.tsx
+++ b/modules/channel-web/src/views/lite/core/api.tsx
@@ -112,7 +112,7 @@ export default class WebchatApi {
   async createConversation(): Promise<number> {
     try {
       const { data } = await this.axios.post('/conversations/new', this.baseUserPayload, this.axiosConfig)
-      return data.conversationId
+      return data.convoId
     } catch (err) {
       console.error('Error in create conversation', err)
     }


### PR DESCRIPTION
There was a structure mismatch between the [data returned by the server](https://github.com/botpress/botpress/blob/4213a3b532f91605972894d11c16295c0345d1a0/modules/channel-web/src/backend/api.ts#L419) and the format expected by the frontend

This causes in infinite loop (create new conversation -> list conversations -> create new conversation -> ...) in the webchat if the oldest conversation has `last_heard_on=null` (i.e. if no user has interacted with the bot, like for new bots) and `startNewConvoOnTimeout=true` in the webchat config.

