### PR TITLE
fix(messaging): fix receiving health events through webhook

### DIFF
--- a/packages/bp/src/core/messaging/messaging-router.ts
+++ b/packages/bp/src/core/messaging/messaging-router.ts
@@ -20,6 +20,10 @@ export class MessagingRouter extends CustomRouter {
     this.router.post(
       '/receive',
       this.asyncMiddleware(async (req, res, next) => {
+        if (req.body.type !== 'message.new') {
+          return res.sendStatus(200)
+        }
+
         let msg: ReceiveRequest
         try {
           msg = await joi.validate<ReceiveRequest>(req.body, ReceiveSchema)
@@ -35,10 +39,6 @@ export class MessagingRouter extends CustomRouter {
             req.headers['x-webhook-token'] !== this.messaging.getWebhookToken(msg.data.clientId))
         ) {
           return next?.(new UnauthorizedError('Invalid webhook token'))
-        }
-
-        if (msg.type !== 'message.new') {
-          return res.sendStatus(200)
         }
 
         await this.messaging.receive({


### PR DESCRIPTION
## Description

This PR fixes an issue where messaging would retry many times to send a health event to Botpress. This was caused because Botpress would return a 400 error code, it would retry 10 times per event.

![Screenshot from 2021-10-08 14-32-43](https://user-images.githubusercontent.com/9640576/136609584-bda1bc88-b6a0-47b7-9c17-56f70276e37c.png)


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Tested locally and now all events other than new messages are discarded.

**Test configuration**:
* BP version: master
* Node version: 12.18.1
* OS: Arch Linux
* Browser: Chrome
* Binary or source ?: Source

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
