### PR TITLE
fix(qna): do not process event if bot is unmounted

### DIFF
--- a/modules/qna/src/backend/setup.ts
+++ b/modules/qna/src/backend/setup.ts
@@ -23,7 +23,7 @@ export const initModule = async (bp: typeof sdk, bots: ScopedBots) => {
       if (!event.hasFlag(bp.IO.WellKnownFlags.SKIP_QNA_PROCESSING)) {
         const botInfo = bots[event.botId]
         if (botInfo) {
-          await processEvent(event, bots[event.botId])
+          await processEvent(event, botInfo)
         }
         next()
       }

--- a/modules/qna/src/backend/setup.ts
+++ b/modules/qna/src/backend/setup.ts
@@ -21,7 +21,10 @@ export const initModule = async (bp: typeof sdk, bots: ScopedBots) => {
     direction: 'incoming',
     handler: async (event: sdk.IO.IncomingEvent, next) => {
       if (!event.hasFlag(bp.IO.WellKnownFlags.SKIP_QNA_PROCESSING)) {
-        await processEvent(event, bots[event.botId])
+        const botInfo = bots[event.botId]
+        if (botInfo) {
+          await processEvent(event, bots[event.botId])
+        }
         next()
       }
     },


### PR DESCRIPTION
Fixes an issue where the server would crash if:
* the bot was unmounted
* the Emulator was open 
* the user refreshed the page (sending a `visit` event)

The `visit` event caused the following error:

```
[snip]
06/08/2021 13:36:58.012 launcher NLU Server is ready at http://localhost:3200/
06/08/2021 13:37:30.726 Launcher Unhandled Rejection [TypeError, Cannot destructure property `storage` of 'undefined' or 'null'.]
STACK TRACE
TypeError: Cannot destructure property `storage` of 'undefined' or 'null'.
    at processEvent (/Users/spg/bp-ge/modules/qna/dist/backend/setup.js:66:38)
    at handler (/Users/spg/bp-ge/modules/qna/dist/backend/setup.js:34:15)
    at Promise.fromCallback.multiArgs (/Users/spg/bp-ge/out/bp/core/events/middleware-chain.js:28:58)
    at tryCatcher (/Users/spg/bp-ge/modules/nlu/node_modules/bluebird/js/release/util.js:16:23)
    at Function.Promise.fromNode.Promise.fromCallback (/Users/spg/bp-ge/modules/nlu/node_modules/bluebird/js/release/promise.js:185:30)
    at MiddlewareChain.run (/Users/spg/bp-ge/out/bp/core/events/middleware-chain.js:28:39)
    at async /Users/spg/bp-ge/out/bp/core/events/event-engine.js:131:13 
Waiting for the debugger to disconnect...
06/08/2021 13:37:30.842 Cluster NLU server exited with code null and signal SIGKILL 
[snip]
```