### PR TITLE
chore(messaging):  Add optional metadata field to Converse API

### DIFF
--- a/src/bp/core/converse/converse-router.ts
+++ b/src/bp/core/converse/converse-router.ts
@@ -18,7 +18,11 @@ const conversePayloadSchema = {
     .array()
     .items(joi.string())
     .optional()
-    .default(['global'])
+    .default(['global']),
+  metadata: joi
+    .object()
+    .optional()
+    .default({})
 }
 
 export class ConverseRouter extends CustomRouter {


### PR DESCRIPTION
Developers may now add a metadata object to the requests made via the Converse API. The metadata is then available in the event payload for use in actions, hooks and flows:

Example request: 
```
{
  "type": "text",
  "text": "Google Stock Price",
  "metadata": {
    "UA": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
  }
}
```

The metadata is then accessible at `event.payload.metadata` in hooks, actions and flows

Notes:
The metadata field is optional and can be omitted.
If the metadata field is set, it must be an object.