### PR TITLE
fix(core): display url when error while mounting

### DIFF
--- a/src/bp/core/modules/module-loader.ts
+++ b/src/bp/core/modules/module-loader.ts
@@ -319,7 +319,8 @@ export class ModuleLoader {
         const api = await createForModule(module.name)
         await entryPoint.onBotMount?.(api, botId)
       } catch (err) {
-        throw new Error(`while mounting bot in module ${module.name}: ${err}`)
+        const details = err.response ? `for url ${err.response.config?.url}` : ''
+        throw new Error(`while mounting bot in module ${module.name}: ${err} ${details}`)
       }
     }
   }


### PR DESCRIPTION
Minor change to display the URL when a bot fails to load on a specific module. Just seeing "status code 404" doesn't help at all.

Before:
![image](https://user-images.githubusercontent.com/42552874/112374497-8ea54900-8cb8-11eb-8215-45079ff46286.png)

After:
![image](https://user-images.githubusercontent.com/42552874/112374438-77fef200-8cb8-11eb-9f83-714b5a7d8fff.png)
