### PR TITLE
fix(build): check module-builder image on master only

### DIFF
--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -1,5 +1,8 @@
 name: Module Builder Docker Image
-on: [push]
+on:
+  push:
+    branches:
+      - master
 jobs:
   build_and_push:
     name: Test Module Builder Image

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
-          ls modules/channel-web/channel-we.tgz || exit 1
+          ls modules/channel-web/channel-web.tgz || exit 1
       - name: Build has failed
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -11,7 +11,7 @@ jobs:
         run: |
           docker build -t module-builder-test -f build/module-builder/Dockerfile .
           docker run -v `pwd`/modules/channel-web:/botpress/modules/channel-web module-builder-test sh -c 'cd modules/channel-web && yarn && yarn build && yarn package'
-          ls modules/channel-web/channel-web.tgz || exit 1
+          ls modules/channel-web/channel-we.tgz || exit 1
       - name: Build has failed
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
The module-builder image was tested on each push. We only want it to run on master.