### PR TITLE
feat(core): allow CSRF Token Cookies

### DIFF
--- a/packages/bp/src/core/app/server.ts
+++ b/packages/bp/src/core/app/server.ts
@@ -282,6 +282,7 @@ export class HTTPServer {
     await this.sdkApiRouter.initialize()
 
     process.USE_JWT_COOKIES = yn(botpressConfig.jwtToken.useCookieStorage)
+    process.ALLOW_CSRF_COOKIES = yn(botpressConfig.jwtToken.allowCSRFCookieStorage)
 
     this.setupMessagingProxy()
 

--- a/packages/bp/src/core/config/botpress.config.ts
+++ b/packages/bp/src/core/config/botpress.config.ts
@@ -302,6 +302,11 @@ export interface BotpressConfig {
      */
     useCookieStorage: boolean
     /**
+     * Allow appending the CSRF token to cookies (Only valid when using JWT Cookies)
+     * @default false
+     */
+    allowCSRFCookieStorage: boolean
+    /**
      * Configure the options of the cookie sent to the user, for example the domain
      * @default {}
      */

--- a/packages/bp/src/core/security/auth-service.ts
+++ b/packages/bp/src/core/security/auth-service.ts
@@ -1,5 +1,5 @@
 import { Logger, StrategyUser } from 'botpress/sdk'
-import { JWT_COOKIE_NAME } from 'common/auth'
+import { JWT_COOKIE_NAME, CSRF_TOKEN_HEADER_LC } from 'common/auth'
 import { AuthPayload, AuthStrategyConfig, ChatUserAuth, TokenUser, TokenResponse } from 'common/typings'
 import { TYPES } from 'core/app/types'
 import { AuthStrategy, ConfigProvider } from 'core/config'
@@ -20,6 +20,7 @@ import _ from 'lodash'
 import moment from 'moment'
 import ms from 'ms'
 import { studioActions } from 'orchestrator'
+import yn from 'yn'
 
 export const TOKEN_AUDIENCE = 'collaborators'
 export const CHAT_USERS_AUDIENCE = 'chat_users'
@@ -371,6 +372,10 @@ export class AuthService {
 
     const config = await this.configProvider.getBotpressConfig()
     const cookieOptions = config.jwtToken.cookieOptions
+
+    if (yn(process.ALLOW_CSRF_COOKIES)) {
+      res.cookie(CSRF_TOKEN_HEADER_LC, token.csrf, { maxAge: token.exp, httpOnly: true, ...cookieOptions })
+    }
 
     res.cookie(JWT_COOKIE_NAME, token.jwt, { maxAge: token.exp, httpOnly: true, ...cookieOptions })
     return true

--- a/packages/bp/src/core/security/router-security.ts
+++ b/packages/bp/src/core/security/router-security.ts
@@ -51,7 +51,7 @@ export const checkTokenHeader = (authService: AuthService, audience?: string) =>
   }
 
   try {
-    const csrfToken = req.headers[CSRF_TOKEN_HEADER_LC] as string
+    const csrfToken = (req.headers[CSRF_TOKEN_HEADER_LC] || req.cookies[CSRF_TOKEN_HEADER_LC]) as string
     const tokenUser = await authService.checkToken(token, csrfToken, audience)
 
     if (!tokenUser) {

--- a/packages/bp/src/typings/global.d.ts
+++ b/packages/bp/src/typings/global.d.ts
@@ -63,6 +63,7 @@ declare namespace NodeJS {
     WEB_WORKER: number
     TRAINING_WORKERS: number[]
     USE_JWT_COOKIES: boolean
+    ALLOW_CSRF_COOKIES: boolean
     // The internal password is used for inter-process communication
     INTERNAL_PASSWORD: string
   }


### PR DESCRIPTION
## Description

Adds an option that allows including the CSRF token in the cookies whenever using JWT Cookies.

This is necessary to allow authenticated custom routes (bp.http.createRouterForBots) of being accessible in the browser in case the user is logged, the alternative is to use third-party tools to create the request but that will make this not practical for custom reports, for example. This is necessary because the CSRF token is necessary for authentication.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How has this been tested?

Tested using chrome by enabling and disabling the environment variables:

`BP_CONFIG_JWTTOKEN_USECOOKIESTORAGE=true` and
`BP_CONFIG_JWTTOKEN_ALLOWCSRFCOOKIESTORAGE=true`

The code below can be used to create a custom router in a hook 

`const router = bp.http.createRouterForBot('reports', { checkAuthentication: true })`
```
router.get('/report_1', (req, res) => {
          res.send('test')
})
```

Then the route is accessible by using `http://localhost:3000/api/v1/bots/___/mod/reports/report_1` in the browser in case you are logged

If you don't set `BP_CONFIG_JWTTOKEN_ALLOWCSRFCOOKIESTORAGE=true` the authentication will fail

- [X] Local Testing

**Test configuration**:
* BP version: 12.26.6
* Node version: 12.18.1
* Browser: Chrome
* Binary or source ?: Source

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
