### PR TITLE
fix(bp): attach error in logger.error in action strategy

### DIFF
--- a/packages/bp/src/core/dialog/instruction/strategy.ts
+++ b/packages/bp/src/core/dialog/instruction/strategy.ts
@@ -143,7 +143,7 @@ export class ActionStrategy implements InstructionStrategy {
 
       await service.runAction({ actionName, incomingEvent: event, actionArgs: args, actionServer })
     } catch (err) {
-      this.logger.error(err.message)
+      this.logger.attachError(err).error(err.message)
       const { currentNode, currentFlow } = _.get(event, 'state.context', {})
       addErrorToEvent(
         {


### PR DESCRIPTION
Title says it all.

I kept having an error related to my liscence, but there was no messages or stack trace so I had no Idea what was going on for a while... 