### PR TITLE
chore(ci_cd): add comment when closing issues

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -13,3 +13,5 @@ jobs:
 
       - name: Close PR Issues
         uses: botpress/gh-actions/close_pull_request_issues@next
+        with:
+          comment: Available on ${{ github.event.release.tag_name }}


### PR DESCRIPTION
This PR adds a comment as parameter to the action that closes and comments on issues that were mentioned in pull requests that were merged, after a new release

The resulting message will look like: `Available on v12.26.10`