### PR TITLE
fix(core): removed empty object in default alerting rules

### DIFF
--- a/src/bp/core/config/botpress.config.ts
+++ b/src/bp/core/config/botpress.config.ts
@@ -640,6 +640,7 @@ export interface AlertingConfig {
   /**
    * The list of rules which triggers an incident. When triggered, the OnIncidentChangedStatus hook
    * is called with the incident.
+   * @default []
    */
   rules: IncidentRule[]
 }

--- a/src/bp/core/config/config-loader.ts
+++ b/src/bp/core/config/config-loader.ts
@@ -113,6 +113,10 @@ export class ConfigProvider {
     const content = await this.ghostService.global().readFileAsString('/', 'botpress.config.json')
     const config = _.merge(JSON.parse(content), partialConfig)
 
+    await this.setBotpressConfig(config, clearHash)
+  }
+
+  async setBotpressConfig(config: BotpressConfig, clearHash?: boolean): Promise<void> {
     await this.ghostService.global().upsertFile('/', 'botpress.config.json', stringify(config))
 
     if (clearHash) {

--- a/src/bp/migrations/v12_21_2-1620240653-fix_empty_alerting_rules.ts
+++ b/src/bp/migrations/v12_21_2-1620240653-fix_empty_alerting_rules.ts
@@ -1,0 +1,29 @@
+import * as sdk from 'botpress/sdk'
+import { Migration, MigrationOpts } from 'core/migration'
+import { isEmpty } from 'lodash'
+
+const migration: Migration = {
+  info: {
+    description: 'Removes empty object in default alerting rules config',
+    target: 'core',
+    type: 'config'
+  },
+  up: async ({ configProvider }: MigrationOpts): Promise<sdk.MigrationResult> => {
+    const config = await configProvider.getBotpressConfig()
+
+    if (!config.pro.alerting.rules.length || !isEmpty(config.pro.alerting.rules[0])) {
+      return { success: true, message: 'Skipping migration since alerting rules are already defined' }
+    }
+
+    config.pro.alerting.rules = []
+
+    await configProvider.setBotpressConfig(config)
+
+    return { success: true, message: 'Configuration updated successfully' }
+  },
+  down: async (): Promise<sdk.MigrationResult> => {
+    return { success: true, message: 'Skipping migration...' }
+  }
+}
+
+export default migration


### PR DESCRIPTION
This PR fixes an issue (#4546) where enabling alerting could result in Botpress not being able to boot.

Since there was no default value set for the alerting rules in the `botpress.config.ts` file, the default config would contain an empty object (`IncidentRule`).

e.g.

```js
"alerting": {
      "enabled": false,
      "watcherInterval": "10s",
      "retentionPeriod": "10d",
      "janitorInterval": "15m",
      "rules": [
        {} // <--
      ]
    },
```

Then, once you decided to enable the alerting service, and restarted Botpress, the application would crash with this error:

![Screenshot from 2021-05-05 14-42-00](https://user-images.githubusercontent.com/9640576/117199029-b7d8ef00-adb7-11eb-844b-756081d55a8b.png)

This is due to the fact that the `pro-alerting-service.ts` checks if the rules are empty (which is not the case since it contains an object) and then calls `ms` with `rule.timeframe` which is undefined causing the library to throw this error.