### PR TITLE
fix(admin): various fixes

### DIFF
--- a/src/bp/admin/management/management-router.ts
+++ b/src/bp/admin/management/management-router.ts
@@ -75,9 +75,10 @@ class ManagementRouter extends CustomAdminRouter {
           return res.status(400).send('Rebooting the server is disabled in the botpress.config.json file')
         }
 
-        this.logger.info(`User ${user} requested a server reboot for ${req.query.hostname}`)
+        const { hostname, serverId } = req.query
+        this.logger.info(`User ${user} requested a server reboot for ${hostname}/${serverId}`)
 
-        await this._rebootServer(req.query.hostname)
+        await this._rebootServer(serverId, hostname)
         res.sendStatus(200)
       })
     )
@@ -85,8 +86,8 @@ class ManagementRouter extends CustomAdminRouter {
     this._rebootServer = await this.jobService.broadcast<void>(this.__local_rebootServer.bind(this))
   }
 
-  private __local_rebootServer(hostname?: string) {
-    if (!hostname || hostname === os.hostname()) {
+  private __local_rebootServer(serverId?: string, hostname?: string) {
+    if (!hostname || !serverId || (hostname === os.hostname() && serverId === process.SERVER_ID)) {
       process.send!({ type: 'reboot_server' })
     }
   }

--- a/src/bp/admin/ui/src/app/common/CheckRequirements/index.tsx
+++ b/src/bp/admin/ui/src/app/common/CheckRequirements/index.tsx
@@ -6,6 +6,7 @@ import React, { FC, useEffect, useState } from 'react'
 import { connect, ConnectedProps } from 'react-redux'
 
 import api from '~/app/api'
+import LoadingSection from '~/app/common/LoadingSection'
 import { fetchServerConfig } from '~/management/checklist/reducer'
 import { AppState } from '../../rootReducer'
 import style from './style.scss'
@@ -76,6 +77,10 @@ const CheckRequirements: FC<Props> = props => {
         </Callout>
       </div>
     )
+  }
+
+  if (!props.serverConfigLoaded) {
+    return <LoadingSection />
   }
 
   return isEnabled ? (

--- a/src/bp/admin/ui/src/app/translations/en.json
+++ b/src/bp/admin/ui/src/app/translations/en.json
@@ -156,6 +156,8 @@
         "eventsIn": "Events In",
         "eventsOut": "Events Out",
         "host": "Host",
+        "serverId": "Server ID",
+        "lastUpdate": "Last Update",
         "peakCpuUsage": "Peak CPU Usage",
         "peakMemUsage": "Peak Mem Usage",
         "requests": "Requests",
@@ -165,6 +167,7 @@
         "uptime": "Uptime",
         "warnings": "Warnings"
       },
+      "currentServer": "This is the server you are currently on",
       "restart": "Restart server",
       "restartInProgress": "Server restart in progress. To know when the server is back up, watch the uptime for that server in the Overview. You can close this window safely.",
       "restartNow": "Restart server now",

--- a/src/bp/admin/ui/src/health/monitoring/ServerControl.tsx
+++ b/src/bp/admin/ui/src/health/monitoring/ServerControl.tsx
@@ -6,6 +6,7 @@ import api from '~/app/api'
 
 interface Props {
   hostname: string
+  serverId: string
   isOpen?: boolean
   toggle: () => void
 }
@@ -19,7 +20,10 @@ const ServerControl: FC<Props> = props => {
 
   const restartServer = async () => {
     try {
-      await api.getSecured().post(`/admin/management/rebootServer?hostname=${props.hostname}`)
+      await api
+        .getSecured()
+        .post(`/admin/management/rebootServer?hostname=${props.hostname}&serverId=${props.serverId}`)
+
       setRestarting(true)
     } catch (err) {
       toast.failure(err.message)
@@ -37,7 +41,8 @@ const ServerControl: FC<Props> = props => {
       <div className={Classes.DIALOG_BODY}>
         {!isRestarting ? (
           <div>
-            {lang.tr('admin.monitoring.youAreAboutToRestart')} <br /> <strong>{props.hostname}</strong>. <br /> <br />
+            {lang.tr('admin.monitoring.youAreAboutToRestart')} <br /> <strong>{props.hostname}</strong> (id:{' '}
+            {props.serverId}). <br /> <br />
             {lang.tr('admin.monitoring.areYouSure')}
           </div>
         ) : (

--- a/src/bp/admin/ui/src/health/monitoring/SummaryTable.tsx
+++ b/src/bp/admin/ui/src/health/monitoring/SummaryTable.tsx
@@ -13,9 +13,11 @@ import style from './style.scss'
 const SummaryTable = ({ data }) => {
   const [isModalOpen, setModalOpen] = useState(false)
   const [host, setHost] = useState('')
+  const [serverId, setServerId] = useState('')
 
-  const restartServer = async host => {
+  const restartServer = async (host: string, serverId: string) => {
     setHost(host)
+    setServerId(serverId)
     setModalOpen(true)
   }
 
@@ -25,73 +27,97 @@ const SummaryTable = ({ data }) => {
       accessor: 'host'
     },
     {
+      Header: lang.tr('admin.monitoring.column.serverId'),
+      Cell: x => {
+        const { serverId } = x.original
+
+        return window.SERVER_ID === serverId ? (
+          <Tooltip content={lang.tr('admin.monitoring.currentServer')}>
+            <strong>{serverId}</strong>
+          </Tooltip>
+        ) : (
+          serverId
+        )
+      },
+      width: 90,
+      accessor: 'serverId'
+    },
+    {
       Header: lang.tr('admin.monitoring.column.uptime'),
       Cell: x => {
         const minutes = moment.duration(x.value, 'seconds').asMinutes()
         return `${Math.round(minutes)} mins`
       },
-      width: 120,
+      width: 70,
       className: 'center',
       accessor: 'uptime'
     },
     {
+      Header: lang.tr('admin.monitoring.column.lastUpdate'),
+      Cell: x => {
+        return `${moment(x.value).fromNow()}`
+      },
+      width: 90,
+      className: 'center',
+      accessor: 'lastUpdate'
+    },
+    {
       Header: lang.tr('admin.monitoring.column.peakCpuUsage'),
       Cell: x => x.value + '%',
-      width: 120,
+      width: 90,
       accessor: 'cpu.usage'
     },
     {
       Header: lang.tr('admin.monitoring.column.peakMemUsage'),
       Cell: x => x.value + '%',
-      width: 120,
+      width: 90,
       accessor: 'mem.usage'
     },
     {
       Header: lang.tr('admin.monitoring.column.requests'),
-      width: 120,
+      width: 60,
       className: 'center',
       accessor: Metric.Requests
     },
     {
       Header: lang.tr('admin.monitoring.column.eventsIn'),
-      width: 120,
+      width: 60,
       className: 'center',
       accessor: Metric.EventsIn,
       align: 'right'
     },
     {
       Header: lang.tr('admin.monitoring.column.eventsOut'),
-      width: 120,
+      width: 60,
       className: 'center',
       accessor: Metric.EventsOut
     },
     {
       Header: lang.tr('admin.monitoring.column.warnings'),
-      width: 120,
+      width: 60,
       className: 'center',
       accessor: Metric.Warnings
     },
     {
       Header: lang.tr('admin.monitoring.column.errors'),
-      width: 120,
+      width: 60,
       className: 'center',
       accessor: Metric.Errors
     },
     {
       Header: lang.tr('admin.monitoring.column.criticals'),
-      width: 120,
+      width: 60,
       className: 'center',
       accessor: Metric.Criticals
     },
     {
       Cell: x => (
         <Tooltip content={lang.tr('admin.monitoring.restart')}>
-          <Button icon="power" onClick={() => restartServer(x.original.host)} small />
+          <Button icon="power" onClick={() => restartServer(x.original.host, x.original.serverId)} small />
         </Tooltip>
       ),
-
-      filterable: false,
-      width: 45
+      width: 45,
+      filterable: false
     }
   ]
 
@@ -104,7 +130,12 @@ const SummaryTable = ({ data }) => {
         defaultSorted={[{ id: 'host', desc: false }]}
         className={cx(style.monitoringOverview, '-striped -highlight')}
       />
-      <ServerControl hostname={host} isOpen={isModalOpen} toggle={() => setModalOpen(!isModalOpen)} />
+      <ServerControl
+        hostname={host}
+        serverId={serverId}
+        isOpen={isModalOpen}
+        toggle={() => setModalOpen(!isModalOpen)}
+      />
     </React.Fragment>
   )
 }

--- a/src/bp/admin/ui/src/typings.d.ts
+++ b/src/bp/admin/ui/src/typings.d.ts
@@ -14,6 +14,7 @@ declare global {
     __BP_VISITOR_SOCKET_ID: string
     __BP_VISITOR_ID: string
     SOCKET_TRANSPORTS: any
+    SERVER_ID: string
     BOT_ID: string
     botpress: {
       [moduleName: string]: any

--- a/src/bp/admin/ui/src/workspace/logs/index.tsx
+++ b/src/bp/admin/ui/src/workspace/logs/index.tsx
@@ -263,7 +263,7 @@ const Logs: FC<Props> = props => {
         filtered={filters}
         onFilteredChange={filtered => setFilters(filtered)}
         filterable
-        defaultSorted={[{ id: 'level', desc: false }]}
+        defaultSorted={[{ id: 'timestamp', desc: true }]}
         className={cx(style.monitoringOverview, '-striped -highlight ')}
         previousText={lang.tr('previous')}
         nextText={lang.tr('next')}

--- a/src/bp/common/monitoring.ts
+++ b/src/bp/common/monitoring.ts
@@ -1,4 +1,3 @@
-import { MonitoringStats } from 'core/health'
 import _ from 'lodash'
 import ms from 'ms'
 
@@ -61,7 +60,7 @@ const calculateAverageAndSum = (allEntries: MonitoringStats[], ts: string, uniqu
 
   for (const host of uniqueHosts) {
     hosts[host] = hosts[host] || {}
-    const hostEntries = _.filter(allEntries, entry => entry.host === host)
+    const hostEntries = _.filter(allEntries, entry => entry.uniqueId === host)
     AVG_KEYS.forEach(key => {
       const sum = _.sumBy(hostEntries, key)
 
@@ -93,4 +92,35 @@ export const calculateOverviewForHost = (hostStats: MonitoringStats[]) => {
   SUM_KEYS.forEach(key => _.set(overview, key, _.sumBy(hostStats, key)))
 
   return overview
+}
+
+export type MonitoringStats = MonitoringMetrics & {
+  // Auto-generated from host and server id
+  uniqueId?: string
+  host: string
+  serverId: string
+  ts: number
+  uptime: number
+  cpu: {
+    usage: number
+  }
+  mem: {
+    usage: number
+    free: number
+  }
+}
+
+export interface MonitoringMetrics {
+  requests: {
+    count: number
+    latency_avg: number
+    latency_sum: number
+  }
+  eventsIn: {
+    count: number
+  }
+  eventsOut: { count: number }
+  warnings: { count: number }
+  errors: { count: number }
+  criticals: { count: number }
 }

--- a/src/bp/core/app/server.ts
+++ b/src/bp/core/app/server.ts
@@ -247,7 +247,8 @@ export class HTTPServer {
     window.EXPERIMENTAL = ${config.experimental};
     window.SOCKET_TRANSPORTS = ["${getSocketTransports(config).join('","')}"];
     window.SHOW_POWERED_BY = ${!!config.showPoweredBy};
-    window.UUID = "${this.machineId}"`
+    window.UUID = "${this.machineId}";
+    window.SERVER_ID = "${process.SERVER_ID}";`
   }
 
   async start() {

--- a/src/bp/core/health/index.ts
+++ b/src/bp/core/health/index.ts
@@ -1,2 +1,3 @@
 export * from './alerting-service'
 export * from './monitoring-service'
+export * from 'common/monitoring'

--- a/src/bp/core/health/monitoring-service.ts
+++ b/src/bp/core/health/monitoring-service.ts
@@ -1,4 +1,4 @@
-import { Metric } from 'common/monitoring'
+import { Metric, MonitoringMetrics } from 'common/monitoring'
 import { injectable } from 'inversify'
 import { Redis } from 'ioredis'
 import _ from 'lodash'
@@ -56,34 +56,6 @@ export const incrementMetric = (metricName: string, value?: number | undefined) 
  */
 export interface MetricsContainer {
   [metricName: string]: number
-}
-
-export type MonitoringStats = MonitoringMetrics & {
-  host: string
-  ts: number
-  uptime: number
-  cpu: {
-    usage: number
-  }
-  mem: {
-    usage: number
-    free: number
-  }
-}
-
-export interface MonitoringMetrics {
-  requests: {
-    count: number
-    latency_avg: number
-    latency_sum: number
-  }
-  eventsIn: {
-    count: number
-  }
-  eventsOut: { count: number }
-  warnings: { count: number }
-  errors: { count: number }
-  criticals: { count: number }
 }
 
 export interface Status {


### PR DESCRIPTION
A couple of changes related to monitoring.

1. Added the `serverId` to monitoring entries so we really know the number of servers running on a specific host. Previously, if you ran more than 1 server on the same host, it would only display one client, which may be misleading (if a process is stuck, for example).
2. The server you are currently on is displayed in bold, so it's easier to restart the other servers first
3. Added the "Last Update" column so we know when the entry was last updated. When redeploying a cluster, the last servers are still displayed until we're out of the time frame window

![image](https://user-images.githubusercontent.com/42552874/121962250-80564e80-cd36-11eb-8d6e-9a28a70b4c64.png)

4. Loading the monitoring page displayed the "Enable feature" page shortly before displaying the monitoring values
5. Logs are sorted by timestamp descending by default, instead of by errors first.
6. Added a name on the redis connection so we can display meaningful information in the diagnostic report
