### PR TITLE
chore(studio): do not set cloud nlu endpoint to value of nlu endpoint

### DIFF
--- a/packages/bp/src/orchestrator/studio-client.ts
+++ b/packages/bp/src/orchestrator/studio-client.ts
@@ -111,7 +111,6 @@ export const startStudio = async (logger: sdk.Logger, params: StudioParams) => {
     APP_SECRET: params.APP_SECRET,
     ROOT_PATH: params.ROOT_PATH,
     NLU_ENDPOINT: params.NLU_ENDPOINT,
-    CLOUD_NLU_ENDPOINT: params.NLU_ENDPOINT,
     SERVER_ID: process.SERVER_ID,
     BOTPRESS_VERSION: process.BOTPRESS_VERSION
   }


### PR DESCRIPTION
`params.NLU_ENDPOINT` points to the local NLU server. Meaning that `CLOUD_NLU_ENDPOINT` to the same value as NLU_ENDPOINT causes cloud bots to train on the local server instead of the cloud.