### PR TITLE
fix(core): minor fixes for logs and admin

### DIFF
--- a/src/bp/admin/ui/src/app/BottomPanel/Logs/index.tsx
+++ b/src/bp/admin/ui/src/app/BottomPanel/Logs/index.tsx
@@ -183,7 +183,8 @@ class BottomPanel extends React.Component<Props, State> {
 
   render() {
     const allLogs = [...this.state.initialLogs, ...this.logs]
-    const filtered = this.state.botFilter === '*' ? allLogs : allLogs.filter(x => x.botId === this.state.botFilter)
+    const filtered =
+      this.state.botFilter === '*' ? allLogs : allLogs.filter(x => x.botId === this.state.botFilter || !x.botId)
 
     const LogsPanel = (
       <ul

--- a/src/bp/admin/ui/src/app/BottomPanel/Logs/index.tsx
+++ b/src/bp/admin/ui/src/app/BottomPanel/Logs/index.tsx
@@ -183,8 +183,12 @@ class BottomPanel extends React.Component<Props, State> {
 
   render() {
     const allLogs = [...this.state.initialLogs, ...this.logs]
-    const filtered =
-      this.state.botFilter === '*' ? allLogs : allLogs.filter(x => x.botId === this.state.botFilter || !x.botId)
+    let filtered = allLogs
+
+    if (this.state.botFilter !== '*') {
+      // Include global logs and those of the selected bot
+      filtered = allLogs.filter(x => x.botId === this.state.botFilter || !x.botId)
+    }
 
     const LogsPanel = (
       <ul

--- a/src/bp/admin/ui/src/app/BottomPanel/Logs/index.tsx
+++ b/src/bp/admin/ui/src/app/BottomPanel/Logs/index.tsx
@@ -182,12 +182,11 @@ class BottomPanel extends React.Component<Props, State> {
   }
 
   render() {
-    const allLogs = [...this.state.initialLogs, ...this.logs]
-    let filtered = allLogs
+    let logs = [...this.state.initialLogs, ...this.logs]
 
     if (this.state.botFilter !== '*') {
       // Include global logs and those of the selected bot
-      filtered = allLogs.filter(x => x.botId === this.state.botFilter || !x.botId)
+      logs = logs.filter(x => x.botId === this.state.botFilter || !x.botId)
     }
 
     const LogsPanel = (
@@ -196,7 +195,7 @@ class BottomPanel extends React.Component<Props, State> {
         ref={this.messageListRef}
         onScroll={this.handleLogsScrolled}
       >
-        {filtered.map(e => this.renderEntry(e))}
+        {logs.map(e => this.renderEntry(e))}
         <li className={logStyle.end}>{lang.tr('bottomPanel.logs.endOfLogs')}</li>
       </ul>
     )

--- a/src/bp/admin/ui/src/app/Menu/index.tsx
+++ b/src/bp/admin/ui/src/app/Menu/index.tsx
@@ -7,7 +7,7 @@ import React, { FC, useEffect, Fragment } from 'react'
 import { MdAndroid, MdCopyright } from 'react-icons/md'
 import { connect, ConnectedProps } from 'react-redux'
 import { generatePath, RouteComponentProps, withRouter } from 'react-router'
-import { matchPath } from 'react-router-dom'
+import { matchPath, Link } from 'react-router-dom'
 
 import AccessControl from '~/auth/AccessControl'
 import { getActiveWorkspace } from '~/auth/basicAuth'
@@ -69,13 +69,13 @@ const Menu: FC<Props> = props => {
               </div>
             }
           >
-            <a
+            <Link
               className={cx({ [style.active]: active })}
-              onClick={() => props.history.push(generatePath(url, { workspaceId: workspaceId || undefined }))}
+              to={generatePath(url, { workspaceId: workspaceId || undefined })}
             >
               <Icon icon={icon} />
               {tag && <span className={style.small_tag}>{tag}</span>}{' '}
-            </a>
+            </Link>
           </Tooltip>
         </li>
       </AccessControl>

--- a/src/bp/core/bots/bot-service.ts
+++ b/src/bp/core/bots/bot-service.ts
@@ -61,7 +61,6 @@ export class BotService {
 
   private _botIds: string[] | undefined
   private static _mountedBots: Map<string, boolean> = new Map()
-  private static _botListenerHandles: Map<string, IDisposable> = new Map()
   private static _botHealth: { [botId: string]: BotHealth } = {}
   private _updateBotHealthDebounce = _.debounce(this._updateBotHealth, 500)
 
@@ -613,24 +612,6 @@ export class BotService {
       await this.hookService.executeHook(new Hooks.AfterBotMount(api, botId))
       BotService._mountedBots.set(botId, true)
       this._invalidateBotIds()
-
-      if (BotService._botListenerHandles.has(botId)) {
-        BotService._botListenerHandles.get(botId)!.dispose()
-        BotService._botListenerHandles.delete(botId)
-      }
-
-      BotService._botListenerHandles.set(
-        botId,
-        PersistedConsoleLogger.listenForAllLogs((level, message, args) => {
-          this.realtimeService.sendToSocket(
-            RealTimePayload.forAdmins(`logs::${botId}`, {
-              level,
-              message,
-              args
-            })
-          )
-        }, botId)
-      )
 
       BotService.setBotStatus(botId, 'healthy')
       return true

--- a/src/bp/core/logger/persister/console-logger.ts
+++ b/src/bp/core/logger/persister/console-logger.ts
@@ -49,7 +49,7 @@ export class PersistedConsoleLogger implements Logger {
   private serverHostname: string = ''
   private event?: IO.Event
 
-  private static LogStreamEmitter: EventEmitter2 = new EventEmitter2({
+  public static LogStreamEmitter: EventEmitter2 = new EventEmitter2({
     delimiter: '::',
     maxListeners: 1000,
     verboseMemoryLeak: true,

--- a/src/bp/ui-shared/src/Dropdown/index.tsx
+++ b/src/bp/ui-shared/src/Dropdown/index.tsx
@@ -70,7 +70,7 @@ const Dropdown: FC<DropdownProps> = props => {
       inputProps={{ placeholder: filterPlaceholder || lang('filter') }}
       items={items}
       activeItem={activeItem}
-      popoverProps={{ minimal: true, usePortal: false }}
+      popoverProps={{ minimal: true, usePortal: true }}
       itemRenderer={customItemRenderer || itemRenderer}
       itemPredicate={filterOptions}
       itemListPredicate={filterList}

--- a/src/bp/ui-studio/src/web/components/Layout/BottomPanel/Logs/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/BottomPanel/Logs/index.tsx
@@ -61,8 +61,11 @@ class BottomPanel extends React.Component<Props, State> {
   }
 
   setupListener = () => {
-    // @ts-ignore
-    EventBus.default.on(`logs::${window.BOT_ID}`, ({ id, level, message, args }) => {
+    EventBus.default.onAny((name, { level, message, args }) => {
+      if (!name || typeof name !== 'string' || ![`logs::${window.BOT_ID}`, 'logs::*'].includes(name)) {
+        return
+      }
+
       this.logs.push({
         ts: new Date(),
         id: nanoid(10),

--- a/src/bp/ui-studio/src/web/components/Layout/BottomPanel/Logs/index.tsx
+++ b/src/bp/ui-studio/src/web/components/Layout/BottomPanel/Logs/index.tsx
@@ -61,8 +61,10 @@ class BottomPanel extends React.Component<Props, State> {
   }
 
   setupListener = () => {
+    const isGlobalOrCurrentBotLog = (scope: string) => [`logs::${window.BOT_ID}`, 'logs::*'].includes(scope)
+
     EventBus.default.onAny((name, { level, message, args }) => {
-      if (!name || typeof name !== 'string' || ![`logs::${window.BOT_ID}`, 'logs::*'].includes(name)) {
+      if (!name || typeof name !== 'string' || !isGlobalOrCurrentBotLog(name)) {
         return
       }
 


### PR DESCRIPTION
This PR fixes 3 annoying issues.

1. The way logs were implemented causes each "global" logs to be displayed multiple times (one entry for each bot on the server). When a "non-bot-scoped" log was sent, it was sent to each individual listener. I've changed the logic a bit so logs unrelated to a bot are scoped to `logs::*` and changed the studio so it listen on both the current bot ID, and global logs.
![image](https://user-images.githubusercontent.com/42552874/121942683-c30c2c80-cd1e-11eb-84d8-772fb6e9cbdd.png)

2. Filters were not usable on the logs panel, they appeared like this:

![image](https://user-images.githubusercontent.com/42552874/121942591-a7a12180-cd1e-11eb-8627-fd2b38ccf972.png)

3. Right-clicking a menu item on the admin panel would display "back / forwards" instead of "open in a new tab", which pissed me off.
![image](https://user-images.githubusercontent.com/42552874/121943054-2e55fe80-cd1f-11eb-975f-faebbb9a3ede.png)
![image](https://user-images.githubusercontent.com/42552874/121943093-3746d000-cd1f-11eb-9a43-593eb45d1f28.png)
