### PR TITLE
feat(channel-web): disable composer dropdown

### DIFF
--- a/modules/extensions/src/content-types/dropdown.js
+++ b/modules/extensions/src/content-types/dropdown.js
@@ -26,7 +26,8 @@ function render(data) {
       width: data.width,
       collectFeedback: data.collectFeedback,
       placeholderText: data.placeholderText,
-      markdown: data.markdown
+      markdown: data.markdown,
+      disableFreeText: data.disableFreeText
     }
   ]
 }
@@ -133,6 +134,10 @@ module.exports = {
       allowCreation: {
         type: 'boolean',
         title: 'module.extensions.types.dropdown.allowCreate'
+      },
+      disableFreeText: {
+        type: 'boolean',
+        title: 'Disable composer'
       },
       allowMultiple: {
         type: 'boolean',

--- a/modules/extensions/src/views/lite/components/Dropdown.jsx
+++ b/modules/extensions/src/views/lite/components/Dropdown.jsx
@@ -18,6 +18,7 @@ export class Dropdown extends React.Component {
       })
       this.setState({ options })
     }
+    this.props.store.composer.setLocked(this.props.disableFreeText)
   }
 
   handleChange = selectedOption => {

--- a/modules/extensions/src/views/lite/components/Dropdown.jsx
+++ b/modules/extensions/src/views/lite/components/Dropdown.jsx
@@ -43,6 +43,7 @@ export class Dropdown extends React.Component {
     }
 
     this.props.onSendData && this.props.onSendData({ type: 'quick_reply', text: label, payload: value || label })
+    this.props.store.composer.setLocked(false)
   }
 
   renderSelect(inKeyboard) {


### PR DESCRIPTION
Added the ability to disable the composer when creating a dropdown using the SDK.