### PR TITLE
chore: update studio dev branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "studio": {
     "version": "0.0.44",
-    "devBranch": "refs_pull_120_merge"
+    "devBranch": "next"
   },
   "messaging": {
     "version": "0.1.18"


### PR DESCRIPTION
The actual fix is here: https://github.com/botpress/studio/pull/221

Binaries were manually published to `botpress-dev-bins` S3 bucket. Github actions where bypassed. 