### PR TITLE
fix(messaging): use headers instead of basic auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "version": "0.0.24"
   },
   "messaging": {
-    "version": "0.1.0"
+    "version": "0.1.2"
   },
   "scripts": {
     "postinstall": "yarn cmd postinstall",

--- a/packages/bp/src/core/messaging/messaging-client.ts
+++ b/packages/bp/src/core/messaging/messaging-client.ts
@@ -48,7 +48,8 @@ export class MessagingClient {
     }
 
     if (auth) {
-      config.auth = { username: this.clientId!, password: this.clientToken! }
+      config.headers['x-bp-messaging-client-id'] = this.clientId!
+      config.headers['x-bp-messaging-client-token'] = this.clientToken!
     }
 
     return config


### PR DESCRIPTION
This PR fixes an issue where multiple authentication mechanisms could conflict with our basic authentication. We will now need to provide a 'x-bp-messaging-client-*' headers to provide the clientId and clientToken.

Related to: https://github.com/botpress/messaging/pull/89