### PR TITLE
fix(twilio): fix legacy twilio validation

### DIFF
--- a/packages/bp/src/core/messaging/legacy.ts
+++ b/packages/bp/src/core/messaging/legacy.ts
@@ -64,8 +64,7 @@ export class MessagingLegacy {
         },
         changeOrigin: false,
         ignorePath: true,
-        logLevel: 'silent',
-        headers: { 'x-bp-host': process.core_env.EXTERNAL_URL! }
+        logLevel: 'silent'
       })
     )
   }

--- a/packages/bp/src/orchestrator/messaging-server.ts
+++ b/packages/bp/src/orchestrator/messaging-server.ts
@@ -67,7 +67,9 @@ export const startMessagingServer = async (opts: Partial<MessagingServerOptions>
     SKIP_LOAD_CONFIG: 'true',
     SPINNED: 'true',
     SPINNED_URL: `http://localhost:${opts.CORE_PORT}/api/v1/chat/receive`,
-    NO_LAZY_LOADING: 'true'
+    NO_LAZY_LOADING: 'true',
+    // Needed for legacy twilio validation
+    MASTER_URL: opts.EXTERNAL_URL
   }
 
   if (!process.core_env.DEV_MESSAGING_PATH) {


### PR DESCRIPTION
The previous fix wasn't working because process.EXTERNAL_URL is undefined at this point (so it was producing 400 errors for having a undefined header).

This PR fixes legacy webhooks for twilio.