### PR TITLE
fix(channel-web): fix display of carousels on wide screens

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/renderer/Carousel.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/renderer/Carousel.tsx
@@ -27,13 +27,10 @@ export class Carousel extends React.Component<ICarouselProps, ICarouselState> {
     const defaultSettings = {
       dots: false,
       infinite: false,
-      responsive: [
-        { breakpoint: adjustBreakpoint(550), settings: { slidesToShow: 1 } },
-        { breakpoint: adjustBreakpoint(1024), settings: { slidesToShow: 2 } },
-        { breakpoint: adjustBreakpoint(1548), settings: { slidesToShow: 3 } },
-        { breakpoint: adjustBreakpoint(2072), settings: { slidesToShow: 4 } },
-        { breakpoint: adjustBreakpoint(10000), settings: 'unslick' }
-      ],
+      responsive: [...Array(10)].map((_, i) => ({
+        breakpoint: adjustBreakpoint(550 + i * 524),
+        settings: { slidesToShow: i + 1 }
+      })), // Carousel will be responsive for screens as width as ~5300px
       slidesToScroll: 1,
       autoplay: false,
       centerMode: false,


### PR DESCRIPTION
## Description

This PR fixes the display of carousels on wide screens. When a screen was larger than around 2172px, the carousel would simply be hidden.

Fixes botpress/v12#1503
Closes DEV-1876

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Locally by opening the Webchat from the admin 

_http://<HOST>/lite/<BOTID>/?m=channel-web&v=Fullscreen&options=%7B%22hideWidget%22%3Atrue%2C%22config%22%3A%7B%22enableReset%22%3Atrue%2C%22enableTranscriptDownload%22%3Atrue%7D%7D_

**Test configuration**:
* BP version: Master
* Node version: 12.18.1
* OS: Arch Linux
* Browser: Chrome
* Binary or source ?: Source

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
