### PR TITLE
fix(skills): fix subsequent call api

### DIFF
--- a/modules/basic-skills/src/actions/call_api.js
+++ b/modules/basic-skills/src/actions/call_api.js
@@ -13,6 +13,7 @@ const callApi = async (url, method, body, memory, variable, headers) => {
   }
   const renderedHeaders = bp.cms.renderTemplate(headers, context)
   const renderedBody = bp.cms.renderTemplate(body, context)
+  const keySuffix = args.randomId ? `_${args.randomId}` : ''
 
   try {
     const response = await axios({
@@ -23,13 +24,13 @@ const callApi = async (url, method, body, memory, variable, headers) => {
     })
 
     event.state[memory][variable] = { body: response.data, status: response.status }
-    event.state.temp.valid = true
+    event.state.temp[`valid${keySuffix}`] = true
   } catch (error) {
     const errorCode = (error.response && error.response.status) || error.code || ''
     bp.logger.error(`Error: ${errorCode} while calling resource "${url}"`)
 
     event.state[memory][variable] = { status: errorCode }
-    event.state.temp.valid = false
+    event.state.temp[`valid${keySuffix}`] = false
   }
 }
 

--- a/modules/basic-skills/src/backend/callApi.ts
+++ b/modules/basic-skills/src/backend/callApi.ts
@@ -3,7 +3,7 @@ import _ from 'lodash'
 
 const generateFlow = async (data: any, metadata: sdk.FlowGeneratorMetadata): Promise<sdk.FlowGenerationResult> => {
   return {
-    transitions: createTransitions(),
+    transitions: createTransitions(data),
     flow: {
       nodes: createNodes(data),
       catchAll: {
@@ -22,6 +22,7 @@ const createNodes = data => {
           type: sdk.NodeActionType.RunAction,
           name: 'basic-skills/call_api',
           args: {
+            randomId: data.randomId,
             url: data.url,
             method: data.method,
             body: data.body,
@@ -37,10 +38,12 @@ const createNodes = data => {
   return nodes
 }
 
-const createTransitions = (): sdk.NodeTransition[] => {
+const createTransitions = (data): sdk.NodeTransition[] => {
+  const keySuffix = data.randomId ? `_${data.randomId}` : ''
+
   return [
-    { caption: 'On success', condition: 'temp.valid', node: '' },
-    { caption: 'On failure', condition: '!temp.valid', node: '' }
+    { caption: 'On success', condition: `temp.valid${keySuffix}`, node: '' },
+    { caption: 'On failure', condition: `!temp.valid${keySuffix}`, node: '' }
   ]
 }
 

--- a/modules/basic-skills/src/views/full/callApi.jsx
+++ b/modules/basic-skills/src/views/full/callApi.jsx
@@ -5,6 +5,7 @@ import Select from 'react-select'
 import style from './style.scss'
 import { BotpressTooltip } from 'botpress/tooltip'
 import { LinkDocumentationProvider } from 'botpress/documentation'
+import nanoid from 'nanoid/generate'
 
 const methodOptions = [
   { label: 'Get', value: 'get' },
@@ -37,6 +38,7 @@ export class CallAPI extends React.Component {
     selectedMemory: memoryOptions[0],
     variable: 'response',
     body: undefined,
+    randomId: nanoid('abcdefghijklmnopqrstuvwxyz0123456789', 10),
     headers: undefined,
     url: undefined,
     invalidJson: false
@@ -51,6 +53,7 @@ export class CallAPI extends React.Component {
       this.setState({
         selectedMethod: this.createSelectOption(this.getInitialDataProps('method')) || this.state.selectedMethod,
         selectedMemory: this.createSelectOption(this.getInitialDataProps('memory')) || this.state.selectedMemory,
+        randomId: this.getOrDefault('randomId', 'randomId'),
         headers: stringify(this.getInitialDataProps('headers')) || this.state.headers,
         variable: this.getOrDefault('variable', 'variable'),
         body: this.getOrDefault('body', 'body'),
@@ -65,6 +68,7 @@ export class CallAPI extends React.Component {
       const data = {
         method: selectedMethod.value,
         memory: selectedMemory.value,
+        randomId: this.state.randomId,
         body,
         headers: headers ? JSON.parse(headers) : undefined,
         url,


### PR DESCRIPTION
## Description

When using call api then a slot skill, the second usage wasn't working because of a variable collision. We used temp.valid in both skills. I've implemented the same logic we have on the choice skill (we use a random id for the validation variable), 

Will not fix previous call api. Only applies when it will be saved the next time, and it will not break existing calls.


Fixes # https://linear.app/botpress/issue/DEV-1382/[bug]-successful-api-skill-breaks-follow-up-slot-skills-in-same-flow

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
