### PR TITLE
fix(channel-web): prevent sending proactive messages on webchatLoaded

### DIFF
--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -223,6 +223,11 @@ class Web extends React.Component<MainProps> {
   }
 
   handleNewMessage = async (event: Message) => {
+    if (!this.props.isInitialized) {
+      console.warn('[webchat] Cannot send messages until the webchat is ready')
+      return
+    }
+
     if (event.payload?.type === 'visit') {
       // don't do anything, it's the system message
       return
@@ -251,6 +256,11 @@ class Web extends React.Component<MainProps> {
   }
 
   handleTyping = async (event: Message) => {
+    if (!this.props.isInitialized) {
+      console.warn('[webchat] Cannot send typing indicators until the webchat is ready')
+      return
+    }
+
     if (!this.isCurrentConversation(event)) {
       // don't do anything, it's a message from another conversation
       return
@@ -393,7 +403,8 @@ export default inject(({ store }: { store: RootStore }) => ({
   widgetTransition: store.view.widgetTransition,
   displayWidgetView: store.view.displayWidgetView,
   setLoadingCompleted: store.view.setLoadingCompleted,
-  sendFeedback: store.sendFeedback
+  sendFeedback: store.sendFeedback,
+  isInitialized: store.isInitialized
 }))(injectIntl(observer(Web)))
 
 type MainProps = { store: RootStore } & Pick<
@@ -430,4 +441,5 @@ type MainProps = { store: RootStore } & Pick<
   | 'resetUnread'
   | 'setLoadingCompleted'
   | 'dimensions'
+  | 'isInitialized'
 >

--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -225,11 +225,6 @@ class Web extends React.Component<MainProps> {
   }
 
   handleNewMessage = async (event: Message) => {
-    if (!this.props.isInitialized) {
-      console.warn('[webchat] Cannot send messages until the webchat is ready')
-      return
-    }
-
     if (event.payload?.type === 'visit') {
       // don't do anything, it's the system message
       return
@@ -258,11 +253,6 @@ class Web extends React.Component<MainProps> {
   }
 
   handleTyping = async (event: Message) => {
-    if (!this.props.isInitialized) {
-      console.warn('[webchat] Cannot send typing indicators until the webchat is ready')
-      return
-    }
-
     if (!this.isCurrentConversation(event)) {
       // don't do anything, it's a message from another conversation
       return

--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -51,7 +51,7 @@ class Web extends React.Component<MainProps> {
       }
     })
 
-    await this.initialize()
+    await this.load()
     await this.initializeIfChatDisplayed()
 
     this.props.setLoadingCompleted()
@@ -83,7 +83,7 @@ class Web extends React.Component<MainProps> {
     }
   }
 
-  async initialize() {
+  async load() {
     this.config = this.extractConfig()
 
     if (this.config.exposeStore) {

--- a/modules/channel-web/src/views/lite/main.tsx
+++ b/modules/channel-web/src/views/lite/main.tsx
@@ -395,8 +395,7 @@ export default inject(({ store }: { store: RootStore }) => ({
   widgetTransition: store.view.widgetTransition,
   displayWidgetView: store.view.displayWidgetView,
   setLoadingCompleted: store.view.setLoadingCompleted,
-  sendFeedback: store.sendFeedback,
-  isInitialized: store.isInitialized
+  sendFeedback: store.sendFeedback
 }))(injectIntl(observer(Web)))
 
 type MainProps = { store: RootStore } & Pick<
@@ -433,5 +432,4 @@ type MainProps = { store: RootStore } & Pick<
   | 'resetUnread'
   | 'setLoadingCompleted'
   | 'dimensions'
-  | 'isInitialized'
 >

--- a/modules/channel-web/src/views/lite/store/index.ts
+++ b/modules/channel-web/src/views/lite/store/index.ts
@@ -382,6 +382,11 @@ class RootStore {
   /** Sends an event or a message, depending on how the backend manages those types */
   @action.bound
   async sendData(data: any): Promise<void> {
+    if (!this.isInitialized) {
+      console.warn('[webchat] Cannot send data until the webchat is ready')
+      return
+    }
+
     if (!constants.MESSAGE_TYPES.includes(data.type)) {
       return this.api.sendEvent(data, this.currentConversationId)
     }

--- a/modules/channel-web/src/views/lite/store/index.ts
+++ b/modules/channel-web/src/views/lite/store/index.ts
@@ -171,6 +171,11 @@ class RootStore {
 
   @action.bound
   async addEventToConversation(event: Message): Promise<void> {
+    if (!this.isInitialized) {
+      console.warn('[webchat] Cannot receive messages until the webchat is ready')
+      return
+    }
+
     if (this.isInitialized && this.currentConversationId !== event.conversationId) {
       await this.fetchConversations()
       await this.fetchConversation(event.conversationId)
@@ -192,6 +197,11 @@ class RootStore {
 
   @action.bound
   async updateTyping(event: Message): Promise<void> {
+    if (!this.isInitialized) {
+      console.warn('[webchat] Cannot send typing indicators until the webchat is ready')
+      return
+    }
+
     if (this.isInitialized && this.currentConversationId !== event.conversationId) {
       await this.fetchConversations()
       await this.fetchConversation(event.conversationId)

--- a/modules/channel-web/src/views/lite/store/index.ts
+++ b/modules/channel-web/src/views/lite/store/index.ts
@@ -171,11 +171,6 @@ class RootStore {
 
   @action.bound
   async addEventToConversation(event: Message): Promise<void> {
-    if (!this.isInitialized) {
-      console.warn('[webchat] Cannot receive messages until the webchat is ready')
-      return
-    }
-
     if (this.isInitialized && this.currentConversationId !== event.conversationId) {
       await this.fetchConversations()
       await this.fetchConversation(event.conversationId)
@@ -197,11 +192,6 @@ class RootStore {
 
   @action.bound
   async updateTyping(event: Message): Promise<void> {
-    if (!this.isInitialized) {
-      console.warn('[webchat] Cannot send typing indicators until the webchat is ready')
-      return
-    }
-
     if (this.isInitialized && this.currentConversationId !== event.conversationId) {
       await this.fetchConversations()
       await this.fetchConversation(event.conversationId)


### PR DESCRIPTION
This PR fixes an issue where using the `webchatLoaded` event to send proactive messages would print errors in the browser´s console.

The channel-web exposes [4 events](https://botpress.com/docs/tutorials/proactive#webchat-events) that users can use as hooks to either configure the channel, update its configs, send proactive messages, ... As per the [documentation](https://botpress.com/docs/tutorials/proactive#send-message-when-the-webchat-is-loaded), a user should use the `webchatReady` event when wanting the send proactive messages. Now, if he mistakenly uses the `webchatLoaded` event instead, a warning will be displayed in the console saying the webchat is not ready to receive messages yet.

Closes botpress/v12#1426 and DEV-1515