### PR TITLE
fix(dx): fix warnings with logger attachError

### DIFF
--- a/packages/bp/src/core/logger/persister/console-logger.ts
+++ b/packages/bp/src/core/logger/persister/console-logger.ts
@@ -80,8 +80,11 @@ export class PersistedConsoleLogger implements Logger {
     return this
   }
 
-  attachError(error: Error): this {
-    this.attachedError = error
+  attachError(error: unknown): this {
+    if (error instanceof Error) {
+      this.attachedError = error
+    }
+
     return this
   }
 

--- a/packages/bp/src/sdk/botpress.d.ts
+++ b/packages/bp/src/sdk/botpress.d.ts
@@ -98,7 +98,7 @@ declare module 'botpress/sdk' {
 
   export interface Logger {
     forBot(botId: string): this
-    attachError(error: Error): this
+    attachError(error: unknown): this
     /**
      * Attaching an event to the log entry will display the associated logs in the Processing tab on the debugger
      */


### PR DESCRIPTION
Since a recent TS update, exceptions are now typed as "unknown" instead of "any", meaning that we get a lot of warnings when opening files, ex:

![image](https://user-images.githubusercontent.com/42552874/134255062-28e0c4f7-93d3-40af-aeaa-d63f8ff6fa3d.png)
