### PR TITLE
chore(tests): removed extra test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "package": "yarn cmd package",
     "test": "cross-env NATIVE_EXTENSIONS_DIR=build/native-extensions cross-env jest -i --detectOpenHandles -c jest.config.js",
     "reference": "yarn cmd build:reference",
-    "test": "yarn workspace botpress test",
     "itest": "yarn workspace botpress itest",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "bpd": "node build/downloader/out/index.js"


### PR DESCRIPTION
This PR removes the extra "test" script from the root package.json. I only kept the one that was added here: https://github.com/botpress/botpress/pull/5371