### PR TITLE
fix(messaging): proxy fixes

### DIFF
--- a/packages/bp/src/core/app/server.ts
+++ b/packages/bp/src/core/app/server.ts
@@ -427,6 +427,9 @@ export class HTTPServer {
         router: () => {
           return process.core_env.MESSAGING_ENDPOINT || `http://localhost:${process.MESSAGING_PORT}`
         },
+        onError: (err, req, res) => {
+          this.logger.error(`Error while proxy request to messaging endpoint:`, err)
+        },
         changeOrigin: false,
         logLevel: 'silent'
       })

--- a/packages/bp/src/core/app/server.ts
+++ b/packages/bp/src/core/app/server.ts
@@ -430,7 +430,7 @@ export class HTTPServer {
         onError: (err, req, res) => {
           this.logger.error(`Error while proxy request to messaging endpoint:`, err)
         },
-        changeOrigin: false,
+        changeOrigin: true,
         logLevel: 'silent'
       })
     )


### PR DESCRIPTION
* Sets `changeOrigin` to `true` to avoid the following error: https://github.com/chimurai/http-proxy-middleware/issues/238
* Adds logging when an error happens when proxying to the messaging API