### PR TITLE
fix(code-editor): admin should be able to edit bot config

### DIFF
--- a/modules/code-editor/src/views/full/SidePanel.tsx
+++ b/modules/code-editor/src/views/full/SidePanel.tsx
@@ -140,7 +140,7 @@ class PanelContent extends React.Component<Props> {
   }
 
   renderSectionConfig() {
-    if (!this.hasPermission('global.main_config') || !this.hasPermission('bot.bot_config')) {
+    if (!this.hasPermission('global.main_config') && !this.hasPermission('bot.bot_config')) {
       return null
     }
 


### PR DESCRIPTION
Even if you had permissions to edit the bot config, you wouldn't see the option in the code editor unless you are a super admin, because you had to have permission to see both config (botpress and bot)