### PR TITLE
fix(misunderstood): bring back event.state.user.language

### DIFF
--- a/modules/misunderstood/src/backend/index.ts
+++ b/modules/misunderstood/src/backend/index.ts
@@ -26,7 +26,9 @@ const onServerReady = async (bp: typeof sdk) => {
     const data: FlaggedEvent = {
       eventId: event.id,
       botId,
-      language: [event.nlu.language, event.nlu.detectedLanguage].filter(l => l && l !== 'n/a')[0],
+      language: [event.nlu.language, event.nlu.detectedLanguage, event.state?.user?.language].filter(
+        l => l && l !== 'n/a'
+      )[0],
       preview: event.preview,
       reason: 'thumbs_down' as FLAG_REASON
     }


### PR DESCRIPTION
@charlescatta pointed out that some customers run botpress without NLU, so it may be worthwhile to keep event.state.user.language (with null checks now!) in the misunderstood module as a fallback if we don't have an NLU language. This brings it back and is an update to #5431