### PR TITLE
fix(admin): add missing translation change collaborators role

### DIFF
--- a/src/bp/admin/ui/src/workspace/collaborators/UserList/UserActions.tsx
+++ b/src/bp/admin/ui/src/workspace/collaborators/UserList/UserActions.tsx
@@ -142,7 +142,7 @@ const UserActions: FC<Props> = props => {
         <MenuItem id="btn-changeRole" text={lang.tr('admin.workspace.users.collaborators.changeRole')} icon="people">
           {props.roles.map(role => (
             <MenuItem
-              text={role.name}
+              text={lang.tr(role.name)}
               key={role.id}
               id={`btn-role-${role.id}`}
               disabled={user.role === role.id}


### PR DESCRIPTION
This PR adds the missing call to lang.tr for roles when you try to change a collaborator's role:

![Screenshot from 2021-06-11 16-29-50](https://user-images.githubusercontent.com/9640576/121745580-821fd800-cad2-11eb-8dbf-4bb4e7bcfe59.png)
