### PR TITLE
feat(core): bot-scoped libraries

### DIFF
--- a/modules/code-editor/src/backend/definitions.ts
+++ b/modules/code-editor/src/backend/definitions.ts
@@ -18,6 +18,7 @@ export interface FileDefinition {
     dirListingAddFields?: (filepath: string) => object | undefined
     upsertLocation?: (file: EditableFile) => string
     upsertFilename?: (file: EditableFile) => string
+    dirListingExcluded?: string[]
     shouldSyncToDisk?: boolean
   }
   /** Validation if the selected file can be deleted */
@@ -76,10 +77,11 @@ export const FileTypes: { [type: string]: FileDefinition } = {
     canDelete: () => false
   },
   shared_libs: {
-    allowGlobal: true,
-    allowScoped: false,
+    allowGlobal: false,
+    allowScoped: true,
     permission: 'shared_libs',
     ghost: {
+      dirListingExcluded: ['node_modules'],
       baseDir: '/libraries'
     },
     canDelete: file => {

--- a/modules/code-editor/src/backend/editor.ts
+++ b/modules/code-editor/src/backend/editor.ts
@@ -97,7 +97,7 @@ export default class Editor {
 
   async loadFiles(fileTypeId: string, botId?: string, listBuiltin?: boolean): Promise<EditableFile[]> {
     const def: FileDefinition = FileTypes[fileTypeId]
-    const { baseDir, dirListingAddFields } = def.ghost
+    const { baseDir, dirListingAddFields, dirListingExcluded } = def.ghost
 
     if ((!def.allowGlobal && !botId) || (!def.allowScoped && botId)) {
       return []
@@ -108,7 +108,9 @@ export default class Editor {
       fileExt = def.isJSON ? '*.json' : '*.js'
     }
 
-    const excluded = this._config.includeBuiltin || listBuiltin ? undefined : getBuiltinExclusion()
+    const baseExcluded = this._config.includeBuiltin || listBuiltin ? undefined : getBuiltinExclusion()
+    const excluded = [...baseExcluded, ...(dirListingExcluded ?? [])]
+
     const ghost = botId ? this.bp.ghost.forBot(botId) : this.bp.ghost.forGlobal()
     const files = def.filenames ? def.filenames : await ghost.directoryListing(baseDir, fileExt, excluded, true)
 

--- a/modules/code-editor/src/translations/en.json
+++ b/modules/code-editor/src/translations/en.json
@@ -53,7 +53,7 @@
     "moduleConf": "Module Configurations",
     "pipelineHooks": "Pipeline Hooks",
     "rawFileEditor": "Raw File Editor",
-    "sharedLibs": "Shared Libraries"
+    "sharedLibs": "Libraries"
   },
   "splash": {
     "advancedEditor": "Advanced Editor",

--- a/modules/code-editor/src/views/full/SidePanel.tsx
+++ b/modules/code-editor/src/views/full/SidePanel.tsx
@@ -82,6 +82,7 @@ class PanelContent extends React.Component<Props> {
     this.addFiles('global.module_config', lang.tr('module.code-editor.sidePanel.global'), moduleConfigFiles)
 
     const sharedLibs = []
+    this.addFiles('bot.shared_libs', lang.tr('module.code-editor.sidePanel.currentBot'), sharedLibs)
     this.addFiles('global.shared_libs', lang.tr('module.code-editor.sidePanel.global'), sharedLibs)
 
     this.addFiles('hook_example', EXAMPLE_FOLDER_LABEL, hookFiles)
@@ -200,7 +201,7 @@ class PanelContent extends React.Component<Props> {
   }
 
   renderSharedLibs() {
-    if (!this.hasPermission('global.shared_libs')) {
+    if (!this.hasPermission('bot.shared_libs')) {
       return null
     }
 
@@ -368,6 +369,7 @@ class PanelContent extends React.Component<Props> {
             <React.Fragment>
               {this.renderSectionActions()}
               {this.renderSectionHooks()}
+              {this.renderSharedLibs()}
               {this.renderSectionConfig()}
               {this.renderSectionModuleConfig()}
             </React.Fragment>

--- a/modules/libraries/src/backend/index.ts
+++ b/modules/libraries/src/backend/index.ts
@@ -96,7 +96,9 @@ const entryPoint: sdk.ModuleEntryPoint = {
     name: 'libraries',
     menuIcon: 'book',
     menuText: 'Libraries',
-    noInterface: false,
+    // Do we still keep it as a web app for global (shared libs.. ?)
+    noInterface: true,
+    workspaceApp: { bots: false, global: true },
     experimental: true,
     fullName: 'Libraries',
     homepage: 'https://botpress.com'

--- a/packages/bp/src/core/bots/bot-service.ts
+++ b/packages/bp/src/core/bots/bot-service.ts
@@ -605,15 +605,9 @@ export class BotService {
       return
     }
 
-    const bpfs = this.ghostService.forBot(botId)
-    const files = await bpfs.directoryListing('libraries', '*.*', ['node_modules'])
-
-    for (const file of files) {
-      const destPath = path.join(process.PROJECT_LOCATION, 'data/bots', botId, 'libraries', file)
-
-      mkdirp.sync(path.dirname(destPath))
-      await fse.writeFile(destPath, bpfs.readFileAsBuffer('libraries', file))
-    }
+    await this.ghostService.forBot(botId).syncDatabaseFilesToDisk('libraries')
+    await this.ghostService.forBot(botId).syncDatabaseFilesToDisk('actions')
+    await this.ghostService.forBot(botId).syncDatabaseFilesToDisk('hooks')
   }
 
   // Do not use directly use the public version instead due to broadcasting

--- a/packages/bp/src/core/bpfs/cache-invalidators.ts
+++ b/packages/bp/src/core/bpfs/cache-invalidators.ts
@@ -53,7 +53,8 @@ export namespace CacheInvalidators {
 
       const watcher = chokidar.watch(foldersToWatch, {
         ignoreInitial: true,
-        ignorePermissionErrors: true
+        ignorePermissionErrors: true,
+        ignored: path => path.includes('node_modules')
       })
 
       watcher.on('add', this.handle)

--- a/packages/bp/src/core/bpfs/ghost-service.ts
+++ b/packages/bp/src/core/bpfs/ghost-service.ts
@@ -49,7 +49,7 @@ interface ScopedGhostOptions {
 
 const MAX_GHOST_FILE_SIZE = process.core_env.BP_BPFS_MAX_FILE_SIZE || '100mb'
 const BP_BPFS_UPLOAD_CONCURRENCY = parseInt((process.core_env.BP_BPFS_UPLOAD_CONCURRENCY as unknown) as string) || 50
-const bpfsIgnoredFiles = ['models/**', 'data/bots/*/models/**', '**/*.js.map']
+const bpfsIgnoredFiles = ['models/**', 'data/bots/*/models/**', '**/*.js.map', 'data/bots/*/libraries/node_modules/**']
 const GLOBAL_GHOST_KEY = '__global__'
 const BOTS_GHOST_KEY = '__bots__'
 const DIFFABLE_EXTS = ['.js', '.json', '.txt', '.csv', '.yaml']

--- a/packages/bp/src/core/user-code/action-service.ts
+++ b/packages/bp/src/core/user-code/action-service.ts
@@ -355,7 +355,7 @@ export class ScopedActionService {
 
     const botFolder = action.scope === 'global' ? 'global' : `bots/${this.botId}`
     const dirPath = path.resolve(path.join(process.PROJECT_LOCATION, `/data/${botFolder}/actions/${actionName}.js`))
-    const lookups = getBaseLookupPaths(dirPath, 'actions')
+    const lookups = getBaseLookupPaths(dirPath, 'actions', this.botId)
 
     return { code, dirPath, lookups, action }
   }

--- a/packages/bp/src/core/user-code/hook-service.ts
+++ b/packages/bp/src/core/user-code/hook-service.ts
@@ -245,8 +245,8 @@ export class HookService {
     return new HookScript(path, filename, script, filename.replace('.js', ''), botId)
   }
 
-  private _prepareRequire(fullPath: string, hookType: string) {
-    const lookups = getBaseLookupPaths(fullPath, hookType)
+  private _prepareRequire(fullPath: string, hookType: string, botId?: string) {
+    const lookups = getBaseLookupPaths(fullPath, hookType, botId)
 
     return (module: string) => requireAtPaths(module, lookups, fullPath)
   }
@@ -257,7 +257,7 @@ export class HookService {
 
     const dirPath = path.resolve(path.join(process.PROJECT_LOCATION, hookPath))
 
-    const _require = this._prepareRequire(dirPath, hook.folder)
+    const _require = this._prepareRequire(dirPath, hook.folder, hookScript.botId)
 
     const botId = _.get(hook.args, 'event.botId')
 

--- a/packages/bp/src/core/user-code/utils.ts
+++ b/packages/bp/src/core/user-code/utils.ts
@@ -3,13 +3,19 @@ import { ActionScope } from 'common/typings'
 import { requireAtPaths } from 'core/modules/utils/require'
 import path from 'path'
 
-export const getBaseLookupPaths = (fullPath: string, lastPathPart: string) => {
+export const getBaseLookupPaths = (fullPath: string, lastPathPart: string, botId?: string) => {
   const actionLocation = path.dirname(fullPath)
 
   let parts = path.relative(process.PROJECT_LOCATION, actionLocation).split(path.sep)
   parts = parts.slice(parts.indexOf(lastPathPart) + 1) // We only keep the parts after /actions/...
 
-  const lookups: string[] = [actionLocation, path.join(process.PROJECT_LOCATION, 'shared_libs')]
+  const lookups: string[] = [actionLocation]
+
+  if (botId) {
+    lookups.push(path.join(process.PROJECT_LOCATION, 'data/bots', botId, 'libraries'))
+  }
+
+  lookups.push(path.join(process.PROJECT_LOCATION, 'shared_libs'))
 
   if (parts[0] in process.LOADED_MODULES) {
     // the hook/action is in a directory by the same name as a module


### PR DESCRIPTION
Another step to move all bot creation to the studio. There is no more "shared" libraries, all libraries added on the studio will be packaged with that bot and will follow it when bots are exported. 

The end goal is to run the studio offline. Add libraries (eg: edit manually package.json), add any js files in "libraries" folder, then click on a button to package the node_modules as an archive, then it will be shipped with the bot's archive. When the bot is mounted somewhere, its node_modules will be expanded on the disk so actions/hooks can use them


Studio code: https://github.com/botpress/studio/pull/34

Not sure what to do with libraries module right now, thinking of keeping it to not be breaking short-term...