### PR TITLE
chore(dx): update typescript

### DIFF
--- a/build/downloader/package.json
+++ b/build/downloader/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "cli-progress": "^3.8.2",
-    "typescript": "^4.2.4"
+    "typescript": "^4.4.4"
   },
   "devDependencies": {
     "@types/cli-progress": "^3.8.0"

--- a/build/downloader/tsconfig.json
+++ b/build/downloader/tsconfig.json
@@ -13,6 +13,7 @@
     "baseUrl": "./src",
     "outDir": "./out",
     "typeRoots": ["../../node_modules/@types"],
-    "types": []
+    "types": [],
+    "useUnknownInCatchVariables": false
   }
 }

--- a/build/module-builder/package.json
+++ b/build/module-builder/package.json
@@ -39,7 +39,7 @@
     "style-loader": "^0.23.0",
     "tar": "^4.4.19",
     "ts-loader": "^6.0.0",
-    "typescript": "^3.9.7",
+    "typescript": "^4.4.4",
     "typescript-json-schema": "^0.50.0",
     "webpack": "^4.20.2",
     "yar": "^9.0.2",

--- a/build/module-builder/yarn.lock
+++ b/build/module-builder/yarn.lock
@@ -5934,15 +5934,15 @@ typescript-json-schema@^0.50.0:
     typescript "^4.2.3"
     yargs "^16.2.0"
 
-typescript@^3.9.7:
-  version "3.9.9"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
-  integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
-
 typescript@^4.2.3:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+
+typescript@^4.4.4:
+  version "4.5.2"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 uglify-es@^3.3.4:
   version "3.3.9"

--- a/modules/tsconfig.shared.json
+++ b/modules/tsconfig.shared.json
@@ -8,6 +8,7 @@
     "resolveJsonModule": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
+    "useUnknownInCatchVariables": false,
     "noEmit": true,
     "module": "commonjs",
     "moduleResolution": "node",

--- a/modules/tsconfig_view.shared.json
+++ b/modules/tsconfig_view.shared.json
@@ -4,6 +4,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "experimentalDecorators": true,
+    "useUnknownInCatchVariables": false,
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "es5",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "showdown": "^1.9.1",
     "ts-jest": "^24.3.0",
     "typedoc": "^0.13.0",
-    "typescript": "^4.2.4",
+    "typescript": "^4.4.4",
     "typescript-json-schema": "^0.50.0"
   },
   "optionalDependencies": {

--- a/packages/bp/src/admin/ui/tsconfig_bp.json
+++ b/packages/bp/src/admin/ui/tsconfig_bp.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "noImplicitAny": false,
+    "useUnknownInCatchVariables": false,
     "baseUrl": "./",
     "paths": {
       "~/*": ["src/*"],

--- a/packages/bp/src/core/dialog/flow/flow-service.ts
+++ b/packages/bp/src/core/dialog/flow/flow-service.ts
@@ -58,7 +58,7 @@ export class FlowService {
   }
 
   private _localInvalidateFlow(botId: string, key: string, flow?: FlowView, newKey?: string) {
-    this.forBot(botId).localInvalidateFlow(key, flow, newKey)
+    return this.forBot(botId).localInvalidateFlow(key, flow, newKey)
   }
 
   private _listenForCacheInvalidation() {
@@ -112,7 +112,7 @@ export class ScopedFlowService {
     this.expectedSavesCache = new LRUCache({ max: 100, maxAge: ms('20s') })
   }
 
-  public localInvalidateFlow(key: string, flow?: FlowView, newKey?: string) {
+  public async localInvalidateFlow(key: string, flow?: FlowView, newKey?: string) {
     if (!this.cache.values().length) {
       return
     }
@@ -126,7 +126,7 @@ export class ScopedFlowService {
     }
 
     // parent flows are only used by the NDU
-    if (this._isOneFlow()) {
+    if (await this._isOneFlow()) {
       const flows = this.cache.values()
       const flowsWithParents = this.addParentsToFlows(flows)
 
@@ -146,9 +146,9 @@ export class ScopedFlowService {
 
       if (await this.ghost.fileExists(FLOW_DIR, flowPath)) {
         const flow = await this.parseFlow(flowPath)
-        this.localInvalidateFlow(flowPath, flow)
+        await this.localInvalidateFlow(flowPath, flow)
       } else {
-        this.localInvalidateFlow(flowPath, undefined)
+        await this.localInvalidateFlow(flowPath, undefined)
       }
     } else {
       if (!isFromFile) {
@@ -172,7 +172,7 @@ export class ScopedFlowService {
       })
 
       // parent flows are only used by the NDU
-      if (this._isOneFlow()) {
+      if (await this._isOneFlow()) {
         const flowsWithParents = this.addParentsToFlows(flows)
         this.cache.initialize(flowsWithParents)
 

--- a/packages/bp/tsconfig.json
+++ b/packages/bp/tsconfig.json
@@ -11,6 +11,7 @@
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
+    "useUnknownInCatchVariables": false,
     "baseUrl": "./src",
     "outDir": "dist",
     "typeRoots": ["./src/typings", "../../node_modules/@types", "./src/common"],

--- a/packages/ui-lite/tsconfig.json
+++ b/packages/ui-lite/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,
+    "useUnknownInCatchVariables": false,
     "target": "es5",
     "lib": ["es7", "dom"],
     "jsx": "react",

--- a/packages/ui-shared/tsconfig.json
+++ b/packages/ui-shared/tsconfig.json
@@ -12,6 +12,7 @@
     "target": "es5",
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
+    "useUnknownInCatchVariables": false,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15166,10 +15166,15 @@ typescript@^2.5.0:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
   integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
-typescript@^4.2.3, typescript@^4.2.4:
+typescript@^4.2.3:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+
+typescript@^4.4.4:
+  version "4.5.2"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 uglify-es@^3.3.4:
   version "3.3.9"


### PR DESCRIPTION
## Description
I'm sure a couple of you are getting used to opening files and seeing error messages in catch clauses, but the build is working properly. Ex:

![image](https://user-images.githubusercontent.com/42552874/143365303-69811796-ac0e-4cba-a07c-5549b87e56a1.png)

This is because since TS 4.4, catch clauses are treated as "unknown" instead of "any" to ensure we handle exceptions properly.  VSCode uses a more recent Typescript version (4.4.3) when evaluating the code, while the build process uses the one defined in dependencies (4.2.4), which is why we get errors in the editor and not during the build.

I agree that we should handle those exceptions properly, however since we're moving a lot of code around and considering the number of places where we need to address it, I've upgraded the version to 4.4 and added a flag to treat those catch clauses as "any", like before. 

One nice improvement is that auto completion will be smarter when auto-importing a file.

The changelog is available here: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html

## Type of change

- [x] Chore change (refactoring and / or test changes)