### PR TITLE
fix(nlu): nlu client set proxy false when querying localhost

### DIFF
--- a/modules/nlu/src/api.ts
+++ b/modules/nlu/src/api.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance } from 'axios'
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
 import * as sdk from 'botpress/sdk'
 
 export type NLUApi = ReturnType<typeof makeApi>
@@ -9,7 +9,9 @@ export const makeApi = (bp: { axios: AxiosInstance }) => ({
 })
 
 export const createApi = async (bp: typeof sdk, botId: string) => {
-  const axiosForBot = axios.create(await bp.http.getAxiosConfigForBot(botId, { localUrl: true }))
+  const config: AxiosRequestConfig = await bp.http.getAxiosConfigForBot(botId, { localUrl: true })
+  config.proxy = false // always false as this client queries localhost
+  const axiosForBot = axios.create(config)
   const api = makeApi({ axios: axiosForBot })
   return api
 }

--- a/modules/nlu/src/backend/application/bot-factory.ts
+++ b/modules/nlu/src/backend/application/bot-factory.ts
@@ -26,7 +26,7 @@ export type IScopedServicesFactory = I<ScopedServicesFactory>
 
 export class ScopedServicesFactory {
   constructor(
-    private _languageSource: LanguageSource & { isExternal: boolean },
+    private _languageSource: LanguageSource & { isLocal: boolean },
     private _logger: sdk.Logger,
     private _makeDefRepo: DefinitionRepositoryFactory
   ) {}

--- a/modules/nlu/src/backend/application/bot-factory.ts
+++ b/modules/nlu/src/backend/application/bot-factory.ts
@@ -1,9 +1,9 @@
-import { Client } from '@botpress/nlu-client'
 import * as sdk from 'botpress/sdk'
 import _ from 'lodash'
 import { LanguageSource } from 'src/config'
 
 import { NLUCloudClient } from '../cloud/client'
+import { NLUClientNoProxy } from '../no-proxy-client'
 import { IStanEngine, StanEngine } from '../stan'
 import pickSeed from './pick-seed'
 import { Bot, IBot } from './scoped/bot'
@@ -26,7 +26,7 @@ export type IScopedServicesFactory = I<ScopedServicesFactory>
 
 export class ScopedServicesFactory {
   constructor(
-    private _languageSource: LanguageSource,
+    private _languageSource: LanguageSource & { isExternal: boolean },
     private _logger: sdk.Logger,
     private _makeDefRepo: DefinitionRepositoryFactory
   ) {}
@@ -36,7 +36,7 @@ export class ScopedServicesFactory {
 
     const stanClient = cloud
       ? new NLUCloudClient({ ...cloud, endpoint: this._languageSource.endpoint })
-      : new Client(this._languageSource.endpoint, this._languageSource.authToken)
+      : new NLUClientNoProxy(this._languageSource)
 
     return new StanEngine(stanClient, this._languageSource.authToken ?? '')
   }

--- a/modules/nlu/src/backend/bootstrap.ts
+++ b/modules/nlu/src/backend/bootstrap.ts
@@ -3,6 +3,7 @@ import * as sdk from 'botpress/sdk'
 import { makeNLUPassword } from 'common/nlu-token'
 import _ from 'lodash'
 
+import url from 'url'
 import { Config, LanguageSource } from '../config'
 
 import { getWebsocket } from './api'
@@ -16,12 +17,17 @@ import { BotDefinition } from './application/typings'
 import { NLUClientNoProxy } from './no-proxy-client'
 import { StanEngine } from './stan'
 
-const getNLUServerConfig = (config: Config['nluServer']): LanguageSource & { isExternal: boolean } => {
+export const isLocalHost = (endpoint: string) => {
+  const { hostname } = new url.URL(endpoint)
+  return ['localhost', '127.0.0.1', '0.0.0.0'].includes(hostname)
+}
+
+const getNLUServerConfig = (config: Config['nluServer']): LanguageSource & { isLocal: boolean } => {
   if (config.autoStart) {
     return {
       endpoint: `http://localhost:${process.NLU_PORT}`,
       authToken: makeNLUPassword(),
-      isExternal: false
+      isLocal: true
     }
   }
 
@@ -29,7 +35,7 @@ const getNLUServerConfig = (config: Config['nluServer']): LanguageSource & { isE
   return {
     endpoint,
     authToken,
-    isExternal: true
+    isLocal: isLocalHost(endpoint)
   }
 }
 

--- a/modules/nlu/src/backend/localhost.test.ts
+++ b/modules/nlu/src/backend/localhost.test.ts
@@ -1,0 +1,17 @@
+import { isLocalHost } from './bootstrap'
+
+const testcases: [string, boolean][] = [
+  ['http://localhost:3200', true],
+  ['https://localhost:3201', true],
+  ['http://127.0.0.1:8080/aresource', true],
+  ['https://0.0.0.0:8080/aresource', true],
+  ['ws://localhost:8080', true],
+  ['https://www.google.com', false],
+  ['https://www.botpress.com/documentation', false],
+  ['http://local-host:8080', false]
+]
+
+test.each(testcases)('expect isLocalHost %s to be %s', (uri: string, expected: boolean) => {
+  const actual = isLocalHost(uri)
+  expect(actual).toBe(expected)
+})

--- a/modules/nlu/src/backend/no-proxy-client.ts
+++ b/modules/nlu/src/backend/no-proxy-client.ts
@@ -1,0 +1,28 @@
+import { Client } from '@botpress/nlu-client'
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
+
+interface ClientArgs {
+  endpoint: string
+  authToken?: string
+  isExternal: boolean
+}
+
+export class NLUClientNoProxy extends Client {
+  private _client: AxiosInstance
+
+  constructor(args: ClientArgs) {
+    super(args.endpoint, args.authToken)
+
+    const { endpoint, authToken, isExternal: externalNLUServer } = args
+
+    const config: AxiosRequestConfig = { baseURL: endpoint }
+    if (authToken) {
+      config.headers = { Authorization: `Bearer ${authToken}` }
+    }
+
+    if (!externalNLUServer) {
+      config.proxy = false
+    }
+    this._client = axios.create(config)
+  }
+}

--- a/modules/nlu/src/backend/no-proxy-client.ts
+++ b/modules/nlu/src/backend/no-proxy-client.ts
@@ -4,7 +4,7 @@ import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
 interface ClientArgs {
   endpoint: string
   authToken?: string
-  isExternal: boolean
+  isLocal: boolean
 }
 
 export class NLUClientNoProxy extends Client {
@@ -13,14 +13,14 @@ export class NLUClientNoProxy extends Client {
   constructor(args: ClientArgs) {
     super(args.endpoint, args.authToken)
 
-    const { endpoint, authToken, isExternal: externalNLUServer } = args
+    const { endpoint, authToken, isLocal } = args
 
     const config: AxiosRequestConfig = { baseURL: endpoint }
     if (authToken) {
       config.headers = { Authorization: `Bearer ${authToken}` }
     }
 
-    if (!externalNLUServer) {
+    if (isLocal) {
       config.proxy = false
     }
     this._client = axios.create(config)


### PR DESCRIPTION
Allright, this PR fixes botpress/v12#1515

It should have been included with PR botpress/botpress#5579, but it didn't because I was negligent. To be honest, I misunderstood the nature of the bug and I thought it wouldn't happen with the NLU. 

To reproduce, just set `HTTP_PROXY="foobar"`. 
- on master, only the nlu breaks (other services have already been fixed in `12.26.6`). 
- on this branch, everything works.

The code is ugly but it works. Anyway, it has already been fully rewritten on branch `next` so let's not focus too much on style. I just need to remember to bring this fix to branch `next`.