### PR TITLE
fix(core): wrong path for config

### DIFF
--- a/src/bp/core/security/router-security.ts
+++ b/src/bp/core/security/router-security.ts
@@ -235,7 +235,7 @@ export const checkBotVisibility = (configProvider: ConfigProvider, checkTokenHea
     const config = await configProvider.getBotConfig(req.params.botId)
     if (config.disabled) {
       // The user must be able to get the config to change the bot status
-      if (req.originalUrl.endsWith(`/api/v1/bots/${req.params.botId}`)) {
+      if (req.originalUrl.endsWith(`/api/v1/studio/${req.params.botId}/config`)) {
         return next()
       }
 


### PR DESCRIPTION
When the bot is unmounted, the config page (`http://localhost:3000/studio/mybot/config`) was empty.
The call to `http://localhost:3000/api/v1/studio/mybot/config` was returning 404, when it should return the bot config instead.
