### PR TITLE
fix(messaging): fix proxying search params

### DIFF
--- a/packages/bp/src/core/messaging/legacy.ts
+++ b/packages/bp/src/core/messaging/legacy.ts
@@ -59,7 +59,12 @@ export class MessagingLegacy {
             this.warned[`${botId}-${channel}`] = true
           }
 
-          const newUrl = `${this.getMessagingUrl()}/webhooks/${botId}/${channel}${messagingRoute ? messagingRoute : ''}`
+          const search = new URL(req.originalUrl, process.EXTERNAL_URL).search
+
+          const newUrl = `${this.getMessagingUrl()}/webhooks/${botId}/${channel}${
+            messagingRoute ? messagingRoute : ''
+          }${search || ''}`
+
           return newUrl
         },
         changeOrigin: false,


### PR DESCRIPTION
This PR fixes an issue where requests with search params failed because we were not proxying the search params to the messaging server.

e.g. Messenger legacy webhook validation was failing with 403.