### PR TITLE
chore(ci_cd): add action to close pr linked issues upon new release

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,15 @@
+name: Release Binaries
+on:
+  release:
+    types: [published]
+
+jobs:
+  close_issues:
+    name: Close issues mentioned in pull requests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+
+      - name: Close PR Issues
+        uses: botpress/gh-actions/close_pull_request_issues@next


### PR DESCRIPTION
This PR adds a Github Action that runs after a new release is created and closes issues that were linked in PR merged during the latest release.

The code behind the `close_pull_request_issues` action can be found here: https://github.com/botpress/gh-actions/tree/next/close_pull_request_issues/src

Closes DEV-2151