### PR TITLE
chore(core): add more content to diag

### DIFF
--- a/src/bp/core/distributed/redis.ts
+++ b/src/bp/core/distributed/redis.ts
@@ -1,6 +1,19 @@
 import RedisIo, { Cluster, ClusterNode, ClusterOptions, Redis, RedisOptions } from 'ioredis'
 import _ from 'lodash'
 
+interface ClientEntry {
+  raw: string
+  parsed: RedisClient
+}
+
+interface RedisClient {
+  name: string
+  addr: string
+  id: string
+  cmd: string
+  age: number
+}
+
 const _clients: { [key: string]: Redis } = {}
 
 export const getOrCreate = (type: 'subscriber' | 'commands' | 'socket', url?: string): Redis => {
@@ -55,4 +68,33 @@ export const getOrCreate = (type: 'subscriber' | 'commands' | 'socket', url?: st
 
 export const makeRedisKey = (key: string): string => {
   return process.env.BP_REDIS_SCOPE ? `${process.env.BP_REDIS_SCOPE}/${key}` : key
+}
+
+const parseLine = (client: string): ClientEntry => {
+  return {
+    raw: client,
+    parsed: client.split(' ').reduce((acc, curr) => {
+      const [param, value] = curr.split('=')
+      acc[param] = value
+      return acc
+    }, {}) as RedisClient
+  }
+}
+
+export const getClientsList = async (redis: Redis): Promise<ClientEntry[]> => {
+  try {
+    const clients = await redis.client('list')
+
+    // We don't want to get clients which issues commands
+    const subscribers = clients
+      .split('\n')
+      .map(parseLine)
+      .filter(x => x.parsed.name && x.parsed.cmd === 'subscribe')
+
+    return _.uniqBy(subscribers, x => x.parsed.name)
+  } catch (err) {
+    console.error('error parsing clients', err)
+  }
+
+  return []
 }

--- a/src/bp/diag/utils.ts
+++ b/src/bp/diag/utils.ts
@@ -1,9 +1,11 @@
 import axios from 'axios'
 import chalk from 'chalk'
+import { spawnSync } from 'child_process'
 import { centerText } from 'core/logger'
 import { OBFUSCATED, print, SECRET_KEYS } from 'diag'
 import dns from 'dns'
 import fs from 'fs'
+import fse from 'fs-extra'
 import _ from 'lodash'
 import os from 'os'
 import path from 'path'
@@ -80,5 +82,21 @@ export const wrapMethodCall = async (label: string, method: any) => {
     printRow(label, `${chalk.green('success')} (${Date.now() - start}ms)`)
   } catch (err) {
     printRow(label, `${chalk.red(`failure: ${err.message}`)} (${Date.now() - start}ms)`)
+  }
+}
+
+export const getToolVersion = async name => {
+  try {
+    const basePath = process.pkg ? path.dirname(process.execPath) : path.resolve(__dirname, '../')
+    const toolPath = path.resolve(basePath, 'bin', process.distro.os === 'win32' ? `${name}.exe` : name)
+
+    if (await fse.pathExists(toolPath)) {
+      const child = spawnSync(`${toolPath}`, ['--version'])
+      return child.stdout.toString().trim()
+    } else {
+      return 'Executable not found'
+    }
+  } catch (err) {
+    return `Error checking version: ${err}`
   }
 }

--- a/src/bp/orchestrator/studio-client.ts
+++ b/src/bp/orchestrator/studio-client.ts
@@ -99,7 +99,8 @@ export const startStudio = async (logger: sdk.Logger, params: WebWorkerParams) =
     // These params are processed by the web worker
     EXTERNAL_URL: params.EXTERNAL_URL,
     APP_SECRET: params.APP_SECRET,
-    ROOT_PATH: params.ROOT_PATH
+    ROOT_PATH: params.ROOT_PATH,
+    SERVER_ID: process.SERVER_ID
   }
 
   // We store the dynamic params so we can reuse them when auto-restarting the studio process


### PR DESCRIPTION
This adds a bit more information on the diagnostic report. 

1. Adds the detected version of NLU / Studio (we call each binaries with --version flag)

![image](https://user-images.githubusercontent.com/42552874/123013527-64842580-d392-11eb-82af-df58a2881e58.png)

2. Adds the list of clients connected to the redis instance, and the current scope of the running server
![image](https://user-images.githubusercontent.com/42552874/123013746-c8a6e980-d392-11eb-810b-21b7cc36d146.png)

