### PR TITLE
fix(core): bad path with pro enabled

### DIFF
--- a/src/bp/core/app/inversify/app.inversify.ts
+++ b/src/bp/core/app/inversify/app.inversify.ts
@@ -129,7 +129,7 @@ container.load(...TelemetryContainerModules)
 
 if (process.IS_PRO_ENABLED) {
   // Otherwise this will fail on compile when the submodule is not available.
-  const ProContainerModule = require('pro/services/pro.inversify')
+  const ProContainerModule = require('pro/pro.inversify')
   container.load(ProContainerModule)
 }
 


### PR DESCRIPTION
After cleaning the out folder, the files were not building correctly because of the bad path. Didn't see the error with the binary because pro was not enabled..