### PR TITLE
chore(misunderstood): DB Tests harness

### DIFF
--- a/modules/misunderstood/src/backend/db.test.ts
+++ b/modules/misunderstood/src/backend/db.test.ts
@@ -14,8 +14,9 @@ import Database from '../../../../src/bp/core/database'
 
 import { createDatabaseSuite } from '../../../../src/bp/core/database/index.tests'
 
-createDatabaseSuite('Misunderstood', (database: Database) => {
+createDatabaseSuite('Misunderstood - DB', (database: Database) => {
   const db = new Db({ database: database.knex })
+
   beforeAll(async () => {
     db.knex = database.knex
     await db.initialize()
@@ -27,7 +28,15 @@ createDatabaseSuite('Misunderstood', (database: Database) => {
     }
   })
 
-  describe('Get', () => {
+  describe('listEvents', () => {
+    it('Returns no events when none in table', async () => {
+      const botId = 'mybot'
+      const eventId = '1234'
+      const language = 'en'
+
+      const events = await db.listEvents(botId, language, FLAGGED_MESSAGE_STATUS.new)
+      expect(events).toHaveLength(0)
+    })
     it("Returns undefined if key doesn't exist", async () => {
       const botId = 'mybot'
       const eventId = '1234'

--- a/modules/misunderstood/src/backend/db.test.ts
+++ b/modules/misunderstood/src/backend/db.test.ts
@@ -24,9 +24,12 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
     await db.knex.raw(`${statement} "${TABLE_NAME}";`)
   })
 
+  beforeEach(async () => {
+    await db.knex.raw(db.knex.isLite ? 'BEGIN TRANSACTION' : 'START TRANSACTION')
+  })
+
   afterEach(async () => {
-    const statement = db.knex.isLite ? 'DELETE FROM' : 'TRUNCATE TABLE'
-    await db.knex.raw(`${statement} "${TABLE_NAME}";`)
+    await db.knex.raw(db.knex.isLite ? 'ROLLBACK TRANSACTION' : 'ROLLBACK')
   })
 
   describe('listEvents', () => {

--- a/modules/misunderstood/src/backend/db.test.ts
+++ b/modules/misunderstood/src/backend/db.test.ts
@@ -1,0 +1,5 @@
+describe('Module - Misunderstood - DB', () => {
+  it('Empty test', async () => {
+    console.log('hello')
+  })
+})

--- a/modules/misunderstood/src/backend/db.test.ts
+++ b/modules/misunderstood/src/backend/db.test.ts
@@ -39,6 +39,7 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
       await db.addEvent({ botId, eventId, language, preview: 'some message', reason: FLAG_REASON.action })
 
       const events = await db.listEvents(botId, language, FLAGGED_MESSAGE_STATUS.new)
+
       expect(events).toHaveLength(1)
     })
 
@@ -46,9 +47,9 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
       const botId = 'mybot'
       const eventId = '1234'
       const language = 'en'
-      await db.addEvent({ botId, eventId, language, preview: 'some message', reason: FLAG_REASON.action })
-      await db.addEvent({ botId, eventId, language, preview: 'some message', reason: FLAG_REASON.action })
-      await db.addEvent({ botId, eventId, language, preview: 'some message', reason: FLAG_REASON.action })
+      for (let i = 0; i < 3; i++) {
+        await db.addEvent({ botId, eventId, language, preview: 'some message', reason: FLAG_REASON.action })
+      }
 
       const events = await db.listEvents(botId, language, FLAGGED_MESSAGE_STATUS.new)
 
@@ -91,18 +92,12 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
         reason: FLAG_REASON.action
       }
 
-      await db.addEvent({
-        ...props,
-        language: 'en'
-      })
-      await db.addEvent({
-        ...props,
-        language: 'fr'
-      })
-      await db.addEvent({
-        ...props,
-        language: 'fr'
-      })
+      for (const language of ['en', 'fr', 'fr']) {
+        await db.addEvent({
+          ...props,
+          language
+        })
+      }
 
       // Filter by botId
       expect(await db.listEvents(props.botId, 'en', FLAGGED_MESSAGE_STATUS.new)).toHaveLength(1)

--- a/modules/misunderstood/src/backend/db.test.ts
+++ b/modules/misunderstood/src/backend/db.test.ts
@@ -1,14 +1,5 @@
 import Db, { TABLE_NAME } from './db'
-import {
-  DbFlaggedEvent,
-  FilteringOptions,
-  FlaggedEvent,
-  FLAGGED_MESSAGE_STATUS,
-  FLAGGED_MESSAGE_STATUSES,
-  FLAG_REASON,
-  ResolutionData,
-  RESOLUTION_TYPE
-} from '../types'
+import { FLAGGED_MESSAGE_STATUS, FLAG_REASON } from '../types'
 import 'reflect-metadata'
 import Database from '../../../../src/bp/core/database'
 

--- a/modules/misunderstood/src/backend/db.test.ts
+++ b/modules/misunderstood/src/backend/db.test.ts
@@ -34,25 +34,24 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
 
     it('Returns no events when none in table', async () => {
       const events = await db.listEvents(props.botId, props.language, FLAGGED_MESSAGE_STATUS.new)
+
       expect(events).toHaveLength(0)
     })
 
     it('Returns one event if one exists', async () => {
-      const { botId, eventId, language } = props
-      await db.addEvent({ botId, eventId, language, preview: 'some message', reason: FLAG_REASON.action })
+      await db.addEvent(props)
 
-      const events = await db.listEvents(botId, language, FLAGGED_MESSAGE_STATUS.new)
+      const events = await db.listEvents(props.botId, props.language, FLAGGED_MESSAGE_STATUS.new)
 
       expect(events).toHaveLength(1)
     })
 
     it('Returns many events if many exist', async () => {
-      const { botId, eventId, language } = props
       for (let i = 0; i < 3; i++) {
-        await db.addEvent({ botId, eventId, language, preview: 'some message', reason: FLAG_REASON.action })
+        await db.addEvent(props)
       }
 
-      const events = await db.listEvents(botId, language, FLAGGED_MESSAGE_STATUS.new)
+      const events = await db.listEvents(props.botId, props.language, FLAGGED_MESSAGE_STATUS.new)
 
       expect(events).toHaveLength(3)
     })

--- a/modules/misunderstood/src/backend/db.test.ts
+++ b/modules/misunderstood/src/backend/db.test.ts
@@ -78,9 +78,13 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
         ...props,
         botId: 'bot2'
       })
+      await db.addEvent({
+        ...props,
+        botId: 'bot2'
+      })
 
       expect(await db.listEvents('bot1', 'en', FLAGGED_MESSAGE_STATUS.new)).toHaveLength(1)
-      expect(await db.listEvents('bot2', 'en', FLAGGED_MESSAGE_STATUS.new)).toHaveLength(1)
+      expect(await db.listEvents('bot2', 'en', FLAGGED_MESSAGE_STATUS.new)).toHaveLength(2)
       expect(await db.listEvents('bot3', 'en', FLAGGED_MESSAGE_STATUS.new)).toHaveLength(0)
     })
 

--- a/modules/misunderstood/src/backend/db.test.ts
+++ b/modules/misunderstood/src/backend/db.test.ts
@@ -37,7 +37,7 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
       const events = await db.listEvents(botId, language, FLAGGED_MESSAGE_STATUS.new)
       expect(events).toHaveLength(0)
     })
-    it("Returns undefined if key doesn't exist", async () => {
+    it('Returns one event if one exists', async () => {
       const botId = 'mybot'
       const eventId = '1234'
       const language = 'en'

--- a/modules/misunderstood/src/backend/db.test.ts
+++ b/modules/misunderstood/src/backend/db.test.ts
@@ -57,6 +57,7 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
       await db.addEvent({ botId, eventId, language, preview: 'some message', reason: FLAG_REASON.action })
 
       const events = await db.listEvents(botId, language, FLAGGED_MESSAGE_STATUS.new)
+
       expect(events).toHaveLength(3)
     })
 
@@ -78,7 +79,6 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
         botId: 'bot2'
       })
 
-      // Filter by botId
       expect(await db.listEvents('bot1', 'en', FLAGGED_MESSAGE_STATUS.new)).toHaveLength(1)
       expect(await db.listEvents('bot2', 'en', FLAGGED_MESSAGE_STATUS.new)).toHaveLength(1)
       expect(await db.listEvents('bot3', 'en', FLAGGED_MESSAGE_STATUS.new)).toHaveLength(0)

--- a/modules/misunderstood/src/backend/db.test.ts
+++ b/modules/misunderstood/src/backend/db.test.ts
@@ -1,5 +1,30 @@
-describe('Module - Misunderstood - DB', () => {
-  it('Empty test', async () => {
-    console.log('hello')
+import Db from './db'
+// import * as sdk from 'botpress/sdk'
+import {
+  DbFlaggedEvent,
+  FilteringOptions,
+  FlaggedEvent,
+  FLAGGED_MESSAGE_STATUS,
+  FLAGGED_MESSAGE_STATUSES,
+  FLAG_REASON,
+  ResolutionData,
+  RESOLUTION_TYPE
+} from '../types'
+import 'reflect-metadata'
+import Database from '../../../../src/bp/core/database'
+
+import { PersistedConsoleLogger } from '../../../../src/bp/core/logger'
+import { createSpyObject, MockObject } from '../../../../src/bp/core/misc/utils'
+import { createDatabaseSuite } from '../../../../src/bp/core/database/index.tests'
+
+createDatabaseSuite('Misunderstood', (database: Database) => {
+  const logger: MockObject<PersistedConsoleLogger> = createSpyObject<PersistedConsoleLogger>()
+
+  describe('Get', () => {
+    it("Returns undefined if key doesn't exist", async () => {
+      const db = new Db({ database: database.knex })
+      await db.initialize()
+      await db.listEvents('', '', FLAGGED_MESSAGE_STATUS.new)
+    })
   })
 })

--- a/modules/misunderstood/src/backend/db.test.ts
+++ b/modules/misunderstood/src/backend/db.test.ts
@@ -23,9 +23,8 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
   })
 
   afterEach(async () => {
-    if (!db.knex.isLite) {
-      await db.knex.raw(`TRUNCATE TABLE "${TABLE_NAME}";`)
-    }
+    const statement = db.knex.isLite ? 'DELETE FROM' : 'TRUNCATE TABLE'
+    await db.knex.raw(`${statement} "${TABLE_NAME}";`)
   })
 
   describe('listEvents', () => {
@@ -45,6 +44,17 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
 
       const events = await db.listEvents(botId, language, FLAGGED_MESSAGE_STATUS.new)
       expect(events).toHaveLength(1)
+    })
+    it('Returns many events if many exist', async () => {
+      const botId = 'mybot'
+      const eventId = '1234'
+      const language = 'en'
+      await db.addEvent({ botId, eventId, language, preview: 'some message', reason: FLAG_REASON.action })
+      await db.addEvent({ botId, eventId, language, preview: 'some message', reason: FLAG_REASON.action })
+      await db.addEvent({ botId, eventId, language, preview: 'some message', reason: FLAG_REASON.action })
+
+      const events = await db.listEvents(botId, language, FLAGGED_MESSAGE_STATUS.new)
+      expect(events).toHaveLength(3)
     })
   })
 })

--- a/modules/misunderstood/src/backend/db.test.ts
+++ b/modules/misunderstood/src/backend/db.test.ts
@@ -20,6 +20,8 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
   beforeAll(async () => {
     db.knex = database.knex
     await db.initialize()
+    const statement = db.knex.isLite ? 'DELETE FROM' : 'TRUNCATE TABLE'
+    await db.knex.raw(`${statement} "${TABLE_NAME}";`)
   })
 
   afterEach(async () => {
@@ -36,6 +38,7 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
       const events = await db.listEvents(botId, language, FLAGGED_MESSAGE_STATUS.new)
       expect(events).toHaveLength(0)
     })
+
     it('Returns one event if one exists', async () => {
       const botId = 'mybot'
       const eventId = '1234'
@@ -45,6 +48,7 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
       const events = await db.listEvents(botId, language, FLAGGED_MESSAGE_STATUS.new)
       expect(events).toHaveLength(1)
     })
+
     it('Returns many events if many exist', async () => {
       const botId = 'mybot'
       const eventId = '1234'
@@ -55,6 +59,121 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
 
       const events = await db.listEvents(botId, language, FLAGGED_MESSAGE_STATUS.new)
       expect(events).toHaveLength(3)
+    })
+
+    it('Filters - by botId', async () => {
+      const props = {
+        botId: 'bot1',
+        eventId: '1234',
+        language: 'en',
+        preview: 'some message',
+        reason: FLAG_REASON.action
+      }
+
+      await db.addEvent({
+        ...props,
+        botId: 'bot1'
+      })
+      await db.addEvent({
+        ...props,
+        botId: 'bot2'
+      })
+
+      // Filter by botId
+      expect(await db.listEvents('bot1', 'en', FLAGGED_MESSAGE_STATUS.new)).toHaveLength(1)
+      expect(await db.listEvents('bot2', 'en', FLAGGED_MESSAGE_STATUS.new)).toHaveLength(1)
+      expect(await db.listEvents('bot3', 'en', FLAGGED_MESSAGE_STATUS.new)).toHaveLength(0)
+    })
+
+    it('Filters - by language', async () => {
+      const props = {
+        botId: 'bot1',
+        eventId: '1234',
+        language: 'en',
+        preview: 'some message',
+        reason: FLAG_REASON.action
+      }
+
+      await db.addEvent({
+        ...props,
+        language: 'en'
+      })
+      await db.addEvent({
+        ...props,
+        language: 'fr'
+      })
+      await db.addEvent({
+        ...props,
+        language: 'fr'
+      })
+
+      // Filter by botId
+      expect(await db.listEvents(props.botId, 'en', FLAGGED_MESSAGE_STATUS.new)).toHaveLength(1)
+      expect(await db.listEvents(props.botId, 'fr', FLAGGED_MESSAGE_STATUS.new)).toHaveLength(2)
+      expect(await db.listEvents(props.botId, 'es', FLAGGED_MESSAGE_STATUS.new)).toHaveLength(0)
+    })
+
+    it('Filters - by status', async () => {
+      const props = {
+        botId: 'bot1',
+        eventId: '1234',
+        language: 'en',
+        preview: 'some message',
+        reason: FLAG_REASON.action
+      }
+
+      await db.addEvent(props)
+      await db.addEvent(props)
+      await db.addEvent(props)
+
+      const [{ id: id1 }, { id: id2 }, { id: id3 }] = await db.listEvents(
+        props.botId,
+        props.language,
+        FLAGGED_MESSAGE_STATUS.new
+      )
+      await db.updateStatus(props.botId, id1.toString(), FLAGGED_MESSAGE_STATUS.pending)
+      await db.updateStatus(props.botId, id2.toString(), FLAGGED_MESSAGE_STATUS.pending)
+      await db.updateStatus(props.botId, id3.toString(), FLAGGED_MESSAGE_STATUS.deleted)
+
+      expect(await db.listEvents(props.botId, props.language, FLAGGED_MESSAGE_STATUS.pending)).toHaveLength(2)
+      expect(await db.listEvents(props.botId, props.language, FLAGGED_MESSAGE_STATUS.deleted)).toHaveLength(1)
+      expect(await db.listEvents(props.botId, props.language, FLAGGED_MESSAGE_STATUS.new)).toHaveLength(0)
+    })
+
+    it('Filters - by reason', async () => {
+      const props = {
+        botId: 'bot1',
+        eventId: '1234',
+        language: 'en',
+        preview: 'some message',
+        reason: FLAG_REASON.action
+      }
+
+      for (const reason of [
+        FLAG_REASON.thumbs_down,
+        FLAG_REASON.thumbs_down,
+        FLAG_REASON.auto_hook,
+        FLAG_REASON.action,
+        FLAG_REASON.manual
+      ]) {
+        await db.addEvent({
+          ...props,
+          reason
+        })
+      }
+
+      for (const { reason, expectedCount } of [
+        { reason: FLAG_REASON.thumbs_down, expectedCount: 2 },
+        { reason: FLAG_REASON.auto_hook, expectedCount: 3 },
+        { reason: FLAG_REASON.action, expectedCount: 3 },
+        { reason: FLAG_REASON.manual, expectedCount: 3 }
+      ]) {
+        expect(
+          await db.listEvents(props.botId, props.language, FLAGGED_MESSAGE_STATUS.new, {
+            reason
+          })
+        ).toHaveLength(expectedCount)
+      }
     })
   })
 })

--- a/modules/misunderstood/src/backend/db.test.ts
+++ b/modules/misunderstood/src/backend/db.test.ts
@@ -32,7 +32,6 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
   describe('listEvents', () => {
     it('Returns no events when none in table', async () => {
       const botId = 'mybot'
-      const eventId = '1234'
       const language = 'en'
 
       const events = await db.listEvents(botId, language, FLAGGED_MESSAGE_STATUS.new)

--- a/modules/misunderstood/src/backend/db.test.ts
+++ b/modules/misunderstood/src/backend/db.test.ts
@@ -24,18 +24,21 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
   })
 
   describe('listEvents', () => {
-    it('Returns no events when none in table', async () => {
-      const botId = 'mybot'
-      const language = 'en'
+    const props = {
+      botId: 'bot1',
+      eventId: '1234',
+      language: 'en',
+      preview: 'some message',
+      reason: FLAG_REASON.action
+    }
 
-      const events = await db.listEvents(botId, language, FLAGGED_MESSAGE_STATUS.new)
+    it('Returns no events when none in table', async () => {
+      const events = await db.listEvents(props.botId, props.language, FLAGGED_MESSAGE_STATUS.new)
       expect(events).toHaveLength(0)
     })
 
     it('Returns one event if one exists', async () => {
-      const botId = 'mybot'
-      const eventId = '1234'
-      const language = 'en'
+      const { botId, eventId, language } = props
       await db.addEvent({ botId, eventId, language, preview: 'some message', reason: FLAG_REASON.action })
 
       const events = await db.listEvents(botId, language, FLAGGED_MESSAGE_STATUS.new)
@@ -44,9 +47,7 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
     })
 
     it('Returns many events if many exist', async () => {
-      const botId = 'mybot'
-      const eventId = '1234'
-      const language = 'en'
+      const { botId, eventId, language } = props
       for (let i = 0; i < 3; i++) {
         await db.addEvent({ botId, eventId, language, preview: 'some message', reason: FLAG_REASON.action })
       }
@@ -57,14 +58,6 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
     })
 
     it('Filters - by botId', async () => {
-      const props = {
-        botId: 'bot1',
-        eventId: '1234',
-        language: 'en',
-        preview: 'some message',
-        reason: FLAG_REASON.action
-      }
-
       await db.addEvent({
         ...props,
         botId: 'bot1'
@@ -78,20 +71,12 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
         botId: 'bot2'
       })
 
-      expect(await db.listEvents('bot1', 'en', FLAGGED_MESSAGE_STATUS.new)).toHaveLength(1)
-      expect(await db.listEvents('bot2', 'en', FLAGGED_MESSAGE_STATUS.new)).toHaveLength(2)
-      expect(await db.listEvents('bot3', 'en', FLAGGED_MESSAGE_STATUS.new)).toHaveLength(0)
+      expect(await db.listEvents('bot1', props.language, FLAGGED_MESSAGE_STATUS.new)).toHaveLength(1)
+      expect(await db.listEvents('bot2', props.language, FLAGGED_MESSAGE_STATUS.new)).toHaveLength(2)
+      expect(await db.listEvents('bot3', props.language, FLAGGED_MESSAGE_STATUS.new)).toHaveLength(0)
     })
 
     it('Filters - by language', async () => {
-      const props = {
-        botId: 'bot1',
-        eventId: '1234',
-        language: 'en',
-        preview: 'some message',
-        reason: FLAG_REASON.action
-      }
-
       for (const language of ['en', 'fr', 'fr']) {
         await db.addEvent({
           ...props,
@@ -106,14 +91,6 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
     })
 
     it('Filters - by status', async () => {
-      const props = {
-        botId: 'bot1',
-        eventId: '1234',
-        language: 'en',
-        preview: 'some message',
-        reason: FLAG_REASON.action
-      }
-
       await db.addEvent(props)
       await db.addEvent(props)
       await db.addEvent(props)
@@ -133,14 +110,6 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
     })
 
     it('Filters - by reason', async () => {
-      const props = {
-        botId: 'bot1',
-        eventId: '1234',
-        language: 'en',
-        preview: 'some message',
-        reason: FLAG_REASON.action
-      }
-
       for (const reason of [
         FLAG_REASON.thumbs_down,
         FLAG_REASON.thumbs_down,
@@ -169,14 +138,6 @@ createDatabaseSuite('Misunderstood - DB', (database: Database) => {
     })
 
     it('Filters - by date', async () => {
-      const props = {
-        botId: 'bot1',
-        eventId: '1234',
-        language: 'en',
-        preview: 'some message',
-        reason: FLAG_REASON.action
-      }
-
       for (const updatedAt of ['2020-09-29T04:00:00Z', '2020-09-29T06:00:00Z', '2020-09-29T08:00:00Z']) {
         await db.knex(TABLE_NAME).insert({
           ...props,

--- a/modules/misunderstood/src/backend/db.ts
+++ b/modules/misunderstood/src/backend/db.ts
@@ -16,7 +16,7 @@ import {
 
 import applyChanges from './applyChanges'
 
-const TABLE_NAME = 'misunderstood'
+export const TABLE_NAME = 'misunderstood'
 const EVENTS_TABLE_NAME = 'events'
 
 export default class Db {


### PR DESCRIPTION
Creates a test harness for database tests. 
This lays the foundations to add more tests in future PRs.

This is not aimed at being a comprehensive test suite of all methods in the `db` module of `misunderstood`.