### PR TITLE
fix(core): migrations not running

### DIFF
--- a/src/bp/core/migration/migration-service.ts
+++ b/src/bp/core/migration/migration-service.ts
@@ -278,7 +278,7 @@ ${_.repeat(' ', 9)}========================================`)
   }
 
   public getAllMigrations(): MigrationFile[] {
-    const coreMigrations = this._getMigrations(path.join(__dirname, '../../../migrations'))
+    const coreMigrations = this._getMigrations(path.join(__dirname, '../../migrations'))
     const moduleMigrations = _.flatMap(Object.keys(process.LOADED_MODULES), module =>
       this._getMigrations(path.join(process.LOADED_MODULES[module], 'dist/migrations'))
     )


### PR DESCRIPTION
I realized while making a migration for the core that migrations weren't running. It turns out this was because the migration service was using a relative path to look for migrations that wasn't correct anymore so I changed it.