### PR TITLE
fix(messaging): fix issue with path on external url

### DIFF
--- a/packages/bp/src/core/app/botpress.ts
+++ b/packages/bp/src/core/app/botpress.ts
@@ -240,7 +240,8 @@ export class Botpress {
 
     startLocalMessagingServer({
       CORE_PORT: process.PORT.toString(),
-      EXTERNAL_URL: process.EXTERNAL_URL
+      EXTERNAL_URL: process.EXTERNAL_URL,
+      ROOT_PATH: process.ROOT_PATH
     })
   }
 

--- a/packages/bp/src/orchestrator/messaging-server.ts
+++ b/packages/bp/src/orchestrator/messaging-server.ts
@@ -10,6 +10,7 @@ export interface MessagingServerOptions {
   host: string
   port: number
   EXTERNAL_URL?: string
+  ROOT_PATH?: string
   CORE_PORT?: string
 }
 
@@ -67,7 +68,7 @@ export const startMessagingServer = async (opts: Partial<MessagingServerOptions>
     SKIP_LOAD_ENV: 'true',
     SKIP_LOAD_CONFIG: 'true',
     SPINNED: 'true',
-    SPINNED_URL: `http://localhost:${opts.CORE_PORT}/api/v1/chat/receive`,
+    SPINNED_URL: `http://localhost:${opts.CORE_PORT}${opts.ROOT_PATH || ''}/api/v1/chat/receive`,
     NO_LAZY_LOADING: 'true',
     ENABLE_LEGACY_CHANNELS: 'true',
     DISABLE_SOCKETS: 'true',


### PR DESCRIPTION
This PR fixes an issue where the `EXTERNAL_URL` can sometimes contain a path (e.g. `http://localhost:3000/botpress`.

Closes DEV-2392