### PR TITLE
fix(messaging): filter module errors for channels

### DIFF
--- a/packages/bp/src/core/app/bootstrap.ts
+++ b/packages/bp/src/core/app/bootstrap.ts
@@ -137,7 +137,12 @@ async function start() {
 
   const resolver = new ModuleResolver(logger)
 
-  const { loadedModules, erroredModules } = await resolveModules(enabledModules, resolver)
+  let { loadedModules, erroredModules } = await resolveModules(enabledModules, resolver)
+
+  // These channels were removed on 12.24.0.
+  // Do not display not found errors as migrations are run after loading modules and will fix those errors.
+  const removedChannels = ['messenger', 'teams', 'telegram', 'twilio', 'slack', 'smooch', 'vonage']
+  erroredModules = erroredModules.filter(m => !removedChannels.some(removed => m.entry.location.includes(removed)))
 
   for (const loadedModule of loadedModules) {
     process.LOADED_MODULES[loadedModule.entryPoint.definition.name] = loadedModule.moduleLocation


### PR DESCRIPTION
This PR fixes an issue where module not found errors were displayed when migrating to 12.24.0 because modules are loaded before migrations and channel modules were removed starting from this version.