### PR TITLE
fix(tests): fix flaky number test

### DIFF
--- a/packages/bp/src/common/number.test.ts
+++ b/packages/bp/src/common/number.test.ts
@@ -4,9 +4,7 @@ const randomNumber = (max = 100) => {
   const number = Math.floor(Math.random() * max)
 
   // When we get 0, the test fails
-  if (number === 0) {
-    return randomNumber(max)
-  }
+  return number > 0 ? number : randomNumber(max)
 }
 
 const arrayGenerator = (size = 10): number[] => {

--- a/packages/bp/src/common/number.test.ts
+++ b/packages/bp/src/common/number.test.ts
@@ -1,6 +1,14 @@
 import { closest } from './number'
 
-const randomNumber = (max = 100) => Math.floor(Math.random() * max)
+const randomNumber = (max = 100) => {
+  const number = Math.floor(Math.random() * max)
+
+  // When we get 0, the test fails
+  if (number === 0) {
+    return randomNumber(max)
+  }
+}
+
 const arrayGenerator = (size = 10): number[] => {
   return Array.from({ length: size }, () => randomNumber())
 }


### PR DESCRIPTION
Thought I fixed that a while ago... Basically once in a while when the random method returns 0, the array is empty and the test fails...

![image](https://user-images.githubusercontent.com/42552874/153245874-e5432d2d-2a6b-49e4-acc8-bd469e486815.png)
