### PR TITLE
fix(channel-telegram): clean up carousel caption

### DIFF
--- a/modules/channel-telegram/src/backend/typings.ts
+++ b/modules/channel-telegram/src/backend/typings.ts
@@ -1,6 +1,6 @@
 import { ChannelContext } from 'common/channel'
 import Telegraf, { ContextMessageUpdate } from 'telegraf'
-import { ChatAction, ExtraEditMessage, InputFile } from 'telegraf/typings/telegram-types'
+import { ChatAction, ExtraEditMessage, ExtraPhoto, InputFile } from 'telegraf/typings/telegram-types'
 
 export interface Clients {
   [key: string]: Telegraf<ContextMessageUpdate>
@@ -17,5 +17,5 @@ export interface TelegramMessage {
   photo?: InputFile
   markdown?: boolean
   action?: ChatAction
-  extra?: ExtraEditMessage
+  extra?: ExtraEditMessage | ExtraPhoto
 }

--- a/modules/channel-telegram/src/renderers/carousel.ts
+++ b/modules/channel-telegram/src/renderers/carousel.ts
@@ -28,13 +28,10 @@ export class TelegramCarouselRenderer implements ChannelRenderer<TelegramContext
     const { messages } = context
     const payload = context.payload as sdk.CarouselContent
 
+    let buttons
     for (const card of payload.items) {
-      if (card.image) {
-        messages.push({ action: 'upload_photo' })
-        messages.push({ photo: { url: formatUrl(context.botUrl, card.image), filename: path.basename(card.image) } })
-      }
+      buttons = []
 
-      const buttons = []
       for (const action of card.actions || []) {
         if (action.action === sdk.ButtonAction.OpenUrl) {
           buttons.push(
@@ -47,10 +44,18 @@ export class TelegramCarouselRenderer implements ChannelRenderer<TelegramContext
         }
       }
 
-      messages.push({
-        text: `*${card.title}*\n${card.subtitle}`,
-        extra: Extra.markdown(true).markup(Markup.inlineKeyboard(buttons))
-      })
+      if (card.image) {
+        messages.push({ action: 'upload_photo' })
+        messages.push({
+          photo: {
+            url: formatUrl(context.botUrl, card.image),
+            filename: path.basename(card.image)
+          },
+          extra: new Extra({ caption: `*${card.title}*${card.subtitle ? '\n' + card.subtitle : ''}` })
+            .markdown(true)
+            .markup(Markup.inlineKeyboard(buttons))
+        })
+      }
     }
   }
 }


### PR DESCRIPTION
This cleans up telegram carousel rendering a bit. It adds the caption as an image caption instead of a separate comment