### PR TITLE
chore(ci_cd): add dependencies changelogs to draft release

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -15,10 +15,16 @@ jobs:
         id: release_details
         uses: botpress/gh-actions/get_release_details@next
 
+      - name: Fetch Dependencies Changelogs
+        id: fetch_dependencies_changelogs
+        uses: botpress/gh-actions/fetch_release_changelogs@next
+        with:
+          repos: '[ "studio", "messaging", "nlu" ]'
+
       - name: Display Release Details
         id: changelog
         run: |
-          echo "Changelog: ${{ steps.release_details.outputs.changelog }}"
+          echo "Changelog: ${{ steps.release_details.outputs.changelog }}${{ steps.fetch_dependencies_changelogs.outputs.changelog }}"
           echo "Is new release?: ${{ steps.release_details.outputs.is_new_release }}"
           echo "Version: ${{ steps.release_details.outputs.version }}"
           echo "Latest Tag: ${{ steps.release_details.outputs.latest_tag }}"
@@ -29,7 +35,7 @@ jobs:
         with:
           prerelease: false
           draft: true
-          body: ${{ steps.release_details.outputs.changelog }}
+          body: ${{ steps.release_details.outputs.changelog }}${{ steps.fetch_dependencies_changelogs.outputs.changelog }}
           name: v${{ steps.release_details.outputs.version }}
           tag_name: v${{ steps.release_details.outputs.version }}
         env:


### PR DESCRIPTION
This PR adds a step to the create draft release Github Action that fetches the changelogs of our "sub repos" (messaging, nlu, studio).

This PR brings us one step closer to a fully automated release process. ~The next step is that we close issues that were referenced in PR descriptions with a comment pointing to the release.~ The PR can be found here: https://github.com/botpress/botpress/pull/11409

The code behind the `fetch_release_changelogs` action can be found here: https://github.com/botpress/gh-actions/tree/next/fetch_release_changelogs/src

Closes DEV-2150