### PR TITLE
chore(studio): yarn.lock

### DIFF
--- a/src/bp/ui-studio/yarn.lock
+++ b/src/bp/ui-studio/yarn.lock
@@ -8840,11 +8840,8 @@ uglifyjs-webpack-plugin@^1.2.4:
     worker-farm "^1.5.2"
 
 "ui-shared@link:../ui-shared":
-  version "0.0.1"
-  dependencies:
-    js-cookie "^2.2.1"
-    react-command-palette "^0.12.0-0"
-    react-router "4.3.1"
+  version "0.0.0"
+  uid ""
 
 uncontrollable@^7.0.2:
   version "7.1.1"


### PR DESCRIPTION
Every time I build the studio on `master`, I have pending changes with its `yarn.lock` file so I thought it might be better to commit them.

Please close this PR if this is the expected behavior.