### PR TITLE
fix(core): change default timeout

### DIFF
--- a/packages/bp/src/core/config/bot.config.ts
+++ b/packages/bp/src/core/config/bot.config.ts
@@ -65,7 +65,7 @@ export interface BotDialogConfig {
   /**
    * The interval until the context of the session expires.
    * This clears the position of the user in the flow and triggers the before_session_timeout hook
-   * @default 5m
+   * @default 25m
    */
   timeoutInterval: string
   /**

--- a/packages/bp/src/core/config/botpress.config.ts
+++ b/packages/bp/src/core/config/botpress.config.ts
@@ -22,7 +22,7 @@ export interface DialogConfig {
    * Interval before a session's context expires.
    * e.g. when the conversation is stale and has not reached the END of the flow.
    * This will reset the position of the user in the flow.
-   * @default 2m
+   * @default 25m
    */
   timeoutInterval: string
   /**


### PR DESCRIPTION
By default, the context timeout was 2 minutes. Meaning, if you started a conversation with the bot, then waited 3 minutes before answering it (choosing which button to click), it would start again at the beginning, forgetting your position.

From what I saw, everybody seems to change this value to something higher, so why shouldn't we put it higher by default? 
