### PR TITLE
chore(e2e): studio tests are now working

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,10 @@ jobs:
           NODE_OPTIONS="--max-old-space-size=6000" yarn build
       - name: Run Tests
         run: |
-          yarn start & HEADLESS=true BP_LICENSE_KEY=${{ secrets.BP_LICENSE_KEY }} BP_CONFIG_PRO_ENABLED=true JEST_TIMEOUT=30000 yarn test:e2e
+          yarn start & HEADLESS=true JEST_TIMEOUT=30000 yarn test:e2e
+        env:
+          BP_LICENSE_KEY: ${{ secrets.BP_LICENSE_KEY }}
+          BP_CONFIG_PRO_ENABLED: true
       - name: Upload Screenshots
         uses: actions/upload-artifact@master
         if: failure()

--- a/package.json
+++ b/package.json
@@ -63,8 +63,9 @@
     "fstream": ">=1.0.12",
     "lodash": ">=4.17.21",
     "@jest/types": ">=27.4.2",
-    "@types/jest": ">=27.0.3",
-    "@types/puppeteer": ">=5.4.4"
+    "@types/jest": ">=27.4.0",
+    "@types/puppeteer": ">=5.4.4",
+    "jest-circus": ">=27.4.6"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.2.1",
@@ -79,7 +80,7 @@
     "@types/express": "^4.16.0",
     "@types/fs-extra": "^5.0.4",
     "@types/ioredis": "^4.0.10",
-    "@types/jest": "^27.0.3",
+    "@types/jest": "^27.4.0",
     "@types/jest-environment-puppeteer": "^4.4.1",
     "@types/joi": "^13.4.5",
     "@types/jsonwebtoken": "^8.3.7",
@@ -127,8 +128,8 @@
     "gulp-typedoc": "^2.2.1",
     "gulp-typescript": "^6.0.0-alpha.1",
     "husky": "^4.2.5",
-    "jest": "^27.4.5",
-    "jest-circus": "^27.4.5",
+    "jest": "^27.4.7",
+    "jest-circus": "^27.4.6",
     "jest-extended": "^1.2.0",
     "jest-html-reporter": "^3.4.2",
     "jest-puppeteer": "^6.0.3",

--- a/packages/bp/e2e/admin/bots.test.ts
+++ b/packages/bp/e2e/admin/bots.test.ts
@@ -85,7 +85,7 @@ describe('Admin - Bot Management', () => {
 
   it('Rollback revision', async () => {
     // FIXME: Super Hack to make sure the revision is 'ready'
-    await page.waitFor(500)
+    await page.waitForTimeout(500)
 
     await clickButtonForBot('#btn-rollbackRevision', tempBotId)
     await expectMatchElement('#select-revisions')
@@ -117,7 +117,7 @@ describe('Admin - Bot Management', () => {
 
     await page.focus('#monaco-editor')
     await page.mouse.click(500, 100)
-    await page.waitFor(500) // Required so the editor is correctly focused at the right place
+    await page.waitForTimeout(500) // Required so the editor is correctly focused at the right place
     await triggerKeyboardShortcut('End', false)
 
     await page.keyboard.type('"converse": {"enableUnsecuredEndpoint": false},') // Edit bot config

--- a/packages/bp/e2e/all.test.ts
+++ b/packages/bp/e2e/all.test.ts
@@ -84,7 +84,6 @@ describe('E2E Tests', () => {
     page?.off('framenavigated', frameNavigatedHandler)
   })
 
-  // TODO: Change me. For test purpose only
   // Change this to test a different pipeline
   customTest.map(x => require(x))
 })

--- a/packages/bp/e2e/all.test.ts
+++ b/packages/bp/e2e/all.test.ts
@@ -33,12 +33,13 @@ if (yn(process.env.BP_CONFIG_PRO_ENABLED)) {
 }
 
 const studio = [test.studio.ui, test.studio.flows, test.studio.cms, test.studio.nlu]
-const modules = [/*test.mod.qna*,*/ test.mod.editor, test.mod.testing, test.mod.webchat]
+const modules = [test.mod.editor, test.mod.testing, test.mod.webchat]
 
 /** Define test pipelines below */
 const allTests = [test.auth, test.login, ...admin, ...studio, ...modules, test.logout]
 const studioTests = [test.login, ...studio, test.logout]
 const adminTests = [test.login, ...admin, test.logout]
+const modulesTests = [test.login, ...modules, test.logout]
 
 // Custom pipeline when testing a  specific part
 const customTest = [test.auth, test.login, ...admin, ...studio, test.logout]
@@ -87,5 +88,5 @@ describe('E2E Tests', () => {
   })
 
   // Change this to test a different pipeline
-  customTest.map(x => require(x))
+  allTests.map(x => require(x))
 })

--- a/packages/bp/e2e/all.test.ts
+++ b/packages/bp/e2e/all.test.ts
@@ -42,7 +42,7 @@ const adminTests = [test.login, ...admin, test.logout]
 // Custom pipeline when testing a  specific part
 const customTest = [test.auth, test.login, ...admin, test.logout]
 
-describe('Integration Tests', () => {
+describe('E2E Tests', () => {
   let page: Page
 
   beforeAll(async () => {
@@ -57,5 +57,5 @@ describe('Integration Tests', () => {
 
   // TODO: Change me. For test purpose only
   // Change this to test a different pipeline
-  adminTests.map(x => require(x))
+  studioTests.map(x => require(x))
 })

--- a/packages/bp/e2e/modules/code-editor.test.ts
+++ b/packages/bp/e2e/modules/code-editor.test.ts
@@ -1,6 +1,5 @@
 import { clickOn, fillField, expectMatchElement } from '../utils/expectPuppeteer'
 import {
-  autoAnswerDialog,
   clickOnTreeNode,
   CONFIRM_DIALOG,
   expectBotApiCallSuccess,
@@ -26,12 +25,12 @@ describe('Module - Code Editor', () => {
 
   it('Create new action', async () => {
     await clickOn('#btn-add-action')
-    await fillField('#input-name', 'hello')
+    await fillField('#input-name', 'hello.js', { delay: 100 })
     await clickOn('#btn-submit')
 
     await page.focus('#monaco-editor')
     await page.mouse.click(469, 297)
-    await page.waitFor(500) // Required so the editor is correctly focused at the right place
+    await page.waitForTimeout(500) // Required so the editor is correctly focused at the right place
     await page.keyboard.type("const lol = 'hi' //")
 
     await Promise.all([
@@ -55,8 +54,9 @@ describe('Module - Code Editor', () => {
     await clickOn('#btn-disable')
 
     await expectBotApiCallSuccess('mod/code-editor/rename', 'POST')
+
     const response = await waitForBotApiResponse('mod/code-editor/files')
-    const disabledFile = response['bot.actions'].find(x => x.name === '.hello_copy.js')
+    const disabledFile = response['bot.actions'].find((x: { name: string }) => x.name === '.hello_copy.js')
     expect(disabledFile).toBeDefined()
   })
 
@@ -67,8 +67,9 @@ describe('Module - Code Editor', () => {
     await clickOn(CONFIRM_DIALOG.ACCEPT)
 
     await expectBotApiCallSuccess('mod/code-editor/remove', 'POST')
+
     const response = await waitForBotApiResponse('mod/code-editor/files')
-    expect(response['bot.actions'].find(x => x.name === '.hello_copy.js')).toBeUndefined()
+    expect(response['bot.actions'].find((x: { name: string }) => x.name === '.hello_copy.js')).toBeUndefined()
   })
 
   it('Open two tabs', async () => {

--- a/packages/bp/e2e/modules/webchat.test.ts
+++ b/packages/bp/e2e/modules/webchat.test.ts
@@ -1,20 +1,12 @@
-import { Page } from 'puppeteer'
-
 import { bpConfig } from '../assets/config'
 import { clickOn, expectMatch, fillField } from '../utils/expectPuppeteer'
-import { getPage, gotoAndExpect } from '../utils'
+import { gotoAndExpect } from '../utils'
 
-const getMessageCount = async (page: Page): Promise<number> => {
+const getMessageCount = async (): Promise<number> => {
   return (await page.$$('.bpw-chat-bubble')).length
 }
 
 describe('Module - Channel Web', () => {
-  let page: Page
-
-  beforeAll(async () => {
-    page = await getPage()
-  })
-
   it('Open chat window with shortlink', async () => {
     await gotoAndExpect(`${bpConfig.host}/s/${bpConfig.botId}`, `${bpConfig.host}/lite/${bpConfig.botId}/`)
   })
@@ -22,7 +14,6 @@ describe('Module - Channel Web', () => {
   it('Start conversation', async () => {
     await fillField('#input-message', 'Much automated!')
     await clickOn('#btn-send')
-    await page.waitFor(3000) // Deliberate wait in case the model needs to be trained (or qna/nlu tests in progress)
   })
 
   it('Testing Context discussion and Dropdown', async () => {
@@ -57,10 +48,9 @@ describe('Module - Channel Web', () => {
   })
 
   it('Create new conversation', async () => {
-    await page.waitFor(1000)
     await clickOn('#btn-conversations')
     await clickOn('#btn-convo-add')
-    await expect(await getMessageCount(page)).toBe(0)
+    await expect(getMessageCount()).resolves.toBe(0)
   })
 
   // puppetter doesn`t have a way of testing sound playback from javascript objects

--- a/packages/bp/e2e/studio/cms.test.ts
+++ b/packages/bp/e2e/studio/cms.test.ts
@@ -18,6 +18,8 @@ const getElementCount = async (all: boolean = false): Promise<number> => {
   return (await page.$$('.icon-edit')).length
 }
 
+const BLUEPRINTJS_TEXT_ELEMENT = '.DraftEditor-root'
+
 describe('Studio - CMS', () => {
   beforeAll(async () => {
     await loginOrRegister()
@@ -49,8 +51,9 @@ describe('Studio - CMS', () => {
     await uploadFile('input[type="file"]', path.join(__dirname, '../assets/alien.png'))
     await expectStudioApiCallSuccess('media', 'POST')
 
-    await clickOn('.DraftEditor-root')
+    await clickOn(BLUEPRINTJS_TEXT_ELEMENT)
     await page.keyboard.type('I am a martian')
+
     await clickOn('button[type="submit"]')
     await expectStudioApiCallSuccess('cms/builtin_image/elements', 'POST')
 
@@ -63,11 +66,13 @@ describe('Studio - CMS', () => {
 
     await page.hover('#btn-filter-builtin_file')
     await clickOn('#btn-list-create-builtin_file')
+
     await uploadFile('input[type="file"]', path.join(__dirname, '../assets/README.pdf'))
     await expectStudioApiCallSuccess('media', 'POST')
 
-    await clickOn('.style__textarea___2P8hT')
+    await clickOn(BLUEPRINTJS_TEXT_ELEMENT)
     await page.keyboard.type('Botpress README')
+
     await clickOn('button[type="submit"]')
     await expectStudioApiCallSuccess('cms/builtin_file/elements', 'POST')
 
@@ -81,8 +86,9 @@ describe('Studio - CMS', () => {
     await page.hover('#btn-filter-builtin_text')
     await clickOn('#btn-list-create-builtin_text')
 
-    await clickOn('.style__textarea___2P8hT')
+    await clickOn(BLUEPRINTJS_TEXT_ELEMENT)
     await page.keyboard.type('hey!')
+
     await clickOn('button[type="submit"]')
     await expectStudioApiCallSuccess('cms/builtin_text/element', 'POST')
 

--- a/packages/bp/e2e/studio/cms.test.ts
+++ b/packages/bp/e2e/studio/cms.test.ts
@@ -1,7 +1,13 @@
 import path from 'path'
 
-import { clickOn, uploadFile } from '../utils/expectPuppeteer'
-import { expectBotApiCallSuccess, expectStudioApiCallSuccess, gotoStudio, loginIfNeeded } from '../utils'
+import { clickOn, fillField, uploadFile } from '../utils/expectPuppeteer'
+import {
+  CONFIRM_DIALOG,
+  expectStudioApiCallSuccess,
+  gotoStudio,
+  loginOrRegister,
+  waitForStudioApiResponse
+} from '../utils'
 
 const getElementCount = async (all: boolean = false): Promise<number> => {
   if (all) {
@@ -14,7 +20,7 @@ const getElementCount = async (all: boolean = false): Promise<number> => {
 
 describe('Studio - CMS', () => {
   beforeAll(async () => {
-    await loginIfNeeded()
+    await loginOrRegister()
     if (!page.url().includes('studio')) {
       await gotoStudio()
     }
@@ -30,63 +36,74 @@ describe('Studio - CMS', () => {
 
     await clickOn('#btn-filter-builtin_text')
     await expectStudioApiCallSuccess('cms/builtin_text/elements', 'POST')
+
     const after = await getElementCount()
     expect(after).toBeLessThan(before)
   })
 
   it('Create an image element', async () => {
     const before = await getElementCount(true)
+
     await page.hover('#btn-filter-builtin_image')
     await clickOn('#btn-list-create-builtin_image')
     await uploadFile('input[type="file"]', path.join(__dirname, '../assets/alien.png'))
     await expectStudioApiCallSuccess('media', 'POST')
+
     await clickOn('.DraftEditor-root')
     await page.keyboard.type('I am a martian')
     await clickOn('button[type="submit"]')
     await expectStudioApiCallSuccess('cms/builtin_image/elements', 'POST')
+
     const after = await getElementCount(true)
     expect(after).toBeGreaterThan(before)
   })
 
   it('Create a file element', async () => {
     const before = await getElementCount(true)
+
     await page.hover('#btn-filter-builtin_file')
     await clickOn('#btn-list-create-builtin_file')
     await uploadFile('input[type="file"]', path.join(__dirname, '../assets/README.pdf'))
     await expectStudioApiCallSuccess('media', 'POST')
+
     await clickOn('.style__textarea___2P8hT')
     await page.keyboard.type('Botpress README')
     await clickOn('button[type="submit"]')
     await expectStudioApiCallSuccess('cms/builtin_file/elements', 'POST')
+
     const after = await getElementCount(true)
     expect(after).toBeGreaterThan(before)
   })
 
-  // it('Create text element', async () => {
+  it('Create text element', async () => {
+    const before = await getElementCount(true)
 
-  //   await page.keyboard.press('Tab')
-  //   await page.keyboard.type('hey!')
-  //   await clickOn('button[type="submit"]')
+    await page.hover('#btn-filter-builtin_text')
+    await clickOn('#btn-list-create-builtin_text')
 
-  //   await expectBotApiCallSuccess('content/builtin_text/element', 'POST')
-  //   await page.waitFor(500) // Ensure the element is created and the list is reloaded
-  //   const after = await getElementCount()
+    await clickOn('.style__textarea___2P8hT')
+    await page.keyboard.type('hey!')
+    await clickOn('button[type="submit"]')
+    await expectStudioApiCallSuccess('cms/builtin_text/element', 'POST')
 
-  //   expect(after).toBe(before + 1)
-  // })
+    const after = await getElementCount(true)
+    expect(after).toBeGreaterThan(before)
+  })
 
-  // it('Search element', async () => {
-  //   await page.waitFor(1000)
-  //   await fillField('#input-search', 'hey')
+  it('Search element', async () => {
+    await page.waitForSelector('#input-search')
 
-  //   const response = await waitForBotApiResponse('content/builtin_text/elements')
-  //   expect(response.length).toBe(1)
-  // })
+    await fillField('#input-search', 'hey')
 
-  // it('Delete element', async () => {
-  //   await clickOn(`[id^='chk-builtin_text']`)
-  //   await clickOn(`#btn-delete`)
-  //   await clickOn(CONFIRM_DIALOG.ACCEPT)
-  //   await expectBotApiCallSuccess('content/elements/bulk_delete', 'POST')
-  // })
+    const response = await waitForStudioApiResponse('cms/elements')
+    console.log('[Search element] - Response', response)
+    expect(response.length).toBe(1)
+  })
+
+  it('Delete element', async () => {
+    await clickOn(`[id^='chk-builtin_text']`)
+    await clickOn(`#btn-delete`)
+    await clickOn(CONFIRM_DIALOG.ACCEPT)
+    await expectStudioApiCallSuccess('cms/elements/bulk_delete', 'POST')
+  })
 })

--- a/packages/bp/e2e/studio/flows.test.ts
+++ b/packages/bp/e2e/studio/flows.test.ts
@@ -25,8 +25,7 @@ describe('Studio - Flows', () => {
     await page.mouse.click(500, 150)
     await page.mouse.click(500, 150, { button: 'right' })
 
-    await page.waitForSelector('li > .bp3-menu-item > .bp3-text-overflow-ellipsis')
-    await page.click('li > .bp3-menu-item > .bp3-text-overflow-ellipsis', { button: 'left' })
+    await clickOn('li > .bp3-menu-item > .bp3-text-overflow-ellipsis', { button: 'left' })
   })
 
   it('Rename Node', async () => {

--- a/packages/bp/e2e/studio/flows.test.ts
+++ b/packages/bp/e2e/studio/flows.test.ts
@@ -14,9 +14,13 @@ describe('Studio - Flows', () => {
   })
 
   it('Create new flow', async () => {
+    await page.waitForSelector('#btn-add-flow')
+
     await clickOn('#btn-add-flow')
     await fillField('#input-flow-name', 'test_flow')
-    await Promise.all([expectStudioApiCallSuccess('flows'), clickOn('#btn-submit')])
+
+    await clickOn('#btn-submit')
+    await expectStudioApiCallSuccess('flows')
   })
 
   it('Create new Node', async () => {
@@ -62,17 +66,15 @@ describe('Studio - Flows', () => {
     await clickOn('#btn-rename')
     await fillField('#input-flow-name', 'test_flow_renamed')
 
-    await Promise.all([expectStudioApiCallSuccess('flows/test_flow_renamed.flow.json', 'POST'), clickOn('#btn-submit')])
+    await clickOn('#btn-submit')
+    await expectStudioApiCallSuccess('flows/test_flow_renamed.flow.json', 'POST')
   })
 
   it('Delete flow', async () => {
     await clickOnTreeNode('test_flow_renamed', 'right')
-
-    await Promise.all([
-      expectStudioApiCallSuccess('flows/test_flow_renamed.flow.json/delete', 'POST'),
-      clickOn('#btn-delete'),
-      clickOn(CONFIRM_DIALOG.ACCEPT)
-    ])
+    await clickOn('#btn-delete')
+    await clickOn(CONFIRM_DIALOG.ACCEPT)
+    await expectStudioApiCallSuccess('flows/test_flow_renamed.flow.json/delete', 'POST')
   })
 
   it('Duplicate flow', async () => {
@@ -80,7 +82,7 @@ describe('Studio - Flows', () => {
     await clickOn('#btn-duplicate')
     await fillField('#input-flow-name', 'new_duplicated_flow')
 
-    await Promise.all([expectStudioApiCallSuccess('flows', 'POST'), clickOn('#btn-submit')])
-    await page.waitFor(3000)
+    await clickOn('#btn-submit')
+    await expectStudioApiCallSuccess('flows', 'POST')
   })
 })

--- a/packages/bp/e2e/studio/nlu.test.ts
+++ b/packages/bp/e2e/studio/nlu.test.ts
@@ -1,5 +1,5 @@
 import { clickOn, fillField, expectMatch } from '../utils/expectPuppeteer'
-import { expectStudioApiCallSuccess, gotoStudio, loginOrRegister } from '../utils'
+import { DEFAULT_TIMEOUT, expectStudioApiCallSuccess, gotoStudio, loginOrRegister } from '../utils'
 
 describe('Studio - NLU', () => {
   beforeAll(async () => {
@@ -35,10 +35,11 @@ describe('Studio - NLU', () => {
     const client = page['_client']
 
     const waitForTraining = new Promise((resolve, reject) => {
+      const timeout = DEFAULT_TIMEOUT - 1000
       const timeoutHandle = setTimeout(() => {
         client.off('Network.webSocketFrameReceived', onWebSocketFrameReceived)
-        reject(new Error('Failed to train chatbot in under 7 seconds'))
-      }, 7000)
+        reject(new Error(`Failed to train chatbot in under ${timeout / 1000} seconds`))
+      }, timeout)
 
       const onWebSocketFrameReceived = ({ response }) => {
         // E.g. 42/admin,["event",{"name":"statusbar.event","data":{"type":"nlu","botId":"test-bot","trainSession":{"key":"training:test-bot:en","language":"en","status":"done","progress":1}}}]

--- a/packages/bp/e2e/studio/nlu.test.ts
+++ b/packages/bp/e2e/studio/nlu.test.ts
@@ -18,7 +18,8 @@ describe('Studio - NLU', () => {
     await clickOn('#btn-create')
     await fillField('#input-intent-name', 'hello_there')
 
-    await Promise.all([expectStudioApiCallSuccess('nlu/intents', 'POST'), clickOn('#btn-submit')])
+    await clickOn('#btn-submit')
+    await expectStudioApiCallSuccess('nlu/intents', 'POST')
   })
 
   it('Create new entity', async () => {
@@ -26,12 +27,16 @@ describe('Studio - NLU', () => {
     await clickOn('#btn-create')
     await fillField('input[name="name"]', 'cars')
 
-    await Promise.all([expectStudioApiCallSuccess('nlu/entities', 'POST'), clickOn('#entity-submit')])
+    await clickOn('#entity-submit')
+    await expectStudioApiCallSuccess('nlu/entities', 'POST')
   })
 
   it('Train Chatbot', async () => {
     await clickOn('button', { text: 'Train Chatbot' })
     await expectMatch('Training')
+
+    // TODO: Find something better
     await page.waitFor(7000) // Awaits for a while to give botpress time to train
-  })
+    await expectMatch('Ready')
+  }, 15000)
 })

--- a/packages/bp/e2e/studio/qna.test.ts
+++ b/packages/bp/e2e/studio/qna.test.ts
@@ -43,10 +43,12 @@ describe('Studio - QNA', () => {
     await page.keyboard.press('Tab')
     await page.keyboard.type('I sure am!')
     await page.keyboard.press('Enter')
-    await clickOn('#btn-submit')
 
-    await expectStudioApiCallSuccess('qna/questions', 'POST')
-    await expectStudioApiCallSuccess('qna/questions', 'GET')
+    await Promise.all([
+      clickOn('#btn-submit'),
+      expectStudioApiCallSuccess('qna/questions', 'POST'),
+      expectStudioApiCallSuccess('qna/questions', 'GET')
+    ])
   })
 
   it('Filter by name', async () => {
@@ -80,9 +82,13 @@ describe('Studio - QNA', () => {
     await expectStudioApiCallSuccess('qna/analyzeImport', 'POST')
 
     await clickOn('#radio-clearInsert')
-    await clickOn('#btn-submit')
-    await expectStudioApiCallSuccess('qna/import', 'POST')
-    await expectStudioApiCallSuccess('qna/questions', 'GET')
+
+    await Promise.all([
+      clickOn('#btn-submit'),
+      expectStudioApiCallSuccess('qna/import', 'POST'),
+      expectStudioApiCallSuccess('qna/questions', 'GET')
+    ])
+
     await page.focus('body') // Sets back the focus to the page when the modal is closed
   })
 })

--- a/packages/bp/e2e/studio/qna.test.ts
+++ b/packages/bp/e2e/studio/qna.test.ts
@@ -26,12 +26,11 @@ describe('Studio - QNA', () => {
   it('Filter by category', async () => {
     await fillField('#select-context', 'monkeys')
 
-    await Promise.all([
-      expectStudioApiCallSuccess('qna/questions?question=&filteredContexts[]=monkeys', 'GET'),
-      page.keyboard.press('Enter')
-    ])
+    await page.keyboard.press('Enter')
+    await expectStudioApiCallSuccess('qna/questions?question=&filteredContexts[]=monkeys', 'GET')
 
     expect(await getQnaCount()).toBe(2)
+
     await page.keyboard.press('Delete')
     await clickOn("[class^='bp3-tag-remove']")
   })
@@ -39,26 +38,31 @@ describe('Studio - QNA', () => {
   it('Create new entry', async () => {
     await clickOn('#btn-create-qna')
     await expectMatch('Create a new')
+
     await fillField('#input-questions', 'are you working?')
     await page.keyboard.press('Tab')
     await page.keyboard.type('I sure am!')
     await page.keyboard.press('Enter')
     await clickOn('#btn-submit')
+
     await expectStudioApiCallSuccess('qna/questions', 'POST')
     await expectStudioApiCallSuccess('qna/questions', 'GET')
   })
 
   it('Filter by name', async () => {
-    await page.waitFor(300) // Required because the create action clears the filter after it loads new qna
-    await Promise.all([
-      expectStudioApiCallSuccess('qna/questions', 'GET'),
-      fillField('#input-search', 'are you working')
-    ])
+    await page.waitForSelector('#input-search')
+    //await page.waitFor(300) // Required because the create action clears the filter after it loads new qna
+
+    await fillField('#input-search', 'are you working')
+    await expectStudioApiCallSuccess('qna/questions', 'GET')
+
     expect(await getQnaCount()).toBe(1)
   })
 
   it('Delete entry', async () => {
-    await page.waitFor(500)
+    await page.waitForSelector('div[role="entry"]')
+    //await page.waitFor(500)
+
     const element = await expectMatchElement('div[role="entry"]', { text: 'are you working' })
     const { x, y } = await getElementCenter(element)
     await page.mouse.move(x, y) // This makes the delete icon visible for the next step
@@ -86,6 +90,5 @@ describe('Studio - QNA', () => {
     await expectStudioApiCallSuccess('qna/import', 'POST')
     await expectStudioApiCallSuccess('qna/questions', 'GET')
     await page.focus('body') // Sets back the focus to the page when the modal is closed
-    await page.waitFor(300)
   })
 })

--- a/packages/bp/e2e/studio/ui.test.ts
+++ b/packages/bp/e2e/studio/ui.test.ts
@@ -8,12 +8,17 @@ describe('Studio - UI', () => {
   })
 
   it('Emulator window toggle properly with shortcut', async () => {
+    //await page.waitForNavigation()
     await page.waitFor(1000)
     await page.keyboard.press('Escape')
+
     await page.focus('#mainLayout')
     await page.type('#mainLayout', 'e')
+
     await page.keyboard.type('Much automated!')
-    await Promise.all([expectBotApiCallSuccess('mod/channel-web/messages'), page.keyboard.press('Enter')])
+    await page.keyboard.press('Enter')
+    await expectBotApiCallSuccess('mod/channel-web/messages')
+
     await page.keyboard.press('Escape')
   })
 
@@ -26,6 +31,7 @@ describe('Studio - UI', () => {
       await page.focus('#mainLayout')
       await triggerKeyboardShortcut('KeyJ', true)
       const bottomPanel = await page.$('div[data-tab-id="debugger"]')
+
       expect(await bottomPanel?.isIntersectingViewport()).toBe(true)
       await triggerKeyboardShortcut('KeyJ', true)
     })
@@ -34,8 +40,10 @@ describe('Studio - UI', () => {
   it('Toggles bottom panel using click toolbar menu', async () => {
     await page.focus('#mainLayout')
     await clickOn('#toggle-bottom-panel')
+
     const bottomPanel = await page.$('div[data-tab-id="debugger"]')
     expect(await bottomPanel?.isIntersectingViewport()).toBe(true)
+
     await clickOn('#toggle-bottom-panel')
   })
 

--- a/packages/bp/e2e/utils/expectPuppeteer.ts
+++ b/packages/bp/e2e/utils/expectPuppeteer.ts
@@ -30,9 +30,9 @@ interface ExpectClickOptions {
 type ExpectPolling = number | 'mutation' | 'raf'
 
 interface ExpectTimingActions {
-  delay?: number | undefined
-  polling?: ExpectPolling | undefined
-  timeout?: number | undefined
+  delay?: number
+  polling?: ExpectPolling
+  timeout?: number
 }
 
 export const uploadFile = async (selector: string, filePath: string, options?: ExpectTimingActions | undefined) => {

--- a/packages/bp/e2e/utils/index.ts
+++ b/packages/bp/e2e/utils/index.ts
@@ -52,7 +52,8 @@ export const logout = async () => {
 export const gotoStudio = async (section?: string) => {
   const resource = section ? `/${section}` : ''
   await gotoAndExpect(`${bpConfig.host}/studio/${bpConfig.botId}${resource}`)
-  return page.waitFor(200)
+
+  return page.waitForNavigation()
 }
 
 /** Opens a new URL and makes sure the resulting url matches */
@@ -113,6 +114,11 @@ export const doesElementExist = async (selector: string): Promise<boolean> => {
 
 export const waitForBotApiResponse = async (endOfUrl: string, method?: HttpMethod): Promise<any> => {
   const response = await getResponse(`${bpConfig.apiHost}/api/v1/bots/${bpConfig.botId}/${endOfUrl}`, method)
+  return response.json()
+}
+
+export const waitForStudioApiResponse = async (endOfUrl: string, method?: HttpMethod): Promise<any> => {
+  const response = await getResponse(`${bpConfig.apiHost}/api/v1/studio/${bpConfig.botId}/${endOfUrl}`, method)
   return response.json()
 }
 

--- a/packages/bp/e2e/utils/index.ts
+++ b/packages/bp/e2e/utils/index.ts
@@ -49,9 +49,7 @@ export const logout = async () => {
 
 export const gotoStudio = async (section?: string) => {
   const resource = section ? `/${section}` : ''
-  await gotoAndExpect(`${bpConfig.host}/studio/${bpConfig.botId}${resource}`)
-
-  return page.waitForNavigation()
+  return gotoAndExpect(`${bpConfig.host}/studio/${bpConfig.botId}${resource}`)
 }
 
 /** Opens a new URL and makes sure the resulting url matches */
@@ -63,7 +61,9 @@ export const gotoAndExpect = async (url: string, matchUrl?: string) => {
 export const getResponse = async (url: string, method?: HttpMethod): Promise<HTTPResponse> => {
   return page.waitForResponse(res => {
     const resUrl = res.url()
-    console.info(`url: ${url}, resUrl: ${resUrl}`)
+    if (shouldLogRequest(url) && shouldLogRequest(resUrl)) {
+      console.info(`url: ${url}, resUrl: ${resUrl}`)
+    }
     return resUrl.includes(url) && (method ? res.request().method() === method : true)
   })
 }
@@ -123,19 +123,6 @@ export const waitForStudioApiResponse = async (endOfUrl: string, method?: HttpMe
 export enum CONFIRM_DIALOG {
   ACCEPT = '#confirm-dialog-accept',
   DECLINE = '#confirm-dialog-decline'
-}
-
-export const autoAnswerDialog = (promptText?: string, repeat?: boolean) => {
-  const dialog = async (dialog: Dialog) => dialog.accept(promptText)
-
-  if (!repeat) {
-    page.once('dialog', dialog)
-  } else {
-    page.on('dialog', dialog)
-    return () => {
-      page.off('dialog', dialog)
-    }
-  }
 }
 
 export const getElementCenter = async (element: ElementHandle): Promise<{ x: number; y: number }> => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,6 +105,13 @@
   dependencies:
     "@babel/highlight" "^7.16.0"
 
+"@babel/code-frame@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
+  integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
+  dependencies:
+    "@babel/highlight" "^7.16.7"
+
 "@babel/compat-data@^7.12.1", "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.16.0", "@babel/compat-data@^7.16.4":
   version "7.16.4"
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.4.tgz#081d6bbc336ec5c2435c6346b2ae1fb98b5ac68e"
@@ -194,6 +201,27 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
+"@babel/core@^7.8.0":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.16.7.tgz#db990f931f6d40cb9b87a0dc7d2adc749f1dcbcf"
+  integrity sha512-aeLaqcqThRNZYmbMqtulsetOQZ/5gbR/dWruUCJcpas4Qoyy+QeagfDsPdMrqwsPRDNxJvBlRiZxxX7THO7qtA==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.16.7"
+    "@babel/helper-compilation-targets" "^7.16.7"
+    "@babel/helper-module-transforms" "^7.16.7"
+    "@babel/helpers" "^7.16.7"
+    "@babel/parser" "^7.16.7"
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.16.7"
+    "@babel/types" "^7.16.7"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.11.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.11.0.tgz#4b90c78d8c12825024568cbe83ee6c9af193585c"
@@ -218,6 +246,15 @@
   integrity sha512-kIvCdjZqcdKqoDbVVdt5R99icaRtrtYhYK/xux5qiWCBmfdvEYMFZ68QCrpE5cbFM1JsuArUNs1ZkuKtTtUcZA==
   dependencies:
     "@babel/types" "^7.16.0"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.16.7", "@babel/generator@^7.16.8":
+  version "7.16.8"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.16.8.tgz#359d44d966b8cd059d543250ce79596f792f2ebe"
+  integrity sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==
+  dependencies:
+    "@babel/types" "^7.16.8"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -276,6 +313,16 @@
     browserslist "^4.17.5"
     semver "^6.3.0"
 
+"@babel/helper-compilation-targets@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz#06e66c5f299601e6c7da350049315e83209d551b"
+  integrity sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==
+  dependencies:
+    "@babel/compat-data" "^7.16.4"
+    "@babel/helper-validator-option" "^7.16.7"
+    browserslist "^4.17.5"
+    semver "^6.3.0"
+
 "@babel/helper-create-class-features-plugin@^7.12.1", "@babel/helper-create-class-features-plugin@^7.16.0":
   version "7.16.0"
   resolved "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.0.tgz#090d4d166b342a03a9fec37ef4fd5aeb9c7c6a4b"
@@ -330,6 +377,13 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
+"@babel/helper-environment-visitor@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz#ff484094a839bde9d89cd63cba017d7aae80ecd7"
+  integrity sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-explode-assignable-expression@^7.16.0":
   version "7.16.0"
   resolved "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.0.tgz#753017337a15f46f9c09f674cff10cee9b9d7778"
@@ -364,6 +418,15 @@
     "@babel/template" "^7.16.0"
     "@babel/types" "^7.16.0"
 
+"@babel/helper-function-name@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz#f1ec51551fb1c8956bc8dd95f38523b6cf375f8f"
+  integrity sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.16.7"
+    "@babel/template" "^7.16.7"
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-get-function-arity@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
@@ -385,12 +448,26 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
+"@babel/helper-get-function-arity@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz#ea08ac753117a669f1508ba06ebcc49156387419"
+  integrity sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-hoist-variables@^7.16.0":
   version "7.16.0"
   resolved "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz#4c9023c2f1def7e28ff46fc1dbcd36a39beaa81a"
   integrity sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==
   dependencies:
     "@babel/types" "^7.16.0"
+
+"@babel/helper-hoist-variables@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz#86bcb19a77a509c7b77d0e22323ef588fa58c246"
+  integrity sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==
+  dependencies:
+    "@babel/types" "^7.16.7"
 
 "@babel/helper-member-expression-to-functions@^7.16.0":
   version "7.16.0"
@@ -412,6 +489,13 @@
   integrity sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==
   dependencies:
     "@babel/types" "^7.16.0"
+
+"@babel/helper-module-imports@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz#25612a8091a999704461c8a222d0efec5d091437"
+  integrity sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==
+  dependencies:
+    "@babel/types" "^7.16.7"
 
 "@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.16.0":
   version "7.16.0"
@@ -440,6 +524,20 @@
     "@babel/template" "^7.16.0"
     "@babel/traverse" "^7.16.5"
     "@babel/types" "^7.16.0"
+
+"@babel/helper-module-transforms@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz#7665faeb721a01ca5327ddc6bba15a5cb34b6a41"
+  integrity sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/helper-simple-access" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/helper-validator-identifier" "^7.16.7"
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.16.7"
+    "@babel/types" "^7.16.7"
 
 "@babel/helper-optimise-call-expression@^7.16.0":
   version "7.16.0"
@@ -509,6 +607,13 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
+"@babel/helper-simple-access@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz#d656654b9ea08dbb9659b69d61063ccd343ff0f7"
+  integrity sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-skip-transparent-expression-wrappers@^7.12.1", "@babel/helper-skip-transparent-expression-wrappers@^7.16.0":
   version "7.16.0"
   resolved "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz#0ee3388070147c3ae051e487eca3ebb0e2e8bb09"
@@ -530,6 +635,13 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
+"@babel/helper-split-export-declaration@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz#0b648c0c42da9d3920d85ad585f2778620b8726b"
+  integrity sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-split-export-declaration@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz#ff94894a340be78f53f06af038b205c49d993677"
@@ -547,10 +659,20 @@
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
   integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
 
+"@babel/helper-validator-identifier@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
+  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+
 "@babel/helper-validator-option@^7.12.1", "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
   resolved "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
   integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
+
+"@babel/helper-validator-option@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz#b203ce62ce5fe153899b617c08957de860de4d23"
+  integrity sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==
 
 "@babel/helper-wrap-function@^7.16.0":
   version "7.16.0"
@@ -590,6 +712,15 @@
     "@babel/traverse" "^7.16.5"
     "@babel/types" "^7.16.0"
 
+"@babel/helpers@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.16.7.tgz#7e3504d708d50344112767c3542fc5e357fffefc"
+  integrity sha512-9ZDoqtfY7AuEOt3cxchfii6C7GDyyMBffktR5B2jvWv8u2+efwvpnVKXMWzNehqy68tKgAfSwfdw/lWpthS2bw==
+  dependencies:
+    "@babel/template" "^7.16.7"
+    "@babel/traverse" "^7.16.7"
+    "@babel/types" "^7.16.7"
+
 "@babel/helpers@^7.4.0":
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.4.2.tgz#3bdfa46a552ca77ef5a0f8551be5f0845ae989be"
@@ -626,6 +757,15 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.7.tgz#81a01d7d675046f0d96f82450d9d9578bdfd6b0b"
+  integrity sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.4.0":
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.2.tgz#b4521a400cb5a871eab3890787b4bc1326d38d91"
@@ -641,10 +781,15 @@
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz#d5f92f57cf2c74ffe9b37981c0e72fee7311372e"
   integrity sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==
 
-"@babel/parser@^7.16.5", "@babel/parser@^7.7.2":
+"@babel/parser@^7.16.5":
   version "7.16.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.6.tgz#8f194828193e8fa79166f34a4b4e52f3e769a314"
   integrity sha512-Gr86ujcNuPDnNOY8mi383Hvi8IYrJVJYuf3XcuBM/Dgd+bINn/7tHqsj+tKkoreMbmGsFLsltI/JJd8fOFWGDQ==
+
+"@babel/parser@^7.16.7", "@babel/parser@^7.16.8":
+  version "7.16.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.8.tgz#61c243a3875f7d0b0962b0543a33ece6ff2f1f17"
+  integrity sha512-i7jDUfrVBWc+7OKcBzEe5n7fbv3i2fWtxKzzCvOjnzSxMfWMigAhtfJ7qzZNGFNMsCCd67+uz553dYKWXPvCKw==
 
 "@babel/parser@^7.4.4", "@babel/parser@^7.4.5":
   version "7.4.5"
@@ -2067,6 +2212,15 @@
     "@babel/parser" "^7.16.0"
     "@babel/types" "^7.16.0"
 
+"@babel/template@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
+  integrity sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/parser" "^7.16.7"
+    "@babel/types" "^7.16.7"
+
 "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.0":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.5.tgz#4e92d1728fd2f1897dafdd321efbff92156c3216"
@@ -2128,6 +2282,22 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.16.7":
+  version "7.16.8"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.16.8.tgz#bab2f2b09a5fe8a8d9cad22cbfe3ba1d126fef9c"
+  integrity sha512-xe+H7JlvKsDQwXRsBhSnq1/+9c+LlQcCK3Tn/l5sbx02HYns/cn7ibp9+RV1sIUqu7hKg91NWsgHurO9dowITQ==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.16.8"
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-function-name" "^7.16.7"
+    "@babel/helper-hoist-variables" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/parser" "^7.16.8"
+    "@babel/types" "^7.16.8"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0"
@@ -2152,6 +2322,14 @@
   integrity sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.15.7"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.16.7", "@babel/types@^7.16.8":
+  version "7.16.8"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.16.8.tgz#0ba5da91dd71e0a4e7781a30f22770831062e3c1"
+  integrity sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -2661,15 +2839,15 @@
     jest-util "^26.6.2"
     slash "^3.0.0"
 
-"@jest/console@^27.4.2":
-  version "27.4.2"
-  resolved "https://registry.yarnpkg.com/@jest/console/-/console-27.4.2.tgz#7a95612d38c007ddb528ee446fe5e5e785e685ce"
-  integrity sha512-xknHThRsPB/To1FUbi6pCe43y58qFC03zfb6R7fDb/FfC7k2R3i1l+izRBJf8DI46KhYGRaF14Eo9A3qbBoixg==
+"@jest/console@^27.4.6":
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-27.4.6.tgz#0742e6787f682b22bdad56f9db2a8a77f6a86107"
+  integrity sha512-jauXyacQD33n47A44KrlOVeiXHEXDqapSdfb9kTekOchH/Pd18kBIO1+xxJQRLuG+LUuljFCwTG92ra4NW7SpA==
   dependencies:
     "@jest/types" "^27.4.2"
     "@types/node" "*"
     chalk "^4.0.0"
-    jest-message-util "^27.4.2"
+    jest-message-util "^27.4.6"
     jest-util "^27.4.2"
     slash "^3.0.0"
 
@@ -2707,15 +2885,15 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/core@^27.4.5":
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.4.5.tgz#cae2dc34259782f4866c6606c3b480cce920ed4c"
-  integrity sha512-3tm/Pevmi8bDsgvo73nX8p/WPng6KWlCyScW10FPEoN1HU4pwI83tJ3TsFvi1FfzsjwUlMNEPowgb/rPau/LTQ==
+"@jest/core@^27.4.7":
+  version "27.4.7"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.4.7.tgz#84eabdf42a25f1fa138272ed229bcf0a1b5e6913"
+  integrity sha512-n181PurSJkVMS+kClIFSX/LLvw9ExSb+4IMtD6YnfxZVerw9ANYtW0bPrm0MJu2pfe9SY9FJ9FtQ+MdZkrZwjg==
   dependencies:
-    "@jest/console" "^27.4.2"
-    "@jest/reporters" "^27.4.5"
-    "@jest/test-result" "^27.4.2"
-    "@jest/transform" "^27.4.5"
+    "@jest/console" "^27.4.6"
+    "@jest/reporters" "^27.4.6"
+    "@jest/test-result" "^27.4.6"
+    "@jest/transform" "^27.4.6"
     "@jest/types" "^27.4.2"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
@@ -2724,24 +2902,24 @@
     exit "^0.1.2"
     graceful-fs "^4.2.4"
     jest-changed-files "^27.4.2"
-    jest-config "^27.4.5"
-    jest-haste-map "^27.4.5"
-    jest-message-util "^27.4.2"
+    jest-config "^27.4.7"
+    jest-haste-map "^27.4.6"
+    jest-message-util "^27.4.6"
     jest-regex-util "^27.4.0"
-    jest-resolve "^27.4.5"
-    jest-resolve-dependencies "^27.4.5"
-    jest-runner "^27.4.5"
-    jest-runtime "^27.4.5"
-    jest-snapshot "^27.4.5"
+    jest-resolve "^27.4.6"
+    jest-resolve-dependencies "^27.4.6"
+    jest-runner "^27.4.6"
+    jest-runtime "^27.4.6"
+    jest-snapshot "^27.4.6"
     jest-util "^27.4.2"
-    jest-validate "^27.4.2"
-    jest-watcher "^27.4.2"
+    jest-validate "^27.4.6"
+    jest-watcher "^27.4.6"
     micromatch "^4.0.4"
     rimraf "^3.0.0"
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/environment@^26.6.0", "@jest/environment@^26.6.2":
+"@jest/environment@^26.6.2":
   version "26.6.2"
   resolved "https://registry.npmjs.org/@jest/environment/-/environment-26.6.2.tgz#ba364cc72e221e79cc8f0a99555bf5d7577cf92c"
   integrity sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==
@@ -2760,6 +2938,16 @@
     "@jest/types" "^27.4.2"
     "@types/node" "*"
     jest-mock "^27.4.2"
+
+"@jest/environment@^27.4.6":
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-27.4.6.tgz#1e92885d64f48c8454df35ed9779fbcf31c56d8b"
+  integrity sha512-E6t+RXPfATEEGVidr84WngLNWZ8ffCPky8RqqRK6u1Bn0LK92INe0MDttyPl/JOzaq92BmDzOeuqk09TvM22Sg==
+  dependencies:
+    "@jest/fake-timers" "^27.4.6"
+    "@jest/types" "^27.4.2"
+    "@types/node" "*"
+    jest-mock "^27.4.6"
 
 "@jest/fake-timers@^26.6.2":
   version "26.6.2"
@@ -2785,6 +2973,18 @@
     jest-mock "^27.4.2"
     jest-util "^27.4.2"
 
+"@jest/fake-timers@^27.4.6":
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-27.4.6.tgz#e026ae1671316dbd04a56945be2fa251204324e8"
+  integrity sha512-mfaethuYF8scV8ntPpiVGIHQgS0XIALbpY2jt2l7wb/bvq4Q5pDLk4EP4D7SAvYT1QrPOPVZAtbdGAOOyIgs7A==
+  dependencies:
+    "@jest/types" "^27.4.2"
+    "@sinonjs/fake-timers" "^8.0.1"
+    "@types/node" "*"
+    jest-message-util "^27.4.6"
+    jest-mock "^27.4.6"
+    jest-util "^27.4.2"
+
 "@jest/globals@^26.6.2":
   version "26.6.2"
   resolved "https://registry.npmjs.org/@jest/globals/-/globals-26.6.2.tgz#5b613b78a1aa2655ae908eba638cc96a20df720a"
@@ -2794,14 +2994,14 @@
     "@jest/types" "^26.6.2"
     expect "^26.6.2"
 
-"@jest/globals@^27.4.4":
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.4.4.tgz#fe501a80c23ea2dab585c42be2a519bb5e38530d"
-  integrity sha512-bqpqQhW30BOreXM8bA8t8JbOQzsq/WnPTnBl+It3UxAD9J8yxEAaBEylHx1dtBapAr/UBk8GidXbzmqnee8tYQ==
+"@jest/globals@^27.4.6":
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.4.6.tgz#3f09bed64b0fd7f5f996920258bd4be8f52f060a"
+  integrity sha512-kAiwMGZ7UxrgPzu8Yv9uvWmXXxsy0GciNejlHvfPIfWkSxChzv6bgTS3YqBkGuHcis+ouMFI2696n2t+XYIeFw==
   dependencies:
-    "@jest/environment" "^27.4.4"
+    "@jest/environment" "^27.4.6"
     "@jest/types" "^27.4.2"
-    expect "^27.4.2"
+    expect "^27.4.6"
 
 "@jest/reporters@^26.6.2":
   version "26.6.2"
@@ -2835,15 +3035,15 @@
   optionalDependencies:
     node-notifier "^8.0.0"
 
-"@jest/reporters@^27.4.5":
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.4.5.tgz#e229acca48d18ea39e805540c1c322b075ae63ad"
-  integrity sha512-3orsG4vi8zXuBqEoy2LbnC1kuvkg1KQUgqNxmxpQgIOQEPeV0onvZu+qDQnEoX8qTQErtqn/xzcnbpeTuOLSiA==
+"@jest/reporters@^27.4.6":
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.4.6.tgz#b53dec3a93baf9b00826abf95b932de919d6d8dd"
+  integrity sha512-+Zo9gV81R14+PSq4wzee4GC2mhAN9i9a7qgJWL90Gpx7fHYkWpTBvwWNZUXvJByYR9tAVBdc8VxDWqfJyIUrIQ==
   dependencies:
     "@bcoe/v8-coverage" "^0.2.3"
-    "@jest/console" "^27.4.2"
-    "@jest/test-result" "^27.4.2"
-    "@jest/transform" "^27.4.5"
+    "@jest/console" "^27.4.6"
+    "@jest/test-result" "^27.4.6"
+    "@jest/transform" "^27.4.6"
     "@jest/types" "^27.4.2"
     "@types/node" "*"
     chalk "^4.0.0"
@@ -2852,14 +3052,14 @@
     glob "^7.1.2"
     graceful-fs "^4.2.4"
     istanbul-lib-coverage "^3.0.0"
-    istanbul-lib-instrument "^4.0.3"
+    istanbul-lib-instrument "^5.1.0"
     istanbul-lib-report "^3.0.0"
     istanbul-lib-source-maps "^4.0.0"
-    istanbul-reports "^3.0.2"
-    jest-haste-map "^27.4.5"
-    jest-resolve "^27.4.5"
+    istanbul-reports "^3.1.3"
+    jest-haste-map "^27.4.6"
+    jest-resolve "^27.4.6"
     jest-util "^27.4.2"
-    jest-worker "^27.4.5"
+    jest-worker "^27.4.6"
     slash "^3.0.0"
     source-map "^0.6.0"
     string-length "^4.0.1"
@@ -2894,7 +3094,7 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
-"@jest/test-result@^26.6.0", "@jest/test-result@^26.6.2":
+"@jest/test-result@^26.6.2":
   version "26.6.2"
   resolved "https://registry.npmjs.org/@jest/test-result/-/test-result-26.6.2.tgz#55da58b62df134576cc95476efa5f7949e3f5f18"
   integrity sha512-5O7H5c/7YlojphYNrK02LlDIV2GNPYisKwHm2QTKjNZeEzezCbwYs9swJySv2UfPMyZ0VdsmMv7jIlD/IKYQpQ==
@@ -2904,12 +3104,12 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
-"@jest/test-result@^27.4.2":
-  version "27.4.2"
-  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-27.4.2.tgz#05fd4a5466ec502f3eae0b39dff2b93ea4d5d9ec"
-  integrity sha512-kr+bCrra9jfTgxHXHa2UwoQjxvQk3Am6QbpAiJ5x/50LW8llOYrxILkqY0lZRW/hu8FXesnudbql263+EW9iNA==
+"@jest/test-result@^27.4.6":
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-27.4.6.tgz#b3df94c3d899c040f602cea296979844f61bdf69"
+  integrity sha512-fi9IGj3fkOrlMmhQqa/t9xum8jaJOOAi/lZlm6JXSc55rJMXKHxNDN1oCP39B0/DhNOa2OMupF9BcKZnNtXMOQ==
   dependencies:
-    "@jest/console" "^27.4.2"
+    "@jest/console" "^27.4.6"
     "@jest/types" "^27.4.2"
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
@@ -2925,15 +3125,15 @@
     jest-runner "^26.6.3"
     jest-runtime "^26.6.3"
 
-"@jest/test-sequencer@^27.4.5":
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.4.5.tgz#1d7e026844d343b60d2ca7fd82c579a17b445d7d"
-  integrity sha512-n5woIn/1v+FT+9hniymHPARA9upYUmfi5Pw9ewVwXCDlK4F5/Gkees9v8vdjGdAIJ2MPHLHodiajLpZZanWzEQ==
+"@jest/test-sequencer@^27.4.6":
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.4.6.tgz#447339b8a3d7b5436f50934df30854e442a9d904"
+  integrity sha512-3GL+nsf6E1PsyNsJuvPyIz+DwFuCtBdtvPpm/LMXVkBJbdFvQYCDpccYT56qq5BGniXWlE81n2qk1sdXfZebnw==
   dependencies:
-    "@jest/test-result" "^27.4.2"
+    "@jest/test-result" "^27.4.6"
     graceful-fs "^4.2.4"
-    jest-haste-map "^27.4.5"
-    jest-runtime "^27.4.5"
+    jest-haste-map "^27.4.6"
+    jest-runtime "^27.4.6"
 
 "@jest/transform@^26.6.2":
   version "26.6.2"
@@ -2956,23 +3156,23 @@
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
-"@jest/transform@^27.4.5":
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.4.5.tgz#3dfe2e3680cd4aa27356172bf25617ab5b94f195"
-  integrity sha512-PuMet2UlZtlGzwc6L+aZmR3I7CEBpqadO03pU40l2RNY2fFJ191b9/ITB44LNOhVtsyykx0OZvj0PCyuLm7Eew==
+"@jest/transform@^27.4.6":
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.4.6.tgz#153621940b1ed500305eacdb31105d415dc30231"
+  integrity sha512-9MsufmJC8t5JTpWEQJ0OcOOAXaH5ioaIX6uHVBLBMoCZPfKKQF+EqP8kACAvCZ0Y1h2Zr3uOccg8re+Dr5jxyw==
   dependencies:
     "@babel/core" "^7.1.0"
     "@jest/types" "^27.4.2"
-    babel-plugin-istanbul "^6.0.0"
+    babel-plugin-istanbul "^6.1.1"
     chalk "^4.0.0"
     convert-source-map "^1.4.0"
     fast-json-stable-stringify "^2.0.0"
     graceful-fs "^4.2.4"
-    jest-haste-map "^27.4.5"
+    jest-haste-map "^27.4.6"
     jest-regex-util "^27.4.0"
     jest-util "^27.4.2"
     micromatch "^4.0.4"
-    pirates "^4.0.1"
+    pirates "^4.0.4"
     slash "^3.0.0"
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
@@ -3713,10 +3913,10 @@
     "@types/puppeteer" "*"
     jest-environment-node ">=24 <=26"
 
-"@types/jest@*", "@types/jest@>=27.0.3", "@types/jest@^25.1.4", "@types/jest@^27.0.3":
-  version "27.0.3"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.3.tgz#0cf9dfe9009e467f70a342f0f94ead19842a783a"
-  integrity sha512-cmmwv9t7gBYt7hNKH5Spu7Kuu/DotGa+Ff+JGRKZ4db5eh8PnKS4LuebJ3YLUoyOyIHraTGyULn23YtEAm0VSg==
+"@types/jest@*", "@types/jest@>=27.4.0", "@types/jest@^25.1.4", "@types/jest@^27.4.0":
+  version "27.4.0"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.4.0.tgz#037ab8b872067cae842a320841693080f9cb84ed"
+  integrity sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==
   dependencies:
     jest-diff "^27.0.0"
     pretty-format "^27.0.0"
@@ -5765,15 +5965,15 @@ babel-jest@^26.6.0, babel-jest@^26.6.3:
     graceful-fs "^4.2.4"
     slash "^3.0.0"
 
-babel-jest@^27.4.5:
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.4.5.tgz#d38bd0be8ea71d8b97853a5fc9f76deeb095c709"
-  integrity sha512-3uuUTjXbgtODmSv/DXO9nZfD52IyC2OYTFaXGRzL0kpykzroaquCrD5+lZNafTvZlnNqZHt5pb0M08qVBZnsnA==
+babel-jest@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.4.6.tgz#4d024e69e241cdf4f396e453a07100f44f7ce314"
+  integrity sha512-qZL0JT0HS1L+lOuH+xC2DVASR3nunZi/ozGhpgauJHgmI7f8rudxf6hUjEHympdQ/J64CdKmPkgfJ+A3U6QCrg==
   dependencies:
-    "@jest/transform" "^27.4.5"
+    "@jest/transform" "^27.4.6"
     "@jest/types" "^27.4.2"
     "@types/babel__core" "^7.1.14"
-    babel-plugin-istanbul "^6.0.0"
+    babel-plugin-istanbul "^6.1.1"
     babel-preset-jest "^27.4.0"
     chalk "^4.0.0"
     graceful-fs "^4.2.4"
@@ -5848,9 +6048,9 @@ babel-plugin-emotion@^9.2.11:
     source-map "^0.5.7"
     touch "^2.0.1"
 
-babel-plugin-istanbul@^6.0.0:
+babel-plugin-istanbul@^6.0.0, babel-plugin-istanbul@^6.1.1:
   version "6.1.1"
-  resolved "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz#fa88ec59232fd9b4e36dbbc540a8ec9a9b47da73"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz#fa88ec59232fd9b4e36dbbc540a8ec9a9b47da73"
   integrity sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -10550,7 +10750,7 @@ expect-puppeteer@^6.0.2:
   resolved "https://registry.yarnpkg.com/expect-puppeteer/-/expect-puppeteer-6.0.2.tgz#3da28c89234ddbf56774454155572488c2303843"
   integrity sha512-Xlor321I2MrrgW9BWei0Lq4C9meU7qmyycwQMjprKh+tLG9MalptqdDPse16+1Ffq+hvM/kAlZcEchcteGWhzw==
 
-expect@^26.6.0, expect@^26.6.2:
+expect@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz#c6b996bf26bf3fe18b67b2d0f51fc981ba934417"
   integrity sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==
@@ -10562,17 +10762,15 @@ expect@^26.6.0, expect@^26.6.2:
     jest-message-util "^26.6.2"
     jest-regex-util "^26.0.0"
 
-expect@^27.4.2:
-  version "27.4.2"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-27.4.2.tgz#4429b0f7e307771d176de9bdf23229b101db6ef6"
-  integrity sha512-BjAXIDC6ZOW+WBFNg96J22D27Nq5ohn+oGcuP2rtOtcjuxNoV9McpQ60PcQWhdFOSBIQdR72e+4HdnbZTFSTyg==
+expect@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-27.4.6.tgz#f335e128b0335b6ceb4fcab67ece7cbd14c942e6"
+  integrity sha512-1M/0kAALIaj5LaG66sFJTbRsWTADnylly82cu4bspI0nl+pgP4E6Bh/aqdHlTUjul06K7xQnnrAoqfxVU0+/ag==
   dependencies:
     "@jest/types" "^27.4.2"
-    ansi-styles "^5.0.0"
     jest-get-type "^27.4.0"
-    jest-matcher-utils "^27.4.2"
-    jest-message-util "^27.4.2"
-    jest-regex-util "^27.4.0"
+    jest-matcher-utils "^27.4.6"
+    jest-message-util "^27.4.6"
 
 expose-loader@^1.0.0, expose-loader@^1.0.3:
   version "1.0.3"
@@ -13576,7 +13774,7 @@ istanbul-lib-instrument@^4.0.3:
     istanbul-lib-coverage "^3.0.0"
     semver "^6.3.0"
 
-istanbul-lib-instrument@^5.0.4:
+istanbul-lib-instrument@^5.0.4, istanbul-lib-instrument@^5.1.0:
   version "5.1.0"
   resolved "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz#7b49198b657b27a730b8e9cb601f1e1bff24c59a"
   integrity sha512-czwUz525rkOFDJxfKK6mYfIs9zBKILyrZQxjz3ABhjQXhbhFsSbo1HW/BFcsDnfJYJWA6thRR5/TUY2qs5W99Q==
@@ -13613,6 +13811,14 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+istanbul-reports@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.1.3.tgz#4bcae3103b94518117930d51283690960b50d3c2"
+  integrity sha512-x9LtDVtfm/t1GFiLl3NffC7hz+I1ragvgX1P/Lg1NlIagifZDKUkuuaAxH/qpwj2IuEfD8G2Bs/UKp+sZ/pKkg==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
+
 javascript-natural-sort@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
@@ -13644,54 +13850,27 @@ jest-changed-files@^27.4.2:
     execa "^5.0.0"
     throat "^6.0.1"
 
-jest-circus@26.6.0:
-  version "26.6.0"
-  resolved "https://registry.npmjs.org/jest-circus/-/jest-circus-26.6.0.tgz#7d9647b2e7f921181869faae1f90a2629fd70705"
-  integrity sha512-L2/Y9szN6FJPWFK8kzWXwfp+FOR7xq0cUL4lIsdbIdwz3Vh6P1nrpcqOleSzr28zOtSHQNV9Z7Tl+KkuK7t5Ng==
+jest-circus@26.6.0, jest-circus@>=27.4.6, jest-circus@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.4.6.tgz#d3af34c0eb742a967b1919fbb351430727bcea6c"
+  integrity sha512-UA7AI5HZrW4wRM72Ro80uRR2Fg+7nR0GESbSI/2M+ambbzVuA63mn5T1p3Z/wlhntzGpIG1xx78GP2YIkf6PhQ==
   dependencies:
-    "@babel/traverse" "^7.1.0"
-    "@jest/environment" "^26.6.0"
-    "@jest/test-result" "^26.6.0"
-    "@jest/types" "^26.6.0"
-    "@types/babel__traverse" "^7.0.4"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    co "^4.6.0"
-    dedent "^0.7.0"
-    expect "^26.6.0"
-    is-generator-fn "^2.0.0"
-    jest-each "^26.6.0"
-    jest-matcher-utils "^26.6.0"
-    jest-message-util "^26.6.0"
-    jest-runner "^26.6.0"
-    jest-runtime "^26.6.0"
-    jest-snapshot "^26.6.0"
-    jest-util "^26.6.0"
-    pretty-format "^26.6.0"
-    stack-utils "^2.0.2"
-    throat "^5.0.0"
-
-jest-circus@^27.4.5:
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.4.5.tgz#70bfb78e0200cab9b84747bf274debacaa538467"
-  integrity sha512-eTNWa9wsvBwPykhMMShheafbwyakcdHZaEYh5iRrQ0PFJxkDP/e3U/FvzGuKWu2WpwUA3C3hPlfpuzvOdTVqnw==
-  dependencies:
-    "@jest/environment" "^27.4.4"
-    "@jest/test-result" "^27.4.2"
+    "@jest/environment" "^27.4.6"
+    "@jest/test-result" "^27.4.6"
     "@jest/types" "^27.4.2"
     "@types/node" "*"
     chalk "^4.0.0"
     co "^4.6.0"
     dedent "^0.7.0"
-    expect "^27.4.2"
+    expect "^27.4.6"
     is-generator-fn "^2.0.0"
-    jest-each "^27.4.2"
-    jest-matcher-utils "^27.4.2"
-    jest-message-util "^27.4.2"
-    jest-runtime "^27.4.5"
-    jest-snapshot "^27.4.5"
+    jest-each "^27.4.6"
+    jest-matcher-utils "^27.4.6"
+    jest-message-util "^27.4.6"
+    jest-runtime "^27.4.6"
+    jest-snapshot "^27.4.6"
     jest-util "^27.4.2"
-    pretty-format "^27.4.2"
+    pretty-format "^27.4.6"
     slash "^3.0.0"
     stack-utils "^2.0.3"
     throat "^6.0.1"
@@ -13715,21 +13894,21 @@ jest-cli@^26.6.0:
     prompts "^2.0.1"
     yargs "^15.4.1"
 
-jest-cli@^27.4.5:
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.4.5.tgz#8708f54c28d13681f3255ec9026a2b15b03d41e8"
-  integrity sha512-hrky3DSgE0u7sQxaCL7bdebEPHx5QzYmrGuUjaPLmPE8jx5adtvGuOlRspvMoVLTTDOHRnZDoRLYJuA+VCI7Hg==
+jest-cli@^27.4.7:
+  version "27.4.7"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.4.7.tgz#d00e759e55d77b3bcfea0715f527c394ca314e5a"
+  integrity sha512-zREYhvjjqe1KsGV15mdnxjThKNDgza1fhDT+iUsXWLCq3sxe9w5xnvyctcYVT5PcdLSjv7Y5dCwTS3FCF1tiuw==
   dependencies:
-    "@jest/core" "^27.4.5"
-    "@jest/test-result" "^27.4.2"
+    "@jest/core" "^27.4.7"
+    "@jest/test-result" "^27.4.6"
     "@jest/types" "^27.4.2"
     chalk "^4.0.0"
     exit "^0.1.2"
     graceful-fs "^4.2.4"
     import-local "^3.0.2"
-    jest-config "^27.4.5"
+    jest-config "^27.4.7"
     jest-util "^27.4.2"
-    jest-validate "^27.4.2"
+    jest-validate "^27.4.6"
     prompts "^2.0.1"
     yargs "^16.2.0"
 
@@ -13757,32 +13936,32 @@ jest-config@^26.6.3:
     micromatch "^4.0.2"
     pretty-format "^26.6.2"
 
-jest-config@^27.4.5:
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-27.4.5.tgz#77ed7f2ba7bcfd7d740ade711d0d13512e08a59e"
-  integrity sha512-t+STVJtPt+fpqQ8GBw850NtSQbnDOw/UzdPfzDaHQ48/AylQlW7LHj3dH+ndxhC1UxJ0Q3qkq7IH+nM1skwTwA==
+jest-config@^27.4.7:
+  version "27.4.7"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-27.4.7.tgz#4f084b2acbd172c8b43aa4cdffe75d89378d3972"
+  integrity sha512-xz/o/KJJEedHMrIY9v2ParIoYSrSVY6IVeE4z5Z3i101GoA5XgfbJz+1C8EYPsv7u7f39dS8F9v46BHDhn0vlw==
   dependencies:
-    "@babel/core" "^7.1.0"
-    "@jest/test-sequencer" "^27.4.5"
+    "@babel/core" "^7.8.0"
+    "@jest/test-sequencer" "^27.4.6"
     "@jest/types" "^27.4.2"
-    babel-jest "^27.4.5"
+    babel-jest "^27.4.6"
     chalk "^4.0.0"
     ci-info "^3.2.0"
     deepmerge "^4.2.2"
     glob "^7.1.1"
     graceful-fs "^4.2.4"
-    jest-circus "^27.4.5"
-    jest-environment-jsdom "^27.4.4"
-    jest-environment-node "^27.4.4"
+    jest-circus "^27.4.6"
+    jest-environment-jsdom "^27.4.6"
+    jest-environment-node "^27.4.6"
     jest-get-type "^27.4.0"
-    jest-jasmine2 "^27.4.5"
+    jest-jasmine2 "^27.4.6"
     jest-regex-util "^27.4.0"
-    jest-resolve "^27.4.5"
-    jest-runner "^27.4.5"
+    jest-resolve "^27.4.6"
+    jest-runner "^27.4.6"
     jest-util "^27.4.2"
-    jest-validate "^27.4.2"
+    jest-validate "^27.4.6"
     micromatch "^4.0.4"
-    pretty-format "^27.4.2"
+    pretty-format "^27.4.6"
     slash "^3.0.0"
 
 jest-dev-server@^6.0.3:
@@ -13818,6 +13997,16 @@ jest-diff@^27.0.0, jest-diff@^27.2.5, jest-diff@^27.4.2:
     jest-get-type "^27.4.0"
     pretty-format "^27.4.2"
 
+jest-diff@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.4.6.tgz#93815774d2012a2cbb6cf23f84d48c7a2618f98d"
+  integrity sha512-zjaB0sh0Lb13VyPsd92V7HkqF6yKRH9vm33rwBt7rPYrpQvS1nCvlIy2pICbKta+ZjWngYLNn4cCK4nyZkjS/w==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.4.0"
+    jest-get-type "^27.4.0"
+    pretty-format "^27.4.6"
+
 jest-docblock@^26.0.0:
   version "26.0.0"
   resolved "https://registry.npmjs.org/jest-docblock/-/jest-docblock-26.0.0.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5"
@@ -13832,7 +14021,7 @@ jest-docblock@^27.4.0:
   dependencies:
     detect-newline "^3.0.0"
 
-jest-each@^26.6.0, jest-each@^26.6.2:
+jest-each@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/jest-each/-/jest-each-26.6.2.tgz#02526438a77a67401c8a6382dfe5999952c167cb"
   integrity sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==
@@ -13843,16 +14032,16 @@ jest-each@^26.6.0, jest-each@^26.6.2:
     jest-util "^26.6.2"
     pretty-format "^26.6.2"
 
-jest-each@^27.4.2:
-  version "27.4.2"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-27.4.2.tgz#19364c82a692d0d26557642098d1f4619c9ee7d3"
-  integrity sha512-53V2MNyW28CTruB3lXaHNk6PkiIFuzdOC9gR3C6j8YE/ACfrPnz+slB0s17AgU1TtxNzLuHyvNlLJ+8QYw9nBg==
+jest-each@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-27.4.6.tgz#e7e8561be61d8cc6dbf04296688747ab186c40ff"
+  integrity sha512-n6QDq8y2Hsmn22tRkgAk+z6MCX7MeVlAzxmZDshfS2jLcaBlyhpF3tZSJLR+kXmh23GEvS0ojMR8i6ZeRvpQcA==
   dependencies:
     "@jest/types" "^27.4.2"
     chalk "^4.0.0"
     jest-get-type "^27.4.0"
     jest-util "^27.4.2"
-    pretty-format "^27.4.2"
+    pretty-format "^27.4.6"
 
 jest-environment-jsdom@^26.6.2:
   version "26.6.2"
@@ -13867,16 +14056,16 @@ jest-environment-jsdom@^26.6.2:
     jest-util "^26.6.2"
     jsdom "^16.4.0"
 
-jest-environment-jsdom@^27.4.4:
-  version "27.4.4"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.4.4.tgz#94f738e99514d7a880e8ed8e03e3a321d43b49db"
-  integrity sha512-cYR3ndNfHBqQgFvS1RL7dNqSvD//K56j/q1s2ygNHcfTCAp12zfIromO1w3COmXrxS8hWAh7+CmZmGCIoqGcGA==
+jest-environment-jsdom@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.4.6.tgz#c23a394eb445b33621dfae9c09e4c8021dea7b36"
+  integrity sha512-o3dx5p/kHPbUlRvSNjypEcEtgs6LmvESMzgRFQE6c+Prwl2JLA4RZ7qAnxc5VM8kutsGRTB15jXeeSbJsKN9iA==
   dependencies:
-    "@jest/environment" "^27.4.4"
-    "@jest/fake-timers" "^27.4.2"
+    "@jest/environment" "^27.4.6"
+    "@jest/fake-timers" "^27.4.6"
     "@jest/types" "^27.4.2"
     "@types/node" "*"
-    jest-mock "^27.4.2"
+    jest-mock "^27.4.6"
     jest-util "^27.4.2"
     jsdom "^16.6.0"
 
@@ -13902,6 +14091,18 @@ jest-environment-node@^27.4.4:
     "@jest/types" "^27.4.2"
     "@types/node" "*"
     jest-mock "^27.4.2"
+    jest-util "^27.4.2"
+
+jest-environment-node@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-27.4.6.tgz#ee8cd4ef458a0ef09d087c8cd52ca5856df90242"
+  integrity sha512-yfHlZ9m+kzTKZV0hVfhVu6GuDxKAYeFHrfulmy7Jxwsq4V7+ZK7f+c0XP/tbVDMQW7E4neG2u147hFkuVz0MlQ==
+  dependencies:
+    "@jest/environment" "^27.4.6"
+    "@jest/fake-timers" "^27.4.6"
+    "@jest/types" "^27.4.2"
+    "@types/node" "*"
+    jest-mock "^27.4.6"
     jest-util "^27.4.2"
 
 jest-environment-puppeteer@^6.0.3:
@@ -13956,10 +14157,10 @@ jest-haste-map@^26.6.2:
   optionalDependencies:
     fsevents "^2.1.2"
 
-jest-haste-map@^27.4.5:
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.4.5.tgz#c2921224a59223f91e03ec15703905978ef0cc1a"
-  integrity sha512-oJm1b5qhhPs78K24EDGifWS0dELYxnoBiDhatT/FThgB9yxqUm5F6li3Pv+Q+apMBmmPNzOBnZ7ZxWMB1Leq1Q==
+jest-haste-map@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.4.6.tgz#c60b5233a34ca0520f325b7e2cc0a0140ad0862a"
+  integrity sha512-0tNpgxg7BKurZeFkIOvGCkbmOHbLFf4LUQOxrQSMjvrQaQe3l6E8x6jYC1NuWkGo5WDdbr8FEzUxV2+LWNawKQ==
   dependencies:
     "@jest/types" "^27.4.2"
     "@types/graceful-fs" "^4.1.2"
@@ -13970,7 +14171,7 @@ jest-haste-map@^27.4.5:
     jest-regex-util "^27.4.0"
     jest-serializer "^27.4.0"
     jest-util "^27.4.2"
-    jest-worker "^27.4.5"
+    jest-worker "^27.4.6"
     micromatch "^4.0.4"
     walker "^1.0.7"
   optionalDependencies:
@@ -14022,28 +14223,27 @@ jest-jasmine2@^26.6.3:
     pretty-format "^26.6.2"
     throat "^5.0.0"
 
-jest-jasmine2@^27.4.5:
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.4.5.tgz#ff79d11561679ff6c89715b0cd6b1e8c0dfbc6dc"
-  integrity sha512-oUnvwhJDj2LhOiUB1kdnJjkx8C5PwgUZQb9urF77mELH9DGR4e2GqpWQKBOYXWs5+uTN9BGDqRz3Aeg5Wts7aw==
+jest-jasmine2@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.4.6.tgz#109e8bc036cb455950ae28a018f983f2abe50127"
+  integrity sha512-uAGNXF644I/whzhsf7/qf74gqy9OuhvJ0XYp8SDecX2ooGeaPnmJMjXjKt0mqh1Rl5dtRGxJgNrHlBQIBfS5Nw==
   dependencies:
-    "@babel/traverse" "^7.1.0"
-    "@jest/environment" "^27.4.4"
+    "@jest/environment" "^27.4.6"
     "@jest/source-map" "^27.4.0"
-    "@jest/test-result" "^27.4.2"
+    "@jest/test-result" "^27.4.6"
     "@jest/types" "^27.4.2"
     "@types/node" "*"
     chalk "^4.0.0"
     co "^4.6.0"
-    expect "^27.4.2"
+    expect "^27.4.6"
     is-generator-fn "^2.0.0"
-    jest-each "^27.4.2"
-    jest-matcher-utils "^27.4.2"
-    jest-message-util "^27.4.2"
-    jest-runtime "^27.4.5"
-    jest-snapshot "^27.4.5"
+    jest-each "^27.4.6"
+    jest-matcher-utils "^27.4.6"
+    jest-message-util "^27.4.6"
+    jest-runtime "^27.4.6"
+    jest-snapshot "^27.4.6"
     jest-util "^27.4.2"
-    pretty-format "^27.4.2"
+    pretty-format "^27.4.6"
     throat "^6.0.1"
 
 jest-leak-detector@^26.6.2:
@@ -14054,15 +14254,15 @@ jest-leak-detector@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
-jest-leak-detector@^27.4.2:
-  version "27.4.2"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-27.4.2.tgz#7fc3120893a7a911c553f3f2bdff9faa4454abbb"
-  integrity sha512-ml0KvFYZllzPBJWDei3mDzUhyp/M4ubKebX++fPaudpe8OsxUE+m+P6ciVLboQsrzOCWDjE20/eXew9QMx/VGw==
+jest-leak-detector@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-27.4.6.tgz#ed9bc3ce514b4c582637088d9faf58a33bd59bf4"
+  integrity sha512-kkaGixDf9R7CjHm2pOzfTxZTQQQ2gHTIWKY/JZSiYTc90bZp8kSZnUMS3uLAfwTZwc0tcMRoEX74e14LG1WapA==
   dependencies:
     jest-get-type "^27.4.0"
-    pretty-format "^27.4.2"
+    pretty-format "^27.4.6"
 
-jest-matcher-utils@^26.6.0, jest-matcher-utils@^26.6.2:
+jest-matcher-utils@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz#8e6fd6e863c8b2d31ac6472eeb237bc595e53e7a"
   integrity sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==
@@ -14072,7 +14272,7 @@ jest-matcher-utils@^26.6.0, jest-matcher-utils@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
-jest-matcher-utils@^27.2.4, jest-matcher-utils@^27.4.2:
+jest-matcher-utils@^27.2.4:
   version "27.4.2"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.4.2.tgz#d17c5038607978a255e0a9a5c32c24e984b6c60b"
   integrity sha512-jyP28er3RRtMv+fmYC/PKG8wvAmfGcSNproVTW2Y0P/OY7/hWUOmsPfxN1jOhM+0u2xU984u2yEagGivz9OBGQ==
@@ -14081,6 +14281,16 @@ jest-matcher-utils@^27.2.4, jest-matcher-utils@^27.4.2:
     jest-diff "^27.4.2"
     jest-get-type "^27.4.0"
     pretty-format "^27.4.2"
+
+jest-matcher-utils@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.4.6.tgz#53ca7f7b58170638590e946f5363b988775509b8"
+  integrity sha512-XD4PKT3Wn1LQnRAq7ZsTI0VRuEc9OrCPFiO1XL7bftTGmfNF0DcEwMHRgqiu7NGf8ZoZDREpGrCniDkjt79WbA==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^27.4.6"
+    jest-get-type "^27.4.0"
+    pretty-format "^27.4.6"
 
 jest-message-util@^25.5.0:
   version "25.5.0"
@@ -14096,7 +14306,7 @@ jest-message-util@^25.5.0:
     slash "^3.0.0"
     stack-utils "^1.0.1"
 
-jest-message-util@^26.6.0, jest-message-util@^26.6.2:
+jest-message-util@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz#58173744ad6fc0506b5d21150b9be56ef001ca07"
   integrity sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==
@@ -14126,6 +14336,21 @@ jest-message-util@^27.4.2:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
+jest-message-util@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-27.4.6.tgz#9fdde41a33820ded3127465e1a5896061524da31"
+  integrity sha512-0p5szriFU0U74czRSFjH6RyS7UYIAkn/ntwMuOwTGWrQIOh5NzXXrq72LOqIkJKKvFbPq+byZKuBz78fjBERBA==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^27.4.2"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    micromatch "^4.0.4"
+    pretty-format "^27.4.6"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
 jest-mock@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.2.tgz#d6cb712b041ed47fe0d9b6fc3474bc6543feb302"
@@ -14138,6 +14363,14 @@ jest-mock@^27.4.2:
   version "27.4.2"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.4.2.tgz#184ff197a25491bfe4570c286daa5d62eb760b88"
   integrity sha512-PDDPuyhoukk20JrQKeofK12hqtSka7mWH0QQuxSNgrdiPsrnYYLS6wbzu/HDlxZRzji5ylLRULeuI/vmZZDrYA==
+  dependencies:
+    "@jest/types" "^27.4.2"
+    "@types/node" "*"
+
+jest-mock@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.4.6.tgz#77d1ba87fbd33ccb8ef1f061697e7341b7635195"
+  integrity sha512-kvojdYRkst8iVSZ1EJ+vc1RRD9llueBjKzXzeCytH3dMM7zvPV/ULcfI2nr0v0VUgm3Bjt3hBCQvOeaBz+ZTHw==
   dependencies:
     "@jest/types" "^27.4.2"
     "@types/node" "*"
@@ -14174,14 +14407,14 @@ jest-resolve-dependencies@^26.6.3:
     jest-regex-util "^26.0.0"
     jest-snapshot "^26.6.2"
 
-jest-resolve-dependencies@^27.4.5:
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-27.4.5.tgz#9398af854bdb12d6a9e5a8a536ee401f889a3ecf"
-  integrity sha512-elEVvkvRK51y037NshtEkEnukMBWvlPzZHiL847OrIljJ8yIsujD2GXRPqDXC4rEVKbcdsy7W0FxoZb4WmEs7w==
+jest-resolve-dependencies@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-27.4.6.tgz#fc50ee56a67d2c2183063f6a500cc4042b5e2327"
+  integrity sha512-W85uJZcFXEVZ7+MZqIPCscdjuctruNGXUZ3OHSXOfXR9ITgbUKeHj+uGcies+0SsvI5GtUfTw4dY7u9qjTvQOw==
   dependencies:
     "@jest/types" "^27.4.2"
     jest-regex-util "^27.4.0"
-    jest-snapshot "^27.4.5"
+    jest-snapshot "^27.4.6"
 
 jest-resolve@26.6.0:
   version "26.6.0"
@@ -14211,23 +14444,23 @@ jest-resolve@^26.6.2:
     resolve "^1.18.1"
     slash "^3.0.0"
 
-jest-resolve@^27.4.5:
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.4.5.tgz#8dc44f5065fb8d58944c20f932cb7b9fe9760cca"
-  integrity sha512-xU3z1BuOz/hUhVUL+918KqUgK+skqOuUsAi7A+iwoUldK6/+PW+utK8l8cxIWT9AW7IAhGNXjSAh1UYmjULZZw==
+jest-resolve@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.4.6.tgz#2ec3110655e86d5bfcfa992e404e22f96b0b5977"
+  integrity sha512-SFfITVApqtirbITKFAO7jOVN45UgFzcRdQanOFzjnbd+CACDoyeX7206JyU92l4cRr73+Qy/TlW51+4vHGt+zw==
   dependencies:
     "@jest/types" "^27.4.2"
     chalk "^4.0.0"
     graceful-fs "^4.2.4"
-    jest-haste-map "^27.4.5"
+    jest-haste-map "^27.4.6"
     jest-pnp-resolver "^1.2.2"
     jest-util "^27.4.2"
-    jest-validate "^27.4.2"
+    jest-validate "^27.4.6"
     resolve "^1.20.0"
     resolve.exports "^1.1.0"
     slash "^3.0.0"
 
-jest-runner@^26.6.0, jest-runner@^26.6.3:
+jest-runner@^26.6.3:
   version "26.6.3"
   resolved "https://registry.npmjs.org/jest-runner/-/jest-runner-26.6.3.tgz#2d1fed3d46e10f233fd1dbd3bfaa3fe8924be159"
   integrity sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
@@ -14253,15 +14486,15 @@ jest-runner@^26.6.0, jest-runner@^26.6.3:
     source-map-support "^0.5.6"
     throat "^5.0.0"
 
-jest-runner@^27.4.5:
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-27.4.5.tgz#daba2ba71c8f34137dc7ac45616add35370a681e"
-  integrity sha512-/irauncTfmY1WkTaRQGRWcyQLzK1g98GYG/8QvIPviHgO1Fqz1JYeEIsSfF+9mc/UTA6S+IIHFgKyvUrtiBIZg==
+jest-runner@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-27.4.6.tgz#1d390d276ec417e9b4d0d081783584cbc3e24773"
+  integrity sha512-IDeFt2SG4DzqalYBZRgbbPmpwV3X0DcntjezPBERvnhwKGWTW7C5pbbA5lVkmvgteeNfdd/23gwqv3aiilpYPg==
   dependencies:
-    "@jest/console" "^27.4.2"
-    "@jest/environment" "^27.4.4"
-    "@jest/test-result" "^27.4.2"
-    "@jest/transform" "^27.4.5"
+    "@jest/console" "^27.4.6"
+    "@jest/environment" "^27.4.6"
+    "@jest/test-result" "^27.4.6"
+    "@jest/transform" "^27.4.6"
     "@jest/types" "^27.4.2"
     "@types/node" "*"
     chalk "^4.0.0"
@@ -14269,19 +14502,19 @@ jest-runner@^27.4.5:
     exit "^0.1.2"
     graceful-fs "^4.2.4"
     jest-docblock "^27.4.0"
-    jest-environment-jsdom "^27.4.4"
-    jest-environment-node "^27.4.4"
-    jest-haste-map "^27.4.5"
-    jest-leak-detector "^27.4.2"
-    jest-message-util "^27.4.2"
-    jest-resolve "^27.4.5"
-    jest-runtime "^27.4.5"
+    jest-environment-jsdom "^27.4.6"
+    jest-environment-node "^27.4.6"
+    jest-haste-map "^27.4.6"
+    jest-leak-detector "^27.4.6"
+    jest-message-util "^27.4.6"
+    jest-resolve "^27.4.6"
+    jest-runtime "^27.4.6"
     jest-util "^27.4.2"
-    jest-worker "^27.4.5"
+    jest-worker "^27.4.6"
     source-map-support "^0.5.6"
     throat "^6.0.1"
 
-jest-runtime@^26.6.0, jest-runtime@^26.6.3:
+jest-runtime@^26.6.3:
   version "26.6.3"
   resolved "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.6.3.tgz#4f64efbcfac398331b74b4b3c82d27d401b8fa2b"
   integrity sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
@@ -14314,37 +14547,33 @@ jest-runtime@^26.6.0, jest-runtime@^26.6.3:
     strip-bom "^4.0.0"
     yargs "^15.4.1"
 
-jest-runtime@^27.4.5:
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.4.5.tgz#97703ad2a1799d4f50ab59049bd21a9ceaed2813"
-  integrity sha512-CIYqwuJQXHQtPd/idgrx4zgJ6iCb6uBjQq1RSAGQrw2S8XifDmoM1Ot8NRd80ooAm+ZNdHVwsktIMGlA1F1FAQ==
+jest-runtime@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.4.6.tgz#83ae923818e3ea04463b22f3597f017bb5a1cffa"
+  integrity sha512-eXYeoR/MbIpVDrjqy5d6cGCFOYBFFDeKaNWqTp0h6E74dK0zLHzASQXJpl5a2/40euBmKnprNLJ0Kh0LCndnWQ==
   dependencies:
-    "@jest/console" "^27.4.2"
-    "@jest/environment" "^27.4.4"
-    "@jest/globals" "^27.4.4"
+    "@jest/environment" "^27.4.6"
+    "@jest/fake-timers" "^27.4.6"
+    "@jest/globals" "^27.4.6"
     "@jest/source-map" "^27.4.0"
-    "@jest/test-result" "^27.4.2"
-    "@jest/transform" "^27.4.5"
+    "@jest/test-result" "^27.4.6"
+    "@jest/transform" "^27.4.6"
     "@jest/types" "^27.4.2"
-    "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
     cjs-module-lexer "^1.0.0"
     collect-v8-coverage "^1.0.0"
     execa "^5.0.0"
-    exit "^0.1.2"
     glob "^7.1.3"
     graceful-fs "^4.2.4"
-    jest-haste-map "^27.4.5"
-    jest-message-util "^27.4.2"
-    jest-mock "^27.4.2"
+    jest-haste-map "^27.4.6"
+    jest-message-util "^27.4.6"
+    jest-mock "^27.4.6"
     jest-regex-util "^27.4.0"
-    jest-resolve "^27.4.5"
-    jest-snapshot "^27.4.5"
+    jest-resolve "^27.4.6"
+    jest-snapshot "^27.4.6"
     jest-util "^27.4.2"
-    jest-validate "^27.4.2"
     slash "^3.0.0"
     strip-bom "^4.0.0"
-    yargs "^16.2.0"
 
 jest-serializer@^26.6.2:
   version "26.6.2"
@@ -14362,7 +14591,7 @@ jest-serializer@^27.4.0:
     "@types/node" "*"
     graceful-fs "^4.2.4"
 
-jest-snapshot@^26.6.0, jest-snapshot@^26.6.2:
+jest-snapshot@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.6.2.tgz#f3b0af1acb223316850bd14e1beea9837fb39c84"
   integrity sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==
@@ -14384,34 +14613,32 @@ jest-snapshot@^26.6.0, jest-snapshot@^26.6.2:
     pretty-format "^26.6.2"
     semver "^7.3.2"
 
-jest-snapshot@^27.4.5:
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.4.5.tgz#2ea909b20aac0fe62504bc161331f730b8a7ecc7"
-  integrity sha512-eCi/iM1YJFrJWiT9de4+RpWWWBqsHiYxFG9V9o/n0WXs6GpW4lUt4FAHAgFPTLPqCUVzrMQmSmTZSgQzwqR7IQ==
+jest-snapshot@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.4.6.tgz#e2a3b4fff8bdce3033f2373b2e525d8b6871f616"
+  integrity sha512-fafUCDLQfzuNP9IRcEqaFAMzEe7u5BF7mude51wyWv7VRex60WznZIC7DfKTgSIlJa8aFzYmXclmN328aqSDmQ==
   dependencies:
     "@babel/core" "^7.7.2"
     "@babel/generator" "^7.7.2"
-    "@babel/parser" "^7.7.2"
     "@babel/plugin-syntax-typescript" "^7.7.2"
     "@babel/traverse" "^7.7.2"
     "@babel/types" "^7.0.0"
-    "@jest/transform" "^27.4.5"
+    "@jest/transform" "^27.4.6"
     "@jest/types" "^27.4.2"
     "@types/babel__traverse" "^7.0.4"
     "@types/prettier" "^2.1.5"
     babel-preset-current-node-syntax "^1.0.0"
     chalk "^4.0.0"
-    expect "^27.4.2"
+    expect "^27.4.6"
     graceful-fs "^4.2.4"
-    jest-diff "^27.4.2"
+    jest-diff "^27.4.6"
     jest-get-type "^27.4.0"
-    jest-haste-map "^27.4.5"
-    jest-matcher-utils "^27.4.2"
-    jest-message-util "^27.4.2"
-    jest-resolve "^27.4.5"
+    jest-haste-map "^27.4.6"
+    jest-matcher-utils "^27.4.6"
+    jest-message-util "^27.4.6"
     jest-util "^27.4.2"
     natural-compare "^1.4.0"
-    pretty-format "^27.4.2"
+    pretty-format "^27.4.6"
     semver "^7.3.2"
 
 jest-util@^25.5.0:
@@ -14461,17 +14688,17 @@ jest-validate@^26.6.2:
     leven "^3.1.0"
     pretty-format "^26.6.2"
 
-jest-validate@^27.4.2:
-  version "27.4.2"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-27.4.2.tgz#eecfcc1b1c9429aa007da08a2bae4e32a81bbbc3"
-  integrity sha512-hWYsSUej+Fs8ZhOm5vhWzwSLmVaPAxRy+Mr+z5MzeaHm9AxUpXdoVMEW4R86y5gOobVfBsMFLk4Rb+QkiEpx1A==
+jest-validate@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-27.4.6.tgz#efc000acc4697b6cf4fa68c7f3f324c92d0c4f1f"
+  integrity sha512-872mEmCPVlBqbA5dToC57vA3yJaMRfIdpCoD3cyHWJOMx+SJwLNw0I71EkWs41oza/Er9Zno9XuTkRYCPDUJXQ==
   dependencies:
     "@jest/types" "^27.4.2"
     camelcase "^6.2.0"
     chalk "^4.0.0"
     jest-get-type "^27.4.0"
     leven "^3.1.0"
-    pretty-format "^27.4.2"
+    pretty-format "^27.4.6"
 
 jest-watch-typeahead@0.6.1:
   version "0.6.1"
@@ -14499,12 +14726,12 @@ jest-watcher@^26.3.0, jest-watcher@^26.6.2:
     jest-util "^26.6.2"
     string-length "^4.0.1"
 
-jest-watcher@^27.4.2:
-  version "27.4.2"
-  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-27.4.2.tgz#c9037edfd80354c9fe90de4b6f8b6e2b8e736744"
-  integrity sha512-NJvMVyyBeXfDezhWzUOCOYZrUmkSCiatpjpm+nFUid74OZEHk6aMLrZAukIiFDwdbqp6mTM6Ui1w4oc+8EobQg==
+jest-watcher@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-27.4.6.tgz#673679ebeffdd3f94338c24f399b85efc932272d"
+  integrity sha512-yKQ20OMBiCDigbD0quhQKLkBO+ObGN79MO4nT7YaCuQ5SM+dkBNWE8cZX0FjU6czwMvWw6StWbe+Wv4jJPJ+fw==
   dependencies:
-    "@jest/test-result" "^27.4.2"
+    "@jest/test-result" "^27.4.6"
     "@jest/types" "^27.4.2"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
@@ -14546,10 +14773,10 @@ jest-worker@^27.3.1:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest-worker@^27.4.5:
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.4.5.tgz#d696e3e46ae0f24cff3fa7195ffba22889262242"
-  integrity sha512-f2s8kEdy15cv9r7q4KkzGXvlY0JTcmCbMHZBfSQDwW77REr45IDWwd0lksDFeVHH2jJ5pqb90T77XscrjeGzzg==
+jest-worker@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.4.6.tgz#5d2d93db419566cb680752ca0792780e71b3273e"
+  integrity sha512-gHWJF/6Xi5CTG5QCvROr6GcmpIqNYpDJyc8A1h/DyXqH1tD6SnRCM0d3U5msV31D2LB/U+E0M+W4oyvKV44oNw==
   dependencies:
     "@types/node" "*"
     merge-stream "^2.0.0"
@@ -14564,14 +14791,14 @@ jest@26.6.0:
     import-local "^3.0.2"
     jest-cli "^26.6.0"
 
-jest@^27.4.5:
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-27.4.5.tgz#66e45acba44137fac26be9d3cc5bb031e136dc0f"
-  integrity sha512-uT5MiVN3Jppt314kidCk47MYIRilJjA/l2mxwiuzzxGUeJIvA8/pDaJOAX5KWvjAo7SCydcW0/4WEtgbLMiJkg==
+jest@^27.4.7:
+  version "27.4.7"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-27.4.7.tgz#87f74b9026a1592f2da05b4d258e57505f28eca4"
+  integrity sha512-8heYvsx7nV/m8m24Vk26Y87g73Ba6ueUd0MWed/NXMhSZIm62U/llVbS0PJe1SHunbyXjJ/BqG1z9bFjGUIvTg==
   dependencies:
-    "@jest/core" "^27.4.5"
+    "@jest/core" "^27.4.7"
     import-local "^3.0.2"
-    jest-cli "^27.4.5"
+    jest-cli "^27.4.7"
 
 joi-browser@^13.4.0:
   version "13.4.0"
@@ -17865,6 +18092,11 @@ pirates@^4.0.1:
   dependencies:
     node-modules-regexp "^1.0.0"
 
+pirates@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.4.tgz#07df81e61028e402735cdd49db701e4885b4e6e6"
+  integrity sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw==
+
 pkg-dir@4.2.0, pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
@@ -19049,7 +19281,7 @@ pretty-error@^2.0.2, pretty-error@^2.1.1:
     lodash "^4.17.20"
     renderkid "^2.0.4"
 
-pretty-format@^26.6.0, pretty-format@^26.6.2:
+pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
@@ -19065,6 +19297,15 @@ pretty-format@^27.0.0, pretty-format@^27.4.2:
   integrity sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==
   dependencies:
     "@jest/types" "^27.4.2"
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.4.6:
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.4.6.tgz#1b784d2f53c68db31797b2348fa39b49e31846b7"
+  integrity sha512-NblstegA1y/RJW2VyML+3LlpFjzx62cUrtBIKIWDXEDkjNeleA7Od7nrzcs/VLQvAeV4CgSYhrN39DRN88Qi/g==
+  dependencies:
     ansi-regex "^5.0.1"
     ansi-styles "^5.0.0"
     react-is "^17.0.1"


### PR DESCRIPTION
## Description

This PR improves the studio E2E tests by removing most (if not all) timeout waits and adapting the code to use the latest API of Jest-Puppeteer. It also uncomments some discarded tests.

## Type of change

Please delete options that are not relevant.

- [X] Chore change (test changes)
