### PR TITLE
fix(messaging): legacy route send ext url in headers

### DIFF
--- a/packages/bp/src/core/messaging/legacy.ts
+++ b/packages/bp/src/core/messaging/legacy.ts
@@ -64,7 +64,8 @@ export class MessagingLegacy {
         },
         changeOrigin: false,
         ignorePath: true,
-        logLevel: 'silent'
+        logLevel: 'silent',
+        headers: { 'x-bp-host': process.core_env.EXTERNAL_URL! }
       })
     )
   }


### PR DESCRIPTION
This PR fixes an issue where having an external URL with a port specified would not allow you to use the old webhooks with Twilio.
