### PR TITLE
chore(nlu): increase timeout for nlu mw

### DIFF
--- a/modules/nlu/src/backend/middlewares.ts
+++ b/modules/nlu/src/backend/middlewares.ts
@@ -45,6 +45,7 @@ export const registerMiddlewares = async (bp: typeof sdk, app: NLUApplication) =
     name: PREDICT_MW,
     direction: 'incoming',
     order: 100,
+    timeout: '6s',
     description:
       'Process natural language in the form of text. Structured data with an action and parameters for that action is injected in the incoming message event.',
     handler: async (event: sdk.IO.IncomingEvent, next: sdk.IO.MiddlewareNextCallback) => {


### PR DESCRIPTION
Temporary fix for Issue botpress/v12#1449.

### Problem

I've detailed the cause of the error on the Github issue thread.

### Possible Solutions

There are few **non-mutually exclusive** ways of solving this:

1. Increase the middleware timeout value
2. Decrease the amount of cache miss with a new cache paradigm, possibly smarter than LRU
3. Fully prevent cache miss with a proper infrastructure. This is done by the user.
4. Reduce the delay caused by a cache miss. This can involve a lot a dev time: 
  4.1. reducing models file size
  4.2. using more buffers and less JSON as JSON parse is costly
  4.3. writing a more efficient compress (*.tar.gz) function using in-memory streams 
  
\*\***Cache miss have been properly studied and documented in a google sheet. HMU to see the results.**\*\*

### This PR

I've chosen solution 1 as it is the simplest and the shortest to implement. It might not be the best for the long run. Let's talk about it when this becomes limiting.

6s whole seconds might be overkill, but this includes a security factor. Our biggest known bot takes about 2.2s to predict on a cache miss.