### PR TITLE
fix(channel-web): Fix non-ready webchat on webchatLoaded event

### DIFF
--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -206,7 +206,7 @@ class Web extends React.Component<MainProps> {
         trackMessage('sent')
         await this.props.sendMessage(text)
       } else if (type === 'loadConversation') {
-        this.props.store.fetchConversation(payload.conversationId)
+        await this.props.store.fetchConversation(payload.conversationId)
       } else if (type === 'toggleBotInfo') {
         this.props.toggleBotInfo()
       } else {

--- a/packages/ui-shared-lite/auth/index.ts
+++ b/packages/ui-shared-lite/auth/index.ts
@@ -65,6 +65,7 @@ export const setVisitorId = (userId: string, userIdScope?: string) => {
   if (typeof userId === 'string' && userId !== 'undefined') {
     storage.set(userIdScope ? `bp/socket/${userIdScope}/user` : 'bp/socket/user', userId)
     window.__BP_VISITOR_ID = userId
+    window.parent?.postMessage({ userId }, '*')
   }
 }
 
@@ -75,6 +76,7 @@ export const getUniqueVisitorId = (userIdScope?: string): string => {
   if (typeof userId !== 'string' || userId === 'undefined') {
     userId = nanoid(24)
     storage.set(key, userId)
+    window.parent?.postMessage({ userId }, '*')
   }
 
   window.__BP_VISITOR_ID = userId


### PR DESCRIPTION
Sometimes the webchat isn't ready yet the webchatLoaded event has already been emitted, causing client-side calls to the botpress inject.js to error out