### PR TITLE
fix(code-editor): change to outgoing event for outgoing hooks

### DIFF
--- a/modules/code-editor/src/typings/hooks.ts
+++ b/modules/code-editor/src/typings/hooks.ts
@@ -1,7 +1,7 @@
 export const HOOK_SIGNATURES = {
   before_incoming_middleware: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
   after_incoming_middleware: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
-  before_outgoing_middleware: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
+  before_outgoing_middleware: 'function hook(bp: typeof sdk, event: sdk.IO.OutgoingEvent)',
   after_event_processed: 'function hook(bp: typeof sdk, event: sdk.IO.IncomingEvent)',
   before_suggestions_election: `function hook(
   bp: typeof sdk,


### PR DESCRIPTION
This quickly fixes a typescript issue users can experience when trying to access the non-existent state on an outgoing hook. Just changed the signature and it seems good to go.

Closes botpress/v12#1582 