### PR TITLE
chore(docs): update commands used to setup the dev environment

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -154,7 +154,8 @@ These instructions assume a parent directory `bar` and we will be adding two chi
    bar $ cd botpress
 
    # Setup the dev environment
-   bar/botpress $ yarn run bootstrap
+   bar/botpress $ yarn install
+   bar/botpress $ yarn build
 
    # Start the botpress server
    bar/botpress $ yarn start


### PR DESCRIPTION
The previous "bootstrap" command no longer exists, and "install" followed by "build" appears to be the equivalent now. Fixes botpress/v12#1576