### PR TITLE
chore: attempt at fixing e2e on next

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "studio": {
     "version": "0.0.44",
-    "devBranch": "next"
+    "devBranch": "refs_pull_120_merge"
   },
   "messaging": {
     "version": "0.1.18"


### PR DESCRIPTION
This is a temporary fix to make e2e tests pass. 

Basically, the prereleases binaries are slightly broken. 

For some technical reason binary names arent branches anymore but pull request tags. 