### PR TITLE
feat(hitlnext): remove obsolete pkg react-itial and add react-avatar

### DIFF
--- a/modules/hitlnext/package.json
+++ b/modules/hitlnext/package.json
@@ -25,7 +25,7 @@
     "lodash": ">=4.17",
     "lru-cache": "^6.0.0",
     "moment": "^2.24",
-    "react-initial": "^1.0.12",
+    "react-avatar": "^3.10.0",
     "serialize-javascript": "^5.0.1",
     "yn": "^4.0.0"
   },

--- a/modules/hitlnext/src/views/full/app/components/AgentList.tsx
+++ b/modules/hitlnext/src/views/full/app/components/AgentList.tsx
@@ -2,7 +2,7 @@ import { Position, Spinner, Tooltip } from '@blueprintjs/core'
 import cx from 'classnames'
 import _, { Dictionary } from 'lodash'
 import React, { FC } from 'react'
-import { Initial } from 'react-initial'
+import Avatar from 'react-avatar'
 
 import { agentName } from '../../../../helper'
 import { IAgent } from '../../../../types'
@@ -22,7 +22,7 @@ const AgentList: FC<Props> = ({ agents, loading }) => {
   if (loading) {
     return (
       <div>
-        <Spinner></Spinner>
+        <Spinner />
       </div>
     )
   }
@@ -36,19 +36,9 @@ const AgentList: FC<Props> = ({ agents, loading }) => {
             <li key={agent.agentId} className={cx(styles.agentListItem)}>
               <Tooltip content={agentName(agent)} position={Position.BOTTOM}>
                 {agent.attributes?.picture_url && (
-                  <img className={styles.agentItem} src={agent.attributes.picture_url} />
+                  <img className={styles.agentItem} src={agent.attributes.picture_url} alt="agent picture" />
                 )}
-                {!agent.attributes?.picture_url && (
-                  <Initial
-                    className={styles.agentItem}
-                    name={agentName(agent)}
-                    charCount={2}
-                    height={30}
-                    width={30}
-                    fontSize={12}
-                    fontWeight={500}
-                  ></Initial>
-                )}
+                {!agent.attributes?.picture_url && <Avatar name={agentName(agent)} round maxInitials={2} size="30px" />}
               </Tooltip>
             </li>
           ))}

--- a/modules/hitlnext/yarn.lock
+++ b/modules/hitlnext/yarn.lock
@@ -114,6 +114,11 @@ call-bind@^1.0.0:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.0"
 
+charenc@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
+
 classnames@^2.2, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
@@ -124,6 +129,11 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
+core-js@^3.6.1:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.17.2.tgz#f960eae710dc62c29cca93d5332e3660e289db10"
+  integrity sha512-XkbXqhcXeMHPRk2ItS+zQYliAMilea2euoMsnpRRdDad6b2VY6CQQcwz1K8AnWesfw4p165RzY0bTnr3UrbYiA==
+
 create-react-context@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.3.0.tgz#546dede9dc422def0d3fc2fe03afe0bc0f4f7d8c"
@@ -131,6 +141,11 @@ create-react-context@^0.3.0:
   dependencies:
     gud "^1.0.0"
     warning "^4.0.3"
+
+crypt@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 custom-event@^1.0.1:
   version "1.0.1"
@@ -296,6 +311,11 @@ is-arguments@^1.0.4:
   dependencies:
     call-bind "^1.0.0"
 
+is-buffer@~1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
 is-callable@^1.1.4, is-callable@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.2.tgz#c7c6715cd22d4ddb48d3e19970223aceabb080d9"
@@ -312,6 +332,11 @@ is-regex@^1.0.4, is-regex@^1.1.1:
   integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
   dependencies:
     has-symbols "^1.0.1"
+
+is-retina@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-retina/-/is-retina-1.0.3.tgz#d7401b286bea2ae37f62477588de504d0b8647e3"
+  integrity sha1-10AbKGvqKuN/Ykd1iN5QTQuGR+M=
 
 is-symbol@^1.0.2:
   version "1.0.3"
@@ -356,7 +381,7 @@ lodash@>=4.17.21:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -369,6 +394,15 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+md5@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
+  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
+  dependencies:
+    charenc "0.0.2"
+    crypt "0.0.2"
+    is-buffer "~1.1.6"
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -449,7 +483,7 @@ popper.js@^1.14.4, popper.js@^1.16.1:
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
-prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -472,24 +506,14 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-react-dom@^16.12.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+react-avatar@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/react-avatar/-/react-avatar-3.10.0.tgz#d8801aef167129fc87bdade82c0f7f5bfb064bf2"
+  integrity sha512-FB20OZIAJif0WNzGy4PwT5Nca4rekrYWiswBofuGAa5FKpRrFbJKY69267dRXbFqIYQrA/OxNB/TjhnmP2gsEQ==
   dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
-
-react-initial@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/react-initial/-/react-initial-1.0.12.tgz#bea6c2fd76c288a68b70efa60a8f84b3682c74bb"
-  integrity sha512-KEsJW7aGnKyWmspm6F/E2ZtwAebErhQPWDrMK9rHcYL+4ldPktIw2Od8O0SgF98aEVpUgsPe2qBxr4av48nwVQ==
-  dependencies:
-    prop-types "^15.7.2"
-    react "^16.12.0"
-    react-dom "^16.12.0"
+    core-js "^3.6.1"
+    is-retina "^1.0.3"
+    md5 "^2.0.0"
 
 react-is@^16.8.1:
   version "16.13.1"
@@ -524,15 +548,6 @@ react-transition-group@^2.9.0:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react@^16.12.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-
 regenerator-runtime@^0.13.4:
   version "0.13.7"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
@@ -562,14 +577,6 @@ safe-buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 serialize-javascript@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
[https://github.com/botpress/v12/issues/1397](Issue: https://github.com/botpress/v12/issues/1397)
**Steps to reproduce the issue:** 

1. Enable hitlnext module
2. Restart server
3. Create a new empty bot
4. Go to Flows and add the hitlnext/handoff action on the "on enter" section of the entry node
5. Open the emulator and talk to the bot
6. Go to hitlnext module
7. Go online
8. See error
sh

**What was the issue**
I didn’t find any specific reason, but my guess is that the **react-profile** module is deprecated (last update about 6-7 years and only hundreds of weekly downloads)

**Solution:**
I changed the **react-profile** module to the **react-avatar** module and everything seems to work like a charm 

**Step to check the solution:**
1. Enable hitlnext module
2. Restart server
3. Create a new empty bot
4. Go to Flows and add the hitlnext/handoff action on the "on entering" section of the entry node
5. Open emulator and talk to bot
6. Go to hitlnext module
7. Go online
8. No errors displayed and the **avatar is displayed** on the top left of the page

<img width="963" alt="Screen Shot 2021-09-03 at 9 12 09 AM" src="https://user-images.githubusercontent.com/13097764/132012777-96e0a47f-f36e-4b7a-b3fb-87dd4f6090c7.png">

