### PR TITLE
fix(nlu): fix bot delete when nlu unavailable

### DIFF
--- a/modules/nlu/src/backend/index.ts
+++ b/modules/nlu/src/backend/index.ts
@@ -24,17 +24,19 @@ const onServerStarted = async (bp: typeof sdk) => {
 }
 
 const onServerReady = async (bp: typeof sdk) => {
-  if (!app) {
-    throw new AppNotInitializedError()
+  if (app) {
+    await registerRouter(bp, app)
+    await app.resumeTrainings()
+  } else {
+    return bp.logger.warn('NLU module is not initialized')
   }
-  await registerRouter(bp, app)
-  await app.resumeTrainings()
 }
 
 const onBotMount = async (bp: typeof sdk, botId: string) => {
   if (!app) {
-    throw new AppNotInitializedError()
+    return bp.logger.warn('NLU module is not initialized')
   }
+
   const botConfig = await bp.bots.getBotById(botId)
   if (!botConfig) {
     throw new Error(`No config found for bot ${botId}`)
@@ -44,9 +46,13 @@ const onBotMount = async (bp: typeof sdk, botId: string) => {
 
 const onBotUnmount = async (bp: typeof sdk, botId: string) => {
   if (!app) {
-    throw new AppNotInitializedError()
+    return bp.logger.warn(`Bot ${botId} is not mounted`)
   }
-  return app.unmountBot(botId)
+  try {
+    await app.unmountBot(botId)
+  } catch (err) {
+    bp.logger.warn(`Error while unloading bot ${botId}: ${err}`)
+  }
 }
 
 const onModuleUnmount = async (bp: typeof sdk) => {


### PR DESCRIPTION
The NLU module is a bit aggressive on exceptions... If the bot isn't mounted on the module (because the nlu crashed, for example), it's not possible to delete the bot... 

Since it's a module, it should be handled gracefully in my opinion

![image](https://user-images.githubusercontent.com/42552874/120337297-2e86e080-c2c1-11eb-802d-a9438b7255ef.png)
