### PR TITLE
proposal(nlu): extract nlu engine in a dedicated binary

### DIFF
--- a/src/bp/nlu/engine/typings.ts
+++ b/src/bp/nlu/engine/typings.ts
@@ -71,6 +71,15 @@ export interface CurrentStan {
   predict: (text: string, modelId: ModelId, password: string) => Promise<PredictOutput>
 }
 
+/**
+ * Roadmap:
+ *
+ * 1 - implement an S3 model repo in stan (for HA)
+ * 2 - refactor the codebase to the new API (still in memory)
+ * 3 - move to an HTTP API
+ * 4 - separate binaries ?
+ */
+
 // Still an http API
 export interface NewStan {
   info: () => EngineInfo // the full deal


### PR DESCRIPTION
# Proposal for NLU binary

## Description

I've been asked to extract the NLU in a dedicated binary. The specs are:

1. The nlu must be http based
2. Reuse as mutch as possible code from Stan (Standalone NLU)
3. The refactor should not break Botpress (it must keep working seemlesly)

## Problem

Currently we have two interfaces for the NLU engine:

1. The engine class
   1.1 Called in memory
   1.2 Not responsible for models persistency
   1.3 Stateless
   1.4 Does few r/w operations in `process.APP_DATA_PATH`, but ideally should not
   1.5 Doesn't know to concept of "Bot"

2. Stan
   2.1 Thin HTTP wrapper around stan
   2.2 Responsible for model storage on file system with configurable model path
   2.3 Uses a password on each model so there's no login/signin needed
   2.4 Doesn't know to concept of "Bot"

Both interfaces are represented in the typings file in this PR (`CurrentEngine` and `CurrentStan`).

\*\* **My plan is to merge both so I don't have to support 2 different products with 2 different APIs. I also don't want to rush things in one afternoon and stay stuck with code that is impossible to maintain / improve for 3 months.** \*\*

## Design

Just check out the code below (the `NewStan` interface)

### Few things two say about this:

1. The `detectLanguage()` function is really usefull and really simplify the client's implementation \+ it accepts a list of models instead of only one.
2. We have to add functions to cleanup old model files and know weither or not a model exists and is available. If not its dirty and must trained. The functions `removeModels` and `listModels` will prevent from breaking the client's (nlu module) state machine
3. We have to make the nlu aware of the notion of "Bot" or at least "owner". The reason is, two bots can share the exact same model if the have the same definitions, language, engine's specs and the same seed. In that scenario, when unmouting a bot, we don't want to
4. I would change the `getCurrentTrainingStatus` function to a callback URL as this would simplify our lives a lot. With this we wouldnt have to store train-sessions in engine and we wouldnt need to make theme available for multi-clusters setup.
5. We would have to implement an S3 model repo or something to make Stan usable in multi-clusters infra. This requires a little new code. One possibility would be to host this S3 server in the nlu module (I don't even know if this is possible, but just thinking out loud here).
6. The `modelIdUtils` should be available both in the client and the engine. Both need to pass from Id to string and both need to make and Id from args. The client need to know what's the latest modelId without starting a training.

### Open questions:

1. What password do we use in botpress ? Should it be made up from the botId ? Should we instead make a login or something and use a "Bearer" token ? Idk how to name this, is it an authorization token/header ?
2. How do we make the `modelIdUtils` available inside both engine and client ? A yarn package ?

### Roadmap:

1. implement an S3 model repo in stan for multi-clusters (2~3 days by one dev)
2. refactor the codebase to the new API (2~3 days by another dev)
3. move to an HTTP API (1 day)
4. separate binaries ?
5. update bitfan for the new Stan API
6. Total (~ 2 weeks including proper QA)

## Alternative design

I though about simply taking the current engine's interface and making a strict we server aroud it without changing anything, but few things bug me:

1. It just makes another product to support instead of reusing Stan.
2. We have to pass 1Gb models over some http calls (both at the end of a training and when loading)
3. I really feel an NLU provider service should handle model persistency.

## Conclusion

I might repeat myself in the description and the typings file, sorry.

What do you guys think ?