### PR TITLE
fix(channel-web): fix user creation when user mapping exists

### DIFF
--- a/modules/channel-web/package.json
+++ b/modules/channel-web/package.json
@@ -25,7 +25,7 @@
     "@types/react-intl": "^2.3.17"
   },
   "dependencies": {
-    "@botpress/messaging-client": "0.0.3",
+    "@botpress/messaging-client": "0.0.7",
     "@juggle/resize-observer": "^3.0.2",
     "apicache": "^1.6.2",
     "aws-sdk": "^2.905.0",

--- a/modules/channel-web/src/backend/db.ts
+++ b/modules/channel-web/src/backend/db.ts
@@ -137,7 +137,8 @@ export default class WebchatDb {
       url: process.core_env.MESSAGING_ENDPOINT
         ? process.core_env.MESSAGING_ENDPOINT
         : `http://localhost:${process.MESSAGING_PORT}`,
-      auth: { clientId: messaging.id, clientToken: messaging.token }
+      auth: { clientId: messaging.id, clientToken: messaging.token },
+      password: process.INTERNAL_PASSWORD
     })
     this.messagingClients[botId] = botClient
 

--- a/modules/channel-web/src/backend/db.ts
+++ b/modules/channel-web/src/backend/db.ts
@@ -29,14 +29,22 @@ export default class WebchatDb {
 
   async mapVisitor(botId: string, visitorId: string, messaging: MessagingClient) {
     const userMapping = await this.getMappingFromVisitor(botId, visitorId)
+    let userId = userMapping?.userId
 
-    let userId: string
-
-    if (!userMapping) {
+    const createUserAndMapping = async () => {
       userId = (await messaging.users.create()).id
       await this.createUserMapping(botId, visitorId, userId)
+    }
+
+    if (!userMapping) {
+      await createUserAndMapping()
     } else {
-      userId = userMapping.userId
+      // Prevents issues when switching between different Messaging servers
+      // TODO: Remove this check once the 'web_user_map' table is removed
+      if (!(await this.checkUserExist(userMapping.userId, messaging))) {
+        await this.deleteMappingFromVisitor(botId, visitorId)
+        await createUserAndMapping()
+      }
     }
 
     return userId
@@ -60,6 +68,17 @@ export default class WebchatDb {
       this.bp.logger.error('An error occurred while fetching a visitor mapping.', err)
 
       return undefined
+    }
+  }
+
+  async deleteMappingFromVisitor(botId: string, visitorId: string): Promise<void> {
+    try {
+      this.cacheByVisitor.del(`${botId}_${visitorId}`)
+      await this.knex('web_user_map')
+        .where({ botId, visitorId })
+        .delete()
+    } catch (err) {
+      this.bp.logger.error('An error occurred while deleting a visitor mapping.', err)
     }
   }
 
@@ -118,7 +137,6 @@ export default class WebchatDb {
       url: process.core_env.MESSAGING_ENDPOINT
         ? process.core_env.MESSAGING_ENDPOINT
         : `http://localhost:${process.MESSAGING_PORT}`,
-      password: process.INTERNAL_PASSWORD,
       auth: { clientId: messaging.id, clientToken: messaging.token }
     })
     this.messagingClients[botId] = botClient
@@ -128,6 +146,12 @@ export default class WebchatDb {
 
   removeMessagingClient(botId: string) {
     this.messagingClients[botId] = undefined
+  }
+
+  private async checkUserExist(userId: string, messaging: MessagingClient): Promise<boolean> {
+    const user = await messaging.users.get(userId)
+
+    return user?.id === userId
   }
 }
 

--- a/modules/channel-web/src/backend/db.ts
+++ b/modules/channel-web/src/backend/db.ts
@@ -138,7 +138,7 @@ export default class WebchatDb {
         ? process.core_env.MESSAGING_ENDPOINT
         : `http://localhost:${process.MESSAGING_PORT}`,
       auth: { clientId: messaging.id, clientToken: messaging.token },
-      password: process.INTERNAL_PASSWORD
+      config: { headers: { password: process.INTERNAL_PASSWORD } }
     })
     this.messagingClients[botId] = botClient
 

--- a/modules/channel-web/yarn.lock
+++ b/modules/channel-web/yarn.lock
@@ -45,11 +45,17 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
-"@botpress/messaging-client@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@botpress/messaging-client/-/messaging-client-0.0.3.tgz#871c0672e7ac488c60fcf6ca57549aac73c0b958"
-  integrity sha512-Aq1EB06jM2uND1GXrZfZ3JAd9wvl4a632exNxI5c2l7AC8iCyCmg5qZtZAiKJKiddO7KyAjbCVhRbi2UTjEhNg==
+"@botpress/messaging-base@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@botpress/messaging-base/-/messaging-base-0.0.1.tgz#1e1347262e4c5f70d73ba62b8a62b9d9576e3c16"
+  integrity sha512-J52YtTu0OxElZUJwtfx8NSVFlTGyZVXGppWgdgckHRa6mAf+8DY3gCkDpG34Elic9Uygz3L0+3HebvgSk6Y3CA==
+
+"@botpress/messaging-client@0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@botpress/messaging-client/-/messaging-client-0.0.7.tgz#697374e857ba4344ecb997977f3278fd292bd091"
+  integrity sha512-PCHZl8semVaAtSl/KxQPPDnFU6ZhMi7YmmgNtoQQPIE/d28OSPDUuost7dfwoNllVxHqQqsdIKmLQqRORxhX4w==
   dependencies:
+    "@botpress/messaging-base" "0.0.1"
     axios "^0.21.1"
 
 "@emotion/babel-utils@^0.6.4":

--- a/modules/hitlnext/package.json
+++ b/modules/hitlnext/package.json
@@ -15,7 +15,7 @@
   "license": "AGPL-3.0-only",
   "dependencies": {
     "@blueprintjs/core": "^3.36.0",
-    "@botpress/messaging-client": "0.0.3",
+    "@botpress/messaging-client": "0.0.7",
     "@webscopeio/react-textarea-autocomplete": "^4.7.2",
     "axios": "^0.21.0",
     "bluebird": "^3.5",

--- a/modules/hitlnext/package.json
+++ b/modules/hitlnext/package.json
@@ -15,6 +15,7 @@
   "license": "AGPL-3.0-only",
   "dependencies": {
     "@blueprintjs/core": "^3.36.0",
+    "@botpress/messaging-client": "0.0.3",
     "@webscopeio/react-textarea-autocomplete": "^4.7.2",
     "axios": "^0.21.0",
     "bluebird": "^3.5",

--- a/modules/hitlnext/src/backend/repository.ts
+++ b/modules/hitlnext/src/backend/repository.ts
@@ -597,7 +597,7 @@ export default class Repository {
         ? process.core_env.MESSAGING_ENDPOINT
         : `http://localhost:${process.MESSAGING_PORT}`,
       auth: { clientId: messaging.id, clientToken: messaging.token },
-      password: process.INTERNAL_PASSWORD
+      config: { headers: { password: process.INTERNAL_PASSWORD } }
     })
     this.messagingClients[botId] = botClient
 

--- a/modules/hitlnext/src/backend/repository.ts
+++ b/modules/hitlnext/src/backend/repository.ts
@@ -596,7 +596,6 @@ export default class Repository {
       url: process.core_env.MESSAGING_ENDPOINT
         ? process.core_env.MESSAGING_ENDPOINT
         : `http://localhost:${process.MESSAGING_PORT}`,
-      password: process.INTERNAL_PASSWORD,
       auth: { clientId: messaging.id, clientToken: messaging.token }
     })
     this.messagingClients[botId] = botClient

--- a/modules/hitlnext/src/backend/repository.ts
+++ b/modules/hitlnext/src/backend/repository.ts
@@ -596,7 +596,8 @@ export default class Repository {
       url: process.core_env.MESSAGING_ENDPOINT
         ? process.core_env.MESSAGING_ENDPOINT
         : `http://localhost:${process.MESSAGING_PORT}`,
-      auth: { clientId: messaging.id, clientToken: messaging.token }
+      auth: { clientId: messaging.id, clientToken: messaging.token },
+      password: process.INTERNAL_PASSWORD
     })
     this.messagingClients[botId] = botClient
 

--- a/modules/hitlnext/yarn.lock
+++ b/modules/hitlnext/yarn.lock
@@ -34,11 +34,17 @@
     classnames "^2.2"
     tslib "~1.13.0"
 
-"@botpress/messaging-client@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@botpress/messaging-client/-/messaging-client-0.0.3.tgz#871c0672e7ac488c60fcf6ca57549aac73c0b958"
-  integrity sha512-Aq1EB06jM2uND1GXrZfZ3JAd9wvl4a632exNxI5c2l7AC8iCyCmg5qZtZAiKJKiddO7KyAjbCVhRbi2UTjEhNg==
+"@botpress/messaging-base@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@botpress/messaging-base/-/messaging-base-0.0.1.tgz#1e1347262e4c5f70d73ba62b8a62b9d9576e3c16"
+  integrity sha512-J52YtTu0OxElZUJwtfx8NSVFlTGyZVXGppWgdgckHRa6mAf+8DY3gCkDpG34Elic9Uygz3L0+3HebvgSk6Y3CA==
+
+"@botpress/messaging-client@0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@botpress/messaging-client/-/messaging-client-0.0.7.tgz#697374e857ba4344ecb997977f3278fd292bd091"
+  integrity sha512-PCHZl8semVaAtSl/KxQPPDnFU6ZhMi7YmmgNtoQQPIE/d28OSPDUuost7dfwoNllVxHqQqsdIKmLQqRORxhX4w==
   dependencies:
+    "@botpress/messaging-base" "0.0.1"
     axios "^0.21.1"
 
 "@hapi/hoek@^9.0.0":

--- a/modules/hitlnext/yarn.lock
+++ b/modules/hitlnext/yarn.lock
@@ -34,6 +34,13 @@
     classnames "^2.2"
     tslib "~1.13.0"
 
+"@botpress/messaging-client@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@botpress/messaging-client/-/messaging-client-0.0.3.tgz#871c0672e7ac488c60fcf6ca57549aac73c0b958"
+  integrity sha512-Aq1EB06jM2uND1GXrZfZ3JAd9wvl4a632exNxI5c2l7AC8iCyCmg5qZtZAiKJKiddO7KyAjbCVhRbi2UTjEhNg==
+  dependencies:
+    axios "^0.21.1"
+
 "@hapi/hoek@^9.0.0":
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.1.1.tgz#9daf5745156fd84b8e9889a2dc721f0c58e894aa"
@@ -92,6 +99,13 @@ axios@^0.21.0:
   integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
     follow-redirects "^1.10.0"
+
+axios@^0.21.1:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -218,6 +232,11 @@ follow-redirects@^1.10.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
   integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
+
+follow-redirects@^1.14.0:
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.4.tgz#838fdf48a8bbdd79e52ee51fb1c94e3ed98b9379"
+  integrity sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==
 
 fs.realpath@^1.0.0:
   version "1.0.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "version": "0.0.39"
   },
   "messaging": {
-    "version": "0.1.14"
+    "version": "0.1.15"
   },
   "scripts": {
     "postinstall": "yarn cmd postinstall",
@@ -38,7 +38,7 @@
     "@apidevtools/json-schema-ref-parser": "^9.0.6",
     "@babel/parser": "^7.11.2",
     "@babel/traverse": "^7.11.0",
-    "@botpress/messaging-client": "0.0.3",
+    "@botpress/messaging-client": "0.0.7",
     "archiver": "^5.3.0",
     "axios": "^0.21.1",
     "bluebird-global": "^1.0.1",

--- a/packages/bp/src/core/messaging/messaging-service.ts
+++ b/packages/bp/src/core/messaging/messaging-service.ts
@@ -42,7 +42,8 @@ export class MessagingService {
 
     await AppLifecycle.waitFor(AppLifecycleEvents.STUDIO_READY)
 
-    this.clientSync = new MessagingClient({ url: this.getMessagingUrl() })
+    this.internalPassword = this.isExternal ? undefined : process.INTERNAL_PASSWORD
+    this.clientSync = new MessagingClient({ url: this.getMessagingUrl(), password: this.internalPassword })
   }
 
   async loadMessagingForBot(botId: string) {
@@ -93,6 +94,7 @@ export class MessagingService {
 
     const botClient = new MessagingClient({
       url: this.getMessagingUrl(),
+      password: this.internalPassword,
       auth: { clientId: messaging.id!, clientToken: messaging.token! }
     })
     this.clientsByBotId[botId] = botClient

--- a/packages/bp/src/core/messaging/messaging-service.ts
+++ b/packages/bp/src/core/messaging/messaging-service.ts
@@ -42,8 +42,7 @@ export class MessagingService {
 
     await AppLifecycle.waitFor(AppLifecycleEvents.STUDIO_READY)
 
-    this.internalPassword = this.isExternal ? undefined : process.INTERNAL_PASSWORD
-    this.clientSync = new MessagingClient({ url: this.getMessagingUrl(), password: this.internalPassword })
+    this.clientSync = new MessagingClient({ url: this.getMessagingUrl() })
   }
 
   async loadMessagingForBot(botId: string) {
@@ -94,7 +93,6 @@ export class MessagingService {
 
     const botClient = new MessagingClient({
       url: this.getMessagingUrl(),
-      password: this.internalPassword,
       auth: { clientId: messaging.id!, clientToken: messaging.token! }
     })
     this.clientsByBotId[botId] = botClient

--- a/yarn.lock
+++ b/yarn.lock
@@ -317,11 +317,17 @@
     classnames "^2.2"
     tslib "~1.13.0"
 
-"@botpress/messaging-client@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@botpress/messaging-client/-/messaging-client-0.0.3.tgz#871c0672e7ac488c60fcf6ca57549aac73c0b958"
-  integrity sha512-Aq1EB06jM2uND1GXrZfZ3JAd9wvl4a632exNxI5c2l7AC8iCyCmg5qZtZAiKJKiddO7KyAjbCVhRbi2UTjEhNg==
+"@botpress/messaging-base@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@botpress/messaging-base/-/messaging-base-0.0.1.tgz#1e1347262e4c5f70d73ba62b8a62b9d9576e3c16"
+  integrity sha512-J52YtTu0OxElZUJwtfx8NSVFlTGyZVXGppWgdgckHRa6mAf+8DY3gCkDpG34Elic9Uygz3L0+3HebvgSk6Y3CA==
+
+"@botpress/messaging-client@0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@botpress/messaging-client/-/messaging-client-0.0.7.tgz#697374e857ba4344ecb997977f3278fd292bd091"
+  integrity sha512-PCHZl8semVaAtSl/KxQPPDnFU6ZhMi7YmmgNtoQQPIE/d28OSPDUuost7dfwoNllVxHqQqsdIKmLQqRORxhX4w==
   dependencies:
+    "@botpress/messaging-base" "0.0.1"
     axios "^0.21.1"
 
 "@cnakazawa/watch@^1.0.3":


### PR DESCRIPTION
## Description

This PR fixes an issue where switching between different instances of the Messaging server would cause the channel-web to constantly send requests trying to initialize itself. 

The reason behind this issue is that the user mapping between channel-web userIds and Messaging userIds is done in the table `web_user_map`, which is created by Botpress. When changing servers, the user entry would not exist anymore but the mapping would.

Fixes https://github.com/botpress/messaging/issues/183
Closes DEV-1867

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Locally. ~Note that this PR relies on changes made here (https://github.com/botpress/messaging/pull/195). Use `yarn link` inside the messaging client package to use this version of the package in the channel-web module.~ **Edit: Not required anymore, the client update was published on NPM**

**Test configuration**:
* BP version: Master
* Node version: 12.18.1
* OS: Archlinux
* Browser: Chrome
* Binary or source ?: Source

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] Any dependent changes have been merged and published in downstream modules
