### PR TITLE
fix(messaging): fix webhook verification

### DIFF
--- a/packages/bp/src/core/messaging/messaging-router.ts
+++ b/packages/bp/src/core/messaging/messaging-router.ts
@@ -59,7 +59,7 @@ export class MessagingRouter extends CustomRouter {
 interface ReceiveRequest {
   type: string
   client: { id: string }
-  channel: { id: string; name: string }
+  channel: { name: string }
   user: { id: string }
   conversation: { id: string }
   message: { id: string; conversationId: string; authorId: string | undefined; sentOn: Date; payload: any }
@@ -68,7 +68,7 @@ interface ReceiveRequest {
 const ReceiveSchema = {
   type: joi.string().required(),
   client: joi.object({ id: joi.string().required() }),
-  channel: joi.object({ id: joi.string().required(), name: joi.string().required() }),
+  channel: joi.object({ name: joi.string().required() }),
   user: joi.object({ id: joi.string().required() }),
   conversation: joi.object({ id: joi.string().required() }),
   message: joi.object({

--- a/packages/bp/src/core/messaging/messaging-router.ts
+++ b/packages/bp/src/core/messaging/messaging-router.ts
@@ -21,7 +21,10 @@ export class MessagingRouter extends CustomRouter {
       this.asyncMiddleware(async (req, res, next) => {
         if (!this.messaging.isExternal && req.headers.password !== this.messaging.internalPassword) {
           return next?.(new UnauthorizedError('Password is missing or invalid'))
-        } else if (this.messaging.isExternal && req.headers['x-webhook-token'] !== this.messaging.webhookToken) {
+        } else if (
+          this.messaging.isExternal &&
+          req.headers['x-webhook-token'] !== this.messaging.getWebhookToken(req?.body.client?.id)
+        ) {
           return next?.(new UnauthorizedError('Invalid webhook token'))
         }
 

--- a/packages/bp/src/core/messaging/messaging-router.ts
+++ b/packages/bp/src/core/messaging/messaging-router.ts
@@ -23,7 +23,7 @@ export class MessagingRouter extends CustomRouter {
           return next?.(new UnauthorizedError('Password is missing or invalid'))
         } else if (
           this.messaging.isExternal &&
-          req.headers['x-webhook-token'] !== this.messaging.getWebhookToken(req?.body.client?.id)
+          req.headers['x-webhook-token'] !== this.messaging.getWebhookToken(req?.body?.client?.id)
         ) {
           return next?.(new UnauthorizedError('Invalid webhook token'))
         }

--- a/packages/bp/src/core/messaging/messaging-service.ts
+++ b/packages/bp/src/core/messaging/messaging-service.ts
@@ -12,11 +12,11 @@ export class MessagingService {
   private clientSync!: MessagingClient
   private clientsByBotId: { [botId: string]: MessagingClient } = {}
   private botsByClientId: { [clientId: string]: string } = {}
+  private webhookTokenByClientId: { [botId: string]: string } = {}
   private channelNames = ['messenger', 'slack', 'smooch', 'teams', 'telegram', 'twilio', 'vonage']
 
   public isExternal: boolean
   public internalPassword: string | undefined
-  public webhookToken: string | undefined
 
   constructor(
     @inject(TYPES.EventEngine) private eventEngine: EventEngine,
@@ -61,7 +61,7 @@ export class MessagingService {
     if (webhooks?.length) {
       for (const webhook of webhooks) {
         if (webhook.url === webhookUrl) {
-          this.webhookToken = webhook.token
+          this.webhookTokenByClientId[id] = webhook.token
         }
       }
     }
@@ -152,5 +152,9 @@ export class MessagingService {
     return process.core_env.MESSAGING_ENDPOINT
       ? process.core_env.MESSAGING_ENDPOINT
       : `http://localhost:${process.MESSAGING_PORT}`
+  }
+
+  public getWebhookToken(clientId: string) {
+    return this.webhookTokenByClientId[clientId]
   }
 }


### PR DESCRIPTION
Fixes a bug where having more than one bot would not work with distant messaging because the webhook token would get set to the last bot that was mounted.

Webhooks ids and tokens are the same for a specified url *per client*, not globally.