### PR TITLE
fix(channel-web): fetch last message for each convo

### DIFF
--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -357,8 +357,16 @@ export default async (bp: typeof sdk, db: Database) => {
       const conversations = await req.messaging.listConversations(userId, MAX_MESSAGE_HISTORY)
       const config = await bp.config.getModuleConfigForBot('channel-web', botId)
 
+      const convsWithLastMessage: (Conversation & { lastMessage?: Message })[] = []
+      for (const conversation of conversations) {
+        convsWithLastMessage.push({
+          ...conversation,
+          lastMessage: (await req.messaging.listMessages(conversation.id, 1))[0]
+        })
+      }
+
       return res.send({
-        conversations: [...conversations],
+        conversations: convsWithLastMessage,
         startNewConvoOnTimeout: config.startNewConvoOnTimeout,
         recentConversationLifetime: config.recentConversationLifetime
       })


### PR DESCRIPTION
Fixes an issue with the channel web that was introduced when the lastMessage was removed from the messaging api when listing conversations. This PR adds it back by calling list messages manually on each conversation

Closes DEV-2228