### PR TITLE
fix(channel-web): display feedback actions on all q&a answers

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/MessageGroup.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/MessageGroup.tsx
@@ -91,11 +91,10 @@ class MessageGroup extends React.Component<Props> {
             {sortBy(messages, ['sent_on', 'eventId']).map((message, i) => {
               let payload = this.convertPayloadFromOldFormat(message)
 
-              if (payload?.wrapped) {
+              if (payload.wrapped) {
                 payload = { ...payload, wrapped: renderPayload(payload.wrapped) }
               } else {
                 payload = renderPayload(payload)
-
               }
 
               const showInlineFeedback =

--- a/modules/channel-web/src/views/lite/components/messages/MessageGroup.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/MessageGroup.tsx
@@ -88,17 +88,18 @@ class MessageGroup extends React.Component<Props> {
             <span data-from={fromLabel} className="from hidden" aria-hidden="true">
               {fromLabel}
             </span>
-            {sortBy(messages, ['sent_on', 'eventId']).map((message, i, messages) => {
-              const isLastMsg = i === messages.length - 1
+            {sortBy(messages, ['sent_on', 'eventId']).map((message, i) => {
               let payload = this.convertPayloadFromOldFormat(message)
+
               if (payload?.wrapped) {
                 payload = { ...payload, wrapped: renderPayload(payload.wrapped) }
               } else {
                 payload = renderPayload(payload)
+
               }
 
               const showInlineFeedback =
-                isBot && isLastMsg && (payload.wrapped ? payload.wrapped.collectFeedback : payload.collectFeedback)
+                isBot && (payload.wrapped ? payload.wrapped.collectFeedback : payload.collectFeedback)
 
               return (
                 <Message

--- a/packages/bp/src/core/events/event-repository.ts
+++ b/packages/bp/src/core/events/event-repository.ts
@@ -75,6 +75,8 @@ export class EventRepository {
     const storedEvent = events[0]
     const incomingEvent = storedEvent.event as sdk.IO.IncomingEvent
 
+    await this.updateEvent(storedEvent.id, {feedback})
+
     if (type) {
       const details = incomingEvent.decision?.sourceDetails
       const metric = feedback === 1 ? 'bp_core_feedback_positive' : 'bp_core_feedback_negative'


### PR DESCRIPTION
## Description

- Remove the condition of only displaying `feedback on lastMessages` 
- Save feedback on the `events table` to prevent displaying `feedbacks on every QnA answers` (see image below)
<img width="909" alt="Screen Shot 2021-11-03 at 8 24 53 AM" src="https://user-images.githubusercontent.com/13097764/140059739-b8e33058-cb3a-413b-8b46-a00a704db152.png">

## Media (how it feels like now)

https://user-images.githubusercontent.com/13097764/140059258-664ca462-6993-4a6a-a551-e1695154aba8.mov


Fixes # https://github.com/botpress/v12/issues/1160

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore change (refactoring and / or test changes)

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual test, by savings feedbacks and checking values on db
- [x] Manual test, by reloading the page and validation that answers with feedbacks (from event db) does not render feedback component anymore

**Test configuration**:
* BP version: 12.26.6
* Node version: 12.14.0
* OS: MacOS
* Browser: Chrome
* Binary or source ?: source

## Checklist:

- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I've included some media (picture/gif/video) if applicable to show the old and new behavior
