### PR TITLE
feat(auth): implement SAML SLO

### DIFF
--- a/packages/bp/e2e/admin/logout.test.ts
+++ b/packages/bp/e2e/admin/logout.test.ts
@@ -21,7 +21,7 @@ describe('Admin - Logout', () => {
     await clickOn('#btn-menu-user-dropdown')
     await clickOn('#btn-logout')
 
-    const response = await getResponse('/api/v2/admin/auth/logout', 'POST')
+    const response = await getResponse('/api/v2/admin/auth/logout', 'GET')
     const headers = response.request().headers()
 
     let profileStatus: number

--- a/packages/bp/e2e/utils/index.ts
+++ b/packages/bp/e2e/utils/index.ts
@@ -43,8 +43,9 @@ export const logout = async () => {
   await clickOn('#btn-menu-user-dropdown')
   await clickOn('#btn-logout')
 
-  const response = await getResponse('/api/v2/admin/auth/logout', 'POST')
-  expect(response.status()).toBe(200)
+  const response = await getResponse('/api/v2/admin/auth/logout', 'GET')
+  expect(response.status()).toBeGreaterThanOrEqual(200)
+  expect(response.status()).toBeLessThan(400)
 
   await page.waitForNavigation()
 }

--- a/packages/bp/src/admin/auth/auth-router.ts
+++ b/packages/bp/src/admin/auth/auth-router.ts
@@ -78,12 +78,12 @@ class AuthRouter extends CustomAdminRouter {
       })
     )
 
-    router.post(
+    router.get(
       '/logout',
       this.checkTokenHeader,
       this.asyncMiddleware(async (req: RequestWithUser, res) => {
         await this.authService.invalidateToken(req.tokenUser!)
-        res.sendStatus(200)
+        return this.authService.logout(req.tokenUser!.strategy, req, res)
       })
     )
 

--- a/packages/bp/src/common/typings.ts
+++ b/packages/bp/src/common/typings.ts
@@ -1,5 +1,5 @@
 import { BotDetails, Flow, FlowNode, IO, RolloutStrategy, StageRequestApprovers, StrategyUser } from 'botpress/sdk'
-import { Request } from 'express'
+import { Request, Response } from 'express'
 import { BotpressConfig } from '../core/config/botpress.config'
 import { LicenseInfo, LicenseStatus } from './licensing-service'
 
@@ -91,6 +91,8 @@ export type RequestWithUser = Request & {
   authUser?: StrategyUser
   workspace?: string
 }
+
+export type LogoutCallback = (strategy: string, req: RequestWithUser, res: Response) => Promise<void>
 
 export interface Bot {
   id: string

--- a/packages/ui-shared-lite/auth/index.ts
+++ b/packages/ui-shared-lite/auth/index.ts
@@ -58,8 +58,7 @@ export const logout = async (getAxiosClient: () => AxiosInstance) => {
   } catch {
     // Silently fails
   } finally {
-    // Clear access token and ID token from local storage
-    localStorage.removeItem(TOKEN_KEY)
+    storage.del(TOKEN_KEY)
 
     if (url) {
       // If /logout gave us a URL, manually redirect to this URL

--- a/packages/ui-shared-lite/auth/index.ts
+++ b/packages/ui-shared-lite/auth/index.ts
@@ -50,14 +50,25 @@ export const tokenNeedsRefresh = () => {
 }
 
 export const logout = async (getAxiosClient: () => AxiosInstance) => {
-  await getAxiosClient()
-    .post('/admin/auth/logout')
-    .catch(() => {})
+  let url = ''
+  try {
+    const resp = await getAxiosClient().get('/admin/auth/logout')
 
-  // Clear access token and ID token from local storage
-  localStorage.removeItem(TOKEN_KEY)
-  // need to force reload otherwise the token wont clear properly
-  window.location.href = window.location.origin + window['ROOT_PATH']
+    url = resp.data.url
+  } catch {
+    // Silently fails
+  } finally {
+    // Clear access token and ID token from local storage
+    localStorage.removeItem(TOKEN_KEY)
+
+    if (url) {
+      // If /logout gave us a URL, manually redirect to this URL
+      window.location.replace(url)
+    } else {
+      // need to force reload otherwise the token wont clear properly
+      window.location.href = window.location.origin + window['ROOT_PATH']
+    }
+  }
 }
 
 export const setVisitorId = (userId: string, userIdScope?: string) => {


### PR DESCRIPTION
This PR adds the implementation of SAML Single Log Out (SLO) to the already existing authentication strategy.

Related PR: https://github.com/botpress/botpress-pro/pull/69

This PR will require extensive testing. Here are the scenarios I thought of:

 - [X] Login when logged out of IdP
 - [X] Login when already logged in within the IdP
 - [X] Logout of Botpress and check if logged out of IdP
 - [x] Logout of IdP and check if logged out of Botpress (does not seem to work with Okta. Will have to test with another provider)
 - [X] Have multiple service providers (e.g. Botpress) logged in and check if logging out from one of them, log us out of the others. This is the SLO flow.


Note: `passport-saml` has some open issues that either bring constraints to using SLO or make it behave weirdly in some circustances:

 - SLO does not work when `authnRequestBinding: "HTTP-POST" ` and `skipRequestCompression` is set to true: https://github.com/node-saml/passport-saml/issues/241
 - Overview of edge cases that are not handled: https://github.com/node-saml/passport-saml/issues/419
 - Good explanation on how to make SLO "work": https://github.com/node-saml/passport-saml/issues/221#issuecomment-1048200363
