### PR TITLE
fix(studio): allow to scroll content of action overlay popover

### DIFF
--- a/src/bp/ui-studio/src/web/translations/en.json
+++ b/src/bp/ui-studio/src/web/translations/en.json
@@ -148,6 +148,8 @@
         "actionToExecute": "Action to execute",
         "actionToRun": "Action to run {help}",
         "actionsRegisteredOnServer": "Actions are registered on the server-side. Read about how to register new actions by searching for `bp.registerActions()`.",
+        "actionInstructionParsingError": "Error while parsing instructions: {msg}",
+        "actionArguments": "Called with these arguments:",
         "add": "add",
         "addAction": "Add new action",
         "cantSeeActions": "Can't see your action?",

--- a/src/bp/ui-studio/src/web/translations/es.json
+++ b/src/bp/ui-studio/src/web/translations/es.json
@@ -148,6 +148,8 @@
         "actionToExecute": "Acción para ejecutar",
         "actionToRun": "Acción para ejecutar {help}",
         "actionsRegisteredOnServer": "Las acciones se registran en el lado del servidor. Lea acerca de cómo registrar nuevas acciones buscando`bp.registerActions()`.",
+        "actionInstructionParsingError": "Error al analizar las instrucciones: {msg}",
+        "actionArguments": "Llamado con estos argumentos:",
         "add": "Añadir",
         "addAction": "Añadir nueva acción",
         "cantSeeActions": "No puedes ver tu acción?",

--- a/src/bp/ui-studio/src/web/translations/fr.json
+++ b/src/bp/ui-studio/src/web/translations/fr.json
@@ -147,6 +147,8 @@
         "actionToExecute": "Action à exécuter",
         "actionToRun": "Action à exécuter {help}",
         "actionsRegisteredOnServer": "Les actions sont enregistrées côté serveur. Découvrez comment enregistrer de nouvelles actions en recherchant `bp.registerActions ()`.",
+        "actionInstructionParsingError": "Erreur lors du formattage des instructions: {msg}",
+        "actionArguments": "Appelé avec ces arguments:",
         "add": "ajouter",
         "addAction": "Ajouter une nouvelle action",
         "cantSeeActions": "Vous ne voyez pas votre action?",

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/common/action.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/common/action.tsx
@@ -1,16 +1,15 @@
 import { lang } from 'botpress/shared'
 import classnames from 'classnames'
-import { parseActionInstruction } from 'common/action'
 import _ from 'lodash'
 import Mustache from 'mustache'
 import React, { Component } from 'react'
-import { OverlayTrigger, Popover } from 'react-bootstrap'
 import Markdown from 'react-markdown'
 import { connect } from 'react-redux'
 import { fetchContentItem, refreshFlowsLinks } from '~/actions'
 
 import { isMissingCurlyBraceClosure } from '../../../components/Util/form.util'
 import withLanguage from '../../../components/Util/withLanguage'
+import { ActionPopover } from './actionPopover'
 
 import style from './style.scss'
 
@@ -28,8 +27,10 @@ export const textToItemId = text => text?.match(/^say #!(.*)$/)?.[1]
 
 class ActionItem extends Component<Props> {
   state = {
-    itemId: null
+    itemId: null,
+    showActionPopover: false
   }
+  target = null
 
   componentDidMount() {
     this.loadElement()
@@ -49,45 +50,12 @@ class ActionItem extends Component<Props> {
     this.setState({ itemId: textToItemId(this.props.text) })
   }
 
-  renderAction() {
-    const actionInstruction = parseActionInstruction(this.props.text.trim())
-
-    const actionName = `${actionInstruction.actionName} (args)`
-
-    let callPreview
-    if (actionInstruction.argsStr) {
-      try {
-        const parameters = JSON.parse(actionInstruction.argsStr)
-        callPreview = JSON.stringify(parameters, null, 2)
-      } catch (err) {
-        console.error(err)
-      }
-    }
-
-    const popoverHoverFocus = (
-      <Popover id="popover-action" title={`⚡ ${actionName}`}>
-        Called with these arguments:
-        <pre>{callPreview}</pre>
-      </Popover>
-    )
-
-    return (
-      <OverlayTrigger trigger={['hover', 'focus']} placement="top" delayShow={500} overlay={popoverHoverFocus}>
-        <div className={classnames(this.props.className, style['fn'], style['action-item'])}>
-          <span className={style.icon}>⚡</span>
-          <span className={style.name}>{actionName}</span>
-          {this.props.children}
-        </div>
-      </OverlayTrigger>
-    )
-  }
-
   render() {
     const action = this.props.text
     const isAction = typeof action !== 'string' || !action.startsWith('say ')
 
     if (isAction) {
-      return this.renderAction()
+      return <ActionPopover text={this.props.text} className={this.props.className} children={this.props.children} />
     }
 
     const item = this.props.items[this.state.itemId]

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/common/action.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/common/action.tsx
@@ -27,10 +27,8 @@ export const textToItemId = text => text?.match(/^say #!(.*)$/)?.[1]
 
 class ActionItem extends Component<Props> {
   state = {
-    itemId: null,
-    showActionPopover: false
+    itemId: null
   }
-  target = null
 
   componentDidMount() {
     this.loadElement()
@@ -55,7 +53,7 @@ class ActionItem extends Component<Props> {
     const isAction = typeof action !== 'string' || !action.startsWith('say ')
 
     if (isAction) {
-      return <ActionPopover text={this.props.text} className={this.props.className} children={this.props.children} />
+      return <ActionPopover text={this.props.text} className={this.props.className} />
     }
 
     const item = this.props.items[this.state.itemId]

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/common/actionPopover.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/common/actionPopover.tsx
@@ -1,3 +1,4 @@
+import { lang } from 'botpress/shared'
 import classnames from 'classnames'
 import { parseActionInstruction } from 'common/action'
 import React, { FC, useState } from 'react'
@@ -24,7 +25,8 @@ export const ActionPopover: FC<Props> = props => {
       const parameters = JSON.parse(actionInstruction.argsStr)
       callPreview = JSON.stringify(parameters, null, 2)
     } catch (err) {
-      console.error(err)
+      console.error('[ActionPopover] Error parsing instructions:', err)
+      callPreview = lang.tr('studio.flow.node.actionInstructionParsingError', { msg: err.message })
     }
   }
 
@@ -50,7 +52,7 @@ export const ActionPopover: FC<Props> = props => {
 
       <Overlay target={() => ReactDOM.findDOMNode(target)} placement="top" show={show}>
         <Popover id="popover-action" title={`⚡ ${actionName}`}>
-          Called with these arguments:
+          {lang.tr('studio.flow.node.actionArguments')}
           <pre>{callPreview}</pre>
         </Popover>
       </Overlay>

--- a/src/bp/ui-studio/src/web/views/FlowBuilder/common/actionPopover.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/common/actionPopover.tsx
@@ -1,0 +1,59 @@
+import classnames from 'classnames'
+import { parseActionInstruction } from 'common/action'
+import React, { FC, useState } from 'react'
+import { Overlay, Popover } from 'react-bootstrap'
+import ReactDOM from 'react-dom'
+
+import style from './style.scss'
+
+interface Props {
+  text: string
+  className: string
+}
+
+export const ActionPopover: FC<Props> = props => {
+  const [show, setShow] = useState<boolean>(false)
+  const [target, setTarget] = useState<HTMLElement>(null)
+
+  const actionInstruction = parseActionInstruction(props.text.trim())
+  const actionName = `${actionInstruction.actionName} (args)`
+
+  let callPreview: string
+  if (actionInstruction.argsStr) {
+    try {
+      const parameters = JSON.parse(actionInstruction.argsStr)
+      callPreview = JSON.stringify(parameters, null, 2)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  const hidePopover = () => {
+    setShow(false)
+  }
+
+  const showPopover = () => {
+    setShow(true)
+  }
+
+  return (
+    <div onMouseLeave={hidePopover}>
+      <div
+        className={classnames(props.className, style['fn'], style['action-item'])}
+        ref={setTarget}
+        onMouseEnter={showPopover}
+      >
+        <span className={style.icon}>⚡</span>
+        <span className={style.name}>{actionName}</span>
+        {props.children}
+      </div>
+
+      <Overlay target={() => ReactDOM.findDOMNode(target)} placement="top" show={show}>
+        <Popover id="popover-action" title={`⚡ ${actionName}`}>
+          Called with these arguments:
+          <pre>{callPreview}</pre>
+        </Popover>
+      </Overlay>
+    </div>
+  )
+}

--- a/src/bp/ui-studio/yarn.lock
+++ b/src/bp/ui-studio/yarn.lock
@@ -8549,11 +8549,8 @@ uglifyjs-webpack-plugin@^1.2.4:
     worker-farm "^1.5.2"
 
 "ui-shared@link:../ui-shared":
-  version "0.0.1"
-  dependencies:
-    js-cookie "^2.2.1"
-    react-command-palette "^0.12.0-0"
-    react-router "4.3.1"
+  version "0.0.0"
+  uid ""
 
 uncontrollable@^7.0.2:
   version "7.1.1"


### PR DESCRIPTION
This PR allows to select an action popover content without the overlay being hidden.

### e.g.

#### Before


https://user-images.githubusercontent.com/9640576/113766928-05483a80-96ec-11eb-9814-89fa909b4675.mp4



#### After

https://user-images.githubusercontent.com/9640576/113766836-e8136c00-96eb-11eb-9d92-f3ec4cc06e8e.mp4

