### PR TITLE
fix(code-editor): prevent "undefined" content in files

### DIFF
--- a/modules/code-editor/src/views/full/store/api.ts
+++ b/modules/code-editor/src/views/full/store/api.ts
@@ -69,7 +69,7 @@ export default class CodeEditorApi {
       const { data } = await this.axios.post('/mod/code-editor/readFile', file)
       return data.fileContent
     } catch (err) {
-      this.handleApiError(err, 'Could not check if file already exists')
+      this.handleApiError(err, 'Error while reading file')
     }
   }
 

--- a/modules/code-editor/src/views/full/store/editor.ts
+++ b/modules/code-editor/src/views/full/store/editor.ts
@@ -138,6 +138,11 @@ class EditorStore {
       }
     }
 
+    // Prevent opening an empty file containing "undefined"
+    if (file.content === undefined) {
+      return
+    }
+
     runInAction('-> openFile', () => {
       const uri = getFileUri(file)
       const existingFile = this.openedFiles.find(x => x.uri.path === uri.path)

--- a/modules/code-editor/src/views/full/store/editor.ts
+++ b/modules/code-editor/src/views/full/store/editor.ts
@@ -138,7 +138,6 @@ class EditorStore {
       }
     }
 
-    // Prevent opening an empty file containing "undefined"
     if (file.content === undefined) {
       return
     }


### PR DESCRIPTION
Minor change to prevent opening files on the code editor with the content "undefined" which is a bit misleading.
Can happen when the server is down, or in some situations. To replicate, we can just block the call to "readFile" in the chrome developer console.

When theres an error, a toast is displayed, but the file is still opened with nothing in it. If someone saves it when the server is back online, then it will overwrite the content with "undefined".

![image](https://user-images.githubusercontent.com/42552874/153020174-c518f06f-75aa-4911-a1d5-c10dd399b24f.png)
