### PR TITLE
feat(messaging): added webhook support when using an external messaging

### DIFF
--- a/packages/bp/src/core/messaging/messaging-client.ts
+++ b/packages/bp/src/core/messaging/messaging-client.ts
@@ -1,11 +1,22 @@
-import axios from 'axios'
+import axios, { AxiosRequestConfig } from 'axios'
+
+interface MessagingSyncWebHookResponse {
+  url: string
+  token: string
+}
+
+interface MessagingSyncResponse {
+  id: string
+  token: string
+  webhooks?: MessagingSyncWebHookResponse[]
+}
 
 export class MessagingClient {
   private apiUrl: string
 
   constructor(
     public baseUrl: string,
-    private password: string,
+    private password?: string,
     private clientId?: string,
     private clientToken?: string
   ) {
@@ -13,7 +24,7 @@ export class MessagingClient {
   }
 
   async syncClient(config: any) {
-    const res = await axios.post(`${this.apiUrl}/sync`, config, { headers: { password: this.password } })
+    const res = await axios.post<MessagingSyncResponse>(`${this.apiUrl}/sync`, config, this.getAxiosConfig())
     return res.data
   }
 
@@ -25,7 +36,21 @@ export class MessagingClient {
         channel,
         payload
       },
-      { headers: { password: this.password }, auth: { username: this.clientId!, password: this.clientToken! } }
+      this.getAxiosConfig(true)
     )
+  }
+
+  private getAxiosConfig(auth: boolean = false): AxiosRequestConfig {
+    const config: AxiosRequestConfig = { headers: {} }
+
+    if (this.password) {
+      config.headers.password = this.password
+    }
+
+    if (auth) {
+      config.auth = { username: this.clientId!, password: this.clientToken! }
+    }
+
+    return config
   }
 }

--- a/packages/bp/src/core/messaging/messaging-router.ts
+++ b/packages/bp/src/core/messaging/messaging-router.ts
@@ -23,6 +23,10 @@ export class MessagingRouter extends CustomRouter {
           return next?.(new UnauthorizedError('Password is missing or invalid'))
         }
 
+        if (req.body?.type === 'health') {
+          res.sendStatus(200)
+        }
+
         try {
           await joi.validate(req.body, ReceiveSchema)
         } catch (err) {
@@ -48,6 +52,7 @@ export class MessagingRouter extends CustomRouter {
 }
 
 interface ReceiveRequest {
+  type: string
   client: { id: string }
   channel: { id: string; name: string }
   user: { id: string }
@@ -56,6 +61,7 @@ interface ReceiveRequest {
 }
 
 const ReceiveSchema = {
+  type: joi.string().required(),
   client: joi.object({ id: joi.string().required() }),
   channel: joi.object({ id: joi.string().required(), name: joi.string().required() }),
   user: joi.object({ id: joi.string().required() }),

--- a/packages/bp/src/core/messaging/messaging-router.ts
+++ b/packages/bp/src/core/messaging/messaging-router.ts
@@ -19,12 +19,12 @@ export class MessagingRouter extends CustomRouter {
     this.router.post(
       '/receive',
       this.asyncMiddleware(async (req, res, next) => {
-        if (req.headers.password !== process.INTERNAL_PASSWORD) {
+        if (!this.messaging.isExternal && req.headers.password !== this.messaging.internalPassword) {
           return next?.(new UnauthorizedError('Password is missing or invalid'))
         }
 
         if (req.body?.type === 'health') {
-          res.sendStatus(200)
+          return res.sendStatus(200)
         }
 
         try {


### PR DESCRIPTION
This PR adds support for configuring webhooks when using an external Messaging server.

Related to https://github.com/botpress/botpress/pull/5237

Closes MES-89 and MES-90