### PR TITLE
fix(nlu): prediction error logging

### DIFF
--- a/modules/nlu/src/backend/application/scoped/prediction-handler.ts
+++ b/modules/nlu/src/backend/application/scoped/prediction-handler.ts
@@ -71,7 +71,7 @@ export class ScopedPredictionHandler {
       }
     }
 
-    if (this.isEmpty(nluResults) || this.isError(nluResults)) {
+    if (this.isEmpty(nluResults)) {
       throw new Error(`No model found for the following languages: ${languagesToTry}`)
     }
 


### PR DESCRIPTION
We shouldnt throw if the error comes from `engine.predict()`. We should return and EventUnderstanding with `{ errored: true }` instead.