### PR TITLE
fix(tests): bigger delay

### DIFF
--- a/packages/bp/src/core/distributed/job-service.test.ts
+++ b/packages/bp/src/core/distributed/job-service.test.ts
@@ -7,7 +7,9 @@ import { CEJobService } from './job-service'
 describe('Lock', () => {
   const jobService = new CEJobService()
   const resourceName = 'testLock'
-  const DURATION = 50
+
+  /** Duration must be longer since tests are executing with Redis enabled */
+  const DURATION = 200
 
   beforeEach(async () => {
     try {

--- a/packages/bp/src/core/events/queue/memory-queue.test.ts
+++ b/packages/bp/src/core/events/queue/memory-queue.test.ts
@@ -170,7 +170,11 @@ describe('Lite Queues', () => {
       queue.enqueue({ ...stubEvent, id: i.toString(), target: 'b' })
     }
 
-    await Promise.delay(50) // Make sure all jobs are executed
+    /**
+     *  Make sure all jobs are executed
+     *  Promise.delay(1) sometimes delays for more than that (10-20ms) which fails this test
+     */
+    await Promise.delay(200)
     expect(userListA.length).toBeLessThan(10)
     expect(userListB.length).toEqual(10)
     expect(userListB).toEqual([10, 11, 12, 13, 14, 15, 16, 17, 18, 19].map(x => x.toString()))


### PR DESCRIPTION
Since tests now use a full setup (postgres/redis), the lock mechanism takes longer than the previous delays, which often fails tests for no reason

![image](https://user-images.githubusercontent.com/42552874/133280938-84d184ae-b031-47cd-ba02-385c321b7410.png)
