### PR TITLE
fix(runtime): revert vm2

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -30,6 +30,7 @@
     ],
     "assets": [
       "../../node_modules/vm2/lib/*.js",
+      "./node_modules/vm2/lib/*.js",
       "../../node_modules/xml-encryption/lib/templates/*.tpl.xml"
     ]
   },
@@ -86,7 +87,7 @@
     "tmp": "^0.0.33",
     "unzipper": "^0.10.3",
     "verror": "^1.10.0",
-    "vm2": "^3.9.6",
+    "vm2": "^3.9.5",
     "yargs": "^16.0.3",
     "yn": "^2.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -23471,9 +23471,9 @@ vm2@3.9.5:
   resolved "https://registry.npmjs.org/vm2/-/vm2-3.9.5.tgz#5288044860b4bbace443101fcd3bddb2a0aa2496"
   integrity sha512-LuCAHZN75H9tdrAiLFf030oW7nJV5xwNMuk1ymOZwopmuK3d2H4L1Kv4+GFHgarKiLfXXLFU+7LDABHnwOkWng==
 
-vm2@^3.9.6:
+vm2@^3.9.5:
   version "3.9.9"
-  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.9.tgz#c0507bc5fbb99388fad837d228badaaeb499ddc5"
+  resolved "https://registry.npmjs.org/vm2/-/vm2-3.9.9.tgz#c0507bc5fbb99388fad837d228badaaeb499ddc5"
   integrity sha512-xwTm7NLh/uOjARRBs8/95H0e8fT3Ukw5D/JJWhxMbhKzNh1Nu981jQKvkep9iKYNxzlVrdzD0mlBGkDKZWprlw==
   dependencies:
     acorn "^8.7.0"


### PR DESCRIPTION
Also reverting vm2 for the runtime (https://github.com/botpress/botpress/pull/11581). Having 2 different versions meant that the lib was no longer hoisted and was not package with the binary. Added the other asset path so we avoid this situation in the future