### PR TITLE
chore(dev): nighly release next binaries

### DIFF
--- a/.github/workflows/next-binaries.yml
+++ b/.github/workflows/next-binaries.yml
@@ -1,0 +1,65 @@
+name: Publish Nightly Next Binaries
+on:
+  schedule:
+    - cron: '0 22 * * *'
+  workflow_dispatch:
+    name:
+      description: 'Name of the ouput file'
+      required: false
+      default: ''
+
+# This workflow is mostly a copy of publish binaries
+# This is by choice as the next branch will eventually be merged in the master
+# It makes it easy to remove when the time comes
+jobs:
+  pre_release_bin:
+    name: Build and Publish Binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@next
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12.18.1'
+          cache: 'yarn'
+
+      - name: Configure SSH Key
+        uses: botpress/gh-actions/set_ssh_key@v1
+        with:
+          ssh_key: ${{ secrets.BP_PRO_SSH }}
+
+      - name: Install python3
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+          architecture: 'x64'
+
+      - name: Install Tools
+        run: pip install awscli
+
+      - name: Build Project
+        run: |
+          yarn
+          yarn build --prod
+        env:
+          EDITION: pro
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Archives
+        run: yarn cmd archive
+
+      - name: Extract Informations
+        id: info
+        uses: botpress/gh-actions/extract_info@v1
+
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
+      - name: Publish
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          aws s3 sync packages/bp/archives s3://botpress-next-bins/${{ github.event.inputs.name || "nightly-" + steps.date.outputs.date }}


### PR DESCRIPTION
Simple workflow that builds and publishes a binary build of the next branch

practically a copy/paste of publish binaries workflow but with slight changes
* builds next
* run as cron or as a manual trigger
* publish to different bucket