### PR TITLE
feat(web): allow fullscreen mode with embedded

### DIFF
--- a/modules/channel-web/assets/inject.js
+++ b/modules/channel-web/assets/inject.js
@@ -25,7 +25,8 @@ function _injectDOMElement(tagName, selector, options) {
 function _generateIFrameHTML(host, config) {
   const botId = config.botId || ''
   const options = encodeURIComponent(JSON.stringify({ config: config }))
-  let iframeSrc = host + '/lite/' + botId + '/?m=channel-web&v=Embedded&options=' + options
+  const viewMode = config.viewMode || 'Embedded'
+  let iframeSrc = host + '/lite/' + botId + '/?m=channel-web&v=' + viewMode + '&options=' + options
   if (config.ref) {
     iframeSrc += '&ref=' + encodeURIComponent(config.ref)
   }

--- a/modules/channel-web/src/views/lite/typings.d.ts
+++ b/modules/channel-web/src/views/lite/typings.d.ts
@@ -223,10 +223,10 @@ export interface Config {
   chatId?: string
   /** CSS class to be applied to iframe */
   className?: string
-  /** Force the display to use a specific mode (fullscreen or Embedded)
+  /** Force the display to use a specific mode (Fullscreen or Embedded)
    * Defaults to 'Embedded'
    */
-  viewMode?: 'Embedded' | string
+  viewMode?: 'Embedded' | 'Fullscreen'
 }
 
 type OverridableComponents = 'below_conversation' | 'before_container' | 'composer'

--- a/modules/channel-web/src/views/lite/typings.d.ts
+++ b/modules/channel-web/src/views/lite/typings.d.ts
@@ -223,6 +223,10 @@ export interface Config {
   chatId?: string
   /** CSS class to be applied to iframe */
   className?: string
+  /** Force the display to use a specific mode (fullscreen or Embedded)
+   * Defaults to 'Embedded'
+   */
+  viewMode?: 'Embedded' | string
 }
 
 type OverridableComponents = 'below_conversation' | 'before_container' | 'composer'


### PR DESCRIPTION
There are use cases where usage of the fullscreen mode in an Embedded chat window is necessary. This PR creates a viewMode option that can be used to modify the hardcoded argument.

Usage example: 
![image](https://user-images.githubusercontent.com/13484138/157439949-b48246bf-2583-438a-bf26-a091a5463479.png))
![image](https://user-images.githubusercontent.com/13484138/157440223-445e2c68-54a0-430a-baa1-1761bee45567.png)

