### PR TITLE
fix(channel-web): fix messaging migration

### DIFF
--- a/modules/channel-web/src/messaging-migration/down-sqlite.ts
+++ b/modules/channel-web/src/messaging-migration/down-sqlite.ts
@@ -11,12 +11,24 @@ export class MessagingSqliteDownMigrator extends MessagingDownMigrator {
   private convoIndex = 0
 
   protected async start() {
-    this.trx = this.bp.database as any
+    if (this.bp.database.isLite) {
+      this.trx = this.bp.database as any
+    } else {
+      this.trx = await this.bp.database.transaction()
+    }
   }
 
-  protected async commit() {}
+  protected async commit() {
+    if (!this.bp.database.isLite) {
+      await this.trx.commit()
+    }
+  }
 
-  protected async rollback() {}
+  protected async rollback() {
+    if (!this.bp.database.isLite) {
+      await this.trx.rollback()
+    }
+  }
 
   protected async migrate() {
     await super.migrate()

--- a/modules/channel-web/src/messaging-migration/down-sqlite.ts
+++ b/modules/channel-web/src/messaging-migration/down-sqlite.ts
@@ -55,7 +55,6 @@ export class MessagingSqliteDownMigrator extends MessagingDownMigrator {
       await this.trx.raw('DROP TABLE msg_users CASCADE')
       await this.trx.raw('DROP TABLE msg_clients CASCADE')
       await this.trx.raw('DROP TABLE msg_providers CASCADE')
-      await this.trx.raw('DROP EXTENSION pgcrypto;')
     }
   }
 

--- a/modules/channel-web/src/messaging-migration/down-sqlite.ts
+++ b/modules/channel-web/src/messaging-migration/down-sqlite.ts
@@ -37,6 +37,8 @@ export class MessagingSqliteDownMigrator extends MessagingDownMigrator {
     const convCount = <number>Object.values((await this.trx('msg_conversations').count('*'))[0])[0] || 0
     this.convoIndex = <number>Object.values((await this.trx('web_conversations').max('id'))[0])[0] || 1
 
+    this.bp.logger.info(`Migration will migrate ${convCount} conversations`)
+
     for (let i = 0; i < convCount; i += batchSize) {
       const convos = await this.trx('msg_conversations')
         .select('*')
@@ -45,6 +47,8 @@ export class MessagingSqliteDownMigrator extends MessagingDownMigrator {
 
       // We migrate batchSize conversations at a time
       await this.migrateConvos(convos)
+
+      this.bp.logger.info(`Migrated conversations ${i} to ${Math.min(i + batchSize, convCount)}`)
     }
   }
 

--- a/modules/channel-web/src/messaging-migration/up-sqlite.ts
+++ b/modules/channel-web/src/messaging-migration/up-sqlite.ts
@@ -12,7 +12,11 @@ export class MessagingSqliteUpMigrator extends MessagingUpMigrator {
   private userCache = new LRUCache<string, string>({ max: 10000 })
 
   protected async start() {
-    this.trx = this.bp.database as any
+    if (this.bp.database.isLite) {
+      this.trx = this.bp.database as any
+    } else {
+      this.trx = await this.bp.database.transaction()
+    }
   }
 
   protected async commit() {}

--- a/modules/channel-web/src/messaging-migration/up-sqlite.ts
+++ b/modules/channel-web/src/messaging-migration/up-sqlite.ts
@@ -37,6 +37,8 @@ export class MessagingSqliteUpMigrator extends MessagingUpMigrator {
     const batchSize = this.bp.database.isLite ? 100 : 5000
     const convCount = <number>Object.values((await this.trx('web_conversations').count('*'))[0])[0]
 
+    this.bp.logger.info(`Migration will migrate ${convCount} conversations`)
+
     for (let i = 0; i < convCount; i += batchSize) {
       const convos = await this.trx('web_conversations')
         .select('*')
@@ -45,6 +47,8 @@ export class MessagingSqliteUpMigrator extends MessagingUpMigrator {
 
       // We migrate batchSize conversations at a time
       await this.migrateConvos(convos)
+
+      this.bp.logger.info(`Migrated conversations ${i} to ${Math.min(i + batchSize, convCount)}`)
     }
   }
 

--- a/modules/channel-web/src/messaging-migration/up-sqlite.ts
+++ b/modules/channel-web/src/messaging-migration/up-sqlite.ts
@@ -19,9 +19,17 @@ export class MessagingSqliteUpMigrator extends MessagingUpMigrator {
     }
   }
 
-  protected async commit() {}
+  protected async commit() {
+    if (!this.bp.database) {
+      await this.trx.commit()
+    }
+  }
 
-  protected async rollback() {}
+  protected async rollback() {
+    if (!this.bp.database) {
+      await this.trx.rollback()
+    }
+  }
 
   protected async migrate() {
     await super.migrate()

--- a/modules/channel-web/src/messaging-migration/up-sqlite.ts
+++ b/modules/channel-web/src/messaging-migration/up-sqlite.ts
@@ -22,31 +22,42 @@ export class MessagingSqliteUpMigrator extends MessagingUpMigrator {
   protected async migrate() {
     await super.migrate()
 
+    const batchSize = this.bp.database.isLite ? 100 : 5000
     const convCount = <number>Object.values((await this.trx('web_conversations').count('*'))[0])[0]
 
-    for (let i = 0; i < convCount; i += 100) {
+    for (let i = 0; i < convCount; i += batchSize) {
       const convos = await this.trx('web_conversations')
         .select('*')
         .offset(i)
-        .limit(100)
+        .limit(batchSize)
 
-      // We migrate 100 conversations at a time
+      // We migrate batchSize conversations at a time
       await this.migrateConvos(convos)
     }
   }
 
   protected async createTables() {
-    await this.trx.raw('PRAGMA foreign_keys = OFF;')
+    if (this.bp.database.isLite) {
+      await this.trx.raw('PRAGMA foreign_keys = OFF;')
 
-    // We delete these tables in case the migration crashed halfway.
-    await this.trx.schema.dropTableIfExists('web_user_map')
-    await this.trx.schema.dropTableIfExists('msg_messages')
-    await this.trx.schema.dropTableIfExists('msg_conversations')
-    await this.trx.schema.dropTableIfExists('msg_users')
-    await this.trx.schema.dropTableIfExists('msg_clients')
-    await this.trx.schema.dropTableIfExists('msg_providers')
+      // We delete these tables in case the migration crashed halfway.
+      await this.trx.schema.dropTableIfExists('web_user_map')
+      await this.trx.schema.dropTableIfExists('msg_messages')
+      await this.trx.schema.dropTableIfExists('msg_conversations')
+      await this.trx.schema.dropTableIfExists('msg_users')
+      await this.trx.schema.dropTableIfExists('msg_clients')
+      await this.trx.schema.dropTableIfExists('msg_providers')
 
-    await this.trx.raw('PRAGMA foreign_keys = ON;')
+      await this.trx.raw('PRAGMA foreign_keys = ON;')
+    } else {
+      // We delete these tables in case the migration crashed halfway.
+      await this.trx.raw('DROP TABLE IF EXISTS web_user_map CASCADE')
+      await this.trx.raw('DROP TABLE IF EXISTS msg_messages CASCADE')
+      await this.trx.raw('DROP TABLE IF EXISTS msg_conversations CASCADE')
+      await this.trx.raw('DROP TABLE IF EXISTS msg_users CASCADE')
+      await this.trx.raw('DROP TABLE IF EXISTS msg_clients CASCADE')
+      await this.trx.raw('DROP TABLE IF EXISTS msg_providers CASCADE')
+    }
 
     await super.createTables()
   }
@@ -56,6 +67,8 @@ export class MessagingSqliteUpMigrator extends MessagingUpMigrator {
   }
 
   private async migrateConvos(convos: any[]) {
+    const maxBatchSize = this.bp.database.isLite ? 50 : 2000
+
     const defaultPayload = JSON.stringify({})
     const defaultDate = new Date().toISOString()
 
@@ -91,12 +104,12 @@ export class MessagingSqliteUpMigrator extends MessagingUpMigrator {
           payload: message.payload || defaultPayload
         })
 
-        if (this.messageBatch.length > 50) {
+        if (this.messageBatch.length > maxBatchSize) {
           await this.emptyMessageBatch()
         }
       }
 
-      if (this.convoBatch.length > 50) {
+      if (this.convoBatch.length > maxBatchSize) {
         await this.emptyConvoBatch()
       }
     }

--- a/modules/channel-web/src/messaging-migration/up-sqlite.ts
+++ b/modules/channel-web/src/messaging-migration/up-sqlite.ts
@@ -20,13 +20,13 @@ export class MessagingSqliteUpMigrator extends MessagingUpMigrator {
   }
 
   protected async commit() {
-    if (!this.bp.database) {
+    if (!this.bp.database.isLite) {
       await this.trx.commit()
     }
   }
 
   protected async rollback() {
-    if (!this.bp.database) {
+    if (!this.bp.database.isLite) {
       await this.trx.rollback()
     }
   }

--- a/modules/channel-web/src/migrations/v12_26_0-1629778300-messaging.ts
+++ b/modules/channel-web/src/migrations/v12_26_0-1629778300-messaging.ts
@@ -28,7 +28,9 @@ const migration: sdk.ModuleMigration = {
       const migrator = new MessagingSqliteUpMigrator(bp, false)
       message = await migrator.run()
     } else {
-      const migrator = new MessagingPostgresUpMigrator(bp, metadata.isDryRun)
+      const migrator = process.env.MIG_MESSAGING_FAST
+        ? new MessagingPostgresUpMigrator(bp, metadata.isDryRun)
+        : new MessagingSqliteUpMigrator(bp, metadata.isDryRun)
       message = await migrator.run()
     }
 
@@ -53,7 +55,9 @@ const migration: sdk.ModuleMigration = {
       const migrator = new MessagingSqliteDownMigrator(bp, false)
       message = await migrator.run()
     } else {
-      const migrator = new MessagingPostgresDownMigrator(bp, metadata.isDryRun)
+      const migrator = process.env.MIG_MESSAGING_FAST
+        ? new MessagingPostgresDownMigrator(bp, metadata.isDryRun)
+        : new MessagingSqliteDownMigrator(bp, metadata.isDryRun)
       message = await migrator.run()
     }
 


### PR DESCRIPTION
Allows postgres users to avoid using the pgcrypto extension for the channel web messaging migration. Since installing this migration requires superuser permissions for versions <13, then it could be preferable to use the migration this way.

