### PR TITLE
fix(channel-web): filter out empty text payload messages

### DIFF
--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -305,16 +305,13 @@ export default async (bp: typeof sdk, db: Database) => {
       const conversation = await req.messaging.conversations.get(conversationId)
       const messages = await req.messaging.messages.list(conversationId, config.maxMessagesHistory)
 
-      const filteredMessages = messages.filter(m => {
-        if (m.payload.type !== 'visit') {
-          if (m.payload.type === 'text') {
-            return !!m.payload.text
-          }
-          return true
-        }
-      })
+      // this function scope can (and probably will) expand to other types as well with a switch case on the type
+      // we do something similar in the cms to determine weather there are translated fields or not
+      const notEmptyPayload = payload => (payload.type === 'text' ? !!payload.text : true)
 
-      return res.send({ ...conversation, messages: filteredMessages })
+      const displayableMessages = messages.filter(({ payload }) => payload.type !== 'visit' && notEmptyPayload(payload))
+
+      return res.send({ ...conversation, messages: displayableMessages })
     })
   )
 

--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -305,7 +305,14 @@ export default async (bp: typeof sdk, db: Database) => {
       const conversation = await req.messaging.conversations.get(conversationId)
       const messages = await req.messaging.messages.list(conversationId, config.maxMessagesHistory)
 
-      const filteredMessages = messages.filter(m => m.payload.type !== 'visit')
+      const filteredMessages = messages.filter(m => {
+        if (m.payload.type !== 'visit') {
+          if (m.payload.type === 'text') {
+            return !!m.payload.text
+          }
+          return true
+        }
+      })
 
       return res.send({ ...conversation, messages: filteredMessages })
     })


### PR DESCRIPTION
## Description

I filtered out empty text messages payload. This is an approach to fix empty messages on the `hitlnext` chat when we go online.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore change (refactoring and / or test changes)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Manual test on my local - partial, need to dive deeper for a more future-proof approach
- [ ] Unit test (ongoing)

**Test configuration**:
* BP version: 12.26.3
* Node version: 12.13.0
* OS: MacOS
* Browser: Chrome
* Binary or source ?: `source` 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I've included some media (picture/gif/video) if applicable to show the old and new behavior

## Media

(before)
![image](https://user-images.githubusercontent.com/13097764/134755226-23e59262-cac0-45c2-af28-57fd99133f27.png)


(after)
![image](https://user-images.githubusercontent.com/13097764/134755216-c56c2c1d-df77-4fd3-bd2b-43e5d2e59415.png)
