### PR TITLE
chore(messaging): remove await when handling typing indicators

### DIFF
--- a/packages/bp/src/core/messaging/messaging-service.ts
+++ b/packages/bp/src/core/messaging/messaging-service.ts
@@ -153,11 +153,6 @@ export class MessagingService {
     )
     event.messageId = message.id
 
-    if (event.payload.typing === true || event.payload.type === 'typing') {
-      const value = (event.payload.type === 'typing' ? event.payload.value : undefined) || DEFAULT_TYPING_DELAY
-      await new Promise(resolve => setTimeout(resolve, value))
-    }
-
     return next(undefined, true, false)
   }
 


### PR DESCRIPTION
## Description

This PR simply removes a redundant timeout of X ms when handling typing indicators.

## Type of change

Please delete options that are not relevant.

- [X] Chore change (refactoring and / or test changes)

## How has this been tested?

Locally

**Test configuration**:
* BP version: Master
* Node version: 12.18.1
* OS: Arch Linux
* Browser: Chrome
* Binary or source ?: Source 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
