### PR TITLE
feat(admin): auto generated bot ids from name and workspace

### DIFF
--- a/packages/bp/e2e/admin/bots.test.ts
+++ b/packages/bp/e2e/admin/bots.test.ts
@@ -30,7 +30,7 @@ describe('Admin - Bot Management', () => {
     await gotoAndExpect(`${bpConfig.host}/admin/workspace/${workspaceId}/bots`)
   })
 
-  it.only('Import bot from archive', async () => {
+  it('Import bot from archive', async () => {
     await page.waitFor(200)
     await clickOn('#btn-create-bot')
     await page.waitFor(100)

--- a/packages/bp/e2e/admin/bots.test.ts
+++ b/packages/bp/e2e/admin/bots.test.ts
@@ -15,7 +15,8 @@ import {
 
 describe('Admin - Bot Management', () => {
   const tempBotId = 'lol-bot'
-  const importBotId = 'import-bot'
+  const importBotName = 'import bot'
+  const importBotId = 'def__import-bot'
   const workspaceId = 'default'
 
   const clickButtonForBot = async (buttonId: string, botId: string) => {
@@ -29,12 +30,13 @@ describe('Admin - Bot Management', () => {
     await gotoAndExpect(`${bpConfig.host}/admin/workspace/${workspaceId}/bots`)
   })
 
-  it('Import bot from archive', async () => {
+  it.only('Import bot from archive', async () => {
     await page.waitFor(200)
     await clickOn('#btn-create-bot')
     await page.waitFor(100)
     await clickOn('#btn-import-bot')
-    await fillField('#input-botId', importBotId)
+    await page.waitFor(100)
+    await fillField('#input-bot-name', importBotName)
     await uploadFile('input[type="file"]', path.join(__dirname, '../assets/bot-import-test.tgz'))
     await clickOn('#btn-upload')
     await expectAdminApiCallSuccess(`workspace/bots/${importBotId}/import`, 'POST')

--- a/packages/bp/e2e/utils.ts
+++ b/packages/bp/e2e/utils.ts
@@ -19,12 +19,19 @@ export const getPage = async (): Promise<Page> => {
 }
 
 export const loginIfNeeded = async () => {
-  if (page.url().includes('login')) {
-    await fillField('#email', bpConfig.email)
-    await fillField('#password', bpConfig.password)
-    await clickOn('#btn-signin')
-    return page.waitForNavigation()
+  const url = page.url()
+  if (!url.includes('login')) {
+    return
   }
+
+  if (url.endsWith('login')) {
+    await page.goto(`${bpConfig.host}/admin/login/default`)
+  }
+
+  await fillField('#email', bpConfig.email)
+  await fillField('#password', bpConfig.password)
+  await clickOn('#btn-signin')
+  return page.waitForNavigation()
 }
 
 export const gotoStudio = async (section?: string) => {

--- a/packages/bp/jest-puppeteer.config.js
+++ b/packages/bp/jest-puppeteer.config.js
@@ -18,7 +18,7 @@ module.exports = {
     windowSize,
     email: 'admin',
     password: '123456',
-    botId: 'test-bot',
+    botId: 'def__test-bot',
     host: 'http://localhost:3000',
     licenseKey: process.env.BP_LICENSE_KEY, // add license key to env variables
     apiHost: 'http://localhost:3000', // When testing the Admin UI on port 3001, set this to the correct port

--- a/packages/bp/src/admin/ui/src/app/WorkspaceSelect/index.tsx
+++ b/packages/bp/src/admin/ui/src/app/WorkspaceSelect/index.tsx
@@ -12,6 +12,7 @@ import { fetchMyWorkspaces, switchWorkspace } from '~/user/reducer'
 import { fetchBots } from '~/workspace/bots/reducer'
 import { fetchUsers } from '~/workspace/collaborators/reducer'
 import { fetchRoles } from '~/workspace/roles/reducer'
+import { getValidWorkspaceId } from '~/workspace/util'
 import { AppState } from '../rootReducer'
 import style from './style.scss'
 
@@ -49,16 +50,6 @@ const WorkspaceSelect: FC<Props> = props => {
     props.fetchBots()
   }, [props.currentWorkspace])
 
-  const getValidWorkspaceId = () => {
-    if (!props.workspaces || !props.workspaces.length) {
-      return
-    }
-
-    const urlId = props.workspaces.find(x => x.workspace === urlWorkspaceId)
-    const storageId = props.workspaces.find(x => x.workspace === getActiveWorkspace())
-    return (urlId && urlId.workspace) || (storageId && storageId.workspace) || props.workspaces[0].workspace
-  }
-
   const refreshOptions = () => {
     const workspaces = props.workspaces!
     setOptions(workspaces)
@@ -66,7 +57,7 @@ const WorkspaceSelect: FC<Props> = props => {
   }
 
   const checkWorkspaceId = () => {
-    const workspaceId = getValidWorkspaceId()
+    const workspaceId = getValidWorkspaceId(props.workspaces!, props.location)
 
     if (!workspaceId) {
       return props.history.replace('/noAccess')

--- a/packages/bp/src/admin/ui/src/app/WorkspaceSelect/index.tsx
+++ b/packages/bp/src/admin/ui/src/app/WorkspaceSelect/index.tsx
@@ -12,7 +12,7 @@ import { fetchMyWorkspaces, switchWorkspace } from '~/user/reducer'
 import { fetchBots } from '~/workspace/bots/reducer'
 import { fetchUsers } from '~/workspace/collaborators/reducer'
 import { fetchRoles } from '~/workspace/roles/reducer'
-import { getValidWorkspaceId } from '~/workspace/util'
+import { getCurrentWorkspaceID } from '~/workspace/util'
 import { AppState } from '../rootReducer'
 import style from './style.scss'
 
@@ -57,7 +57,7 @@ const WorkspaceSelect: FC<Props> = props => {
   }
 
   const checkWorkspaceId = () => {
-    const workspaceId = getValidWorkspaceId(props.workspaces!, props.location)
+    const workspaceId = getCurrentWorkspaceID(props.workspaces!, props.location)
 
     if (!workspaceId) {
       return props.history.replace('/noAccess')

--- a/packages/bp/src/admin/ui/src/user/reducer.ts
+++ b/packages/bp/src/admin/ui/src/user/reducer.ts
@@ -51,6 +51,7 @@ export default (state = initialState, action): UserState => {
       }
 
     case CURRENT_WORKSPACE_CHANGED:
+      console.log('CURRENT_WORKSPACE_CHANGED > ', action.currentWorkspace)
       return {
         ...state,
         currentWorkspace: action.currentWorkspace
@@ -82,6 +83,7 @@ export const fetchMyWorkspaces = (): AppThunk => {
 }
 
 export const switchWorkspace = (workspaceId: string): AppThunk => {
+  console.log('sSwitching to: ', workspaceId)
   return async dispatch => {
     setActiveWorkspace(workspaceId)
     await dispatch(fetchProfile())

--- a/packages/bp/src/admin/ui/src/user/reducer.ts
+++ b/packages/bp/src/admin/ui/src/user/reducer.ts
@@ -51,7 +51,6 @@ export default (state = initialState, action): UserState => {
       }
 
     case CURRENT_WORKSPACE_CHANGED:
-      console.log('CURRENT_WORKSPACE_CHANGED > ', action.currentWorkspace)
       return {
         ...state,
         currentWorkspace: action.currentWorkspace
@@ -83,7 +82,6 @@ export const fetchMyWorkspaces = (): AppThunk => {
 }
 
 export const switchWorkspace = (workspaceId: string): AppThunk => {
-  console.log('sSwitching to: ', workspaceId)
   return async dispatch => {
     setActiveWorkspace(workspaceId)
     await dispatch(fetchProfile())

--- a/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
@@ -1,6 +1,7 @@
 import { Button, Classes, Dialog, FormGroup, InputGroup, Intent, Callout } from '@blueprintjs/core'
 import { BotConfig, BotTemplate } from 'botpress/sdk'
 import { lang } from 'botpress/shared'
+import { makeBotId } from 'common/utils'
 import _ from 'lodash'
 import React, { Component } from 'react'
 import { connect, ConnectedProps } from 'react-redux'
@@ -8,14 +9,7 @@ import Select from 'react-select'
 
 import api from '~/app/api'
 import { AppState } from '~/app/rootReducer'
-import { getActiveWorkspace } from '~/auth/basicAuth'
 import { fetchBotCategories, fetchBotTemplates } from './reducer'
-
-export const sanitizeBotId = (text: string) =>
-  text
-    .toLowerCase()
-    .replace(/\s/g, '-')
-    .replace(/[^a-z0-9_-]/g, '')
 
 interface SelectOption<T> {
   label: string
@@ -28,10 +22,8 @@ type Props = {
   existingBots: BotConfig[]
   onCreateBotSuccess: () => void
   toggle: () => void
-  currentWorkspaceID: string | undefined
+  currentWorkspace: string
 } & ConnectedProps<typeof connector>
-
-const makeBotId = (workspace: string, botName: string) => `${workspace}_${sanitizeBotId(botName)}`
 
 interface State {
   botId: string
@@ -100,11 +92,8 @@ class CreateBotModal extends Component<Props, State> {
   }
 
   handleNameChanged = e => {
-    if (!this.props.currentWorkspaceID) {
-      return
-    }
     const botName = e.target.value
-    const botId = makeBotId(this.props.currentWorkspaceID, botName)
+    const botId = makeBotId(this.props.currentWorkspace, botName)
     this.setState({ botName, botId })
   }
 

--- a/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
@@ -1,7 +1,7 @@
 import { Button, Classes, Dialog, FormGroup, InputGroup, Intent, Callout } from '@blueprintjs/core'
 import { BotConfig, BotTemplate } from 'botpress/sdk'
 import { lang } from 'botpress/shared'
-import { makeBotId } from 'common/utils'
+import { makeWorkspaceScopedBotID } from 'common/utils'
 import _ from 'lodash'
 import React, { Component } from 'react'
 import { connect, ConnectedProps } from 'react-redux'
@@ -93,7 +93,7 @@ class CreateBotModal extends Component<Props, State> {
 
   handleNameChanged = e => {
     const botName = e.target.value
-    const botId = makeBotId(this.props.currentWorkspace, botName)
+    const botId = makeWorkspaceScopedBotID(this.props.currentWorkspace, botName)
     this.setState({ botName, botId })
   }
 

--- a/packages/bp/src/admin/ui/src/workspace/bots/ImportBotModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/ImportBotModal.tsx
@@ -48,7 +48,7 @@ class ImportBotModal extends Component<Props, State> {
       return
     }
 
-    this.setState({ isProcessing: true, progress: 0 })
+    this.setState({ isProcessing: true, progress: 0, botName: this.state.botName.trim() })
 
     try {
       await api
@@ -89,7 +89,7 @@ class ImportBotModal extends Component<Props, State> {
   }, 500)
 
   handleNameChanged = e => {
-    const botName = e.target.value.trim()
+    const botName = e.target.value
     const botId = makeWorkspaceScopedBotID(this.props.currentWorkspace, botName)
     this.setState({ botName, botId })
   }

--- a/packages/bp/src/admin/ui/src/workspace/bots/ImportBotModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/ImportBotModal.tsx
@@ -1,6 +1,6 @@
 import { Button, Checkbox, Classes, Dialog, FileInput, FormGroup, InputGroup, Intent, Callout } from '@blueprintjs/core'
 import { lang, toast } from 'botpress/shared'
-import { makeBotId, sanitizeName } from 'common/utils'
+import { makeWorkspaceScopedBotID, sanitizeName } from 'common/utils'
 import _ from 'lodash'
 import ms from 'ms'
 import React, { Component } from 'react'
@@ -90,7 +90,7 @@ class ImportBotModal extends Component<Props, State> {
 
   handleNameChanged = e => {
     const botName = e.target.value.trim()
-    const botId = makeBotId(this.props.currentWorkspace, botName)
+    const botId = makeWorkspaceScopedBotID(this.props.currentWorkspace, botName)
     this.setState({ botName, botId })
   }
 
@@ -107,7 +107,7 @@ class ImportBotModal extends Component<Props, State> {
 
     this.setState({ filePath: files[0].name })
 
-    if (!this.state.botId.length || this.state.botId === makeBotId(this.props.currentWorkspace, '')) {
+    if (!this.state.botId.length || !this.state.botName.length) {
       this.generateBotId(files[0].name)
     }
   }
@@ -116,7 +116,7 @@ class ImportBotModal extends Component<Props, State> {
     const noExt = filename.substr(0, filename.indexOf('.'))
     const matches = noExt.match(/bot_(.*)_[0-9]+/)
     const botName = sanitizeName((matches && matches[1]) || noExt)
-    const botId = makeBotId(this.props.currentWorkspace, botName)
+    const botId = makeWorkspaceScopedBotID(this.props.currentWorkspace, botName)
 
     this.setState({ botId, botName, overwrite: false }, this.checkIdAvailability)
   }

--- a/packages/bp/src/admin/ui/src/workspace/bots/ImportBotModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/ImportBotModal.tsx
@@ -108,11 +108,11 @@ class ImportBotModal extends Component<Props, State> {
     this.setState({ filePath: files[0].name })
 
     if (!this.state.botId.length || !this.state.botName.length) {
-      this.generateBotId(files[0].name)
+      this.generateBotIdFromFile(files[0].name)
     }
   }
 
-  generateBotId = (filename: string) => {
+  generateBotIdFromFile = (filename: string) => {
     const noExt = filename.substr(0, filename.indexOf('.'))
     const matches = noExt.match(/bot_(.*)_[0-9]+/)
     const botName = sanitizeName((matches && matches[1]) || noExt)

--- a/packages/bp/src/admin/ui/src/workspace/bots/index.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/index.tsx
@@ -31,7 +31,7 @@ import { fetchLicensing } from '~/management/licensing/reducer'
 import { fetchModules } from '~/management/modules/reducer'
 import { fetchMyWorkspaces, switchWorkspace } from '~/user/reducer'
 import { fetchBotHealth, fetchBots, fetchBotNLULanguages } from '~/workspace/bots/reducer'
-import { filterList, getValidWorkspaceId } from '~/workspace/util'
+import { filterList, getCurrentWorkspaceID } from '~/workspace/util'
 
 import BotItemCompact from './BotItemCompact'
 import BotItemPipeline from './BotItemPipeline'
@@ -383,7 +383,7 @@ class Bots extends Component<Props> {
       return <LoadingSection />
     }
 
-    const currentWorkspace = getValidWorkspaceId(this.props.workspaces, this.props.location)
+    const currentWorkspace = getCurrentWorkspaceID(this.props.workspaces, this.props.location)
 
     return (
       <PageContainer title={lang.tr('admin.workspace.bots.bots')}>

--- a/packages/bp/src/admin/ui/src/workspace/bots/index.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/index.tsx
@@ -64,9 +64,6 @@ class Bots extends Component<Props> {
     this.props.fetchBots()
     this.props.fetchBotHealth()
     this.props.fetchBotNLULanguages()
-    this.props.fetchMyWorkspaces()
-
-    console.log('PROPS > ', this.props)
 
     if (!this.props.loadedModules.length && this.props.profile && this.props.profile.isSuperAdmin) {
       this.props.fetchModules()
@@ -74,12 +71,6 @@ class Bots extends Component<Props> {
 
     if (!this.props.licensing) {
       this.props.fetchLicensing()
-    }
-
-    const workspaceId = getValidWorkspaceId(this.props.workspaces, this.props.location)
-    console.log('ID > ', workspaceId)
-    if (workspaceId) {
-      this.props.switchWorkspace(workspaceId)
     }
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -388,9 +379,11 @@ class Bots extends Component<Props> {
   }
 
   render() {
-    if (!this.props.bots) {
+    if (!this.props.bots || !this.props.workspaces) {
       return <LoadingSection />
     }
+
+    const currentWorkspace = getValidWorkspaceId(this.props.workspaces, this.props.location)
 
     return (
       <PageContainer title={lang.tr('admin.workspace.bots.bots')}>
@@ -418,13 +411,13 @@ class Bots extends Component<Props> {
                 toggle={this.toggleCreateBotModal}
                 existingBots={this.props.bots}
                 onCreateBotSuccess={this.props.fetchBots}
-                currentWorkspaceID={this.props.workspaceId}
+                currentWorkspace={currentWorkspace}
               />
               <ImportBotModal
                 isOpen={this.state.isImportBotModalOpen}
                 toggle={this.toggleImportBotModal}
                 onCreateBotSuccess={this.props.fetchBots}
-                currentWorkspaceID={this.props.workspaceId}
+                currentWorkspace={currentWorkspace}
               />
             </AccessControl>
           </Fragment>
@@ -435,7 +428,6 @@ class Bots extends Component<Props> {
 }
 
 const mapStateToProps = (state: AppState) => ({
-  workspaceId: state.user.currentWorkspace,
   loadedModules: state.modules.loadedModules,
   bots: state.bots.bots,
   health: state.bots.health,
@@ -453,8 +445,7 @@ const mapDispatchToProps = {
   fetchBotHealth,
   fetchModules,
   fetchBotNLULanguages,
-  fetchMyWorkspaces,
-  switchWorkspace
+  fetchMyWorkspaces
 }
 
 const connector = connect(mapStateToProps, mapDispatchToProps)

--- a/packages/bp/src/admin/ui/src/workspace/bots/index.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/index.tsx
@@ -29,8 +29,9 @@ import AccessControl from '~/auth/AccessControl'
 import { getActiveWorkspace } from '~/auth/basicAuth'
 import { fetchLicensing } from '~/management/licensing/reducer'
 import { fetchModules } from '~/management/modules/reducer'
+import { fetchMyWorkspaces, switchWorkspace } from '~/user/reducer'
 import { fetchBotHealth, fetchBots, fetchBotNLULanguages } from '~/workspace/bots/reducer'
-import { filterList } from '~/workspace/util'
+import { filterList, getValidWorkspaceId } from '~/workspace/util'
 
 import BotItemCompact from './BotItemCompact'
 import BotItemPipeline from './BotItemPipeline'
@@ -63,6 +64,9 @@ class Bots extends Component<Props> {
     this.props.fetchBots()
     this.props.fetchBotHealth()
     this.props.fetchBotNLULanguages()
+    this.props.fetchMyWorkspaces()
+
+    console.log('PROPS > ', this.props)
 
     if (!this.props.loadedModules.length && this.props.profile && this.props.profile.isSuperAdmin) {
       this.props.fetchModules()
@@ -70,6 +74,12 @@ class Bots extends Component<Props> {
 
     if (!this.props.licensing) {
       this.props.fetchLicensing()
+    }
+
+    const workspaceId = getValidWorkspaceId(this.props.workspaces, this.props.location)
+    console.log('ID > ', workspaceId)
+    if (workspaceId) {
+      this.props.switchWorkspace(workspaceId)
     }
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -408,11 +418,13 @@ class Bots extends Component<Props> {
                 toggle={this.toggleCreateBotModal}
                 existingBots={this.props.bots}
                 onCreateBotSuccess={this.props.fetchBots}
+                currentWorkspaceID={this.props.workspaceId}
               />
               <ImportBotModal
                 isOpen={this.state.isImportBotModalOpen}
                 toggle={this.toggleImportBotModal}
                 onCreateBotSuccess={this.props.fetchBots}
+                currentWorkspaceID={this.props.workspaceId}
               />
             </AccessControl>
           </Fragment>
@@ -423,6 +435,7 @@ class Bots extends Component<Props> {
 }
 
 const mapStateToProps = (state: AppState) => ({
+  workspaceId: state.user.currentWorkspace,
   loadedModules: state.modules.loadedModules,
   bots: state.bots.bots,
   health: state.bots.health,
@@ -430,7 +443,8 @@ const mapStateToProps = (state: AppState) => ({
   loading: state.bots.loadingBots,
   licensing: state.licensing.license,
   profile: state.user.profile,
-  language: state.bots.nluLanguages
+  language: state.bots.nluLanguages,
+  workspaces: state.user.workspaces
 })
 
 const mapDispatchToProps = {
@@ -438,7 +452,9 @@ const mapDispatchToProps = {
   fetchLicensing,
   fetchBotHealth,
   fetchModules,
-  fetchBotNLULanguages
+  fetchBotNLULanguages,
+  fetchMyWorkspaces,
+  switchWorkspace
 }
 
 const connector = connect(mapStateToProps, mapDispatchToProps)

--- a/packages/bp/src/admin/ui/src/workspace/util.ts
+++ b/packages/bp/src/admin/ui/src/workspace/util.ts
@@ -1,3 +1,4 @@
+import { WorkspaceUser } from 'botpress/sdk'
 import { Location } from 'history'
 import _ from 'lodash'
 import { getActiveWorkspace } from '~/auth/basicAuth'
@@ -18,11 +19,8 @@ export function filterList<T>(elements: T[], filterFields: string[], query: stri
   )
 }
 
-export function getValidWorkspaceId(workspaces: any[] | undefined, location: Location): string | null {
-  const [, urlSection, urlWorkspaceId, urlPage] = location.pathname.split('/')
-  if (!workspaces || !workspaces.length) {
-    return null
-  }
+export function getValidWorkspaceId(workspaces: WorkspaceUser[], location: Location): string {
+  const [, _, urlWorkspaceId, __] = location.pathname.split('/')
 
   const urlId = workspaces.find(x => x.workspace === urlWorkspaceId)
   const storageId = workspaces.find(x => x.workspace === getActiveWorkspace())

--- a/packages/bp/src/admin/ui/src/workspace/util.ts
+++ b/packages/bp/src/admin/ui/src/workspace/util.ts
@@ -1,4 +1,6 @@
+import { Location } from 'history'
 import _ from 'lodash'
+import { getActiveWorkspace } from '~/auth/basicAuth'
 
 export function filterList<T>(elements: T[], filterFields: string[], query: string): T[] {
   if (!query) {
@@ -14,4 +16,15 @@ export function filterList<T>(elements: T[], filterFields: string[], query: stri
         .includes(query)
     )
   )
+}
+
+export function getValidWorkspaceId(workspaces: any[] | undefined, location: Location): string | null {
+  const [, urlSection, urlWorkspaceId, urlPage] = location.pathname.split('/')
+  if (!workspaces || !workspaces.length) {
+    return null
+  }
+
+  const urlId = workspaces.find(x => x.workspace === urlWorkspaceId)
+  const storageId = workspaces.find(x => x.workspace === getActiveWorkspace())
+  return (urlId && urlId.workspace) || (storageId && storageId.workspace) || workspaces[0].workspace
 }

--- a/packages/bp/src/admin/ui/src/workspace/util.ts
+++ b/packages/bp/src/admin/ui/src/workspace/util.ts
@@ -19,7 +19,7 @@ export function filterList<T>(elements: T[], filterFields: string[], query: stri
   )
 }
 
-export function getValidWorkspaceId(workspaces: WorkspaceUser[], location: Location): string {
+export function getCurrentWorkspaceID(workspaces: WorkspaceUser[], location: Location): string {
   const [, _, urlWorkspaceId, __] = location.pathname.split('/')
 
   const urlId = workspaces.find(x => x.workspace === urlWorkspaceId)

--- a/packages/bp/src/admin/workspace/bots/bots-router.ts
+++ b/packages/bp/src/admin/workspace/bots/bots-router.ts
@@ -112,7 +112,7 @@ class BotsRouter extends CustomAdminRouter {
             throw new BadRequestError(`Expected bot ID to start with ${correctPrefix}`)
           }
 
-          await this.botService.addBot(bot, req.body.template)
+          await this.botService.addBot(bot, req.body.template, req.workspace!)
         }
 
         if (botLinked) {

--- a/packages/bp/src/admin/workspace/bots/bots-router.ts
+++ b/packages/bp/src/admin/workspace/bots/bots-router.ts
@@ -107,11 +107,6 @@ class BotsRouter extends CustomAdminRouter {
             }
           }
 
-          const correctPrefix = `${req.workspace!}_`
-          if (!(bot.id.startsWith(correctPrefix) && bot.id.length > correctPrefix.length)) {
-            throw new BadRequestError(`Expected bot ID to start with ${correctPrefix}`)
-          }
-
           await this.botService.addBot(bot, req.body.template, req.workspace!)
         }
 

--- a/packages/bp/src/admin/workspace/bots/bots-router.ts
+++ b/packages/bp/src/admin/workspace/bots/bots-router.ts
@@ -2,7 +2,7 @@ import { AdminServices } from 'admin/admin-router'
 import { CustomAdminRouter } from 'admin/utils/customAdminRouter'
 import { BotConfig } from 'botpress/sdk'
 import { UnexpectedError } from 'common/http'
-import { ConflictError, ForbiddenError, sendSuccess } from 'core/routers'
+import { ConflictError, BadRequestError, ForbiddenError, sendSuccess } from 'core/routers'
 import { assertSuperAdmin, assertWorkspace } from 'core/security'
 import Joi from 'joi'
 import _ from 'lodash'
@@ -106,6 +106,12 @@ class BotsRouter extends CustomAdminRouter {
               promoted_by: req.tokenUser!.email
             }
           }
+
+          const correctPrefix = `${req.workspace!}_`
+          if (!(bot.id.startsWith(correctPrefix) && bot.id.length > correctPrefix.length)) {
+            throw new BadRequestError(`Expected bot ID to start with ${correctPrefix}`)
+          }
+
           await this.botService.addBot(bot, req.body.template)
         }
 

--- a/packages/bp/src/common/utils.ts
+++ b/packages/bp/src/common/utils.ts
@@ -20,13 +20,13 @@ export const sanitizeName = (text: string) =>
 
 /**
  *
- * @param workspaceName string
- * @param botId string
+ * @param workspaceName string Not sanitized worskpace name
+ * @param botName string Not sanitized bot name
  * @returns string that repects validation.ts BOT_ID_REGEX
  */
-export const makeBotId = (workspaceName: string, botId: string) => {
-  const trimWID = workspaceName.slice(0, 3)
-  const sanBotId = sanitizeName(botId)
+export const makeWorkspaceScopedBotID = (workspaceName: string, botName: string) => {
+  const trimWID = sanitizeName(workspaceName).slice(0, 3)
+  const sanBotId = sanitizeName(botName)
 
   return `${trimWID}_-_${sanBotId}`
 }

--- a/packages/bp/src/common/utils.ts
+++ b/packages/bp/src/common/utils.ts
@@ -28,5 +28,5 @@ export const makeWorkspaceScopedBotID = (workspaceName: string, botName: string)
   const trimWID = sanitizeName(workspaceName).slice(0, 3)
   const sanBotId = sanitizeName(botName)
 
-  return `${trimWID}_-_${sanBotId}`
+  return `${trimWID}__${sanBotId}`
 }

--- a/packages/bp/src/common/utils.ts
+++ b/packages/bp/src/common/utils.ts
@@ -14,6 +14,7 @@ export const bytesToString = (bytes: number): string => {
 
 export const sanitizeName = (text: string) =>
   text
+    .trim()
     .replace(/\s|\t|\n/g, '-')
     .toLowerCase()
     .replace(/[^a-z0-9-_.]/g, '')

--- a/packages/bp/src/common/utils.ts
+++ b/packages/bp/src/common/utils.ts
@@ -17,3 +17,16 @@ export const sanitizeName = (text: string) =>
     .replace(/\s|\t|\n/g, '-')
     .toLowerCase()
     .replace(/[^a-z0-9-_.]/g, '')
+
+/**
+ *
+ * @param workspaceName string
+ * @param botId string
+ * @returns string that repects validation.ts BOT_ID_REGEX
+ */
+export const makeBotId = (workspaceName: string, botId: string) => {
+  const trimWID = workspaceName.slice(0, 3)
+  const sanBotId = sanitizeName(botId)
+
+  return `${trimWID}_-_${sanBotId}`
+}

--- a/packages/bp/src/common/validation.test.ts
+++ b/packages/bp/src/common/validation.test.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { BOTID_REGEX, LEGACY_BOTID_REGEX } from './validation'
+import { BOTID_REGEX, SANITIZED_NAME_REGEX } from './validation'
 
 describe('BotId validation', () => {
   const validLegacyBotIDs = ['bot123', 'bot_123', 'lol-123', 'bo-t-the-valid-123', 'bo_t-the-valid-123']
@@ -25,21 +25,21 @@ describe('BotId validation', () => {
     '1-'
   ]
   const invalidWSPrefix = ['-', '_', '.', '/', '?', '|', '_a', '-a']
-  const validBotIds = _.flatMap(validLegacyBotIDs, id => validWSPrefix.map(pref => `${pref}_-_${id}`))
+  const validBotIds = _.flatMap(validLegacyBotIDs, id => validWSPrefix.map(pref => `${pref}__${id}`))
   const invalidBotIds = [
     ...validLegacyBotIDs,
     ...invalidLegacyBotIDs,
-    ..._.flatMap(validLegacyBotIDs, id => invalidWSPrefix.map(prefix => `${prefix}_-_${id}`)),
-    ...validBotIds.map(id => id.replace('_-_', ''))
+    ..._.flatMap(validLegacyBotIDs, id => invalidWSPrefix.map(prefix => `${prefix}__${id}`)),
+    ...validBotIds.map(id => id.replace('__', ''))
   ]
 
   test('Legacy bot id validation should pass', () => {
     for (let id of validLegacyBotIDs) {
-      expect(id).toMatch(LEGACY_BOTID_REGEX)
+      expect(id).toMatch(SANITIZED_NAME_REGEX)
     }
 
     for (let id of invalidLegacyBotIDs) {
-      expect(id).not.toMatch(LEGACY_BOTID_REGEX)
+      expect(id).not.toMatch(SANITIZED_NAME_REGEX)
     }
   })
 

--- a/packages/bp/src/common/validation.test.ts
+++ b/packages/bp/src/common/validation.test.ts
@@ -1,0 +1,55 @@
+import _ from 'lodash'
+import { BOTID_REGEX, LEGACY_BOTID_REGEX } from './validation'
+
+describe('BotId validation', () => {
+  const validLegacyBotIDs = ['bot123', 'bot_123', 'lol-123', 'bo-t-the-valid-123', 'bo_t-the-valid-123']
+  const invalidLegacyBotIDs = ['_bot123', '-bot123', '.bot123', '|bot123', '~bot123', 'bot123_', 'bot123-']
+
+  const validWSPrefix = [
+    'asd',
+    'a1s',
+    'a_s',
+    'a_1',
+    'a-1',
+    '1_a',
+    '1-a',
+    'as-',
+    'as_',
+    '1s-',
+    '1s_',
+    'a1',
+    '1a',
+    'a-',
+    'a_',
+    '1_',
+    '1-'
+  ]
+  const invalidWSPrefix = ['-', '_', '.', '/', '?', '|', '_a', '-a']
+  const validBotIds = _.flatMap(validLegacyBotIDs, id => validWSPrefix.map(pref => `${pref}_-_${id}`))
+  const invalidBotIds = [
+    ...validLegacyBotIDs,
+    ...invalidLegacyBotIDs,
+    ..._.flatMap(validLegacyBotIDs, id => invalidWSPrefix.map(prefix => `${prefix}_-_${id}`)),
+    ...validBotIds.map(id => id.replace('_-_', ''))
+  ]
+
+  test('Legacy bot id validation should pass', () => {
+    for (let id of validLegacyBotIDs) {
+      expect(id).toMatch(LEGACY_BOTID_REGEX)
+    }
+
+    for (let id of invalidLegacyBotIDs) {
+      expect(id).not.toMatch(LEGACY_BOTID_REGEX)
+    }
+  })
+
+  test('New worspace id bot id validation should pass', () => {
+    for (let id of validBotIds) {
+      expect(id).toMatch(BOTID_REGEX)
+    }
+
+    for (let id of invalidBotIds) {
+      expect(id).not.toMatch(BOTID_REGEX)
+    }
+  })
+})

--- a/packages/bp/src/common/validation.ts
+++ b/packages/bp/src/common/validation.ts
@@ -2,17 +2,11 @@ import Joi from 'joi'
 
 import { defaultPipelines } from './defaults'
 
-export const LEGACY_BOTID_REGEX = /^[A-Z0-9]+[A-Z0-9_-]{1,}[A-Z0-9]+$/i
-export const BOTID_REGEX = /^[A-Z0-9]{1}[A-Z0-9-_]{1,2}_-_[A-Z0-9_-]+[A-Z0-9]+$/i // <WOR>_-_<BOTNAME>
-export const WORKSPACEID_REGEX = /^[A-Z0-9-_]+$/i
+export const SANITIZED_NAME_REGEX = /^[A-Z0-9]+[A-Z0-9_-]{1,}[A-Z0-9]+$/i
+export const BOTID_REGEX = /^[A-Z0-9]{1}[A-Z0-9-_]{1,2}__[A-Z0-9_-]+[A-Z0-9]+$/i // <WOR>__<BOTNAME>
 const OP_REGEX = /^([\+|-][r|w]){1,2}$/
 
-export const isValidBotId = (botId: string): boolean => LEGACY_BOTID_REGEX.test(botId) || BOTID_REGEX.test(botId)
-
-export const doesBotIdStartWithWorkspace = (botId: string, workspace: string) => {
-  const correctPrefix = `${workspace}_`
-  return botId.startsWith(correctPrefix) && botId.length > correctPrefix.length
-}
+export const isValidBotId = (botId: string): boolean => SANITIZED_NAME_REGEX.test(botId) || BOTID_REGEX.test(botId)
 
 export const BotCreationSchema = Joi.object().keys({
   id: Joi.string()
@@ -103,7 +97,7 @@ const AuthRole = Joi.object().keys({
 
 export const WorkspaceCreationSchema = Joi.object().keys({
   id: Joi.string()
-    .regex(WORKSPACEID_REGEX)
+    .regex(SANITIZED_NAME_REGEX)
     .required(),
   name: Joi.string()
     .max(50)

--- a/packages/bp/src/common/validation.ts
+++ b/packages/bp/src/common/validation.ts
@@ -2,8 +2,8 @@ import Joi from 'joi'
 
 import { defaultPipelines } from './defaults'
 
-export const BOTID_REGEX = /^[A-Z0-9]+[A-Z0-9_-]{1,}[A-Z0-9]+$/i
-export const WORKSPACEID_REGEX = /^[A-Z0-9-_\/]+$/i
+export const BOTID_REGEX = /^[A-Z0-9-_]+_[A-Z0-9-_]+$/i // <WORKSPACEID>_<BOTNAME)>
+export const WORKSPACEID_REGEX = /^[A-Z0-9-_]+$/i
 const OP_REGEX = /^([\+|-][r|w]){1,2}$/
 
 export const isValidBotId = (botId: string): boolean => BOTID_REGEX.test(botId)

--- a/packages/bp/src/common/validation.ts
+++ b/packages/bp/src/common/validation.ts
@@ -2,11 +2,12 @@ import Joi from 'joi'
 
 import { defaultPipelines } from './defaults'
 
-export const BOTID_REGEX = /^[A-Z0-9-_]+_[A-Z0-9-_]+$/i // <WORKSPACEID>_<BOTNAME)>
+export const LEGACY_BOTID_REGEX = /^[A-Z0-9]+[A-Z0-9_-]{1,}[A-Z0-9]+$/i
+export const BOTID_REGEX = /^[A-Z0-9]{1}[A-Z0-9-_]{1,2}_-_[A-Z0-9_-]+[A-Z0-9]+$/i // <WOR>_-_<BOTNAME>
 export const WORKSPACEID_REGEX = /^[A-Z0-9-_]+$/i
 const OP_REGEX = /^([\+|-][r|w]){1,2}$/
 
-export const isValidBotId = (botId: string): boolean => BOTID_REGEX.test(botId)
+export const isValidBotId = (botId: string): boolean => LEGACY_BOTID_REGEX.test(botId) || BOTID_REGEX.test(botId)
 
 export const doesBotIdStartWithWorkspace = (botId: string, workspace: string) => {
   const correctPrefix = `${workspace}_`

--- a/packages/bp/src/common/validation.ts
+++ b/packages/bp/src/common/validation.ts
@@ -8,6 +8,11 @@ const OP_REGEX = /^([\+|-][r|w]){1,2}$/
 
 export const isValidBotId = (botId: string): boolean => BOTID_REGEX.test(botId)
 
+export const doesBotIdStartWithWorkspace = (botId: string, workspace: string) => {
+  const correctPrefix = `${workspace}_`
+  return botId.startsWith(correctPrefix) && botId.length > correctPrefix.length
+}
+
 export const BotCreationSchema = Joi.object().keys({
   id: Joi.string()
     .regex(BOTID_REGEX)

--- a/packages/bp/src/common/validation.ts
+++ b/packages/bp/src/common/validation.ts
@@ -3,7 +3,7 @@ import Joi from 'joi'
 import { defaultPipelines } from './defaults'
 
 export const BOTID_REGEX = /^[A-Z0-9]+[A-Z0-9_-]{1,}[A-Z0-9]+$/i
-export const WORKSPACEID_REGEX = /[A-Z0-9-_\/]/i
+export const WORKSPACEID_REGEX = /^[A-Z0-9-_\/]+$/i
 const OP_REGEX = /^([\+|-][r|w]){1,2}$/
 
 export const isValidBotId = (botId: string): boolean => BOTID_REGEX.test(botId)

--- a/packages/bp/src/core/bots/bot-service.ts
+++ b/packages/bp/src/core/bots/bot-service.ts
@@ -1,7 +1,7 @@
 import { BotConfig, BotTemplate, Logger, Stage, WorkspaceUserWithAttributes } from 'botpress/sdk'
 import cluster from 'cluster'
 import { BotHealth, ServerHealth } from 'common/typings'
-import { BotCreationSchema, BotEditSchema, isValidBotId } from 'common/validation'
+import { BotCreationSchema, BotEditSchema, isValidBotId, doesBotIdStartWithWorkspace } from 'common/validation'
 import { createForGlobalHooks } from 'core/app/api'
 import { TYPES } from 'core/app/types'
 import { FileContent, GhostService, ReplaceContent } from 'core/bpfs'
@@ -152,7 +152,7 @@ export class BotService {
       throw new InvalidOperationError(`An error occurred while creating the bot: ${error.message}`)
     }
 
-    if (!bot.id.startsWith(`${workspaceId}_`)) {
+    if (!doesBotIdStartWithWorkspace(bot.id, workspaceId)) {
       throw new InvalidOperationError('BotId must start with <workspaceID>_')
     }
 
@@ -250,7 +250,7 @@ export class BotService {
       throw new InvalidOperationError("Can't import bot; the bot name contains invalid characters")
     }
 
-    if (!botId.startsWith(`${workspaceId}_`)) {
+    if (!doesBotIdStartWithWorkspace(botId, workspaceId)) {
       throw new InvalidOperationError('BotId must start with <workspaceID>_')
     }
 

--- a/packages/bp/src/core/bots/bot-service.ts
+++ b/packages/bp/src/core/bots/bot-service.ts
@@ -242,7 +242,7 @@ export class BotService {
     const startTime = Date.now()
 
     if (!isValidBotId(botId)) {
-      throw new InvalidOperationError("Can't import bot; the bot name contains invalid characters")
+      throw new InvalidOperationError(`Can't import bot; the bot id: ${botId} contains invalid characters`)
     }
 
     if (await this.botExists(botId)) {

--- a/packages/bp/src/core/bots/bot-service.ts
+++ b/packages/bp/src/core/bots/bot-service.ts
@@ -1,7 +1,7 @@
 import { BotConfig, BotTemplate, Logger, Stage, WorkspaceUserWithAttributes } from 'botpress/sdk'
 import cluster from 'cluster'
 import { BotHealth, ServerHealth } from 'common/typings'
-import { BotCreationSchema, BotEditSchema, isValidBotId, doesBotIdStartWithWorkspace } from 'common/validation'
+import { BotCreationSchema, BotEditSchema, isValidBotId } from 'common/validation'
 import { createForGlobalHooks } from 'core/app/api'
 import { TYPES } from 'core/app/types'
 import { FileContent, GhostService, ReplaceContent } from 'core/bpfs'
@@ -14,8 +14,8 @@ import { extractArchive } from 'core/misc/archive'
 import { listDir } from 'core/misc/list-dir'
 import { stringify } from 'core/misc/utils'
 import { ModuleResourceLoader, ModuleLoader } from 'core/modules'
-import { RealtimeService, RealTimePayload } from 'core/realtime'
-import { BadRequestError, InvalidOperationError } from 'core/routers'
+import { RealtimeService } from 'core/realtime'
+import { InvalidOperationError } from 'core/routers'
 import { AnalyticsService } from 'core/telemetry'
 import { Hooks, HookService } from 'core/user-code'
 import { WorkspaceService } from 'core/users'
@@ -31,7 +31,6 @@ import { studioActions } from 'orchestrator'
 import os from 'os'
 import path from 'path'
 import replace from 'replace-in-file'
-import semver from 'semver'
 import tmp from 'tmp'
 import { VError } from 'verror'
 
@@ -152,10 +151,6 @@ export class BotService {
       throw new InvalidOperationError(`An error occurred while creating the bot: ${error.message}`)
     }
 
-    if (!doesBotIdStartWithWorkspace(bot.id, workspaceId)) {
-      throw new InvalidOperationError('BotId must start with <workspaceID>_')
-    }
-
     const mergedConfigs = await this._createBotFromTemplate(bot, botTemplate)
     if (mergedConfigs) {
       if (!mergedConfigs.disabled) {
@@ -248,10 +243,6 @@ export class BotService {
 
     if (!isValidBotId(botId)) {
       throw new InvalidOperationError("Can't import bot; the bot name contains invalid characters")
-    }
-
-    if (!doesBotIdStartWithWorkspace(botId, workspaceId)) {
-      throw new InvalidOperationError('BotId must start with <workspaceID>_')
     }
 
     if (await this.botExists(botId)) {

--- a/packages/bp/src/core/bots/bot-service.ts
+++ b/packages/bp/src/core/bots/bot-service.ts
@@ -285,7 +285,7 @@ export class BotService {
 
         const newConfigs = <Partial<BotConfig>>{
           id: botId,
-          name: originalConfig.name ? originalConfig.name : `${originalConfig.name} (${botId})`,
+          name: `${originalConfig.name} (${botId})`, //avoid visual conflict when dealing with multiple bots with the same name
           pipeline_status: {
             current_stage: {
               id: pipeline && pipeline[0].id,

--- a/packages/bp/src/core/bots/bot-service.ts
+++ b/packages/bp/src/core/bots/bot-service.ts
@@ -144,12 +144,16 @@ export class BotService {
     return this._botIds
   }
 
-  async addBot(bot: BotConfig, botTemplate: BotTemplate): Promise<void> {
+  async addBot(bot: BotConfig, botTemplate: BotTemplate, workspaceId: string): Promise<void> {
     this.stats.track('bot', 'create')
 
     const { error } = Joi.validate(bot, BotCreationSchema)
     if (error) {
       throw new InvalidOperationError(`An error occurred while creating the bot: ${error.message}`)
+    }
+
+    if (!bot.id.startsWith(`${workspaceId}_`)) {
+      throw new InvalidOperationError('BotId must start with <workspaceID>_')
     }
 
     const mergedConfigs = await this._createBotFromTemplate(bot, botTemplate)
@@ -244,6 +248,10 @@ export class BotService {
 
     if (!isValidBotId(botId)) {
       throw new InvalidOperationError("Can't import bot; the bot name contains invalid characters")
+    }
+
+    if (!botId.startsWith(`${workspaceId}_`)) {
+      throw new InvalidOperationError('BotId must start with <workspaceID>_')
     }
 
     if (await this.botExists(botId)) {


### PR DESCRIPTION
The solution we agreed on is to auto-generate bot IDs that start with the 3 first characters of current workspace id with `__` as join characters resulting as `wor__bot` with a workspace named `workspace12` and a bot named `bot`. Although this could have been done entirely from the backend I wanted to avoid changing most of the logic so it's entirely done in the frontend, and is validated in the backend.

**Potential collisions:**
It was visually annoying to concat the whole workspace name and the bot id while exploring the file tree, thus the 3 starting chars. This can result in collisions if a deployment has 2 workspaces starting by the same prefixes and have the same bot name. for instance:  
ws: `companyA` botName: `test` ==> results in `com__test`
ws: `companyB` botName: `test` ==> results in `com__test`
💥 collision 

**solution1 **: generate a short number making it less likely to collisions. ex: `com__test__123`
**solution2 **: hash the workspace id instead and take the 4 first char but that would require to move the logic in the backend. ex: `p8a9__test`

IMO this is ever engineering, the likelihood is quite low and it's annoying inspecting the file tree. Let me know your thoughts

missing: 
* e2e tests to fix (very soon)