### PR TITLE
fix(auth): remove add to ws in user creation

### DIFF
--- a/packages/bp/src/core/security/auth-service.ts
+++ b/packages/bp/src/core/security/auth-service.ts
@@ -156,11 +156,6 @@ export class AuthService {
     })
     const strategyUser = createdUser.result
 
-    const workspaces = await this._getWorkspacesForStrategy(strategy)
-    await Promise.map(workspaces, workspace =>
-      this.workspaceService.addUserToWorkspace(strategyUser.email, strategyUser.strategy, workspace)
-    )
-
     if (_.get(await this.getStrategy(strategy), 'type') === 'basic') {
       return this.strategyBasic.resetPassword(user.email, strategy)
     }
@@ -258,19 +253,6 @@ export class AuthService {
     }
 
     return false
-  }
-
-  private async _getWorkspacesForStrategy(strategy: string): Promise<string[]> {
-    const workspaces = await this.workspaceService.getWorkspaces()
-
-    const list: string[] = []
-    for (const workspace of workspaces) {
-      if (workspace.authStrategies.includes(strategy)) {
-        list.push(workspace.id)
-      }
-    }
-
-    return list
   }
 
   private async _createFirstUser(user: Partial<StrategyUser>, strategy: string): Promise<StrategyUser> {


### PR DESCRIPTION
## Description

Users were "created" while being added to allowed workspaces but users were created first, meaning we created users twice. I simply moved the code to [pro auth-strategies](https://github.com/botpress/botpress-pro/pull/61) so we get the expected behaviour 

Created a docker image, deployed on an instance, configured auth strategies, created users and single user was created as of before it was doubled. (doubly checked by @sebburon )
If you want to try it yourself, pull [effit/bp:signon](https://hub.docker.com/repository/docker/effit/bp) docker image on docker hub

Fixes https://github.com/botpress/v12/issues/1550
Closes DEV-2007

- [ ] Bug fix (non-breaking change which fixes an issue)
