### PR TITLE
feat(core): custom bot prefix per workspace

### DIFF
--- a/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
@@ -99,16 +99,10 @@ class CreateBotModal extends Component<Props, State> {
 
   handleNameChanged = e => {
     const botName = e.target.value
-    const botId = this.state.generateId ? sanitizeBotId(botName) : this.state.botId
-
-    this.setState({ botName, botId })
+    this.setState({ botName, botId: this.state.generateId ? sanitizeBotId(botName) : this.state.botId })
   }
 
-  handleBotIdChanged = e =>
-    this.setState({
-      botId: sanitizeBotId(e.target.value),
-      generateId: false
-    })
+  handleBotIdChanged = e => this.setState({ botId: sanitizeBotId(e.target.value), generateId: false })
 
   createBot = async e => {
     e.preventDefault()

--- a/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
@@ -16,14 +16,6 @@ export const sanitizeBotId = (text: string) =>
     .replace(/\s/g, '-')
     .replace(/[^a-z0-9_-]/g, '')
 
-export const addBotPrefix = (botId: string, botPrefix?: string) => {
-  if (!botPrefix) {
-    return botId
-  }
-
-  return botId.startsWith(botPrefix) ? botId : `${botPrefix}__${botId}`
-}
-
 interface SelectOption<T> {
   label: string
   value: T
@@ -109,15 +101,12 @@ class CreateBotModal extends Component<Props, State> {
     const botName = e.target.value
     const botId = this.state.generateId ? sanitizeBotId(botName) : this.state.botId
 
-    this.setState({
-      botName,
-      botId: addBotPrefix(botId, this.props.workspace?.botPrefix)
-    })
+    this.setState({ botName, botId })
   }
 
   handleBotIdChanged = e =>
     this.setState({
-      botId: addBotPrefix(sanitizeBotId(e.target.value), this.props.workspace?.botPrefix),
+      botId: sanitizeBotId(e.target.value),
       generateId: false
     })
 

--- a/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
@@ -107,13 +107,11 @@ class CreateBotModal extends Component<Props, State> {
 
   handleNameChanged = e => {
     const botName = e.target.value
+    const botId = this.state.generateId ? sanitizeBotId(botName) : this.state.botId
 
     this.setState({
       botName,
-      botId: addBotPrefix(
-        this.state.generateId ? sanitizeBotId(botName) : this.state.botId,
-        this.props.workspace?.botPrefix
-      )
+      botId: addBotPrefix(botId, this.props.workspace?.botPrefix)
     })
   }
 

--- a/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
@@ -16,6 +16,14 @@ export const sanitizeBotId = (text: string) =>
     .replace(/\s/g, '-')
     .replace(/[^a-z0-9_-]/g, '')
 
+export const addBotPrefix = (botId: string, botPrefix?: string) => {
+  if (!botPrefix) {
+    return botId
+  }
+
+  return botId.startsWith(botPrefix) ? botId : `${botPrefix}__${botId}`
+}
+
 interface SelectOption<T> {
   label: string
   value: T
@@ -99,10 +107,21 @@ class CreateBotModal extends Component<Props, State> {
 
   handleNameChanged = e => {
     const botName = e.target.value
-    this.setState({ botName, botId: this.state.generateId ? sanitizeBotId(botName) : this.state.botId })
+
+    this.setState({
+      botName,
+      botId: addBotPrefix(
+        this.state.generateId ? sanitizeBotId(botName) : this.state.botId,
+        this.props.workspace?.botPrefix
+      )
+    })
   }
 
-  handleBotIdChanged = e => this.setState({ botId: sanitizeBotId(e.target.value), generateId: false })
+  handleBotIdChanged = e =>
+    this.setState({
+      botId: addBotPrefix(sanitizeBotId(e.target.value), this.props.workspace?.botPrefix),
+      generateId: false
+    })
 
   createBot = async e => {
     e.preventDefault()

--- a/packages/bp/src/admin/ui/src/workspace/bots/ImportBotModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/ImportBotModal.tsx
@@ -5,7 +5,6 @@ import ms from 'ms'
 import React, { Component } from 'react'
 
 import api from '~/app/api'
-
 import { sanitizeBotId } from './CreateBotModal'
 
 interface Props {

--- a/packages/bp/src/admin/ui/src/workspace/bots/ImportBotModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/ImportBotModal.tsx
@@ -3,18 +3,16 @@ import { lang, toast } from 'botpress/shared'
 import _ from 'lodash'
 import ms from 'ms'
 import React, { Component } from 'react'
-import { connect, ConnectedProps } from 'react-redux'
 
 import api from '~/app/api'
-import { AppState } from '~/app/rootReducer'
 
 import { sanitizeBotId } from './CreateBotModal'
 
-type Props = {
+interface Props {
   onCreateBotSuccess: () => void
   toggle: () => void
   isOpen: boolean
-} & ConnectedProps<typeof connector>
+}
 
 interface State {
   botId: string
@@ -89,9 +87,8 @@ class ImportBotModal extends Component<Props, State> {
     }
   }, 500)
 
-  handleBotIdChanged = e => {
+  handleBotIdChanged = e =>
     this.setState({ botId: sanitizeBotId(e.target.value), overwrite: false }, this.checkIdAvailability)
-  }
 
   handleFileChanged = (files: FileList | null) => {
     if (!files) {
@@ -221,7 +218,4 @@ class ImportBotModal extends Component<Props, State> {
   }
 }
 
-const mapStateToProps = (state: AppState) => state.bots
-const connector = connect(mapStateToProps)
-
-export default connector(ImportBotModal)
+export default ImportBotModal

--- a/packages/bp/src/admin/ui/src/workspace/bots/ImportBotModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/ImportBotModal.tsx
@@ -8,7 +8,7 @@ import { connect, ConnectedProps } from 'react-redux'
 import api from '~/app/api'
 import { AppState } from '~/app/rootReducer'
 
-import { addBotPrefix, sanitizeBotId } from './CreateBotModal'
+import { sanitizeBotId } from './CreateBotModal'
 
 type Props = {
   onCreateBotSuccess: () => void
@@ -42,16 +42,6 @@ class ImportBotModal extends Component<Props, State> {
   private _form: HTMLFormElement | null = null
 
   state: State = { ...defaultState }
-
-  makeBotId = (botId: string) => {
-    return addBotPrefix(botId, this.props.workspace?.botPrefix)
-  }
-
-  componentDidUpdate(prevProps) {
-    if (this.props.workspace !== prevProps.workspace) {
-      this.setState({ botId: this.makeBotId('') })
-    }
-  }
 
   importBot = async e => {
     e.preventDefault()
@@ -100,7 +90,7 @@ class ImportBotModal extends Component<Props, State> {
   }, 500)
 
   handleBotIdChanged = e => {
-    this.setState({ botId: this.makeBotId(sanitizeBotId(e.target.value)), overwrite: false }, this.checkIdAvailability)
+    this.setState({ botId: sanitizeBotId(e.target.value), overwrite: false }, this.checkIdAvailability)
   }
 
   handleFileChanged = (files: FileList | null) => {
@@ -125,13 +115,13 @@ class ImportBotModal extends Component<Props, State> {
     const noExt = filename.substr(0, filename.indexOf('.'))
     const matches = noExt.match(/bot_(.*)_[0-9]+/)
     this.setState(
-      { botId: this.makeBotId(sanitizeBotId((matches && matches[1]) || noExt)), overwrite: false },
+      { botId: sanitizeBotId((matches && matches[1]) || noExt), overwrite: false },
       this.checkIdAvailability
     )
   }
 
   toggleDialog = () => {
-    this.setState({ ...defaultState, botId: this.makeBotId('') })
+    this.setState({ ...defaultState })
     this.props.toggle()
   }
 

--- a/packages/bp/src/admin/ui/src/workspace/bots/reducer.ts
+++ b/packages/bp/src/admin/ui/src/workspace/bots/reducer.ts
@@ -23,7 +23,7 @@ interface BotState {
   botTemplatesFetched: boolean
   botCategories: string[]
   botCategoriesFetched: boolean
-  workspace?: { name: string; pipeline: any }
+  workspace?: { name: string; pipeline: any; botPrefix?: string }
   // Sets the current bot used by workspace apps
   workspaceAppsBotId?: string
   // Fetches the list of languages available with the NLU

--- a/packages/bp/src/admin/ui/src/workspace/workspaces/CreateWorkspaceModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/workspaces/CreateWorkspaceModal.tsx
@@ -22,9 +22,10 @@ const CreateWorkspaceModal: FC<Props> = props => {
   const [description, setDescription] = useState<string>('')
   const [audience, setAudience] = useState('internal')
   const [pipelineId, setPipelineId] = useState('none')
+  const [botPrefix, setBotPrefix] = useState('')
 
   const submit = async () => {
-    const workspace = { id, name, audience, description, pipelineId }
+    const workspace = { id, name, audience, description, pipelineId, botPrefix }
 
     try {
       await api.getSecured().post('/admin/workspace/workspaces', workspace)
@@ -43,6 +44,7 @@ const CreateWorkspaceModal: FC<Props> = props => {
     setDescription('')
     setAudience('external')
     setPipelineId('none')
+    setBotPrefix('')
     setOpen(false)
     setGenerateId(true)
   }
@@ -86,6 +88,21 @@ const CreateWorkspaceModal: FC<Props> = props => {
                   value={id}
                   onChange={updateId}
                   tabIndex={1}
+                />
+              </FormGroup>
+
+              <FormGroup
+                label={<span>Bot Prefix</span>}
+                labelFor="input-botPrefix"
+                labelInfo="*"
+                helperText="Bots in this workspace must start with this prefix, followed by __"
+              >
+                <InputGroup
+                  id="input-botPrefix"
+                  placeholder=""
+                  value={botPrefix}
+                  onChange={e => setBotPrefix(e.target.value)}
+                  tabIndex={2}
                 />
               </FormGroup>
 

--- a/packages/bp/src/admin/ui/src/workspace/workspaces/CreateWorkspaceModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/workspaces/CreateWorkspaceModal.tsx
@@ -71,7 +71,7 @@ const CreateWorkspaceModal: FC<Props> = props => {
                   placeholder="The name of your workspace"
                   value={name}
                   onChange={updateName}
-                  tabIndex={2}
+                  tabIndex={1}
                   autoFocus={true}
                 />
               </FormGroup>
@@ -87,7 +87,7 @@ const CreateWorkspaceModal: FC<Props> = props => {
                   placeholder="The ID of your workspace"
                   value={id}
                   onChange={updateId}
-                  tabIndex={1}
+                  tabIndex={2}
                 />
               </FormGroup>
 
@@ -102,7 +102,7 @@ const CreateWorkspaceModal: FC<Props> = props => {
                   placeholder=""
                   value={botPrefix}
                   onChange={e => setBotPrefix(e.target.value)}
-                  tabIndex={2}
+                  tabIndex={3}
                 />
               </FormGroup>
 
@@ -114,7 +114,7 @@ const CreateWorkspaceModal: FC<Props> = props => {
                   onChange={e => setDescription(e.currentTarget.value)}
                   fill={true}
                   rows={3}
-                  tabIndex={3}
+                  tabIndex={4}
                   maxLength={500}
                 />
               </FormGroup>

--- a/packages/bp/src/admin/ui/src/workspace/workspaces/EditWorkspaceModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/workspaces/EditWorkspaceModal.tsx
@@ -14,19 +14,21 @@ interface Props {
 const EditWorkspaceModal: FC<Props> = props => {
   const [name, setName] = useState<string>('')
   const [description, setDescription] = useState<string>('')
+  const [botPrefix, setBotPrefix] = useState<string | undefined>('')
 
   useEffect(() => {
     if (props.workspace) {
-      const { name, description } = props.workspace
+      const { name, description, botPrefix } = props.workspace
 
       setName(name)
       setDescription(description || '')
+      setBotPrefix(botPrefix)
     }
   }, [props.workspace, props.isOpen])
 
   const submit = async () => {
     try {
-      await api.getSecured().post(`/admin/workspace/workspaces/${props.workspace.id}`, { name, description })
+      await api.getSecured().post(`/admin/workspace/workspaces/${props.workspace.id}`, { name, description, botPrefix })
       props.refreshWorkspaces()
 
       toast.success('Workspace saved successfully')
@@ -53,6 +55,21 @@ const EditWorkspaceModal: FC<Props> = props => {
             onChange={e => setName(e.currentTarget.value)}
             tabIndex={1}
             autoFocus={true}
+          />
+        </FormGroup>
+
+        <FormGroup
+          label={<span>Bot Prefix</span>}
+          labelFor="input-botPrefix"
+          labelInfo="*"
+          helperText="Bots in this workspace must start with this prefix, followed by __"
+        >
+          <InputGroup
+            id="input-botPrefix"
+            placeholder=""
+            value={botPrefix}
+            onChange={e => setBotPrefix(e.target.value)}
+            tabIndex={2}
           />
         </FormGroup>
 

--- a/packages/bp/src/admin/ui/src/workspace/workspaces/EditWorkspaceModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/workspaces/EditWorkspaceModal.tsx
@@ -81,7 +81,7 @@ const EditWorkspaceModal: FC<Props> = props => {
             onChange={e => setDescription(e.currentTarget.value)}
             rows={3}
             fill={true}
-            tabIndex={2}
+            tabIndex={3}
             maxLength={500}
           />
         </FormGroup>

--- a/packages/bp/src/common/typings.ts
+++ b/packages/bp/src/common/typings.ts
@@ -35,6 +35,8 @@ export interface Workspace {
   id: string
   name: string
   description?: string
+  /** An optional string of characters which must precede the ID of each bots in this workspace */
+  botPrefix?: string
   audience: 'internal' | 'external'
   roles: AuthRole[]
   defaultRole: string

--- a/packages/bp/src/common/validation.ts
+++ b/packages/bp/src/common/validation.ts
@@ -105,6 +105,10 @@ export const WorkspaceCreationSchema = Joi.object().keys({
   description: Joi.string()
     .max(500)
     .allow(''),
+  botPrefix: Joi.string()
+    .max(50)
+    .optional()
+    .allow(''),
   audience: Joi.string()
     .valid(['internal', 'external'])
     .default('external')

--- a/packages/bp/src/core/bots/bot-service.ts
+++ b/packages/bp/src/core/bots/bot-service.ts
@@ -145,6 +145,12 @@ export class BotService {
     return this._botIds
   }
 
+  async validateBotId(botId: string, workspaceId: string) {
+    const workspace = await this.workspaceService.findWorkspace(workspaceId)
+
+    return workspace?.botPrefix ? botId.startsWith(`${workspace.botPrefix}__`) : true
+  }
+
   async addBot(bot: BotConfig, botTemplate: BotTemplate): Promise<void> {
     this.stats.track('bot', 'create')
 

--- a/packages/bp/src/core/bots/bot-service.ts
+++ b/packages/bp/src/core/bots/bot-service.ts
@@ -145,12 +145,6 @@ export class BotService {
     return this._botIds
   }
 
-  async validateBotId(botId: string, workspaceId: string) {
-    const workspace = await this.workspaceService.findWorkspace(workspaceId)
-
-    return workspace?.botPrefix ? botId.startsWith(`${workspace.botPrefix}__`) : true
-  }
-
   async addBot(bot: BotConfig, botTemplate: BotTemplate): Promise<void> {
     this.stats.track('bot', 'create')
 

--- a/packages/bp/src/core/bots/bot-service.ts
+++ b/packages/bp/src/core/bots/bot-service.ts
@@ -145,6 +145,11 @@ export class BotService {
     return this._botIds
   }
 
+  async makeBotId(botId: string, workspaceId: string) {
+    const workspace = await this.workspaceService.findWorkspace(workspaceId)
+    return workspace?.botPrefix ? `${workspace.botPrefix}__${botId}` : botId
+  }
+
   async addBot(bot: BotConfig, botTemplate: BotTemplate): Promise<void> {
     this.stats.track('bot', 'create')
 


### PR DESCRIPTION
I'm trying to explore a better alternative for https://github.com/botpress/botpress/pull/5321. My biggest issue with that PR is that we enforce a naming scheme which can impact active users.

Bot prefix are optional and handled by the backend