### PR TITLE
chore(admin): remove redis scope for list of required env vars

### DIFF
--- a/packages/bp/src/admin/ui/src/management/checklist/index.tsx
+++ b/packages/bp/src/admin/ui/src/management/checklist/index.tsx
@@ -182,22 +182,18 @@ export const Checklist: FC<Props> = props => {
 
         <Item
           title="Enable Redis support"
-          status={
-            isSet(getEnv('REDIS_URL')) && isSet(getEnv('CLUSTER_ENABLED')) && isSet(getEnv('BP_REDIS_SCOPE'))
-              ? 'success'
-              : 'warning'
-          }
+          status={isSet(getEnv('REDIS_URL')) && isSet(getEnv('CLUSTER_ENABLED')) ? 'success' : 'warning'}
           source={[
             { type: 'env', key: 'REDIS_URL', value: getEnv('REDIS_URL') },
             { type: 'env', key: 'CLUSTER_ENABLED', value: getEnv('CLUSTER_ENABLED') },
             { type: 'env', key: 'BP_REDIS_SCOPE', value: getEnv('BP_REDIS_SCOPE') }
           ]}
         >
-          Redis allows you to run multiple Botpress servers, all using the same data. All variables below must be
-          configured for Redis to work properly. Setting a Redis scope allows you to run multiple Botpress clusters
-          (e.g. staging and production) on the same Redis cluster without impacting one another. Simply re-use the same
-          URL for Redis and set the 'BP_REDIS_SCOPE' environment variable to prod on your production instance and
-          staging on your staging environment.
+          Redis allows you to run multiple Botpress servers, all using the same data. Only 'REDIS_URL' and
+          'CLUSTER_ENABLED' are required for Redis to work properly. Setting a Redis scope allows you to run multiple
+          Botpress clusters (e.g. staging and production) on the same Redis cluster without impacting one another (not
+          recommended). Simply re-use the same URL for Redis and set the 'BP_REDIS_SCOPE' environment variable to prod
+          on your production instance and staging on your staging environment.
         </Item>
 
         <Item


### PR DESCRIPTION
## Description

This PR simply removes `REDIS_SCOPE` from the list of required environment variables for Redis to be properly configured in the admin's production checklist page.

Closes DEV-1850

## Type of change

Please delete options that are not relevant.

- [X] Chore change (refactoring and / or test changes)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
