### PR TITLE
chore(docs): fix reference search

### DIFF
--- a/build/gulp.docs.js
+++ b/build/gulp.docs.js
@@ -68,7 +68,7 @@ const alterReference = async () => {
   })
 
   const fixedContentPaths = $.html()
-    .replace('../assets/', 'assets/')
+    .replace(/\.\.\/assets/g, 'assets')
     .replace(/\.\.\/globals.html/g, 'globals.html')
   fs.writeFileSync(path.join(__dirname, '../docs/reference/public/index.html'), fixedContentPaths)
 }


### PR DESCRIPTION
## Description

Fix search on docs. Only the first assets path was fixed (the css), the search scripts were never loaded

## Type of change

Please delete options that are not relevant.

- [x] Chore change (refactoring and / or test changes)

## How has this been tested?

Locally

