### PR TITLE
chore(nlu): pass all required options to standalone NLU

### DIFF
--- a/modules/nlu/src/backend/bootstrap.ts
+++ b/modules/nlu/src/backend/bootstrap.ts
@@ -25,9 +25,14 @@ export async function bootStrap(bp: typeof sdk): Promise<NonBlockingNluApplicati
     )
   }
 
-  const stanEndpoint = 'http://localhost:3200' // TODO: get this from config
-  const stanClient = new StanClient(stanEndpoint)
-  const engine = new StanEngine(stanClient, process.APP_SECRET)
+  const { standaloneNLU } = globalConfig
+  const defaultStanConfig = { endpoint: 'http://localhost:3200', authToken: process.APP_SECRET }
+  const { endpoint: stanURL, authToken: stanToken } = standaloneNLU ?? defaultStanConfig
+
+  const stanClient = new StanClient(stanURL, stanToken)
+
+  const modelPassword = '' // No need for password as Stan is protected by an auth token
+  const engine = new StanEngine(stanClient, modelPassword)
 
   const socket = getWebsocket(bp)
 

--- a/modules/nlu/src/backend/bootstrap.ts
+++ b/modules/nlu/src/backend/bootstrap.ts
@@ -26,10 +26,11 @@ export async function bootStrap(bp: typeof sdk): Promise<NonBlockingNluApplicati
   }
 
   const { standaloneNLU } = globalConfig
-  const defaultStanConfig = { endpoint: 'http://localhost:3200', authToken: process.APP_SECRET }
-  const { endpoint: stanURL, authToken: stanToken } = standaloneNLU ?? defaultStanConfig
+  const { endpoint, authToken } = standaloneNLU.autoStart
+    ? { endpoint: 'http://localhost:3200', authToken: process.APP_SECRET }
+    : standaloneNLU
 
-  const stanClient = new StanClient(stanURL, stanToken)
+  const stanClient = new StanClient(endpoint, authToken)
 
   const modelPassword = '' // No need for password as Stan is protected by an auth token
   const engine = new StanEngine(stanClient, modelPassword)

--- a/modules/nlu/src/backend/stan/client.ts
+++ b/modules/nlu/src/backend/stan/client.ts
@@ -22,7 +22,8 @@ export class StanClient {
 
   constructor(private _stanEndpoint: string, private _authToken?: string) {
     this._client = axios.create({
-      baseURL: this._stanEndpoint
+      baseURL: this._stanEndpoint,
+      headers: { Authorization: `Bearer ${this._authToken}` }
     })
   }
 

--- a/modules/nlu/src/config.ts
+++ b/modules/nlu/src/config.ts
@@ -3,12 +3,14 @@ interface LanguageSource {
   authToken?: string
 }
 
+type StanConfig = { autoStart: true } | ({ autoStart: false } & LanguageSource)
+
 export interface Config {
   /**
-   * If you want to host the Standalone NLU Engine on a different machine than the current one,
-   * you can run the nlu server on a different computer with `bp nlu` and set its URL here
+   * If you want to manually start standalone NLU, set autoStart to false and specify endpoint and auth token.
+   * @default { "autoStart": true }
    */
-  standaloneNLU?: LanguageSource
+  standaloneNLU: StanConfig
 
   /**
    * If you want a fully on-prem installation, you can host

--- a/modules/nlu/src/config.ts
+++ b/modules/nlu/src/config.ts
@@ -5,10 +5,10 @@ interface LanguageSource {
 
 export interface Config {
   /**
-   * If you want to host the Standalone NLU Engine (STAN) on a different machine than the current one,
+   * If you want to host the Standalone NLU Engine on a different machine than the current one,
    * you can run the nlu server on a different computer with `bp nlu` and set its URL here
    */
-  STANUrl?: string
+  standaloneNLU?: LanguageSource
 
   /**
    * If you want a fully on-prem installation, you can host

--- a/src/bp/core/app/botpress.ts
+++ b/src/bp/core/app/botpress.ts
@@ -184,9 +184,9 @@ export class Botpress {
   private async maybeStartLocalSTAN() {
     const config = await this.moduleLoader.configReader.getGlobal('nlu')
 
-    if (config.standaloneNLU) {
+    if (!config.standaloneNLU.autoStart) {
       const { endpoint } = config.standaloneNLU
-      this.logger.info(`Standalone NLU handled by user at endpoint: ${endpoint}`)
+      this.logger.info(`Standalone NLU manually handled at: ${endpoint}`)
       return
     }
     startLocalSTANServer({

--- a/src/bp/core/app/botpress.ts
+++ b/src/bp/core/app/botpress.ts
@@ -184,14 +184,16 @@ export class Botpress {
   private async maybeStartLocalSTAN() {
     const config = await this.moduleLoader.configReader.getGlobal('nlu')
 
-    if (config.STANUrl) {
+    if (config.standaloneNLU) {
+      const { endpoint } = config.standaloneNLU
+      this.logger.info(`Standalone NLU handled by user at endpoint: ${endpoint}`)
       return
     }
     startLocalSTANServer({
-      languageURL: config.languageSources[0].endpoint,
-      languageAuthToken: config.languageSources[0].AuthToken,
+      languageSources: config.languageSources,
       ducklingURL: config.ducklingURL,
-      ducklingEnabled: config.ducklingEnabled
+      ducklingEnabled: config.ducklingEnabled,
+      dbURL: process.core_env.BPFS_STORAGE === 'database' ? process.core_env.DATABASE_URL : undefined
     })
   }
 

--- a/src/bp/nlu/stan/api.ts
+++ b/src/bp/nlu/stan/api.ts
@@ -36,13 +36,17 @@ import {
 export interface APIOptions {
   host: string
   port: number
+
   authToken?: string
+
   limitWindow: string
   limit: number
+
   bodySize: string
   batchSize: number
+
   silent: boolean
-  modelCacheSize: string
+
   dbURL?: string
 }
 

--- a/src/bp/nlu/stan/config.ts
+++ b/src/bp/nlu/stan/config.ts
@@ -1,0 +1,33 @@
+import { LanguageSource } from 'nlu/engine'
+import { APIOptions } from './api'
+
+export type CommandLineOptions = APIOptions & {
+  languageURL: string
+  languageAuthToken?: string
+  ducklingURL: string
+  ducklingEnabled: boolean
+  modelCacheSize: string
+}
+
+export type StanOptions = APIOptions & {
+  languageSources: LanguageSource[] // when passed by env variable, there can be more than one lang server
+  ducklingURL: string
+  ducklingEnabled: boolean
+  modelCacheSize: string
+}
+
+export const mapCli = (c: CommandLineOptions): StanOptions => {
+  const { ducklingEnabled, ducklingURL, modelCacheSize, languageURL, languageAuthToken } = c
+  return {
+    ...c,
+    languageSources: [
+      {
+        endpoint: languageURL,
+        authToken: languageAuthToken
+      }
+    ],
+    ducklingEnabled,
+    ducklingURL,
+    modelCacheSize
+  }
+}

--- a/src/bp/stan-launcher.ts
+++ b/src/bp/stan-launcher.ts
@@ -1,0 +1,63 @@
+import child_process from 'child_process'
+import path from 'path'
+
+export interface LanguageSource {
+  endpoint: string
+  authToken?: string
+}
+
+export interface StanOptions {
+  host: string
+  port: number
+  authToken?: string
+
+  limitWindow?: string
+  limit: number
+  bodySize: string
+  batchSize: number
+  dbURL?: string
+
+  // engine options
+  languageSources: LanguageSource[]
+  ducklingURL: string
+  ducklingEnabled: boolean
+  modelCacheSize: string
+}
+
+const DEFAULT_STAN_OPTIONS: StanOptions = {
+  host: 'localhost',
+  port: 3200,
+  authToken: process.APP_SECRET,
+  limit: 0,
+  bodySize: '2mb', // should be more than enough based on empirical trials
+  batchSize: 1, // one predict at a time
+  languageSources: [
+    {
+      endpoint: 'https://lang-01.botpress.io'
+    }
+  ],
+  ducklingURL: 'https://duckling.botpress.io',
+  ducklingEnabled: true,
+  modelCacheSize: '850mb'
+}
+
+export const runStan = (opts: Partial<StanOptions>): Promise<{ code: number | null; signal: string | null }> => {
+  const options = { ...DEFAULT_STAN_OPTIONS, ...opts }
+
+  return new Promise((resolve, reject) => {
+    try {
+      const STAN_JSON_CONFIG = JSON.stringify(options)
+      const command = path.join(__dirname, 'index.js') // TODO change this when we have a bin
+      const stanProcess = child_process.fork(command, ['nlu', '--silent'], {
+        env: { ...process.env, STAN_JSON_CONFIG },
+        stdio: 'inherit'
+      })
+
+      stanProcess.on('exit', (code, signal) => {
+        resolve({ code, signal })
+      })
+    } catch (err) {
+      reject(err)
+    }
+  })
+}

--- a/src/bp/stan-launcher.ts
+++ b/src/bp/stan-launcher.ts
@@ -10,6 +10,7 @@ export interface StanOptions {
   host: string
   port: number
   authToken?: string
+  silent: boolean
 
   limitWindow?: string
   limit: number
@@ -38,7 +39,8 @@ const DEFAULT_STAN_OPTIONS: StanOptions = {
   ],
   ducklingURL: 'https://duckling.botpress.io',
   ducklingEnabled: true,
-  modelCacheSize: '850mb'
+  modelCacheSize: '850mb',
+  silent: true
 }
 
 export const runStan = (opts: Partial<StanOptions>): Promise<{ code: number | null; signal: string | null }> => {
@@ -48,7 +50,7 @@ export const runStan = (opts: Partial<StanOptions>): Promise<{ code: number | nu
     try {
       const STAN_JSON_CONFIG = JSON.stringify(options)
       const command = path.join(__dirname, 'index.js') // TODO change this when we have a bin
-      const stanProcess = child_process.fork(command, ['nlu', '--silent'], {
+      const stanProcess = child_process.fork(command, ['nlu'], {
         env: { ...process.env, STAN_JSON_CONFIG },
         stdio: 'inherit'
       })


### PR DESCRIPTION
This PR is, I believe, the last thing needed to merge our first extraction.

It does 3 things:
1 - In NLU module, stan client uses the provided stan endpoint and auth-token if defined in module config.
2 - In `botpress.ts`, botpress passes all language sources instead of only the first one.
3 - In Stan, we accept 2 different format of config: one by CLI and one by json env variable.

If this passes our QA. I think we're good to merge the base branch.
