### PR TITLE
fix(webchat): ctrl-enter in webchat does not create a new conversation

### DIFF
--- a/modules/channel-web/src/views/lite/components/Composer.tsx
+++ b/modules/channel-web/src/views/lite/components/Composer.tsx
@@ -27,7 +27,9 @@ class Composer extends React.Component<ComposerProps, { isRecording: boolean }> 
   }
 
   handleKeyPress = async e => {
-    if (this.props.enableResetSessionShortcut && e.ctrlKey && e.key === 'Enter') {
+    const ENTER_CHAR_CODE = 13
+
+    if (this.props.enableResetSessionShortcut && e.ctrlKey && e.charCode === ENTER_CHAR_CODE) {
       e.preventDefault()
       await this.props.resetSession()
       await this.props.sendMessage()


### PR DESCRIPTION
## Description

When using the webchat the ctrl-enter key bindings was not working.

Fixes https://github.com/botpress/v12/issues/1161

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

I used the binding inside the webchat emulator to check if it was working. 
The react key events can be debugged using this `codesandbox`:
https://codesandbox.io/s/react-keyevent-demo-forked-ovk1c

**Test configuration**:
* BP version: 12.26.6
* Node version: 12.18.1
* OS: Windows
* Browser: Chrome
* Binary or source ?: Source

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I've included some media (picture/gif/video) if applicable to show the old and new behavior
