### PR TITLE
fix(nlu-testing): move predict http call in nlu testing from nlu-module to core

### DIFF
--- a/modules/.nlu-testing/src/backend/api.ts
+++ b/modules/.nlu-testing/src/backend/api.ts
@@ -230,7 +230,7 @@ async function runTest(test: Test, axiosConfig: AxiosRequestConfig): Promise<Tes
   const {
     data: { nlu }
   } = await Axios.post(
-    'mod/nlu/predict', // TODO: module nlu no longer exists
+    'nlu/predict',
     { text: test.utterance, contexts: test.context ? [test.context] : [] },
     axiosConfig
   )

--- a/packages/bp/src/core/app/server.ts
+++ b/packages/bp/src/core/app/server.ts
@@ -22,6 +22,7 @@ import { LogsRepository } from 'core/logger'
 import { MediaServiceProvider, MediaRouter } from 'core/media'
 import { MessagingRouter, MessagingService } from 'core/messaging'
 import { ModuleLoader, ModulesRouter } from 'core/modules'
+import { NLUInferenceService } from 'core/nlu'
 import { QnaService } from 'core/qna'
 import { getSocketTransports, RealtimeService } from 'core/realtime'
 import { InvalidExternalToken, PaymentRequiredError, monitoringMiddleware } from 'core/routers'
@@ -124,6 +125,7 @@ export class HTTPServer {
     @inject(TYPES.TelemetryRepository) private telemetryRepo: TelemetryRepository,
     @inject(TYPES.RealtimeService) private realtime: RealtimeService,
     @inject(TYPES.QnaService) private qnaService: QnaService,
+    @inject(TYPES.NLUInferenceService) private nluInferenceService: NLUInferenceService,
     @inject(TYPES.MessagingService) private messagingService: MessagingService,
     @inject(TYPES.ObjectCache) private objectCache: MemoryObjectCache,
     @inject(TYPES.EventRepository) private eventRepo: EventRepository
@@ -181,6 +183,7 @@ export class HTTPServer {
       mediaServiceProvider,
       eventRepo,
       qnaService,
+      nluInferenceService,
       this
     )
     this.sdkApiRouter = new SdkApiRouter(this.logger)

--- a/packages/bp/src/core/bots/bots-router.ts
+++ b/packages/bp/src/core/bots/bots-router.ts
@@ -6,6 +6,8 @@ import { ConverseRouter, ConverseService } from 'core/converse'
 import { EventRepository } from 'core/events'
 import { MediaServiceProvider } from 'core/media'
 import { MessagingBotRouter } from 'core/messaging'
+import { NLUInferenceService } from 'core/nlu'
+import { NLUInferenceRouter } from 'core/nlu/nlu-inference-router'
 import { QnaRouter, QnaService } from 'core/qna'
 import { disableForModule } from 'core/routers'
 import {
@@ -32,6 +34,7 @@ export class BotsRouter extends CustomRouter {
   private converseRouter: ConverseRouter
   private messagingRouter: MessagingBotRouter
   private qnaRouter: QnaRouter
+  private nluInferenceRouter: NLUInferenceRouter
 
   constructor(
     private botService: BotService,
@@ -43,6 +46,7 @@ export class BotsRouter extends CustomRouter {
     private mediaServiceProvider: MediaServiceProvider,
     private eventRepo: EventRepository,
     private qnaService: QnaService,
+    private nluInferenceService: NLUInferenceService,
     private httpServer: HTTPServer
   ) {
     super('Bots', logger, Router({ mergeParams: true }))
@@ -60,6 +64,12 @@ export class BotsRouter extends CustomRouter {
     )
     this.messagingRouter = new MessagingBotRouter(this.logger, this.authService, this.eventRepo)
     this.qnaRouter = new QnaRouter(this.logger, this.authService, this.workspaceService, this.qnaService)
+    this.nluInferenceRouter = new NLUInferenceRouter(
+      this.logger,
+      this.authService,
+      this.workspaceService,
+      this.nluInferenceService
+    )
   }
 
   async setupRoutes(app: express.Express) {
@@ -69,6 +79,7 @@ export class BotsRouter extends CustomRouter {
     this.router.use('/converse', this.converseRouter.router)
     this.router.use('/messaging', this.messagingRouter.router)
     this.router.use('/qna', this.qnaRouter.router)
+    this.router.use('/nlu', this.nluInferenceRouter.router)
 
     this.router.get(
       '/media/:filename',

--- a/packages/bp/src/core/nlu/errors.ts
+++ b/packages/bp/src/core/nlu/errors.ts
@@ -1,0 +1,17 @@
+export class BotNotMountedError extends Error {
+  constructor(botId: string) {
+    super(`No predictor found for bot "${botId}" in nlu service.`)
+  }
+}
+
+export class BotNotTrainedInLanguageError extends Error {
+  constructor(botId: string, languages: string[]) {
+    super(`Bot "${botId}" was not trained in languages [${languages.join(', ')}]. No model found.`)
+  }
+}
+
+export class HTTPError extends Error {
+  constructor(public status: number, message: string) {
+    super(message)
+  }
+}

--- a/packages/bp/src/core/nlu/nlu-inference-router.ts
+++ b/packages/bp/src/core/nlu/nlu-inference-router.ts
@@ -1,0 +1,103 @@
+import { IO, Logger } from 'botpress/sdk'
+
+import { CustomRouter } from 'core/routers/customRouter'
+import { AuthService, TOKEN_AUDIENCE, checkTokenHeader, needPermissions } from 'core/security'
+import { WorkspaceService } from 'core/users'
+import { RequestHandler, Router, Response as ExpressResponse } from 'express'
+import Joi from 'joi'
+import _ from 'lodash'
+import { BotNotMountedError, BotNotTrainedInLanguageError, HTTPError } from './errors'
+import { NLUInferenceService } from './nlu-inference-service'
+
+const PredictSchema = Joi.object().keys({
+  contexts: Joi.array()
+    .items(Joi.string())
+    .default(['global']),
+  text: Joi.string().required()
+})
+
+interface PredictBody {
+  contexts: string[]
+  text: string
+}
+
+interface PredictPath {
+  botId: string
+  lang: string | undefined
+}
+
+export class NLUInferenceRouter extends CustomRouter {
+  private checkTokenHeader!: RequestHandler
+  private needPermissions: (operation: string, resource: string) => RequestHandler
+
+  constructor(
+    private logger: Logger,
+    private authService: AuthService,
+    private workspaceService: WorkspaceService,
+    private nluInferenceService: NLUInferenceService
+  ) {
+    super('NLU-INFERENCE', logger, Router({ mergeParams: true }))
+    this.checkTokenHeader = checkTokenHeader(this.authService, TOKEN_AUDIENCE)
+    this.needPermissions = needPermissions(this.workspaceService)
+    this.setupRoutes()
+  }
+
+  private setupRoutes(): void {
+    const router = this.router
+
+    router.post(
+      ['/predict/', '/predict/:lang'],
+      this.checkTokenHeader,
+      this.needPermissions('read', 'nlu'),
+      this.asyncMiddleware(async (req, res) => {
+        const { text, contexts } = this._validatePredictBody(req.body)
+        const { botId, lang } = this._validatePredictPathParams(req.params)
+
+        try {
+          const nlu = await this.nluInferenceService.predict(botId, {
+            includedContexts: contexts,
+            utterance: text,
+            language: lang
+          })
+          res.send({ nlu })
+        } catch (error) {
+          return this._mapError(botId, error)(res)
+        }
+      })
+    )
+  }
+
+  private _validatePredictBody = (body: any): PredictBody => {
+    const { error, value } = PredictSchema.validate(body)
+    if (error) {
+      throw new HTTPError(400, 'Predict body is invalid')
+    }
+    return value
+  }
+
+  private _validatePredictPathParams = (path: any): PredictPath => {
+    const { botId, lang } = path
+    return { botId, lang }
+  }
+
+  private _mapError = (botId: string, error: Error) => (res: ExpressResponse) => {
+    if (error instanceof BotNotMountedError) {
+      return res.status(404).send(error.message)
+    }
+
+    if (error instanceof BotNotTrainedInLanguageError) {
+      return res.status(422).send(error.message)
+    }
+
+    if (error instanceof HTTPError) {
+      return res.status(error.status).send(error.message)
+    }
+
+    const msg = 'An unexpected error occured.'
+    this.logger
+      .forBot(botId)
+      .attachError(error)
+      .error(msg)
+    return res.status(500).send(msg)
+  }
+}

--- a/packages/bp/src/core/nlu/nlu-inference-service.ts
+++ b/packages/bp/src/core/nlu/nlu-inference-service.ts
@@ -10,14 +10,22 @@ import yn from 'yn'
 import legacyElection from './election/legacy-election'
 import naturalElection from './election/natural-election'
 import pickSpellChecked from './election/spellcheck-handler'
+import { BotNotMountedError } from './errors'
 import { NLUClientProvider } from './nlu-client'
 import { Predictor } from './predictor'
 
 const EVENTS_TO_IGNORE = ['session_reference', 'session_reset', 'bp_dialog_timeout', 'visit', 'say_something', '']
 const PREDICT_MW = 'nlu-predict.incoming'
 
+interface PredictionArgs {
+  utterance: string
+  includedContexts: string[]
+  skipSpellcheck?: boolean
+  language?: string
+}
+
 /**
- * This service takes care of the nlu inferences/predictions
+ * This service takes care of the nlu inferences (predictions)
  *
  * It belongs in the runtime and only in the runtime.
  * It is not responsible for CRUD on intent and entity files.
@@ -80,6 +88,31 @@ export class NLUInferenceService {
     delete this.predictors[botId]
   }
 
+  public async predict(botId: string, args: PredictionArgs) {
+    const bot = this.predictors[botId]
+    if (!bot) {
+      throw new BotNotMountedError(botId)
+    }
+
+    const { includedContexts, utterance, language } = args
+    const skipSpellcheck: boolean = args.skipSpellcheck ?? yn(process.env.NLU_SKIP_SPELLCHECK)
+    const t0 = Date.now()
+
+    const predOutput = await bot.predict(utterance, language)
+
+    const appendTime = <T>(eu: T) => ({ ...eu, ms: Date.now() - t0 })
+
+    let nluResults = { ...predOutput, includedContexts }
+    if (nluResults.spellChecked && nluResults.spellChecked !== utterance && !skipSpellcheck) {
+      const predOutput = await bot.predict(nluResults.spellChecked, language)
+      const spellCheckedResults = { ...predOutput, includedContexts }
+      nluResults = pickSpellChecked(appendTime(nluResults), appendTime(spellCheckedResults))
+    }
+
+    const electionInput = appendTime(nluResults)
+    return this.legacyElection ? legacyElection(electionInput) : naturalElection(electionInput)
+  }
+
   private _modelIdGetter = (botId: string) => async (): Promise<Dic<string>> => {
     // TODO: implement some caching to prevent from reading bot config at each predict
     const botConfig = await this.configProvider.getBotConfig(botId)
@@ -95,30 +128,15 @@ export class NLUInferenceService {
     try {
       const { botId, preview } = incomingEvent
       const anticipatedLanguage: string | undefined = incomingEvent.state.user?.language
-
-      const bot = this.predictors[botId]
-      if (!bot) {
-        const err = new Error(`No predictor found for bot "${botId}" in nlu service.`)
-        return next(err)
-      }
-
-      const t0 = Date.now()
-
-      const predOutput = await bot.predict(preview, anticipatedLanguage)
       const includedContexts = incomingEvent.nlu?.includedContexts ?? []
 
-      const appendTime = <T>(eu: T) => ({ ...eu, ms: Date.now() - t0 })
+      const nlu = this.predict(botId, {
+        utterance: preview,
+        includedContexts,
+        language: anticipatedLanguage
+      })
 
-      let nluResults = { ...predOutput, includedContexts }
-      if (nluResults.spellChecked && nluResults.spellChecked !== preview && !yn(process.env.NLU_SKIP_SPELLCHECK)) {
-        const predOutput = await bot.predict(nluResults.spellChecked, anticipatedLanguage)
-        const spellCheckedResults = { ...predOutput, includedContexts }
-        nluResults = pickSpellChecked(appendTime(nluResults), appendTime(spellCheckedResults))
-      }
-
-      const electionInput = appendTime(nluResults)
-      const postElection = this.legacyElection ? legacyElection(electionInput) : naturalElection(electionInput)
-      _.merge(incomingEvent, { nlu: postElection })
+      _.merge(incomingEvent, { nlu })
       this.removeSensitiveText(incomingEvent)
     } catch (err) {
       this.logger.warn(`Error extracting metadata for incoming text: ${err.message}`)
@@ -150,9 +168,5 @@ export class NLUInferenceService {
       EVENTS_TO_IGNORE.includes(event.type) ||
       event.hasFlag(WellKnownFlags.SKIP_NATIVE_NLU)
     )
-  }
-
-  private _isIncoming = (e: IO.Event): e is IO.IncomingEvent => {
-    return e.direction === 'incoming'
   }
 }

--- a/packages/bp/src/core/nlu/predictor.ts
+++ b/packages/bp/src/core/nlu/predictor.ts
@@ -1,7 +1,7 @@
-import Bluebird from 'bluebird'
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 import { mapPredictOutput } from './api-mapper'
+import { BotNotTrainedInLanguageError } from './errors'
 import { NLUClient } from './nlu-client'
 
 type EventUnderstanding = Omit<sdk.IO.EventUnderstanding, 'includedContexts' | 'ms'>
@@ -61,7 +61,7 @@ export class Predictor {
     }
 
     if (this.isEmpty(nluResults)) {
-      throw new Error(`No model found for the following languages: ${languagesToTry}`)
+      throw new BotNotTrainedInLanguageError(this._botId, languagesToTry)
     }
 
     return { ...nluResults, detectedLanguage }


### PR DESCRIPTION
I broke the nlu-testing module when removing the nlu-module. This PR repairs it by moving the route to core and implementing a new `/predict` route in the nlu-inference router:

![image](https://user-images.githubusercontent.com/25970722/135142651-5d3f53c7-2cdd-42aa-9bf8-88c62558065f.png)
