### PR TITLE
chore(e2e): increase timeout for nlu train test

### DIFF
--- a/packages/bp/e2e/utils/index.ts
+++ b/packages/bp/e2e/utils/index.ts
@@ -9,7 +9,7 @@ import { clickOn, expectMatchElement, fillField } from './expectPuppeteer'
 type HttpMethod = 'POST' | 'GET' | 'PATCH' | 'PUT' | 'DELETE' | 'OPTIONS'
 
 export const DEFAULT_TIMEOUT = Number(process.env.JEST_TIMEOUT || 10000)
-export const NLU_TRAIN_TIMEOUT = Number(process.env.JEST_TIMEOUT || 15000)
+export const NLU_TRAIN_TIMEOUT = DEFAULT_TIMEOUT + 5000 // Add 5sec to the default timeout
 
 export const getPage = async (): Promise<Page> => {
   await page.setViewport(windowSize)


### PR DESCRIPTION
This PR increases the timeout value for the NLU training test that runs in the E2E test suite.

As you can see here: https://github.com/botpress/botpress/runs/5125556176?check_suite_focus=true the test seems to only be failing because the timeout is reached