### PR TITLE
fix(builtin): added removeVariable action

### DIFF
--- a/modules/builtin/src/actions/removeVariable.js
+++ b/modules/builtin/src/actions/removeVariable.js
@@ -1,0 +1,19 @@
+/**
+ * Remove a variable from storage.
+ *
+ * @title Remove Variable
+ * @category Storage
+ * @author Botpress, Inc.
+ * @param {string} type - Pick between: user, session, temp, bot
+ * @param {string} name - The name of the variable
+ */
+const removeVariable = async (type, name) => {
+  if (type === 'bot') {
+    const original = await bp.kvs.forBot(event.botId).get('global')
+    await bp.kvs.forBot(event.botId).set('global', { ...original, [name]: 'null' })
+  } else {
+    delete event.state[type][name]
+  }
+}
+
+return removeVariable(args.type, args.name)

--- a/modules/builtin/src/actions/setVariable.js
+++ b/modules/builtin/src/actions/setVariable.js
@@ -7,7 +7,7 @@
  * @author Botpress, Inc.
  * @param {string} type - Pick between: user, session, temp, bot
  * @param {string} name - The name of the variable
- * @param {any} value - Set the value of the variable. Type 'null' or leave empty to erase it.
+ * @param {any} value - Set the value of the variable.
  */
 const setVariable = async (type, name, value) => {
   if (type === 'bot') {


### PR DESCRIPTION
Removed the remove text on the tooltip and added a new action to delete variable.

Action is a copy of `setVariable` that does not have a value arg. It defaults to deleting the key. It does not change the default behavior and is non breaking.