### PR TITLE
fix(misunderstood): strip slots for amend screen

### DIFF
--- a/modules/misunderstood/src/views/full/MainScreen/IntentPicker.tsx
+++ b/modules/misunderstood/src/views/full/MainScreen/IntentPicker.tsx
@@ -3,6 +3,7 @@ import { MultiSelect } from '@blueprintjs/select'
 import { AxiosStatic } from 'axios'
 import { lang } from 'botpress/shared'
 import classnames from 'classnames'
+import { parseUtterance } from 'common/utterance-parser'
 import without from 'lodash/without'
 import React from 'react'
 
@@ -171,7 +172,7 @@ class IntentPicker extends React.Component<Props, State> {
 
     const { language } = this.props
 
-    const utterances = intent.utterances[language] || []
+    const utterances = (intent.utterances[language] || []).map(u => parseUtterance(u).utterance)
 
     return (
       <Card


### PR DESCRIPTION
## Description

Remove slots markdown from utterance preview in amend screen. See screen captures

Fixes https://github.com/botpress/studio/issues/196
Closes BUS-106

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


**Before:**
![Screen Shot 2022-01-13 at 4 44 44 PM](https://user-images.githubusercontent.com/955524/149414405-b0a77bab-4c6c-4c2a-8acb-58c2016d3fcb.png)

**After**
![Screen Shot 2022-01-13 at 4 43 47 PM](https://user-images.githubusercontent.com/955524/149414430-7f1ede0b-3d63-41ee-b0c2-1bf5f492d1bc.png)
