### PR TITLE
chore(dx): better experience with multiple repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,6 @@ There are a few ways to get started with botpress :
   [![DigitalOcean](.github/do_button.svg)](https://marketplace.digitalocean.com/apps/botpress) [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 - Run from sources, follow [build docs](https://botpress.com/docs/infrastructure/deploying)
 
-## Getting Started - Developers
-
-Botpress is now split in multiple repositories. We provide a tool that can be used to create a workspace where it is easier to work across all those repositories.
-To setup a new workspace, you need to clone this repository first, then type `yarn bpd workspace init --path /new/path/to/workspace`
-
-Once the workspace is created, checkout a branch in the `botpress` repository, then you can type `yarn bpd workspace sync --force --dev` to checkout the correct branches
-
 ## Documentation
 
 - [Main Documentation](https://botpress.com/docs/introduction)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # [Botpress](https://botpress.com/?utm_source=github&utm_medium=organic&utm_campaign=botpress_repo&utm_term=readme) — The building blocks for building chatbots
 
 ## What is Botpress ?
+
 Botpress is the standard developer stack to build, run and improve Conversational-AI applications. Powered by natural language understanding, a messaging API and a fully featured studio, Botpress allows developers around the globe to build remarkable chatbots without compromise.
 a
 <a href='https://botpress.com/?utm_source=github&utm_medium=organic&utm_campaign=botpress_repo&utm_term=readme'><img src='.github/assets/studio.png'></a>
@@ -21,6 +22,13 @@ There are a few ways to get started with botpress :
 - Deploy it in the cloud using these shortlinks:
   [![DigitalOcean](.github/do_button.svg)](https://marketplace.digitalocean.com/apps/botpress) [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 - Run from sources, follow [build docs](https://botpress.com/docs/infrastructure/deploying)
+
+## Getting Started - Developers
+
+Botpress is now split in multiple repositories. We provide a tool that can be used to create a workspace where it is easier to work across all those repositories.
+To setup a new workspace, you need to clone this repository first, then type `yarn bpd workspace init --path /new/path/to/workspace`
+
+Once the workspace is created, checkout a branch in the `botpress` repository, then you can type `yarn bpd workspace sync --force --dev` to checkout the correct branches
 
 ## Documentation
 

--- a/build/downloader/src/cli.ts
+++ b/build/downloader/src/cli.ts
@@ -178,8 +178,8 @@ export const installFile = async (toolName: string, common: CommonArgs, toolVers
 export const useFile = async (toolName: string, version: string, common: CommonArgs) => {
   const toolFolder = path.resolve(common.appData, 'tools', toolName)
 
-  // We remove pre- from the beginning of the "version" because of the prefix of branch binaries
-  const underscoreVersion = version.replace(/^pre\-/, '').replace(/[\W_]+/g, '_')
+  // We remove dev- from the beginning of the "version" because of the prefix of branch binaries
+  const underscoreVersion = version.replace(/^dev\-/, '').replace(/[\W_]+/g, '_')
 
   const matchingFile = await Promise.fromCallback<string[]>(cb =>
     glob(`*${underscoreVersion}-${common.platform.replace('win32', 'win')}*`, { cwd: toolFolder }, cb)

--- a/build/downloader/src/cli.ts
+++ b/build/downloader/src/cli.ts
@@ -177,7 +177,10 @@ export const installFile = async (toolName: string, common: CommonArgs, toolVers
 
 export const useFile = async (toolName: string, version: string, common: CommonArgs) => {
   const toolFolder = path.resolve(common.appData, 'tools', toolName)
-  const underscoreVersion = version.replace(/[\W_]+/g, '_')
+
+  // We remove pre- from the beginning of the "version" because of the prefix of branch binaries
+  const underscoreVersion = version.replace(/^pre\-/, '').replace(/[\W_]+/g, '_')
+
   const matchingFile = await Promise.fromCallback<string[]>(cb =>
     glob(`*${underscoreVersion}-${common.platform.replace('win32', 'win')}*`, { cwd: toolFolder }, cb)
   )

--- a/build/downloader/src/cli.ts
+++ b/build/downloader/src/cli.ts
@@ -7,6 +7,7 @@ import glob from 'glob'
 import { CommonArgs } from 'index'
 import path from 'path'
 import rimraf from 'rimraf'
+import yn from 'yn'
 import { downloadFile } from './download'
 import { getReleasedFiles, logger, APP_PREFIX, ProcessedRelease } from './utils'
 
@@ -41,7 +42,7 @@ export const initProject = async (packageLocation: string, common: CommonArgs) =
     const releases = await getReleasedFiles(toolName, common.platform)
     const devRelease = devBranch && releases.find(x => x.version.endsWith(devBranch))
 
-    if (devBranch && devRelease) {
+    if (devBranch && devRelease && !yn(process.env.IGNORE_DEV_BRANCH)) {
       logger.info(`Using the binary of branch "${devBranch}"`)
       toolVersion = devBranch
 

--- a/build/downloader/src/utils.ts
+++ b/build/downloader/src/utils.ts
@@ -6,13 +6,15 @@ import { toolsList } from './cli'
 interface GithubRelease {
   tag_name: string
   assets: {
+    id: string
     name: string
     size: number
     browser_download_url: string
   }[]
 }
 
-interface ProcessedRelease {
+export interface ProcessedRelease {
+  fileId: string
   version: string
   fileName: string
   fileSize: number
@@ -28,6 +30,7 @@ export const getReleasedFiles = async (toolName: string, platform: string): Prom
       const platformFile = x.assets.find(asset => platformMatch.test(asset.name))
 
       return {
+        fileId: platformFile?.id || '',
         version: x.tag_name,
         fileName: platformFile?.name || '',
         fileSize: platformFile?.size || -1,

--- a/build/downloader/src/workspace-manager.ts
+++ b/build/downloader/src/workspace-manager.ts
@@ -168,7 +168,7 @@ export class WorkspaceManager {
     const dotEnvDir = path.resolve(this.rootFolder, 'botpress/packages/bp/dist/')
     const fileContent = `### Linked Repositories
 DEV_STUDIO_PATH=${this.rootFolder}/studio/packages/studio-be/out
-DEV_NLU_PATH=${this.rootFolder}/nlu/packages/nlu/dist
+DEV_NLU_PATH=${this.rootFolder}/nlu/packages/nlu-cli/dist
 DEV_MESSAGING_PATH=${this.rootFolder}/messaging/dist
 
 ### Connections

--- a/build/downloader/src/workspace-manager.ts
+++ b/build/downloader/src/workspace-manager.ts
@@ -1,0 +1,223 @@
+import 'bluebird-global'
+import chalk from 'chalk'
+import { exec } from 'child_process'
+import fse from 'fs-extra'
+import mkdirp from 'mkdirp'
+import path from 'path'
+
+interface RunCommand {
+  repo: string
+  label: string
+  cmd: string
+  env?: any
+  cwd: string
+}
+
+interface SetupRepository {
+  cloneRepo?: boolean
+  checkoutBranch?: string
+  forceCheckout?: boolean
+  buildAsPro?: boolean
+}
+
+const tryExecute = async (cmd, opts, isVerbose) => {
+  await Promise.fromCallback(cb => {
+    const proc = exec(cmd, opts, cb)
+    if (isVerbose) {
+      proc.stdout.pipe(process.stdout)
+      proc.stderr.pipe(process.stderr)
+    }
+  })
+}
+
+export const setDotEnvComment = async (varName: string, isEnabled: boolean, outputFolder: string) => {
+  const dotEnvFile = path.resolve(outputFolder, '.env')
+  if (!(await fse.pathExists(dotEnvFile))) {
+    return
+  }
+
+  const content = await fse.readFile(dotEnvFile, 'utf-8')
+  const envRegexp = new RegExp(`#?${varName}=(.*)`)
+
+  const result = content.split('\n').map(line => {
+    const match = line.match(envRegexp)
+    return match ? `${isEnabled ? '' : '# '}${varName}=${match[1]}` : line
+  })
+
+  await fse.writeFile(dotEnvFile, result.join('\n'), 'utf-8')
+}
+
+const log = (text: string, eraseLine?: boolean) => {
+  process.stdout.write(`${text}${eraseLine ? '\r' : '\n'}`)
+}
+
+const repositories = ['botpress', 'messaging', 'studio', 'nlu']
+
+export const getManager = (argv): WorkspaceManager => {
+  return new WorkspaceManager(argv.workspace, argv.verbose, argv.skipBuild, argv.quickBuild)
+}
+
+export class WorkspaceManager {
+  constructor(
+    private rootFolder: string,
+    private verbose: boolean,
+    private skipBuild: boolean,
+    private quickBuild?: boolean
+  ) {}
+
+  initializeWorkspace = async ({ usePro }: { usePro: boolean }) => {
+    if (await this.rootPathExists()) {
+      console.error('Cannot initialize a new workspace in an existing path')
+      process.exit(0)
+    }
+
+    await mkdirp.sync(this.rootFolder)
+    await fse.writeFile(path.join(this.rootFolder, '.workspace'), '')
+
+    for (const repo of repositories) {
+      await this.setupRepository(repo, { cloneRepo: true, buildAsPro: repo === 'botpress' && usePro })
+    }
+
+    await this.createDotEnv()
+  }
+
+  /**
+   * Synchronizing a workspace will checkout any dev branches configured in package.json
+   */
+  async syncWorkspace({ forceCheckout, devMode }: { forceCheckout: boolean; devMode: boolean }) {
+    if (!(await this.rootPathExists())) {
+      console.error('To sync a workspace, the path must exist')
+      process.exit(0)
+    }
+
+    const packageJson = await fse.readJson(path.resolve(this.rootFolder, 'botpress/package.json'))
+    for (const repo of repositories) {
+      const config = packageJson[repo]
+
+      if (devMode) {
+        const envVar = `DEV_${repo}_PATH`.toUpperCase()
+        await setDotEnvComment(envVar, true, `${this.rootFolder}/${repo}`)
+      }
+
+      if (config && (config?.devBranch || forceCheckout)) {
+        await this.setupRepository(repo, { checkoutBranch: config?.devBranch || 'master', forceCheckout })
+      }
+    }
+  }
+
+  async checkoutBranch(branchName: string, repo: string, cwd: string, forceCheckout?: boolean) {
+    await this.runCommand({
+      repo,
+      label: `Checkout ${branchName}`,
+      cmd: `git checkout ${forceCheckout ? '-f' : ''} ${branchName}`,
+      cwd
+    })
+  }
+
+  setupRepository = async (repo: string, { cloneRepo, buildAsPro, forceCheckout, checkoutBranch }: SetupRepository) => {
+    log(chalk.magenta(`Setting up ${repo}...`))
+
+    if (cloneRepo) {
+      await this.runCommand({
+        repo,
+        label: 'Cloning repository',
+        cmd: `git clone https://github.com/botpress/${repo}.git`,
+        cwd: this.rootFolder
+      })
+    }
+
+    const cwd = `${this.rootFolder}/${repo}`
+
+    if (checkoutBranch) {
+      await this.runCommand({
+        repo,
+        label: `Checkout ${checkoutBranch}`,
+        cmd: `git checkout ${forceCheckout ? '-f' : ''} ${checkoutBranch}`,
+        cwd
+      })
+    }
+
+    if (buildAsPro) {
+      await this.createEmptyProFile()
+    }
+
+    await this.runCommand({ label: 'Fetching dependencies', repo, cmd: 'yarn', cwd })
+
+    if (!this.skipBuild) {
+      await this.runCommand({
+        label: 'Building repository',
+        repo,
+        cmd: 'yarn build',
+        cwd,
+        env: { GULP_PARALLEL: this.quickBuild }
+      })
+    }
+
+    log('')
+  }
+
+  async createEmptyProFile() {
+    const proFile = path.resolve(this.rootFolder, 'botpress/pro')
+
+    if (!(await fse.pathExists(proFile))) {
+      await fse.writeFile(proFile, '')
+    }
+  }
+
+  async createDotEnv() {
+    const dotEnvDir = path.resolve(this.rootFolder, 'botpress/packages/bp/dist/')
+    const fileContent = `### Linked Repositories
+DEV_STUDIO_PATH=${this.rootFolder}/studio/packages/studio-be/out
+DEV_NLU_PATH=${this.rootFolder}/nlu/packages/nlu/dist
+DEV_MESSAGING_PATH=${this.rootFolder}/messaging/dist
+
+### Connections
+# DATABASE_URL=postgres://user:pw@localhost:5432/dbname
+# BPFS_STORAGE=database
+# CLUSTER_ENABLED=true
+# REDIS_URL=redis://localhost:6379
+# BP_REDIS_SCOPE=
+
+### Server Setup
+# BP_PRODUCTION=true
+# PRO_ENABLED=true
+# EXTERNAL_URL=http://localhost:3000
+# BP_CONFIG_HTTPSERVER_PORT=3000
+# BP_CONFIG_PRO_LICENSEKEY=your_license
+# DEBUG=bp:*
+
+### Migrations
+# AUTO_MIGRATE=true
+# TESTMIG_ALL=true
+# TESTMIG_NEW=true
+
+### Sandbox
+# DISABLE_GLOBAL_SANDBOX=true
+# DISABLE_BOT_SANDBOX=true
+# DISABLE_TRANSITION_SANDBOX=true
+# DISABLE_CONTENT_SANDBOX=true`
+
+    mkdirp.sync(dotEnvDir)
+    await fse.writeFile(path.resolve(dotEnvDir, '.env'), fileContent, 'utf-8')
+  }
+
+  async runCommand({ repo, label, cmd, env, cwd }: RunCommand) {
+    const startTime = Date.now()
+    const calcElapsed = () => `[${Math.round(Date.now() - startTime) / 1000} s]`
+
+    log(`- [${repo}] ${label}...`, true)
+
+    try {
+      await tryExecute(cmd, { cwd, env }, this.verbose)
+      log(`- [${repo}] ${label}... ${chalk.green('Success')} ${calcElapsed()}`, true)
+    } catch (err) {
+      log(`- [${repo}] ${label}... ${chalk.red(`Error: ${err.message}`)}`, true)
+    }
+
+    log('')
+  }
+
+  async rootPathExists() {
+    return fse.pathExists(this.rootFolder)
+  }
+}

--- a/build/downloader/src/workspace-manager.ts
+++ b/build/downloader/src/workspace-manager.ts
@@ -169,7 +169,7 @@ export class WorkspaceManager {
     const fileContent = `### Linked Repositories
 DEV_STUDIO_PATH=${this.rootFolder}/studio/packages/studio-be/out
 DEV_NLU_PATH=${this.rootFolder}/nlu/packages/nlu-cli/dist
-DEV_MESSAGING_PATH=${this.rootFolder}/messaging/dist
+DEV_MESSAGING_PATH=${this.rootFolder}/messaging/packages/server/dist
 
 ### Connections
 # DATABASE_URL=postgres://user:pw@localhost:5432/dbname

--- a/build/downloader/src/workspace-manager.ts
+++ b/build/downloader/src/workspace-manager.ts
@@ -149,7 +149,7 @@ export class WorkspaceManager {
         repo,
         cmd: 'yarn build',
         cwd,
-        env: { GULP_PARALLEL: this.quickBuild }
+        env: { ...process.env, GULP_PARALLEL: this.quickBuild }
       })
     }
 


### PR DESCRIPTION
Ever since we split the code in multiple repositories, testing code and setting up a workspace to actually work on the code was cumbersome and there was a lot of manual steps involved. I'm still testing it, so the associated code is only in the `studio` repository.

## Branch Binaries 

There are two parts associated with this change:
1. Whenever something is pushed on a branch in any of these repositories, the build process kicks in and it generates the same binary files that would be generated if we merged something on master. It is tagged as a pre-release.
2. When a branch is checked out on the `botpress` repository, if a developer branch is configured for the various sub-repos (messaging, studio, nlu), the downloader will pick that binary instead of the official release from "master". I've added some logic so the branch binary is only downloaded when it has been changed.

![image](https://user-images.githubusercontent.com/42552874/132794169-842e92a2-fb36-47d4-8f13-04fc3e8c56b6.png)

## Workspace Manager

I'm also working on a component called `Workspace Manager` (which is a part of the downloader). Basically, the goal is that you can type a single command to setup a development workspace, and you can also use a single command to manage it easily.

For example, typing `yarn bpd workspace init --path /usr/bp/myworkspace` would do this:
- Create a root folder, then clone each repositories in it (botpress, studio, messaging, nlu)
- Build each of those repositories
- Create a `.env` file with a template of commonly used environment variables (including the paths to develop)

![image](https://user-images.githubusercontent.com/42552874/132794463-b88185c7-ab77-4af8-807b-4f6d71865581.png)

Finally, when you checkout a branch on the `botpresss` repository, there is the command `yarn bpd workspace sync` which would automatically checkout the correct devBranch configured in package.json for each sub-repositories. Some options can be passed there, for example typing `yarn bpd workspace sync --force --devMode` would force-checkout the configured devBranches (discarding any change), and it would update the `.env` file to "uncomment" the dev repositories variable (so we use the code, not the binary).

![image](https://user-images.githubusercontent.com/42552874/132796104-823571e8-597e-41c4-bce4-322a94338570.png)

(i'm providing the path here because the repository is located elsewhere, but we could just add a quick method like yarn cmd sync to quickly get up to the task)

Associated code on the studio: https://github.com/botpress/studio/pull/92