### PR TITLE
chore(nlu): implement list and prune models

### DIFF
--- a/src/bp/index.ts
+++ b/src/bp/index.ts
@@ -376,8 +376,8 @@ try {
           description: 'Binds the nlu server to a specific hostname',
           default: 'localhost'
         },
-        modelDir: {
-          description: 'Directory where models will be saved'
+        dbURL: {
+          description: 'URL of database where to persist models. If undefined, models are stored on FS.'
         },
         authToken: {
           description: 'When enabled, this token is required for clients to query your nlu server'

--- a/src/bp/nlu/engine/model-id-service.ts
+++ b/src/bp/nlu/engine/model-id-service.ts
@@ -12,9 +12,7 @@ import {
 
 export const HALF_MD5_REG = /^[a-fA-F0-9]{16}$/
 
-const MD5_BITE_SIZE = 16 // 128 / 8
-const MD5_NIBBLES_SIZE = MD5_BITE_SIZE * 2
-
+const MD5_NIBBLES_SIZE = 32 // (128 bits/hash / 8 bits/byte) * 2 nibbles/byte === 32 nibbles/hash
 export const halfmd5 = (text: string) => {
   return crypto
     .createHash('md5')

--- a/src/bp/nlu/stan/index.ts
+++ b/src/bp/nlu/stan/index.ts
@@ -82,8 +82,6 @@ export default async function(options: ArgV) {
     throw new Error(`Specified body-size "${options.bodySize}" has an invalid format.`)
   }
 
-  options.modelDir = options.modelDir || path.join(process.APP_DATA_PATH, 'models')
-
   global.printLog = args => {
     const message = args[0]
     const rest = args.slice(1)
@@ -126,7 +124,7 @@ ${_.repeat(' ', 9)}========================================`)
   logger.info(`lang server: url=${options.languageURL}`)
 
   logger.info(`body size: allowing HTTP resquests body of size ${options.bodySize}`)
-  logger.info(`models stored at "${options.modelDir}"`)
+  // logger.info(`models stored at "${options.modelDir}"`)
 
   if (options.batchSize > 0) {
     logger.info(`batch size: allowing up to ${options.batchSize} predictions in one call to POST /predict`)


### PR DESCRIPTION
I added 1 commit where:

- model dir is no longer configurable
- dbUrl is configurable (fallback on fs if undefined)
- currently every models is persisted at root
- mode file name format has changed:

```ts
const previousFormat = (modelId: string) => computeHash(`${password}+${modelId}`) + '.model'
const newFormat = (modelId: string) => modelId + computeHash(appSecret) + '.model'
```

This last bullet point is the biggest change, but I believe it offers the same level of security as before and now, it allows to list models and prune in batch