### PR TITLE
fix(nlu): Default to global context when no context matched

### DIFF
--- a/modules/nlu/src/backend/election/natural-election.ts
+++ b/modules/nlu/src/backend/election/natural-election.ts
@@ -2,7 +2,7 @@ import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 
 import { detectAmbiguity } from './ambiguous'
-import { NONE_INTENT } from './typings'
+import { NONE_INTENT, GLOBAL_CONTEXT } from './typings'
 
 export default function naturalElectionPipeline(input: sdk.IO.EventUnderstanding) {
   if (!input.predictions) {
@@ -24,7 +24,7 @@ function electIntent(input: sdk.IO.EventUnderstanding): sdk.IO.EventUnderstandin
     .entries()
     .map(([name, ctx]) => ({ ...ctx, name }))
     .maxBy(ctx => ctx.confidence) || {
-    name: 'global',
+    name: GLOBAL_CONTEXT,
     confidence: 1.0,
     oos: 0.0,
     intents: []

--- a/modules/nlu/src/backend/election/natural-election.ts
+++ b/modules/nlu/src/backend/election/natural-election.ts
@@ -23,14 +23,14 @@ function electIntent(input: sdk.IO.EventUnderstanding): sdk.IO.EventUnderstandin
     .pickBy((_p, ctx) => input.includedContexts.includes(ctx))
     .entries()
     .map(([name, ctx]) => ({ ...ctx, name }))
-    .maxBy(ctx => ctx.confidence)! || {
+    .maxBy(ctx => ctx.confidence) || {
     name: 'global',
     confidence: 1.0,
     oos: 0.0,
     intents: []
   }
 
-  const noneIntent = { label: NONE_INTENT, confidence: mostConfidentCtx?.oos || 1.0, slots: {}, extractor: '' }
+  const noneIntent = { label: NONE_INTENT, confidence: mostConfidentCtx.oos, slots: {}, extractor: '' }
 
   const topTwo: sdk.NLU.Intent[] = _([...mostConfidentCtx.intents, noneIntent])
     .orderBy(i => i.confidence, 'desc')

--- a/modules/nlu/src/backend/election/typings.ts
+++ b/modules/nlu/src/backend/election/typings.ts
@@ -1,3 +1,4 @@
 export const NONE_INTENT = 'none' // should extract in comon code
+export const GLOBAL_CONTEXT = 'global'
 
 export type ValueOf<T> = T[keyof T]


### PR DESCRIPTION
Fixes botpress/v12#1307 
Defaults to the `global` context when no context is matched in natural election

no significant changes in accuracy:

### Before fix
#### regression
`finished running tests with 0.7135231316725978 of accuracy`
#### slot extraction
`finished running tests with 0.6067415730337079 of accuracy`

### After fix
#### regression
`finished running tests with 0.7161921708185054 of accuracy`
#### slot extraction
`finished running tests with 0.6067415730337079 of accuracy`
