### PR TITLE
fix(dx): fix e2e tests

### DIFF
--- a/packages/bp/e2e/studio/ui.test.ts
+++ b/packages/bp/e2e/studio/ui.test.ts
@@ -9,6 +9,7 @@ describe('Studio - UI', () => {
 
   it('Emulator window toggle properly with shortcut', async () => {
     await page.waitFor(1000)
+    await page.keyboard.press('Escape')
     await page.focus('#mainLayout')
     await page.type('#mainLayout', 'e')
     await page.keyboard.type('Much automated!')

--- a/packages/bp/e2e/utils.ts
+++ b/packages/bp/e2e/utils.ts
@@ -142,8 +142,20 @@ export const closeToaster = async () => {
 }
 
 const shouldLogRequest = (url: string) => {
-  const ignoredExt = ['.js', '.mp3', '.png', '.svg', '.css']
-  const ignoredWords = ['image/', 'google-analytics', 'css', 'public/js', 'static/js']
+  const ignoredExt = ['.js', '.mp3', '.png', '.svg', '.css', '.woff2', '.ttf']
+  const ignoredWords = [
+    'image/',
+    'google-analytics',
+    'css',
+    'public/js',
+    'static/js',
+    'google.com',
+    'gstatic',
+    'fonts/',
+    'segment.com',
+    'segment.io',
+    'googletagmanager'
+  ]
 
   return !ignoredExt.find(x => url.endsWith(x)) && !ignoredWords.find(x => url.includes(x))
 }


### PR DESCRIPTION
Since a merge on the studio, the emulator is displayed by default, so of course the toggle didn't work. This will close it then re-open it to make it work. Let's see if it does the trick... Also added some links to the ignore list because logs contained too much garbage