### PR TITLE
fix(studio): right sidebar UI flow

### DIFF
--- a/src/bp/ui-studio/src/web/views/FlowBuilder/inspector/index.tsx
+++ b/src/bp/ui-studio/src/web/views/FlowBuilder/inspector/index.tsx
@@ -49,11 +49,9 @@ class Inspector extends Component<Props> {
       <div className={cx(style.inspector, { [style.sideForm]: nodeType === 'say_something' })}>
         {nodeType !== 'say_something' && (
           <Fragment>
-            {node && (
-              <i className={cx('material-icons', style.closeIcon)} onClick={close}>
-                close
-              </i>
-            )}
+            <i className={cx('material-icons', style.closeIcon)} onClick={close}>
+              close
+            </i>
             <H4>{node ? 'Node Properties' : 'Flow Properties'}</H4>
           </Fragment>
         )}


### PR DESCRIPTION
Added the ability to close the flow inspector with the same icon as the node inspector

Before:
<img width="361" alt="Screen Shot 2021-05-27 at 5 48 04 PM" src="https://user-images.githubusercontent.com/16272318/119901558-0fc8c880-bf14-11eb-812d-f08d5a5c9d39.png">

After:
<img width="355" alt="Screen Shot 2021-05-27 at 5 48 29 PM" src="https://user-images.githubusercontent.com/16272318/119901565-11928c00-bf14-11eb-9872-224c6b381a45.png">