### PR TITLE
chore(ci_cd): improve check that pull request is in shape

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,7 +1,7 @@
 name: 'Check PR'
 on:
   pull_request:
-    types: [synchronize, edited, review_requested, ready_for_review]
+    types: [edited, review_requested, ready_for_review]
 jobs:
   check-pr:
     name: Asserts PR is in shape

--- a/.github/workflows/code/check-pr/index.js
+++ b/.github/workflows/code/check-pr/index.js
@@ -1,5 +1,4 @@
 const core = require('@actions/core')
-const github = require('@actions/github')
 
 const titleRE = /^(build|chore|ci|docs|style|refactor|perf|test|feat|fix|revert)(\([a-z-_0-9]+\)?((?=:\s)|(?=!:\s)))?!?:\s.+/
 
@@ -17,29 +16,6 @@ async function run() {
       core.setFailed(
         'Please set a proper description to your Pull Request. Describe why, how and what. Those are mandatory for the review process.'
       )
-    }
-    if (!pull_request.requested_reviewers.length && !pull_request.requested_teams.length) {
-      core.setFailed('Request at least one reviewer on your Pull Request')
-    }
-
-    if (title.includes('feat')) {
-      const token = process.env.token
-      const octokit = github.getOctokit(token)
-      const options = {
-        repo: 'botpress',
-        owner: 'botpress',
-        pull_number: pull_request.number,
-        per_page: 300
-      }
-
-      const files = await octokit.rest.pulls.listFiles(options)
-
-      const hasTests = files.data.some(f => f.filename.includes('.test.'))
-      if (!hasTests) {
-        core.setFailed(
-          `New features require new tests, please write e2e tests.\nThis eases review process and makes sure we don't introduce regressions in the long run.`
-        )
-      }
     }
   } catch (error) {
     core.setFailed(error.message)


### PR DESCRIPTION
This PR improves the PR check by only running on pull requests (does not run on draft PRs) and by enforcing that the title uses the conventional naming and that the description is filled only.

### Removed
 - The check that a feature should include E2E tests as this is not always true and we want to enforce this action on all PRs
 - The check that at least one reviewer must be set on a PR since approval is already required to merge a PR.