### PR TITLE
fix(google-speech): move closest number utils into google-speech code

### DIFF
--- a/modules/google-speech/src/backend/client.ts
+++ b/modules/google-speech/src/backend/client.ts
@@ -2,7 +2,6 @@ import { protos, v1p1beta1 } from '@google-cloud/speech'
 import { TextToSpeechClient } from '@google-cloud/text-to-speech'
 import axios from 'axios'
 import * as sdk from 'botpress/sdk'
-import { closest } from 'common/number'
 import { isBpUrl } from 'common/url'
 import * as mm from 'music-metadata'
 
@@ -18,7 +17,7 @@ import {
   AudioEncoding,
   IRecognizeRequest
 } from './typings'
-import { TimeoutError, timeoutFn } from './utils'
+import { TimeoutError, timeoutFn, closest } from './utils'
 
 const debug = DEBUG('google-speech')
 const debugSpeechToText = debug.sub('speech-to-text')

--- a/modules/google-speech/src/backend/utils.test.ts
+++ b/modules/google-speech/src/backend/utils.test.ts
@@ -1,0 +1,47 @@
+import { closest } from './utils'
+
+const randomNumber = (max = 100) => Math.floor(Math.random() * max)
+const arrayGenerator = (size = 10): number[] => {
+  return Array.from({ length: size }, () => randomNumber())
+}
+const dumbSearch = (array: number[], value: number) => {
+  const distance = new Array(array.length).fill(0)
+  for (let i = 0; i < array.length; i++) {
+    distance[i] = Math.abs(array[i] - value)
+  }
+
+  let smallestDistance = Number.MAX_VALUE
+  let result: number = 0
+  for (let i = 0; i < distance.length; i++) {
+    if (distance[i] < smallestDistance) {
+      smallestDistance = distance[i]
+      result = array[i]
+    } else if (distance[i] === smallestDistance) {
+      smallestDistance = distance[i]
+      result = result > array[i] ? result : array[i]
+    }
+  }
+
+  return result
+}
+
+describe('Number', () => {
+  let array: number[]
+
+  beforeEach(() => {
+    array = arrayGenerator(randomNumber())
+  })
+
+  describe('Closest', () => {
+    it('Find the closest number inside an array of numbers', () => {
+      for (let i = 0; i < 100; i++) {
+        const value: number = randomNumber()
+        const resClosest: number = closest(array, value)
+        const resDumbSearch: number = dumbSearch(array, value)
+
+        expect(typeof resClosest).toEqual('number')
+        expect(resClosest).toEqual(resDumbSearch)
+      }
+    })
+  })
+})

--- a/modules/google-speech/src/backend/utils.ts
+++ b/modules/google-speech/src/backend/utils.ts
@@ -19,3 +19,16 @@ export const timeoutFn = async <R>(promise: Promise<R>, timeout?: string): Promi
     return promise
   }
 }
+
+export const closest = (arr: number[], value: number) => {
+  return arr.reduce((prev, curr) => {
+    const diffPref = Math.abs(prev - value)
+    const diffCurr = Math.abs(curr - value)
+
+    if (diffPref === diffCurr) {
+      return prev > curr ? prev : curr
+    } else {
+      return diffCurr < diffPref ? curr : prev
+    }
+  })
+}


### PR DESCRIPTION
This PR fixes an issue with google-speech and studio. When the studio is requiring google-speech (for f-e rendering) it tries to require util that does not exist in this repository. The solution here is to move the util into the only place where is it used.

Solves the same issue as described here: https://github.com/botpress/studio/pull/33