### PR TITLE
fix(channel-web): avatar won`t crash if there is no name

### DIFF
--- a/modules/channel-web/src/views/lite/components/common/Avatar.tsx
+++ b/modules/channel-web/src/views/lite/components/common/Avatar.tsx
@@ -7,7 +7,7 @@ const Avatar = ({ name, avatarUrl, height, width }: AvatarProps) => {
       {!avatarUrl && (
         <svg width={width} height={width}>
           <text textAnchor={'middle'} x={'50%'} y={'50%'} dy={'0.35em'} fill={'#ffffff'} fontSize={15}>
-            {name[0]}
+            {name && name[0]}
           </text>
         </svg>
       )}


### PR DESCRIPTION
An error occurred when using the option showUserAvatar as true.

Cannot read properties of undefined (reading '0')