### PR TITLE
fix(core): fix generating diag report with the pro version

### DIFF
--- a/src/bp/core/app/core-loader.ts
+++ b/src/bp/core/app/core-loader.ts
@@ -21,19 +21,25 @@ export interface BotpressApp {
   localActionServer: LocalActionServerImpl
 }
 
+let app: BotpressApp
+
 export function createApp(): BotpressApp {
+  if (app) {
+    return app
+  }
+
   try {
-    const app = {
+    app = {
       botpress: container.get<Core>(TYPES.Botpress),
       logger: container.get<LoggerProvider>(TYPES.LoggerProvider),
       config: container.get<ConfigProvider>(TYPES.ConfigProvider),
       ghost: container.get<GhostService>(TYPES.GhostService),
       database: container.get<Database>(TYPES.Database),
-      localActionServer: container.get<LocalActionServerImpl>(TYPES.LocalActionServer),
-      licensing: container.get<LicensingService>(TYPES.LicensingService)
+      localActionServer: container.get<LocalActionServerImpl>(TYPES.LocalActionServer)
     }
 
-    app.licensing.installProtection()
+    const licensing = container.get<LicensingService>(TYPES.LicensingService)
+    licensing.installProtection()
 
     return app
   } catch (err) {


### PR DESCRIPTION
When using the pro version of Botpress, generating a diagnostic report, would cause Botpress to crash. The reason being that some object properties were being re-defined without having the ["configurable" description](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description). 

See the changes in the pro repo for more details!