### PR TITLE
fix(code-editor): file listing error 'undefined is not iterable'

### DIFF
--- a/modules/code-editor/src/backend/editor.ts
+++ b/modules/code-editor/src/backend/editor.ts
@@ -108,7 +108,7 @@ export default class Editor {
       fileExt = def.isJSON ? '*.json' : '*.js'
     }
 
-    const baseExcluded = this._config.includeBuiltin || listBuiltin ? undefined : getBuiltinExclusion()
+    const baseExcluded = this._config.includeBuiltin || listBuiltin ? [] : getBuiltinExclusion()
     const excluded = [...baseExcluded, ...(dirListingExcluded ?? [])]
 
     const ghost = botId ? this.bp.ghost.forBot(botId) : this.bp.ghost.forGlobal()


### PR DESCRIPTION
fix the following error on code editor: 

 Mod[code-editor] [___] [Error, Error fetching files: TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))]
