### PR TITLE
fix(admin): show when env variable is set

### DIFF
--- a/packages/bp/src/admin/management/checklist/checklist-router.ts
+++ b/packages/bp/src/admin/management/checklist/checklist-router.ts
@@ -33,7 +33,9 @@ class ChecklistRouter extends CustomAdminRouter {
             'BP_PRODUCTION',
             'CLUSTER_ENABLED',
             'AUTO_MIGRATE',
-            'BP_LICENSE_KEY'
+            'BP_LICENSE_KEY',
+            'BP_CONFIG_PRO_ENABLED',
+            'BP_CONFIG_PRO_LICENSEKEY'
           ])
         }
         res.send(serverConfig)


### PR DESCRIPTION
## Description

Now it is shown in the production checklist when env variable BP_CONFIG_PRO_ENABLED and BP_CONFIG_PRO_LICENSEKEY are set via env variables
Fixes botpress/v12#1490 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Set env variable and see if it is shown
- [x] Delete env variable and see if it is not shown

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I've included some media (picture/gif/video) if applicable to show the old and new behavior
