### PR TITLE
fix(hitlnext): fix scrolling overflow for HITLNext shortcuts

### DIFF
--- a/modules/hitlnext/src/views/lite/style.scss
+++ b/modules/hitlnext/src/views/lite/style.scss
@@ -62,16 +62,17 @@
             background-color: #fff;
             color: var(--shark);
             display: flex;
+            overflow: hidden;
             &.selected {
               background-color: var(--hover-ocean);
             }
             .shortcutKey {
-              width: 100px;
+              padding-right: var(--spacing-medium);
             }
             .shortcutValue {
               width: 100%;
               text-overflow: ellipsis;
-              overflow-y: hidden;
+              overflow: hidden;
               white-space: nowrap;
             }
           }


### PR DESCRIPTION
shortcuts with long text values in HITLNNext end up overflowing with a scrollbar, fixed so that text is truncated with an ellipsis at the end `...` 

<img width="606" alt="Screen Shot 2021-09-09 at 5 18 00 PM" src="https://user-images.githubusercontent.com/18604963/132756733-769ae59e-2f5e-4cba-87ee-526eb16e026c.png">
