### PR TITLE
fix(bot): we now delete old file when overwriting a bot

### DIFF
--- a/packages/bp/src/core/bots/bot-service.ts
+++ b/packages/bp/src/core/bots/bot-service.ts
@@ -25,14 +25,12 @@ import glob from 'glob'
 import { inject, injectable, postConstruct, tagged } from 'inversify'
 import Joi from 'joi'
 import _ from 'lodash'
-import mkdirp from 'mkdirp'
 import moment from 'moment'
 import ms from 'ms'
 import { studioActions } from 'orchestrator'
 import os from 'os'
 import path from 'path'
 import replace from 'replace-in-file'
-import semver from 'semver'
 import tmp from 'tmp'
 import { VError } from 'verror'
 
@@ -289,9 +287,14 @@ export class BotService {
         })
 
         const folder = await this._validateBotArchive(tmpDir.name)
-        await this.ghostService.forBot(botId).importFromDirectory(folder)
-        const originalConfig = await this.configProvider.getBotConfig(botId)
 
+        if (await this.botExists(botId)) {
+          await this.unmountBot(botId)
+        }
+
+        await this.ghostService.forBot(botId).importFromDirectory(folder)
+
+        const originalConfig = await this.configProvider.getBotConfig(botId)
         const newConfigs = <Partial<BotConfig>>{
           id: botId,
           name: botId === originalConfig.name ? originalConfig.name : `${originalConfig.name} (${botId})`,
@@ -303,10 +306,6 @@ export class BotService {
             }
           }
         }
-        if (await this.botExists(botId)) {
-          await this.unmountBot(botId)
-        }
-
         await this.configProvider.mergeBotConfig(botId, newConfigs, true)
 
         await this.workspaceService.addBotRef(botId, workspaceId)

--- a/packages/bp/src/core/bots/utils.ts
+++ b/packages/bp/src/core/bots/utils.ts
@@ -1,0 +1,19 @@
+import { existsSync } from 'fs'
+import { join } from 'path'
+
+/**
+ * Finds files that were deleted in a given folder.
+ * @param files A list of files (relative path)
+ * @param folder A folder to walk through and test if files were deleted from it
+ * @returns A list of deleted files (relative path)
+ */
+export const findDeletedFiles = async (files: string[], folder: string): Promise<string[]> => {
+  const deletedFiles: string[] = []
+  for (const f of files) {
+    const path = join(folder, f)
+    if (!existsSync(path)) {
+      deletedFiles.push(f)
+    }
+  }
+  return deletedFiles
+}


### PR DESCRIPTION
This PR fixes an issue where overwriting a bot with deleted files would result in the files being kept on the disk.

To solve the issue, we now iterate over all the old files and check for deleted ones by comparing with the new archive.

Closes DEV-2180
Closes https://github.com/botpress/v12/issues/1569