### PR TITLE
fix(admin): create bot from template is fast again

### DIFF
--- a/packages/bp/src/core/bots/bot-service.ts
+++ b/packages/bp/src/core/bots/bot-service.ts
@@ -562,7 +562,7 @@ export class BotService {
 
         await scopedGhost.ensureDirs('/', BOT_DIRECTORIES)
         await scopedGhost.upsertFile('/', BOT_CONFIG_FILENAME, stringify(mergedConfigs))
-        await scopedGhost.upsertFiles('/', files)
+        await scopedGhost.upsertFiles('/', files, { ignoreLock: true })
 
         return mergedConfigs
       } else {

--- a/packages/bp/src/core/bpfs/ghost-service.ts
+++ b/packages/bp/src/core/bpfs/ghost-service.ts
@@ -478,7 +478,7 @@ export class ScopedGhostService {
       await this._assertBotUnlocked(rootFolder)
     }
 
-    await Promise.all(content.map(c => this.upsertFile(rootFolder, c.name, c.content)))
+    await Promise.all(content.map(c => this.upsertFile(rootFolder, c.name, c.content, options)))
   }
 
   /**


### PR DESCRIPTION
## Description

For some reason creating a bot from a template was taking ages.  Imn short for each file that we write we ensured that the bot wasn't locked. In the case of creating a chatbot, it is by design not locked, for sure. Simply ignoring the locking status drastically speed the bot creation up.

Here are screenshots of time spent on bot creation request.

**Before**: (6.84s)
![Screen Shot 2022-01-14 at 4 23 03 PM](https://user-images.githubusercontent.com/955524/149587683-5450194b-bc48-465d-8302-2db623ef36af.png)

**After** (410ms)
![Screen Shot 2022-01-14 at 4 21 28 PM](https://user-images.githubusercontent.com/955524/149587728-ddf548e5-9de8-494d-b22c-619e6adf4646.png)

## Type of change

- [x] Bug fix

