### PR TITLE
fix(admin): fix user management

### DIFF
--- a/packages/bp/src/core/security/auth-service.ts
+++ b/packages/bp/src/core/security/auth-service.ts
@@ -139,7 +139,7 @@ export class AuthService {
     return this.users.findUser(email, strategy) as Promise<StrategyUser>
   }
 
-  async createUser(user: Partial<StrategyUser>, strategy: string): Promise<StrategyUser | string> {
+  async createUser(user: Partial<StrategyUser>, strategy: string, role?: string): Promise<StrategyUser | string> {
     if (!user.email || !strategy) {
       throw new Error('Email and strategy are required.')
     }
@@ -158,7 +158,7 @@ export class AuthService {
 
     const workspaces = await this._getWorkspacesForStrategy(strategy)
     await Promise.map(workspaces, workspace =>
-      this.workspaceService.addUserToWorkspace(strategyUser.email, strategyUser.strategy, workspace)
+      this.workspaceService.addUserToWorkspace(strategyUser.email, strategyUser.strategy, workspace, { role })
     )
 
     if (_.get(await this.getStrategy(strategy), 'type') === 'basic') {


### PR DESCRIPTION
## Description

When a user self-created an account via another provider, the account would not be displayed in the dialog to add him in the workspace. While working on this, I found other issues, which are fixed here:

1. Only members of another existing workspace would be displayed in the dialog to add them to the current workspace
2. Adding a user would add him twice (once with the selected role, one with the default workspace role)

![image](https://user-images.githubusercontent.com/42552874/139690290-b8d8d487-523a-44b8-8b71-4b6a2964e577.png)


Fixes # https://linear.app/botpress/issue/DEV-1839/[bug]-when-adding-a-collaborator-unable-to-find-newly-self-signed

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

