### PR TITLE
fix(nlu): Fix unavailable NLU when language provider is not ready

### DIFF
--- a/modules/nlu/src/api.ts
+++ b/modules/nlu/src/api.ts
@@ -1,9 +1,11 @@
 import axios, { AxiosInstance } from 'axios'
 import * as sdk from 'botpress/sdk'
+// import { Health } from 'common/nlu/engine'
 
 export type NLUApi = ReturnType<typeof makeApi>
 
 export const makeApi = (bp: { axios: AxiosInstance }) => ({
+  fetchHealth: (): Promise<any> => bp.axios.get('/nlu/health').then(res => res.data),
   fetchContexts: (): Promise<string[]> => bp.axios.get('/nlu/contexts').then(res => res.data),
   fetchIntentsWithQNAs: (): Promise<sdk.NLU.IntentDefinition[]> => bp.axios.get('/nlu/intents').then(res => res.data),
   fetchIntents: async (): Promise<sdk.NLU.IntentDefinition[]> => {

--- a/modules/nlu/src/backend/module-lifecycle/on-bot-mount.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-bot-mount.ts
@@ -64,137 +64,139 @@ function registerNeedTrainingWatcher(bp: typeof sdk, botId: string, engine: NLUE
 
 export function getOnBotMount(state: NLUState) {
   return async (bp: typeof sdk, botId: string) => {
-    const bot = await bp.bots.getBotById(botId)
-    const ghost = bp.ghost.forBot(botId)
+    state.engine.waitUntilReady().then(async () => {
+      const bot = await bp.bots.getBotById(botId)
+      const ghost = bp.ghost.forBot(botId)
 
-    const { modelIdService } = NLUEngine
-    const modelService = new ModelService(modelIdService, ghost, botId)
-    await modelService.initialize()
+      const { modelIdService } = NLUEngine
+      const modelService = new ModelService(modelIdService, ghost, botId)
+      await modelService.initialize()
 
-    const { engine } = state
-    const trainOrLoad = async (languageCode: string, disableTraining: boolean) => {
-      // bot got deleted
-      const botState = state.nluByBot[botId]
-      if (!botState) {
-        return
-      }
-
-      const api = await createApi(bp, botId)
-      const intentDefs = await api.fetchIntentsWithQNAs()
-      const entityDefs = await api.fetchEntities()
-
-      const kvs = bp.kvs.forBot(botId)
-      await kvs.set(KVS_TRAINING_STATUS_KEY, 'training')
-
-      try {
-        // shorter lock and extend in training steps
-        const lock = await bp.distributed.acquireLock(makeTrainSessionKey(botId, languageCode), ms('5m'))
-        if (!lock) {
+      const { engine } = state
+      const trainOrLoad = async (languageCode: string, disableTraining: boolean) => {
+        // bot got deleted
+        const botState = state.nluByBot[botId]
+        if (!botState) {
           return
         }
 
-        const trainSet: NLUEngine.TrainingSet = {
-          intentDefs,
-          entityDefs,
-          languageCode,
-          seed: getSeed(bot)
-        }
+        const api = await createApi(bp, botId)
+        const intentDefs = await api.fetchIntentsWithQNAs()
+        const entityDefs = await api.fetchEntities()
 
-        const specifications = engine.getSpecifications()
-        const modelId = modelIdService.makeId({
-          ...trainSet,
-          specifications
-        })
+        const kvs = bp.kvs.forBot(botId)
+        await kvs.set(KVS_TRAINING_STATUS_KEY, 'training')
 
-        const modelsOfLang = await modelService.listModels({ languageCode })
-        await modelService.pruneModels(modelsOfLang, { toKeep: 2 })
-
-        let model = await modelService.getModel(modelId)
-
-        const trainSession = makeTrainingSession(botId, languageCode, lock)
-
-        botState.trainSessions[languageCode] = trainSession
-        if (!model && !disableTraining) {
-          await state.sendNLUStatusEvent(botId, trainSession)
-
-          const progressCallback = async (progress: number) => {
-            trainSession.status = 'training'
-            trainSession.progress = progress
-            await state.sendNLUStatusEvent(botId, trainSession)
+        try {
+          // shorter lock and extend in training steps
+          const lock = await bp.distributed.acquireLock(makeTrainSessionKey(botId, languageCode), ms('5m'))
+          if (!lock) {
+            return
           }
 
-          const previousModel = botState.modelsByLang[languageCode]
-          const options: NLUEngine.TrainingOptions = { previousModel, progressCallback }
-          try {
-            model = await engine.train(trainSession.key, trainSet, options)
+          const trainSet: NLUEngine.TrainingSet = {
+            intentDefs,
+            entityDefs,
+            languageCode,
+            seed: getSeed(bot)
+          }
 
-            trainSession.status = 'done'
+          const specifications = engine.getSpecifications()
+          const modelId = modelIdService.makeId({
+            ...trainSet,
+            specifications
+          })
+
+          const modelsOfLang = await modelService.listModels({ languageCode })
+          await modelService.pruneModels(modelsOfLang, { toKeep: 2 })
+
+          let model = await modelService.getModel(modelId)
+
+          const trainSession = makeTrainingSession(botId, languageCode, lock)
+
+          botState.trainSessions[languageCode] = trainSession
+          if (!model && !disableTraining) {
             await state.sendNLUStatusEvent(botId, trainSession)
-            botState.modelsByLang[languageCode] = modelId
-            await engine.loadModel(model)
-            await modelService.saveModel(model)
-          } catch (err) {
-            if (NLUEngine.errors.isTrainingCanceled(err)) {
-              bp.logger.forBot(botId).info('Training cancelled')
-              trainSession.status = 'needs-training'
-              await state.sendNLUStatusEvent(botId, trainSession)
-            } else if (NLUEngine.errors.isTrainingAlreadyStarted(err)) {
-              bp.logger.forBot(botId).info('Training already started')
-            } else {
-              bp.logger
-                .forBot(botId)
-                .attachError(err)
-                .error('Training could not finish because of an unexpected error.')
-              trainSession.status = 'needs-training'
+
+            const progressCallback = async (progress: number) => {
+              trainSession.status = 'training'
+              trainSession.progress = progress
               await state.sendNLUStatusEvent(botId, trainSession)
             }
+
+            const previousModel = botState.modelsByLang[languageCode]
+            const options: NLUEngine.TrainingOptions = { previousModel, progressCallback }
+            try {
+              model = await engine.train(trainSession.key, trainSet, options)
+
+              trainSession.status = 'done'
+              await state.sendNLUStatusEvent(botId, trainSession)
+              botState.modelsByLang[languageCode] = modelId
+              await engine.loadModel(model)
+              await modelService.saveModel(model)
+            } catch (err) {
+              if (NLUEngine.errors.isTrainingCanceled(err)) {
+                bp.logger.forBot(botId).info('Training cancelled')
+                trainSession.status = 'needs-training'
+                await state.sendNLUStatusEvent(botId, trainSession)
+              } else if (NLUEngine.errors.isTrainingAlreadyStarted(err)) {
+                bp.logger.forBot(botId).info('Training already started')
+              } else {
+                bp.logger
+                  .forBot(botId)
+                  .attachError(err)
+                  .error('Training could not finish because of an unexpected error.')
+                trainSession.status = 'needs-training'
+                await state.sendNLUStatusEvent(botId, trainSession)
+              }
+            }
+          } else {
+            trainSession.progress = 1
+            trainSession.status = 'done'
+            await state.sendNLUStatusEvent(botId, trainSession)
           }
-        } else {
-          trainSession.progress = 1
-          trainSession.status = 'done'
-          await state.sendNLUStatusEvent(botId, trainSession)
-        }
-        try {
-          if (model) {
-            const modelId = modelIdService.toId(model)
-            await state.broadcastLoadModel(botId, modelId)
+          try {
+            if (model) {
+              const modelId = modelIdService.toId(model)
+              await state.broadcastLoadModel(botId, modelId)
+            }
+          } finally {
+            await lock.unlock()
           }
         } finally {
-          await lock.unlock()
+          await kvs.delete(KVS_TRAINING_STATUS_KEY)
         }
-      } finally {
-        await kvs.delete(KVS_TRAINING_STATUS_KEY)
       }
-    }
 
-    const cancelTraining = async (lang: string) => {
-      const key = makeTrainSessionKey(botId, lang)
-      await bp.distributed.clearLock(key)
-      return state.broadcastCancelTraining(botId, lang)
-    }
+      const cancelTraining = async (lang: string) => {
+        const key = makeTrainSessionKey(botId, lang)
+        await bp.distributed.clearLock(key)
+        return state.broadcastCancelTraining(botId, lang)
+      }
 
-    const needsTrainingWatcher = registerNeedTrainingWatcher(bp, botId, engine, state)
+      const needsTrainingWatcher = registerNeedTrainingWatcher(bp, botId, engine, state)
 
-    const { defaultLanguage } = bot
-    const languages = _.intersection(bot.languages, state.engine.getLanguages())
-    if (bot.languages.length !== languages.length) {
-      bp.logger.forBot(botId).warn(missingLangMsg(botId), { notSupported: _.difference(bot.languages, languages) })
-    }
+      const { defaultLanguage } = bot
+      const languages = _.intersection(bot.languages, state.engine.getLanguages())
+      if (bot.languages.length !== languages.length) {
+        bp.logger.forBot(botId).warn(missingLangMsg(botId), { notSupported: _.difference(bot.languages, languages) })
+      }
 
-    state.nluByBot[botId] = {
-      botId,
-      defaultLanguage,
-      languages,
-      trainOrLoad,
-      trainSessions: {},
-      cancelTraining,
-      needsTrainingWatcher,
-      modelsByLang: {},
-      modelService
-    }
+      state.nluByBot[botId] = {
+        botId,
+        defaultLanguage,
+        languages,
+        trainOrLoad,
+        trainSessions: {},
+        cancelTraining,
+        needsTrainingWatcher,
+        modelsByLang: {},
+        modelService
+      }
 
-    const disableTraining = true
-    await Promise.mapSeries(languages, lang => trainOrLoad(lang, disableTraining))
-    await annouceNeedsTraining(bp, bot.id, state)
+      const disableTraining = true
+      await Promise.mapSeries(languages, lang => trainOrLoad(lang, disableTraining))
+      await annouceNeedsTraining(bp, bot.id, state)
+    })
   }
 }

--- a/modules/nlu/src/backend/module-lifecycle/on-server-ready.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-ready.ts
@@ -13,7 +13,6 @@ export function getOnServerReady(state: NLUState) {
         return
       }
 
-      const ghost = bp.ghost.forBot(botId)
       const model = await state.nluByBot[botId].modelService.getModel(modelId)
       if (model) {
         const botState = state.nluByBot[botId]

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -25,6 +25,7 @@ const ignoreEvent = (bp: typeof sdk, state: NLUState, event: sdk.IO.IncomingEven
   return (
     !state.nluByBot[event.botId] ||
     !health.isEnabled ||
+    !health.isReady ||
     !event.preview ||
     EVENTS_TO_IGNORE.includes(event.type) ||
     event.hasFlag(bp.IO.WellKnownFlags.SKIP_NATIVE_NLU)
@@ -129,7 +130,6 @@ export function getOnSeverStarted(state: NLUState) {
       modelCacheSize: bytes(modelCacheSize)
     }
     state.engine = await NLUEngine.makeEngine(parsedConfig, logger)
-
     await registerMiddleware(bp, state)
   }
 }

--- a/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
+++ b/modules/nlu/src/backend/module-lifecycle/on-server-started.ts
@@ -130,6 +130,8 @@ export function getOnSeverStarted(state: NLUState) {
       modelCacheSize: bytes(modelCacheSize)
     }
     state.engine = await NLUEngine.makeEngine(parsedConfig, logger)
-    await registerMiddleware(bp, state)
+    state.engine.waitUntilReady().then(async () => {
+      await registerMiddleware(bp, state)
+    })
   }
 }

--- a/src/bp/nlu/engine/engine/index.ts
+++ b/src/bp/nlu/engine/engine/index.ts
@@ -74,12 +74,16 @@ export default class Engine implements Engine {
     return this._tools.getSpecifications()
   }
 
+  public async waitUntilReady(): Promise<void> {
+    return this._tools.waitUntilReady()
+  }
+
   public async initialize(config: LanguageConfig, logger: Logger): Promise<void> {
     this._tools = await initializeTools(config, logger)
-    const { nluVersion, languageServer } = this._tools.getSpecifications()
-    if (!_.isString(nluVersion) || !this._dictionnaryIsFilled(languageServer)) {
-      logger.warning('Either the nlu version or the lang server version is not set correctly.')
-    }
+    // const { nluVersion, languageServer } = this._tools.getSpecifications()
+    // if (!_.isString(nluVersion) || !this._dictionnaryIsFilled(languageServer)) {
+    //   logger.warning('Either the nlu version or the lang server version is not set correctly.')
+    // }
 
     this._trainingWorkerQueue = new TrainingWorkerQueue(config, logger)
   }

--- a/src/bp/nlu/engine/engine/initialize-tools.ts
+++ b/src/bp/nlu/engine/engine/initialize-tools.ts
@@ -14,9 +14,10 @@ import { LanguageProvider, SystemEntityExtractor, Tools } from './typings'
 const NLU_VERSION = '2.1.0'
 
 const healthGetter = (languageProvider: LanguageProvider) => (): Health => {
-  const { validProvidersCount, validLanguages } = languageProvider.getHealth()
+  const { validProvidersCount, validLanguages, isReady } = languageProvider.getHealth()
   return {
     isEnabled: validProvidersCount! > 0 && validLanguages!.length > 0,
+    isReady: isReady!,
     validProvidersCount: validProvidersCount!,
     validLanguages: validLanguages!
   }
@@ -49,6 +50,7 @@ const initializeLanguageProvider = async (
       seededLodashProvider
     )
     const getHealth = healthGetter(languageProvider)
+    await languageProvider.waitUntilReady()
     return { languageProvider, health: getHealth() }
   } catch (e) {
     if (e.failure && e.failure.code === 'ECONNREFUSED') {

--- a/src/bp/nlu/engine/engine/initialize-tools.ts
+++ b/src/bp/nlu/engine/engine/initialize-tools.ts
@@ -103,6 +103,7 @@ export async function initializeTools(config: LanguageConfig, logger: Logger): P
     getHealth: healthGetter(languageProvider),
     getLanguages: () => languageProvider.languages,
     getSpecifications: versionGetter(languageProvider),
+    waitUntilReady: languageProvider.waitUntilReady,
     seededLodashProvider,
     mlToolkit: MLToolkit,
     systemEntityExtractor: await makeSystemEntityExtractor(config, logger)

--- a/src/bp/nlu/engine/engine/initialize-tools.ts
+++ b/src/bp/nlu/engine/engine/initialize-tools.ts
@@ -42,25 +42,24 @@ const initializeLanguageProvider = async (
   logger: Logger,
   seededLodashProvider: SeededLodashProvider
 ) => {
-  try {
-    const languageProvider = await LangProvider.initialize(
-      config.languageSources,
-      logger,
-      NLU_VERSION,
-      seededLodashProvider
-    )
-    const getHealth = healthGetter(languageProvider)
-    await languageProvider.waitUntilReady()
-    return { languageProvider, health: getHealth() }
-  } catch (e) {
-    if (e.failure && e.failure.code === 'ECONNREFUSED') {
-      logger.error(`Language server can't be reached at address ${e.failure.address}:${e.failure.port}`)
-      if (!process.IS_FAILSAFE) {
-        process.exit()
-      }
-    }
-    throw e
-  }
+  // try {
+  const languageProvider = await LangProvider.initialize(
+    config.languageSources,
+    logger,
+    NLU_VERSION,
+    seededLodashProvider
+  )
+  const getHealth = healthGetter(languageProvider)
+  return { languageProvider, health: getHealth() }
+  // } catch (e) {
+  //   // if (e.failure && e.failure.code === 'ECONNREFUSED') {
+  //   //   logger.error(`Language server can't be reached at address ${e.failure.address}:${e.failure.port}`)
+  //   //   if (!process.IS_FAILSAFE) {
+  //   //     process.exit()
+  //   //   }
+  //   // }
+  //   throw e
+  // }
 }
 
 const makeSystemEntityExtractor = async (config: LanguageConfig, logger: Logger): Promise<SystemEntityExtractor> => {

--- a/src/bp/nlu/engine/engine/language/language-provider.ts
+++ b/src/bp/nlu/engine/engine/language/language-provider.ts
@@ -257,6 +257,7 @@ class ServerConnection extends EventEmitter2 {
         this.emit('error', err)
       } finally {
         this._retryCount++
+        debug(`Retry for ${this.endpoint}: ${this._retryCount}/${maxRetryCount}`)
         if (this._retryCount >= maxRetryCount) {
           this._stopRetry()
         }
@@ -356,7 +357,7 @@ export class RemoteLanguageProvider implements LanguageProvider {
 
     return this as LanguageProvider
   }
-  public waitUntilReady(): Promise<void> {
+  public waitUntilReady = (): Promise<void> => {
     return new Promise(resolve => {
       if (this.ready) {
         resolve()

--- a/src/bp/nlu/engine/engine/test-utils/fake-tools.ts
+++ b/src/bp/nlu/engine/engine/test-utils/fake-tools.ts
@@ -56,6 +56,7 @@ export const makeFakeTools = (dim: number, languages: string[]): Tools => {
   const getHealth = () => {
     return {
       isEnabled: true,
+      isReady: true,
       validProvidersCount: 1,
       validLanguages: [...languages]
     }

--- a/src/bp/nlu/engine/engine/test-utils/fake-tools.ts
+++ b/src/bp/nlu/engine/engine/test-utils/fake-tools.ts
@@ -94,6 +94,10 @@ export const makeFakeTools = (dim: number, languages: string[]): Tools => {
     KMeans: fakeKmeans
   }
 
+  const waitUntilReady = async (): Promise<void> => {
+    return
+  }
+
   return {
     tokenize_utterances,
     vectorize_tokens,
@@ -101,6 +105,7 @@ export const makeFakeTools = (dim: number, languages: string[]): Tools => {
     generateSimilarJunkWords,
     getStopWordsForLang,
     getHealth,
+    waitUntilReady,
     getLanguages,
     getSpecifications,
     seededLodashProvider: fakeSeededLodash,

--- a/src/bp/nlu/engine/engine/typings.ts
+++ b/src/bp/nlu/engine/engine/typings.ts
@@ -132,6 +132,7 @@ export interface Tools {
   getStopWordsForLang(lang: string): Promise<string[]>
 
   // system info
+  waitUntilReady(): Promise<void>
   getHealth(): Health
   getLanguages(): string[]
   getSpecifications(): Specifications

--- a/src/bp/nlu/engine/engine/typings.ts
+++ b/src/bp/nlu/engine/engine/typings.ts
@@ -39,6 +39,7 @@ export interface LanguageProvider {
   vectorize(tokens: string[], lang: string): Promise<Float32Array[]>
   tokenize(utterances: string[], lang: string, vocab?: string[]): Promise<string[][]>
   generateSimilarJunkWords(subsetVocab: string[], lang: string): Promise<string[]>
+  waitUntilReady(): Promise<void>
   getHealth(): Partial<Health>
 }
 

--- a/src/bp/nlu/engine/typings.ts
+++ b/src/bp/nlu/engine/typings.ts
@@ -38,6 +38,7 @@ export interface TrainingOptions {
 
 export interface Engine {
   getHealth: () => Health
+  waitUntilReady: () => Promise<void>
   getLanguages: () => string[]
   getSpecifications: () => Specifications
   loadModel: (model: Model) => Promise<void>

--- a/src/bp/nlu/engine/typings.ts
+++ b/src/bp/nlu/engine/typings.ts
@@ -86,6 +86,7 @@ export type Model = ModelId & {
 
 export interface Health {
   isEnabled: boolean
+  isReady: boolean
   validProvidersCount: number
   validLanguages: string[]
 }


### PR DESCRIPTION
NLU Engine exposes a new method: `waitUntilReady(): Promise<void>` which is then used in the lifecycle hook of the NLU module to debounce the startup of the module without blocking the whole server start.

This is a draft!:
- the try logic isn't complete
- the retry logic is missing error handling
- the healthGetter for the NLU module isn't updating ready state properly
- lots of code smell