### PR TITLE
fix(channel-web): file upload quick reply uses whole button space

### DIFF
--- a/modules/channel-web/assets/default-emulator.css
+++ b/modules/channel-web/assets/default-emulator.css
@@ -230,6 +230,10 @@
     transition: border 0.3s, background 0.3s, color 0.3s;
   }
 
+  .bpw-file-button {
+    padding: 0 10px;
+  }
+
   .bpw-button-alt {
     background-color: var(--main-bg-color);
     font-size: 1rem;

--- a/modules/channel-web/assets/default.css
+++ b/modules/channel-web/assets/default.css
@@ -120,6 +120,10 @@ body {
   align-items: flex-start;
 }
 
+.bpw-file-button {
+  padding: 0;
+}
+
 .bpw-button-alt {
   background-color: var(--main-bg-color);
   font-size: 1rem;

--- a/modules/channel-web/src/views/lite/components/messages/renderer/Button.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/renderer/Button.tsx
@@ -35,8 +35,7 @@ export class Button extends Component<Renderer.Button> {
 
   renderFileUpload(accept) {
     return (
-      <button className={'bpw-button'}>
-        <span>{this.props.label}</span>
+      <button className={'bpw-button bpw-file-button'}>
         <FileInput
           name={'uploadField'}
           accept={accept}
@@ -44,6 +43,7 @@ export class Button extends Component<Renderer.Button> {
           placeholder={this.props.label}
           onFileChanged={this.handleFileUpload}
         />
+        <span>{this.props.label}</span>
       </button>
     )
   }

--- a/modules/channel-web/src/views/lite/components/messages/renderer/FileInput.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/renderer/FileInput.tsx
@@ -26,8 +26,9 @@ export class FileInput extends React.Component<Renderer.FileInput> {
             top: 0,
             left: 0,
             opacity: 0,
+            padding: 0,
             width: '100%',
-            zIndex: 1
+            zIndex: 100
           }}
         />
         <input
@@ -38,7 +39,13 @@ export class FileInput extends React.Component<Renderer.FileInput> {
           onChange={() => {}}
           placeholder={this.props.placeholder}
           disabled={this.props.disabled}
-          style={{ position: 'relative', zIndex: -1 }}
+          style={{
+            position: 'absolute',
+            zIndex: -1,
+            width: '100%',
+            top: 0,
+            left: 0
+          }}
         />
       </div>
     )

--- a/packages/bp/src/core/messaging/messaging-service.ts
+++ b/packages/bp/src/core/messaging/messaging-service.ts
@@ -118,6 +118,10 @@ export class MessagingService {
   }
 
   async receive(event: MessageNewEventData) {
+    if(!this.channelNames.includes(event.channel)) {
+      return
+    }
+
     return this.eventEngine.sendEvent(
       Event({
         direction: 'incoming',


### PR DESCRIPTION
While fixing another issue I realized it the upload file was barely clickable so I ended up doing a little css to fix this.

Now channel web and emulator buttons are clickable :) 

Closes DEV-196

![upload](https://user-images.githubusercontent.com/955524/139750406-eac70731-8773-487d-b2df-a0eb170bd103.gif)
![upload-2](https://user-images.githubusercontent.com/955524/139750326-1ddcd081-061c-4ec9-b464-5cb4bba05cae.gif)
7