### PR TITLE
feat(admin): create bot cloud-ready option

### DIFF
--- a/packages/bp/e2e/admin/bots.test.ts
+++ b/packages/bp/e2e/admin/bots.test.ts
@@ -64,12 +64,18 @@ describe('Admin - Bot Management', () => {
 
   it('Create temporary bot', async () => {
     await clickOn('#btn-create-bot')
-    await page.waitFor(100)
+    await page.waitForSelector('#btn-new-bot')
     await clickOn('#btn-new-bot')
 
     await fillField('#input-bot-name', tempBotId)
     await fillField('#select-bot-templates', 'Welcome Bot') // Using fill instead of select because options are created dynamically
     await page.keyboard.press('Enter')
+
+    // Test cloud bot interface
+    await clickOn('#checkbox-bot-cloud')
+    await fillField('#cloud-client-id', 'abc')
+    await fillField('#cloud-client-secret', '123')
+    await clickOn('#checkbox-bot-cloud')
 
     await Promise.all([expectAdminApiCallSuccess('workspace/bots', 'POST'), clickOn('#btn-modal-create-bot')])
   })

--- a/packages/bp/src/admin/workspace/bots/bots-router.ts
+++ b/packages/bp/src/admin/workspace/bots/bots-router.ts
@@ -57,7 +57,7 @@ class BotsRouter extends CustomAdminRouter {
       this.checkTokenHeader,
       this.needPermissions('write', 'admin.bots'),
       this.asyncMiddleware(async (req, res) => {
-        const bot = <BotConfig>_.pick(req.body, ['id', 'name', 'category', 'defaultLanguage'])
+        const bot = <BotConfig>_.pick(req.body, ['id', 'name', 'category', 'defaultLanguage', 'isCloudBot', 'cloud'])
 
         const botExists = (await this.botService.getBotsIds()).includes(bot.id)
         const botLinked = (await this.workspaceService.getBotRefs()).includes(bot.id)

--- a/packages/bp/src/common/defaults.ts
+++ b/packages/bp/src/common/defaults.ts
@@ -155,3 +155,5 @@ export const BUILTIN_MODULES = [
   'testing',
   'uipath'
 ]
+
+export const defaultOauthUrl = 'https://oauth.botpress.dev/oauth2/token'

--- a/packages/ui-admin/src/app/translations/en.json
+++ b/packages/ui-admin/src/app/translations/en.json
@@ -270,7 +270,14 @@
           "nameHelper": "It will be displayed to your visitors. You can change it anytime.",
           "namePlaceholder": "The name of your bot",
           "newBot": "Create a new bot",
-          "template": "Bot Template"
+          "template": "Bot Template",
+          "cloud": "Botpress Cloud Deployment",
+          "cloudCheckbox": "Create a Botpress cloud-ready bot",
+          "cloudHelper": "This bot can then be exported using the Export option in the upper right section of the Studio. Once exported on disk, it should be imported via the Botpress Cloud Deployment manager for cloud deployment. Sign up here for the Alpha release.",
+          "cloudConfiguration": "Cloud Configuration",
+          "cloudConfigurationHelper": "You can get your Client Key and Secret from the Botpress Cloud Deployment manager.",
+          "clientIdPlaceholder": "Client Key",
+          "clientSecretPlaceholder": "Client Secret"
         },
         "createBot": "Create Bot",
         "createYourFirstBot": "Create your first bot to start building.",

--- a/packages/ui-admin/src/app/translations/es.json
+++ b/packages/ui-admin/src/app/translations/es.json
@@ -265,7 +265,14 @@
           "nameHelper": "Se mostrará a sus visitantes. Puede cambiarlo en cualquier momento.",
           "namePlaceholder": "El nombre de tu bot",
           "newBot": "Crea un nuevo bot",
-          "template": "Plantilla de bot"
+          "template": "Plantilla de bot",
+          "cloud": "Botpress Cloud Deployment",
+          "cloudCheckbox": "Create a Botpress cloud-ready bot",
+          "cloudHelper": "This bot can then be exported using the Export option in the upper right section of the Studio. Once exported on disk, it should be imported via the Botpress Cloud Deployment manager for cloud deployment. Sign up here for the Alpha release.",
+          "cloudConfiguration": "Cloud Configuration",
+          "cloudConfigurationHelper": "You can get your Client Key and Secret from the Botpress Cloud Deployment manager.",
+          "clientIdPlaceholder": "Client Key",
+          "clientSecretPlaceholder": "Client Secret"
         },
         "createBot": "Create Bot",
         "createYourFirstBot": "Crea tu primer bot para comenzar a construir.",

--- a/packages/ui-admin/src/app/translations/fr.json
+++ b/packages/ui-admin/src/app/translations/fr.json
@@ -265,7 +265,14 @@
           "nameHelper": "Il sera affiché à vos visiteurs. Vous pouvez le modifier à tout moment.",
           "namePlaceholder": "Le nom de votre bot",
           "newBot": "Créer un nouveau bot",
-          "template": "Modèle de bot"
+          "template": "Modèle de bot",
+          "cloud": "Botpress Cloud Deployment",
+          "cloudCheckbox": "Create a Botpress cloud-ready bot",
+          "cloudHelper": "This bot can then be exported using the Export option in the upper right section of the Studio. Once exported on disk, it should be imported via the Botpress Cloud Deployment manager for cloud deployment. Sign up here for the Alpha release.",
+          "cloudConfiguration": "Cloud Configuration",
+          "cloudConfigurationHelper": "You can get your Client Key and Secret from the Botpress Cloud Deployment manager.",
+          "clientIdPlaceholder": "Client Key",
+          "clientSecretPlaceholder": "Client Secret"
         },
         "createBot": "Créer un bot",
         "createYourFirstBot": "Créez votre premier bot pour commencer à construire.",

--- a/packages/ui-admin/src/workspace/bots/CreateBotModal.tsx
+++ b/packages/ui-admin/src/workspace/bots/CreateBotModal.tsx
@@ -276,7 +276,7 @@ class CreateBotModal extends Component<Props, State> {
                   placeholder={lang.tr('admin.workspace.bots.create.clientSecretPlaceholder')}
                   value={this.state.cloudClientSecret}
                   type="password"
-                  pattern="\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b"
+                  pattern=".+"
                   required={this.state.isCloudBot}
                   onChange={e =>
                     this.setState({

--- a/packages/ui-admin/src/workspace/bots/CreateBotModal.tsx
+++ b/packages/ui-admin/src/workspace/bots/CreateBotModal.tsx
@@ -157,7 +157,15 @@ class CreateBotModal extends Component<Props, State> {
       !botId ||
       !botName ||
       (this.props.existingBots && this.props.existingBots.some(bot => bot.name === botName || bot.id === botId))
-    return isNameOrIdInvalid || isProcessing || !selectedTemplate || !this._form || !this._form.checkValidity()
+    const isCloudConfigInvalid = this.state.isCloudBot && (!this.state.cloudClientId || !this.state.cloudClientSecret)
+    return (
+      isNameOrIdInvalid ||
+      isCloudConfigInvalid ||
+      isProcessing ||
+      !selectedTemplate ||
+      !this._form ||
+      !this._form.checkValidity()
+    )
   }
 
   render() {
@@ -255,6 +263,8 @@ class CreateBotModal extends Component<Props, State> {
                   placeholder={lang.tr('admin.workspace.bots.create.clientIdPlaceholder')}
                   value={this.state.cloudClientId}
                   className={style.clientId}
+                  pattern="\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b"
+                  required={this.state.isCloudBot}
                   onChange={e =>
                     this.setState({
                       cloudClientId: e.target.value
@@ -266,6 +276,8 @@ class CreateBotModal extends Component<Props, State> {
                   placeholder={lang.tr('admin.workspace.bots.create.clientSecretPlaceholder')}
                   value={this.state.cloudClientSecret}
                   type="password"
+                  pattern="\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b"
+                  required={this.state.isCloudBot}
                   onChange={e =>
                     this.setState({
                       cloudClientSecret: e.target.value

--- a/packages/ui-admin/src/workspace/bots/CreateBotModal.tsx
+++ b/packages/ui-admin/src/workspace/bots/CreateBotModal.tsx
@@ -1,6 +1,7 @@
-import { Button, Classes, Dialog, FormGroup, InputGroup, Intent, Callout } from '@blueprintjs/core'
+import { Button, Classes, Dialog, FormGroup, InputGroup, Intent, Callout, Checkbox } from '@blueprintjs/core'
 import { BotConfig, BotTemplate } from 'botpress/sdk'
-import { Checkbox, lang } from 'botpress/shared'
+import { lang } from 'botpress/shared'
+import { defaultOauthUrl } from 'common/defaults'
 import _ from 'lodash'
 import ms from 'ms'
 import React, { Component } from 'react'
@@ -133,7 +134,7 @@ class CreateBotModal extends Component<Props, State> {
       newBot.cloud = {
         clientId: this.state.cloudClientId,
         clientSecret: this.state.cloudClientSecret,
-        oauthUrl: 'https://oauth.botpress.dev/oauth2/token'
+        oauthUrl: defaultOauthUrl
       }
     }
 
@@ -157,15 +158,7 @@ class CreateBotModal extends Component<Props, State> {
       !botId ||
       !botName ||
       (this.props.existingBots && this.props.existingBots.some(bot => bot.name === botName || bot.id === botId))
-    const isCloudConfigInvalid = this.state.isCloudBot && (!this.state.cloudClientId || !this.state.cloudClientSecret)
-    return (
-      isNameOrIdInvalid ||
-      isCloudConfigInvalid ||
-      isProcessing ||
-      !selectedTemplate ||
-      !this._form ||
-      !this._form.checkValidity()
-    )
+    return isNameOrIdInvalid || isProcessing || !selectedTemplate || !this._form || !this._form.checkValidity()
   }
 
   render() {
@@ -247,7 +240,7 @@ class CreateBotModal extends Component<Props, State> {
                 checked={this.state.isCloudBot}
                 onChange={e =>
                   this.setState({
-                    isCloudBot: e.target.checked
+                    isCloudBot: e.currentTarget.checked
                   })
                 }
               />
@@ -263,8 +256,6 @@ class CreateBotModal extends Component<Props, State> {
                   placeholder={lang.tr('admin.workspace.bots.create.clientIdPlaceholder')}
                   value={this.state.cloudClientId}
                   className={style.clientId}
-                  pattern="\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b"
-                  required={this.state.isCloudBot}
                   onChange={e =>
                     this.setState({
                       cloudClientId: e.target.value
@@ -276,8 +267,6 @@ class CreateBotModal extends Component<Props, State> {
                   placeholder={lang.tr('admin.workspace.bots.create.clientSecretPlaceholder')}
                   value={this.state.cloudClientSecret}
                   type="password"
-                  pattern=".+"
-                  required={this.state.isCloudBot}
                   onChange={e =>
                     this.setState({
                       cloudClientSecret: e.target.value

--- a/packages/ui-admin/src/workspace/bots/style.scss
+++ b/packages/ui-admin/src/workspace/bots/style.scss
@@ -180,3 +180,7 @@
   height: 18px;
   padding-right: 10px;
 }
+
+.clientId {
+  margin-bottom: 5px;
+}

--- a/packages/ui-admin/src/workspace/bots/style.scss.d.ts
+++ b/packages/ui-admin/src/workspace/bots/style.scss.d.ts
@@ -6,6 +6,7 @@ interface CssExports {
   'bot_views': string;
   'botbadge': string;
   'bottomRow': string;
+  'clientId': string;
   'compact_view': string;
   'create': string;
   'createbot_btn': string;

--- a/packages/ui-shared-lite/Checkbox/index.tsx
+++ b/packages/ui-shared-lite/Checkbox/index.tsx
@@ -1,15 +1,14 @@
-// @ts-nocheck
 import { Checkbox } from '@blueprintjs/core'
 import cx from 'classnames'
-import React, { FC } from 'react'
+import React from 'react'
 
 import style from './style.scss'
 import { CheckboxProps } from './typings'
 
-const SharedCheckbox: FC<CheckboxProps> = ({ fieldKey, label, className, checked, onChange, children }) => {
+const SharedCheckbox = ({ fieldKey, label, className, checked, onChange, children, ...props }: CheckboxProps) => {
   return (
     <div key={fieldKey} className={cx(style.checkboxWrapper, className, 'checkbox-wrapper')}>
-      <Checkbox checked={checked} key={fieldKey} label={label} onChange={onChange} />
+      <Checkbox checked={checked} key={fieldKey} label={label as string} onChange={onChange} {...props} />
       {children}
     </div>
   )

--- a/packages/ui-shared-lite/Checkbox/index.tsx
+++ b/packages/ui-shared-lite/Checkbox/index.tsx
@@ -1,14 +1,15 @@
+// @ts-nocheck
 import { Checkbox } from '@blueprintjs/core'
 import cx from 'classnames'
-import React from 'react'
+import React, { FC } from 'react'
 
 import style from './style.scss'
 import { CheckboxProps } from './typings'
 
-const SharedCheckbox = ({ fieldKey, label, className, checked, onChange, children, ...props }: CheckboxProps) => {
+const SharedCheckbox: FC<CheckboxProps> = ({ fieldKey, label, className, checked, onChange, children }) => {
   return (
     <div key={fieldKey} className={cx(style.checkboxWrapper, className, 'checkbox-wrapper')}>
-      <Checkbox checked={checked} key={fieldKey} label={label as string} onChange={onChange} {...props} />
+      <Checkbox checked={checked} key={fieldKey} label={label} onChange={onChange} />
       {children}
     </div>
   )

--- a/packages/ui-shared-lite/Checkbox/typings.d.ts
+++ b/packages/ui-shared-lite/Checkbox/typings.d.ts
@@ -1,6 +1,6 @@
-// @ts-nocheck
+import { CheckboxProps as BlueprintCheckboxProps } from '@blueprintjs/core'
 import { ChangeEvent } from 'react'
-export interface CheckboxProps {
+export interface CheckboxProps extends BlueprintCheckboxProps {
   fieldKey?: string
   className?: string
   label: string | JSX.Element

--- a/packages/ui-shared-lite/Checkbox/typings.d.ts
+++ b/packages/ui-shared-lite/Checkbox/typings.d.ts
@@ -1,6 +1,6 @@
-import { CheckboxProps as BlueprintCheckboxProps } from '@blueprintjs/core'
+// @ts-nocheck
 import { ChangeEvent } from 'react'
-export interface CheckboxProps extends BlueprintCheckboxProps {
+export interface CheckboxProps {
   fieldKey?: string
   className?: string
   label: string | JSX.Element


### PR DESCRIPTION
## Description

Adds a cloud-ready option checkbox to the create bot modal. Also allows entering (but does not require) a cloud API Key.

### Alpha

- copy not finalized
- translations not present

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

Made sure these options are visited in current e2e tests

## Related PRs

- https://github.com/botpress/typings/pull/2
- https://github.com/botpress/studio/pull/212

![Screen Shot 2021-11-24 at 11 04 58 AM 2](https://user-images.githubusercontent.com/159949/143315502-a4133a09-2b85-4e5e-a7f6-200106cb2f55.png)