### PR TITLE
fix(skills): dialog overflow on too many params, fixes #149

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "version": "0.1.8"
   },
   "studio": {
-    "version": "0.0.41"
+    "version": "0.0.41",
+    "devBranch": "sp_fix_1956"
   },
   "messaging": {
     "version": "0.1.15"

--- a/packages/ui-shared/src/Dialog/style.scss
+++ b/packages/ui-shared/src/Dialog/style.scss
@@ -5,7 +5,7 @@
 .dialog {
   max-height: 90%;
   background-color: white !important;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   .form,
   :global(.bp3-dialog-body) {

--- a/packages/ui-shared/src/Dialog/style.scss
+++ b/packages/ui-shared/src/Dialog/style.scss
@@ -5,6 +5,7 @@
 .dialog {
   max-height: 90%;
   background-color: white !important;
+  overflow-y: scroll;
 
   .form,
   :global(.bp3-dialog-body) {


### PR DESCRIPTION
https://linear.app/botpress/issue/DEV-1956/[bug]-ui-issue-when-using-multiple-arguments-in-an-action

## Description

When there are too many action parameters, the inputs where overflowing the modal dialog.  I adjusted the CSS so that the form scrolls on overflow.

This fix requires this studio fix as well to work properly: https://github.com/botpress/studio/pull/151
## Before
<img width="640" alt="image" src="https://user-images.githubusercontent.com/1315508/139677005-849969ef-0bd7-4e48-89ba-3a7baf31b55e.png">

## After

<img width="633" alt="image" src="https://user-images.githubusercontent.com/1315508/139676006-291a1b48-31e5-4aad-ad10-e1def6fc1e85.png">

<img width="637" alt="image" src="https://user-images.githubusercontent.com/1315508/139676108-b2ef07d3-4f81-456d-bfbb-9e1c3d9a5f0e.png">

Fixes # 149

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore change (refactoring and / or test changes