### PR TITLE
chore(nlu): upgrade nlu version to 0.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "license": "AGPL-3.0",
   "private": true,
   "nlu": {
-    "version": "0.0.1",
-    "downloadURL": "https://github.com/botpress/nlu/releases/download/v0.0.1"
+    "version": "0.0.2",
+    "downloadURL": "https://github.com/botpress/nlu/releases/download/v0.0.2"
   },
   "scripts": {
     "postinstall": "yarn cmd install:nlu",


### PR DESCRIPTION
There's still no change log I can point to in nlu repo, but basically,

Previously nlu:0.0.1 you could not train an empty bot and now in nlu:0.0.2, you can