### PR TITLE
fix (channel-web): remove double curly braces in stylesheet

### DIFF
--- a/modules/channel-web/assets/default.css
+++ b/modules/channel-web/assets/default.css
@@ -864,7 +864,6 @@ body {
   margin-right: auto;
   max-width: 50%;
 }
-}
 
 .bpw-botinfo-cover-picture {
   width: 100%;


### PR DESCRIPTION
I realized that a selector has two curly braces. So I removed the redundancy

PS:  this is my first pull request to an open source