### PR TITLE
fix(core): fix chat auth expiry with messaging

### DIFF
--- a/packages/bp/src/core/security/auth-service.ts
+++ b/packages/bp/src/core/security/auth-service.ts
@@ -309,8 +309,10 @@ export class AuthService {
 
   private async _getChatAuthExpiry(channel: string, botId: string): Promise<Date | undefined> {
     try {
-      const config = await this.moduleLoader.configReader.getForBot(`channel-${channel}`, botId)
-      const authDuration = ms(_.get(config, 'chatUserAuthDuration', DEFAULT_CHAT_USER_AUTH_DURATION))
+      const config = await this.configProvider.getBotConfig(botId)
+      const authDuration = ms(
+        _.get(config.messaging?.channels[channel], 'chatUserAuthDuration', DEFAULT_CHAT_USER_AUTH_DURATION)
+      )
       return moment()
         .add(authDuration)
         .toDate()

--- a/packages/bp/src/core/security/auth-service.ts
+++ b/packages/bp/src/core/security/auth-service.ts
@@ -311,12 +311,14 @@ export class AuthService {
     let authDuration: string | undefined
 
     try {
-      if (channel === 'web') {
+      const config = await this.configProvider.getBotConfig(botId)
+      const channelConfig = config.messaging?.channels?.[channel]
+
+      if (channelConfig) {
+        authDuration = channelConfig.chatUserAuthDuration
+      } else {
         const config = await this.moduleLoader.configReader.getForBot(`channel-${channel}`, botId)
         authDuration = config?.chatUserAuthDuration
-      } else {
-        const config = await this.configProvider.getBotConfig(botId)
-        authDuration = config.messaging?.channels?.[channel]?.chatUserAuthDuration
       }
     } catch (err) {
       this.logger

--- a/packages/bp/src/core/security/auth-service.ts
+++ b/packages/bp/src/core/security/auth-service.ts
@@ -310,9 +310,8 @@ export class AuthService {
   private async _getChatAuthExpiry(channel: string, botId: string): Promise<Date | undefined> {
     try {
       const config = await this.configProvider.getBotConfig(botId)
-      const authDuration = ms(
-        _.get(config.messaging?.channels[channel], 'chatUserAuthDuration', DEFAULT_CHAT_USER_AUTH_DURATION)
-      )
+      const channelConfig = config.messaging?.channels?.[channel]
+      const authDuration = ms(_.get(channelConfig, 'chatUserAuthDuration', DEFAULT_CHAT_USER_AUTH_DURATION))
       return moment()
         .add(authDuration)
         .toDate()


### PR DESCRIPTION
Cherry picked from https://github.com/botpress/botpress/pull/5654/commits/68eda02d33449edbccb8418dceada57bd7c4e52b

** Edit: actually had to handle the case of channel web which was not migrated yet. Also re-edited to make it future proof, so even if we forget to change this part of the code when we move channel web, it will just work.