### PR TITLE
chore(dev): v12.26.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [12.26.4](https://github.com/botpress/botpress/compare/v12.26.3...v12.26.4) (2021-09-28)
+
+
+### Bug Fixes
+
+* **channel-web:** avatar won`t crash if there is no name ([#5472](https://github.com/botpress/botpress/issues/5472)) ([c52592e](https://github.com/botpress/botpress/commit/c52592e))
+* **channel-web:** fix display of image, file, audio and video content-elements ([#5488](https://github.com/botpress/botpress/issues/5488)) ([6321d23](https://github.com/botpress/botpress/commit/6321d23))
+* **channel-web:** prevent sending proactive messages on webchatLoaded ([#5469](https://github.com/botpress/botpress/issues/5469)) ([e3878bb](https://github.com/botpress/botpress/commit/e3878bb))
+* **core:** fix unhandled rejections ([#5489](https://github.com/botpress/botpress/issues/5489)) ([e9a6d41](https://github.com/botpress/botpress/commit/e9a6d41))
+* **dev:** fix warnings with logger ([#5483](https://github.com/botpress/botpress/issues/5483)) ([3e1dac5](https://github.com/botpress/botpress/commit/3e1dac5))
+* **misunderstood:** fix remove duplicated preview and add scroll for chats ([#5458](https://github.com/botpress/botpress/issues/5458)) ([ecf0d62](https://github.com/botpress/botpress/commit/ecf0d62))
+
+
+
 ## [12.26.3](https://github.com/botpress/botpress/compare/v12.26.2...v12.26.3) (2021-09-17)
 
 

--- a/build/package.pkg.json
+++ b/build/package.pkg.json
@@ -1,6 +1,6 @@
 {
   "name": "botpress",
-  "version": "12.26.3",
+  "version": "12.26.4",
   "description": "The world's most powerful conversational engine",
   "main": "index.js",
   "bin": "index.js",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "version": "0.1.6"
   },
   "studio": {
-    "version": "0.0.37"
+    "version": "0.0.38"
   },
   "messaging": {
     "version": "0.1.13"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bp_main",
-  "version": "12.26.3",
+  "version": "12.26.4",
   "description": "The world's most powerful conversational engine",
   "engines": {
     "node": "^12"


### PR DESCRIPTION
Release Notes
=====

### Bug Fixes

* **channel-web:** down mig drop all msg_ tables ([#5452](https://github.com/botpress/botpress/issues/5452)) ([6f03d1c](https://github.com/botpress/botpress/commit/6f03d1c))
* **channel-web:** fix useSessionStorage config option ([#5118](https://github.com/botpress/botpress/issues/5118)) ([edac7c6](https://github.com/botpress/botpress/commit/edac7c6)), closes [#5405](https://github.com/botpress/botpress/issues/5405)
* **core:** add small safeguards ([#5459](https://github.com/botpress/botpress/issues/5459)) ([a1a83c8](https://github.com/botpress/botpress/commit/a1a83c8))
* **core:** bigger frontend timeout ([#5455](https://github.com/botpress/botpress/issues/5455)) ([f976538](https://github.com/botpress/botpress/commit/f976538))
* **hitl:** use renderPayload from ui-shared-lite to fix undefined ([#5454](https://github.com/botpress/botpress/issues/5454)) ([56a020c](https://github.com/botpress/botpress/commit/56a020c))

## Studio Bug fixes

* **flow**: edit translated caroussel data [studio 122](https://github.com/botpress/studio/issues/122), closes [studio botpress/botpress#118](https://github.com/botpress/studio/issues/108)
* **flow**: fix editing content elements using action modal [studio 109](https://github.com/botpress/studio/issues/109), closes [studio botpress/botpress#75](https://github.com/botpress/studio/issues/75)
* **qna**: fix language dropdown overlay issue [studio 115](https://github.com/botpress/studio/issues/115), closes [#5417](https://github.com/botpress/v12/issues/1466)
* **studio**: allow changing content-type when editing node content-element [studio 121](https://github.com/botpress/studio/issues/121), closes [#5334](https://github.com/botpress/v12/issues/1430)
* **studio**: error when state missing in debugger [studio 111](https://github.com/botpress/studio/issues/111)
* **studio**: fix permissions for libraries [studio 119](https://github.com/botpress/studio/issues/119)
* **studio**: prevent creating empty actions [studio 118](https://github.com/botpress/studio/issues/118), closes [studio botpress/botpress#76](https://github.com/botpress/studio/issues/76)
