### PR TITLE
fix(core): log an error if an action isn't found (#2826)

### DIFF
--- a/src/bp/core/dialog/instruction/strategy.ts
+++ b/src/bp/core/dialog/instruction/strategy.ts
@@ -136,12 +136,15 @@ export class ActionStrategy implements InstructionStrategy {
       if (!actionServerId) {
         const hasAction = await service.hasAction(actionName)
         if (!hasAction) {
-          throw new Error(`Action "${actionName}" not found, `)
+          const { currentNode, currentFlow } = _.get(event, 'state.context', {})
+          throw new Error(`Action "${actionName}" not found in ${currentFlow}:${currentNode} `)
         }
       }
 
       await service.runAction({ actionName, incomingEvent: event, actionArgs: args, actionServer })
     } catch (err) {
+      this.logger.error(err.message)
+
       const { onErrorFlowTo } = event.state.temp
       const errorFlow = typeof onErrorFlowTo === 'string' && onErrorFlowTo.length ? onErrorFlowTo : 'error.flow.json'
 


### PR DESCRIPTION
If an action wasn't found, it was failing silently, this logs an error.
