### PR TITLE
fix(admin): check license limits exist before counting nodes

### DIFF
--- a/src/bp/admin/ui/src/management/licensing/index.tsx
+++ b/src/bp/admin/ui/src/management/licensing/index.tsx
@@ -226,7 +226,7 @@ class LicenseStatus extends React.Component<Props> {
 
     // @TODO: Fix those typings once we are sure what they represent
     // @ts-ignore
-    const nodes = Number(this.license.limits.nodes)
+    const nodes = Number((this.license.limits && this.license.limits.nodes) || 0)
 
     return (
       <PageContainer title={lang.tr('admin.sideMenu.serverLicense')} superAdmin={true}>


### PR DESCRIPTION
This PR fixes an issue where enabling pro without having specified a license key first would result in a blank admin license page and a console error:

![Screenshot from 2021-03-29 14-38-17](https://user-images.githubusercontent.com/9640576/112885082-4ca44a80-909e-11eb-9fe2-af52955f957b.png)
 