### PR TITLE
chore(core): add option to get test coverage to jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,13 @@ module.exports = {
   globalSetup: '<rootDir>/packages/bp/src/jest-rewire.ts',
   setupFilesAfterEnv: [],
   collectCoverage: false,
+  coverageReporters: ['text-summary'],
+  collectCoverageFrom: [
+    '**/*.ts',
+    '!**/{node_modules,dist,out,e2e,build,docs,examples}/**',
+    '!**/migrations/v*.ts',
+    '!**/*.d.ts'
+  ],
   resetModules: true,
   verbose: true,
   modulePaths: ['<rootDir>/packages/bp/src/'],


### PR DESCRIPTION
This adds some defaults to get code coverage summary results from jest. Coverage will remain off by default.

You can run the tests and get coverage by running `yarn test --coverage`

- The summary option can be overridden to get more detailed output by adding `--coverageReporters=text`, or [see jest docs](https://jestjs.io/docs/configuration#coveragereporters-arraystring--string-options) for more options
- Currently this only looks at `.ts` files because some of the `.js` builds differently than how jest expects
- This ignores build files and migrations
- Our current coverage is suboptimal

```
=============================== Coverage summary ===============================
Statements   : 18.94% ( 3575/18880 )
Branches     : 5.07% ( 230/4540 )
Functions    : 7.64% ( 351/4593 )
Lines        : 18.61% ( 3313/17805 )
================================================================================
```