### PR TITLE
chore(telemetry): add isProduction in server stats

### DIFF
--- a/packages/bp/src/common/telemetry.ts
+++ b/packages/bp/src/common/telemetry.ts
@@ -18,6 +18,7 @@ export interface TelemetryEntry {
 }
 
 export interface ServerStats {
+  isProduction: boolean
   externalUrl: string
   botpressVersion: string
   clusterEnabled: boolean

--- a/packages/bp/src/core/telemetry/stats/legacy-stats.ts
+++ b/packages/bp/src/core/telemetry/stats/legacy-stats.ts
@@ -118,6 +118,7 @@ export class LegacyStats extends TelemetryStats {
 
   protected async getServerStats() {
     return {
+      isProduction: process.IS_PRODUCTION,
       externalUrl: process.EXTERNAL_URL,
       botpressVersion: process.BOTPRESS_VERSION,
       clusterEnabled: yn(process.CLUSTER_ENABLED, { default: false }),
@@ -183,3 +184,4 @@ export class LegacyStats extends TelemetryStats {
     return (await this.authService.getAllUsers()).length
   }
 }
+

--- a/packages/bp/src/core/telemetry/stats/telemetry-stats.ts
+++ b/packages/bp/src/core/telemetry/stats/telemetry-stats.ts
@@ -62,6 +62,7 @@ export abstract class TelemetryStats {
 
   protected async getServerStats(): Promise<ServerStats> {
     return {
+      isProduction: process.IS_PRODUCTION,
       externalUrl: process.EXTERNAL_URL,
       botpressVersion: process.BOTPRESS_VERSION,
       clusterEnabled: yn(process.CLUSTER_ENABLED, { default: false }),


### PR DESCRIPTION
This PR is pretty self explanatory. We want to start tracking data that comes from production servers.

Closes DEV-1819