### PR TITLE
fix(core): fix unhandled rejections

### DIFF
--- a/packages/bp/src/index.ts
+++ b/packages/bp/src/index.ts
@@ -59,9 +59,6 @@ process.stderr.write = stripDeprecationWrite
 
 process.on('unhandledRejection', err => {
   global.printErrorDefault(err)
-  if (!process.IS_FAILSAFE) {
-    process.exit(1)
-  }
 })
 
 process.on('uncaughtException', err => {


### PR DESCRIPTION
Code executed in actions/hooks (inside the vm) triggers an unhandled rejection, which bubbles up to the main process, which exits the web process. The sandbox doesn't seem to handle promise rejections correctly, and there's no fix in sight on the lib's repository. 

Closes DEV-1822