### PR TITLE
fix(webchat): changing language also updates ui

### DIFF
--- a/modules/builtin/src/actions/switchLanguage.js
+++ b/modules/builtin/src/actions/switchLanguage.js
@@ -19,4 +19,4 @@ const switchLanguage = async language => {
   await event.setFlag(bp.IO.WellKnownFlags.FORCE_PERSIST_STATE, true)
 }
 
-return switchLanguage(args.lang)
+return switchLanguage(args.lang.toLowerCase())

--- a/modules/channel-web/src/views/lite/store/index.ts
+++ b/modules/channel-web/src/views/lite/store/index.ts
@@ -469,6 +469,7 @@ class RootStore {
 
   @action.bound
   async updatePreferredLanguage(lang: string): Promise<void> {
+    this.updateBotUILanguage(lang)
     this.preferredLanguage = lang
     await this.api.updateUserPreferredLanguage(lang)
   }


### PR DESCRIPTION
When the bot info page is enabled, the user can switch language using the dropdown. However, the UI wasn't changed to the selected language until the page was refreshed. This makes it instantaneous.

![image](https://user-images.githubusercontent.com/42552874/153233111-fc0f16f2-9bec-49c8-acdf-7e5bc5f92ece.png)
