### PR TITLE
fix(launch): added instructions for newbies

### DIFF
--- a/packages/bp/src/core/app/bootstrap.ts
+++ b/packages/bp/src/core/app/bootstrap.ts
@@ -223,8 +223,8 @@ This is a fatal error, process will exit.`
   logger.info(`=`.repeat(75))
   logger.info(``)
 
-  logger.info(chalk.green`Botpress is ready`)
-  logger.info(chalk.bold`Botpress is listening at ${process.LOCAL_URL}`)
+  logger.info(chalk.bold`Botpress is ready.. open the Studio in your favorite browser.`)
+  logger.info(chalk.bold`Botpress is listening at ${process.LOCAL_URL} (browser)`)
   logger.info(chalk.bold`Botpress is exposed at ${process.EXTERNAL_URL}`)
 }
 

--- a/packages/bp/src/core/app/bootstrap.ts
+++ b/packages/bp/src/core/app/bootstrap.ts
@@ -215,8 +215,17 @@ This is a fatal error, process will exit.`
 
   // This ensures that the last log displayed is the correct URL
   await AppLifecycle.waitFor(AppLifecycleEvents.STUDIO_READY)
-  logger.info(`Botpress is listening at: ${process.LOCAL_URL}`)
-  logger.info(`Botpress is exposed at: ${process.EXTERNAL_URL}`)
+
+  logger.info(``)
+  logger.info(`=`.repeat(75))
+  logger.info(`-->  Documentation is available at    📘 https://botpress.com/docs`)
+  logger.info(`-->  Ask your questions on            👥 https://forum.botpress.com`)
+  logger.info(`=`.repeat(75))
+  logger.info(``)
+
+  logger.info(chalk.green`Botpress is ready`)
+  logger.info(chalk.bold`Botpress is listening at ${process.LOCAL_URL}`)
+  logger.info(chalk.bold`Botpress is exposed at ${process.EXTERNAL_URL}`)
 }
 
 start().catch(global.printErrorDefault)


### PR DESCRIPTION
## Description

When you use botpress for the first time, the amount of logs & information displayed is overwhelming.  There is way too many services & useless information logged.. 

A temporary fix is just to display that botpress is ready (in green) and point people to the documentation and the forum if they are stuck.

Also, it may not seem obvious for everybody that you should navigate the URL in your browser.. 

![image](https://user-images.githubusercontent.com/1315508/139756462-122dd603-7196-45d3-9e4a-792ba4e25deb.png)
