### PR TITLE
fix(messaging): fix webhook url validation

### DIFF
--- a/packages/bp/src/core/messaging/messaging-router.ts
+++ b/packages/bp/src/core/messaging/messaging-router.ts
@@ -24,7 +24,7 @@ export class MessagingRouter extends CustomRouter {
           return next?.(new UnauthorizedError('Password is missing or invalid'))
         } else if (
           this.messaging.isExternal &&
-          req.headers['x-webhook-token'] !== this.messaging.getWebhookToken(req?.body?.client?.id)
+          req.headers['x-webhook-token'] !== this.messaging.getWebhookToken(req?.body?.data?.clientId)
         ) {
           return next?.(new UnauthorizedError('Invalid webhook token'))
         }

--- a/packages/bp/src/core/messaging/messaging-router.ts
+++ b/packages/bp/src/core/messaging/messaging-router.ts
@@ -20,26 +20,26 @@ export class MessagingRouter extends CustomRouter {
     this.router.post(
       '/receive',
       this.asyncMiddleware(async (req, res, next) => {
-        if (!this.messaging.isExternal && req.headers.password !== process.INTERNAL_PASSWORD) {
-          return next?.(new UnauthorizedError('Password is missing or invalid'))
-        } else if (
-          this.messaging.isExternal &&
-          req.headers['x-webhook-token'] !== this.messaging.getWebhookToken(req?.body?.data?.clientId)
-        ) {
-          return next?.(new UnauthorizedError('Invalid webhook token'))
-        }
-
-        if (req.body?.type !== 'message.new') {
-          return res.sendStatus(200)
-        }
-
+        let msg: ReceiveRequest
         try {
-          await joi.validate(req.body, ReceiveSchema)
+          msg = await joi.validate<ReceiveRequest>(req.body, ReceiveSchema)
         } catch (err) {
           throw new StandardError('Invalid payload', err)
         }
 
-        const msg = req.body as ReceiveRequest
+        if (!this.messaging.isExternal && req.headers.password !== process.INTERNAL_PASSWORD) {
+          return next?.(new UnauthorizedError('Password is missing or invalid'))
+        } else if (
+          this.messaging.isExternal &&
+          (!req.headers['x-webhook-token'] ||
+            req.headers['x-webhook-token'] !== this.messaging.getWebhookToken(msg.data.clientId))
+        ) {
+          return next?.(new UnauthorizedError('Invalid webhook token'))
+        }
+
+        if (msg.type !== 'message.new') {
+          return res.sendStatus(200)
+        }
 
         await this.messaging.receive({
           clientId: msg.data.clientId,


### PR DESCRIPTION
## Description

This PR fixes an issue where running a standalone version of Messaging with Botpress would return 401 when receiving a message.  

Fixes https://github.com/botpress/messaging/issues/185

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Locally

**Test configuration**:
* BP version: Master
* Node version: 12.18.1
* OS: Arch Linux
* Browser: Chrome
* Binary or source ?:  Source

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I've included some media (picture/gif/video) if applicable to show the old and new behavior
