### PR TITLE
chore(e2e): fix failing test

### DIFF
--- a/packages/bp/e2e/jest-puppeteer.config.js
+++ b/packages/bp/e2e/jest-puppeteer.config.js
@@ -13,5 +13,6 @@ module.exports = {
     slowMo: 20 // Set this value to slow down tests globally
     // devtools: true // Access the dev tools on the headless chrome
   },
+  exitOnPageError: false,
   windowSize
 }


### PR DESCRIPTION
Turns out that the `exitOnPageError` config was needed in some cases so putting it back in the `jest-puppeteer` config file.