### PR TITLE
chore(core): expressjs use res.sendStatus

### DIFF
--- a/modules/nlu-testing/src/backend/api.ts
+++ b/modules/nlu-testing/src/backend/api.ts
@@ -108,7 +108,7 @@ export default async (bp: typeof sdk) => {
       res.send(result)
     } catch (err) {
       bp.logger.warn('could not get response from converse api', err)
-      res.send(400)
+      res.sendStatus(400)
     }
   })
 

--- a/src/bp/core/routers/bots/nlu.ts
+++ b/src/bp/core/routers/bots/nlu.ts
@@ -206,7 +206,7 @@ export class NLURouter extends CustomRouter {
             .forBot(botId)
             .attachError(err)
             .error(`Could not get entity ${entityName}`)
-          res.send(400)
+          res.sendStatus(400)
         }
       })
     )

--- a/src/bp/studio/flows/flows-router.ts
+++ b/src/bp/studio/flows/flows-router.ts
@@ -67,7 +67,7 @@ export class FlowsRouter extends CustomStudioRouter {
           res.sendStatus(200)
         } catch (err) {
           if (err.type && err.type === MutexError.name) {
-            return res.send(423) // Mutex locked
+            return res.sendStatus(423) // Mutex locked
           }
 
           throw new UnexpectedError('Error saving flow', err)


### PR DESCRIPTION
This PR fixes some deprecation warning that ExpressJS was sending when using `res.send(status)` instead of (res.sendStatus(status)`