### PR TITLE
fix(docs): remove warning about Custom Modules

### DIFF
--- a/docs/guide/website/versioned_docs/version-11.0.1/create-module.md
+++ b/docs/guide/website/versioned_docs/version-11.0.1/create-module.md
@@ -4,10 +4,6 @@ title: Creating Modules
 original_id: create-module
 ---
 
-<br/>
-
-> ⚠️ Not yet finalized, subject to breaking changes
-
 ## Why should I create a module?
 
 Modules are very powerful and have a lot more features than before. They can register new actions, create multiple skills, provide new hooks, and soon they will be able to add new content types and content elements.

--- a/docs/guide/website/versioned_docs/version-11.2.0/create-module.md
+++ b/docs/guide/website/versioned_docs/version-11.2.0/create-module.md
@@ -4,10 +4,6 @@ title: Creating Modules
 original_id: create-module
 ---
 
-<br/>
-
-> ⚠️ Not yet finalized, subject to breaking changes
-
 ## Why should I create a module?
 
 Modules are very powerful and have a lot more features than before. They can register new actions, create multiple skills, provide new hooks, and soon they will be able to add new content types and content elements.

--- a/docs/guide/website/versioned_docs/version-11.5.1/developers/create-module.md
+++ b/docs/guide/website/versioned_docs/version-11.5.1/developers/create-module.md
@@ -4,10 +4,6 @@ title: Creating Modules
 original_id: create-module
 ---
 
-<br/>
-
-> ⚠️ Not yet finalized, subject to breaking changes
-
 ## Why should I create a module?
 
 Modules are very powerful and have a lot more features than before. They can register new actions, create multiple skills, provide new hooks, and soon they will be able to add new content types and content elements.

--- a/docs/guide/website/versioned_docs/version-11.6.0/developers/create-module.md
+++ b/docs/guide/website/versioned_docs/version-11.6.0/developers/create-module.md
@@ -4,10 +4,6 @@ title: Creating Modules
 original_id: create-module
 ---
 
-<br/>
-
-> ⚠️ Not yet finalized, subject to breaking changes
-
 ## Why should I create a module?
 
 Modules are very powerful and have a lot more features than before. They can register new actions, create multiple skills, provide new hooks, and soon they will be able to add new content types and content elements.


### PR DESCRIPTION
Removes a warning about Custom Modules being subject to breaking changes.
This warning scares developers in not creating Custom Modules. We don't want that happening. Custom Modules are ready to be used in production.