### PR TITLE
fix(analytics): fix n/a lang entries description

### DIFF
--- a/modules/analytics/src/views/full/index.tsx
+++ b/modules/analytics/src/views/full/index.tsx
@@ -514,7 +514,7 @@ const Analytics: FC<any> = ({ bp }) => {
                 key={i.language}
                 value={i.value}
                 color="#F2B824"
-                name={`${lang.tr(`isoLangs.${i.language}.name`)}: ${i.value}`}
+                name={`${i.language !== 'n/a' ? lang.tr(`isoLangs.${i.language}.name`) : 'Unknown'}: ${i.value}`}
               />
             ))}
           </div>

--- a/modules/analytics/src/views/full/index.tsx
+++ b/modules/analytics/src/views/full/index.tsx
@@ -514,7 +514,7 @@ const Analytics: FC<any> = ({ bp }) => {
                 key={i.language}
                 value={i.value}
                 color="#F2B824"
-                name={`${i.language !== 'n/a' ? lang.tr(`isoLangs.${i.language}.name`) : 'Unknown'}: ${i.value}`}
+                name={`${lang.tr(`isoLangs.${i.language}.name`)}: ${i.value}`}
               />
             ))}
           </div>

--- a/packages/ui-shared/src/translations/en.json
+++ b/packages/ui-shared/src/translations/en.json
@@ -140,6 +140,10 @@
     "es": {
       "name": "Spanish",
       "nativeName": "español"
+    },
+    "n/a": {
+      "name": "Unknown",
+      "nativeName": "Unknown"
     }
   },
   "label": "Label",

--- a/packages/ui-shared/src/translations/es.json
+++ b/packages/ui-shared/src/translations/es.json
@@ -140,6 +140,10 @@
     "es": {
       "name": "Español",
       "nativeName": "Español"
+    },
+    "n/a": {
+      "name": "Desconocido",
+      "nativeName": "Desconocido"
     }
   },
   "label": "Etiqueta",

--- a/packages/ui-shared/src/translations/fr.json
+++ b/packages/ui-shared/src/translations/fr.json
@@ -140,6 +140,10 @@
     "es": {
       "name": "Espagnole",
       "nativeName": "español"
+    },
+    "n/a": {
+      "name": "Inconnue",
+      "nativeName": "Inconnue"
     }
   },
   "label": "Étiquette",


### PR DESCRIPTION
For language analytics entries in the database with the value `n/a` the analytics display would show: 
<img width="246" alt="Screen Shot 2021-09-09 at 1 45 30 PM" src="https://user-images.githubusercontent.com/18604963/132728441-80c4e5ee-6450-4015-9470-b819e5cec3c9.png">

Fixed to show `Unknown`:
<img width="239" alt="Screen Shot 2021-09-09 at 1 49 03 PM" src="https://user-images.githubusercontent.com/18604963/132728501-25cb634f-fab8-40af-b49d-1252f8f525f8.png">
