### PR TITLE
fix(builtin): smalltalk qnas have no contexts

### DIFF
--- a/modules/builtin/src/bot-templates/small-talk/qna/0xbmxyusvu_tell_me_a_joke.json
+++ b/modules/builtin/src/bot-templates/small-talk/qna/0xbmxyusvu_tell_me_a_joke.json
@@ -38,7 +38,9 @@
     "redirectFlow": "",
     "redirectNode": "",
     "action": "text",
-    "category": "global",
-    "enabled": true
+    "enabled": true,
+    "contexts": [
+      "global"
+    ]
   }
 }

--- a/modules/builtin/src/bot-templates/small-talk/qna/2wys1802lo_thank_you.json
+++ b/modules/builtin/src/bot-templates/small-talk/qna/2wys1802lo_thank_you.json
@@ -39,7 +39,9 @@
     "redirectFlow": "",
     "redirectNode": "",
     "action": "text",
-    "category": "global",
-    "enabled": true
+    "enabled": true,
+    "contexts": [
+      "global"
+    ]
   }
 }

--- a/modules/builtin/src/bot-templates/small-talk/qna/3xcljo3jr5_where_are_you_right_now.json
+++ b/modules/builtin/src/bot-templates/small-talk/qna/3xcljo3jr5_where_are_you_right_now.json
@@ -38,7 +38,9 @@
     "redirectFlow": "",
     "redirectNode": "",
     "action": "text",
-    "category": "global",
-    "enabled": true
+    "enabled": true,
+    "contexts": [
+      "global"
+    ]
   }
 }

--- a/modules/builtin/src/bot-templates/small-talk/qna/4wywaoky6v_bye.json
+++ b/modules/builtin/src/bot-templates/small-talk/qna/4wywaoky6v_bye.json
@@ -40,7 +40,9 @@
     "redirectFlow": "",
     "redirectNode": "",
     "action": "text",
-    "category": "global",
-    "enabled": true
+    "enabled": true,
+    "contexts": [
+      "global"
+    ]
   }
 }

--- a/modules/builtin/src/bot-templates/small-talk/qna/4xue79vezl_how_old_are_you.json
+++ b/modules/builtin/src/bot-templates/small-talk/qna/4xue79vezl_how_old_are_you.json
@@ -38,7 +38,9 @@
     "redirectFlow": "",
     "redirectNode": "",
     "action": "text",
-    "category": "global",
-    "enabled": true
+    "enabled": true,
+    "contexts": [
+      "global"
+    ]
   }
 }

--- a/modules/builtin/src/bot-templates/small-talk/qna/54qp2njdz0_how_are_you.json
+++ b/modules/builtin/src/bot-templates/small-talk/qna/54qp2njdz0_how_are_you.json
@@ -38,7 +38,9 @@
     "redirectFlow": "",
     "redirectNode": "",
     "action": "text",
-    "category": "global",
-    "enabled": true
+    "enabled": true,
+    "contexts": [
+      "global"
+    ]
   }
 }

--- a/modules/builtin/src/bot-templates/small-talk/qna/5i6fs3vzfj_what_can_you_do.json
+++ b/modules/builtin/src/bot-templates/small-talk/qna/5i6fs3vzfj_what_can_you_do.json
@@ -39,7 +39,9 @@
     "redirectFlow": "",
     "redirectNode": "",
     "action": "text",
-    "category": "global",
-    "enabled": true
+    "enabled": true,
+    "contexts": [
+      "global"
+    ]
   }
 }

--- a/modules/builtin/src/bot-templates/small-talk/qna/bvj5soxdb7_who_are_you.json
+++ b/modules/builtin/src/bot-templates/small-talk/qna/bvj5soxdb7_who_are_you.json
@@ -38,7 +38,9 @@
     "redirectFlow": "",
     "redirectNode": "",
     "action": "text",
-    "category": "global",
-    "enabled": true
+    "enabled": true,
+    "contexts": [
+      "global"
+    ]
   }
 }

--- a/modules/builtin/src/bot-templates/small-talk/qna/d6q3rr8u64_you_are_great.json
+++ b/modules/builtin/src/bot-templates/small-talk/qna/d6q3rr8u64_you_are_great.json
@@ -41,7 +41,9 @@
     "redirectFlow": "",
     "redirectNode": "",
     "action": "text",
-    "category": "global",
-    "enabled": true
+    "enabled": true,
+    "contexts": [
+      "global"
+    ]
   }
 }

--- a/modules/builtin/src/bot-templates/small-talk/qna/ewbosxr8fa_who_created_you.json
+++ b/modules/builtin/src/bot-templates/small-talk/qna/ewbosxr8fa_who_created_you.json
@@ -40,7 +40,9 @@
     "redirectFlow": "",
     "redirectNode": "",
     "action": "text",
-    "category": "global",
-    "enabled": true
+    "enabled": true,
+    "contexts": [
+      "global"
+    ]
   }
 }

--- a/modules/builtin/src/bot-templates/small-talk/qna/f2osy09wyi_what_s_your_hobby.json
+++ b/modules/builtin/src/bot-templates/small-talk/qna/f2osy09wyi_what_s_your_hobby.json
@@ -38,7 +38,9 @@
     "redirectFlow": "",
     "redirectNode": "",
     "action": "text",
-    "category": "global",
-    "enabled": true
+    "enabled": true,
+    "contexts": [
+      "global"
+    ]
   }
 }

--- a/modules/builtin/src/bot-templates/small-talk/qna/fejwh1accg_would_you_marry_me.json
+++ b/modules/builtin/src/bot-templates/small-talk/qna/fejwh1accg_would_you_marry_me.json
@@ -38,7 +38,9 @@
     "redirectFlow": "",
     "redirectNode": "",
     "action": "text",
-    "category": "global",
-    "enabled": true
+    "enabled": true,
+    "contexts": [
+      "global"
+    ]
   }
 }

--- a/modules/builtin/src/bot-templates/small-talk/qna/pfd6iuovva_what_are_you_doing.json
+++ b/modules/builtin/src/bot-templates/small-talk/qna/pfd6iuovva_what_are_you_doing.json
@@ -39,7 +39,9 @@
     "redirectFlow": "",
     "redirectNode": "",
     "action": "text",
-    "category": "global",
-    "enabled": true
+    "enabled": true,
+    "contexts": [
+      "global"
+    ]
   }
 }

--- a/modules/builtin/src/bot-templates/small-talk/qna/r1kyn11enn_i_love_you.json
+++ b/modules/builtin/src/bot-templates/small-talk/qna/r1kyn11enn_i_love_you.json
@@ -29,13 +29,19 @@
       ]
     },
     "answers": {
-      "en": ["People tell me all the time that I'm a lovable little bot :-)"],
-      "fr": ["S'il vous plait, continuez à me dire que je un petit robot aimable!"]
+      "en": [
+        "People tell me all the time that I'm a lovable little bot :-)"
+      ],
+      "fr": [
+        "S'il vous plait, continuez à me dire que je un petit robot aimable!"
+      ]
     },
     "redirectFlow": "main.flow.json",
     "redirectNode": "node-1fe2",
     "action": "text",
-    "category": "global",
-    "enabled": true
+    "enabled": true,
+    "contexts": [
+      "global"
+    ]
   }
 }

--- a/modules/builtin/src/bot-templates/small-talk/qna/rkmsylph53_hello.json
+++ b/modules/builtin/src/bot-templates/small-talk/qna/rkmsylph53_hello.json
@@ -38,7 +38,9 @@
     "redirectFlow": "",
     "redirectNode": "",
     "action": "text",
-    "category": "global",
-    "enabled": true
+    "enabled": true,
+    "contexts": [
+      "global"
+    ]
   }
 }

--- a/modules/builtin/src/bot-templates/small-talk/qna/uqvj6jdj32_you_are_annoying.json
+++ b/modules/builtin/src/bot-templates/small-talk/qna/uqvj6jdj32_you_are_annoying.json
@@ -30,13 +30,19 @@
       ]
     },
     "answers": {
-      "en": ["I'm sorry you feel that way."],
-      "fr": ["Je suis désolé, que vous vous sentiez comme ça."]
+      "en": [
+        "I'm sorry you feel that way."
+      ],
+      "fr": [
+        "Je suis désolé, que vous vous sentiez comme ça."
+      ]
     },
     "redirectFlow": "",
     "redirectNode": "",
     "action": "text",
-    "category": "global",
-    "enabled": true
+    "enabled": true,
+    "contexts": [
+      "global"
+    ]
   }
 }


### PR DESCRIPTION
For some reason, the Smalltalk bot skipped [this migration](https://github.com/botpress/studio/blob/master/packages/studio-be/src/migrations/v12_8_0-1583933939-qna_multi_contexts.ts) which used to be located [here](https://github.com/botpress/botpress/blob/57e5f20956dec55e2ae67cd7a582c1924f1ef901/modules/qna/src/migrations/v12_8_0-1583933939-qna_multi_contexts.ts) a few minors ago.

These exact changes have been made on `botpress/studio@next` few weeks ago, so the situation is already addressed in `12.27.x`. This PR fixes the problem in `12.26.x`.

I made the required changes manually by running this custom script:

```ts
import fse from 'fs-extra'
import path from 'path'

const BOT_PATH = 'modules/builtin/src/bot-templates/small-talk'
const QNA_PATH = `${BOT_PATH}/qna`

const allFiles = fse
  .readdirSync(QNA_PATH)
  .filter(f => f.endsWith('.json'))
  .map(f => path.join(QNA_PATH, f))

for (const f of allFiles) {
  const content = fse.readJSONSync(f)
  const { data } = content

  const { category } = data
  delete data.category

  content.data = { ...data, contexts: [category] }

  fse.writeJSONSync(f, content, {
    EOL: '\n',
    encoding: 'utf8',
    spaces: 2
  })
}

```