### PR TITLE
fix(strategy-basic): disallow reusing previous password

### DIFF
--- a/packages/bp/src/core/security/strategy-basic.ts
+++ b/packages/bp/src/core/security/strategy-basic.ts
@@ -98,6 +98,10 @@ export class StrategyBasic {
     const strategyOptions = _.get(await this.authService.getStrategy(strategy), 'options') as AuthStrategyBasic
 
     if (newPassword) {
+      if (password === newPassword) {
+        throw new WeakPasswordError('New password should not match old password')
+      }
+
       this._validatePassword(newPassword, strategyOptions)
       const hash = saltHashPassword(newPassword)
 


### PR DESCRIPTION
## Description

When a new collaborator is created, a one-time password is generated. After the collaborator signs in for the first time using that generated password, they need to create a new one. Currently, we allow for the one-time password to be reused.

Fixes botpress/v12#1474 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore change (refactoring and / or test changes)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

1. Create a new collaborator
2. Log in as the new collaborator
3. At the password change, use the same provided password as your new password

## Screenshot of the new behavior

<img width="601" alt="Screen Shot 2021-11-01 at 19 31 47" src="https://user-images.githubusercontent.com/26189247/139679709-21ed3bed-6f4b-4d3e-94f1-c2b62dabfd9b.png">


**Test configuration**:
* BP version: v12.26.6
* Node version: v12.18.1
* OS: MacOS
* Browser: Chrome Version 95.0.4638.69 (Official Build) (x86_64)
* Binary or source ?: source

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I've included some media (picture/gif/video) if applicable to show the old and new behavior