### PR TITLE
chore: nlu v0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "AGPL-3.0",
   "private": true,
   "nlu": {
-    "version": "0.1.4"
+    "version": "0.1.5"
   },
   "studio": {
     "version": "0.0.32"


### PR DESCRIPTION
release is [here](https://github.com/botpress/nlu/releases/tag/v0.1.5)

## [0.1.5](https://github.com/botpress/nlu/compare/1.0.0-rc.1...0.1.5) (2021-09-01)


### Bug Fixes

* **nlu-engine:** launch intent trainings in parallel and log each ctx ([d9b8152](https://github.com/botpress/nlu/commit/d9b81528bd3580634736ef9628db61a8f1121573))
* **nlu-engine:** launch svm trainings one after the other ([a7dcad0](https://github.com/botpress/nlu/commit/a7dcad00562ac737af81514abb3911b1c855200e))
* **nlu-engine:** use a stratified kfold to limit the amount of grid search iterations ([4197e78](https://github.com/botpress/nlu/commit/4197e7834a1e95ea5aeb7ed757fea18b05df3065))