### PR TITLE
chore(ci_cd): enable dependabot auto deps update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    time: '08:00'
+    timezone: 'America/Montreal'
+    # Disable rebasing for npm pull requests
+    rebase-strategy: 'disabled'
+    open-pull-requests-limit: 3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,9 @@
 name: Docker
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/*'
+
 jobs:
   build_and_push:
     name: Build and push Docker image to GitHub Packages

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -8,13 +8,19 @@ on:
 jobs:
   pre_release_bin:
     # Do not publish dependabot branches
-    if: (startsWith(github.head_ref , 'dependabot/')) == true
+    #if: startsWith(github.head_ref, 'dependabot/') == true
 
     name: Build and Publish Binaries
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@master
+
+      - name: Echo PR info
+        run: |
+          echo "Event name ${{ github.event_name }}"
+          echo "Head ref ${{ github.head_ref }}"
+          echo "PR head ref ${{ github.event.pull_request.head.ref }}"
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -2,13 +2,13 @@ name: Release Binaries
 on:
   pull_request:
     types: [review_requested]
-    branches-ignore:
-      - 'dependabot/*'
   release:
     types: [published]
 
 jobs:
   pre_release_bin:
+    if: (startsWith(github.head_ref , 'dependabot/')) != true
+
     name: Build and Publish Binaries
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -2,6 +2,8 @@ name: Release Binaries
 on:
   pull_request:
     types: [review_requested]
+    branches-ignore:
+      - 'dependabot/*'
   release:
     types: [published]
 

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -8,19 +8,13 @@ on:
 jobs:
   pre_release_bin:
     # Do not publish dependabot branches
-    #if: startsWith(github.head_ref, 'dependabot/') == true
+    if: startsWith(github.head_ref, 'dependabot/') != true
 
     name: Build and Publish Binaries
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@master
-
-      - name: Echo PR info
-        run: |
-          echo "Event name ${{ github.event_name }}"
-          echo "Head ref ${{ github.head_ref }}"
-          echo "PR head ref ${{ github.event.pull_request.head.ref }}"
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   pre_release_bin:
-    if: (startsWith(github.head_ref , 'dependabot/')) != true
+    # Do not publish dependabot branches
+    if: (startsWith(github.head_ref , 'dependabot/')) == true
 
     name: Build and Publish Binaries
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR enables dependabot to automatically update our dependencies.

It's currently configured to run each day at 8:00 AM EST. It will open a maximum of 3 PRs at a time and run on our packages.

I also update two actions that do not need to run on PRs open by dependabot.