### PR TITLE
fix(ui): allow setting buttonText when using isDropdown in choice

### DIFF
--- a/packages/ui-shared-lite/Payloads/index.ts
+++ b/packages/ui-shared-lite/Payloads/index.ts
@@ -68,7 +68,7 @@ const renderChoicePayload = (content: sdk.ChoiceContent & ExtraChoiceProperties)
       module: 'extensions',
       component: 'Dropdown',
       message: content.text,
-      buttonText: '',
+      buttonText: (content.buttonText) ? content.buttonText : '',
       displayInKeyboard: true,
       options: content.choices.map(c => ({ label: c.title, value: c.value.toUpperCase() })),
       width: 300,


### PR DESCRIPTION
Unless I'm missing it there doesn't seem to be a reason to not allow buttonText to be set in the renderChoicePayload method.  This adds support for it.