### PR TITLE
fix(builtin): fix erase variable handling

### DIFF
--- a/modules/builtin/src/actions/deleteVariable.js
+++ b/modules/builtin/src/actions/deleteVariable.js
@@ -1,0 +1,20 @@
+/**
+ * Delete data to desired storage. Read the
+ * documentation for more details
+ *
+ * @title Delete Variable
+ * @category Storage
+ * @author Botpress, Inc.
+ * @param {string} type - Pick between: user, session, temp, bot
+ * @param {string} name - The name of the variable
+ */
+const setVariable = async (type, name) => {
+  if (type === 'bot') {
+    const original = await bp.kvs.forBot(event.botId).get('global')
+    await bp.kvs.forBot(event.botId).set('global', { ...original, [name]: '' })
+  } else {
+    delete event.state[type][name]
+  }
+}
+
+return setVariable(args.type, args.name)

--- a/modules/builtin/src/actions/setVariable.js
+++ b/modules/builtin/src/actions/setVariable.js
@@ -7,14 +7,12 @@
  * @author Botpress, Inc.
  * @param {string} type - Pick between: user, session, temp, bot
  * @param {string} name - The name of the variable
- * @param {any} value - Set the value of the variable. Type 'null' or leave empty to erase it.
+ * @param {any} value - Set the value of the variable.
  */
 const setVariable = async (type, name, value) => {
   if (type === 'bot') {
     const original = await bp.kvs.forBot(event.botId).get('global')
     await bp.kvs.forBot(event.botId).set('global', { ...original, [name]: value })
-  } else if (value === 'null' || value === '' || typeof value === 'undefined') {
-    delete event.state[type][name]
   } else {
     event.state[type][name] = value
   }


### PR DESCRIPTION
## Description

Fixes https://github.com/botpress/v12/issues/1381
By: 
1- Remove the "leave empty in the tooltip"

2- Add an "erase variable" action that does it for you. it'll make it more clear to the end user instead of having to type. 'null' . 


Fixes # https://github.com/botpress/v12/issues/1381

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore change (refactoring and / or test changes)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test configuration**:
* BP version:
* Node version:
* OS:
* Browser:
* Binary or source ?: 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I've included some media (picture/gif/video) if applicable to show the old and new behavior
