### PR TITLE
chore(dev): benchmark using web instead of converse

### DIFF
--- a/packages/bp/src/index.ts
+++ b/packages/bp/src/index.ts
@@ -290,6 +290,11 @@ try {
           description: 'Minimum percentage of respected SLA required to continue incrementing users',
           default: 100
         },
+        useWeb: {
+          alias: 'web',
+          description: 'Use channel-web instead of converse for benchmarking',
+          default: false
+        },
         increments: {
           alias: 'i',
           description: 'If set, the test will increment users by this value until the SLA is breached',

--- a/packages/bp/src/orchestrator/nlu-server.ts
+++ b/packages/bp/src/orchestrator/nlu-server.ts
@@ -44,7 +44,7 @@ export const startNluServer = async (opts: Partial<NLUServerOptions>, logger: sd
     nluServerProcess = spawn(getNluBinaryPath(), [], { env, stdio: 'inherit' })
   } else {
     const file = path.resolve(process.core_env.DEV_NLU_PATH, 'index.js')
-    nluServerProcess = fork(file, undefined, { execArgv: undefined, env, cwd: path.dirname(file) })
+    nluServerProcess = fork(file, undefined, { execArgv: [], env, cwd: path.dirname(file) })
   }
 
   nluServerProcess?.on('exit', (code, signal) => {

--- a/packages/bp/src/orchestrator/studio-client.ts
+++ b/packages/bp/src/orchestrator/studio-client.ts
@@ -118,7 +118,7 @@ export const startStudio = async (logger: sdk.Logger, params: WebWorkerParams) =
     studioHandle = spawn(file, [], { env, stdio: 'inherit' })
   } else if (process.core_env.DEV_STUDIO_PATH) {
     const file = path.resolve(process.core_env.DEV_STUDIO_PATH, 'index.js')
-    studioHandle = fork(file, undefined, { execArgv: undefined, env, cwd: path.dirname(file) })
+    studioHandle = fork(file, undefined, { execArgv: [], env, cwd: path.dirname(file) })
   }
 
   studioHandle.on('exit', async (code: number, signal: string) => {


### PR DESCRIPTION
The "bench" tool only supports converse, which couldn't be used to test messaging performance because it is not supported yet. For that purpose, I've added a flag which will use channel-web instead, so the logic is a bit trickier than converse.

For each user, we must establish a socket connection (to obtain a socket ID) that we can then use to post messages to the backend. I'm sending a user visit as the first message, because if the nlu module is disabled, language is undefined and misunderstood doesn't work properly. 

Since the post request to channel-web is almost instant, we need to wait until a reply is sent to the end user (using the socket) to count that as a completed request.

