### PR TITLE
chore(ci_cd): add automation to do module-builder release WIP

### DIFF
--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -11,15 +11,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.1.0
-      - name: Build
-        run: |
-          docker build -t module-builder-test -f build/module-builder/Dockerfile .
-      - name: Build has failed
-        if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_GH_ACTIONS }}
-          SLACK_COLOR: ${{ job.status }}
       - name: Prepare
         id: prep
         run: |

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -4,7 +4,7 @@ on:
     types: [edited]
 jobs:
   publish_module_builder:
-    if: ${{ github.base_ref == 'module-builder-release/v0.0.3' }}
+    #if: ${{ github.base_ref == 'module-builder-release/v0.0.3' }}
     name: Build and publish module builder
     runs-on: ubuntu-latest
     steps:
@@ -15,6 +15,7 @@ jobs:
         run: |
           BRANCH_NAME="$GITHUB_HEAD_REF"
           echo "Building with origin Branch name $BRANCH_NAME"
+          echo "This is base ref: ${{ github.base_ref }}"
           VALID_BRANCH_NAME="^module-builder-release/v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
           DOCKER_IMAGE=botpress/module-builder
           if [[ $BRANCH_NAME =~ $VALID_BRANCH_NAME ]]; then

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -2,9 +2,6 @@ name: Publish and release module builder
 on:
   pull_request:
     types: - edited
-    #branches:
-    #  - 'module-builder-release/v*' # Pull Request events with branch names matching module-builder-release/v*
-
 jobs:
   publish_module_builder:
     name: Build and publish module builder

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -4,7 +4,6 @@ on:
     types: [edited]
 jobs:
   publish_module_builder:
-    #if: ${{ github.base_ref == 'module-builder-release/v0.0.3' }}
     name: Build and publish module builder
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -3,10 +3,10 @@ on:
   pull_request:
     types: [ edited ]
     branches:
-      - "module-builder-release/v**" # Pull Request events with branch names matching module-builder-release/v*
+      - 'module-builder-release/v*' # Pull Request events with branch names matching module-builder-release/v*
 
 jobs:
-  test_module_builder:
+  publish_module_builder:
     name: Build and publish module builder
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -26,12 +26,12 @@ jobs:
             VERSION+=($(echo ${TAG} | sed -r 's/\./_/g')) # Transform v12.13.0 to v12_13_0 ## Added backward compatibility
             echo ::set-output name=release::"true"
             TAGS+=("${VERSION[@]/#/${DOCKER_IMAGE}:}")
-            echo "Will publish tags $TAGS"
           else
             echo "Invalid tag format, use module-builder-vXXX.XXX.XXX"
           fi
           GITHUB_REGISTRY="ghcr.io/${{ github.repository_owner }}/${DOCKER_IMAGE}"
           TAGS+=("${VERSION[@]/#/${GITHUB_REGISTRY}:}")
+          echo "Will publish tags $TAGS"
           IFS=,
           echo ::set-output name=version::${VERSION[*]}
           echo ::set-output name=tags::"${TAGS[*]}"

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -2,7 +2,7 @@ name: Publish and release module builder
 on:
   push:
     tags:
-      - "module-builder-v*" # Push events to matching bpib-v*
+      - "module-builder-v*" # Push events to matching module-builder-v*
 
 jobs:
   test_module_builder:
@@ -15,18 +15,20 @@ jobs:
         id: prep
         run: |
           TAG=$(echo $(git describe ${{ github.sha }} --tags)) ## Get the tags from the SHA hash
-          echo "Build with tag $TAG"
+          echo "Building with origin tag $TAG"
           VALID_TAG="^module-builder-v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
           DOCKER_IMAGE=botpress/module-builder
           VERSION=()
           TAGS=()
           if [[ $TAG =~ $VALID_TAG ]]; then
-            echo "Tag is valid"
             VERSION+=($(echo ${TAG} | sed -r 's/module-builder-v//')) # transform module-builder-v12.23.0 to 12.23.0
             VERSION+=('latest')
             VERSION+=($(echo ${TAG} | sed -r 's/\./_/g')) # Transform v12.13.0 to v12_13_0 ## Added backward compatibility
             echo ::set-output name=release::"true"
             TAGS+=("${VERSION[@]/#/${DOCKER_IMAGE}:}")
+            echo "Will publish tags $TAGS"
+          el 
+            echo "Invalid tag format, use module-builder-vXXX.XXX.XXX"
           fi
           GITHUB_REGISTRY="ghcr.io/${{ github.repository_owner }}/${DOCKER_IMAGE}"
           TAGS+=("${VERSION[@]/#/${GITHUB_REGISTRY}:}")

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -19,7 +19,7 @@ jobs:
           VALID_TAG="^module-builder-v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
           DOCKER_IMAGE=botpress/module-builder
           if [[ $TAG =~ $VALID_TAG ]]; then
-            VERSION=($(echo ${TAG} | sed -r 's/module-builder-//')) # transform module-builder-v0.0.0 to v0.0.0
+            VERSION=($(echo ${TAG} | sed -r 's/module-builder-v//')) # transform module-builder-v0.0.0 to 0.0.0
             GITHUB_REGISTRY="ghcr.io/${{ github.repository_owner }}/${DOCKER_IMAGE}"
             TAGS=("${VERSION[@]/#/${GITHUB_REGISTRY}:}")
             echo "Will publish tag $TAGS"

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -1,7 +1,9 @@
 name: Publish and release module builder
+
 on:
   pull_request:
-    types: [closed]
+    types: [ closed ]
+
 jobs:
   publish_module_builder:
     name: Build and publish module builder

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -13,7 +13,7 @@ jobs:
         id: prep
         run: |
           BRANCH_NAME=${GITHUB_REF##*/}
-          echo "Building with origin Branch name $BRANCH"
+          echo "Building with origin Branch name $BRANCH_NAME | $GITHUB_REF"
           VALID_BRANCH_NAME="^module-builder-v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
           DOCKER_IMAGE=botpress/module-builder
           if [[ $BRANCH_NAME =~ $VALID_BRANCH_NAME ]]; then

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -1,8 +1,8 @@
 name: Publish and release module builder
 on:
-  push:
-    tags:
-      - "module-builder-v*" # Push events to matching module-builder-v*
+  pull_request:
+    branches:
+      - "module-builder-release/v*" # Pull Request events with branch names matching module-builder-release/v*
 
 jobs:
   test_module_builder:
@@ -14,12 +14,12 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          TAG=$(echo $(git describe ${{ github.sha }} --tags)) ## Get the tags from the SHA hash
-          echo "Building with origin tag $TAG"
-          VALID_TAG="^module-builder-v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
+          BRANCH_NAME=${GITHUB_REF##*/}
+          echo "Building with origin Branch name $BRANCH"
+          VALID_BRANCH_NAME="^module-builder-v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
           DOCKER_IMAGE=botpress/module-builder
-          if [[ $TAG =~ $VALID_TAG ]]; then
-            VERSION=($(echo ${TAG} | sed -r 's/module-builder-v//')) # transform module-builder-v0.0.0 to 0.0.0
+          if [[ $BRANCH_NAME =~ $VALID_BRANCH_NAME ]]; then
+            VERSION=($(echo ${BRANCH_NAME} | sed -r 's/module-builder-release/v//')) # transform module-builder-release/v0.0.0 to 0.0.0
             GITHUB_REGISTRY="ghcr.io/${{ github.repository_owner }}/${DOCKER_IMAGE}"
             TAGS=("${VERSION[@]/#/${GITHUB_REGISTRY}:}")
             echo "Will publish tag $TAGS"
@@ -29,7 +29,7 @@ jobs:
             echo ::set-output name=tags::"${TAGS[*]}"
             echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           else
-            echo "Invalid tag format, use module-builder-vXXX.XXX.XXX"
+            echo "Invalid Branch Name format, use module-builder-release/vXXX.XXX.XXX"
             exit 1
           fi
       - name: DockerHub Authentication

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -1,8 +1,9 @@
 name: Publish and release module builder
 on:
   pull_request:
+    types: [ edited ]
     branches:
-      - "module-builder-release/v*" # Pull Request events with branch names matching module-builder-release/v*
+      - "module-builder-release/v**" # Pull Request events with branch names matching module-builder-release/v*
 
 jobs:
   test_module_builder:

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -12,8 +12,8 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          BRANCH_NAME=${GITHUB_REF##*/}
-          echo "Building with origin Branch name $BRANCH_NAME"
+          BRANCH_NAME=${GITHUB_HEAD_REF##*/}
+          echo "Building with origin Branch name $BRANCH_NAME | $GITHUB_HEAD_REF"
           VALID_BRANCH_NAME="^module-builder-release/v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
           DOCKER_IMAGE=botpress/module-builder
           if [[ $BRANCH_NAME =~ $VALID_BRANCH_NAME ]]; then

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -22,7 +22,7 @@ jobs:
           TAGS=()
           if [[ $TAG =~ $VALID_TAG ]]; then
             echo "Tag is valid"
-            VERSION+=($(echo ${TAG} | sed -r 's/v//')) # transform v12.23.0 to 12.23.0
+            VERSION+=($(echo ${TAG} | sed -r 's/module-builder-v//')) # transform module-builder-v12.23.0 to 12.23.0
             VERSION+=('latest')
             VERSION+=($(echo ${TAG} | sed -r 's/\./_/g')) # Transform v12.13.0 to v12_13_0 ## Added backward compatibility
             echo ::set-output name=release::"true"

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -2,8 +2,6 @@ name: Publish and release module builder
 on:
   pull_request:
     types: [edited]
-    branches:
-    - 'module-builder-release/v*'
 jobs:
   publish_module_builder:
     name: Build and publish module builder

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -1,8 +1,9 @@
 name: Publish and release module builder
 on:
-  pull_request_target:
-    branches:
-      - 'module-builder-release/v*' # Pull Request events with branch names matching module-builder-release/v*
+  pull_request:
+    types: - edited
+    #branches:
+    #  - 'module-builder-release/v*' # Pull Request events with branch names matching module-builder-release/v*
 
 jobs:
   publish_module_builder:

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -2,7 +2,7 @@ name: Publish and release module builder
 on:
   pull_request:
     types: [edited]
-  branches:
+    branches:
     - 'module-builder-release/v*'
 jobs:
   publish_module_builder:

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -18,22 +18,20 @@ jobs:
           echo "Building with origin tag $TAG"
           VALID_TAG="^module-builder-v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
           DOCKER_IMAGE=botpress/module-builder
-          VERSION=()
-          TAGS=()
           if [[ $TAG =~ $VALID_TAG ]]; then
             VERSION=($(echo ${TAG} | sed -r 's/module-builder-//')) # transform module-builder-v0.0.0 to v0.0.0
-            VERSION=($(echo ${VERSION} | sed -r 's/\./_/g')) # Transform v0.0.3 to v0_0_3
+            GITHUB_REGISTRY="ghcr.io/${{ github.repository_owner }}/${DOCKER_IMAGE}"
+            TAGS=("${VERSION[@]/#/${GITHUB_REGISTRY}:}")
+            echo "Will publish tag $TAGS"
+            IFS=,
             echo ::set-output name=release::"true"
+            echo ::set-output name=version::${VERSION[*]}
+            echo ::set-output name=tags::"${TAGS[*]}"
+            echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           else
             echo "Invalid tag format, use module-builder-vXXX.XXX.XXX"
+            exit 1
           fi
-          GITHUB_REGISTRY="ghcr.io/${{ github.repository_owner }}/${DOCKER_IMAGE}"
-          TAGS=("${VERSION[@]/#/${GITHUB_REGISTRY}:}")
-          echo "Will publish tags $TAGS"
-          IFS=,
-          echo ::set-output name=version::${VERSION[*]}
-          echo ::set-output name=tags::"${TAGS[*]}"
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       - name: DockerHub Authentication
         uses: docker/login-action@v1
         if: ${{ steps.prep.outputs.release }}

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -2,6 +2,8 @@ name: Publish and release module builder
 on:
   pull_request:
     types: [edited]
+  branches:
+    - 'module-builder-release/v*'
 jobs:
   publish_module_builder:
     name: Build and publish module builder
@@ -13,8 +15,8 @@ jobs:
         id: prep
         run: |
           BRANCH_NAME=${GITHUB_REF##*/}
-          echo "Building with origin Branch name $BRANCH_NAME | $GITHUB_REF"
-          VALID_BRANCH_NAME="^module-builder-v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
+          echo "Building with origin Branch name $BRANCH_NAME"
+          VALID_BRANCH_NAME="^module-builder-release/v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
           DOCKER_IMAGE=botpress/module-builder
           if [[ $BRANCH_NAME =~ $VALID_BRANCH_NAME ]]; then
             VERSION=($(echo ${BRANCH_NAME} | sed -r 's/module-builder-release/v//')) # transform module-builder-release/v0.0.0 to 0.0.0

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -12,8 +12,8 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          BRANCH_NAME=${GITHUB_HEAD_REF##*/}
-          echo "Building with origin Branch name $BRANCH_NAME | $GITHUB_HEAD_REF"
+          BRANCH_NAME="$GITHUB_HEAD_REF"
+          echo "Building with origin Branch name $BRANCH_NAME"
           VALID_BRANCH_NAME="^module-builder-release/v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
           DOCKER_IMAGE=botpress/module-builder
           if [[ $BRANCH_NAME =~ $VALID_BRANCH_NAME ]]; then

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -1,0 +1,66 @@
+name: Publish and release module builder
+on:
+  push:
+    tags:
+      - "module-builder-v*" # Push events to matching bpib-v*
+
+jobs:
+  test_module_builder:
+    name: Build and publish module builder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2.1.0
+      - name: Build
+        run: |
+          docker build -t module-builder-test -f build/module-builder/Dockerfile .
+      - name: Build has failed
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_GH_ACTIONS }}
+          SLACK_COLOR: ${{ job.status }}
+      - name: Prepare
+        id: prep
+        run: |
+          TAG=$(echo $(git describe ${{ github.sha }} --tags)) ## Get the tags from the SHA hash
+          VALID_TAG="^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
+          DOCKER_IMAGE=botpress/module-builder
+          VERSION=()
+          TAGS=()
+          if [[ $TAG =~ $VALID_TAG ]]; then
+            VERSION+=($(echo ${TAG} | sed -r 's/v//')) # transform v12.23.0 to 12.23.0
+            VERSION+=('latest')
+            VERSION+=($(echo ${TAG} | sed -r 's/\./_/g')) # Transform v12.13.0 to v12_13_0 ## Added backward compatibility
+            echo ::set-output name=release::"true"
+            TAGS+=("${VERSION[@]/#/${DOCKER_IMAGE}:}")
+          fi
+          GITHUB_REGISTRY="ghcr.io/${{ github.repository_owner }}/${DOCKER_IMAGE}"
+          TAGS+=("${VERSION[@]/#/${GITHUB_REGISTRY}:}")
+          IFS=,
+          echo ::set-output name=version::${VERSION[*]}
+          echo ::set-output name=tags::"${TAGS[*]}"
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      - name: DockerHub Authentication
+        uses: docker/login-action@v1
+        if: ${{ steps.prep.outputs.release }}
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: build/module-builder/Dockerfile
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -15,11 +15,13 @@ jobs:
         id: prep
         run: |
           TAG=$(echo $(git describe ${{ github.sha }} --tags)) ## Get the tags from the SHA hash
+          echo "Build with tag $TAG"
           VALID_TAG="^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
           DOCKER_IMAGE=botpress/module-builder
           VERSION=()
           TAGS=()
           if [[ $TAG =~ $VALID_TAG ]]; then
+            echo "Tag is valid"
             VERSION+=($(echo ${TAG} | sed -r 's/v//')) # transform v12.23.0 to 12.23.0
             VERSION+=('latest')
             VERSION+=($(echo ${TAG} | sed -r 's/\./_/g')) # Transform v12.13.0 to v12_13_0 ## Added backward compatibility

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -21,16 +21,14 @@ jobs:
           VERSION=()
           TAGS=()
           if [[ $TAG =~ $VALID_TAG ]]; then
-            VERSION+=($(echo ${TAG} | sed -r 's/module-builder-v//')) # transform module-builder-v12.23.0 to 12.23.0
-            VERSION+=('latest')
-            VERSION+=($(echo ${TAG} | sed -r 's/\./_/g')) # Transform v12.13.0 to v12_13_0 ## Added backward compatibility
+            VERSION=($(echo ${TAG} | sed -r 's/module-builder-//')) # transform module-builder-v0.0.0 to v0.0.0
+            VERSION=($(echo ${VERSION} | sed -r 's/\./_/g')) # Transform v0.0.3 to v0_0_3
             echo ::set-output name=release::"true"
-            TAGS+=("${VERSION[@]/#/${DOCKER_IMAGE}:}")
           else
             echo "Invalid tag format, use module-builder-vXXX.XXX.XXX"
           fi
           GITHUB_REGISTRY="ghcr.io/${{ github.repository_owner }}/${DOCKER_IMAGE}"
-          TAGS+=("${VERSION[@]/#/${GITHUB_REGISTRY}:}")
+          TAGS=("${VERSION[@]/#/${GITHUB_REGISTRY}:}")
           echo "Will publish tags $TAGS"
           IFS=,
           echo ::set-output name=version::${VERSION[*]}

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -1,7 +1,7 @@
 name: Publish and release module builder
 on:
   pull_request:
-    types: [edited]
+    types: [closed]
 jobs:
   publish_module_builder:
     name: Build and publish module builder
@@ -15,6 +15,7 @@ jobs:
           BRANCH_NAME="$GITHUB_HEAD_REF"
           echo "Building with origin Branch name $BRANCH_NAME"
           echo "This is base ref: ${{ github.base_ref }}"
+          echo "Is merged ?? ${{ github.event.pull_request.merged }}"
           VALID_BRANCH_NAME="^module-builder-release/v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
           DOCKER_IMAGE=botpress/module-builder
           if [[ $BRANCH_NAME =~ $VALID_BRANCH_NAME ]]; then

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -1,7 +1,7 @@
 name: Publish and release module builder
 on:
   pull_request:
-    types: - edited
+    types: [edited]
 jobs:
   publish_module_builder:
     name: Build and publish module builder

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -1,7 +1,6 @@
 name: Publish and release module builder
 on:
-  pull_request:
-    types: [ edited ]
+  pull_request_target:
     branches:
       - 'module-builder-release/v*' # Pull Request events with branch names matching module-builder-release/v*
 

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -17,7 +17,7 @@ jobs:
           VALID_BRANCH_NAME="^module-builder-release/v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
           DOCKER_IMAGE=botpress/module-builder
           if [[ $BRANCH_NAME =~ $VALID_BRANCH_NAME ]]; then
-            VERSION=($(echo ${BRANCH_NAME} | sed -r 's/module-builder-release/v//')) # transform module-builder-release/v0.0.0 to 0.0.0
+            VERSION=($(echo ${BRANCH_NAME} | sed -r 's/module-builder-release\/v//')) # transform module-builder-release/v0.0.0 to 0.0.0
             GITHUB_REGISTRY="ghcr.io/${{ github.repository_owner }}/${DOCKER_IMAGE}"
             TAGS=("${VERSION[@]/#/${GITHUB_REGISTRY}:}")
             echo "Will publish tag $TAGS"

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -27,7 +27,7 @@ jobs:
             echo ::set-output name=release::"true"
             TAGS+=("${VERSION[@]/#/${DOCKER_IMAGE}:}")
             echo "Will publish tags $TAGS"
-          el 
+          else
             echo "Invalid tag format, use module-builder-vXXX.XXX.XXX"
           fi
           GITHUB_REGISTRY="ghcr.io/${{ github.repository_owner }}/${DOCKER_IMAGE}"

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           TAG=$(echo $(git describe ${{ github.sha }} --tags)) ## Get the tags from the SHA hash
           echo "Build with tag $TAG"
-          VALID_TAG="^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
+          VALID_TAG="^module-builder-v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$"  ## Will match Tags in the following format v123.231.123 or v1.2.3 will discard the following format v1.2.4-<revision>
           DOCKER_IMAGE=botpress/module-builder
           VERSION=()
           TAGS=()

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -4,6 +4,7 @@ on:
     types: [edited]
 jobs:
   publish_module_builder:
+    if: ${{ github.base_ref == 'module-builder-release/v0.0.3' }}
     name: Build and publish module builder
     runs-on: ubuntu-latest
     steps:

--- a/build/module-builder/Dockerfile
+++ b/build/module-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18.1-alpine as builder
+FROM node:12.22.10-alpine as builder
 # git is required to resolve `git+` dependencies
 RUN apk add --no-cache git
 WORKDIR /botpress
@@ -11,7 +11,7 @@ COPY . .
 RUN yarn --frozen-lockfile && yarn build
 
 
-FROM node:12.18.1-alpine
+FROM node:12.22.10-alpine
 
 WORKDIR /botpress
 


### PR DESCRIPTION
This adds a Github workflow to publish an updated module-builder image after merging a PR with a branch name that matches module-builder-release/vXXX.XXX.XXX

https://github.com/botpress/botpress/pkgs/container/botpress%2Fmodule-builder

Today we have a manual release for https://hub.docker.com/r/botpress/module-builder/tags

Ver 1.2