### PR TITLE
fix(basic-skills): Allow -1 as slot filling retry value

### DIFF
--- a/modules/analytics/src/views/full/ItemsList.tsx
+++ b/modules/analytics/src/views/full/ItemsList.tsx
@@ -1,9 +1,9 @@
+import { Icon } from '@blueprintjs/core'
 import { lang } from 'botpress/shared'
 import cx from 'classnames'
 import React, { FC } from 'react'
 
 import style from './style.scss'
-import { Icon } from '@blueprintjs/core'
 
 interface Props {
   name: string

--- a/modules/analytics/src/views/full/index.tsx
+++ b/modules/analytics/src/views/full/index.tsx
@@ -17,6 +17,7 @@ import _ from 'lodash'
 import moment from 'moment'
 import React, { FC, Fragment, useEffect, useRef, useState } from 'react'
 
+import { MetricTypes } from '../../backend/db'
 import { MetricEntry } from '../../backend/typings'
 
 import {
@@ -39,7 +40,6 @@ import RadialMetric from './RadialMetric'
 import style from './style.scss'
 import TimeSeriesChart from './TimeSeriesChart'
 import { fillMissingValues, getNotNaN } from './utils'
-import { MetricTypes } from '../../backend/db'
 
 interface State {
   previousRangeMetrics: MetricEntry[]

--- a/modules/basic-skills/src/views/full/slot.jsx
+++ b/modules/basic-skills/src/views/full/slot.jsx
@@ -257,7 +257,7 @@ export class Slot extends React.Component {
               id="retryAttempts"
               name="retryAttempts"
               type="number"
-              min="0"
+              min="-1"
               max={MAX_RETRIES}
               value={this.state.maxRetryAttempts}
               onChange={this.handleMaxRetryAttemptsChange}


### PR DESCRIPTION
## Description
Previously -1 could not be entered as a value for the retry field, -1 means retry infinitely
Fixes botpress/v12#1517 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Create slot filling skill
- Change retry value to any positive integer
- Change value to -1
- Save skill



https://user-images.githubusercontent.com/18604963/139680354-3c754237-35c3-42c9-8bd2-c1660050609f.mov


**Test configuration**:
* OS: Mac OS
* Browser: Chrome 95.0
* Binary or source ?: source

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I've included some media (picture/gif/video) if applicable to show the old and new behavior
