### PR TITLE
chore(ci_cd): only run long running actions when necessary

### DIFF
--- a/.github/workflows/tests-skipped.yml
+++ b/.github/workflows/tests-skipped.yml
@@ -8,8 +8,6 @@ on:
       - 'modules/**'
       - 'build/**'
       - 'jest.*.config.ts'
-    branches-ignore:
-      - 'release/**'
 
 jobs:
   unit:

--- a/.github/workflows/tests-skipped.yml
+++ b/.github/workflows/tests-skipped.yml
@@ -1,0 +1,41 @@
+name: Tests
+on:
+  pull_request:
+    paths-ignore:
+      - 'package.json'
+      - 'yarn.lock'
+      - 'packages/**'
+      - 'modules/**'
+      - 'build/**'
+      - 'jest.*.config.ts'
+
+jobs:
+  unit:
+    name: Unit
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Unit tests skipped" '
+
+  integration:
+    name: Integration
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Integration tests skipped" '
+
+  e2e:
+    name: e2e
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "E2E (linux) tests skipped" '
+
+  e2e-windows:
+    name: e2e (windows-latest)
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "E2E (windows) tests skipped" '
+# TODO: Fix the E2E tests on macos
+#  e2e-macos:
+#    name: e2e (macos-latest)
+#    runs-on: ubuntu-latest
+#    steps:
+#      - run: 'echo "E2E (macos) tests skipped" '

--- a/.github/workflows/tests-skipped.yml
+++ b/.github/workflows/tests-skipped.yml
@@ -8,6 +8,8 @@ on:
       - 'modules/**'
       - 'build/**'
       - 'jest.*.config.ts'
+    branches-ignore:
+      - 'release/**'
 
 jobs:
   unit:

--- a/.github/workflows/tests-skipped.yml
+++ b/.github/workflows/tests-skipped.yml
@@ -23,19 +23,19 @@ jobs:
       - run: 'echo "Integration tests skipped" '
 
   e2e:
-    name: e2e
+    name: E2E (ubuntu-latest)
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "E2E (linux) tests skipped" '
 
   e2e-windows:
-    name: e2e (windows-latest)
+    name: E2E (windows-latest)
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "E2E (windows) tests skipped" '
 # TODO: Fix the E2E tests on macos
 #  e2e-macos:
-#    name: e2e (macos-latest)
+#    name: E2E (macos-latest)
 #    runs-on: ubuntu-latest
 #    steps:
 #      - run: 'echo "E2E (macos) tests skipped" '

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,9 @@ on:
       - 'modules/**'
       - 'build/**'
       - 'jest.*.config.ts'
+  push:
+    branches:
+      - 'release/**'
 
 jobs:
   unit:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,6 @@ on:
       - 'modules/**'
       - 'build/**'
       - 'jest.*.config.ts'
-  push:
-    branches:
-      - 'release/**'
 
 jobs:
   unit:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,17 +1,15 @@
 name: Tests
-on: [pull_request]
-jobs:
-  pre_job:
-    # continue-on-error: true # Uncomment once integration is finished
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v3
-        with:
-          paths: '["package.json", "yarn.lock", "packages/**", "modules/**", "build/**", "jest.*.config.ts"]'
+on:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'yarn.lock'
+      - 'packages/**'
+      - 'modules/**'
+      - 'build/**'
+      - 'jest.*.config.ts'
 
+jobs:
   unit:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
           PG_PORT: 5432
 
   e2e:
-    name: e2e
+    name: E2E (linux-latest)
     runs-on: ubuntu-latest
 
     steps:
@@ -118,7 +118,7 @@ jobs:
           path: build/tests/e2e/screenshots
 
   e2e-windows:
-    name: e2e (windows-latest)
+    name: E2E (windows-latest)
     runs-on: windows-latest
 
     steps:
@@ -152,7 +152,7 @@ jobs:
           path: build/tests/e2e/screenshots
 # TODO: Fix the E2E tests on macos
 #  e2e-macos:
-#    name: e2e (macos-latest)
+#    name: E2E (macos-latest)
 #    runs-on: macos-latest
 #
 #    steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,6 @@ on:
 
 jobs:
   unit:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     name: Unit
     runs-on: ubuntu-latest
     steps:
@@ -34,8 +32,6 @@ jobs:
           yarn test:unit
 
   integration:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     name: Integration
     runs-on: ubuntu-latest
 
@@ -88,8 +84,6 @@ jobs:
           PG_PORT: 5432
 
   e2e:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     name: e2e
     runs-on: ubuntu-latest
 
@@ -124,8 +118,6 @@ jobs:
           path: build/tests/e2e/screenshots
 
   e2e-windows:
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     name: e2e (windows-latest)
     runs-on: windows-latest
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,20 @@
 name: Tests
 on: [pull_request]
 jobs:
+  pre_job:
+    # continue-on-error: true # Uncomment once integration is finished
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v3
+        with:
+          paths: '["package.json", "yarn.lock", "packages/**", "modules/**", "build/**", "jest.*.config.ts"]'
+
   unit:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     name: Unit
     runs-on: ubuntu-latest
     steps:
@@ -23,6 +36,8 @@ jobs:
           yarn test:unit
 
   integration:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     name: Integration
     runs-on: ubuntu-latest
 
@@ -75,6 +90,8 @@ jobs:
           PG_PORT: 5432
 
   e2e:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     name: e2e
     runs-on: ubuntu-latest
 
@@ -109,6 +126,8 @@ jobs:
           path: build/tests/e2e/screenshots
 
   e2e-windows:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     name: e2e (windows-latest)
     runs-on: windows-latest
 


### PR DESCRIPTION
## Description

This PR aims at reducing the time it takes to merge a Pull Request by only running tests and builds when files related to the server are edited.


This documentation was used to properly skip tests: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks