### PR TITLE
fix(channel-web): display uploaded file in bold

### DIFF
--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -238,7 +238,7 @@ export default async (bp: typeof sdk, db: Database) => {
       await bp.users.getOrCreateUser('web', userId, botId) // Just to create the user if it doesn't exist
 
       const payload = {
-        text: `Uploaded a file [${req.file.originalname}]`,
+        text: `Uploaded a file **${req.file.originalname}**`,
         type: 'file',
         storage: req.file.location ? 's3' : 'local',
         url: req.file.location || req.file.path || undefined,

--- a/packages/bp/src/core/messaging/messaging-service.ts
+++ b/packages/bp/src/core/messaging/messaging-service.ts
@@ -118,6 +118,10 @@ export class MessagingService {
   }
 
   async receive(event: MessageNewEventData) {
+    if(!this.channelNames.includes(event.channel)) {
+      return
+    }
+
     return this.eventEngine.sendEvent(
       Event({
         direction: 'incoming',


### PR DESCRIPTION
## Description

An file uploaded in the webchat by the user is currently displayed as a downloadable link (with an undefined link). I first added the proper file url on the server but then realized that the file could not be downloadable as link, it's not exposed to the outside world through our media service. So, I decided to simply render the file name in bold instead to not break the current behaviour.

Fixes 1st issue mentioned here https://github.com/botpress/v12/issues/1519
Closes DEV-1931

Before
![7cb7869b-2d92-4bef-aa68-e7a4fca8c606](https://user-images.githubusercontent.com/955524/139748778-f879f632-07da-4caf-9308-4d2239d6d62d.png)
 
 After:
![Screen Shot 2021-11-01 at 6 13 00 PM](https://user-images.githubusercontent.com/955524/139748913-8a80bc6c-49bd-465e-91dd-329a4907e485.png)

(Notice, filename isn't clickable anymore)