### PR TITLE
feat(hitlnext): display user's object props as string on UserProfile for hitlnext

### DIFF
--- a/modules/hitlnext/src/views/full/app/components/UserProfile.tsx
+++ b/modules/hitlnext/src/views/full/app/components/UserProfile.tsx
@@ -7,7 +7,7 @@ import style from '../../style.scss'
 
 import UserName from './UserName'
 
-const UserProfile: FC<IUser> = user => {
+const UserProfile: FC<IUser> = (user) => {
   const [expanded, setExpanded] = useState(true)
 
   return (
@@ -34,7 +34,7 @@ const UserProfile: FC<IUser> = user => {
               {Object.entries(user.attributes).map((entry, index) => (
                 <tr key={index}>
                   <td>{entry[0]}</td>
-                  <td>{entry[1]}</td>
+                  <td>{_.isObject(entry[1]) ? JSON.stringify(entry[1]) : entry[1]}</td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
This is a bug fix that end's up being a feature request.
[Link to the issue...](https://github.com/botpress/v12/issues/1365)
https://github.com/botpress/v12/issues/1365
React error when selecting a pending handoff (Offline or Online)

To Reproduce

Create a bot
Add a handoff
Say hi! (or whatver...)