### PR TITLE
chore(server): v12.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,19 @@
-## [12.26.2](https://github.com/botpress/botpress/compare/v12.26.0...v12.26.2) (2021-09-14)
-
+## [12.26.2](https://github.com/botpress/botpress/compare/v12.26.1...v12.26.2) (2021-09-14)
 
 ### Bug Fixes
 
-* **analytics:** fix n/a lang entries description ([#5428](https://github.com/botpress/botpress/issues/5428)) ([87a4005](https://github.com/botpress/botpress/commit/87a4005))
-* **builtin_image:** Modified how we search for Minetype in the image component. ([#5401](https://github.com/botpress/botpress/issues/5401)) ([4dc35be](https://github.com/botpress/botpress/commit/4dc35be))
-* **channel-web:** fix messaging migration ([#5410](https://github.com/botpress/botpress/issues/5410)) ([a8881a6](https://github.com/botpress/botpress/commit/a8881a6))
-* **channel-web:** fix migration when duplicate bot ids ([#5445](https://github.com/botpress/botpress/issues/5445)) ([3f143ed](https://github.com/botpress/botpress/commit/3f143ed))
-* **channel-web:** fix typing indicator display ([#5421](https://github.com/botpress/botpress/issues/5421)) ([84cc6b5](https://github.com/botpress/botpress/commit/84cc6b5))
-* **code-editor:** file listing error 'undefined is not iterable' ([#5439](https://github.com/botpress/botpress/issues/5439)) ([1a8e329](https://github.com/botpress/botpress/commit/1a8e329))
-* **google-speech:** fix using google-speech with ogg opus files ([#5450](https://github.com/botpress/botpress/issues/5450)) ([4d76d3f](https://github.com/botpress/botpress/commit/4d76d3f))
-* **hitlnext:** fix scrolling overflow for shortcut ([#5432](https://github.com/botpress/botpress/issues/5432)) ([81aa3ad](https://github.com/botpress/botpress/commit/81aa3ad))
-* **misunderstood:** bring back event.state.user.language ([#5436](https://github.com/botpress/botpress/issues/5436)) ([d0268c9](https://github.com/botpress/botpress/commit/d0268c9))
-* **misunderstood:** remove user language, it's never defined ([#5431](https://github.com/botpress/botpress/issues/5431)) ([1c04dd2](https://github.com/botpress/botpress/commit/1c04dd2))
-* **tests:** bigger delay ([#5448](https://github.com/botpress/botpress/issues/5448)) ([320dc79](https://github.com/botpress/botpress/commit/320dc79))
-
-
-### Features
-
-* **docker-compose:** Added https example with Certbot and letsencrypt ([#5361](https://github.com/botpress/botpress/issues/5361)) ([f6632ba](https://github.com/botpress/botpress/commit/f6632ba))
-* **hitlnext:** remove obsolete pkg react-itial and add react-avatar ([#5408](https://github.com/botpress/botpress/issues/5408)) ([4fe31f6](https://github.com/botpress/botpress/commit/4fe31f6))
-* **misunderstood:** add reason to setEventStatus when switching tabs ([#5384](https://github.com/botpress/botpress/issues/5384)) ([a991500](https://github.com/botpress/botpress/commit/a991500))
-
-
+- **analytics:** fix n/a lang entries description ([#5428](https://github.com/botpress/botpress/issues/5428)) ([87a4005](https://github.com/botpress/botpress/commit/87a4005))
+- **builtin_image:** modified how we search for mimetype in the image component. ([#5401](https://github.com/botpress/botpress/issues/5401)) ([4dc35be](https://github.com/botpress/botpress/commit/4dc35be))
+- **channel-web:** fix messaging migration ([#5410](https://github.com/botpress/botpress/issues/5410)) ([a8881a6](https://github.com/botpress/botpress/commit/a8881a6))
+- **channel-web:** fix migration when duplicate bot ids ([#5445](https://github.com/botpress/botpress/issues/5445)) ([3f143ed](https://github.com/botpress/botpress/commit/3f143ed))
+- **channel-web:** fix typing indicator display ([#5421](https://github.com/botpress/botpress/issues/5421)) ([84cc6b5](https://github.com/botpress/botpress/commit/84cc6b5))
+- **code-editor:** file listing error 'undefined is not iterable' ([#5439](https://github.com/botpress/botpress/issues/5439)) ([1a8e329](https://github.com/botpress/botpress/commit/1a8e329))
+- **google-speech:** fix using google-speech with ogg opus files ([#5450](https://github.com/botpress/botpress/issues/5450)) ([4d76d3f](https://github.com/botpress/botpress/commit/4d76d3f))
+- **hitlnext:** fix scrolling overflow for shortcut ([#5432](https://github.com/botpress/botpress/issues/5432)) ([81aa3ad](https://github.com/botpress/botpress/commit/81aa3ad))
+- **misunderstood:** bring back event.state.user.language ([#5436](https://github.com/botpress/botpress/issues/5436)) ([d0268c9](https://github.com/botpress/botpress/commit/d0268c9))
+- **misunderstood:** remove user language, it's never defined ([#5431](https://github.com/botpress/botpress/issues/5431)) ([1c04dd2](https://github.com/botpress/botpress/commit/1c04dd2))
+- **misunderstood:** add reason to setEventStatus when switching tabs ([#5384](https://github.com/botpress/botpress/issues/5384)) ([a991500](https://github.com/botpress/botpress/commit/a991500))
+- **hitlnext:** remove obsolete pkg react-itial and add react-avatar ([#5408](https://github.com/botpress/botpress/issues/5408)) ([4fe31f6](https://github.com/botpress/botpress/commit/4fe31f6))
 
 # [12.26.1](https://github.com/botpress/botpress/compare/v12.26.0...v12.26.1) (2021-09-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## [12.26.2](https://github.com/botpress/botpress/compare/v12.26.0...v12.26.2) (2021-09-14)
+
+
+### Bug Fixes
+
+* **analytics:** fix n/a lang entries description ([#5428](https://github.com/botpress/botpress/issues/5428)) ([87a4005](https://github.com/botpress/botpress/commit/87a4005))
+* **builtin_image:** Modified how we search for Minetype in the image component. ([#5401](https://github.com/botpress/botpress/issues/5401)) ([4dc35be](https://github.com/botpress/botpress/commit/4dc35be))
+* **channel-web:** fix messaging migration ([#5410](https://github.com/botpress/botpress/issues/5410)) ([a8881a6](https://github.com/botpress/botpress/commit/a8881a6))
+* **channel-web:** fix migration when duplicate bot ids ([#5445](https://github.com/botpress/botpress/issues/5445)) ([3f143ed](https://github.com/botpress/botpress/commit/3f143ed))
+* **channel-web:** fix typing indicator display ([#5421](https://github.com/botpress/botpress/issues/5421)) ([84cc6b5](https://github.com/botpress/botpress/commit/84cc6b5))
+* **code-editor:** file listing error 'undefined is not iterable' ([#5439](https://github.com/botpress/botpress/issues/5439)) ([1a8e329](https://github.com/botpress/botpress/commit/1a8e329))
+* **google-speech:** fix using google-speech with ogg opus files ([#5450](https://github.com/botpress/botpress/issues/5450)) ([4d76d3f](https://github.com/botpress/botpress/commit/4d76d3f))
+* **hitlnext:** fix scrolling overflow for shortcut ([#5432](https://github.com/botpress/botpress/issues/5432)) ([81aa3ad](https://github.com/botpress/botpress/commit/81aa3ad))
+* **misunderstood:** bring back event.state.user.language ([#5436](https://github.com/botpress/botpress/issues/5436)) ([d0268c9](https://github.com/botpress/botpress/commit/d0268c9))
+* **misunderstood:** remove user language, it's never defined ([#5431](https://github.com/botpress/botpress/issues/5431)) ([1c04dd2](https://github.com/botpress/botpress/commit/1c04dd2))
+* **tests:** bigger delay ([#5448](https://github.com/botpress/botpress/issues/5448)) ([320dc79](https://github.com/botpress/botpress/commit/320dc79))
+
+
+### Features
+
+* **docker-compose:** Added https example with Certbot and letsencrypt ([#5361](https://github.com/botpress/botpress/issues/5361)) ([f6632ba](https://github.com/botpress/botpress/commit/f6632ba))
+* **hitlnext:** remove obsolete pkg react-itial and add react-avatar ([#5408](https://github.com/botpress/botpress/issues/5408)) ([4fe31f6](https://github.com/botpress/botpress/commit/4fe31f6))
+* **misunderstood:** add reason to setEventStatus when switching tabs ([#5384](https://github.com/botpress/botpress/issues/5384)) ([a991500](https://github.com/botpress/botpress/commit/a991500))
+
+
+
 # [12.26.1](https://github.com/botpress/botpress/compare/v12.26.0...v12.26.1) (2021-09-03)
 
 ### Bug Fixes

--- a/build/package.pkg.json
+++ b/build/package.pkg.json
@@ -1,6 +1,6 @@
 {
   "name": "botpress",
-  "version": "12.26.1",
+  "version": "12.26.2",
   "description": "The world's most powerful conversational engine",
   "main": "index.js",
   "bin": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bp_main",
-  "version": "12.26.1",
+  "version": "12.26.2",
   "description": "The world's most powerful conversational engine",
   "engines": {
     "node": "^12"

--- a/packages/bp/src/core/app/banner.ts
+++ b/packages/bp/src/core/app/banner.ts
@@ -25,7 +25,7 @@ export const showBanner = (config: BannerConfig) => {
   try {
     const metadata: BuildMetadata = require('../../metadata.json')
     const builtFrom = process.pkg ? 'BIN' : 'SRC'
-    const branchInfo = metadata.branch !== 'master' ? `/${metadata.branch}` : ''
+    const branchInfo = !['master', 'HEAD'].find(x => x === metadata.branch) ? `/${metadata.branch}` : ''
 
     buildMetadata = `Build ${moment(metadata.date).format('YYYYMMDD-HHmm')}_${builtFrom}${branchInfo}`
   } catch (err) {}

--- a/release-version.sh
+++ b/release-version.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-DOCS_VERSION_COMMAND="run version"
-
 echo "Select an option for release："
 echo
 
@@ -25,7 +23,6 @@ select VERSION in patch minor major "Specific Version"
         CURRENT_VERSION=$(node -p "require('./package.json').version")
         yarn version --new-version $VERSION --no-git-tag-version
         NEW_VERSION=$(node -p "require('./package.json').version")
-        cd docs/guide/website && yarn && yarn $DOCS_VERSION_COMMAND $NEW_VERSION && cd ../../..
         
         # Update changelog from git history
         yarn cmd changelog


### PR DESCRIPTION
# Release Notes

### Bug Fixes

- **analytics:** fix n/a lang entries description ([#5428](https://github.com/botpress/botpress/issues/5428)) ([87a4005](https://github.com/botpress/botpress/commit/87a4005))
- **builtin_image:** modified how we search for mimetype in the image component. ([#5401](https://github.com/botpress/botpress/issues/5401)) ([4dc35be](https://github.com/botpress/botpress/commit/4dc35be))
- **channel-web:** fix migration when duplicate bot ids ([#5445](https://github.com/botpress/botpress/issues/5445)) ([3f143ed](https://github.com/botpress/botpress/commit/3f143ed))
- **channel-web:** fix typing indicator display ([#5421](https://github.com/botpress/botpress/issues/5421)) ([84cc6b5](https://github.com/botpress/botpress/commit/84cc6b5))
- **code-editor:** file listing error 'undefined is not iterable' ([#5439](https://github.com/botpress/botpress/issues/5439)) ([1a8e329](https://github.com/botpress/botpress/commit/1a8e329))
- **google-speech:** fix using google-speech with ogg opus files ([#5450](https://github.com/botpress/botpress/issues/5450)) ([4d76d3f](https://github.com/botpress/botpress/commit/4d76d3f))
- **hitlnext:** fix scrolling overflow for shortcut ([#5432](https://github.com/botpress/botpress/issues/5432)) ([81aa3ad](https://github.com/botpress/botpress/commit/81aa3ad))
- **misunderstood:** bring back event.state.user.language ([#5436](https://github.com/botpress/botpress/issues/5436)) ([d0268c9](https://github.com/botpress/botpress/commit/d0268c9))
- **misunderstood:** remove user language, it's never defined ([#5431](https://github.com/botpress/botpress/issues/5431)) ([1c04dd2](https://github.com/botpress/botpress/commit/1c04dd2))
- **misunderstood:** add reason to setEventStatus when switching tabs ([#5384](https://github.com/botpress/botpress/issues/5384)) ([a991500](https://github.com/botpress/botpress/commit/a991500))

## NLU
0.1.5 ==> 0.1.6 see changes [here](https://github.com/botpress/nlu/releases)

## Studio
0.0.34 ==> 0.0.36 see changes [here](https://github.com/botpress/studio/releases)

## Messaging
0.1.12 ==> 0.1.13 see changes [here](https://github.com/botpress/messaging/releases)