### PR TITLE
chore(core): event ids and message ids are shared

### DIFF
--- a/src/bp/core/app/api.ts
+++ b/src/bp/core/app/api.ts
@@ -15,9 +15,9 @@ import { EventEngine, EventRepository, Event } from 'core/events'
 import { KeyValueStore } from 'core/kvs'
 import { LoggerProvider } from 'core/logger'
 import * as logEnums from 'core/logger/enums'
-import { MappingRepository } from 'core/mapping/mapping-repository'
 import { MediaServiceProvider } from 'core/media'
-import { ConversationService, MessageService } from 'core/messaging'
+import { ConversationService } from 'core/messaging'
+import { ChatService } from 'core/messaging/chat-service'
 import { ModuleLoader } from 'core/modules'
 import { RealtimeService, RealTimePayload } from 'core/realtime'
 import { getMessageSignature } from 'core/security'
@@ -195,14 +195,14 @@ const distributed = (jobService: JobService): typeof sdk.distributed => {
 const experimental = (
   hookService: HookService,
   conversationService: ConversationService,
-  messageService: MessageService,
+  chatService: ChatService,
   renderService: RenderService
 ): typeof sdk.experimental => {
   return {
     disableHook: hookService.disableHook.bind(hookService),
     enableHook: hookService.enableHook.bind(hookService),
     conversations: conversations(conversationService),
-    messages: messages(messageService),
+    messages: messages(chatService),
     render: render(renderService)
   }
 }
@@ -213,9 +213,9 @@ const conversations = (conversationService: ConversationService): typeof sdk.exp
   }
 }
 
-const messages = (messageService: MessageService): typeof sdk.experimental.messages => {
+const messages = (chatService: ChatService): typeof sdk.experimental.messages => {
   return {
-    forBot: messageService.forBot.bind(messageService)
+    forBot: chatService.forBot.bind(chatService)
   }
 }
 
@@ -286,9 +286,8 @@ export class BotpressAPIProvider {
     @inject(TYPES.JobService) jobService: JobService,
     @inject(TYPES.StateManager) stateManager: StateManager,
     @inject(TYPES.ConversationService) conversationService: ConversationService,
-    @inject(TYPES.MessageService) messageService: MessageService,
-    @inject(TYPES.RenderService) renderService: RenderService,
-    @inject(TYPES.MappingRepository) mappingRepo: MappingRepository
+    @inject(TYPES.ChatService) chatService: ChatService,
+    @inject(TYPES.RenderService) renderService: RenderService
   ) {
     this.http = http(httpServer)
     this.events = event(eventEngine, eventRepo)
@@ -301,7 +300,7 @@ export class BotpressAPIProvider {
     this.bots = bots(botService)
     this.ghost = ghost(ghostService)
     this.cms = cms(cmsService, mediaServiceProvider)
-    this.experimental = experimental(hookService, conversationService, messageService, renderService)
+    this.experimental = experimental(hookService, conversationService, chatService, renderService)
     this.security = security()
     this.workspaces = workspaces(workspaceService)
     this.distributed = distributed(jobService)

--- a/src/bp/core/app/inversify/services.inversify.ts
+++ b/src/bp/core/app/inversify/services.inversify.ts
@@ -12,6 +12,7 @@ import { KeyValueStore } from 'core/kvs'
 import { LogsJanitor } from 'core/logger'
 import { MediaServiceProvider } from 'core/media'
 import { MessageService, ConversationService } from 'core/messaging'
+import { ChatService } from 'core/messaging/chat-service'
 import { RealtimeService } from 'core/realtime'
 import { AuthService, AuthStrategies, CEAuthStrategies } from 'core/security'
 import { StatsService } from 'core/telemetry'
@@ -29,6 +30,10 @@ const ServicesContainerModule = new ContainerModule((bind: interfaces.Bind) => {
 
   bind<MessageService>(TYPES.MessageService)
     .to(MessageService)
+    .inSingletonScope()
+
+  bind<ChatService>(TYPES.ChatService)
+    .to(ChatService)
     .inSingletonScope()
 
   bind<CMSService>(TYPES.CMSService)

--- a/src/bp/core/converse/converse-service.ts
+++ b/src/bp/core/converse/converse-service.ts
@@ -2,6 +2,7 @@ import { IO } from 'botpress/sdk'
 import { ConfigProvider } from 'core/config/config-loader'
 import { EventEngine } from 'core/events'
 import { MessageService, ConversationService } from 'core/messaging'
+import { ChatService } from 'core/messaging/chat-service'
 import { TYPES } from 'core/types'
 import { ChannelUserRepository } from 'core/users'
 import { InvalidParameterError } from 'errors'
@@ -32,7 +33,8 @@ export class ConverseService {
     @inject(TYPES.EventEngine) private eventEngine: EventEngine,
     @inject(TYPES.UserRepository) private userRepository: ChannelUserRepository,
     @inject(TYPES.ConversationService) private conversationService: ConversationService,
-    @inject(TYPES.MessageService) private messageService: MessageService
+    @inject(TYPES.MessageService) private messageService: MessageService,
+    @inject(TYPES.ChatService) private chatService: ChatService
   ) {}
 
   @postConstruct()
@@ -102,7 +104,7 @@ export class ConverseService {
     const timeoutPromise = this._createTimeoutPromise(botId, userKey)
     const donePromise = this._createDonePromise(botId, userKey)
 
-    await this.messageService.forBot(botId).receive(conversation.id, payload, {
+    await this.chatService.forBot(botId).receive(conversation.id, payload, {
       channel: 'api',
       credentials,
       nlu: { includedContexts }

--- a/src/bp/core/events/event-sdk-impl.ts
+++ b/src/bp/core/events/event-sdk-impl.ts
@@ -28,7 +28,7 @@ export class IOEvent implements sdk.IO.Event {
     this.botId = args.botId
     this.createdOn = new Date()
     this.threadId = args.threadId ? args.threadId.toString() : undefined
-    this.id = this.makeId()
+    this.id = args.id || this.makeId()
     this.preview = args.preview || this.constructPreview()
     this.flags = {}
     this.state = { __stacktrace: [] }

--- a/src/bp/core/messaging/chat-service.ts
+++ b/src/bp/core/messaging/chat-service.ts
@@ -1,0 +1,181 @@
+import * as sdk from 'botpress/sdk'
+import { TYPES } from 'core/app/types'
+import { JobService } from 'core/distributed'
+import { EventEngine, IOEvent } from 'core/events'
+import { KeyValueStore } from 'core/kvs'
+import { inject, injectable, postConstruct } from 'inversify'
+import { AppLifecycle, AppLifecycleEvents } from 'lifecycle'
+import LRU from 'lru-cache'
+import ms from 'ms'
+
+import { ConversationService, ScopedConversationService } from './conversation-service'
+import { MessageService, ScopedMessageService } from './message-service'
+
+@injectable()
+export class ChatService {
+  private scopes: { [botId: string]: ScopedChatService } = {}
+  private invalidateLastChannel: (botId: string, userId: string, lastChannel: string) => void = this
+    ._localInvalidateLastChannel
+
+  constructor(
+    @inject(TYPES.EventEngine) private eventEngine: EventEngine,
+    @inject(TYPES.JobService) private jobService: JobService,
+    @inject(TYPES.MessageService) private messageService: MessageService,
+    @inject(TYPES.ConversationService) private conversationService: ConversationService,
+    @inject(TYPES.KeyValueStore) private kvs: KeyValueStore
+  ) {}
+
+  @postConstruct()
+  async init() {
+    await AppLifecycle.waitFor(AppLifecycleEvents.CONFIGURATION_LOADED)
+
+    this.eventEngine.onSendIncoming = async event => {
+      await this.forBot(event.botId).updateLastChannel(event.target, event.channel)
+    }
+
+    this.invalidateLastChannel = <any>await this.jobService.broadcast<void>(this._localInvalidateLastChannel.bind(this))
+  }
+
+  private _localInvalidateLastChannel(botId: string, userId: string, lastChannel: string) {
+    this.forBot(botId).localInvalidateLastChannel(userId, lastChannel)
+  }
+
+  public forBot(botId: string): ScopedChatService {
+    let scope = this.scopes[botId]
+    if (!scope) {
+      scope = new ScopedChatService(
+        botId,
+        this.eventEngine,
+        this.messageService.forBot(botId),
+        this.conversationService.forBot(botId),
+        this.kvs,
+        (userId, lastChannel) => this.invalidateLastChannel(botId, userId, lastChannel)
+      )
+      this.scopes[botId] = scope
+    }
+    return scope
+  }
+}
+
+export class ScopedChatService implements sdk.experimental.messages.BotMessages {
+  private lastChannelCache: LRU<string, string>
+
+  constructor(
+    private botId: string,
+    private eventEngine: EventEngine,
+    private messageService: ScopedMessageService,
+    private conversationService: ScopedConversationService,
+    private kvs: KeyValueStore,
+    private invalidateLastChannel: (userId: string, lastChannel: string) => void
+  ) {
+    this.lastChannelCache = new LRU<string, string>({ max: 10000, maxAge: ms('5min') })
+  }
+
+  public create(
+    conversationId: string,
+    payload: any,
+    authorId?: string,
+    eventId?: string,
+    incomingEventId?: string
+  ): Promise<sdk.Message> {
+    return this.messageService.create(conversationId, payload, authorId, eventId, incomingEventId)
+  }
+
+  public delete(filters: sdk.MessageDeleteFilters): Promise<number> {
+    return this.messageService.delete(filters)
+  }
+
+  public get(id: string): Promise<sdk.Message | undefined> {
+    return this.messageService.get(id)
+  }
+
+  public list(filters: sdk.MessageListFilters): Promise<sdk.Message[]> {
+    return this.messageService.list(filters)
+  }
+
+  public async receive(conversationId: sdk.uuid, payload: any, args?: sdk.MessageArgs) {
+    return this.sendMessage(conversationId, payload, 'incoming', args)
+  }
+
+  public async send(conversationId: sdk.uuid, payload: any, args?: sdk.MessageArgs) {
+    return this.sendMessage(conversationId, payload, 'outgoing', args)
+  }
+
+  private async sendMessage(
+    conversationId: sdk.uuid,
+    payload: any,
+    direction: sdk.EventDirection,
+    args?: sdk.MessageArgs
+  ) {
+    const conversation = await this.conversationService.get(conversationId)
+    if (!conversation) {
+      throw new Error(
+        'conversationId: conversation not found. conversationId must be the id of an existing conversation'
+      )
+    }
+
+    let channel = args?.channel
+    if (!channel) {
+      const lastChannel = await this.getLastChannel(conversation.userId)
+      if (!lastChannel) {
+        throw new Error('No previous channel was set for the user. You must provide a channel in the args parameter')
+      }
+      channel = lastChannel
+    } else if (direction === 'incoming') {
+      await this.updateLastChannel(conversation.userId, channel)
+    }
+
+    const authorId = direction === 'incoming' ? conversation.userId : undefined
+    const message = await this.messageService.create(conversationId, payload, authorId)
+
+    const event = new IOEvent(<sdk.IO.EventCtorArgs>{
+      ...args,
+      id: message.id,
+      channel,
+      direction,
+      type: payload.type,
+      payload,
+      threadId: conversation.id,
+      target: conversation.userId,
+      botId: conversation.botId
+    })
+    await this.eventEngine.sendEvent(event)
+
+    return message
+  }
+
+  private async getLastChannel(userId: string): Promise<string | undefined> {
+    const cached = this.lastChannelCache.get(userId)
+    if (cached) {
+      return cached
+    }
+
+    const lastChannel = await this.kvs.forBot(this.botId).get(this.getLastChannelKvsKey(userId))
+    this.lastChannelCache.set(userId, lastChannel)
+
+    return lastChannel
+  }
+
+  public async updateLastChannel(userId: string, channel: string) {
+    const current = this.lastChannelCache.get(userId)
+    if (current === channel) {
+      return
+    }
+
+    await this.kvs.forBot(this.botId).set(this.getLastChannelKvsKey(userId), channel, undefined, '48h')
+    this.invalidateLastChannel(userId, channel)
+  }
+
+  private getLastChannelKvsKey(userId: string) {
+    return `lastChannel_${this.botId}_${userId}`
+  }
+
+  public localInvalidateLastChannel(userId: string, lastChannel: string) {
+    if (userId) {
+      const cachedLastChannel = this.lastChannelCache.peek(userId)
+      if (cachedLastChannel !== lastChannel) {
+        this.lastChannelCache.del(userId)
+      }
+    }
+  }
+}

--- a/src/bp/core/types.ts
+++ b/src/bp/core/types.ts
@@ -90,6 +90,7 @@ const TYPES = {
   MessageRepository: Symbol.for('MessageRepository'),
   ConversationRepository: Symbol.for('ConversationRepository'),
   MessageService: Symbol.for('MessageService'),
+  ChatService: Symbol.for('ChatService'),
   ConversationService: Symbol.for('ConversationService'),
   RenderService: Symbol.for('RenderService'),
   MappingRepository: Symbol.for('MappingRepository')

--- a/src/bp/sdk/botpress.d.ts
+++ b/src/bp/sdk/botpress.d.ts
@@ -459,6 +459,7 @@ declare module 'botpress/sdk' {
      * These are the arguments required when creating a new {@link Event}
      */
     interface EventCtorArgs {
+      id?: string
       type: string
       channel: string
       target: string
@@ -1516,7 +1517,9 @@ declare module 'botpress/sdk' {
   }
 
   export interface MessageArgs
-    extends Partial<Omit<IO.EventCtorArgs, 'type' | 'direction' | 'payload' | 'target' | 'botId' | 'threadId'>> {}
+    extends Partial<
+      Omit<IO.EventCtorArgs, 'id' | 'type' | 'direction' | 'payload' | 'target' | 'botId' | 'threadId'>
+    > {}
 
   export interface MessageDeleteFilters {
     id?: uuid


### PR DESCRIPTION
A problem I noticed doing #4990 is that you can't know which message is associated with an event. So in this PR I fixed it by giving events the same id as their associated message (1:1 relationship). Since the event table could already hold strings, there's no need to do a migration (although it's worth noting that we are storing uuids in string form which isn't ideal).

We now also persist messages in the db directly from the event engine. So we'll be able to remove all the bp.messages.create in the channels. However this introduces a problem for now : if we modify the event payload in a middleware somewhere, the message will not be updated. A way of solving this issue would be to do it the other way around : the event gives the id to the message and persist it in the channel like we were doing before.

Todo: 
- Remove eventId and incomingEventId from messages table
- Created ChatService for now to avoid circular depency. Not great. Could avoid by tansfering a bit of the logic to the MessageRepo and injecting that instead in the EventEngine