### PR TITLE
chore(nlu): rm spellcheck method from engine's api

### DIFF
--- a/build/nlu-regression/current_scores/bpds-intent.json
+++ b/build/nlu-regression/current_scores/bpds-intent.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-03-16T17:04:50.210Z",
+  "generatedOn": "2021-03-29T15:22:43.839Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/bpds-slots.json
+++ b/build/nlu-regression/current_scores/bpds-slots.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-03-16T17:05:02.412Z",
+  "generatedOn": "2021-03-29T15:22:56.348Z",
   "scores": [
     {
       "metric": "avgScore:slotsAre",

--- a/build/nlu-regression/current_scores/bpds-spell.json
+++ b/build/nlu-regression/current_scores/bpds-spell.json
@@ -1,5 +1,5 @@
 {
-  "generatedOn": "2021-03-16T17:05:06.623Z",
+  "generatedOn": "2021-03-29T15:22:59.556Z",
   "scores": [
     {
       "metric": "accuracy",

--- a/build/nlu-regression/current_scores/clinc150.json
+++ b/build/nlu-regression/current_scores/clinc150.json
@@ -1,35 +1,35 @@
 {
-  "generatedOn": "2021-03-16T17:12:39.607Z",
+  "generatedOn": "2021-03-29T15:30:14.745Z",
   "scores": [
     {
       "metric": "accuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.7254651162790697
+      "score": 0.7246511627906976
     },
     {
       "metric": "oosAccuracy",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.8558139534883721
+      "score": 0.8554651162790697
     },
     {
       "metric": "oosPrecision",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.2865853658536585
+      "score": 0.28134556574923547
     },
     {
       "metric": "oosRecall",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.08545454545454545
+      "score": 0.08363636363636363
     },
     {
       "metric": "oosF1",
       "problem": "clinc150, 20 utt/intent, seed 42",
       "seed": 42,
-      "score": 0.13165266106442577
+      "score": 0.1289418360196216
     }
   ]
 }

--- a/modules/nlu/src/backend/application/scoped/prediction-handler.ts
+++ b/modules/nlu/src/backend/application/scoped/prediction-handler.ts
@@ -89,20 +89,12 @@ export class ScopedPredictionHandler {
       await this.engine.loadModel(model)
     }
 
-    let spellChecked: string | undefined
-    try {
-      spellChecked = await this.engine.spellCheck(textInput, modelsByLang[language])
-    } catch (err) {
-      let msg = `An error occured when spell checking input "${textInput}"\n`
-      msg += 'Falling back on original input.'
-      this.logger.attachError(err).error(msg)
-    }
-
     const t0 = Date.now()
     try {
       const originalOutput = await this.engine.predict(textInput, modelsByLang[language])
       const ms = Date.now() - t0
 
+      const { spellChecked } = originalOutput
       if (spellChecked && spellChecked !== textInput) {
         const spellCheckedOutput = await this.engine.predict(spellChecked, modelsByLang[language])
         const merged = mergeSpellChecked(originalOutput, spellCheckedOutput)
@@ -115,7 +107,7 @@ export class ScopedPredictionHandler {
       this.logger.attachError(err).error(msg)
 
       const ms = Date.now() - t0
-      return { errored: true, spellChecked, language, ms }
+      return { errored: true, language, ms }
     }
   }
 

--- a/src/bp/nlu/engine/engine/index.ts
+++ b/src/bp/nlu/engine/engine/index.ts
@@ -5,7 +5,16 @@ import LRUCache from 'lru-cache'
 import sizeof from 'object-sizeof'
 import modelIdService from '../model-id-service'
 
-import { TrainingOptions, LanguageConfig, Logger, ModelId, TrainingSet, Model, PredictOutput } from '../typings'
+import {
+  TrainingOptions,
+  LanguageConfig,
+  Logger,
+  ModelId,
+  TrainingSet,
+  Model,
+  PredictOutput,
+  Engine as IEngine
+} from '../typings'
 import { deserializeKmeans } from './clustering'
 import { EntityCacheManager } from './entities/entity-cache-manager'
 import { initializeTools } from './initialize-tools'
@@ -50,7 +59,7 @@ interface EngineOptions {
   legacyElection: boolean
 }
 
-export default class Engine implements Engine {
+export default class Engine implements IEngine {
   private _tools!: Tools
   private _trainingWorkerQueue!: TrainingWorkerQueue
 
@@ -328,18 +337,6 @@ export default class Engine implements Engine {
       this._tools,
       loaded.predictors
     )
-  }
-
-  async spellCheck(sentence: string, modelId: ModelId) {
-    const stringId = modelIdService.toString(modelId)
-    const loaded = this.modelsById.get(stringId)
-    if (!loaded) {
-      throw new Error(`model ${stringId} not loaded`)
-    }
-
-    const preprocessed = preprocessRawUtterance(sentence)
-    const spellChecker = makeSpellChecker(loaded.predictors.vocab, loaded.model.languageCode, this._tools)
-    return spellChecker(preprocessed)
   }
 
   async detectLanguage(text: string, modelsByLang: _.Dictionary<ModelId>): Promise<string> {

--- a/src/bp/nlu/engine/typings.ts
+++ b/src/bp/nlu/engine/typings.ts
@@ -41,14 +41,16 @@ export interface Engine {
   getHealth: () => Health
   getLanguages: () => string[]
   getSpecifications: () => Specifications
+
   loadModel: (model: Model) => Promise<void>
   unloadModel: (modelId: ModelId) => void
   hasModel: (modelId: ModelId) => boolean
+
   train: (trainSessionId: string, trainSet: TrainingSet, options?: Partial<TrainingOptions>) => Promise<Model>
   cancelTraining: (trainSessionId: string) => Promise<void>
+
   detectLanguage: (text: string, modelByLang: { [key: string]: ModelId }) => Promise<string>
   predict: (text: string, modelId: ModelId) => Promise<PredictOutput>
-  spellCheck: (sentence: string, modelId: ModelId) => Promise<string>
 }
 
 export interface ModelIdService {
@@ -187,4 +189,5 @@ export interface ContextPrediction {
 export interface PredictOutput {
   readonly entities: Entity[]
   readonly predictions: Predictions
+  readonly spellChecked: string
 }

--- a/src/bp/nlu/stan/api.ts
+++ b/src/bp/nlu/stan/api.ts
@@ -187,8 +187,7 @@ export default async function(options: APIOptions, engine: NLUEngine.Engine) {
 
       const rawPredictions: BpPredictOutput[] = await Promise.map(utterances as string[], async utterance => {
         const detectedLanguage = await engine.detectLanguage(utterance, { [modelId.languageCode]: modelId })
-        const spellChecked = await engine.spellCheck(utterance, modelId)
-        const { entities, predictions } = await engine.predict(utterance, modelId)
+        const { entities, predictions, spellChecked } = await engine.predict(utterance, modelId)
         return { entities, contexts: predictions, spellChecked, detectedLanguage, utterance }
       })
 

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -703,15 +703,12 @@ declare module 'botpress/sdk' {
       readonly intents?: NLU.Intent[]
       readonly ambiguous?: boolean /** Predicted intents needs disambiguation */
       readonly slots?: NLU.SlotCollection
+      readonly spellChecked?: string
 
       // pre-prediction
       readonly detectedLanguage:
         | string
         | undefined /** Language detected from users input. If undefined, detection failed. */
-      readonly spellChecked:
-        | string
-        | undefined /** Result of spell checking on users input. If undefined, spell check failed. */
-
       readonly language: string /** The language used for prediction */
       readonly includedContexts: string[]
       readonly ms: number


### PR DESCRIPTION
Nothing important here, I simply removed the `spellCheck` method from `Engine`'s API...

My first plan was to make spell-checker intent clf that would wrap the currently used intent clf, but this was way faster.

Also, the current logic to merge spell-check and original predictions uses all contexts/topics and a single intent clf should not have access to other contexts predictions...