### PR TITLE
feat(studio): add support for video content-type

### DIFF
--- a/modules/builtin/src/content-types/video.js
+++ b/modules/builtin/src/content-types/video.js
@@ -1,0 +1,89 @@
+const base = require('./_base')
+const path = require('path')
+const utils = require('./_utils')
+
+function render(data) {
+  const events = []
+
+  if (data.typing) {
+    events.push({
+      type: 'typing',
+      value: data.typing
+    })
+  }
+
+  return [
+    ...events,
+    {
+      type: 'video',
+      title: data.title,
+      url: utils.formatURL(data.BOT_URL, data.video),
+      collectFeedback: data.collectFeedback
+    }
+  ]
+}
+
+function renderElement(data, channel) {
+  if (channel === 'vonage') {
+    return data
+  } else {
+    return render(data)
+  }
+}
+
+module.exports = {
+  id: 'builtin_video',
+  group: 'Built-in Video',
+  title: 'Video',
+
+  jsonSchema: {
+    description: 'module.builtin.types.video.description',
+    type: 'object',
+    $subtype: 'video',
+    required: ['video'],
+    properties: {
+      video: {
+        type: 'string',
+        $subtype: 'video',
+        $filter: '.mp4, .ogg, .webm|video/*',
+        title: 'module.builtin.types.video.title'
+      },
+      title: {
+        type: 'string',
+        title: 'module.builtin.types.video.videoLabel'
+      },
+      ...base.typingIndicators
+    }
+  },
+
+  uiSchema: {
+    title: {
+      'ui:field': 'i18n_field'
+    }
+  },
+
+  computePreviewText: formData => {
+    if (!formData.video) {
+      return
+    }
+
+    const link = utils.formatURL(formData.BOT_URL, formData.video)
+    const title = formData.title ? ' | ' + formData.title : ''
+    let fileName = ''
+
+    if (utils.isUrl(link)) {
+      fileName = path.basename(formData.video)
+      if (fileName.includes('-')) {
+        fileName = fileName
+          .split('-')
+          .slice(1)
+          .join('-')
+      }
+      return `Video: (${fileName}) ${title}`
+    } else {
+      return `Expression: ${link}${title}`
+    }
+  },
+
+  renderElement: renderElement
+}

--- a/modules/builtin/src/translations/en.json
+++ b/modules/builtin/src/translations/en.json
@@ -32,6 +32,11 @@
       "audioLabel": "Title",
       "title": "Audio"
     },
+    "video": {
+      "description": "A message showing a video file with an optional title",
+      "videoLabel": "Title",
+      "title": "Video"
+    },
     "singleChoice": {
       "choice": "Choice",
       "description": "Suggest choices to the user with the intention of picking only one (with an optional message)",

--- a/modules/builtin/src/translations/es.json
+++ b/modules/builtin/src/translations/es.json
@@ -32,6 +32,11 @@
       "audioLabel": "Título",
       "title": "Audio"
     },
+    "video": {
+      "description": "Un mensaje que muestra un archivo de video con un título opcional",
+      "videoLabel": "Título",
+      "title": "Video"
+    },
     "singleChoice": {
       "choice": "Elección",
       "description": "Sugerir opciones al usuario con la intención de seleccionar solo una (con un mensaje opcional)",

--- a/modules/builtin/src/translations/fr.json
+++ b/modules/builtin/src/translations/fr.json
@@ -32,6 +32,11 @@
       "audioLabel": "Titre",
       "title": "Audio"
     },
+    "video": {
+      "description": "Un message affichant un fichier vidéo avec un titre facultatif",
+      "videoLabel": "Titre",
+      "title": "Vidéo"
+    },
     "singleChoice": {
       "choice": "Choix",
       "description": "Suggérer un choix à l'utilisateur avec l'intention de n'en sélectionner qu'un (avec un message optionnel)",

--- a/src/bp/ui-shared/src/FileDisplay/index.tsx
+++ b/src/bp/ui-shared/src/FileDisplay/index.tsx
@@ -33,6 +33,16 @@ const FileDisplay: FC<FileDisplayProps> = props => {
           </audio>
         </div>
       )
+    case 'video':
+      return (
+        <div className={style.videoWrapper}>
+          <div className={style.videoWrapperActions}>{deletable && deletableFile()}</div>
+          <video controls width={200} height={200} className={style.videoWrapperSource}>
+            <source src={url} type={mimeType} />
+            Your browser does not support the video element.
+          </video>
+        </div>
+      )
     default:
       return null
   }

--- a/src/bp/ui-shared/src/FileDisplay/style.scss
+++ b/src/bp/ui-shared/src/FileDisplay/style.scss
@@ -52,3 +52,21 @@
     left: 0;
   }
 }
+
+.videoWrapper {
+  border-radius: 3px;
+  height: 200px;
+  position: relative;
+  width: 200px;
+
+  &Actions {
+    position: absolute;
+    right: 5px;
+    top: 5px;
+    z-index: 100;
+  }
+
+  &Source {
+    background-color: rgba(30, 30, 30, 0.5);
+  }
+}

--- a/src/bp/ui-shared/src/FileDisplay/style.scss.d.ts
+++ b/src/bp/ui-shared/src/FileDisplay/style.scss.d.ts
@@ -7,6 +7,9 @@ interface CssExports {
   'deleteFile': string;
   'imageWrapper': string;
   'imageWrapperActions': string;
+  'videoWrapper': string;
+  'videoWrapperActions': string;
+  'videoWrapperSource': string;
 }
 declare var cssExports: CssExports;
 export = cssExports;

--- a/src/bp/ui-shared/src/FileDisplay/typings.d.ts
+++ b/src/bp/ui-shared/src/FileDisplay/typings.d.ts
@@ -1,6 +1,8 @@
+import { SupportedFileType } from '../Form/FormFields/typings'
+
 export interface FileDisplayProps {
   url: string
-  type: 'image' | 'audio' | string
+  type: SupportedFileType
   deletable: boolean
   onDelete(): void
 }

--- a/src/bp/ui-shared/src/Form/FormFields/typings.d.ts
+++ b/src/bp/ui-shared/src/Form/FormFields/typings.d.ts
@@ -59,10 +59,12 @@ export interface FieldWrapperProps {
 
 export type TextProps = FieldProps & { field: FormField }
 
+export type SupportedFileType = 'image' | 'audio' | 'video'
+
 export interface UploadFieldProps extends FieldProps {
   axios: any
   customPath?: string
   onChange?: (url: string | undefined) => void
-  type: 'image' | 'audio' | string
+  type: SupportedFileType
   filter?: string
 }

--- a/src/bp/ui-shared/src/typings.d.ts
+++ b/src/bp/ui-shared/src/typings.d.ts
@@ -149,7 +149,7 @@ declare module 'botpress/shared' {
   export const sharedStyle: CssExports
 
   export { Option, MoreOptionsItems, HeaderButtonProps, ToolbarButtonProps, QuickShortcut, MenuItem, HeaderButton }
-  export { RequiredPermission, PermissionAllowedProps, AccessControlProps, PermissionOperation }
+  export { RequiredPermission, PermissionAllowedProps, AccessControlProps, PermissionOperation, UploadFieldProps }
 }
 
 declare global {

--- a/src/bp/ui-studio/src/web/components/ContentForm/UploadWidget/UrlUpload.tsx
+++ b/src/bp/ui-studio/src/web/components/ContentForm/UploadWidget/UrlUpload.tsx
@@ -1,5 +1,5 @@
 import { Button, Intent, Position, Tooltip } from '@blueprintjs/core'
-import { lang, FileDisplay } from 'botpress/shared'
+import { lang, FileDisplay, UploadFieldProps } from 'botpress/shared'
 import React, { FC, Fragment, useEffect, useState } from 'react'
 import SmartInput from '~/components/SmartInput'
 import style from '~/views/FlowBuilder/sidePanelTopics/form/style.scss'
@@ -8,7 +8,7 @@ import localStyle from './style.scss'
 
 interface IUrlUploadProps {
   value: string | null
-  type: 'image' | 'audio' | string
+  type: UploadFieldProps['type']
   onChange(value: string | null): void
   onDelete(): void
   onError(value: string | Error): void
@@ -37,7 +37,6 @@ const UrlUpload: FC<IUrlUploadProps> = props => {
   }
 
   const isUrlOrRelativePath = (str: string) => {
-    console.log('str', str)
     const re = /^(?:[a-z]+:)?\/\/|^\//i
 
     return re.test(str)

--- a/src/bp/ui-studio/src/web/components/ContentForm/UploadWidget/index.tsx
+++ b/src/bp/ui-studio/src/web/components/ContentForm/UploadWidget/index.tsx
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { FormFields, lang, FileDisplay } from 'botpress/shared'
+import { FormFields, lang, UploadFieldProps } from 'botpress/shared'
 import cn from 'classnames'
 import React, { FC, Fragment, useState } from 'react'
 import { AccessControl } from '~/components/Shared/Utils'
@@ -14,7 +14,7 @@ interface IUploadWidgetProps {
   onChange(value: string | null): void
   schema: {
     type: string
-    $subtype: string
+    $subtype: UploadFieldProps['type']
     $filter: string
     title: string
   }

--- a/src/bp/ui-studio/src/web/components/ContentForm/index.tsx
+++ b/src/bp/ui-studio/src/web/components/ContentForm/index.tsx
@@ -1,5 +1,5 @@
 import { Colors, Icon } from '@blueprintjs/core'
-import { lang } from 'botpress/shared'
+import { lang, UploadFieldProps } from 'botpress/shared'
 import _ from 'lodash'
 import React, { FC } from 'react'
 import Form from 'react-jsonschema-form'
@@ -27,7 +27,7 @@ interface Props {
 }
 
 const CustomBaseInput = props => {
-  const SUPPORTED_MEDIA_SUBTYPES = ['audio', 'image']
+  const SUPPORTED_MEDIA_SUBTYPES: UploadFieldProps['type'][] = ['audio', 'image', 'video']
   const { type, $subtype: subtype } = props.schema
 
   if (type === 'string') {
@@ -47,15 +47,19 @@ const widgets = {
   BaseInput: CustomBaseInput
 }
 
-// TODO: Remove this once audio content-type is support on multiple channels
+// TODO: Remove this once audio and video content-types are support on multiple channels
 const CustomDescriptionField = ({ description, id, formContext }) => {
-  if (id === 'root__description' && formContext.subtype === 'audio') {
+  if (id === 'root__description' && ['audio', 'video'].includes(formContext.subtype)) {
+    const capitalize = (str: string) => {
+      return str.charAt(0).toUpperCase() + str.slice(1)
+    }
+
     return (
       <div id={id} style={{ lineHeight: 'normal' }}>
         <div>
           <span style={{ color: Colors.ORANGE3 }}>
             <Icon icon="warning-sign" color={Colors.ORANGE3} />
-            &nbsp;Audio content-type is currently only supported by channel-vonage
+            &nbsp;{capitalize(formContext.subtype)} content-type is currently only supported by channel-vonage
           </span>
         </div>
         <br />


### PR DESCRIPTION
This PR adds support for video content-type.

#### e.g.


https://user-images.githubusercontent.com/9640576/114075406-80882880-9873-11eb-8579-56ee6831e308.mp4

