### PR TITLE
fix(channel-web): disable autoscroll when user scroll manually

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
@@ -45,8 +45,7 @@ class MessageList extends React.Component<MessageListProps, State> {
     // this should account for keyboard rendering as it triggers a resize of the messagesDiv
     this.divSizeObserver = new ResizeObserver(
       debounce(
-        ([divResizeEntry]) => {
-          // we don't need to do anything with the resize entry
+        ([_divResizeEntry]) => {
           this.tryScrollToBottom()
         },
         200,
@@ -205,7 +204,7 @@ class MessageList extends React.Component<MessageListProps, State> {
 
   handleScroll = debounce(e => {
     const scroll = this.messagesDiv.scrollHeight - this.messagesDiv.scrollTop - this.messagesDiv.clientHeight
-    const manualScroll = scroll >= 150
+    const manualScroll = scroll > 0
     const showNewMessageIndicator = this.state.showNewMessageIndicator && manualScroll
 
     this.setState({ manualScroll, showNewMessageIndicator })


### PR DESCRIPTION
## Description

This PR fixes an issue where scrolling less than 150px would automatically scroll you back at the bottom of the webchat

Fixes botpress/v12#1527 and botpress/v12#1527
Closes DEV-1952

**Before**

https://user-images.githubusercontent.com/9640576/142050099-16232e4b-05f7-450a-96ae-b9a693f83cee.mp4

**After**

https://user-images.githubusercontent.com/9640576/142049837-e7bb06f4-d742-456d-a711-ec4eba9e4acf.mp4

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
