### PR TITLE
fix(hitlnext): flatten user object information

### DIFF
--- a/modules/hitlnext/package.json
+++ b/modules/hitlnext/package.json
@@ -19,6 +19,7 @@
     "axios": "^0.21.0",
     "bluebird": "^3.5",
     "classnames": "^2.2.6",
+    "flat": "^5.0.2",
     "haikunator": "^2.1.2",
     "immer": "^8",
     "joi": "^17",

--- a/modules/hitlnext/src/views/full/app/components/UserProfile.tsx
+++ b/modules/hitlnext/src/views/full/app/components/UserProfile.tsx
@@ -1,4 +1,5 @@
 import { Collapsible, lang } from 'botpress/shared'
+import flatten from 'flat'
 import _ from 'lodash'
 import React, { FC, useState } from 'react'
 
@@ -34,7 +35,7 @@ const UserProfile: FC<IUser> = user => {
               {Object.entries(user.attributes).map((entry, index) => (
                 <tr key={index}>
                   <td>{entry[0]}</td>
-                  <td>{_.isObject(entry[1]) ? JSON.stringify(entry[1]) : entry[1]}</td>
+                  <td>{_.isObject(entry[1]) ? flatten(entry[1]) : entry[1]}</td>
                 </tr>
               ))}
             </tbody>

--- a/modules/hitlnext/yarn.lock
+++ b/modules/hitlnext/yarn.lock
@@ -214,6 +214,11 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+flat@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
+  integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
+
 follow-redirects@^1.10.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"


### PR DESCRIPTION
Conflicts:
	modules/hitlnext/src/views/full/app/components/UserProfile.tsx

## Description

This PR helps nested values on hitlnext to be `flatten` instead of being displayed as `stringified Object`

Fixes https://github.com/botpress/v12/issues/1510

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?

- [X] I performed a local test of my feature

**Test configuration**:
* BP version: 12.26.5
* Node version: 12.10.3
* OS: MacOS
* Browser: Chrome
* Binary or source ?: source

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I've included some media (picture/gif/video) if applicable to show the old and new behavior
