### PR TITLE
feat: adds hit counter for repo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,5 @@ Botpress is dual-licensed under [AGPLv3](/licenses/LICENSE_AGPL3) and the [Botpr
 By default, any bot created with Botpress is licensed under AGPLv3, but you may change to the Botpress License from within your bot's web interface in a few clicks.
 
 For more information about how the dual-license works and why it works that way, please see the <a href="https://botpress.com/faq">FAQS</a>.
+
+![](https://api.segment.io/v1/pixel/page?data=eyJ3cml0ZUtleSI6InczR0xQaGFwY1RqTjdZVnJZQVFYU05Wam9yVUFNOXBmIiwidXNlcklkIjoiYW5vbnltb3VzIn0=)


### PR DESCRIPTION
## Description

Adds hit counter (tracking pixel) to README.md connecting to Segment. It's anonymous, but it will help us have the GitHub repo stats all in one place.

Fixes # (issue)

## Type of change

## How has this been tested?

I just opened the readme in the branch, and got a hit event in Segment!