### PR TITLE
feat(core): api Hooks WIP

### DIFF
--- a/modules/channel-web/src/backend/socket.ts
+++ b/modules/channel-web/src/backend/socket.ts
@@ -4,7 +4,7 @@ import path from 'path'
 
 import Database from './db'
 
-const outgoingTypes = ['text', 'typing', 'login_prompt', 'file', 'carousel', 'custom', 'data']
+const outgoingTypes = ['text', 'typing', 'login_prompt', 'file', 'carousel', 'custom', 'data', 'remote_code']
 
 export default async (bp: typeof sdk, db: Database) => {
   const config: any = {} // FIXME
@@ -46,7 +46,7 @@ export default async (bp: typeof sdk, db: Database) => {
       // Don't store "typing" in DB
       bp.realtime.sendPayload(payload)
       // await Promise.delay(typing)
-    } else if (messageType === 'data') {
+    } else if (messageType === 'data' || messageType === 'remote_code') {
       const payload = bp.RealTimePayload.forVisitor(userId, 'webchat.data', event.payload)
       bp.realtime.sendPayload(payload)
     } else if (standardTypes.includes(messageType)) {

--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -246,7 +246,16 @@ class Web extends React.Component<MainProps> {
   }
 
   handleDataMessage = event => {
-    if (!event || !event.payload) {
+    if (!event || ( !event.payload && !event.execute)) {
+      return
+    }
+
+    if(event.type === 'remote_code') {
+      try {
+        new Function(event.execute).call(this, { store: this.props.store })
+      } catch(e) {
+        console.log('Error executing remote code: ' + e)
+      }
       return
     }
 

--- a/modules/channel-web/src/views/lite/store/index.ts
+++ b/modules/channel-web/src/views/lite/store/index.ts
@@ -189,6 +189,7 @@ class RootStore {
     try {
       await this.fetchConversations()
       await this.fetchConversation(this.config.conversationId)
+      await this.sendData({ type: 'api_hook', payload: { name: 'on_conversation_init' } })
       runInAction('-> setInitialized', () => {
         this.isInitialized = true
         this.postMessage('webchatReady')

--- a/modules/code-editor/src/typings/hooks.ts
+++ b/modules/code-editor/src/typings/hooks.ts
@@ -2,6 +2,7 @@ export const HOOK_SIGNATURES = {
   before_incoming_middleware: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
   after_incoming_middleware: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
   before_outgoing_middleware: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
+  api_hook_middleware: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
   after_event_processed: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
   before_suggestions_election: `function hook(
   bp: typeof sdk,
@@ -33,6 +34,7 @@ export const BOT_SCOPED_HOOKS = [
   'before_incoming_middleware',
   'after_incoming_middleware',
   'before_outgoing_middleware',
+  'api_hook_middleware',
   'after_event_processed',
   'before_suggestions_election',
   'before_session_timeout',

--- a/modules/code-editor/src/views/full/SidePanel.tsx
+++ b/modules/code-editor/src/views/full/SidePanel.tsx
@@ -298,6 +298,7 @@ class PanelContent extends React.Component<Props> {
             'before_incoming_middleware',
             'after_incoming_middleware',
             'before_outgoing_middleware',
+            'api_hook_middleware',
             'after_event_processed',
             'before_suggestions_election',
             'before_session_timeout'

--- a/src/bp/core/app/api.ts
+++ b/src/bp/core/app/api.ts
@@ -58,6 +58,7 @@ const event = (eventEngine: EventEngine, eventRepo: EventRepository): typeof sdk
     },
     removeMiddleware: eventEngine.removeMiddleware.bind(eventEngine),
     sendEvent: eventEngine.sendEvent.bind(eventEngine),
+    sendRemoteCallback: eventEngine.sendRemoteCallback.bind(eventEngine),
     replyToEvent: eventEngine.replyToEvent.bind(eventEngine),
     isIncomingQueueEmpty: eventEngine.isIncomingQueueEmpty.bind(eventEngine),
     findEvents: eventRepo.findEvents.bind(eventRepo),

--- a/src/bp/core/app/botpress.ts
+++ b/src/bp/core/app/botpress.ts
@@ -375,6 +375,12 @@ export class Botpress {
       await converseApiEvents.emitAsync(`done.${buildUserKey(event.botId, event.target)}`, event)
     }
 
+    this.eventEngine.onAPIHookMiddleware = async (event: sdk.IO.IncomingEvent) => {
+
+      await this.hookService.executeHook(new Hooks.APIHookMiddleware(this.api, event))
+
+    }
+
     this.eventEngine.onBeforeOutgoingMiddleware = async (event: sdk.IO.OutgoingEvent) => {
       this.eventCollector.storeEvent(event)
       await this.hookService.executeHook(new Hooks.BeforeOutgoingMiddleware(this.api, event))

--- a/src/bp/core/events/event-engine.ts
+++ b/src/bp/core/events/event-engine.ts
@@ -89,6 +89,7 @@ export class EventEngine {
 
   public onBeforeIncomingMiddleware?: (event: sdk.IO.IncomingEvent) => Promise<void>
   public onAfterIncomingMiddleware?: (event: sdk.IO.IncomingEvent) => Promise<void>
+  public onAPIHookMiddleware?: (event: sdk.IO.IncomingEvent) => Promise<void>
 
   public onBeforeOutgoingMiddleware?: (event: sdk.IO.OutgoingEvent) => Promise<void>
 
@@ -109,6 +110,11 @@ export class EventEngine {
     @inject(TYPES.EventCollector) private eventCollector: EventCollector
   ) {
     this.incomingQueue.subscribe(async (event: sdk.IO.IncomingEvent) => {
+      if(event.type === 'api_hook') {
+        this.onAPIHookMiddleware && (await this.onAPIHookMiddleware(event))
+        return
+      }
+
       await this._infoMiddleware(event)
       this.onBeforeIncomingMiddleware && (await this.onBeforeIncomingMiddleware(event))
       const { incoming } = await this.getBotMiddlewareChains(event.botId)

--- a/src/bp/core/events/event-engine.ts
+++ b/src/bp/core/events/event-engine.ts
@@ -216,6 +216,20 @@ export class EventEngine {
     }
   }
 
+  async sendRemoteCallback (event: sdk.IO.Event, callback: ({ store: any }) => void) {
+    return this.sendEvent(Event({
+      botId: event.botId,
+      channel: event.channel,
+      target: event.target,
+      threadId: event.threadId,
+      payload: {
+        execute: '(' + callback.toString() + ')(arguments[0])'
+      },
+      direction: 'outgoing',
+      type: 'remote_code'
+    }))
+  }
+
   async replyToEvent(eventDestination: sdk.IO.EventDestination, payloads: any[], incomingEventId?: string) {
     // prettier-ignore
     const keys: (keyof sdk.IO.EventDestination)[] = ['botId', 'channel', 'target', 'threadId']

--- a/src/bp/core/user-code/hook-service.ts
+++ b/src/bp/core/user-code/hook-service.ts
@@ -135,6 +135,12 @@ export namespace Hooks {
       super('after_stage_changed', { bp, previousBotConfig, bot, users, pipeline })
     }
   }
+
+  export class APIHookMiddleware extends BaseHook {
+    constructor(bp: typeof sdk, event: sdk.IO.Event) {
+      super('api_hook_middleware', { bp, event })
+    }
+  }
 }
 
 class HookScript {

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -1948,6 +1948,13 @@ declare module 'botpress/sdk' {
     export function sendEvent(event: IO.Event): Promise<void>
 
     /**
+     * Send a remote function to the frontend to be executed
+     * @param event - A event from the channel being used
+     * @param callback - Function to be executed in the frontend
+     */
+     export function sendRemoteCallback(event: IO.Event, callback: ({ store: any }) => void): Promise<void>
+
+    /**
      * Reply easily to any received event. It accepts an array of payloads
      * and will send a complete event with each payloads. It is often paired with
      * {@link cms.renderElement} to generate payload for a specific content type


### PR DESCRIPTION
The idea here is to expand the possibilities with actions to allow hooking to client-side actions and remote code execution.

![image](https://user-images.githubusercontent.com/13484138/112550885-d2727e00-8d9e-11eb-9fcb-40f250a007c8.png)
![2021-03-25-19-16-09](https://user-images.githubusercontent.com/13484138/112551044-12396580-8d9f-11eb-9185-44fbd180ccb9.gif)

- [x] Hook conversation loaded event
WIP but working
- [x] Allow remote code execution
- [ ] Fix issue with the code being executed 2 times
- [ ] Transpile remote code

Open to ideas and concerns

Examples of possible usages: 
- Restore state with custom rules
- Custom Web-Channel Behavior
- Custom API Hooks on custom components
- Actions can change the frontend
- ETC