### PR TITLE
fix(channel-web): fix typing indicator display

### DIFF
--- a/modules/channel-web/src/backend/socket.ts
+++ b/modules/channel-web/src/backend/socket.ts
@@ -3,6 +3,8 @@ import _ from 'lodash'
 
 import Database from './db'
 
+const DEFAULT_TYPING_DELAY = 500
+
 export default async (bp: typeof sdk, db: Database) => {
   bp.events.registerMiddleware({
     description:
@@ -39,7 +41,7 @@ export default async (bp: typeof sdk, db: Database) => {
       bp.realtime.sendPayload(payload)
     } else {
       if (event.payload.typing === true || event.payload.type === 'typing') {
-        const value = event.payload.type === 'typing' ? event.payload.value : 500
+        const value = (event.payload.type === 'typing' ? event.payload.value : undefined) || DEFAULT_TYPING_DELAY
         const payload = bp.RealTimePayload.forVisitor(visitorId, 'webchat.typing', { timeInMs: value, conversationId })
         // Don't store "typing" in DB
         bp.realtime.sendPayload(payload)


### PR DESCRIPTION
This PR fixes an issue where typing indicators would stay displayed on the channel-web and re-adds the ability to send a typing event with a custom amount of time.

### e.g.

#### Text content-element with typing indicators enabled

https://user-images.githubusercontent.com/9640576/132545401-c5576fdb-b9c7-48f5-9627-b91c96741a10.mp4

#### Action that sends typing indicators for ~10sec then sends a text content-element


https://user-images.githubusercontent.com/9640576/132545528-b37cbac4-4ddf-4265-9379-99d9c2e9dc19.mp4



Closes DEV-1692 and botpress/v12#1465