### PR TITLE
fix(dialog): find flow now case insensitive

### DIFF
--- a/packages/bp/src/core/dialog/dialog-engine.ts
+++ b/packages/bp/src/core/dialog/dialog-engine.ts
@@ -573,9 +573,9 @@ export class DialogEngine {
       throw new FlowError('Could not find any flow.', botId, flowName)
     }
 
-    flowName = flowName.endsWith('.flow.json') ? flowName : `${flowName.toLowerCase()}.flow.json`
+    const fileName = flowName.endsWith('.flow.json') ? flowName : `${flowName || ''}.flow.json`
 
-    const flow = flows.find(x => x.name === flowName)
+    const flow = flows.find(x => x.name.toLowerCase() === fileName.toLowerCase())
     if (!flow) {
       throw new FlowError(`Flow not found: ${flowName}`, botId, flowName)
     }

--- a/packages/bp/src/core/dialog/dialog-engine.ts
+++ b/packages/bp/src/core/dialog/dialog-engine.ts
@@ -573,7 +573,7 @@ export class DialogEngine {
       throw new FlowError('Could not find any flow.', botId, flowName)
     }
 
-    const fileName = flowName.endsWith('.flow.json') ? flowName : `${flowName || ''}.flow.json`
+    const fileName = flowName.endsWith('.flow.json') ? flowName : `${flowName}.flow.json`
 
     const flow = flows.find(x => x.name.toLowerCase() === fileName.toLowerCase())
     if (!flow) {


### PR DESCRIPTION
## Description

Find Flow usage is inconsistent, providing a flow name was case insensitive, providing a flow file name was case sensitive providing a poor user experience. The changes provide a quality of live improvement for botpress sdk users.

**Potential risks:**
Currently Botpress Studio allows for creating a flow with same name with different casing, if any user uses that weird feature, this is breaking. We'll have to change flow creation logic in studio (which IMO would be the best)

Another non breaking solution would be to make this 100% case sensitive all the time, but that might be breaking for some users as well

## Example
Say I have a flow named `HelpDesk` stored as `HelpDesk.flow.json`
Using the `jumpTo` function

**Before**
`jumpTo(/*args*/, 'helpdesk')` ==> works
`jumpTo(/*args*/, 'HelpDesk')` ==> works
`jumpTo(/*args*/, 'HelpDesk.flow.json')` ==> works
`jumpTo(/*args*/, 'helpdesk.flow.json')` ==> not working

**After**
`jumpTo(/*args*/, 'helpdesk')` ==> works
`jumpTo(/*args*/, 'HelpDesk')` ==> works
`jumpTo(/*args*/, 'HelpDesk.flow.json')` ==> works
`jumpTo(/*args*/, 'helpdesk.flow.json')` ==> works
