### PR TITLE
fix(channel-web): messagelist now updates scroll position on update

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
@@ -60,6 +60,10 @@ class MessageList extends React.Component<MessageListProps, State> {
     this.divSizeObserver.disconnect()
   }
 
+  componentDidUpdate() {
+    this.tryScrollToBottom()
+  }
+
   tryScrollToBottom(delayed?: boolean) {
     setTimeout(
       () => {


### PR DESCRIPTION
## Description

Merely add a `componentDidUpdate` lifecycle method that uses an existing scroll position reset function.

Fixes botpress/v12#1434 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [Without](https://www.loom.com/share/33800d95ba614ddcb2bbdbb2aa3be8da?sharedAppSource=personal_library) and [with](https://www.loom.com/share/cf1f3d2751eb465d930a1c3aa6ce4fb2?sharedAppSource=personal_library) componentDidUpdate lifecycle method.

**NOTE**: videos are on the Google browser

**Test configuration**:
* BP version: v12.26.4
* Node version: v12.22.1
* OS: Linux Ubuntu
* Browser: Mozilla Firefox and Google Chrome

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I've included some media (picture/gif/video) if applicable to show the old and new behavior