### PR TITLE
feat(admin): create bot cloud-ready options

### DIFF
--- a/packages/bp/e2e/admin/bots.test.ts
+++ b/packages/bp/e2e/admin/bots.test.ts
@@ -13,10 +13,11 @@ import {
   triggerKeyboardShortcut
 } from '../utils'
 
-describe('Admin - Bot Management', () => {
+describe.only('Admin - Bot Management', () => {
   const tempBotId = 'lol-bot'
   const importBotId = 'import-bot'
   const workspaceId = 'default'
+  const apiKey = '1234567890'
 
   const clickButtonForBot = async (buttonId: string, botId: string) => {
     const botRow = await expectMatchElement('.bp_table-row', { text: botId })
@@ -62,12 +63,15 @@ describe('Admin - Bot Management', () => {
 
   it('Create temporary bot', async () => {
     await clickOn('#btn-create-bot')
-    await page.waitFor(100)
+    await page.waitForSelector('#btn-new-bot')
     await clickOn('#btn-new-bot')
 
     await fillField('#input-bot-name', tempBotId)
     await fillField('#select-bot-templates', 'Welcome Bot') // Using fill instead of select because options are created dynamically
     await page.keyboard.press('Enter')
+
+    await clickOn('#checkbox-bot-cloud')
+    await fillField('#bot-api-key', apiKey)
 
     await Promise.all([expectAdminApiCallSuccess('workspace/bots', 'POST'), clickOn('#btn-modal-create-bot')])
   })

--- a/packages/bp/src/admin/ui/src/app/translations/en.json
+++ b/packages/bp/src/admin/ui/src/app/translations/en.json
@@ -268,7 +268,13 @@
           "nameHelper": "It will be displayed to your visitors. You can change it anytime.",
           "namePlaceholder": "The name of your bot",
           "newBot": "Create a new bot",
-          "template": "Bot Template"
+          "template": "Bot Template",
+          "cloud": "Botpress Cloud Deployment",
+          "cloudCheckbox": "Create a Botpress cloud-ready bot",
+          "cloudHelper": "This bot can then be exported using the Export option in the upper right section of the Studio. Once exported on disk, it should be imported via the Botpress Cloud Deployment manager for cloud deployment. <a>Sign up here</a> for the Alpha release.",
+          "api": "API Key",
+          "apiPlaceholder": "API Key",
+          "apiHelper": "You can get your API key from the <a>Botpress Cloud Deployment manager</a>."
         },
         "createBot": "Create Bot",
         "createYourFirstBot": "Create your first bot to start building.",

--- a/packages/bp/src/admin/ui/src/app/translations/es.json
+++ b/packages/bp/src/admin/ui/src/app/translations/es.json
@@ -264,7 +264,13 @@
           "nameHelper": "Se mostrará a sus visitantes. Puede cambiarlo en cualquier momento.",
           "namePlaceholder": "El nombre de tu bot",
           "newBot": "Crea un nuevo bot",
-          "template": "Plantilla de bot"
+          "template": "Plantilla de bot",
+          "cloud": "Botpress Cloud Deployment",
+          "cloudCheckbox": "Create a Botpress cloud-ready bot",
+          "cloudHelper": "This bot can then be exported using the Export option in the upper right section of the Studio. Once exported on disk, it should be imported via the Botpress Cloud Deployment manager for cloud deployment. <a>Sign up here</a> for the Alpha release.",
+          "api": "API Key",
+          "apiPlaceholder": "API Key",
+          "apiHelper": "You can get your API key from the <a>Botpress Cloud Deployment manager</a>."
         },
         "createBot": "Create Bot",
         "createYourFirstBot": "Crea tu primer bot para comenzar a construir.",

--- a/packages/bp/src/admin/ui/src/app/translations/fr.json
+++ b/packages/bp/src/admin/ui/src/app/translations/fr.json
@@ -265,7 +265,13 @@
           "nameHelper": "Il sera affiché à vos visiteurs. Vous pouvez le modifier à tout moment.",
           "namePlaceholder": "Le nom de votre bot",
           "newBot": "Créer un nouveau bot",
-          "template": "Modèle de bot"
+          "template": "Modèle de bot",
+          "cloud": "Botpress Cloud Deployment",
+          "cloudCheckbox": "Create a Botpress cloud-ready bot",
+          "cloudHelper": "This bot can then be exported using the Export option in the upper right section of the Studio. Once exported on disk, it should be imported via the Botpress Cloud Deployment manager for cloud deployment. <a>Sign up here</a> for the Alpha release.",
+          "api": "API Key",
+          "apiPlaceholder": "API Key",
+          "apiHelper": "You can get your API key from the <a>Botpress Cloud Deployment manager</a>."
         },
         "createBot": "Créer un bot",
         "createYourFirstBot": "Créez votre premier bot pour commencer à construire.",

--- a/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
@@ -163,7 +163,7 @@ class CreateBotModal extends Component<Props, State> {
           <div className={Classes.DIALOG_BODY}>
             <FormGroup
               label={lang.tr('admin.workspace.bots.create.name')}
-              labelFor="bot-name"
+              labelFor="input-bot-name"
               labelInfo="*"
               helperText={lang.tr('admin.workspace.bots.create.nameHelper')}
             >
@@ -223,11 +223,13 @@ class CreateBotModal extends Component<Props, State> {
             )}
             <FormGroup
               label={lang.tr('admin.workspace.bots.create.cloud')}
+              labelFor="checkbox-bot-cloud"
               helperText={lang.tr('admin.workspace.bots.create.cloudHelper', {
                 a: (str: string) => <a href={'/#' /* TODO: Replace with link to Alpha Release Signup */}>{str}</a>
               })}
             >
               <Checkbox
+                id="checkbox-bot-cloud"
                 label={lang.tr('admin.workspace.bots.create.cloudCheckbox')}
                 checked={this.state.isCloudBot}
                 onChange={e => this.setState({ isCloudBot: e.target.checked })}
@@ -236,6 +238,7 @@ class CreateBotModal extends Component<Props, State> {
             {this.state.isCloudBot && (
               <FormGroup
                 label={lang.tr('admin.workspace.bots.create.api')}
+                labelFor="bot-api-key"
                 helperText={lang.tr('admin.workspace.bots.create.apiHelper', {
                   a: (str: string) => (
                     <a href={'/#' /* TODO: Replace with link to Botpress Cloud Deployment manager */}>{str}</a>
@@ -243,7 +246,7 @@ class CreateBotModal extends Component<Props, State> {
                 })}
               >
                 <InputGroup
-                  id="botapikey"
+                  id="bot-api-key"
                   tabIndex={2}
                   placeholder={lang.tr('admin.workspace.bots.create.apiPlaceholder')}
                   value={this.state.bpCloudApiKey}

--- a/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
+++ b/packages/bp/src/admin/ui/src/workspace/bots/CreateBotModal.tsx
@@ -1,6 +1,6 @@
 import { Button, Classes, Dialog, FormGroup, InputGroup, Intent, Callout } from '@blueprintjs/core'
 import { BotConfig, BotTemplate } from 'botpress/sdk'
-import { lang } from 'botpress/shared'
+import { Checkbox, lang } from 'botpress/shared'
 import _ from 'lodash'
 import ms from 'ms'
 import React, { Component } from 'react'
@@ -44,16 +44,20 @@ interface State {
 
   selectedTemplate?: BotTemplate
   selectedCategory?: SelectOption<string>
+  isCloudBot: boolean
+  bpCloudApiKey: string
 }
 
-const defaultState = {
+const defaultState: Omit<State, 'templates' | 'categories'> = {
   botId: '',
   botName: '',
   selectedCategory: undefined,
   selectedTemplate: undefined,
   error: undefined,
   isProcessing: false,
-  generateId: true
+  generateId: true,
+  isCloudBot: false,
+  bpCloudApiKey: ''
 }
 
 class CreateBotModal extends Component<Props, State> {
@@ -117,7 +121,9 @@ class CreateBotModal extends Component<Props, State> {
       id: this.state.botId,
       name: this.state.botName,
       template: _.pick(this.state.selectedTemplate, ['id', 'moduleId']),
-      category: this.state.selectedCategory && this.state.selectedCategory.value
+      category: this.state.selectedCategory && this.state.selectedCategory.value,
+      isCloudBot: this.state.isCloudBot,
+      bpCloudApiKey: this.state.bpCloudApiKey
     }
 
     try {
@@ -212,6 +218,36 @@ class CreateBotModal extends Component<Props, State> {
                   options={this.state.categories}
                   value={this.state.selectedCategory}
                   onChange={selectedCategory => this.setState({ selectedCategory: selectedCategory as any })}
+                />
+              </FormGroup>
+            )}
+            <FormGroup
+              label={lang.tr('admin.workspace.bots.create.cloud')}
+              helperText={lang.tr('admin.workspace.bots.create.cloudHelper', {
+                a: (str: string) => <a href={'/#' /* TODO: Replace with link to Alpha Release Signup */}>{str}</a>
+              })}
+            >
+              <Checkbox
+                label={lang.tr('admin.workspace.bots.create.cloudCheckbox')}
+                checked={this.state.isCloudBot}
+                onChange={e => this.setState({ isCloudBot: e.target.checked })}
+              />
+            </FormGroup>
+            {this.state.isCloudBot && (
+              <FormGroup
+                label={lang.tr('admin.workspace.bots.create.api')}
+                helperText={lang.tr('admin.workspace.bots.create.apiHelper', {
+                  a: (str: string) => (
+                    <a href={'/#' /* TODO: Replace with link to Botpress Cloud Deployment manager */}>{str}</a>
+                  )
+                })}
+              >
+                <InputGroup
+                  id="botapikey"
+                  tabIndex={2}
+                  placeholder={lang.tr('admin.workspace.bots.create.apiPlaceholder')}
+                  value={this.state.bpCloudApiKey}
+                  onChange={e => this.setState({ bpCloudApiKey: e.target.value })}
                 />
               </FormGroup>
             )}

--- a/packages/ui-shared-lite/Checkbox/index.tsx
+++ b/packages/ui-shared-lite/Checkbox/index.tsx
@@ -1,15 +1,14 @@
-// @ts-nocheck
 import { Checkbox } from '@blueprintjs/core'
 import cx from 'classnames'
-import React, { FC } from 'react'
+import React from 'react'
 
 import style from './style.scss'
 import { CheckboxProps } from './typings'
 
-const SharedCheckbox: FC<CheckboxProps> = ({ fieldKey, label, className, checked, onChange, children }) => {
+const SharedCheckbox = ({ fieldKey, label, className, checked, onChange, children, ...props }: CheckboxProps) => {
   return (
     <div key={fieldKey} className={cx(style.checkboxWrapper, className, 'checkbox-wrapper')}>
-      <Checkbox checked={checked} key={fieldKey} label={label} onChange={onChange} />
+      <Checkbox checked={checked} key={fieldKey} label={label as string} onChange={onChange} {...props} />
       {children}
     </div>
   )

--- a/packages/ui-shared-lite/Checkbox/typings.d.ts
+++ b/packages/ui-shared-lite/Checkbox/typings.d.ts
@@ -1,6 +1,6 @@
-// @ts-nocheck
+import { CheckboxProps as BlueprintCheckboxProps } from '@blueprintjs/core'
 import { ChangeEvent } from 'react'
-export interface CheckboxProps {
+export interface CheckboxProps extends BlueprintCheckboxProps {
   fieldKey?: string
   className?: string
   label: string | JSX.Element


### PR DESCRIPTION
## Description

This PR adds the cloud-ready options to the CreatBotModal
Linear: https://linear.app/botpress/issue/DEV-2026/a-user-can-enter-cloud-ready-options-when-creating-a-bot-on-the-admin

### Alpha Version
- Missing Translations
- Not final copy
- Missing links to alpha sign up and cloud manager

![Screen Shot 2021-11-24 at 11 42 22 AM](https://user-images.githubusercontent.com/159949/143279557-e5e4ae8b-3645-4f42-b6c3-d56dc91d8eae.png)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
