### PR TITLE
chore(ci_cd): make actions compatible with dependabot

### DIFF
--- a/.github/workflows/branch-deleted.yml
+++ b/.github/workflows/branch-deleted.yml
@@ -2,7 +2,7 @@ name: Branch deleted
 on: delete
 
 jobs:
-  remove:
+  delete_branch_binaries:
     if: github.event.ref_type == 'branch'
     name: Delete Branch Binaries
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build
 on: [pull_request]
 jobs:
-  server:
+  botpress:
     name: Botpress
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+on: [pull_request]
+jobs:
+  server:
+    name: Botpress
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.BOTPRESS_BOT_APP_ID }}
+          private_key: ${{ secrets.BOTPRESS_BOT_APP_PRIVATE_KEY }}
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          submodules: true
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12.18.1'
+          cache: 'yarn'
+      - name: Fetch Node Packages
+        run: |
+          yarn --frozen-lockfile
+      - name: Build Botpress
+        run: yarn build --prod --linux
+        env:
+          NODE_OPTIONS: '--max-old-space-size=6000'
+          EDITION: pro

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -2,7 +2,7 @@ name: Code Style
 on: [pull_request]
 jobs:
   prettier:
-    name: Run Prettier on codebase
+    name: Prettier
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -18,7 +18,7 @@ jobs:
         run: |
           yarn prettier
   eslint:
-    name: Run ESLint on codebase
+    name: ESLint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -1,7 +1,7 @@
-name: Codestyle
+name: Code Style
 on: [pull_request]
 jobs:
-  run_prettier:
+  prettier:
     name: Run Prettier on codebase
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -9,7 +9,7 @@ jobs:
         uses: actions/checkout@master
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.18.1'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Install Dependencies
         run: |
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@master
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.18.1'
+          node-version-file: '.nvmrc'
       - name: Install Dependencies
         run: |
           yarn --frozen-lockfile

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -9,8 +9,8 @@ on:
         default: 'patch'
 
 jobs:
-  create_pull_request:
-    name: Create Pull Request
+  create_release_pull_request:
+    name: Create Release Pull Request
     runs-on: 'ubuntu-latest'
 
     steps:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.18.1'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
 
       - name: Bump version

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -33,9 +33,16 @@ jobs:
         id: release_details
         uses: botpress/gh-actions/get_release_details@next
 
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.BOTPRESS_BOT_APP_ID }}
+          private_key: ${{ secrets.BOTPRESS_BOT_APP_PRIVATE_KEY }}
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           title: 'chore(server): release v${{ steps.bump.outputs.new_version }}'
           commit-message: 'chore(server): release v${{ steps.bump.outputs.new_version }}'
           branch: 'release/v${{ steps.bump.outputs.new_version }}'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 jobs:
-  build_and_push:
+  build_and_push_docker:
     name: Build and push Docker image to GitHub Packages
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,8 +68,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ steps.generate-token.outputs.token }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build_and_push_docker:
-    name: Build and push Docker image to GitHub Packages
+    name: Build and Push Docker Image
     runs-on: ubuntu-latest
     steps:
       - uses: tibdex/github-app-token@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,6 @@
 name: Docker
 on:
   push:
-    branches-ignore:
-      - 'dependabot/**'
   release:
     types: [published]
 
@@ -11,10 +9,16 @@ jobs:
     name: Build and push Docker image to GitHub Packages
     runs-on: ubuntu-latest
     steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.BOTPRESS_BOT_APP_ID }}
+          private_key: ${{ secrets.BOTPRESS_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@master
         with:
-          token: ${{ secrets.PAT_DOCKER }}
+          token: ${{ steps.generate-token.outputs.token }}
           submodules: true
       # Create an array of version to push to the Dockerhub registry
       - name: Prepare
@@ -65,7 +69,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ steps.generate-token.outputs.token }}
       - name: Build and push
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '12.18.1'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Build
         run: |

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@master
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.18.1'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Fetch Node Packages
         run: |

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
 jobs:
-  build_and_push:
+  test_module_builder:
     name: Test Module Builder Image
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/next-binaries.yml
+++ b/.github/workflows/next-binaries.yml
@@ -13,8 +13,8 @@ on:
 # This is by choice as the next branch will eventually be merged in the master
 # It makes it easy to remove when the time comes
 jobs:
-  pre_release_bin:
-    name: Build and Publish Binaries
+  release_next_bin:
+    name: Build and Publish Next Binaries
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
 
 jobs:
-  pre_release_bin:
+  release_bin:
     # Do not publish dependabot branches
     if: startsWith(github.head_ref, 'dependabot/') != true
 

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.18.1'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
 
       - name: Configure SSH Key

--- a/.github/workflows/publish-next-binaries.yml
+++ b/.github/workflows/publish-next-binaries.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.18.1'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
 
       - name: Configure SSH Key

--- a/.github/workflows/publish-next-binaries.yml
+++ b/.github/workflows/publish-next-binaries.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       name:
-        description: 'Name of the ouput file'
+        description: 'Name of the output file'
         required: false
         default: ''
 

--- a/.github/workflows/publish-reference.yml
+++ b/.github/workflows/publish-reference.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@master
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.18.1'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Install python3
         uses: actions/setup-python@v1

--- a/.github/workflows/publish-reference.yml
+++ b/.github/workflows/publish-reference.yml
@@ -1,8 +1,8 @@
 name: Publish Reference
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published]
+
 jobs:
   publish_reference:
     name: Publish Reference

--- a/.github/workflows/publish-reference.yml
+++ b/.github/workflows/publish-reference.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
 jobs:
-  publish-reference:
+  publish_reference:
     name: Publish Reference
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,6 +1,7 @@
 on:
   discussion:
     types: [created]
+
 name: Slack Notification Demo
 jobs:
   slack_notification:

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,39 +1,39 @@
-on:   
+on:
   discussion:
-    types: [created]  
+    types: [created]
 name: Slack Notification Demo
 jobs:
-  slackNotification:
+  slack_notification:
     name: Slack Notification
     runs-on: ubuntu-latest
-    steps:      
+    steps:
       - name: Send custom JSON data to Slack workflow
         id: slack
         uses: slackapi/slack-github-action@v1.16.0
         if: ${{ github.event.discussion.category.name  == 'Community Support' }}
         with:
           payload: |
-              {
-                "blocks": [
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": "*There is a new post to the Botpress Forums!*"
-                    }
-                  },
-                  {
-                    "type": "divider"
-                  },
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": "> *${{ github.event.discussion.title }}* \n> ${{ github.event.discussion.html_url }}"
-                    }
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*There is a new post to the Botpress Forums!*"
                   }
-                ]
-              }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "> *${{ github.event.discussion.title }}* \n> ${{ github.event.discussion.html_url }}"
+                  }
+                }
+              ]
+            }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.DISCUSSIONS_SLACK_WEBHOOK }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@master
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.18.1'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Fetch Node Packages
         run: |
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@master
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.18.1'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Fetch Node Packages
         run: |
@@ -91,7 +91,7 @@ jobs:
           submodules: true
       - uses: actions/setup-node@v2
         with:
-          node-version: '12.18.1'
+          node-version-file: '.nvmrc'
           cache: 'yarn'
       - name: Fetch Node Packages
         run: |
@@ -127,7 +127,7 @@ jobs:
 #        uses: actions/checkout@master
 #      - uses: actions/setup-node@v2
 #        with:
-#          node-version: '12.18.1'
+#          node-version-file: '.nvmrc'
 #          cache: 'yarn'
 #      - name: Fetch Node Packages
 #        run: |
@@ -160,7 +160,7 @@ jobs:
 #        uses: actions/checkout@master
 #      - uses: actions/setup-node@v2
 #        with:
-#          node-version: '12.18.1'
+#          node-version-file: '.nvmrc'
 #          cache: 'yarn'
 #      - name: Fetch Node Packages
 #        run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,8 +78,17 @@ jobs:
     name: E2E (ubuntu-latest)
     runs-on: ubuntu-latest
     steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.BOTPRESS_BOT_APP_ID }}
+          private_key: ${{ secrets.BOTPRESS_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@master
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          submodules: true
       - uses: actions/setup-node@v2
         with:
           node-version: '12.18.1'
@@ -88,9 +97,10 @@ jobs:
         run: |
           yarn --frozen-lockfile
       - name: Build core, UI and modules
-        run: yarn build
+        run: yarn build --prod --linux
         env:
           NODE_OPTIONS: '--max-old-space-size=6000'
+          EDITION: pro
       - name: Run Tests
         run: |
           yarn start & 


### PR DESCRIPTION
This PR aims at making sure that our actions can also be run by dependabot. It also uses credentials from an internal application instead of using PATs (Personal Access Tokens).

Closes DEV-2355