### PR TITLE
fix(slot-filling): allow -1 as slot filling retry

### DIFF
--- a/modules/basic-skills/src/views/full/slot.jsx
+++ b/modules/basic-skills/src/views/full/slot.jsx
@@ -257,7 +257,7 @@ export class Slot extends React.Component {
               id="retryAttempts"
               name="retryAttempts"
               type="number"
-              min="0"
+              min="-1"
               max={MAX_RETRIES}
               value={this.state.maxRetryAttempts}
               onChange={this.handleMaxRetryAttemptsChange}


### PR DESCRIPTION
## Description

Allows -1 for slot-filling skill to be entered in the input, -1 means infinite retries

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Create a slot filling skill
- Change the retry value to any positive integer
- Try setting it to -1 again

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I've included some media (picture/gif/video) if applicable to show the old and new behavior
