### PR TITLE
chore(messaging): add admin key to env

### DIFF
--- a/packages/bp/src/typings/global.d.ts
+++ b/packages/bp/src/typings/global.d.ts
@@ -91,6 +91,9 @@ declare interface BotpressEnvironmentVariables {
   /** The URL used to reach an external Messaging server */
   readonly MESSAGING_ENDPOINT?: string
 
+  /** Admin key of the messaging server to make calls to admin routes */
+  readonly MESSAGING_ADMIN_KEY?: string
+
   /** Use this to override the hostname that botpress will listen on (by default it's localhost) - replaces httpServer.host */
   readonly BP_HOST?: string
 


### PR DESCRIPTION
Allows setting a MESSAGING_ADMIN_KEY environment variable to go with MESSAGING_ENDPOINT. This key is used to authenticate messaging admin routes.