### PR TITLE
fix(core): bigger frontend timeout

### DIFF
--- a/packages/bp/src/admin/ui/src/app/api.tsx
+++ b/packages/bp/src/admin/ui/src/app/api.tsx
@@ -84,7 +84,7 @@ export default {
   getSecured({
     token = undefined,
     toastErrors = true,
-    timeout = 10000,
+    timeout = 20000,
     useV1 = false,
     appendPath = ''
   }: SecuredApi = {}) {

--- a/packages/bp/src/admin/ui/src/management/checklist/DiagReport.tsx
+++ b/packages/bp/src/admin/ui/src/management/checklist/DiagReport.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@blueprintjs/core'
 import { toast } from 'botpress/shared'
+import ms from 'ms'
 import React, { useState } from 'react'
 
 import api from '~/app/api'
@@ -11,7 +12,7 @@ export const DiagReport = () => {
     setLoading(true)
 
     try {
-      const { data } = await api.getSecured().get('/admin/management/checklist/diag')
+      const { data } = await api.getSecured({ timeout: ms('2m') }).get('/admin/management/checklist/diag')
 
       const link = document.createElement('a')
       link.href = URL.createObjectURL(new Blob([data]))

--- a/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
@@ -2,6 +2,7 @@ import { Button, Classes, Dialog, FormGroup, InputGroup, Intent, Callout } from 
 import { BotConfig, BotTemplate } from 'botpress/sdk'
 import { lang } from 'botpress/shared'
 import _ from 'lodash'
+import ms from 'ms'
 import React, { Component } from 'react'
 import { connect, ConnectedProps } from 'react-redux'
 import Select from 'react-select'
@@ -119,7 +120,7 @@ class CreateBotModal extends Component<Props, State> {
     }
 
     try {
-      await api.getSecured().post('/admin/workspace/bots', newBot)
+      await api.getSecured({ timeout: ms('2m') }).post('/admin/workspace/bots', newBot)
       this.props.onCreateBotSuccess()
       this.toggleDialog()
     } catch (error) {

--- a/packages/bp/src/core/bpfs/ghost-service.ts
+++ b/packages/bp/src/core/bpfs/ghost-service.ts
@@ -491,7 +491,11 @@ export class ScopedGhostService {
       return
     }
 
-    const localFiles = await this.diskDriver.directoryListing(this.baseDir, { includeDotFiles: true })
+    const localFiles = await this.diskDriver.directoryListing(this.baseDir, {
+      includeDotFiles: true,
+      excludes: ['**/node_modules/**']
+    })
+
     const diskRevs = await this.diskDriver.listRevisions(this.baseDir)
     const dbRevs = await this.dbDriver.listRevisions(this.baseDir)
     const syncedRevs = _.intersectionBy(diskRevs, dbRevs, x => `${x.path} | ${x.revision}`)


### PR DESCRIPTION
- Sets a bigger timeout by default on the admin panel.
- Bigger timeout for diag reports and bot creation
- Avoid syncing node_modules, only the archive should be synced if needed