### PR TITLE
chore(messaging): bump messaging to v0.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "version": "0.0.32"
   },
   "messaging": {
-    "version": "0.1.8"
+    "version": "0.1.11"
   },
   "scripts": {
     "postinstall": "yarn cmd postinstall",


### PR DESCRIPTION
This PR bumps the version of the messaging binary to its latest version (v0.1.11)