### PR TITLE
fix: dev-1034 subdomain media path

### DIFF
--- a/modules/builtin/src/content-types/_utils.js
+++ b/modules/builtin/src/content-types/_utils.js
@@ -2,7 +2,7 @@ const URL = require('url').URL
 const path = require('path')
 
 function isBpUrl(str) {
-  const re = /^\/api\/.*\/bots\/.*\/media\/.*/
+  const re = /^api\/.*\/bots\/.*\/media\/.*/
 
   return re.test(str)
 }
@@ -17,7 +17,7 @@ function isUrl(str) {
 }
 
 function formatURL(baseUrl, url) {
-  if (isBpUrl(url)) {
+  if (!url.startsWith('http')) {
     return `${baseUrl}${url}`
   } else {
     return url
@@ -55,6 +55,7 @@ function extractPayload(type, data) {
 module.exports = {
   formatURL: formatURL,
   isUrl: isUrl,
+  isBpUrl: isBpUrl,
   extractPayload: extractPayload,
   extractFileName: extractFileName
 }

--- a/modules/builtin/src/content-types/audio.js
+++ b/modules/builtin/src/content-types/audio.js
@@ -41,14 +41,17 @@ module.exports = {
       return
     }
 
-    const link = utils.formatURL(formData.BOT_URL, formData.audio)
+    let audioUrl = formData.audio
+    if (utils.isBpUrl(audioUrl)) {
+      audioUrl = '/' + audioUrl
+    }
+    const link = utils.formatURL(formData.BOT_URL, audioUrl)
     const title = formData.title ? ' | ' + formData.title : ''
 
     if (utils.isUrl(link)) {
       const fileName = utils.extractFileName(formData.audio)
       return `Audio: (${fileName}) ${title}`
     } else {
-      return `Expression: ${link}${title}`
     }
   },
 

--- a/modules/builtin/src/content-types/image.js
+++ b/modules/builtin/src/content-types/image.js
@@ -41,7 +41,11 @@ module.exports = {
       return
     }
 
-    const link = utils.formatURL(formData.BOT_URL, formData.image)
+    let imageUrl = formData.image
+    if (utils.isBpUrl(imageUrl)) {
+      imageUrl = '/' + imageUrl
+    }
+    const link = utils.formatURL(formData.BOT_URL, imageUrl)
     const title = formData.title ? ' | ' + formData.title : ''
 
     if (utils.isUrl(link)) {

--- a/modules/builtin/src/content-types/video.js
+++ b/modules/builtin/src/content-types/video.js
@@ -40,8 +40,12 @@ module.exports = {
     if (!formData.video) {
       return
     }
+    let videoUrl = formData.video
+    if (utils.isBpUrl(videoUrl)) {
+      videoUrl = '/' + videoUrl
+    }
 
-    const link = utils.formatURL(formData.BOT_URL, formData.video)
+    const link = utils.formatURL(formData.BOT_URL, videoUrl)
     const title = formData.title ? ' | ' + formData.title : ''
 
     if (utils.isUrl(link)) {

--- a/packages/bp/src/common/url.ts
+++ b/packages/bp/src/common/url.ts
@@ -1,5 +1,5 @@
 export const isBpUrl = (str: string): boolean => {
-  const re = /^\/api\/.*\/bots\/.*\/media\/.*/g
+  const re = /^api\/.*\/bots\/.*\/media\/.*/g
 
   return re.test(str)
 }

--- a/packages/bp/src/core/media/providers/ghost-media-service.ts
+++ b/packages/bp/src/core/media/providers/ghost-media-service.ts
@@ -50,9 +50,9 @@ export class GhostMediaService implements MediaService {
     // make sure the file name is a valid URI
     fileName = encodeURIComponent(fileName)
     if (this.botId) {
-      return `/api/v1/bots/${this.botId}/media/${fileName}`
+      return `api/v1/bots/${this.botId}/media/${fileName}`
     } else {
-      return `/api/v1/media/${fileName}`
+      return `api/v1/media/${fileName}`
     }
   }
 }

--- a/packages/ui-shared-lite/Payloads/index.ts
+++ b/packages/ui-shared-lite/Payloads/index.ts
@@ -23,7 +23,7 @@ interface CollectFeedback {
 }
 
 const isBpUrl = (str: string): boolean => {
-  const re = /^\/api\/.*\/bots\/.*\/media\/.*/g
+  const re = /^api\/.*\/bots\/.*\/media\/.*/g
 
   return re.test(str)
 }


### PR DESCRIPTION
## Description

Fixing the paths when EXTERNAL_URL is set

Fixes botpress/v12#1032 

RELATED TO https://github.com/botpress/studio/pull/178

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- [ ] Manual Testing

**Test configuration**:
* BP version: 12.26.6
* Node version: 12.18.1
* OS: Mac Intel
* Browser: Chrome
* Binary or source ?: Source

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I've included some media (picture/gif/video) if applicable to show the old and new behavior
