### PR TITLE
fix(core): use relative file path for media files

### DIFF
--- a/src/bp/admin/user/user-router.ts
+++ b/src/bp/admin/user/user-router.ts
@@ -66,7 +66,7 @@ class UserRouter extends CustomAdminRouter {
               .trim()
               .allow(''),
             picture_url: Joi.string()
-              .uri()
+              .uri({ allowRelative: true })
               .allow('')
           })
         )

--- a/src/bp/core/media/providers/ghost-media-service.ts
+++ b/src/bp/core/media/providers/ghost-media-service.ts
@@ -47,6 +47,8 @@ export class GhostMediaService implements MediaService {
   }
 
   getPublicURL(fileName: string): string {
+    // make sure the file name is a valid URI
+    fileName = encodeURIComponent(fileName)
     if (this.botId) {
       return `/api/v1/bots/${this.botId}/media/${fileName}`
     } else {

--- a/src/bp/ui-shared/src/Form/FormFields/Upload.tsx
+++ b/src/bp/ui-shared/src/Form/FormFields/Upload.tsx
@@ -64,10 +64,7 @@ const Upload: FC<UploadFieldProps> = props => {
     await props.axios
       .post(props.customPath ? props.customPath : 'media', data, { headers: { 'Content-Type': 'multipart/form-data' } })
       .then(response => {
-        let url: string = response.data.url
-        if (url.startsWith('/')) {
-          url = `${window.location.protocol}//${window.location.host}${url}`
-        }
+        const url: string = response.data.url
 
         dispatch({ type: 'uploadSuccess', data: { url } })
       })


### PR DESCRIPTION
This PR fixes an issue where uploaded media files URL would be prefixes with the server address (e.g. `http://localhost:.../media.jpg`) making it difficult to develop channels on your local machine.