### PR TITLE
fix(nlu): no more nlu token when nlu server is auto started

### DIFF
--- a/modules/nlu/src/backend/bootstrap.ts
+++ b/modules/nlu/src/backend/bootstrap.ts
@@ -1,6 +1,5 @@
 import * as sdk from 'botpress/sdk'
 
-import crypto from 'crypto'
 import _ from 'lodash'
 
 import { Config, LanguageSource } from '../config'
@@ -16,21 +15,10 @@ import { BotDefinition } from './application/typings'
 import { StanEngine } from './stan'
 import { StanClient } from './stan/client'
 
-const makeNLUPassword = () => {
-  const random = Math.random() * 10 ** 10
-  const text = `${random}`
-  return crypto
-    .createHash('md5')
-    .update(text)
-    .digest('hex')
-}
-
 const getNLUServerConfig = (config: Config['nluServer']): LanguageSource => {
   if (config.autoStart) {
-    process.NLU_PASSWORD = makeNLUPassword() // will be used by core
     return {
-      endpoint: 'http://localhost:3200',
-      authToken: process.NLU_PASSWORD
+      endpoint: 'http://localhost:3200'
     }
   }
 

--- a/modules/nlu/src/backend/bootstrap.ts
+++ b/modules/nlu/src/backend/bootstrap.ts
@@ -1,5 +1,6 @@
 import * as sdk from 'botpress/sdk'
 
+import { makeNLUPassword } from 'common/nlu-token'
 import _ from 'lodash'
 
 import { Config, LanguageSource } from '../config'
@@ -18,7 +19,8 @@ import { StanClient } from './stan/client'
 const getNLUServerConfig = (config: Config['nluServer']): LanguageSource => {
   if (config.autoStart) {
     return {
-      endpoint: 'http://localhost:3200'
+      endpoint: 'http://localhost:3200',
+      authToken: makeNLUPassword()
     }
   }
 

--- a/src/bp/common/nlu-token.ts
+++ b/src/bp/common/nlu-token.ts
@@ -1,0 +1,13 @@
+import crypto from 'crypto'
+
+/**
+ * @description generates a token based on process app-secret for nlu client (in nlu module) to communicate with nlu server.
+ * @returns the token
+ */
+export const makeNLUPassword = () => {
+  const text = `nlu-${process.APP_SECRET}`
+  return crypto
+    .createHash('sha512')
+    .update(text)
+    .digest('hex')
+}

--- a/src/bp/core/app/botpress.ts
+++ b/src/bp/core/app/botpress.ts
@@ -194,8 +194,7 @@ export class Botpress {
       legacyElection: config.legacyElection,
       dbURL: process.core_env.BPFS_STORAGE === 'database' ? process.core_env.DATABASE_URL : undefined,
       modelDir: process.cwd(),
-      modelCacheSize: config.modelCacheSize,
-      authToken: process.NLU_PASSWORD // defined by nlu module
+      modelCacheSize: config.modelCacheSize
     })
   }
 

--- a/src/bp/core/app/botpress.ts
+++ b/src/bp/core/app/botpress.ts
@@ -1,5 +1,6 @@
 import * as sdk from 'botpress/sdk'
 import lang from 'common/lang'
+import { makeNLUPassword } from 'common/nlu-token'
 import { createForGlobalHooks } from 'core/app/api'
 import { BotService, BotMonitoringService } from 'core/bots'
 import { GhostService } from 'core/bpfs'
@@ -194,7 +195,8 @@ export class Botpress {
       legacyElection: config.legacyElection,
       dbURL: process.core_env.BPFS_STORAGE === 'database' ? process.core_env.DATABASE_URL : undefined,
       modelDir: process.cwd(),
-      modelCacheSize: config.modelCacheSize
+      modelCacheSize: config.modelCacheSize,
+      authToken: makeNLUPassword()
     })
   }
 

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -21,7 +21,6 @@ declare namespace NodeJS {
     IS_PRODUCTION: boolean // TODO: look to remove this
     BPFS_STORAGE: 'database' | 'disk'
     APP_SECRET: string
-    NLU_PASSWORD: string | undefined
     /**
      * Path to the global APP DATA folder, shared across all installations of Botpress Server
      * Use this folder to store stuff you'd like to cache, like NLU language models etc


### PR DESCRIPTION
Currently on master when you unmount/mount-back the nlu module, you change the NLU-token used to communicate with the nlu server so you can't communicate with it anymore.

Now, the NLU-token is constant through all reboots/reloads so reloading the NLU module simply re-computes the same NLU-token has it had prior to reloading.

