### PR TITLE
feat(core): allow middlewares to override timeout limit of runtime duration

### DIFF
--- a/src/bp/core/events/event-engine.ts
+++ b/src/bp/core/events/event-engine.ts
@@ -76,7 +76,8 @@ const mwSchema = {
     .regex(directionRegex)
     .required(),
   order: joi.number().default(0),
-  enabled: joi.boolean().default(true)
+  enabled: joi.boolean().default(true),
+  timeout: joi.string().optional()
 }
 
 const debug = DEBUG('middleware')

--- a/src/bp/core/events/middleware-chain.test.ts
+++ b/src/bp/core/events/middleware-chain.test.ts
@@ -5,27 +5,35 @@ import 'jest-extended'
 import 'reflect-metadata'
 
 import { MiddlewareChain } from './middleware-chain'
+import { StepScopes, StepStatus } from './utils'
 
 const base = { description: 'test', order: 1, direction: <EventDirection>'incoming' }
+const defaultTimeout = 5
+
 describe('Middleware', () => {
   let middleware: MiddlewareChain
   let event: MockObject<IO.Event>
 
   beforeEach(() => {
-    middleware = new MiddlewareChain({ timeoutInMs: 5 })
+    middleware = new MiddlewareChain({ timeoutInMs: defaultTimeout })
     event = createSpyObject<IO.Event>()
+  })
+
+  afterEach(async () => {
+    // Makes sure the timeout promise has time to finish
+    await Promise.delay(defaultTimeout)
   })
 
   it('should call middleware in order', async () => {
     const mock1 = jest.fn()
     const mock2 = jest.fn()
 
-    const fn1 = (event, next) => {
+    const fn1 = (event: IO.Event, next: IO.MiddlewareNextCallback) => {
       mock1(event)
       next()
     }
 
-    const fn2 = (event, next) => {
+    const fn2 = (event: IO.Event, next: IO.MiddlewareNextCallback) => {
       mock2(event)
       next()
     }
@@ -42,7 +50,7 @@ describe('Middleware', () => {
     const mock1 = jest.fn()
     const mock2 = jest.fn()
 
-    const fn1 = (event, next) => {
+    const fn1 = (event: IO.Event, next: IO.MiddlewareNextCallback) => {
       mock1(event)
       next(undefined, true) // We swallow the event
     }
@@ -60,7 +68,7 @@ describe('Middleware', () => {
     const mock1 = jest.fn()
     const mock2 = jest.fn()
 
-    const fn1 = (event, next) => {
+    const fn1 = (event: IO.Event, next: IO.MiddlewareNextCallback) => {
       mock1(event)
       next(undefined, false, true) // Mark the first mw as skipped
     }
@@ -96,7 +104,7 @@ describe('Middleware', () => {
     const err = new Error('lol')
 
     middleware.use({
-      handler: event => {
+      handler: _event => {
         throw err
       },
       name: 'throw',
@@ -105,5 +113,60 @@ describe('Middleware', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     expect(middleware.run({} as IO.Event)).rejects.toEqual(err)
+  })
+
+  it('if should set the timed out processing step on the event if the mw hits the timeout limit', async () => {
+    const extraTime = 10
+    const mock = jest.fn(async (_event: IO.Event) => {
+      await Promise.delay(defaultTimeout + extraTime)
+    })
+
+    const mw = {
+      handler: async (event: IO.Event, cb: IO.MiddlewareNextCallback) => {
+        await mock(event)
+        cb(undefined, true)
+      },
+      name: 'event',
+      ...base
+    }
+    const processingKey = `${StepScopes.Middleware}:${mw.name}:${StepStatus.TimedOut}`
+
+    middleware.use(mw)
+
+    await middleware.run(event.T)
+    expect(mock).toHaveBeenCalled()
+    expect(event.processing![processingKey]).not.toBeUndefined()
+
+    // make sure the promise has time to finis
+    await Promise.delay(extraTime)
+  })
+
+  it('if should let mw set a custom timeout value', async () => {
+    const extraTime = 10
+    const mock = jest.fn(async (_event: IO.Event) => {
+      await Promise.delay(defaultTimeout + extraTime)
+    })
+
+    const mw = {
+      handler: async (event: IO.Event, cb: IO.MiddlewareNextCallback) => {
+        await mock(event)
+        cb(undefined, true)
+      },
+      name: 'event',
+      timeout: `${defaultTimeout + extraTime * 2}ms`,
+      ...base
+    }
+    const timedOutProcessingKey = `${StepScopes.Middleware}:${mw.name}:${StepStatus.TimedOut}`
+    const swallowedProcessingKey = `${StepScopes.Middleware}:${mw.name}:${StepStatus.Swallowed}`
+
+    middleware.use(mw)
+
+    await middleware.run(event.T)
+    expect(mock).toHaveBeenCalled()
+    expect(event.processing![timedOutProcessingKey]).toBeUndefined()
+    expect(event.processing![swallowedProcessingKey]).not.toBeUndefined()
+
+    // make sure the promise has time to finis
+    await Promise.delay(extraTime)
   })
 })

--- a/src/bp/core/events/middleware-chain.test.ts
+++ b/src/bp/core/events/middleware-chain.test.ts
@@ -137,7 +137,7 @@ describe('Middleware', () => {
     expect(mock).toHaveBeenCalled()
     expect(event.processing![processingKey]).not.toBeUndefined()
 
-    // make sure the promise has time to finis
+    // make sure the promise has time to finish
     await Promise.delay(extraTime)
   })
 
@@ -166,7 +166,7 @@ describe('Middleware', () => {
     expect(event.processing![timedOutProcessingKey]).toBeUndefined()
     expect(event.processing![swallowedProcessingKey]).not.toBeUndefined()
 
-    // make sure the promise has time to finis
+    // make sure the promise has time to finish
     await Promise.delay(extraTime)
   })
 })

--- a/src/bp/core/events/middleware-chain.ts
+++ b/src/bp/core/events/middleware-chain.ts
@@ -8,26 +8,32 @@ interface MiddlewareChainOptions {
   timeoutInMs: number
 }
 
+interface MiddlewareProperties {
+  mw: sdk.IO.MiddlewareHandler
+  name: string
+  timeoutInMs: number
+}
+
 const defaultOptions = {
   timeoutInMs: ms('2s')
 }
 
 export class MiddlewareChain {
-  private stack: { mw: sdk.IO.MiddlewareHandler; name: string; timeout: number }[] = []
+  private stack: MiddlewareProperties[] = []
 
   constructor(private options: MiddlewareChainOptions = defaultOptions) {
     this.options = { ...defaultOptions, ...options }
   }
 
   use({ handler, name, timeout }: sdk.IO.MiddlewareDefinition) {
-    const timeoutInMs = timeout ? ms(timeout) : 0
-    this.stack.push({ mw: handler, name, timeout: timeoutInMs })
+    const timeoutInMs = timeout ? ms(timeout) : this.options.timeoutInMs
+    this.stack.push({ mw: handler, name, timeoutInMs })
   }
 
   async run(event: sdk.IO.Event) {
-    for (const { mw, name, timeout } of this.stack) {
+    for (const { mw, name, timeoutInMs } of this.stack) {
       let timedOut = false
-      const timePromise = new Promise(() => {}).timeout(timeout || this.options.timeoutInMs).catch(() => {
+      const timePromise = new Promise(() => {}).timeout(timeoutInMs).catch(() => {
         timedOut = true
       })
       const mwPromise = Promise.fromCallback<boolean>(cb => mw(event, cb), { multiArgs: true })

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -917,7 +917,11 @@ declare module 'botpress/sdk' {
       handler: MiddlewareHandler
       /** Indicates if this middleware should act on incoming or outgoing events */
       direction: EventDirection
-      /** Allows to override the middleware chain timeout limit */
+      /**
+       * Allows to specify a timeout for the middleware instead of using the middleware chain timeout value
+       * @example '500ms', '2s', '5m'
+       * @default '2s'
+       * */
       timeout?: string
     }
 

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -917,6 +917,8 @@ declare module 'botpress/sdk' {
       handler: MiddlewareHandler
       /** Indicates if this middleware should act on incoming or outgoing events */
       direction: EventDirection
+      /** Allows to override the middleware chain timeout limit */
+      timeout?: string
     }
 
     export interface EventConstructor {


### PR DESCRIPTION
This PR allows, in the middleware definition, to specify a timeout limit for the middleware runtime duration.

Another option would be to have a `bypassTimeout` property. But, in either case, I need a way to be able to run a particular middleware for a variable amount of time.