### PR TITLE
fix(channel-web): fix conversationId validation bypass

### DIFF
--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -33,6 +33,8 @@ const SUPPORTED_MESSAGES = [
 
 type ChatRequest = BPRequest & { userId: string; botId: string; conversationId: number }
 
+const isInt = (str: string) => !isNaN(parseInt(str))
+
 const userIdIsValid = (userId: string): boolean => {
   const hasBreakingConstraints = userId.length > USER_ID_MAX_LENGTH || userId.toLowerCase() === 'undefined'
 
@@ -119,12 +121,14 @@ export default async (bp: typeof sdk, db: Database) => {
       return next(ERR_USER_ID_INVALID)
     }
 
-    if (conversationId && conversationId !== 'null') {
-      req.conversationId = parseInt(conversationId)
+    if (isInt(conversationId)) {
+      const parsedConversationId = parseInt(conversationId)
 
-      if (!(await db.isValidConversationOwner(userId, req.conversationId, botId))) {
+      if (!(await db.isValidConversationOwner(userId, parsedConversationId, botId))) {
         next(ERR_BAD_CONV_ID)
       }
+
+      req.conversationId = parsedConversationId
     }
 
     if (options.convoIdRequired && req.conversationId === undefined) {


### PR DESCRIPTION
This PR fixes an issue where making a call to the back-end of channel-web where conversationId is required could be bypassed by sending a convoId of '0'.

Tested with those payloads:

```js
// return 400 bad request: `conversationId` is required and must be valid
{"webSessionId":"/guest#Ir_W6YlueLS91D8IAAAE", "conversationId": "", "payload":{"type":"text","text":"ok"}}
```
```js
// return 400 bad request: `conversationId` is required and must be valid
{"webSessionId":"/guest#Ir_W6YlueLS91D8IAAAE", "conversationId": null, "payload":{"type":"text","text":"ok"}}
```
```js
// return 400 bad request: `conversationId` is required and must be valid
{"webSessionId":"/guest#Ir_W6YlueLS91D8IAAAE", "payload":{"type":"text","text":"ok"}}
```
```js
// return 400 bad request: The conversation ID doesn't belong to that user
{"webSessionId":"/guest#Ir_W6YlueLS91D8IAAAE", "conversationId": "0", "payload":{"type":"text","text":"ok"}}
```
```js
// return 200 OK
{"webSessionId":"/guest#Ir_W6YlueLS91D8IAAAE", "conversationId": "5", "payload":{"type":"text","text":"ok"}}
```