### PR TITLE
chore(modules): change module splash logo position

### DIFF
--- a/packages/ui-shared/src/ModuleUI/style.scss
+++ b/packages/ui-shared/src/ModuleUI/style.scss
@@ -92,7 +92,7 @@ $status-bar-height: 30px;
 
   svg {
     font-size: 250px;
-    margin-bottom: -50px;
+    margin-bottom: -30px;
   }
 
   > div {


### PR DESCRIPTION
Just bring up the splash screen icon a little bit

Before : 
<img width="670" alt="Screen Shot 2021-10-29 at 12 09 05 PM" src="https://user-images.githubusercontent.com/955524/139467684-341cd102-d52d-41d8-9bb9-e9d1dc201819.png">

After
<img width="689" alt="Screen Shot 2021-10-29 at 12 08 56 PM" src="https://user-images.githubusercontent.com/955524/139467740-5775d61f-5616-4887-8d50-97b5284f3555.png">
: