### PR TITLE
chore: upgrade nlu to v0.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "AGPL-3.0",
   "private": true,
   "nlu": {
-    "version": "0.1.7"
+    "version": "0.1.8"
   },
   "studio": {
     "version": "0.0.39"


### PR DESCRIPTION
Here's the [release with changelog](https://github.com/botpress/nlu/releases/tag/v0.1.8).

Closes DEV-1838