### PR TITLE
fix(code-editor): allow folder in file names

### DIFF
--- a/modules/code-editor/src/backend/editor.ts
+++ b/modules/code-editor/src/backend/editor.ts
@@ -17,8 +17,6 @@ import {
   RAW_TYPE
 } from './utils'
 
-export const FILENAME_REGEX = /^[0-9a-zA-Z_\-.]+$/
-
 const RAW_FILES_FILTERS = ['**/*.map', 'modules/.cache/**/*', 'modules/*.cache', 'modules/*.temp_cache']
 
 export default class Editor {
@@ -161,9 +159,7 @@ export default class Editor {
   }
 
   async renameFile(file: EditableFile, newName: string): Promise<void> {
-    if (file.type !== RAW_TYPE) {
-      assertValidFilename(newName)
-    }
+    assertValidFilename(newName)
 
     const { folder, filename } = getFileLocation(file)
     const newFilename = filename.replace(filename, newName)

--- a/modules/code-editor/src/backend/utils.ts
+++ b/modules/code-editor/src/backend/utils.ts
@@ -1,9 +1,9 @@
 import { BUILTIN_MODULES } from 'common/defaults'
+import { isValid } from 'common/utils'
 import jsonlintMod from 'jsonlint-mod'
 import _ from 'lodash'
 
 import { FileDefinition, FileTypes } from './definitions'
-import { FILENAME_REGEX } from './editor'
 import { EditorError } from './editorError'
 import { EditableFile, FilePermissions, FileType } from './typings'
 
@@ -37,7 +37,7 @@ export const assertValidJson = (content: string): boolean => {
 }
 
 export const assertValidFilename = (filename: string) => {
-  if (!FILENAME_REGEX.test(filename)) {
+  if (!isValid(filename, 'path')) {
     throw new EditorError('Filename has invalid characters')
   }
 }
@@ -95,10 +95,7 @@ export const validateFilePayload = async (
     throw new EditorError(`Invalid file name. Must match ${def.filenames}`)
   }
 
-  // Skip standard validation for raw, since you can set a complete folder path
-  if (type !== RAW_TYPE) {
-    assertValidFilename(name)
-  }
+  assertValidFilename(name)
 }
 
 export const buildRestrictedProcessVars = () => {

--- a/packages/bp/src/common/utils.test.ts
+++ b/packages/bp/src/common/utils.test.ts
@@ -1,0 +1,10 @@
+import { sanitize, isValid } from './utils'
+
+test('test invalid paths', () => {
+  expect(isValid('../folder', 'path')).toEqual(false)
+  expect(isValid('../folder/file.js', 'path')).toEqual(false)
+  expect(isValid('folder/file.js', 'path')).toEqual(true)
+  expect(isValid('folder/../file.js', 'path')).toEqual(false)
+  expect(isValid('file.js', 'path')).toEqual(true)
+  expect(isValid('file..js', 'path')).toEqual(true)
+})

--- a/packages/bp/src/common/utils.ts
+++ b/packages/bp/src/common/utils.ts
@@ -29,3 +29,25 @@ export const getErrorMessage = (error: Error | string | unknown): string => {
 
   return ''
 }
+
+const regex = {
+  illegalFile: /[\/\?<>\\:\*\|"]/,
+  illegalPath: /[\?<>:\*\|"]/,
+  control: /[\x00-\x1f\x80-\x9f]/,
+  reserved: /\.\.+?(\/|\\)/g
+}
+
+export const isValid = (input: string, type: 'file' | 'path') => {
+  if (regex.control.test(input) || input.match(regex.reserved)) {
+    return false
+  }
+
+  return (type === 'file' && !regex.illegalFile.test(input)) || !regex.illegalPath.test(input)
+}
+
+export const sanitize = (input: string, type?: 'file' | 'path') => {
+  return input
+    .replace(regex.control, '')
+    .replace(regex.reserved, '')
+    .replace(type === 'path' ? regex.illegalPath : regex.illegalFile, '')
+}


### PR DESCRIPTION
## Description

Not possible to add a folder when creating a file on the code editor. This had a bit more implications than just changing the regex, since we had to add some sanitization to the provided path to ensure someone can't climb up in the folder hierarchy.

This also secures more the "raw" access 

Before:

![image](https://user-images.githubusercontent.com/42552874/139681703-336cf412-fb52-4f6d-b357-b41579d2607d.png)

After: 
![image](https://user-images.githubusercontent.com/42552874/139681780-7cd7848b-dc42-4701-9c8a-f2f0d2dade5b.png)


Fixes # https://linear.app/botpress/issue/DEV-1222/[bug]-unable-to-create-folders-for-actions-in-the-code-editor

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## How has this been tested?

Added tests

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I've included some media (picture/gif/video) if applicable to show the old and new behavior
