### PR TITLE
fix(basic-skills): slot filling issues if using validation function 

### DIFF
--- a/modules/basic-skills/src/actions/slot_update_contexts.js
+++ b/modules/basic-skills/src/actions/slot_update_contexts.js
@@ -20,6 +20,7 @@ const updateContexts = async intentName => {
   temp.tryFillSlotCount = 1
   temp.extracted = false
   temp.notExtracted = false
+  temp.valid = undefined
   temp.alreadyExtracted = false
 }
 

--- a/modules/basic-skills/src/backend/slot.ts
+++ b/modules/basic-skills/src/backend/slot.ts
@@ -86,6 +86,10 @@ const createNodes = data => {
         {
           type: sdk.NodeActionType.RenderElement,
           name: `#!${data.notFoundElement}`
+        },
+        {
+          type: sdk.NodeActionType.RunAction,
+          name: 'builtin/setVariable {"type":"temp","name":"valid","value": "true"}'
         }
       ],
       onReceive: slotExtractOnReceive,
@@ -130,9 +134,14 @@ const createNodes = data => {
         {
           type: sdk.NodeActionType.RunAction,
           name: 'builtin/setVariable {"type":"temp","name":"alreadyExtracted","value":"true"}'
-        }
+        },
+        {
+          type: sdk.NodeActionType.RunAction,
+          name: 'builtin/setVariable {"type":"temp","name":"valid","value": "true"}'
+        },
+        ...runValidationActions
       ],
-      onReceive: runValidationActions,
+      onReceive: undefined,
       next: [
         {
           condition: ' (temp.valid === undefined || temp.valid == "true")',
@@ -140,7 +149,7 @@ const createNodes = data => {
         },
         {
           condition: 'true',
-          node: 'not-extracted'
+          node: 'slot-extract'
         }
       ]
     }

--- a/modules/basic-skills/src/backend/slot.ts
+++ b/modules/basic-skills/src/backend/slot.ts
@@ -39,6 +39,11 @@ const createNodes = data => {
     ...runValidationActions
   ]
 
+  const resetValid = {
+    type: sdk.NodeActionType.RunAction,
+    name: 'builtin/setVariable {"type":"temp","name":"valid","value": "true"}'
+  }
+
   return [
     {
       name: 'slot-extract',
@@ -87,10 +92,7 @@ const createNodes = data => {
           type: sdk.NodeActionType.RenderElement,
           name: `#!${data.notFoundElement}`
         },
-        {
-          type: sdk.NodeActionType.RunAction,
-          name: 'builtin/setVariable {"type":"temp","name":"valid","value": "true"}'
-        }
+        resetValid
       ],
       onReceive: slotExtractOnReceive,
       next: [
@@ -135,10 +137,7 @@ const createNodes = data => {
           type: sdk.NodeActionType.RunAction,
           name: 'builtin/setVariable {"type":"temp","name":"alreadyExtracted","value":"true"}'
         },
-        {
-          type: sdk.NodeActionType.RunAction,
-          name: 'builtin/setVariable {"type":"temp","name":"valid","value": "true"}'
-        },
+        resetValid,
         ...runValidationActions
       ],
       onReceive: undefined,


### PR DESCRIPTION
## Description


Fixes # (https://github.com/botpress/v12/issues/1514)

1 - Once the validation fails, the bot keeps stuck in the not-extracted loop again even if it validates (valid is not cleared)
2 - Once on-already-extracted validation fails, there is no input message, just the fail message and wait for input (redirect to not-extracted and not extract)
3 - (sequential extractions) If validation failed in a previous slot filling skill, the temp.valid variable is not cleared, causing validation issues on a new slot filling skill (valid is not cleared)
4 - Skill waits for input if it goes to on-already-extracted (the input is not even used)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [x] Manual testing with bot [bot_no-validation-on-already (1).zip](https://github.com/botpress/botpress/files/7354317/bot_no-validation-on-already.1.zip), commenting the 'temp.valid = false' when necessary

**Test configuration**:
* BP version: 12.26.5
* Node version: 12.20
* OS: Windows
* Binary or source ?: Source

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
