### PR TITLE
fix(channel-web): fix messaging tables schema in channel-web migration

### DIFF
--- a/modules/channel-web/src/messaging-migration/up.ts
+++ b/modules/channel-web/src/messaging-migration/up.ts
@@ -154,7 +154,7 @@ export abstract class MessagingUpMigrator {
         .references('id')
         .inTable('msg_providers')
         .unique()
-        .notNullable()
+        .nullable()
       table
         .string('token')
         .unique()


### PR DESCRIPTION
## Description

This PR fixes an issue where the table schema for `msg_clients` created by the channel-web migration of 12.26.0 differs from the one defined by the Messaging server.

This would cause users which tables were created during the migration to have a `not null` constraint on the `providerId` column that would result in issues when syncing with Messaging. The issue would only happen when you create or upload a bot with the same name as an old (deleted) bot. 

Closes DEV-2190

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
