### PR TITLE
fix(core): prevent double start

### DIFF
--- a/src/bp/core/app/core-loader.ts
+++ b/src/bp/core/app/core-loader.ts
@@ -12,30 +12,35 @@ import { Botpress as Core } from './botpress'
 import { container } from './inversify/app.inversify'
 import { TYPES } from './types'
 
-let botpress
-let logger: LoggerProvider | undefined
-let config: ConfigProvider | undefined
-let ghost: GhostService | undefined
-let database: Database | undefined
-let localActionServer: LocalActionServerImpl | undefined
-
-try {
-  botpress = container.get<Core>(TYPES.Botpress)
-  logger = container.get<LoggerProvider>(TYPES.LoggerProvider)
-  config = container.get<ConfigProvider>(TYPES.ConfigProvider)
-  ghost = container.get<GhostService>(TYPES.GhostService)
-  database = container.get<Database>(TYPES.Database)
-  localActionServer = container.get<LocalActionServerImpl>(TYPES.LocalActionServer)
-
-  const licensing = container.get<LicensingService>(TYPES.LicensingService)
-  licensing.installProtection()
-} catch (err) {
-  throw new FatalError(err, 'Error during initialization')
+export interface BotpressApp {
+  botpress: Core
+  logger: LoggerProvider
+  config: ConfigProvider
+  ghost: GhostService
+  database: Database
+  localActionServer: LocalActionServerImpl
 }
 
-export const Botpress = botpress
-export const Logger = logger!
-export const Config = config
-export const Ghost = ghost
-export const Db = database
-export const LocalActionServer = localActionServer
+export function createApp(): BotpressApp {
+  try {
+    const app = {
+      botpress: container.get<Core>(TYPES.Botpress),
+      logger: container.get<LoggerProvider>(TYPES.LoggerProvider),
+      config: container.get<ConfigProvider>(TYPES.ConfigProvider),
+      ghost: container.get<GhostService>(TYPES.GhostService),
+      database: container.get<Database>(TYPES.Database),
+      localActionServer: container.get<LocalActionServerImpl>(TYPES.LocalActionServer),
+      licensing: container.get<LicensingService>(TYPES.LicensingService)
+    }
+
+    app.licensing.installProtection()
+
+    return app
+  } catch (err) {
+    throw new FatalError(err, 'Error during initialization')
+  }
+}
+
+export function createLoggerProvider(): LoggerProvider {
+  return container.get<LoggerProvider>(TYPES.LoggerProvider)
+}

--- a/src/bp/diag/index.ts
+++ b/src/bp/diag/index.ts
@@ -6,7 +6,7 @@ import '../sdk/rewire'
 import { BotConfig } from 'botpress/sdk'
 
 import { Workspace } from 'common/typings'
-import { Db, Ghost } from 'core/app/core-loader'
+import { BotpressApp, createApp } from 'core/app/core-loader'
 import { getOrCreate as redisFactory } from 'core/distributed/redis'
 import fse from 'fs-extra'
 import IORedis from 'ioredis'
@@ -82,6 +82,7 @@ const PASSWORD_REGEX = new RegExp(/(.*):(.*)@(.*)/)
 const REDIS_TEST_KEY = 'botpress_redis_test_key'
 const REDIS_TEST_VALUE = nanoid()
 
+let app: BotpressApp
 let redisClient: IORedis.Redis
 let includePasswords = false
 let botpressConfig = undefined
@@ -96,7 +97,7 @@ export const print = (text: string) => {
 }
 
 const printModulesConfig = async (botId?: string) => {
-  const ghost = botId ? Ghost.forBot(botId) : Ghost.global()
+  const ghost = botId ? app.ghost.forBot(botId) : app.ghost.global()
   const configs = await ghost.directoryListing('config/', '*.json')
 
   await Promise.mapSeries(configs, async file => {
@@ -126,15 +127,15 @@ const testConnectivity = async () => {
   printHeader('Connectivity ')
 
   await wrapMethodCall('Connecting to Database', async () => {
-    await Db.initialize()
-    printRow('Database Type', Db.knex.isLite ? 'SQLite' : 'Postgres')
+    await app.database.initialize()
+    printRow('Database Type', app.database.knex.isLite ? 'SQLite' : 'Postgres')
 
-    if ((await Db.knex.raw('select 1+1 as result')) === undefined) {
+    if ((await app.database.knex.raw('select 1+1 as result')) === undefined) {
       throw new Error('Database error')
     }
 
     const useDbDriver = process.BPFS_STORAGE === 'database'
-    await Ghost.initialize(useDbDriver)
+    await app.ghost.initialize(useDbDriver)
   })
 
   if (process.env.CLUSTER_ENABLED && redisFactory) {
@@ -179,7 +180,7 @@ const testNetworkConnections = async () => {
   ]
 
   try {
-    const nluConfig = await Ghost.global().readFileAsObject<any>('config/', 'nlu.json')
+    const nluConfig = await app.ghost.global().readFileAsObject<any>('config/', 'nlu.json')
     const duckling = process.env.BP_MODULE_NLU_DUCKLINGURL || nluConfig?.ducklingURL
     const langServer =
       (process.env.BP_MODULE_NLU_LANGUAGESOURCES &&
@@ -200,10 +201,13 @@ const testNetworkConnections = async () => {
 
 const printDatabaseTables = async () => {
   let tables
-  if (Db.knex.isLite) {
-    tables = await Db.knex.raw("SELECT name FROM sqlite_master WHERE type='table'").then(res => res.map(x => x.name))
+  if (app.database.knex.isLite) {
+    tables = await app.database.knex
+      .raw("SELECT name FROM sqlite_master WHERE type='table'")
+      .then(res => res.map(x => x.name))
   } else {
-    tables = await Db.knex('pg_catalog.pg_tables')
+    tables = await app.database
+      .knex('pg_catalog.pg_tables')
       .select('tablename')
       .where({ schemaname: 'public' })
       .then(res => res.map(x => x.tablename))
@@ -245,13 +249,13 @@ const printConfig = async () => {
 }
 
 const printBotsList = async () => {
-  const workspaces = await Ghost.global().readFileAsObject<Workspace[]>('/', 'workspaces.json')
-  const botIds = (await Ghost.bots().directoryListing('/', 'bot.config.json')).map(path.dirname)
+  const workspaces = await app.ghost.global().readFileAsObject<Workspace[]>('/', 'workspaces.json')
+  const botIds = (await app.ghost.bots().directoryListing('/', 'bot.config.json')).map(path.dirname)
 
   await Promise.mapSeries(botIds, async botId => {
     printHeader(`Bot "${botId}" (workspace: ${workspaces.find(x => x.bots.includes(botId))?.id})`)
 
-    const botConfig = await Ghost.forBot(botId).readFileAsObject<BotConfig>('/', 'bot.config.json')
+    const botConfig = await app.ghost.forBot(botId).readFileAsObject<BotConfig>('/', 'bot.config.json')
     printObject(botConfig, includePasswords)
 
     await printModulesConfig(botId)
@@ -259,7 +263,8 @@ const printBotsList = async () => {
 }
 
 const printMigrationHistory = async () => {
-  const history = await Db.knex('srv_migrations')
+  const history = await app.database
+    .knex('srv_migrations')
     .select('*')
     .orderBy('created_at', 'desc')
 
@@ -272,6 +277,7 @@ const printMigrationHistory = async () => {
 }
 
 export default async function(options: Options) {
+  app = createApp()
   includePasswords = options.includePasswords || yn(process.env.BP_DIAG_INCLUDE_PASSWORDS)
   outputFile = options.outputFile || yn(process.env.BP_DIAG_OUTPUT)
 
@@ -281,7 +287,7 @@ export default async function(options: Options) {
   await testConnectivity()
   try {
     // Must be after the connectivity test, but before network connections so we have duckling/lang server urls
-    botpressConfig = await Ghost.global().readFileAsObject<any>('/', 'botpress.config.json')
+    botpressConfig = await app.ghost.global().readFileAsObject<any>('/', 'botpress.config.json')
   } catch (err) {}
 
   await testNetworkConnections()

--- a/src/bp/extractor.ts
+++ b/src/bp/extractor.ts
@@ -1,14 +1,15 @@
 /* eslint-disable import/order */
 import './sdk/rewire'
 
-import { Config, Logger } from 'core/app/core-loader'
+import { createApp } from 'core/app/core-loader'
 import { ModuleResolver } from 'core/modules'
 
 export default async argv => {
   process.VERBOSITY_LEVEL = argv.verbose ? Number(argv.verbose) : -1
 
-  const logger = await Logger('Extractor')
-  const modules = await Config.getModulesListConfig()
+  const app = createApp()
+  const logger = await app.logger('Extractor')
+  const modules = await app.config.getModulesListConfig()
   const resolver = new ModuleResolver(logger)
 
   for (const entry of modules) {


### PR DESCRIPTION
The cluster master was initializing all the the services before creating the master node so this PR fixes that. This bug made the startup slower, and also caused some unwanted bugs with chokidar sending two events for every file change.