### PR TITLE
fix(core): remove leftover debug logging

### DIFF
--- a/packages/bp/src/core/users/chat-users/chat-users-repository.ts
+++ b/packages/bp/src/core/users/chat-users/chat-users-repository.ts
@@ -128,8 +128,6 @@ export class ChannelUserRepository {
       return { result: user, created: false }
     }
 
-    console.log('wtf', id)
-
     const newUser = await this.database.knex
       .insertAndRetrieve<User>(
         this.tableName,


### PR DESCRIPTION
This PR removes a forgotten console.log that got merged with #5349. Not sure with this console.log was not flagged by prettier or eslint.