### PR TITLE
fix(core): various fixes

### DIFF
--- a/modules/code-editor/src/backend/definitions.ts
+++ b/modules/code-editor/src/backend/definitions.ts
@@ -82,7 +82,8 @@ export const FileTypes: { [type: string]: FileDefinition } = {
     permission: 'shared_libs',
     ghost: {
       dirListingExcluded: ['node_modules'],
-      baseDir: '/libraries'
+      baseDir: '/libraries',
+      shouldSyncToDisk: true
     },
     canDelete: file => {
       return !file.name.endsWith('.json')

--- a/modules/libraries/src/translations/en.json
+++ b/modules/libraries/src/translations/en.json
@@ -12,5 +12,5 @@
   "viewGithub": "View on Github",
   "customCommand": "Type a custom command",
   "openConsole": "Open the console to view command output",
-  "betaWarning": "This is an experimental module. Please do not rely on it too much because the implementation may change in the near future"
+  "betaWarning": "This module is deprecated and will be removed soon. Please use the 'Libraries' tab on the studio instead"
 }

--- a/modules/libraries/src/translations/fr.json
+++ b/modules/libraries/src/translations/fr.json
@@ -19,5 +19,5 @@
   "deleteSuccess": "Librairie retirée avec succès",
   "removeFailure": "Il y a eu une erreur lors du retrait de la librairie. Veuillez regarder les journaux du serveur pour plus de détails",
   "bundleError": "Il y a eu une erreur lors de l'empaquetage de la librairie.",
-  "betaWarning": "C'est un module expérmental. L'implémentation peut changer drastiquement à court terme"
+  "betaWarning": "Ce module sera bientôt supprimé. Veuillez utiliser l'onglet 'Librairie' sur le studio."
 }

--- a/modules/libraries/src/views/full/AddLibrary.tsx
+++ b/modules/libraries/src/views/full/AddLibrary.tsx
@@ -1,7 +1,5 @@
 import { Button, ControlGroup, InputGroup, Radio, RadioGroup } from '@blueprintjs/core'
 import { lang, toast } from 'botpress/shared'
-// @ts-ignore - provided by the studio
-import { isOperationAllowed } from 'botpress/utils'
 import React, { useState } from 'react'
 
 import Dropdown from './LibDropdown'
@@ -88,6 +86,8 @@ const AddLibrary = props => {
     // const { data } = await props.axios.get(`/mod/libraries/details/${item.name}`)
   }
 
+  const isSuperAdmin = props.userProfile?.isSuperAdmin
+
   return (
     <div>
       <div className={style.title}>{lang.tr('module.libraries.addLibrary')}</div>
@@ -96,9 +96,7 @@ const AddLibrary = props => {
         <Radio label={lang.tr('module.libraries.searchGithub')} value="github" />
         <Radio label={lang.tr('module.libraries.uploadArchive')} value="archive" />
 
-        {isOperationAllowed && isOperationAllowed({ superAdmin: true }) && (
-          <Radio label={lang.tr('module.libraries.customCommand')} value="command" />
-        )}
+        {isSuperAdmin && <Radio label={lang.tr('module.libraries.customCommand')} value="command" />}
       </RadioGroup>
       <br />
 

--- a/modules/libraries/src/views/full/index.tsx
+++ b/modules/libraries/src/views/full/index.tsx
@@ -92,7 +92,7 @@ const MainView = props => {
         )}
 
         <div className={style.container}>
-          {page === 'add' && <AddLibrary axios={props.bp.axios} {...commonProps} />}
+          {page === 'add' && <AddLibrary axios={props.bp.axios} userProfile={props.userProfile} {...commonProps} />}
         </div>
       </div>
     </Container>

--- a/modules/libraries/src/views/full/style.scss
+++ b/modules/libraries/src/views/full/style.scss
@@ -19,6 +19,6 @@
 
 .beta {
   height: 20px;
-  background-color: lightblue;
+  background-color: lightcoral;
   text-align: center;
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "version": "0.1.3"
   },
   "studio": {
-    "version": "0.0.30"
+    "version": "0.0.31"
   },
   "messaging": {
     "version": "0.1.7"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "version": "0.1.3"
   },
   "studio": {
-    "version": "0.0.29"
+    "version": "0.0.30"
   },
   "messaging": {
     "version": "0.1.7"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "version": "0.1.3"
   },
   "studio": {
-    "version": "0.0.31"
+    "version": "0.0.32"
   },
   "messaging": {
     "version": "0.1.7"

--- a/packages/bp/src/admin/ui/src/app/InjectedModuleView/AppLoader.tsx
+++ b/packages/bp/src/admin/ui/src/app/InjectedModuleView/AppLoader.tsx
@@ -29,7 +29,10 @@ const AppLoader: FC<Props> = props => {
 
   return (
     <PageContainer title={lang.tr(`module.${module?.name}.fullName`) || module?.fullName || appName} noWrapper>
-      <InjectedModuleView moduleName={appName} extraProps={{ botId, contentLang: props.contentLang }} />
+      <InjectedModuleView
+        moduleName={appName}
+        extraProps={{ botId, contentLang: props.contentLang, userProfile: props.profile }}
+      />
     </PageContainer>
   )
 }
@@ -37,6 +40,7 @@ const AppLoader: FC<Props> = props => {
 const mapStateToProps = (state: AppState) => ({
   contentLang: state.ui.contentLang,
   modules: state.modules.loadedModules,
+  profile: state.user.profile,
   translationsLoaded: state.modules.translationsLoaded
 })
 

--- a/packages/bp/src/admin/ui/src/management/checklist/index.tsx
+++ b/packages/bp/src/admin/ui/src/management/checklist/index.tsx
@@ -116,10 +116,12 @@ export const Checklist: FC<Props> = props => {
         <Item
           title="Enable Botpress Professional"
           docs="https://botpress.com/docs/pro/about-pro/"
-          status={getEnv('PRO_ENABLED') === 'true' || getConfig('pro.enabled') === 'true' ? 'success' : 'warning'}
+          status={
+            getEnv('BP_CONFIG_PRO_ENABLED') === 'true' || getConfig('pro.enabled') === 'true' ? 'success' : 'warning'
+          }
           source={[
-            { type: 'env', key: 'PRO_ENABLED', value: getEnv('PRO_ENABLED') }, // deprecated
-            { type: 'env', key: 'BP_LICENSE_KEY', value: getEnv('BP_LICENSE_KEY') }, // deprecated
+            { type: 'env', key: 'BP_CONFIG_PRO_ENABLED', value: getEnv('BP_CONFIG_PRO_ENABLED') },
+            { type: 'env', key: 'BP_CONFIG_PRO_LICENSEKEY', value: getEnv('BP_CONFIG_PRO_LICENSEKEY') },
             { type: 'config', key: 'pro.enabled', value: getConfig('pro.enabled') },
             { type: 'config', key: 'pro.licenseKey', value: getConfig('pro.licenseKey') }
           ]}

--- a/packages/bp/src/core/app/internal-router.ts
+++ b/packages/bp/src/core/app/internal-router.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import { Logger } from 'botpress/sdk'
 import { UnauthorizedError } from 'common/http'
+import { BotService } from 'core/bots'
 import { MemoryObjectCache } from 'core/bpfs'
 import { CMSService } from 'core/cms'
 import { ModuleLoader } from 'core/modules'
@@ -18,6 +19,7 @@ export class InternalRouter extends CustomRouter {
     private moduleLoader: ModuleLoader,
     private realtime: RealtimeService,
     private objectCache: MemoryObjectCache,
+    private botService: BotService,
     private httpServer: HTTPServer
   ) {
     super('Internal', logger, Router({ mergeParams: true }))
@@ -115,6 +117,15 @@ export class InternalRouter extends CustomRouter {
       '/setStudioReady',
       this.asyncMiddleware(async (req, res) => {
         AppLifecycle.setDone(AppLifecycleEvents.STUDIO_READY)
+        res.sendStatus(200)
+      })
+    )
+
+    router.post(
+      '/syncBotLibs',
+      this.asyncMiddleware(async (req, res) => {
+        const { botId, serverId } = req.body
+        this.botService.syncLibs(botId, serverId)
         res.sendStatus(200)
       })
     )

--- a/packages/bp/src/core/app/server.ts
+++ b/packages/bp/src/core/app/server.ts
@@ -202,6 +202,7 @@ export class HTTPServer {
       this.moduleLoader,
       this.realtime,
       this.objectCache,
+      this.botService,
       this
     )
 

--- a/packages/bp/src/core/config/config-loader.ts
+++ b/packages/bp/src/core/config/config-loader.ts
@@ -27,6 +27,7 @@ export class ConfigProvider {
   private _botpressConfigCache: BotpressConfig | undefined
   public initialConfigHash: string | undefined
   public currentConfigHash!: string
+  private _deprecateEnvVarWarned = false
 
   constructor(
     @inject(TYPES.GhostService) private ghostService: GhostService,
@@ -64,6 +65,22 @@ export class ConfigProvider {
       config.pro.licenseKey = process.env.BP_LICENSE_KEY || config.pro.licenseKey
     }
 
+    this._warnDeprecatedKeys()
+
+    this._botpressConfigCache = config
+
+    if (!this.initialConfigHash) {
+      this.initialConfigHash = calculateHash(JSON.stringify(removeDynamicProps(config)))
+    }
+
+    return config
+  }
+
+  private _warnDeprecatedKeys() {
+    if (this._deprecateEnvVarWarned) {
+      return
+    }
+
     const deprecatedEnvKeys = [
       ['BP_PORT', 'httpServer.port'],
       ['BP_HOST', 'httpServer.host'],
@@ -80,13 +97,7 @@ export class ConfigProvider {
       }
     })
 
-    this._botpressConfigCache = config
-
-    if (!this.initialConfigHash) {
-      this.initialConfigHash = calculateHash(JSON.stringify(removeDynamicProps(config)))
-    }
-
-    return config
+    this._deprecateEnvVarWarned = true
   }
 
   private _makeBPConfigEnvKey(option: string): string {

--- a/packages/bp/src/core/modules/module-resources-loader.ts
+++ b/packages/bp/src/core/modules/module-resources-loader.ts
@@ -138,6 +138,11 @@ export class ModuleResourceLoader {
         await this._upsertModuleResources(resource)
       }
     }
+
+    if (process.BPFS_STORAGE === 'database') {
+      await this.ghost.global().syncDatabaseFilesToDisk('actions')
+      await this.ghost.global().syncDatabaseFilesToDisk('hooks')
+    }
   }
 
   async getBotTemplatePath(templateName: string) {

--- a/packages/bp/src/core/user-code/action-service.ts
+++ b/packages/bp/src/core/user-code/action-service.ts
@@ -101,7 +101,7 @@ export class ActionService {
   // Debouncing invalidate since we get a lot of events when it happens
   private _invalidateRequire() {
     Object.keys(require.cache)
-      .filter(r => r.match(/(\\|\/)actions(\\|\/)/g) || r.match(/(\\|\/)shared_libs(\\|\/)/g))
+      .filter(r => r.match(/(\\|\/)(actions|shared_libs|libraries)(\\|\/)/g))
       .map(file => delete require.cache[file])
 
     clearRequireCache()

--- a/packages/bp/src/core/user-code/hook-service.ts
+++ b/packages/bp/src/core/user-code/hook-service.ts
@@ -175,7 +175,7 @@ export class HookService {
 
   private _invalidateRequire() {
     Object.keys(require.cache)
-      .filter(r => r.match(/(\\|\/)hooks(\\|\/)/g) || r.match(/(\\|\/)shared_libs(\\|\/)/g))
+      .filter(r => r.match(/(\\|\/)(hooks|shared_libs|libraries)(\\|\/)/g))
       .map(file => delete require.cache[file])
 
     clearRequireCache()

--- a/packages/bp/src/index.ts
+++ b/packages/bp/src/index.ts
@@ -96,13 +96,13 @@ try {
   if (process.IS_PRO_AVAILABLE) {
     process.CLUSTER_ENABLED = yn(process.env.CLUSTER_ENABLED)
 
-    if (process.env.PRO_ENABLED === undefined && process.env['BP_CONFIG_PRO.ENABLED'] === undefined) {
+    if (process.env.PRO_ENABLED === undefined && process.env.BP_CONFIG_PRO_ENABLED === undefined) {
       if (fs.existsSync(configPath)) {
         const config = require(configPath)
         process.IS_PRO_ENABLED = config.pro && config.pro.enabled
       }
     } else {
-      process.IS_PRO_ENABLED = yn(process.env.PRO_ENABLED) || yn(process.env['BP_CONFIG_PRO.ENABLED'])
+      process.IS_PRO_ENABLED = yn(process.env.PRO_ENABLED) || yn(process.env.BP_CONFIG_PRO_ENABLED)
     }
   }
 

--- a/packages/bp/src/migrations/v12_25_0-1629145370-remove_qna_module.ts
+++ b/packages/bp/src/migrations/v12_25_0-1629145370-remove_qna_module.ts
@@ -1,11 +1,9 @@
 import * as sdk from 'botpress/sdk'
-import { BotService } from 'core/bots'
 import { Migration, MigrationOpts } from 'core/migration'
-import { TYPES } from 'core/types'
 
 const migration: Migration = {
   info: {
-    description: '',
+    description: 'Remove QNA module',
     target: 'core',
     type: 'config'
   },

--- a/packages/bp/src/migrations/v12_25_0-1629391854-remove_extensions_module.ts
+++ b/packages/bp/src/migrations/v12_25_0-1629391854-remove_extensions_module.ts
@@ -1,0 +1,23 @@
+import * as sdk from 'botpress/sdk'
+import { Migration, MigrationOpts } from 'core/migration'
+
+const migration: Migration = {
+  info: {
+    description: 'Remove module extensions',
+    target: 'core',
+    type: 'config'
+  },
+  up: async ({ bp, configProvider }: MigrationOpts): Promise<sdk.MigrationResult> => {
+    const config = await configProvider.getBotpressConfig()
+    const entry = config.modules.find(x => x.location.endsWith('/extensions'))
+
+    if (entry) {
+      entry.enabled = false
+      await configProvider.setBotpressConfig(config)
+    }
+
+    return { success: true, message: 'Configuration updated successfully' }
+  }
+}
+
+export default migration


### PR DESCRIPTION
I merged multiple PR on the studio and on the core, and there's some fixes that had to be done since i'm still testing different scenarios.

This is still a work in progress

- Fix libraries staying in cache

- Fixed warnings of deprecation which were sent everytime the config was changed
![image](https://user-images.githubusercontent.com/42552874/130119025-52efffd3-f66a-44c4-bd0e-f1ad759541de.png)

- Fixed typo for an env var, which caused BP to not start when you followed instructions or the documentation: `(Deprecated) use standard syntax to set config from environment variable: PRO_ENABLED ==> BP_CONFIG_PRO_ENABLED` (the code was expecting `BP_CONFIG_PRO.ENABLED`)

- Fix for syncing libraries across nodes, temporarily while you can still run the studio alongside the server
