### PR TITLE
chore(doc): updated the main channels doc to point to the proper pages

### DIFF
--- a/docs/guide/docs/main/channels.md
+++ b/docs/guide/docs/main/channels.md
@@ -1,0 +1,16 @@
+---
+id: channels
+title: Messaging Channels
+---
+
+## Channels
+
+For the channels documentation, please refer to [this page](../channels/web).
+
+## Converse API
+
+For information about this Converse API, go to [this page](../channels/converse).
+
+## FAQ
+
+FAQ can be found [here](../channels/faq).


### PR DESCRIPTION
This PR updates [this page](https://botpress.com/docs/main/channels) so that instead of duplicating the information, it refers to the proper pages.