### PR TITLE
fix(core): fix missing await in mapping migration

### DIFF
--- a/src/bp/migrations/v12_20_2-1617829329-mapping_migration.ts
+++ b/src/bp/migrations/v12_20_2-1617829329-mapping_migration.ts
@@ -9,7 +9,7 @@ const migration: Migration = {
   },
   up: async ({ bp }: sdk.ModuleMigrationOpts): Promise<sdk.MigrationResult> => {
     // This wasn't in use anywhere so we can just delete the old table
-    if (bp.database.schema.hasTable('mapping')) {
+    if (await bp.database.schema.hasTable('mapping')) {
       await bp.database.schema.dropTable('mapping')
 
       await bp.database.createTableIfNotExists('mapping', table => {


### PR DESCRIPTION
This PR adds a missing await on the mapping migration which could have caused the migration to crash if the table did not exist.