### PR TITLE
fix(channel-web): fix switching user language

### DIFF
--- a/modules/builtin/src/actions/switchLanguage.js
+++ b/modules/builtin/src/actions/switchLanguage.js
@@ -1,3 +1,10 @@
+async function getVisitorId(userId) {
+  const rows = await bp.database('web_user_map').where({ userId })
+  if (rows && rows.length) {
+    return rows[0] && rows[0].visitorId
+  }
+}
+
 /**
  * Update user language
  * @title Update user language
@@ -7,7 +14,8 @@
  */
 const switchLanguage = async language => {
   event.state.user.language = language
-  bp.realtime.sendPayload(bp.RealTimePayload.forVisitor(event.target, 'webchat.data', { payload: { language } }))
+  const visitorId = await getVisitorId(event.target)
+  bp.realtime.sendPayload(bp.RealTimePayload.forVisitor(visitorId, 'webchat.data', { payload: { language } }))
   await event.setFlag(bp.IO.WellKnownFlags.FORCE_PERSIST_STATE, true)
 }
 


### PR DESCRIPTION
## Description

This PR adds the mapping between visitorId and userId logic inside the switchLanguage builtin action. This fixes changing the user language and updating the channel-web UI accordingly.

Another solution I tough about was to handle this logic inside the `forVisitor` function (packages/bp/src/core/realtime/payload-sdk-impl.ts). But I think it would be overkill to have to make sure the user sends a visitorId and if not, to check if the userId corresponds to some visitorId and then fetch this value.

We could also expose a `getVisitorId` in the SDK but considering that `web_user_map` is a temporary table and will be deprecated in the future, we might not want to go that route.

Please, let me know if you have a better idea of what we could do here!

Fixes botpress/v12#1541
Closes DEV-1984

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

Use the builtin/switchLanguage function and set the language to `fr` and then `en`. You will see the UI if the webchat change from English to French and then back to English.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
