### PR TITLE
chore(ci_cd): allow tests and build to safely run on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: [pull_request]
+on: [pull_request_target]
 jobs:
   botpress:
     name: Botpress

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   unit:


### PR DESCRIPTION
This PR should fix running builds and tests on PRs that were created from a fork. 

Doc: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target