### PR TITLE
fix(google-speech): use studio url for tts audio upload to media storage

### DIFF
--- a/modules/google-speech/src/backend/middleware.ts
+++ b/modules/google-speech/src/backend/middleware.ts
@@ -122,7 +122,7 @@ export class Middleware {
       formData.append('file', audio, `${uuidv4()}.mp3`)
 
       // TODO: Add cache (preview -> buffer)
-      const axiosConfig = await this.bp.http.getAxiosConfigForBot(event.botId, { localUrl: true })
+      const axiosConfig = await this.bp.http.getAxiosConfigForBot(event.botId, { studioUrl: true })
       axiosConfig.headers['Content-Type'] = `multipart/form-data; boundary=${formData.getBoundary()}`
 
       const {


### PR DESCRIPTION
This PR fixes google-speech by using the studio URL when uploading the resulting audio file of the Text-To-Speech (TTS) middleware into Botpress media storage.