### PR TITLE
chore(server): v12.26.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [12.26.3](https://github.com/botpress/botpress/compare/v12.26.2...v12.26.3) (2021-09-17)
+
+
+### Bug Fixes
+
+* **channel-web:** down mig drop all msg_ tables ([#5452](https://github.com/botpress/botpress/issues/5452)) ([6f03d1c](https://github.com/botpress/botpress/commit/6f03d1c))
+* **channel-web:** fix useSessionStorage config option ([#5118](https://github.com/botpress/botpress/issues/5118)) ([edac7c6](https://github.com/botpress/botpress/commit/edac7c6)), closes [#5405](https://github.com/botpress/botpress/issues/5405)
+* **core:** add small safeguards ([#5459](https://github.com/botpress/botpress/issues/5459)) ([a1a83c8](https://github.com/botpress/botpress/commit/a1a83c8))
+* **core:** bigger frontend timeout ([#5455](https://github.com/botpress/botpress/issues/5455)) ([f976538](https://github.com/botpress/botpress/commit/f976538))
+* **hitl:** use renderPayload from ui-shared-lite to fix undefined ([#5454](https://github.com/botpress/botpress/issues/5454)) ([56a020c](https://github.com/botpress/botpress/commit/56a020c))
+
+
+
 ## [12.26.2](https://github.com/botpress/botpress/compare/v12.26.1...v12.26.2) (2021-09-14)
 
 ### Bug Fixes

--- a/build/package.pkg.json
+++ b/build/package.pkg.json
@@ -1,6 +1,6 @@
 {
   "name": "botpress",
-  "version": "12.26.2",
+  "version": "12.26.3",
   "description": "The world's most powerful conversational engine",
   "main": "index.js",
   "bin": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bp_main",
-  "version": "12.26.2",
+  "version": "12.26.3",
   "description": "The world's most powerful conversational engine",
   "engines": {
     "node": "^12"


### PR DESCRIPTION
# Release notes

### Bug Fixes

* **channel-web:** down mig drop all msg_ tables ([#5452](https://github.com/botpress/botpress/issues/5452)) ([6f03d1c](https://github.com/botpress/botpress/commit/6f03d1c))
* **channel-web:** fix useSessionStorage config option ([#5118](https://github.com/botpress/botpress/issues/5118)) ([edac7c6](https://github.com/botpress/botpress/commit/edac7c6)), closes [#5405](https://github.com/botpress/botpress/issues/5405)
* **core:** add small safeguards ([#5459](https://github.com/botpress/botpress/issues/5459)) ([a1a83c8](https://github.com/botpress/botpress/commit/a1a83c8))
* **core:** bigger frontend timeout ([#5455](https://github.com/botpress/botpress/issues/5455)) ([f976538](https://github.com/botpress/botpress/commit/f976538))
* **hitl:** use renderPayload from ui-shared-lite to fix undefined ([#5454](https://github.com/botpress/botpress/issues/5454)) ([56a020c](https://github.com/botpress/botpress/commit/56a020c))

## Studio
0.0.36 ==> 0.0.37 see changes [here](https://github.com/botpress/studio/releases)