### PR TITLE
fix(channel-web): fix migrating large number of conversations:

### DIFF
--- a/modules/channel-web/src/messaging-migration/down-sqlite.ts
+++ b/modules/channel-web/src/messaging-migration/down-sqlite.ts
@@ -45,6 +45,7 @@ export class MessagingSqliteDownMigrator extends MessagingDownMigrator {
         .select('*')
         .offset(i)
         .limit(batchSize)
+        .orderBy('id')
 
       // We migrate batchSize conversations at a time
       await this.migrateConvos(convos)

--- a/modules/channel-web/src/messaging-migration/up-sqlite.ts
+++ b/modules/channel-web/src/messaging-migration/up-sqlite.ts
@@ -45,6 +45,7 @@ export class MessagingSqliteUpMigrator extends MessagingUpMigrator {
         .select('*')
         .offset(i)
         .limit(batchSize)
+        .orderBy('id')
 
       // We migrate batchSize conversations at a time
       await this.migrateConvos(convos)


### PR DESCRIPTION
## Description

This PR fixes an issue with the channel-web migration of 12.26 where sometimes, there could be a duplicate key constrain violation thrown when migrating the conversations. This is due to the fact that there was an `ORDE BY` missing when listing batches of conversations causing the same column to be listed more than once on some occasions.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Make sure you have a great number of conversations in `web_conversations`, something around 200k.

- [X] Run the migration using `yarn start migrate up --target 12.26.7`
- [X] Run the down migration using `yarn start migrate down --target 12.25.0`

Both runs should succeed
