### PR TITLE
fix(bot): add catch to try statement and wrap throwable tmp fn in it

### DIFF
--- a/packages/bp/src/core/bots/bot-service.ts
+++ b/packages/bp/src/core/bots/bot-service.ts
@@ -326,7 +326,7 @@ export class BotService {
         this.logger.forBot(botId).info(`Import of bot ${botId} was denied by hook validation`)
       }
     } catch (error) {
-      const errorMessage = error && error instanceof Error ? (error as Error).message : JSON.stringify(error)
+      const errorMessage = error && error instanceof Error ? error.message : JSON.stringify(error)
       this.logger.error(`Error in ${this.importBot.name} function: ${errorMessage}`)
     } finally {
       this._invalidateBotIds()


### PR DESCRIPTION
## Description

The [tmp](https://www.npmjs.com/package/tmp) dependency's `dirSync()` can throw, but it wasn't in the `try` statement two lines below. I moved it in there and added a `catch` to the `try` statement because there wasn't any. In the same stroke I added error logging this way we'll have a better idea if the bug referred to by the linked issue is in fact hiding in that `try/catch`. 

Partial-fix to [#5354](https://github.com/botpress/v12/issues/1442)

## Type of change

- [x] Chore change (refactoring and / or test changes)