### PR TITLE
fix(bp): running multiple times the nlu module removal migration still works

### DIFF
--- a/packages/bp/src/migrations/v12_27_0-1632339710755-move_nlu_config_in_main_config.ts
+++ b/packages/bp/src/migrations/v12_27_0-1632339710755-move_nlu_config_in_main_config.ts
@@ -120,6 +120,12 @@ const migration: Migration = {
     try {
       const ghost = bp.ghost.forGlobal()
 
+      const botpressConfig = await configProvider.getBotpressConfig()
+      if (!!botpressConfig.nlu) {
+        await ghost.deleteFile('config', 'nlu.json')
+        return { success: true, message: 'Migration not needed.' }
+      }
+
       const nluJsonExists = await ghost.fileExists('config', 'nlu.json')
 
       let nluCoreConfig: NLUCoreConfig
@@ -137,11 +143,11 @@ const migration: Migration = {
       return { success: false, message: `The following error occured when running the migration ${err.message}.` }
     }
   },
-  down: async ({ bp }: MigrationOpts): Promise<sdk.MigrationResult> => {
+  down: async ({ bp, configProvider }: MigrationOpts): Promise<sdk.MigrationResult> => {
     try {
       const ghost = bp.ghost.forGlobal()
 
-      const currentBotpressConfig = await ghost.readFileAsObject<BotpressConfig>('.', 'botpress.config.json')
+      const currentBotpressConfig = await configProvider.getBotpressConfig()
       const { nlu: coreNluConfig } = currentBotpressConfig
       const modNluConfig = { ...DEFAULT_NLU_MOD_CONFIG, ...mapCoreConfigToMod(coreNluConfig) }
 

--- a/packages/bp/src/migrations/v12_27_0-1632339710755-move_nlu_config_in_main_config.ts
+++ b/packages/bp/src/migrations/v12_27_0-1632339710755-move_nlu_config_in_main_config.ts
@@ -119,14 +119,13 @@ const migration: Migration = {
   up: async ({ bp, configProvider }: MigrationOpts): Promise<sdk.MigrationResult> => {
     try {
       const ghost = bp.ghost.forGlobal()
+      const nluJsonExists = await ghost.fileExists('config', 'nlu.json')
 
       const botpressConfig = await configProvider.getBotpressConfig()
       if (!!botpressConfig.nlu) {
-        await ghost.deleteFile('config', 'nlu.json')
+        nluJsonExists && (await ghost.deleteFile('config', 'nlu.json'))
         return { success: true, message: 'Migration not needed.' }
       }
-
-      const nluJsonExists = await ghost.fileExists('config', 'nlu.json')
 
       let nluCoreConfig: NLUCoreConfig
       if (!nluJsonExists) {


### PR DESCRIPTION
This PR allows running migration `v12_27_0-1632339710755-move_nlu_config_in_main_config.ts` more than one time without overriding the modified config.