### PR TITLE
chore(nlu): rm ml git submodules as unused

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,6 @@ build/tests/e2e/screenshots/*
 .python-version
 /internal-modules
 /private-modules
-/src/bp/ml/node-svm
 
 # tests output
 cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,3 @@
 [submodule "src/bp/pro"]
 	path = src/bp/pro
 	url = git@github.com:botpress/botpress-pro.git
-[submodule "src/bp/ml/crfsuite"]
-	path = src/bp/ml/crfsuite
-	url = https://github.com/botpress/node-crfsuite-napi.git
-[submodule "src/bp/ml/fasttext"]
-	path = src/bp/ml/fasttext
-	url = https://github.com/botpress/node-fasttext.git
-[submodule "src/bp/ml/node-svm"]
-	path = src/bp/ml/node-svm
-	url = https://github.com/botpress/node-svm-napi.git
-[submodule "src/bp/ml/sentencepiece"]
-	path = src/bp/ml/sentencepiece
-	url = git@github.com:botpress/node-sentencepiece.git


### PR DESCRIPTION
Git submodules for every ml related library are no longer in the repo, but I forgot to remove the submodules references.

These submodules where only there so we can browse the code, but were not used at all. Instead we build them separately and place the binaries in `build/native-extensions/`. This was only confusing.

The binary has been working just fine without the submodules, so this PR is absolutely harmless.