### PR TITLE
fix(channel-web): fix display of carousels in emulator

### DIFF
--- a/modules/channel-web/assets/default-emulator.css
+++ b/modules/channel-web/assets/default-emulator.css
@@ -462,7 +462,7 @@
     padding: 0px;
     margin: 10px 0;
     text-align: left;
-    width: 100%;
+    width: 230px; /* Magic number so that it fits properly in the emulator */
   }
 
   .bpw-bubble-file {


### PR DESCRIPTION
## Description

This PR fixes a display issue with the carousel in the emulator. Since the emulator has a fixed size that is lower than the minimum required width, we have to set a fixed size for the carousel to properly be displayed.

**Without a scrollbar**

![Screenshot from 2021-10-12 13-40-12](https://user-images.githubusercontent.com/9640576/137004144-cfe9f0d4-9b32-48de-83cf-ee2edf00e5e9.png)

**With a scrollbar**

![Screenshot from 2021-10-12 13-40-36](https://user-images.githubusercontent.com/9640576/137004147-0ba21832-61f5-44a2-b947-505cb5531535.png)


Fixes botpress/v12#1508
Closes DEV-1888

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Locally

**Test configuration**:
* BP version: Master
* Node version: 12.18.1
* OS: Arch Linux
* Browser: Chrome
* Binary or source ?: Source

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
