### PR TITLE
fix(core): fix createdOn save order

### DIFF
--- a/packages/bp/src/core/events/event-collector.ts
+++ b/packages/bp/src/core/events/event-collector.ts
@@ -124,11 +124,12 @@ export class EventCollector {
       success: activeWorkflow?.success,
       incomingEventId: event.direction === 'outgoing' ? incomingEventId : id,
       event: ignoredProps.length ? (_.omit(event, ignoredProps) as sdk.IO.Event) : event,
-      createdOn: this.knex.date.now()
+      createdOn: this.knex.date.format(new Date())
     }
 
     const existingIndex = this.batch.findIndex(x => x.id === id)
     if (existingIndex !== -1) {
+      entry.createdOn = this.batch[existingIndex].createdOn
       this.batch.splice(existingIndex, 1, entry)
     } else {
       this.batch.push(entry)

--- a/packages/bp/src/core/events/event-engine.ts
+++ b/packages/bp/src/core/events/event-engine.ts
@@ -184,10 +184,8 @@ export class EventEngine {
   async sendEvent(event: sdk.IO.Event): Promise<void> {
     this.validateEvent(event)
 
-    if (event.debugger) {
-      addStepToEvent(event, StepScopes.Received)
-      this.eventCollector.storeEvent(event)
-    }
+    addStepToEvent(event, StepScopes.Received)
+    this.eventCollector.storeEvent(event)
 
     const isIncoming = (event: sdk.IO.Event): event is sdk.IO.IncomingEvent => event.direction === 'incoming'
     if (isIncoming(event)) {


### PR DESCRIPTION
## Description

Events were not stored with the correct createdOn date.  We didn't store incoming events right after their arrival unless it came from someone using the debugger.

The previous logic used the strftime now of the database server, so it was only parsed when we actually inserted the row in the database, which didn't work perfectly, since we batch events when storing them.

Fixes # https://linear.app/botpress/issue/DEV-1351/[bug]-botpress-converse-api-event-order-mixed-up-in-the-database

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

