### PR TITLE
fix(examples): custom-component typo for webchat overrides

### DIFF
--- a/examples/custom-component/assets/embedded-webchat.html
+++ b/examples/custom-component/assets/embedded-webchat.html
@@ -15,12 +15,14 @@
       //There are only two possible overrides for the moment.
       overrides: {
         // For now, the composer is the only component which is editable. It represents the zone where the user is typing
-        composer: {
-          // Name of the module, as declared in package.json
-          module: 'custom-component',
-          // The name of your exported component. It must be in your lite view: `/views/lite/index.jsx`
-          component: 'Composer'
-        },
+        composer: [
+          {
+            // Name of the module, as declared in package.json
+            module: 'custom-component',
+            // The name of your exported component. It must be in your lite view: `/views/lite/index.jsx`
+            component: 'Composer'
+          }
+        ],
         // You can use this override to inject your component and interact with the web chat. Make it invisible by returning null
         below_conversation: {
           module: 'custom-component',


### PR DESCRIPTION
## Description

Wrap override values in an array as suggested in linked issue.

Fixes botpress/v12#1422 

## Type of change

- [x] Chore change (refactoring and / or test changes)
