### PR TITLE
chore: update typings for nlu-server errors

### DIFF
--- a/packages/bp/src/core/nlu/nlu-client/client.ts
+++ b/packages/bp/src/core/nlu/nlu-client/client.ts
@@ -10,6 +10,17 @@ interface Options {
   cloud?: CloudConfig
 }
 
+/**
+ * in "@botpress/nlu-client@v1.0.0": typeof response.error === "string"
+ * in "@botpress/nlu-client@v1.0.1": typeof response.error === "object"
+ */
+interface NLUError {
+  message: string
+  stack?: string
+  type: string
+  code: number
+}
+
 export class NLUClient {
   private _client: Client | CloudClient
 
@@ -68,7 +79,11 @@ export class NLUClient {
     return preds
   }
 
-  private _throwError(err: string): never {
-    throw new Error(`An error occured in NLU server: ${err}`)
+  private _throwError(err: string | NLUError): never {
+    const prefix = 'An error occured in NLU server'
+    if (_.isString(err)) {
+      throw new Error(`${prefix}: ${err}`)
+    }
+    throw new Error(`${prefix}: ${err.message}`)
   }
 }

--- a/packages/runtime/src/runtime/nlu/nlu-client/client.ts
+++ b/packages/runtime/src/runtime/nlu/nlu-client/client.ts
@@ -10,6 +10,17 @@ interface Options {
   cloud?: CloudConfig
 }
 
+/**
+ * in "@botpress/nlu-client@v1.0.0": typeof response.error === "string"
+ * in "@botpress/nlu-client@v1.0.1": typeof response.error === "object"
+ */
+interface NLUError {
+  message: string
+  stack?: string
+  type: string
+  code: number
+}
+
 export class NLUClient {
   private _client: Client | CloudClient
 
@@ -68,7 +79,11 @@ export class NLUClient {
     return preds
   }
 
-  private _throwError(err: string): never {
-    throw new Error(`An error occured in NLU server: ${err}`)
+  private _throwError(err: string | NLUError): never {
+    const prefix = 'An error occured in NLU server'
+    if (_.isString(err)) {
+      throw new Error(`${prefix}: ${err}`)
+    }
+    throw new Error(`${prefix}: ${err.message}`)
   }
 }


### PR DESCRIPTION
Botpress uses 2 different versions of NLU Server simultaneously (the one on the cloud and the one in local). This change ensures both API are supported at the same time. 