### PR TITLE
feat(module-builder): add Dockerfile #4790

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .git
+**/node_modules
 node_modules
 out
 dist

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,7 @@
 node_modules
 out
 dist
+Dockerfile
+**/Dockerfile
+.dockerignore
+**/.dockerignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+node_modules
+out
+dist

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -11,4 +11,5 @@ jobs:
         run: |
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
+          [ -f modules/channel-web/channel-web.tgz ] && echo "modules/channel-web/channel-web.tgz exists"
           [ ! -f modules/channel-web/channel-web.tgz ] && echo "modules/channel-web/channel-web.tgz does not exist" && exit 1

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -19,7 +19,6 @@ jobs:
           test modules/channel-web/package.json
           echo "testing package.json does not exist"
           test -f modules/channel-web/package.json
-          echo "testing channel-web.tgz does not exist"
-          test ! -f modules/channel-web/channel-web.tgz
+
           echo "after"
           echo $?

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -1,0 +1,12 @@
+name: Module Builder Docker Image
+on: [push]
+jobs:
+  build_and_push:
+    name: Test Module Builder Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2.1.0
+      - name: Build
+        run: |
+          docker build -t module-builder-test -f build/module-builder/Dockerfile .

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -11,6 +11,7 @@ jobs:
         run: |
           pwd
           ls
+          [ ! -f docs/guide/buildspec.ym ] && echo "docs/guide/buildspec.ym does not exist"
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
           ls modules/channel-web

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -15,6 +15,11 @@ jobs:
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
           ls modules/channel-web
           echo "before"
+          echo "testing package.json exists"
+          test modules/channel-web/package.json
+          echo "testing package.json does not exist"
+          test -f modules/channel-web/package.json
+          echo "testing channel-web.tgz does not exist"
           test ! -f modules/channel-web/channel-web.tgz
           echo "after"
           echo $?

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -11,8 +11,10 @@ jobs:
         run: |
           pwd
           ls
+          test -f package.json && echo "package.json exists" && exit 1
           test ! -f modules/channel-web/channel-web.tgz && echo "File does not exit" && exit 1
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
           ls
+          ls modules/channel-web
           test ! -f modules/channel-web/channel-web.tgz && echo "File does not exit" && exit 1

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -11,8 +11,6 @@ jobs:
         run: |
           pwd
           ls
-          test -f package.json && echo "package.json exists"
-          test ! -f modules/channel-web/channel-web.tgz && echo "File does not exit" && exit 1
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
           ls modules/channel-web

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -11,10 +11,9 @@ jobs:
         run: |
           pwd
           ls
-          test -f package.json && echo "package.json exists" && exit 1
+          test -f package.json && echo "package.json exists"
           test ! -f modules/channel-web/channel-web.tgz && echo "File does not exit" && exit 1
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
-          ls
           ls modules/channel-web
           test ! -f modules/channel-web/channel-web.tgz && echo "File does not exit" && exit 1

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -11,4 +11,5 @@ jobs:
         run: |
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
-          [ ! -f modules/channel-web/channel-web.tgz ] && echo "File does not exit" && exit 1
+          ls
+          test ! -f modules/channel-web/channel-web.tgz && echo "File does not exit" && exit 1

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -12,3 +12,15 @@ jobs:
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
           ls modules/channel-web/channel-web.tgz || exit 1
+      - name: Build has failed
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_GH_ACTIONS }}
+          SLACK_COLOR: ${{ job.status }} # or a specific color like 'green' or '#ff00ff'
+      - name: Build has succeeded
+        if: ${{ success() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_GH_ACTIONS }}
+          SLACK_COLOR: ${{ job.status }} # or a specific color like 'green' or '#ff00ff'

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -16,9 +16,10 @@ jobs:
           ls modules/channel-web
           echo "before"
           echo "testing package.json exists"
-          test modules/channel-web/package.json
-          echo "testing package.json does not exist"
           test -f modules/channel-web/package.json
-
+          echo "testing package.json does not exist"
+          test ! -f modules/channel-web/package.json
+          echo "testing channel-web.tgz does not exist"
+          test ! -f modules/channel-web/channel-web.tgz
           echo "after"
           echo $?

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -1,5 +1,5 @@
 name: Module Builder Docker Image
-on: [push]
+on: [pull_request]
 jobs:
   build_and_push:
     name: Test Module Builder Image

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -14,5 +14,7 @@ jobs:
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
           ls modules/channel-web
+          echo "before"
           test ! -f modules/channel-web/channel-web.tgz
+          echo "after"
           echo $?

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -14,4 +14,5 @@ jobs:
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
           ls modules/channel-web
-          test ! -f modules/channel-web/channel-web.tgz && echo "File does not exit" && exit 1
+          test ! -f modules/channel-web/channel-web.tgz
+          echo $?

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -10,3 +10,5 @@ jobs:
       - name: Build
         run: |
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
+          docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
+          [ ! -f modules/channel-web/channel-web.tgz ] && echo "File does not exit" && exit 1

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -18,9 +18,3 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_GH_ACTIONS }}
           SLACK_COLOR: ${{ job.status }}
-      - name: Build has succeeded
-        if: ${{ success() }}
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_GH_ACTIONS }}
-          SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -11,7 +11,7 @@ jobs:
         run: |
           pwd
           ls
-          [ ! -f docs/guide/buildspec.ym ] && echo "docs/guide/buildspec.ym does not exist"
+          [ ! -f docs/guide/buildspec.ym ] && echo "docs/guide/buildspec.ym does not exist" && exit 1
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
           ls modules/channel-web

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -9,18 +9,6 @@ jobs:
         uses: actions/checkout@v2.1.0
       - name: Build
         run: |
-          pwd
-          ls
-          [ ! -f docs/guide/buildspec.ym ] && echo "docs/guide/buildspec.ym does not exist" && exit 1
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
-          ls modules/channel-web
-          echo "before"
-          echo "testing package.json exists"
-          test -f modules/channel-web/package.json
-          echo "testing package.json does not exist"
-          test ! -f modules/channel-web/package.json
-          echo "testing channel-web.tgz does not exist"
-          test ! -f modules/channel-web/channel-web.tgz
-          echo "after"
-          echo $?
+          [ ! -f modules/channel-web/channel-web.tgz ] && echo "modules/channel-web/channel-web.tgz does not exist" && exit 1

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -11,5 +11,4 @@ jobs:
         run: |
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
-          [ -f modules/channel-web/channel-web.tgz ] && echo "modules/channel-web/channel-web.tgz exists"
           [ ! -f modules/channel-web/channel-web.tgz ] && echo "modules/channel-web/channel-web.tgz does not exist" && exit 1

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -9,6 +9,9 @@ jobs:
         uses: actions/checkout@v2.1.0
       - name: Build
         run: |
+          pwd
+          ls
+          test ! -f modules/channel-web/channel-web.tgz && echo "File does not exit" && exit 1
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
           ls

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -11,5 +11,4 @@ jobs:
         run: |
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
-          [ -f modules/channel-web/channel-web.tgz ] && echo "modules/channel-web/channel-web.tgz exists"
           ls modules/channel-web/channel-web.tgz || exit 1

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -1,5 +1,5 @@
 name: Module Builder Docker Image
-on: [pull_request]
+on: [push]
 jobs:
   build_and_push:
     name: Test Module Builder Image
@@ -17,10 +17,10 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_GH_ACTIONS }}
-          SLACK_COLOR: ${{ job.status }} # or a specific color like 'green' or '#ff00ff'
+          SLACK_COLOR: ${{ job.status }}
       - name: Build has succeeded
         if: ${{ success() }}
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_GH_ACTIONS }}
-          SLACK_COLOR: ${{ job.status }} # or a specific color like 'green' or '#ff00ff'
+          SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -11,4 +11,5 @@ jobs:
         run: |
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
-          [ ! -f modules/channel-web/channel-web.tgz ] && echo "modules/channel-web/channel-web.tgz does not exist" && exit 1
+          [ -f modules/channel-web/channel-web.tgz ] && echo "modules/channel-web/channel-web.tgz exists"
+          ls modules/channel-web/channel-web.tgz || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,20 @@
-FROM botpress/server:v12_5_0
+FROM node:12-alpine
 WORKDIR /botpress
-CMD ["./bp"]
+# install dependencies
+ADD ./package.json ./yarn.lock ./
+RUN yarn install
+# add build config
+ADD ./build ./build
+ADD ./gulpfile.js ./
+# add source
+ADD ./modules ./modules
+# add botpress sdk
+ADD ./src ./src
+
+# build & package module
+# TODO extract into entry point, make it reusable to accept a list of modules
+RUN yarn run gulp build:modules --m complete-module
+RUN cd modules/complete-module && yarn && yarn build && yarn package
+
+ENTRYPOINT [ "yarn" ]
+CMD [ "run gulp build:modules" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,3 @@
-FROM node:12-alpine
+FROM botpress/server:v12_5_0
 WORKDIR /botpress
-# install dependencies
-ADD ./package.json ./yarn.lock ./
-RUN yarn install
-# add build config
-ADD ./build ./build
-ADD ./gulpfile.js ./
-# add source
-ADD ./modules ./modules
-# add botpress sdk
-ADD ./src ./src
-
-# build & package module
-# TODO extract into entry point, make it reusable to accept a list of modules
-RUN yarn run gulp build:modules --m complete-module
-RUN cd modules/complete-module && yarn && yarn build && yarn package
-
-ENTRYPOINT [ "yarn" ]
-CMD [ "run gulp build:modules" ]
+CMD ["./bp"]

--- a/build/module-builder/Dockerfile
+++ b/build/module-builder/Dockerfile
@@ -4,34 +4,32 @@ RUN apk add --no-cache git
 WORKDIR /botpress
 # this builder stage scope also includes additional files required for a full build, 
 # e.g.: docs, app.json, .eslintrc.js and .tool-versions
-COPY . botpress
-# alternatively RUN git clone https://github.com/botpress/botpress.git
+COPY . .
+# alternatively RUN git clone https://github.com/botpress/botpress.git .
 
 # fully build once
-RUN cd botpress && yarn install
-RUN cd botpress && yarn run gulp build
+RUN yarn install
+RUN yarn run gulp build
 
 FROM node:12-alpine
 WORKDIR /botpress
-# add botpress source dependencies from builder
-COPY --from=builder ./botpress/botpress/package.json ./botpress/botpress/yarn.lock ./
+# add build config
+COPY --from=builder ./botpress/build ./build
+COPY --from=builder ./botpress/gulpfile.js ./
+# add botpress source dependencies
+COPY --from=builder ./botpress/package.json ./botpress/yarn.lock ./
 # install dependencies
 RUN yarn install
-# add build config
-COPY --from=builder ./botpress/botpress/build ./build
-COPY --from=builder ./botpress/botpress/gulpfile.js ./
 RUN cd build/module-builder && yarn install
 RUN cd build/module-builder && yarn build
 
 # add botpress sdk source & typings
-COPY --from=builder ./botpress/botpress/src ./src
-# add docs
-#COPY --from=builder ./botpress/botpress/docs ./docs
-# add source
-COPY --from=builder ./botpress/botpress/modules ./modules
-
+COPY --from=builder ./botpress/src ./src
 # copy built dependencies (up to 300mb)
-COPY --from=builder ./botpress/botpress/out ./out
+COPY --from=builder ./botpress/out ./out
+# add source
+COPY --from=builder ./botpress/modules ./modules
+
 
 RUN yarn run gulp build:modules
 
@@ -40,5 +38,5 @@ RUN yarn run gulp build:modules
 #RUN yarn run gulp build:modules --m complete-module
 #RUN cd modules/complete-module && yarn && yarn build && yarn package
 
-ENTRYPOINT [ "yarn" ]
-CMD [ "run gulp build:modules" ]
+ENTRYPOINT [ "sh", "-c" ]
+CMD [ "yarn run gulp build:modules" ]

--- a/build/module-builder/Dockerfile
+++ b/build/module-builder/Dockerfile
@@ -31,4 +31,6 @@ COPY --from=builder ./botpress/modules ./modules
 # prebuild other modules
 RUN yarn run gulp build:modules
 
+#Test1
+
 CMD [ "echo", "-e", "Which module would you like to build?\nUse sh -c 'cd modules/your-module && yarn && yarn build && yarn package'" ]

--- a/build/module-builder/Dockerfile
+++ b/build/module-builder/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:12-alpine as builder
 WORKDIR /botpress
-RUN apk add --no-cache git
-RUN git clone https://github.com/botpress/botpress.git
+COPY . botpress
 
 FROM node:12-alpine
 # still need git, because of the gulp initStudio task!?
@@ -21,6 +20,8 @@ COPY --from=builder ./botpress/botpress/modules ./modules
 COPY --from=builder ./botpress/botpress/app.json ./app.json
 COPY --from=builder ./botpress/botpress/.eslintrc.js ./.eslintrc.js
 COPY --from=builder ./botpress/botpress/.tool-versions ./.tool-versions
+# add docs
+COPY --from=builder ./botpress/botpress/docs ./docs
 
 # TODO move into builder image if possible, expose build/module builder instead
 # fully build once, takes 10min+

--- a/build/module-builder/Dockerfile
+++ b/build/module-builder/Dockerfile
@@ -31,4 +31,4 @@ COPY --from=builder ./botpress/modules ./modules
 # prebuild other modules
 RUN yarn run gulp build:modules
 
-CMD [ "echo", "-e", "Which module would you like to build?\nUse sh -c 'yarn run gulp build:modules --m your-module && cd modules/your-module && yarn && yarn build && yarn package'" ]
+CMD [ "echo", "-e", "Which module would you like to build?\nUse sh -c 'cd modules/your-module && yarn && yarn build && yarn package'" ]

--- a/build/module-builder/Dockerfile
+++ b/build/module-builder/Dockerfile
@@ -8,18 +8,22 @@ COPY . .
 # alternatively RUN git clone https://github.com/botpress/botpress.git .
 
 # fully build once
-RUN yarn install
-RUN yarn run gulp build
+RUN yarn && yarn build
+#RUN yarn run gulp build
+
+#COPY build ./build
+#RUN cd build/module-builder && yarn install && yarn build
 
 FROM node:12-alpine
 WORKDIR /botpress
 # add build config & dependencies
 COPY --from=builder ./botpress/build ./build
+COPY --from=builder ./botpress/node_modules ./node_modules
 COPY --from=builder ./botpress/gulpfile.js ./botpress/metadata.json ./botpress/package.json ./botpress/yarn.lock ./
 # install dependencies
-RUN yarn install
-RUN cd build/module-builder && yarn install
-RUN cd build/module-builder && yarn build
+#RUN yarn install
+# RUN cd build/module-builder && yarn install
+# RUN cd build/module-builder && yarn build
 
 # add botpress sdk source & typings
 COPY --from=builder ./botpress/src ./src
@@ -29,9 +33,9 @@ COPY --from=builder ./botpress/out ./out
 COPY --from=builder ./botpress/modules ./modules
 
 # prebuild other modules
-RUN yarn run gulp build:modules
+#RUN yarn run gulp build:modules
 
 # workaround unreleased getos fix (make botpress recognise alpine an select the correct native extensions)
-RUN wget -qO- https://raw.githubusercontent.com/retrohacker/getos/master/os.json > ./node_modules/getos/os.json
+#RUN wget -qO- https://raw.githubusercontent.com/retrohacker/getos/master/os.json > ./node_modules/getos/os.json
 
 CMD [ "echo", "-e", "Which module would you like to build?\nUse sh -c 'cd modules/your-module && yarn && yarn build && yarn package'" ]

--- a/build/module-builder/Dockerfile
+++ b/build/module-builder/Dockerfile
@@ -1,0 +1,35 @@
+FROM node:12-alpine as builder
+WORKDIR /botpress
+RUN apk add --no-cache git
+RUN git clone https://github.com/botpress/botpress.git
+
+FROM node:12-alpine
+# still need git, because of the gulp initStudio task!?
+RUN apk add --no-cache git
+WORKDIR /botpress
+# add botpress source dependencies from builder
+# install dependencies
+COPY --from=builder ./botpress/botpress/package.json ./botpress/botpress/yarn.lock ./
+RUN yarn install
+# add build config
+COPY --from=builder ./botpress/botpress/build ./build
+COPY --from=builder ./botpress/botpress/gulpfile.js ./
+# add botpress sdk
+COPY --from=builder ./botpress/botpress/src ./src
+# add source
+COPY --from=builder ./botpress/botpress/modules ./modules
+COPY --from=builder ./botpress/botpress/app.json ./app.json
+COPY --from=builder ./botpress/botpress/.eslintrc.js ./.eslintrc.js
+COPY --from=builder ./botpress/botpress/.tool-versions ./.tool-versions
+
+# TODO move into builder image if possible, expose build/module builder instead
+# fully build once, takes 10min+
+RUN yarn run gulp build
+
+# build & package module
+# TODO extract into entry point, make it reusable to accept a list of modules
+#RUN yarn run gulp build:modules --m complete-module
+#RUN cd modules/complete-module && yarn && yarn build && yarn package
+
+ENTRYPOINT [ "yarn" ]
+CMD [ "run gulp build:modules" ]

--- a/build/module-builder/Dockerfile
+++ b/build/module-builder/Dockerfile
@@ -15,7 +15,7 @@ FROM node:12-alpine
 WORKDIR /botpress
 # add build config & dependencies
 COPY --from=builder ./botpress/build ./build
-COPY --from=builder ./botpress/gulpfile.js ./botpress/package.json ./botpress/yarn.lock ./
+COPY --from=builder ./botpress/gulpfile.js ./botpress/metadata.json ./botpress/package.json ./botpress/yarn.lock ./
 # install dependencies
 RUN yarn install
 RUN cd build/module-builder && yarn install

--- a/build/module-builder/Dockerfile
+++ b/build/module-builder/Dockerfile
@@ -9,33 +9,32 @@ COPY . .
 
 # fully build once
 RUN yarn && yarn build
-#RUN yarn run gulp build
 
-#COPY build ./build
-#RUN cd build/module-builder && yarn install && yarn build
 
 FROM node:12-alpine
+
 WORKDIR /botpress
-# add build config & dependencies
+
+# add necessary dependencies
 COPY --from=builder ./botpress/build ./build
-COPY --from=builder ./botpress/node_modules ./node_modules
-COPY --from=builder ./botpress/gulpfile.js ./botpress/metadata.json ./botpress/package.json ./botpress/yarn.lock ./
-# install dependencies
-#RUN yarn install
-# RUN cd build/module-builder && yarn install
-# RUN cd build/module-builder && yarn build
+COPY --from=builder ./botpress/src/typings ./src/typings
+COPY --from=builder ./botpress/src/bp/sdk/botpress.d.ts ./src/bp/sdk/botpress.d.ts
+COPY --from=builder ./botpress/src/bp/ui-shared/src/typings.d.ts ./src/bp/ui-shared/src/typings.d.ts
 
-# add botpress sdk source & typings
-COPY --from=builder ./botpress/src ./src
-# copy built dependencies (up to 300mb)
-COPY --from=builder ./botpress/out ./out
-# add source
-COPY --from=builder ./botpress/modules ./modules
+COPY --from=builder ./botpress/src/bp/ui-studio/node_modules/@blueprintjs ./src/bp/ui-studio/node_modules/@blueprintjs
+COPY --from=builder ./botpress/src/bp/ui-studio/node_modules/react ./src/bp/ui-studio/node_modules/react
+COPY --from=builder ./botpress/src/bp/ui-studio/node_modules/@types/react ./src/bp/ui-studio/node_modules/@types/react
+COPY --from=builder ./botpress/src/bp/ui-studio/src/web/components/Shared/Interface/typings.d.ts ./src/bp/ui-studio/src/web/components/Shared/Interface/typings.d.ts
 
-# prebuild other modules
-#RUN yarn run gulp build:modules
+COPY --from=builder ./botpress/modules/tsconfig_view.shared.json ./modules/tsconfig_view.shared.json
+COPY --from=builder ./botpress/modules/tsconfig.shared.json ./modules/tsconfig.shared.json
 
-# workaround unreleased getos fix (make botpress recognise alpine an select the correct native extensions)
-#RUN wget -qO- https://raw.githubusercontent.com/retrohacker/getos/master/os.json > ./node_modules/getos/os.json
+COPY --from=builder ./botpress/node_modules/knex ./node_modules/knex
+COPY --from=builder ./botpress/node_modules/@types/bluebird-global ./node_modules/@types/bluebird-global
+COPY --from=builder ./botpress/node_modules/@types/node ./node_modules/@types/node
+COPY --from=builder ./botpress/node_modules/@types/jest ./node_modules/@types/jest
+COPY --from=builder ./botpress/node_modules/reflect-metadata ./node_modules/reflect-metadata
+COPY --from=builder ./botpress/node_modules/bluebird ./node_modules/bluebird
+COPY --from=builder ./botpress/node_modules/express ./node_modules/express
 
 CMD [ "echo", "-e", "Which module would you like to build?\nUse sh -c 'cd modules/your-module && yarn && yarn build && yarn package'" ]

--- a/build/module-builder/Dockerfile
+++ b/build/module-builder/Dockerfile
@@ -1,31 +1,39 @@
 FROM node:12-alpine as builder
-WORKDIR /botpress
-COPY . botpress
-
-FROM node:12-alpine
-# still need git, because of the gulp initStudio task!?
+# git is required to resolve `git+` dependencies
 RUN apk add --no-cache git
 WORKDIR /botpress
+# this builder stage scope also includes additional files required for a full build, 
+# e.g.: docs, app.json, .eslintrc.js and .tool-versions
+COPY . botpress
+# alternatively RUN git clone https://github.com/botpress/botpress.git
+
+# fully build once
+RUN cd botpress && yarn install
+RUN cd botpress && yarn run gulp build
+
+FROM node:12-alpine
+WORKDIR /botpress
 # add botpress source dependencies from builder
-# install dependencies
 COPY --from=builder ./botpress/botpress/package.json ./botpress/botpress/yarn.lock ./
+# install dependencies
 RUN yarn install
 # add build config
 COPY --from=builder ./botpress/botpress/build ./build
 COPY --from=builder ./botpress/botpress/gulpfile.js ./
-# add botpress sdk
+RUN cd build/module-builder && yarn install
+RUN cd build/module-builder && yarn build
+
+# add botpress sdk source & typings
 COPY --from=builder ./botpress/botpress/src ./src
+# add docs
+#COPY --from=builder ./botpress/botpress/docs ./docs
 # add source
 COPY --from=builder ./botpress/botpress/modules ./modules
-COPY --from=builder ./botpress/botpress/app.json ./app.json
-COPY --from=builder ./botpress/botpress/.eslintrc.js ./.eslintrc.js
-COPY --from=builder ./botpress/botpress/.tool-versions ./.tool-versions
-# add docs
-COPY --from=builder ./botpress/botpress/docs ./docs
 
-# TODO move into builder image if possible, expose build/module builder instead
-# fully build once, takes 10min+
-RUN yarn run gulp build
+# copy built dependencies (up to 300mb)
+COPY --from=builder ./botpress/botpress/out ./out
+
+RUN yarn run gulp build:modules
 
 # build & package module
 # TODO extract into entry point, make it reusable to accept a list of modules

--- a/build/module-builder/Dockerfile
+++ b/build/module-builder/Dockerfile
@@ -31,6 +31,7 @@ COPY --from=builder ./botpress/modules ./modules
 # prebuild other modules
 RUN yarn run gulp build:modules
 
-#Test1
+# workaround unreleased getos fix (make botpress recognise alpine an select the correct native extensions)
+RUN wget -qO- https://raw.githubusercontent.com/retrohacker/getos/master/os.json > ./node_modules/getos/os.json
 
 CMD [ "echo", "-e", "Which module would you like to build?\nUse sh -c 'cd modules/your-module && yarn && yarn build && yarn package'" ]

--- a/build/module-builder/Dockerfile
+++ b/build/module-builder/Dockerfile
@@ -17,24 +17,12 @@ WORKDIR /botpress
 
 # add necessary dependencies
 COPY --from=builder ./botpress/build ./build
-COPY --from=builder ./botpress/src/typings ./src/typings
-COPY --from=builder ./botpress/src/bp/sdk/botpress.d.ts ./src/bp/sdk/botpress.d.ts
-COPY --from=builder ./botpress/src/bp/ui-shared/src/typings.d.ts ./src/bp/ui-shared/src/typings.d.ts
-
-COPY --from=builder ./botpress/src/bp/ui-studio/node_modules/@blueprintjs ./src/bp/ui-studio/node_modules/@blueprintjs
-COPY --from=builder ./botpress/src/bp/ui-studio/node_modules/react ./src/bp/ui-studio/node_modules/react
-COPY --from=builder ./botpress/src/bp/ui-studio/node_modules/@types/react ./src/bp/ui-studio/node_modules/@types/react
-COPY --from=builder ./botpress/src/bp/ui-studio/src/web/components/Shared/Interface/typings.d.ts ./src/bp/ui-studio/src/web/components/Shared/Interface/typings.d.ts
 
 COPY --from=builder ./botpress/modules/tsconfig_view.shared.json ./modules/tsconfig_view.shared.json
 COPY --from=builder ./botpress/modules/tsconfig.shared.json ./modules/tsconfig.shared.json
 
-COPY --from=builder ./botpress/node_modules/knex ./node_modules/knex
-COPY --from=builder ./botpress/node_modules/@types/bluebird-global ./node_modules/@types/bluebird-global
-COPY --from=builder ./botpress/node_modules/@types/node ./node_modules/@types/node
-COPY --from=builder ./botpress/node_modules/@types/jest ./node_modules/@types/jest
-COPY --from=builder ./botpress/node_modules/reflect-metadata ./node_modules/reflect-metadata
-COPY --from=builder ./botpress/node_modules/bluebird ./node_modules/bluebird
-COPY --from=builder ./botpress/node_modules/express ./node_modules/express
+COPY --from=builder ./botpress/node_modules ./node_modules
+
+COPY --from=builder ./botpress/src ./src
 
 CMD [ "echo", "-e", "Which module would you like to build?\nUse sh -c 'cd modules/your-module && yarn && yarn build && yarn package'" ]

--- a/build/module-builder/Dockerfile
+++ b/build/module-builder/Dockerfile
@@ -13,11 +13,9 @@ RUN yarn run gulp build
 
 FROM node:12-alpine
 WORKDIR /botpress
-# add build config
+# add build config & dependencies
 COPY --from=builder ./botpress/build ./build
-COPY --from=builder ./botpress/gulpfile.js ./
-# add botpress source dependencies
-COPY --from=builder ./botpress/package.json ./botpress/yarn.lock ./
+COPY --from=builder ./botpress/gulpfile.js ./botpress/package.json ./botpress/yarn.lock ./
 # install dependencies
 RUN yarn install
 RUN cd build/module-builder && yarn install
@@ -30,13 +28,7 @@ COPY --from=builder ./botpress/out ./out
 # add source
 COPY --from=builder ./botpress/modules ./modules
 
-
+# prebuild other modules
 RUN yarn run gulp build:modules
 
-# build & package module
-# TODO extract into entry point, make it reusable to accept a list of modules
-#RUN yarn run gulp build:modules --m complete-module
-#RUN cd modules/complete-module && yarn && yarn build && yarn package
-
-ENTRYPOINT [ "sh", "-c" ]
-CMD [ "yarn run gulp build:modules" ]
+CMD [ "echo", "-e", "Which module would you like to build?\nUse sh -c 'yarn run gulp build:modules --m your-module && cd modules/your-module && yarn && yarn build && yarn package'" ]

--- a/docs/guide/docs/advanced/custom-module.md
+++ b/docs/guide/docs/advanced/custom-module.md
@@ -498,3 +498,17 @@ They are then accessible by the name `$MY_MODULE/$MY_ACTION` in any node or skil
 If your action requires external dependencies, you must add them on your module's `package.json` as dependencies. When the VM is initialized, we redirect `require` requests to the node_modules of its parent module.
 
 > Many dependencies are already included with Botpress and do not need to be added to your package (ex: lodash, axios, etc... )
+
+## module-builder Docker image
+
+We provide a Docker image that can be used to compile your custom module. This is useful in CI/CD situations, where your pipeline will checkout your Custom Module's source code, and the Docker container will spit out a compiled `.tgz` file.
+
+## Instructions
+
+In the instructions beloew, replace `vX_X_X` by the latest version of the Docker image available on Docker Hub:
+
+```
+docker run -v `pwd`/your-custom-module:/botpress/modules/your-custom-module botpress/module-builder:vX_X_X sh -c 'cd modules/your-custom-module && yarn && yarn build && yarn package'
+```
+
+The compiled module will be availble in the directory you mounted as a `your-custom-module.tgz` file.

--- a/src/bp/ui-studio/webpack.web.js
+++ b/src/bp/ui-studio/webpack.web.js
@@ -247,7 +247,10 @@ compiler.hooks.done.tap('ExitCodePlugin', stats => {
   const errors = stats.compilation.errors
   if (errors && errors.length && process.argv.indexOf('--watch') === -1) {
     for (const e of errors) {
-      console.error(e.message)
+      console.error(e)
+      if (e.message) {
+        console.error(e.message)
+      }
     }
     console.error('Webpack build failed')
     process.exit(1)


### PR DESCRIPTION
I've been testing a bit and got these docker build steps working with the example "complete-module". It still needs be be generalized a bit more but this PR allows me to add some detail questions as annotations :)


Closes: https://github.com/botpress/v12/issues/1304
How to provide e2e tests for this?
Where to put this documentation (docker-compose):
> Create a copy of the `complete-module` example and rename it e.g. 'your-module':
```yaml
services:
  module-builder:
    image: botpress-module-builder TODO fixme with official name
    volumes:
      - ./your-module:/botpress/modules/your-module
    command: sh -c 'yarn run gulp build:modules --m your-module && cd modules/your-module && yarn && yarn build && yarn package'
```

TODO officially publish image (github pipeline)
I can't test your github hooks, but copying or enhancing the existing one is not difficult as soon as an official image name is chosen and its repo initialized.
