### PR TITLE
fix(channel-web): move setLocked logic to message component

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/Message.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/Message.tsx
@@ -163,6 +163,12 @@ class Message extends Component<MessageProps> {
     await this.props.store.loadEventInDebugger(this.props.messageId, true)
   }
 
+  componentDidMount() {
+    this.props.isLastGroup &&
+      this.props.isLastOfGroup &&
+      this.props.store.composer.setLocked(this.props.payload.disableFreeText)
+  }
+
   render() {
     if (this.state.hasError) {
       return '* Cannot display message *'

--- a/modules/channel-web/src/views/lite/components/messages/renderer/QuickReplies.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/renderer/QuickReplies.tsx
@@ -15,16 +15,6 @@ import { Button } from './Button'
  * @return onSendData is called with the reply
  */
 export class QuickReplies extends Component<Renderer.QuickReply> {
-  componentDidMount() {
-    this.props.isLastGroup &&
-      this.props.isLastOfGroup &&
-      this.props.store.composer.setLocked(this.props.disableFreeText)
-  }
-
-  componentWillUnmount() {
-    this.props.store.composer.setLocked(false)
-  }
-
   handleButtonClicked = (title, payload) => {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.props.onSendData?.({


### PR DESCRIPTION
There bug was caused by the `QuickReplies` component having the only entry point to toggle the input box on/off. By moving the logic out to the message, any message has the potential to have that flag. This way it will re-evaluate if the input  should be disabled every message that is the last in its group and gList. This also allows for the absolute edge case of 'You have been BANNED from using our chat bot" message that has `disableFreeText` set to `true` on its `payload`...so yea...here are some jifs:

Working with text:
![emulatorDisableFixText](https://user-images.githubusercontent.com/23468320/155864038-24f7bb9b-83d2-458b-97fd-3c09d10de299.gif)

Working with text AND HD Picture:
![emulatorDisableFixText](https://user-images.githubusercontent.com/23468320/155864042-39f0af19-e6e5-410d-b777-89fb3ad471ad.gif)

Working with everything else: Guaranteed!!1


Closes botpress/v12#1469