### PR TITLE
chore(heroku): Removed CMD from heroku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,2 @@
 FROM botpress/server:latest
 WORKDIR /botpress
-CMD ["./bp"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,1 @@
 FROM botpress/server:latest
-WORKDIR /botpress


### PR DESCRIPTION
I'm using the default CMD from the original dockerfile.