### PR TITLE
chore(e2e): fix saving screenshot when some test fail

### DIFF
--- a/packages/bp/e2e/customEnvironment.js
+++ b/packages/bp/e2e/customEnvironment.js
@@ -1,11 +1,14 @@
 const PuppeteerEnvironment = require('jest-environment-puppeteer')
 
 class CustomEnvironment extends PuppeteerEnvironment {
-  async handleTestEvent(event, state) {
-    if (event.name == 'test_fn_failure') {
-      const testName = state.currentlyRunningTest.name
+  savePath = path.join(__dirname, '../../../', 'build/tests/e2e/screenshots')
+
+  async handleTestEvent(event, _state) {
+    if (event.name === 'test_fn_failure') {
+      const filename = path.format({ dir: this.savePath, name: event.test.name, ext: '.png' })
+
       // Take a screenshot at the point of failure
-      await this.global.page.screenshot({ path: `build/tests/e2e/screenshots/${testName}.png` })
+      await this.global.page.screenshot({ path: filename })
     }
   }
 }

--- a/packages/bp/e2e/customEnvironment.js
+++ b/packages/bp/e2e/customEnvironment.js
@@ -1,4 +1,5 @@
 const PuppeteerEnvironment = require('jest-environment-puppeteer')
+const path = require('path')
 
 class CustomEnvironment extends PuppeteerEnvironment {
   savePath = path.join(__dirname, '../../../', 'build/tests/e2e/screenshots')

--- a/packages/bp/e2e/customEnvironment.js
+++ b/packages/bp/e2e/customEnvironment.js
@@ -4,9 +4,9 @@ const path = require('path')
 class CustomEnvironment extends PuppeteerEnvironment {
   savePath = path.join(__dirname, '../../../', 'build/tests/e2e/screenshots')
 
-  async handleTestEvent(event, _state) {
+  async handleTestEvent(event, state) {
     if (event.name === 'test_fn_failure') {
-      const filename = path.format({ dir: this.savePath, name: event.test.name, ext: '.png' })
+      const filename = path.format({ dir: this.savePath, name: state.currentlyRunningTest.name, ext: '.png' })
 
       // Take a screenshot at the point of failure
       await this.global.page.screenshot({ path: filename })


### PR DESCRIPTION
## Description

This PR fixes an issue where sometimes ;) E2E tests fail and screenshots were not saved because the specified path to where they should be stored was wrong.

## Type of change

Please delete options that are not relevant.

- [X] Chore change (refactoring and / or test changes)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
