### PR TITLE
fix(bot): fix unmounting bot before writing files when overwriting

### DIFF
--- a/packages/bp/src/core/bots/bot-service.ts
+++ b/packages/bp/src/core/bots/bot-service.ts
@@ -25,14 +25,12 @@ import glob from 'glob'
 import { inject, injectable, postConstruct, tagged } from 'inversify'
 import Joi from 'joi'
 import _ from 'lodash'
-import mkdirp from 'mkdirp'
 import moment from 'moment'
 import ms from 'ms'
 import { studioActions } from 'orchestrator'
 import os from 'os'
 import path from 'path'
 import replace from 'replace-in-file'
-import semver from 'semver'
 import tmp from 'tmp'
 import { VError } from 'verror'
 
@@ -289,9 +287,14 @@ export class BotService {
         })
 
         const folder = await this._validateBotArchive(tmpDir.name)
-        await this.ghostService.forBot(botId).importFromDirectory(folder)
-        const originalConfig = await this.configProvider.getBotConfig(botId)
 
+        if (await this.botExists(botId)) {
+          await this.unmountBot(botId)
+        }
+
+        await this.ghostService.forBot(botId).importFromDirectory(folder)
+
+        const originalConfig = await this.configProvider.getBotConfig(botId)
         const newConfigs = <Partial<BotConfig>>{
           id: botId,
           name: botId === originalConfig.name ? originalConfig.name : `${originalConfig.name} (${botId})`,
@@ -303,10 +306,6 @@ export class BotService {
             }
           }
         }
-        if (await this.botExists(botId)) {
-          await this.unmountBot(botId)
-        }
-
         await this.configProvider.mergeBotConfig(botId, newConfigs, true)
 
         await this.workspaceService.addBotRef(botId, workspaceId)


### PR DESCRIPTION
This PR fixes an issue where we upserted the bots files before unmounting it which would cause services relying on the "old"  `bot.config` to fail. For example, it would cause the messaging service to throw an error when calling `/sync` because it relies on info stored inside the botconfig.

To solve the issue, the call to unmount is done before importing the bot.