### PR TITLE
fix(core): fix multiple invalidate

### DIFF
--- a/src/bp/core/dialog/flow/flow-service.ts
+++ b/src/bp/core/dialog/flow/flow-service.ts
@@ -171,9 +171,9 @@ export class ScopedFlowService {
     if (!expectedSaves) {
       if (await this.ghost.fileExists(FLOW_DIR, flowPath)) {
         const flow = await this.parseFlow(flowPath)
-        this.invalidateFlow(flowPath, flow)
+        this.localInvalidateFlow(flowPath, flow)
       } else {
-        this.invalidateFlow(flowPath, undefined)
+        this.localInvalidateFlow(flowPath, undefined)
       }
     } else {
       if (!isFromFile) {


### PR DESCRIPTION
When the server receives an invalidation for a flow, it was broadcasting the invalidation instead of processing it locally. This caused each server to invalidate flows `n` times, n being the number of nodes in the cluster.... 