### PR TITLE
feat(core): add env variable to support pg schema

### DIFF
--- a/docs/guide/docs/infrastructure/database.md
+++ b/docs/guide/docs/infrastructure/database.md
@@ -4,28 +4,36 @@ title: Supported databases
 ---
 
 ## Introduction
+
 By default, Botpress uses SQLite as its database. However, we recommend that you switch to PostgreSQL as early as you can in your chatbot development cycle because it is highly fault tolerant, stable, scalable and secure.
 
-## How to switch from SQLite to Postgres
-You should set up the database (considered as Infrastructure) before executing the Botpress software is executed.
-In this case, that means that you need to configure `DATABASE_URL` environment variables.
+## How to switch from SQLite to PostgresSQL
+
+First, make sure you're running PostgreSQL 9.5+ and create your database before starting Botpress.
+
+Once your database is created the only thing Botpress needs is a [standard PG connection string](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING) configured in the `DATABASE_URL` environment variables.
 
 - `DATABASE_URL=postgres://login:password@your-db-host.com:5432/your-db-name`.
 
-If you want to use the default Postgres connection string, set it as follows:
+If you want to use the default PostgresSQL connection string, set it as follows:
 
 - `DATABASE_URL=postgres`.
 
-While using Postgres, you can configure the Connection Pools by using the `DATABASE_POOL` environment variable. For detailed options please refer to [tarn.js](https://github.com/vincit/tarn.js) for all configuration options. You must enter valid json. Example:
+While using PostgresSQL, you can configure the Connection Pools by using the `DATABASE_POOL` environment variable. For detailed options please refer to [tarn.js](https://github.com/vincit/tarn.js) for all configuration options. You must enter valid json. Example:
 
 `DATABASE_POOL={"min": 3, "max": 10}`
 
-Please make sure you are using Postgres 9.5 or higher.
+You can also set the PostgreSQL Schema Search Path for every database connection (official pg doc [here](https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH)) by setting the `DATABASE_PG_SEARCH_PATH` environment variable.
 
-If you don't want to type those variables each time you start Botpress, we also support `.env` files. Check out our [configuration section](../advanced/configuration) for more information about that
+- `DATABASE_PG_SEARCH_PATH=mySchema`
 
+This will be the equivalent of using the following SQL statement `SET search_path to mySchema`. Although it's not recommended, you can set multiple search path using a comma sperated value syntax as you would do using the sql statement. Use multiple search path only if you know what you're doing. The default search path
+
+If you don't want to type those variables each time you start Botpress, we also support `.env` files. Check out our [configuration section](../advanced/configuration) for more information about that.
 
 ## Accessing databases
+
 Two handy ways to access whichever database you choose to use are:
+
 1. The [key-value store](https://botpress.com/reference/modules/_botpress_sdk_.kvs.html)
 2. A [knex instance](http://knexjs.org/)

--- a/docs/guide/docs/infrastructure/database.md
+++ b/docs/guide/docs/infrastructure/database.md
@@ -27,7 +27,7 @@ You can also set the PostgreSQL Schema Search Path for every database connection
 
 - `DATABASE_PG_SEARCH_PATH=mySchema`
 
-This will be the equivalent of using the following SQL statement `SET search_path to mySchema`. This feature requires you to create the schema prior to setting it. More oever, although it's not recommended, you can set multiple search path using a comma sperated value syntax as you would do using the sql statement. Use multiple search path only if you know what you're doing. The default search path
+This will be the equivalent of using the following SQL statement `SET search_path to mySchema`. This feature requires you to create the schema prior to setting it. Moreover, although it's not recommended, you can set multiple schemas in your search path using a comma separated value syntax as you would do using the SQL statement. Use multiple schemas only if you know what you're doing. The default search path
 
 If you don't want to type these variables each time you start Botpress, we also support `.env` files. Check out our [configuration section](../advanced/configuration) for more information.
 

--- a/docs/guide/docs/infrastructure/database.md
+++ b/docs/guide/docs/infrastructure/database.md
@@ -27,7 +27,7 @@ You can also set the PostgreSQL Schema Search Path for every database connection
 
 - `DATABASE_PG_SEARCH_PATH=mySchema`
 
-This will be the equivalent of using the following SQL statement `SET search_path to mySchema`. This feature requires you to create the schema prior to setting it. Moreover, although it's not recommended, you can set multiple schemas in your search path using a comma separated value syntax as you would do using the SQL statement. Use multiple schemas only if you know what you're doing. The default search path
+This will be the equivalent of using the following SQL statement `SET search_path to mySchema`. This feature requires you to create the schema prior to setting it. Moreover, although it's not recommended, you can set multiple schemas in your search path using a comma separated value syntax as you would do using the SQL statement. Use multiple schemas only if you know what you're doing.
 
 If you don't want to type these variables each time you start Botpress, we also support `.env` files. Check out our [configuration section](../advanced/configuration) for more information.
 

--- a/docs/guide/docs/infrastructure/database.md
+++ b/docs/guide/docs/infrastructure/database.md
@@ -27,7 +27,7 @@ You can also set the PostgreSQL Schema Search Path for every database connection
 
 - `DATABASE_PG_SEARCH_PATH=mySchema`
 
-This will be the equivalent of using the following SQL statement `SET search_path to mySchema`. Although it's not recommended, you can set multiple search path using a comma sperated value syntax as you would do using the sql statement. Use multiple search path only if you know what you're doing. The default search path
+This will be the equivalent of using the following SQL statement `SET search_path to mySchema`. This feature requires you to create the schema prior to setting it. More oever, although it's not recommended, you can set multiple search path using a comma sperated value syntax as you would do using the sql statement. Use multiple search path only if you know what you're doing. The default search path
 
 If you don't want to type those variables each time you start Botpress, we also support `.env` files. Check out our [configuration section](../advanced/configuration) for more information about that.
 

--- a/docs/guide/docs/infrastructure/database.md
+++ b/docs/guide/docs/infrastructure/database.md
@@ -29,7 +29,7 @@ You can also set the PostgreSQL Schema Search Path for every database connection
 
 This will be the equivalent of using the following SQL statement `SET search_path to mySchema`. This feature requires you to create the schema prior to setting it. More oever, although it's not recommended, you can set multiple search path using a comma sperated value syntax as you would do using the sql statement. Use multiple search path only if you know what you're doing. The default search path
 
-If you don't want to type those variables each time you start Botpress, we also support `.env` files. Check out our [configuration section](../advanced/configuration) for more information about that.
+If you don't want to type these variables each time you start Botpress, we also support `.env` files. Check out our [configuration section](../advanced/configuration) for more information.
 
 ## Accessing databases
 

--- a/src/bp/core/database/index.ts
+++ b/src/bp/core/database/index.ts
@@ -86,10 +86,12 @@ export default class Database {
     }
 
     if (databaseType === 'postgres') {
+      const searchPath = (process.env.DATABASE_PG_SEARCH_PATH || 'public').split(',')
       Object.assign(config, {
         client: 'pg',
         connection: databaseUrl,
-        pool: poolOptions
+        pool: poolOptions,
+        searchPath
       })
     } else {
       const dbLocation = databaseUrl ? databaseUrl : `${process.PROJECT_LOCATION}/data/storage/core.sqlite`


### PR DESCRIPTION
In a multi environment setup PostgreSQL schema might come handy. As of now it's impossible to set the current schema for a running botpress instance. This small PR adds the feature.

Example use case:
This means that a user can have a single `bp` database with different schemas for each environment (eg. staging & prod).
Using `DATABASE_PG_SEARCH_PATH=staging`, will scope every relation and data to the `staging` schema.