### PR TITLE
chore: remove business apps from studio side bar

### DIFF
--- a/modules/analytics/src/backend/index.ts
+++ b/modules/analytics/src/backend/index.ts
@@ -35,6 +35,7 @@ const entryPoint: sdk.ModuleEntryPoint = {
   onModuleUnmount,
   translations: { en, fr, es },
   definition: {
+    noInterface: true,
     name: 'analytics',
     fullName: 'Analytics',
     homepage: 'https://botpress.com',

--- a/modules/hitlnext/package.json
+++ b/modules/hitlnext/package.json
@@ -22,7 +22,7 @@
     "classnames": "^2.2.6",
     "flat": "^5.0.2",
     "haikunator": "^2.1.2",
-    "immer": "^8",
+    "immer": "^8.0.4",
     "joi": "^17",
     "lodash": ">=4.17",
     "lru-cache": "^6.0.0",

--- a/modules/hitlnext/src/backend/index.ts
+++ b/modules/hitlnext/src/backend/index.ts
@@ -52,7 +52,7 @@ const entryPoint: sdk.ModuleEntryPoint = {
     menuText: 'HITL Next',
     fullName: 'HITL Next',
     homepage: 'https://botpress.com',
-    noInterface: false,
+    noInterface: true,
     experimental: false,
     workspaceApp: { bots: true }
   }

--- a/modules/hitlnext/yarn.lock
+++ b/modules/hitlnext/yarn.lock
@@ -304,10 +304,10 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-immer@^8:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.0.tgz#08763549ba9dd7d5e2eb4bec504a8315bd9440c2"
-  integrity sha512-jm87NNBAIG4fHwouilCHIecFXp5rMGkiFrAuhVO685UnMAlOneEAnOyzPt8OnP47TC11q/E7vpzZe0WvwepFTg==
+immer@^8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.4.tgz#3a21605a4e2dded852fb2afd208ad50969737b7a"
+  integrity sha512-jMfL18P+/6P6epANRvRk6q8t+3gGhqsJ9EuJ25AXE+9bNTYtssvzeYbEd0mXRYWCmmXSIbnlpz6vd6iJlmGGGQ==
 
 inflight@^1.0.4:
   version "1.0.6"

--- a/modules/misunderstood/src/backend/index.ts
+++ b/modules/misunderstood/src/backend/index.ts
@@ -49,6 +49,7 @@ const entryPoint: sdk.ModuleEntryPoint = {
   translations: { en, fr, es },
   definition: {
     experimental: false,
+    noInterface: true,
     name: 'misunderstood',
     menuIcon: 'icon.svg',
     menuText: 'Misunderstood',

--- a/packages/bp/src/admin/ui/src/app/translations/en.json
+++ b/packages/bp/src/admin/ui/src/app/translations/en.json
@@ -1,6 +1,6 @@
 {
   "admin": {
-    "apps": "Apps",
+    "apps": "Business Apps",
     "needsTraining": "This bot needs training.",
     "howToTrain": "On the studio, click on the \"Train Now\" button (located on the bottom right corner).",
     "alerting": {

--- a/packages/bp/src/admin/ui/src/app/translations/es.json
+++ b/packages/bp/src/admin/ui/src/app/translations/es.json
@@ -1,5 +1,6 @@
 {
   "admin": {
+    "apps": "Aplicaciones para negocios",
     "needsTraining": "Este bot necesita entrenamiento.",
     "howToTrain": "En el estudio, haga clic en el botón \"Entrenar ahora\" (ubicado en la esquina inferior derecha).",
     "alerting": {

--- a/packages/bp/src/admin/ui/src/app/translations/fr.json
+++ b/packages/bp/src/admin/ui/src/app/translations/fr.json
@@ -1,6 +1,6 @@
 {
   "admin": {
-    "apps": "Applications",
+    "apps": "Applications d'Affaires",
     "needsTraining": "Ce bot a besoin d'être entraîné.",
     "howToTrain": "Dans le studio, cliquez sur le bouton \"Entraîner maintenant\" (situé dans le coin en bas, à droite).",
     "alerting": {


### PR DESCRIPTION
**For the 1st requirement,** 
I simply used the `noInterface` property which is used in the studio sidebar to determine if a module icon should be displayed or not. 

**Before :**
<img width="273" alt="Screen Shot 2021-12-02 at 4 02 06 PM" src="https://user-images.githubusercontent.com/955524/144502505-e1a84257-ed1d-455d-ba1a-1c7898213cb2.png">

**After**
<img width="324" alt="Screen Shot 2021-12-02 at 3 59 49 PM" src="https://user-images.githubusercontent.com/955524/144502382-236edb43-79b9-46ec-bf07-e505214214f7.png">


**For the 2nd requirement**
pretty straightforward, I simply renamed the field:

<img width="583" alt="Screen Shot 2021-12-02 at 4 16 51 PM" src="https://user-images.githubusercontent.com/955524/144504482-de63b9ff-0337-4ca6-ac0c-b23e8d788dd4.png">


---
closes: DEV-1827