### PR TITLE
fix(google-speech): fix using google-speech with ogg opus files

### DIFF
--- a/modules/google-speech/src/backend/client.ts
+++ b/modules/google-speech/src/backend/client.ts
@@ -117,9 +117,9 @@ export class GoogleSpeechClient {
         debugSpeechToText('Audio file successfully re-sampled')
 
         meta = await mm.parseBuffer(buffer)
-
-        encoding = AudioEncoding.OGG_OPUS
       }
+
+      encoding = AudioEncoding.OGG_OPUS
     } else if (container === Container['ebml/webm'] && codec === Codec.opus) {
       encoding = AudioEncoding.WEBM_OPUS
     } else if (container === Container['iso5/isom/hlsf'] && codec === Codec['mpeg-4/aac']) {
@@ -147,7 +147,7 @@ export class GoogleSpeechClient {
       return
     }
 
-    debugSpeechToText(`Audio file metadata: ${meta}`)
+    debugSpeechToText('Audio file metadata:', meta)
 
     // Note that transcription is limited to 60 seconds audio.
     // Use a GCS file for audio longer than 1 minute.


### PR DESCRIPTION
This PR fixes an issue where receiving _Ogg Opus_ files with sample rates of _8000, 12000, 16000, 24000, or 48000_ on **Google-Speech** would result in a warning saying that the format is unsupported when it's supposed to be.

Closes https://github.com/botpress/v12/issues/1475
