### PR TITLE
chore(messaging): accept converse api messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "version": "0.0.39"
   },
   "messaging": {
-    "version": "0.1.14"
+    "version": "0.1.15"
   },
   "scripts": {
     "postinstall": "yarn cmd postinstall",

--- a/packages/bp/src/core/messaging/messaging-service.ts
+++ b/packages/bp/src/core/messaging/messaging-service.ts
@@ -8,8 +8,6 @@ import { inject, injectable, postConstruct } from 'inversify'
 import { AppLifecycle, AppLifecycleEvents } from 'lifecycle'
 import { MessageNewEventData } from './messaging-router'
 
-const DEFAULT_TYPING_DELAY = 500
-
 @injectable()
 export class MessagingService {
   private clientSync!: MessagingClient

--- a/packages/bp/src/core/messaging/messaging-service.ts
+++ b/packages/bp/src/core/messaging/messaging-service.ts
@@ -16,7 +16,7 @@ export class MessagingService {
   private clientsByBotId: { [botId: string]: MessagingClient } = {}
   private botsByClientId: { [clientId: string]: string } = {}
   private webhookTokenByClientId: { [botId: string]: string } = {}
-  private channelNames = ['messenger', 'slack', 'smooch', 'teams', 'telegram', 'twilio', 'vonage']
+  private channelNames = ['messenger', 'slack', 'smooch', 'teams', 'telegram', 'twilio', 'vonage', 'messaging']
   private newUsers: number = 0
 
   public isExternal: boolean


### PR DESCRIPTION
## Description

Adds `messaging` to the list of channels so that messages that come from the Converse API can be processed and sent back.

Related to: https://github.com/botpress/messaging/pull/194

## Type of change

- [X] Chore change (refactoring and / or test changes)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] Any dependent changes have been merged and published in downstream modules