### PR TITLE
fix(channel-web): fix display of image, file, audio and video content-elements

### DIFF
--- a/modules/channel-web/assets/default-emulator.css
+++ b/modules/channel-web/assets/default-emulator.css
@@ -472,7 +472,8 @@
     padding: 0.5rem 0.75rem;
   }
 
-  .bpw-bubble-file a {
+  .bpw-bubble-file a,
+  .bpw-bubble-image a {
     cursor: pointer;
     border-top-left-radius: inherit;
     border-top-right-radius: inherit;
@@ -480,7 +481,7 @@
     border-bottom-left-radius: inherit;
   }
 
-  .bpw-bubble-file a img,
+  .bpw-bubble-image a img,
   .bpw-bubble-audio audio,
   .bpw-bubble-video video {
     max-width: 100%;

--- a/modules/channel-web/assets/default.css
+++ b/modules/channel-web/assets/default.css
@@ -400,7 +400,8 @@ body {
   padding: 0.5rem 0.75rem;
 }
 
-.bpw-bubble-file a {
+.bpw-bubble-file a,
+.bpw-bubble-image a {
   cursor: pointer;
   border-top-left-radius: inherit;
   border-top-right-radius: inherit;
@@ -408,7 +409,9 @@ body {
   border-bottom-left-radius: inherit;
 }
 
-.bpw-bubble-file a img {
+.bpw-bubble-image a img,
+.bpw-bubble-audio audio,
+.bpw-bubble-video video {
   max-height: 240px;
   max-width: 100%;
   border-top-left-radius: inherit;

--- a/modules/channel-web/src/views/lite/components/messages/Message.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/Message.tsx
@@ -73,6 +73,10 @@ class Message extends Component<MessageProps> {
     return <FileMessage file={this.props.payload} escapeTextHTML={this.props.store.escapeHTML} />
   }
 
+  render_image() {
+    return <FileMessage file={this.props.payload} escapeTextHTML={this.props.store.escapeHTML} />
+  }
+
   render_file() {
     return <FileMessage file={this.props.payload} escapeTextHTML={this.props.store.escapeHTML} />
   }

--- a/modules/channel-web/src/views/lite/components/messages/renderer/FileMessage.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/renderer/FileMessage.tsx
@@ -1,4 +1,5 @@
 import mimeTypes from 'mime/lite'
+import path from 'path'
 import React from 'react'
 
 import { Renderer } from '../../../typings'
@@ -18,8 +19,8 @@ export const FileMessage = (props: Renderer.FileMessage) => {
 
     extension = validUrl.pathname
   } catch (error) {
-    // If the URL is not valid return a dummy component.
-    return null
+    // Try using path.extname since url might be relative.
+    extension = path.extname(url)
   }
 
   const mime = mimeTypes.getType(extension)

--- a/packages/ui-shared-lite/Payloads/index.ts
+++ b/packages/ui-shared-lite/Payloads/index.ts
@@ -111,7 +111,7 @@ const renderDropdownPayload = (content: sdk.DropdownContent & ExtraDropdownPrope
 
 const renderImagePayload = (content: sdk.ImageContent & CollectFeedback) => {
   return {
-    type: 'file',
+    type: 'image',
     title: content.title,
     url: formatUrl('', content.image),
     collectFeedback: content.collectFeedback
@@ -140,7 +140,7 @@ const renderFilePayload = (content: sdk.FileContentType & CollectFeedback) => {
   return {
     type: 'file',
     title: content.title,
-    file: formatUrl('', content.file),
+    url: formatUrl('', content.file),
     collectFeedback: content.collectFeedback
   }
 }


### PR DESCRIPTION
This PR fixes an issue where images, files, audio, and video would not be rendered in the channel-web

**Before**

![Screenshot from 2021-09-22 14-06-03](https://user-images.githubusercontent.com/9640576/134397896-56a3895a-52e3-43b3-adc9-afcc68304121.png)


**After**

![Screenshot from 2021-09-22 13-31-32](https://user-images.githubusercontent.com/9640576/134397904-5344be5a-4ac1-483e-9d32-b6c08588f45b.png)


One of the issues was brought by PR https://github.com/botpress/botpress/pull/5401 since doing `new URL()` on relative URLs throws an error.

The other issue was related to the way we rendered the file payload which wasn't compatible with the FileMessage component.

Closes botpress/v12#1491 and DEV-1849