### PR TITLE
fix(core): give user access to workspaces on signup

### DIFF
--- a/packages/bp/src/core/security/auth-service.ts
+++ b/packages/bp/src/core/security/auth-service.ts
@@ -157,10 +157,9 @@ export class AuthService {
     const strategyUser = createdUser.result
 
     const workspaces = await this._getWorkspacesForStrategy(strategy)
-    const promises = workspaces.map(workspace =>
+    await Promise.map(workspaces, workspace =>
       this.workspaceService.addUserToWorkspace(strategyUser.email, strategyUser.strategy, workspace)
     )
-    await Promise.all(promises)
 
     if (_.get(await this.getStrategy(strategy), 'type') === 'basic') {
       return this.strategyBasic.resetPassword(user.email, strategy)


### PR DESCRIPTION
## Description

This PR fixes an issue where even if you set auth strategies in your workspaces definition and `allowSelfSignup` in your Botpress config, it wouldn't add newly created users to the workspaces it should have access to.

Fixes botpress/v12#1432
Closes  DEV-1538

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

By adding an OAuth authentication strategy using Google Cloud (See: https://botpress.com/docs/managing/ssotools#sso-with-google-oauth2), login in with a test user, and making sure that this user had access to the right workspaces.

- [X] User has only access to one of the two workspaces that I have configured
- [X] User has access to both workspaces
- [X] User has no access to any workspaces 

**Test configuration**:
* BP version: Master
* Node version: 12.18.1
* OS: Arch Linux
* Browser: Chrome
* Binary or source ?: Source

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
