### PR TITLE
fix(core): fix error when creating or importing a bot

### DIFF
--- a/packages/bp/src/core/dialog/flow/flow-service.ts
+++ b/packages/bp/src/core/dialog/flow/flow-service.ts
@@ -139,6 +139,11 @@ export class ScopedFlowService {
     const expectedSaves = this.expectedSavesCache.get(flowPath)
 
     if (!expectedSaves) {
+      // fix an issue when creating a bot where the .flow.json is written but not the .ui.json because of the locking mechanism
+      if (!(await this.ghost.fileExists(FLOW_DIR, this.toUiPath(flowPath)))) {
+        return
+      }
+
       if (await this.ghost.fileExists(FLOW_DIR, flowPath)) {
         const flow = await this.parseFlow(flowPath)
         this.localInvalidateFlow(flowPath, flow)


### PR DESCRIPTION
When creating or importing a bot, there are sometimes errors displayed in the console from the flow service. When creating a bot, we insert the `.flow.json` file and the `.ui.json` file, this triggers the invalidation, which try to parse the two files to generate the flow. 

Before, both files were written before the invalidation was triggered, but since the locking mechanism was added (which reads+write a lock file), the invalidation is received before the second file is written.

We just ignore the invalidation at that time, the next time the flow is loaded it will be processed correctly