### PR TITLE
fix(channel-web): fix migration when duplicate bot ids

### DIFF
--- a/modules/channel-web/src/messaging-migration/up.ts
+++ b/modules/channel-web/src/messaging-migration/up.ts
@@ -240,7 +240,7 @@ export abstract class MessagingUpMigrator {
 
     await this.onClientCreated(botId, client.id)
 
-    if (exists && this.isDryRun) {
+    if (exists && !this.isDryRun) {
       try {
         await this.bp.config.mergeBotConfig(botId, {
           messaging: { id: client.id, token, channels: {} }

--- a/modules/channel-web/src/messaging-migration/up.ts
+++ b/modules/channel-web/src/messaging-migration/up.ts
@@ -216,8 +216,8 @@ export abstract class MessagingUpMigrator {
   protected async createClients() {
     const bots = await this.bp.bots.getAllBots()
 
-    for (const bot of bots.values()) {
-      await this.createClient(bot.id, true)
+    for (const botId of bots.keys()) {
+      await this.createClient(botId, true)
     }
   }
 


### PR DESCRIPTION
This fixes a problem in the channel-web migration to messaging where we assumed that the keys for the getAllBots function returned configurations that have the same id as the keys. It turns out the keys are the folder names, and the ids are apparently useless data. 

A client we tested the migration on had a bot with the same id in two different folders so the same provider was created with the same name twice (which would cause a failure of the unique constraint).

Closes DEV-1711