### PR TITLE
chore(dx): exclude some results from quick search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,9 +9,9 @@
     "source.fixAll": true
   },
   "search.exclude": {
-    "**/website/versioned/**": true,
-    "**/out/bp/**/*.js": true,
-    "**/out/bp/**/*.d.ts": true,
+    "**versioned**": true,
+    "**out/**/*.js": true,
+    "**out/**/*.d.ts": true,
     "**.scss.d.ts": true
   },
   "files.associations": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,12 @@
   "editor.codeActionsOnSave": {
     "source.fixAll": true
   },
+  "search.exclude": {
+    "**/website/versioned/**": true,
+    "**/out/bp/**/*.js": true,
+    "**/out/bp/**/*.d.ts": true,
+    "**.scss.d.ts": true
+  },
   "files.associations": {
     "*.styl": "scss",
     "mutex": "cpp",


### PR DESCRIPTION
Simply adding a filter for most "auto-generated files. 

From: 

![image](https://user-images.githubusercontent.com/42552874/120588247-e1ac2280-c404-11eb-86cd-a06b684d5f20.png)

To: 
![image](https://user-images.githubusercontent.com/42552874/120588293-f5578900-c404-11eb-994a-2da4ccb6f4f5.png)
