### PR TITLE
chore(ci_cd): use gh-actions v1

### DIFF
--- a/.github/workflows/branch-deleted.yml
+++ b/.github/workflows/branch-deleted.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Extract Informations
         id: info
-        uses: botpress/gh-actions/extract_info@master
+        uses: botpress/gh-actions/extract_info@v1
         with:
           branch: ${{ github.event.ref }}
 

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -19,7 +19,7 @@ jobs:
           cache: 'yarn'
 
       - name: Configure SSH Key
-        uses: botpress/gh-actions/set_ssh_key@master
+        uses: botpress/gh-actions/set_ssh_key@v1
         with:
           ssh_key: ${{ secrets.BP_PRO_SSH }}
 
@@ -45,13 +45,13 @@ jobs:
 
       - name: Rename Binary Files
         if: ${{ github.event_name == 'pull_request' && github.event.action == 'review_requested' }}
-        uses: botpress/gh-actions/rename_binaries@master
+        uses: botpress/gh-actions/rename_binaries@v1
         with:
           path: ./packages/bp/archives
 
       - name: Extract Informations
         id: info
-        uses: botpress/gh-actions/extract_info@master
+        uses: botpress/gh-actions/extract_info@v1
 
       - name: Publish Dev Binaries
         if: ${{ github.event_name == 'pull_request' && github.event.action == 'review_requested' }}


### PR DESCRIPTION
## Description

This PR makes sure we use the `v1` of our custom actions from `botpress/gh-actions`. This allows us to potentially push breaking changes on master without ever impacting actions that currently depend on them.

Related PR in the studio: https://github.com/botpress/studio/pull/236

## Type of change

- [X] Chore change (refactoring and / or test changes)
