### PR TITLE
fix: bring back needs-training warning in admin

### DIFF
--- a/packages/bp/e2e/admin/bots.test.ts
+++ b/packages/bp/e2e/admin/bots.test.ts
@@ -78,7 +78,7 @@ describe('Admin - Bot Management', () => {
   })
 
   it('Train Warning', async () => {
-    await expectStudioApiCallSuccess('training/en', 'GET')
+    await expectCallSuccess(`${bpConfig.apiHost}/api/v1/studio/${tempBotId}/nlu/training/en`, 'GET')
   })
 
   it('Export bot', async () => {

--- a/packages/bp/e2e/admin/bots.test.ts
+++ b/packages/bp/e2e/admin/bots.test.ts
@@ -9,6 +9,7 @@ import {
   expectAdminApiCallSuccess,
   expectCallSuccess,
   expectModuleApiCallSuccess,
+  expectStudioApiCallSuccess,
   gotoAndExpect,
   loginIfNeeded,
   triggerKeyboardShortcut
@@ -77,7 +78,7 @@ describe('Admin - Bot Management', () => {
   })
 
   it('Train Warning', async () => {
-    await expectModuleApiCallSuccess('nlu', tempBotId, 'training/en', 'GET')
+    await expectStudioApiCallSuccess('training/en', 'GET')
   })
 
   it('Export bot', async () => {

--- a/packages/bp/e2e/admin/bots.test.ts
+++ b/packages/bp/e2e/admin/bots.test.ts
@@ -76,6 +76,10 @@ describe('Admin - Bot Management', () => {
     ])
   })
 
+  it('Train Warning', async () => {
+    await expectModuleApiCallSuccess('nlu', tempBotId, 'training/en', 'GET')
+  })
+
   it('Export bot', async () => {
     await clickButtonForBot('#btn-export', tempBotId)
 

--- a/packages/bp/src/admin/ui/src/workspace/bots/NeedsTrainingWarning.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/NeedsTrainingWarning.tsx
@@ -1,0 +1,48 @@
+import { Icon, Intent, Position, Tooltip } from '@blueprintjs/core'
+import { Promise as BbPromise } from 'bluebird'
+import { lang } from 'botpress/shared'
+import React, { FC, Fragment, useEffect, useState } from 'react'
+import api from '~/app/api'
+
+interface Props {
+  bot: string
+  languages: string[]
+}
+
+export const NeedsTrainingWarning: FC<Props> = (props: Props) => {
+  const { bot, languages } = props
+
+  const [needsTraining, setNeedsTraining] = useState(false)
+
+  useEffect(() => {
+    const axios = api.getSecured({ useV1: true })
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    BbPromise.map(languages, async lang => {
+      try {
+        const { data } = await axios.get(`studio/${bot}/nlu/training/${lang}`)
+        return data.status === 'needs-training'
+      } catch (err) {
+        return false
+      }
+    }).then(langNeedsTraining => {
+      setNeedsTraining(langNeedsTraining.some(Boolean))
+    })
+  }, [])
+
+  const message = () => (
+    <Fragment>
+      <div>{lang.tr('admin.needsTraining')}</div>
+      <div>{lang.tr('admin.howToTrain')}</div>
+    </Fragment>
+  )
+
+  if (needsTraining) {
+    return (
+      <Tooltip intent={Intent.WARNING} content={message()} position={Position.TOP}>
+        <Icon icon="warning-sign" intent={Intent.WARNING} style={{ marginLeft: 10 }} />
+      </Tooltip>
+    )
+  }
+  return null
+}

--- a/packages/bp/src/admin/ui/src/workspace/bots/index.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/index.tsx
@@ -29,7 +29,7 @@ import AccessControl from '~/auth/AccessControl'
 import { getActiveWorkspace } from '~/auth/basicAuth'
 import { fetchLicensing } from '~/management/licensing/reducer'
 import { fetchModules } from '~/management/modules/reducer'
-import { fetchBotHealth, fetchBots } from '~/workspace/bots/reducer'
+import { fetchBotHealth, fetchBots, fetchBotNLULanguages } from '~/workspace/bots/reducer'
 import { filterList } from '~/workspace/util'
 
 import BotItemCompact from './BotItemCompact'
@@ -62,6 +62,7 @@ class Bots extends Component<Props> {
   componentDidMount() {
     this.props.fetchBots()
     this.props.fetchBotHealth()
+    this.props.fetchBotNLULanguages()
 
     if (!this.props.loadedModules.length && this.props.profile && this.props.profile.isSuperAdmin) {
       this.props.fetchModules()
@@ -233,6 +234,7 @@ class Bots extends Component<Props> {
               rollback={this.toggleRollbackModal.bind(this, bot.id)}
               reloadBot={this.reloadBot.bind(this, bot.id)}
               viewLogs={this.viewLogs.bind(this, bot.id)}
+              installedNLULanguages={this.props.language}
             />
           </Fragment>
         ))}
@@ -285,6 +287,7 @@ class Bots extends Component<Props> {
                       rollback={this.toggleRollbackModal.bind(this, bot.id)}
                       reloadBot={this.reloadBot.bind(this, bot.id)}
                       viewLogs={this.viewLogs.bind(this, bot.id)}
+                      installedNLULanguages={this.props.language}
                     />
                   </Fragment>
                 ))}
@@ -426,14 +429,16 @@ const mapStateToProps = (state: AppState) => ({
   workspace: state.bots.workspace,
   loading: state.bots.loadingBots,
   licensing: state.licensing.license,
-  profile: state.user.profile
+  profile: state.user.profile,
+  language: state.bots.nluLanguages
 })
 
 const mapDispatchToProps = {
   fetchBots,
   fetchLicensing,
   fetchBotHealth,
-  fetchModules
+  fetchModules,
+  fetchBotNLULanguages
 }
 
 const connector = connect(mapStateToProps, mapDispatchToProps)

--- a/packages/bp/src/admin/ui/src/workspace/bots/reducer.ts
+++ b/packages/bp/src/admin/ui/src/workspace/bots/reducer.ts
@@ -12,6 +12,7 @@ const FETCH_BOTS_BY_WORKSPACE = 'bots/FETCH_BOTS_BY_WORKSPACE'
 const RECEIVED_BOT_CATEGORIES = 'bots/RECEIVED_BOT_CATEGORIES'
 const RECEIVED_BOT_TEMPLATES = 'bots/RECEIVED_BOT_TEMPLATES'
 const SET_WORKSPACE_APPS_BOT_ID = 'bots/SET_WORKSPACE_APPS_BOT_ID'
+const FETCH_BOT_NLU_LANGUAGES_RECEIVED = 'bots/FETCH_BOT_NLU_LANGUAGES_RECEIVED'
 
 interface BotState {
   bots: BotConfig[]
@@ -25,6 +26,8 @@ interface BotState {
   workspace?: { name: string; pipeline: any; botPrefix?: string }
   // Sets the current bot used by workspace apps
   workspaceAppsBotId?: string
+  // Fetches the list of languages available with the NLU
+  nluLanguages: string[]
 }
 
 const initialState: BotState = {
@@ -35,7 +38,8 @@ const initialState: BotState = {
   botTemplatesFetched: false,
   botCategories: [],
   botCategoriesFetched: false,
-  workspace: undefined
+  workspace: undefined,
+  nluLanguages: []
 }
 
 export default (state = initialState, action): BotState => {
@@ -82,6 +86,12 @@ export default (state = initialState, action): BotState => {
       return {
         ...state,
         workspaceAppsBotId: action.botId
+      }
+
+    case FETCH_BOT_NLU_LANGUAGES_RECEIVED:
+      return {
+        ...state,
+        nluLanguages: action.languages
       }
 
     default:
@@ -146,6 +156,16 @@ export const fetchBotHealth = (): AppThunk => {
     }
 
     dispatch({ type: FETCH_BOT_HEALTH_RECEIVED, health: data.payload })
+  }
+}
+
+export const fetchBotNLULanguages = (): AppThunk => {
+  return async dispatch => {
+    const { data } = await api.getSecured({ useV1: true }).get(`/studio/${ALL_BOTS}/nlu/health`)
+    if (!data || !data.validLanguages) {
+      return
+    }
+    dispatch({ type: FETCH_BOT_NLU_LANGUAGES_RECEIVED, languages: data.validLanguages })
   }
 }
 


### PR DESCRIPTION
To go faster when removing the nlu module, I temporarily removed the small warning signs that say if a bot needs a training or if a bot has languages that are not enabled in the language server.

This PR brings those back in branch `next`.