### PR TITLE
chore(messaging): bump to 1.0.0

### DIFF
--- a/.github/workflows/code/check-pr/index.js
+++ b/.github/workflows/code/check-pr/index.js
@@ -12,7 +12,7 @@ async function run() {
         'Title should be a conventionnal commit. Please refer to specification: https://www.conventionalcommits.org/en/v1.0.0/'
       )
     }
-    if (!pull_request.body?.toString().trim()) {
+    if (!pull_request.body || !pull_request.body.toString().trim()) {
       core.setFailed(
         'Please set a proper description to your Pull Request. Describe why, how and what. Those are mandatory for the review process.'
       )

--- a/.github/workflows/code/check-pr/index.js
+++ b/.github/workflows/code/check-pr/index.js
@@ -12,7 +12,7 @@ async function run() {
         'Title should be a conventionnal commit. Please refer to specification: https://www.conventionalcommits.org/en/v1.0.0/'
       )
     }
-    if (!pull_request.body.toString().trim()) {
+    if (!pull_request.body?.toString().trim()) {
       core.setFailed(
         'Please set a proper description to your Pull Request. Describe why, how and what. Those are mandatory for the review process.'
       )

--- a/modules/channel-web/package.json
+++ b/modules/channel-web/package.json
@@ -25,7 +25,7 @@
     "@types/react-intl": "^2.3.17"
   },
   "dependencies": {
-    "@botpress/messaging-client": "^0.0.14",
+    "@botpress/messaging-client": "^1.0.0",
     "@juggle/resize-observer": "^3.0.2",
     "apicache": "^1.6.2",
     "aws-sdk": "^2.905.0",

--- a/modules/channel-web/yarn.lock
+++ b/modules/channel-web/yarn.lock
@@ -45,17 +45,17 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
-"@botpress/messaging-base@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@botpress/messaging-base/-/messaging-base-0.0.2.tgz#3e8129130f326894f1615305ddf36357f90478a2"
-  integrity sha512-YZwHLMqJtsv/4v6Ss+h+pBJm9gjCvu737lDv8JGfD2gWVT/PCfh32YAaN11CSyuVW0vD4tA1NPXaHRKOmbD28Q==
+"@botpress/messaging-base@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@botpress/messaging-base/-/messaging-base-1.0.0.tgz#7bf70d26ceb8b9128a517e03ff6ae6931e193373"
+  integrity sha512-q8GKsoGIM2X+eMa8mGugaMerCv8P133OLR/3wEWdkk3R2MvVGh7on7lwVa+TuSaQhwqUawy7LM/9fcVawG6imQ==
 
-"@botpress/messaging-client@^0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@botpress/messaging-client/-/messaging-client-0.0.14.tgz#deb3675af1e0760e240b63ea9b54aea460133e0d"
-  integrity sha512-oXvvBZU0+aAnSHnar8d4PVOxY3cauWNmt74LKtZGDuHTZb3appIyuzj/Y5z4srDAG/nubuR9mc7W/5xZsQCzaQ==
+"@botpress/messaging-client@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@botpress/messaging-client/-/messaging-client-1.0.0.tgz#7d446cbb497305b1c227aba6cc6fce70bd2487e2"
+  integrity sha512-Lb/dwGm8a/YdvFdWuNrFaHdBIlDKutgn0ki1df6YtmnKV7kZ1R814BYBO/y6P1YZoEMqxdyDJWAiiG6Ps073iQ==
   dependencies:
-    "@botpress/messaging-base" "0.0.2"
+    "@botpress/messaging-base" "1.0.0"
     axios "^0.21.4"
     joi "^17.5.0"
 

--- a/modules/hitl/package.json
+++ b/modules/hitl/package.json
@@ -26,7 +26,7 @@
     "@types/react-bootstrap": "^0.32.19"
   },
   "dependencies": {
-    "@botpress/messaging-components": "^0.0.8",
+    "@botpress/messaging-components": "^0.1.0",
     "bluebird": "^3.5.3",
     "classnames": "^2.2.6",
     "csstype": "^2.2.0",

--- a/modules/hitl/yarn.lock
+++ b/modules/hitl/yarn.lock
@@ -9,16 +9,16 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@botpress/messaging-components@^0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@botpress/messaging-components/-/messaging-components-0.0.8.tgz#6d34d0c556632e9605bced4a00232c35c620c934"
-  integrity sha512-CJFVZmcm6jvRRIpElmeC9VbsupnXz2h4GzMYDI3gDgwtlY5SvP3BQ/Dctj629rLPz/OfuJd2Gt8QdBt+uGEa+g==
+"@botpress/messaging-components@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@botpress/messaging-components/-/messaging-components-0.1.0.tgz#667e4d636d003e025561f47cbe08bd789e0c25af"
+  integrity sha512-Wjj3UkwMFWCQ72US+Cwxl17vFd8KbAERzt1SERiHQ3xJgxCsWScb8EYu8NTpaXVwimHud/6saw3/DFwZv6e7UQ==
   dependencies:
     html-truncate "^1.2.2"
     mime "^2.5.2"
     react-intl "^3.12.1"
     react-linkify "^0.2.2"
-    react-select "^5.1.0"
+    react-select "^5.2.1"
     react-slick "^0.28.1"
     react-text-format "^2.0.28"
     snarkdown "^2.0.0"
@@ -435,10 +435,10 @@ react-linkify@^0.2.2:
     prop-types "^15.5.8"
     tlds "^1.57.0"
 
-react-select@^5.1.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.2.1.tgz#416c25c6b79b94687702374e019c4f2ed9d159d6"
-  integrity sha512-OOyNzfKrhOcw/BlembyGWgdlJ2ObZRaqmQppPFut1RptJO423j+Y+JIsmxkvsZ4D/3CpOmwIlCvWbbAWEdh12A==
+react-select@^5.2.1:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.2.2.tgz#3d5edf0a60f1276fd5f29f9f90a305f0a25a5189"
+  integrity sha512-miGS2rT1XbFNjduMZT+V73xbJEeMzVkJOz727F6MeAr2hKE0uUSA8Ff7vD44H32x2PD3SRB6OXTY/L+fTV3z9w==
   dependencies:
     "@babel/runtime" "^7.12.0"
     "@emotion/cache" "^11.4.0"

--- a/modules/hitlnext/package.json
+++ b/modules/hitlnext/package.json
@@ -15,7 +15,7 @@
   "license": "AGPL-3.0-only",
   "dependencies": {
     "@blueprintjs/core": "^3.36.0",
-    "@botpress/messaging-client": "^0.0.14",
+    "@botpress/messaging-client": "^1.0.0",
     "@webscopeio/react-textarea-autocomplete": "^4.7.2",
     "axios": "^0.21.1",
     "bluebird": "^3.5",

--- a/modules/hitlnext/yarn.lock
+++ b/modules/hitlnext/yarn.lock
@@ -34,17 +34,17 @@
     classnames "^2.2"
     tslib "~1.13.0"
 
-"@botpress/messaging-base@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@botpress/messaging-base/-/messaging-base-0.0.2.tgz#3e8129130f326894f1615305ddf36357f90478a2"
-  integrity sha512-YZwHLMqJtsv/4v6Ss+h+pBJm9gjCvu737lDv8JGfD2gWVT/PCfh32YAaN11CSyuVW0vD4tA1NPXaHRKOmbD28Q==
+"@botpress/messaging-base@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@botpress/messaging-base/-/messaging-base-1.0.0.tgz#7bf70d26ceb8b9128a517e03ff6ae6931e193373"
+  integrity sha512-q8GKsoGIM2X+eMa8mGugaMerCv8P133OLR/3wEWdkk3R2MvVGh7on7lwVa+TuSaQhwqUawy7LM/9fcVawG6imQ==
 
-"@botpress/messaging-client@^0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@botpress/messaging-client/-/messaging-client-0.0.14.tgz#deb3675af1e0760e240b63ea9b54aea460133e0d"
-  integrity sha512-oXvvBZU0+aAnSHnar8d4PVOxY3cauWNmt74LKtZGDuHTZb3appIyuzj/Y5z4srDAG/nubuR9mc7W/5xZsQCzaQ==
+"@botpress/messaging-client@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@botpress/messaging-client/-/messaging-client-1.0.0.tgz#7d446cbb497305b1c227aba6cc6fce70bd2487e2"
+  integrity sha512-Lb/dwGm8a/YdvFdWuNrFaHdBIlDKutgn0ki1df6YtmnKV7kZ1R814BYBO/y6P1YZoEMqxdyDJWAiiG6Ps073iQ==
   dependencies:
-    "@botpress/messaging-base" "0.0.2"
+    "@botpress/messaging-base" "1.0.0"
     axios "^0.21.4"
     joi "^17.5.0"
 

--- a/modules/misunderstood/package.json
+++ b/modules/misunderstood/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@blueprintjs/datetime": "3.15.2",
-    "@botpress/messaging-components": "0.0.8",
+    "@botpress/messaging-components": "0.1.0",
     "axios": "^0.21.1",
     "bluebird": "^3.7.0",
     "classnames": "^2.2.6",

--- a/modules/misunderstood/yarn.lock
+++ b/modules/misunderstood/yarn.lock
@@ -51,16 +51,16 @@
     classnames "^2.2"
     tslib "~1.13.0"
 
-"@botpress/messaging-components@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@botpress/messaging-components/-/messaging-components-0.0.8.tgz#6d34d0c556632e9605bced4a00232c35c620c934"
-  integrity sha512-CJFVZmcm6jvRRIpElmeC9VbsupnXz2h4GzMYDI3gDgwtlY5SvP3BQ/Dctj629rLPz/OfuJd2Gt8QdBt+uGEa+g==
+"@botpress/messaging-components@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@botpress/messaging-components/-/messaging-components-0.1.0.tgz#667e4d636d003e025561f47cbe08bd789e0c25af"
+  integrity sha512-Wjj3UkwMFWCQ72US+Cwxl17vFd8KbAERzt1SERiHQ3xJgxCsWScb8EYu8NTpaXVwimHud/6saw3/DFwZv6e7UQ==
   dependencies:
     html-truncate "^1.2.2"
     mime "^2.5.2"
     react-intl "^3.12.1"
     react-linkify "^0.2.2"
-    react-select "^5.1.0"
+    react-select "^5.2.1"
     react-slick "^0.28.1"
     react-text-format "^2.0.28"
     snarkdown "^2.0.0"
@@ -678,10 +678,10 @@ react-popper@^1.3.7:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-select@^5.1.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.2.1.tgz#416c25c6b79b94687702374e019c4f2ed9d159d6"
-  integrity sha512-OOyNzfKrhOcw/BlembyGWgdlJ2ObZRaqmQppPFut1RptJO423j+Y+JIsmxkvsZ4D/3CpOmwIlCvWbbAWEdh12A==
+react-select@^5.2.1:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.2.2.tgz#3d5edf0a60f1276fd5f29f9f90a305f0a25a5189"
+  integrity sha512-miGS2rT1XbFNjduMZT+V73xbJEeMzVkJOz727F6MeAr2hKE0uUSA8Ff7vD44H32x2PD3SRB6OXTY/L+fTV3z9w==
   dependencies:
     "@babel/runtime" "^7.12.0"
     "@emotion/cache" "^11.4.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "version": "0.0.46"
   },
   "messaging": {
-    "version": "0.1.23"
+    "version": "1.0.0"
   },
   "scripts": {
     "postinstall": "yarn cmd postinstall",
@@ -39,7 +39,7 @@
     "@apidevtools/json-schema-ref-parser": "^9.0.6",
     "@babel/parser": "^7.11.2",
     "@babel/traverse": "^7.11.0",
-    "@botpress/messaging-client": "^0.0.14",
+    "@botpress/messaging-client": "^1.0.0",
     "archiver": "^5.3.0",
     "axios": "^0.21.1",
     "bluebird-global": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2432,17 +2432,17 @@
     classnames "^2.2"
     tslib "~1.13.0"
 
-"@botpress/messaging-base@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@botpress/messaging-base/-/messaging-base-0.0.2.tgz#3e8129130f326894f1615305ddf36357f90478a2"
-  integrity sha512-YZwHLMqJtsv/4v6Ss+h+pBJm9gjCvu737lDv8JGfD2gWVT/PCfh32YAaN11CSyuVW0vD4tA1NPXaHRKOmbD28Q==
+"@botpress/messaging-base@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@botpress/messaging-base/-/messaging-base-1.0.0.tgz#7bf70d26ceb8b9128a517e03ff6ae6931e193373"
+  integrity sha512-q8GKsoGIM2X+eMa8mGugaMerCv8P133OLR/3wEWdkk3R2MvVGh7on7lwVa+TuSaQhwqUawy7LM/9fcVawG6imQ==
 
-"@botpress/messaging-client@^0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@botpress/messaging-client/-/messaging-client-0.0.14.tgz#deb3675af1e0760e240b63ea9b54aea460133e0d"
-  integrity sha512-oXvvBZU0+aAnSHnar8d4PVOxY3cauWNmt74LKtZGDuHTZb3appIyuzj/Y5z4srDAG/nubuR9mc7W/5xZsQCzaQ==
+"@botpress/messaging-client@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@botpress/messaging-client/-/messaging-client-1.0.0.tgz#7d446cbb497305b1c227aba6cc6fce70bd2487e2"
+  integrity sha512-Lb/dwGm8a/YdvFdWuNrFaHdBIlDKutgn0ki1df6YtmnKV7kZ1R814BYBO/y6P1YZoEMqxdyDJWAiiG6Ps073iQ==
   dependencies:
-    "@botpress/messaging-base" "0.0.2"
+    "@botpress/messaging-base" "1.0.0"
     axios "^0.21.4"
     joi "^17.5.0"
 


### PR DESCRIPTION
Bumps all messaging packages to be 1.0.0 https://github.com/botpress/messaging/pull/323