### PR TITLE
feat(runtime): add media url support

### DIFF
--- a/packages/runtime/src/common/url.test.ts
+++ b/packages/runtime/src/common/url.test.ts
@@ -1,10 +1,10 @@
 import { formatUrl, parseBotpressMediaUrl } from './url'
 
-describe('URL Fromatting', () => {
+describe('URL Formatting', () => {
   const EXTERNAL_URL = 'http://localhost:3000'
   const MEDIA_URL = 'http://media.service'
 
-  it('Validate url parsing', () => {
+  it('Validate URL parsing', () => {
     const result = parseBotpressMediaUrl('/api/v1/bots/welcome-bot/media/abc123.png')
     expect(result).toEqual({
       isBotpressUrl: true,
@@ -13,17 +13,17 @@ describe('URL Fromatting', () => {
     })
   })
 
-  it('Basic url', () => {
+  it('Basic URL', () => {
     const result = formatUrl(EXTERNAL_URL, '/api/v1/bots/welcome-bot/media/abc123.png')
     expect(result).toBe(`${EXTERNAL_URL}/api/v1/bots/welcome-bot/media/abc123.png`)
   })
 
-  it('Not a botpress URL', () => {
+  it('Not a Botpress URL', () => {
     const result = formatUrl(EXTERNAL_URL, 'http://google.com/images/abc123.png')
     expect(result).toBe('http://google.com/images/abc123.png')
   })
 
-  it('With a custom media url', () => {
+  it('With a custom media URL', () => {
     const result = formatUrl(EXTERNAL_URL, '/api/v1/bots/welcome-bot/media/abc123.png', MEDIA_URL)
     expect(result).toBe(`${MEDIA_URL}/welcome-bot/abc123.png`)
   })

--- a/packages/runtime/src/common/url.test.ts
+++ b/packages/runtime/src/common/url.test.ts
@@ -1,0 +1,30 @@
+import { formatUrl, parseBotpressMediaUrl } from './url'
+
+describe('URL Fromatting', () => {
+  const EXTERNAL_URL = 'http://localhost:3000'
+  const MEDIA_URL = 'http://media.service'
+
+  it('Validate url parsing', () => {
+    const result = parseBotpressMediaUrl('/api/v1/bots/welcome-bot/media/abc123.png')
+    expect(result).toEqual({
+      isBotpressUrl: true,
+      botId: 'welcome-bot',
+      mediaId: 'abc123.png'
+    })
+  })
+
+  it('Basic url', () => {
+    const result = formatUrl(EXTERNAL_URL, '/api/v1/bots/welcome-bot/media/abc123.png')
+    expect(result).toBe(`${EXTERNAL_URL}/api/v1/bots/welcome-bot/media/abc123.png`)
+  })
+
+  it('Not a botpress URL', () => {
+    const result = formatUrl(EXTERNAL_URL, 'http://google.com/images/abc123.png')
+    expect(result).toBe('http://google.com/images/abc123.png')
+  })
+
+  it('With a custom media url', () => {
+    const result = formatUrl(EXTERNAL_URL, '/api/v1/bots/welcome-bot/media/abc123.png', MEDIA_URL)
+    expect(result).toBe(`${MEDIA_URL}/welcome-bot/abc123.png`)
+  })
+})

--- a/packages/runtime/src/common/url.ts
+++ b/packages/runtime/src/common/url.ts
@@ -10,7 +10,7 @@ interface MediaUrlElements {
   isBotpressUrl: boolean
 }
 
-const parseBotpressMediaUrl = (url: string): MediaUrlElements => {
+export const parseBotpressMediaUrl = (url: string): MediaUrlElements => {
   const bpUrlRegex = /^\/api\/.*\/bots\/(.*)\/media\/(.*)/g
   const parts = bpUrlRegex.exec(url)
 
@@ -21,12 +21,12 @@ const parseBotpressMediaUrl = (url: string): MediaUrlElements => {
   return { isBotpressUrl: false }
 }
 
-export const formatUrl = (baseUrl: string, url: string): string => {
+export const formatUrl = (baseUrl: string, url: string, mediaUrl?: string): string => {
   const item = parseBotpressMediaUrl(url)
 
   if (!item.isBotpressUrl) {
     return url
   }
 
-  return process.env.MEDIA_URL ? `${process.env.MEDIA_URL}/${item.botId}/${item.mediaId}` : `${baseUrl}${url}`
+  return mediaUrl ? `${mediaUrl}/${item.botId}/${item.mediaId}` : `${baseUrl}${url}`
 }

--- a/packages/runtime/src/common/url.ts
+++ b/packages/runtime/src/common/url.ts
@@ -4,17 +4,29 @@ export const isBpUrl = (str: string): boolean => {
   return re.test(str)
 }
 
-export const formatUrl = (baseUrl: string, url: string): string => {
+interface MediaUrlElements {
+  botId?: string
+  mediaId?: string
+  isBotpressUrl: boolean
+}
+
+const parseBotpressMediaUrl = (url: string): MediaUrlElements => {
   const bpUrlRegex = /^\/api\/.*\/bots\/(.*)\/media\/(.*)/g
   const parts = bpUrlRegex.exec(url)
 
-  if(!parts){
+  if (parts) {
+    return { botId: parts[1], mediaId: parts[2], isBotpressUrl: true }
+  }
+
+  return { isBotpressUrl: false }
+}
+
+export const formatUrl = (baseUrl: string, url: string): string => {
+  const item = parseBotpressMediaUrl(url)
+
+  if (!item.isBotpressUrl) {
     return url
   }
 
-  if(!process.env.MEDIA_URL){
-    return `${baseUrl}${url}`
-  }
-
-  return `${process.env.MEDIA_URL}/${parts[1]}/${parts[2]}`
+  return process.env.MEDIA_URL ? `${process.env.MEDIA_URL}/${item.botId}/${item.mediaId}` : `${baseUrl}${url}`
 }

--- a/packages/runtime/src/common/url.ts
+++ b/packages/runtime/src/common/url.ts
@@ -1,8 +1,4 @@
-export const isBpUrl = (str: string): boolean => {
-  const re = /^\/api\/.*\/bots\/.*\/media\/.*/g
 
-  return re.test(str)
-}
 
 interface MediaUrlElements {
   botId?: string

--- a/packages/runtime/src/common/url.ts
+++ b/packages/runtime/src/common/url.ts
@@ -4,11 +4,17 @@ export const isBpUrl = (str: string): boolean => {
   return re.test(str)
 }
 
-// Duplicate of modules/builtin/src/content-types/_utils.js
 export const formatUrl = (baseUrl: string, url: string): string => {
-  if (isBpUrl(url)) {
-    return `${baseUrl}${url}`
-  } else {
+  const bpUrlRegex = /^\/api\/.*\/bots\/(.*)\/media\/(.*)/g
+  const parts = bpUrlRegex.exec(url)
+
+  if(!parts){
     return url
   }
+
+  if(!process.env.MEDIA_URL){
+    return `${baseUrl}${url}`
+  }
+
+  return `${process.env.MEDIA_URL}/${parts[1]}/${parts[2]}`
 }

--- a/packages/runtime/src/runtime/messaging/messaging-service.ts
+++ b/packages/runtime/src/runtime/messaging/messaging-service.ts
@@ -6,7 +6,7 @@ import LRUCache from 'lru-cache'
 import ms from 'ms'
 import yn from 'yn'
 
-import { formatUrl, isBpUrl } from '../../common/url'
+import { formatUrl } from '../../common/url'
 import { ConfigProvider } from '../config'
 import { EventEngine, Event } from '../events'
 import { TYPES } from '../types'
@@ -227,10 +227,7 @@ export class MessagingService {
         payload = payload.replace('BOT_URL', process.EXTERNAL_URL)
       }
 
-      if (isBpUrl(payload)) {
-        payload = formatUrl(process.EXTERNAL_URL, payload)
-      }
-      return payload
+      return formatUrl(process.EXTERNAL_URL, payload, process.env.MEDIA_URL)
     }
 
     for (const [key, value] of Object.entries(payload)) {

--- a/packages/runtime/src/typings/global.d.ts
+++ b/packages/runtime/src/typings/global.d.ts
@@ -73,6 +73,9 @@ declare interface RuntimeEnvironmentVariables {
   /** The URL exposed by Botpress to external users (eg: when displaying links) */
   readonly EXTERNAL_URL?: string
 
+  /** A custom URL where bot medias will be served. Format: MEDIA_URL/botId/assetName */
+  readonly MEDIA_URL?: string
+
   /** The URL used to reach an external Messaging server */
   readonly MESSAGING_ENDPOINT?: string
 


### PR DESCRIPTION
Adds the support of MEDIA_URL for the runtime. Basically, it just fixes the output, so we don't migrate anything or change the content of the bot.

The previous logic simply added EXTERNAL_URL before the asset path (which is /api/v1/bots/BOT_ID/media/ASSET

I've updated it slightly, so if you specify MEDIA_URL, it will simply fix the url on the fly to MEDIA_URL/BOT_ID/ASSET