### PR TITLE
fix(emulator): manual scroll doesnt auto scroll to bottom

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
@@ -61,6 +61,10 @@ class MessageList extends React.Component<MessageListProps, State> {
   }
 
   componentDidUpdate() {
+    console.log(this.state.manualScroll)
+    if (this.state.manualScroll) {
+      return
+    }
     this.tryScrollToBottom()
   }
 

--- a/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
@@ -61,7 +61,6 @@ class MessageList extends React.Component<MessageListProps, State> {
   }
 
   componentDidUpdate() {
-    console.log(this.state.manualScroll)
     if (this.state.manualScroll) {
       return
     }


### PR DESCRIPTION
## Description

Scrolling in the emulator triggers state modification, which means previous fix in botpress/botpress#5520 made it so even manual scrolling towards the top would scroll you at the bottom after 250 milliseconds. This PR puts an evaluator on `componentDidUpdate()` to make ascertain whether the scrolling has been initiated by the user or the program. If the former, don't do anything.

Fixes botpress/v12#1434 botpress/botpress#5520

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Execute the program, select a bot, go in emulator, spam it until it scrolls, then scroll up. No need to do anymore really.
