### PR TITLE
feat(devops): Dockerhub Added latest, edge and feature branch for dockerhub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          context: ./out/binaries/
+          context: ./packages/bp/binaries
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           labels: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,30 +1,34 @@
 name: Docker
-on:
-  push:
-    branches:
-      - '*'
-      - '*/*'
-      - '**'
-    tags:
-      - 'v*.*.*'
+on: [push]
 jobs:
   build_and_push:
     name: Build and push Docker image to GitHub Packages
     runs-on: ubuntu-latest
     steps:
+      # Create an array of version to push to the Dockerhub registery
       - name: Prepare
         id: prep
         run: |
+          TAG=$(echo $(git describe ${{github.sha}} --tags)) ## Get the tags from the SHA hash
+          VALID_TAG="^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
           DOCKER_IMAGE=botpress/server
-          VERSION=edge
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=latest
+          VERSION=()
+          if [[ $TAG =~ $VALID_TAG ]]; then
+            echo "VALID TAG"
+            VERSION+=($(echo ${TAG} | sed -r 's/v//')) # transform v12.23.0 to 12.23.0
+            VERSION+=("latest")
+            VERSION+=($(echo ${TAG} | sed -r 's/\./_/g')) # Transform v12.13.0 to v12_13_0 ## Added backward compatibility
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+            VERSION+=($(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')) # transform feature/00-feature-branch to feature-00-feature-branch
           fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
+          if [[ $GITHUB_REG == "refs/heads/${{secrets.PRINCIPAL_BRANCH}} " ]]; then
+            ## Check if code is pushed on the PRINCIPAL_BRANCH. PRINCIPAL_BRANCH is set as a SECRET
+            VERSION+=(${{secrets.PRINCIPAL_BRANCH}})
+          fi
+          TAGS=("${VERSION[@]/#/${DOCKER_IMAGE}:}")
+          echo ::set-output name=version::${VERSION[@]}
+          IFS=,
+          echo ::set-output name=tags::"${TAGS[*]}"
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       - name: Checkout code
         uses: actions/checkout@v2.1.0
@@ -45,7 +49,6 @@ jobs:
           yarn run package --linux
           cp build/docker/Dockerfile packages/bp/binaries/
       - name: DockerHub Authentication
-        if: steps.check-tag.outputs.match == 'true'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -53,7 +56,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          context: .
+          context: ./out/binaries/
+          push: true
           tags: ${{ steps.prep.outputs.tags }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,31 @@
 name: Docker
-on: [push]
+on:
+  push:
+    branches:
+      - '*'
+      - '*/*'
+      - '**'
+    tags:
+      - 'v*.*.*'
 jobs:
   build_and_push:
     name: Build and push Docker image to GitHub Packages
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=botpress/server
+          VERSION=edge
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=latest
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       - name: Checkout code
         uses: actions/checkout@v2.1.0
         with:
@@ -23,6 +44,21 @@ jobs:
           yarn run build --linux --prod --verbose
           yarn run package --linux
           cp build/docker/Dockerfile packages/bp/binaries/
+      - name: DockerHub Authentication
+        if: steps.check-tag.outputs.match == 'true'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
       - name: Docker build and push
         uses: docker/build-push-action@v1
         with:

--- a/build/docker/docker-readme.md
+++ b/build/docker/docker-readme.md
@@ -1,28 +1,16 @@
-![botpress](https://botpress.com/blog/content/images/2017/06/xnobg_primary_black.png.pagespeed.ic.siY4jfFl48.png)
+# Botpress Docker image
 
-### Installation
-
-Create persistent storage to keep botpress data:
+## Running Your botpress container
 
 ```bash
-docker volume create botpress_data
+docker run -d --name=botpress -p 3000:3000 botpress/server
 ```
 
----
-
-Start the container with minimal necessary options:
-
-```bash
-docker run --detach \
-           --name=botpress \
-           --publish 3000:3000 \
-           --volume botpress_data:/botpress/data \
-           botpress/server:latest
-```
-
----
+### Extra information
 
 There are some predefined defaults. However, you can specify ones via environmental variables:
+
+This example modified the expose port in botpress and add a connection to a postgres database.
 
 ```bash
 docker run --detach \
@@ -57,6 +45,12 @@ docker exec --interactive --tty botpress bash
 ```
 
 ---
+
+### How to use the botpress container
+
+Further documentation can be found on the botpress [website](https://botpress.com/docs/infrastructure/docker)
+
+### Changeleg
 
 Full documentation resource is available on the [official website](https://botpress.com/docs/).
 [Changelog resides here](https://github.com/botpress/botpress/blob/master/CHANGELOG.md).


### PR DESCRIPTION
Added the latest tag for the docker hub via Github action.

I will update the documentation to talk about the latest tags.

## Example

Every branch will be push to the dockerhub registry.  If the branch is named `feature/00-modified-documentation`

The tag in the dockerhub will be `feature-00-modified-documentation`. It can be useful to test a branch for a PR really quickly. The only thing to do is to pull from the register

```
docker pull botpress/server:feature-00-modified-documentation
```

For example, I created 2 tags in one build to show the behavior of the code. I'm building a list of tags and I'm pushing it to the dockerhub registery.

![image](https://user-images.githubusercontent.com/6981314/127048887-a9a41ac5-9a50-41a2-bb76-27cdb1020efd.png)


## Example
The dockerHub tags was created by the github action
![image](https://user-images.githubusercontent.com/6981314/126994281-3633fb65-44ff-4adf-aa9a-a26994eb90aa.png)


![image](https://user-images.githubusercontent.com/6981314/127012057-db8e0562-9171-4231-a77e-8c23a8452744.png)


## UNIT-Test 

The documentation for the push event $GITHUB_REF is a little bit obscure. I tried a different set-up and I was not able to get the tags. I came with a different approach. I getting the tags from the SHA hash.

```
[Docker/Build and push Docker image to GitHub Packages] ⭐  Run Prepare
[Docker/Build and push Docker image to GitHub Packages]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /Users/botpress/github/botpress/botpress/workflow/prep] user=
[Module Builder Docker Image/Test Module Builder Image] ⭐  Run Build
[Module Builder Docker Image/Test Module Builder Image]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /Users/botpress/github/botpress/botpress/workflow/1] user=
| VALID TAG
[Docker/Build and push Docker image to GitHub Packages]   ⚙  ::set-output:: version=100.0.2 latest v100_0_2
[Docker/Build and push Docker image to GitHub Packages]   ⚙  ::set-output:: tags=botpress/server:100.0.2,botpress/server:latest,botpress/server:v100_0_2
[Docker/Build and push Docker image to GitHub Packages]   ⚙  ::set-output:: created=2021-07-27T19:56:07Z
```

The tags push to the dockerhub will be 

```
botpress/server:100.0.2
botpress/server:latest
botpress/server:v100_0_2
```


## Further action

- Create a Clean-up function to remove older tags.
- Reduce the size of the image
- Migrate from `master` to `main` branch name 

