### PR TITLE
fix(channel-web): fix voice audio support

### DIFF
--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -269,7 +269,7 @@ export default async (bp: typeof sdk, db: Database) => {
       const formData = new FormData()
       formData.append('file', buffer, audio!.title)
 
-      const axiosConfig = await bp.http.getAxiosConfigForBot(botId, { localUrl: true })
+      const axiosConfig = await bp.http.getAxiosConfigForBot(botId, { studioUrl: true })
       axiosConfig.headers['Content-Type'] = `multipart/form-data; boundary=${formData.getBoundary()}`
 
       // Upload the audio buffer to the Media Service


### PR DESCRIPTION
This PR fixes voice audio support on channel-web by using the studio URL when uploading received audio file into Botpress media storage.