### PR TITLE
fix(core): fix caching issue in CMS between studio and bp

### DIFF
--- a/packages/bp/src/core/bots/bot-service.ts
+++ b/packages/bp/src/core/bots/bot-service.ts
@@ -419,6 +419,7 @@ export class BotService {
     await Promise.all(
       botContent.map(async file => destGhost.upsertFile('/', file, await sourceGhost.readFileAsBuffer('/', file)))
     )
+    await studioActions.invalidateCmsForBot(destBotId)
     const workspaceId = await this.workspaceService.getBotWorkspaceId(sourceBotId)
     await this.workspaceService.addBotRef(destBotId, workspaceId)
   }

--- a/packages/bp/src/orchestrator/studio-client.ts
+++ b/packages/bp/src/orchestrator/studio-client.ts
@@ -56,6 +56,9 @@ export const studioActions = {
     try {
       await studioClient?.post('/setDebugScopes', { scopes })
     } catch {}
+  },
+  invalidateCmsForBot: async (botId: string) => {
+    await studioClient?.post('/invalidateCmsForBot', { botId })
   }
 }
 


### PR DESCRIPTION
This PR fixes an issue where overriding a bot inside the Bot Pipeline would not invalidate the CMS cache in the studio causing the UI not to display newly created content-elements.

Closes https://github.com/botpress/v12/issues/1581

Closes DEV-2203