### PR TITLE
fix(channel-web): focus on composer when it gets unlocked

### DIFF
--- a/modules/channel-web/src/views/lite/components/Composer.tsx
+++ b/modules/channel-web/src/views/lite/components/Composer.tsx
@@ -20,7 +20,7 @@ class Composer extends React.Component<ComposerProps, { isRecording: boolean }> 
   }
 
   componentDidMount() {
-    focus()
+    this.focus()
 
     observe(this.props.focusedArea, focus => {
       focus.newValue === 'input' && this.textInput.current.focus()
@@ -30,7 +30,7 @@ class Composer extends React.Component<ComposerProps, { isRecording: boolean }> 
   componentWillReceiveProps(newProps: Readonly<ComposerProps>) {
     // Focus on the composer when it's unlocked
     if (this.props.composerLocked === true && newProps.composerLocked === false) {
-      focus()
+      this.focus()
     }
   }
 

--- a/modules/channel-web/src/views/lite/components/Composer.tsx
+++ b/modules/channel-web/src/views/lite/components/Composer.tsx
@@ -20,13 +20,24 @@ class Composer extends React.Component<ComposerProps, { isRecording: boolean }> 
   }
 
   componentDidMount() {
-    setTimeout(() => {
-      this.textInput.current.focus()
-    }, 50)
+    focus()
 
     observe(this.props.focusedArea, focus => {
       focus.newValue === 'input' && this.textInput.current.focus()
     })
+  }
+
+  componentWillReceiveProps(newProps: Readonly<ComposerProps>) {
+    // Focus on the composer when it's unlocked
+    if (this.props.composerLocked === true && newProps.composerLocked === false) {
+      focus()
+    }
+  }
+
+  focus = () => {
+    setTimeout(() => {
+      this.textInput.current.focus()
+    }, 50)
   }
 
   handleKeyPress = async e => {

--- a/modules/channel-web/src/views/lite/store/composer.ts
+++ b/modules/channel-web/src/views/lite/store/composer.ts
@@ -82,7 +82,7 @@ class ComposerStore {
 
   @action.bound
   setLocked(locked: boolean) {
-    this.locked = locked
+    this.locked = !!locked
   }
 
   @action.bound


### PR DESCRIPTION
This PR fixes an issue with the composer not being focused on when it gets unlocked.

**Before**

https://user-images.githubusercontent.com/9640576/157742834-312f7f73-d8e6-4793-b14e-92ad7ad151a7.mp4


**After**


https://user-images.githubusercontent.com/9640576/157742860-289ef9e8-37a3-4a09-9225-bc2ff26cc3cb.mp4

