### PR TITLE
chore(messaging): better communication

### DIFF
--- a/packages/bp/src/core/app/server.ts
+++ b/packages/bp/src/core/app/server.ts
@@ -284,7 +284,7 @@ export class HTTPServer {
     const config = botpressConfig.httpServer
     await this.sdkApiRouter.initialize()
 
-    this.setupMessagingProxy()
+    await this.messagingService.setupProxy(this.app, BASE_API_PATH)
 
     /**
      * The loading of language models can take some time, access to Botpress is disabled until it is completed
@@ -434,22 +434,6 @@ export class HTTPServer {
     })
 
     return this.app
-  }
-
-  private setupMessagingProxy() {
-    this.app.use(
-      `${BASE_API_PATH}/messaging`,
-      createProxyMiddleware({
-        pathRewrite: path => {
-          return path.replace(`${BASE_API_PATH}/messaging`, '')
-        },
-        router: () => {
-          return `http://localhost:${process.MESSAGING_PORT}`
-        },
-        changeOrigin: false,
-        logLevel: 'silent'
-      })
-    )
   }
 
   private setupUILite(app) {

--- a/packages/bp/src/core/messaging/messaging-service.ts
+++ b/packages/bp/src/core/messaging/messaging-service.ts
@@ -96,15 +96,7 @@ export class MessagingService {
       `${baseApiPath}/messaging`,
       createProxyMiddleware({
         pathRewrite: path => {
-          const shortPath = path.replace(`${baseApiPath}/messaging`, '')
-          const botIdAndChannelPath = shortPath
-            .replace('/webhooks', '')
-            .replace('/v1', '')
-            .substring(1)
-          const scopeId = botIdAndChannelPath.substring(0, botIdAndChannelPath.indexOf('/'))
-          const clientId = this.clientIdToBotId[scopeId] ? scopeId : this.botIdToClientId[scopeId]
-
-          return shortPath.replace(scopeId, clientId)
+          return path.replace(`${baseApiPath}/messaging`, '')
         },
         router: () => {
           return `http://localhost:${process.MESSAGING_PORT}`
@@ -151,6 +143,7 @@ export class MessagingService {
       await this.configProvider.mergeBotConfig(botId, { messaging })
     }
 
+    await this.messaging.renameClient(messaging.id!, botId)
     this.clientIdToBotId[messaging.id!] = botId
     this.botIdToClientId[botId] = messaging.id!
 

--- a/packages/bp/src/core/messaging/messaging-service.ts
+++ b/packages/bp/src/core/messaging/messaging-service.ts
@@ -194,7 +194,7 @@ export class MessagingService {
   private printWebhooks(botId: string, channels: any) {
     const webhooksSpecialCases = { slack: ['interactive', 'events'], vonage: ['inbound', 'status'] }
 
-    for (const [key, config] of Object.entries<any>(channels)) {
+    for (const [key, config] of Object.entries<any>(channels || {})) {
       const webhooks = config.version === '1.0.0' ? undefined : webhooksSpecialCases[key]
 
       for (const webhook of webhooks || [undefined]) {

--- a/packages/bp/src/core/messaging/messaging-service.ts
+++ b/packages/bp/src/core/messaging/messaging-service.ts
@@ -192,16 +192,24 @@ export class MessagingService {
   }
 
   private printWebhooks(botId: string, channels: any) {
-    for (const key in channels) {
-      this.logger
-        .forBot(botId)
-        .info(
-          `[${botId}] ${chalk.bold(key.charAt(0).toUpperCase() + key.slice(1))} webhook ${chalk.dim(
-            `${process.EXTERNAL_URL}/api/v1/messaging/webhooks${
-              channels[key].version === '1.0.0' ? '/v1' : ''
-            }/${botId}/${key}`
-          )}`
-        )
+    const webhooksSpecialCases = { slack: ['interactive', 'events'], vonage: ['inbound', 'status'] }
+
+    for (const [key, config] of Object.entries<any>(channels)) {
+      const webhooks = config.version === '1.0.0' ? undefined : webhooksSpecialCases[key]
+
+      for (const webhook of webhooks || [undefined]) {
+        this.logger
+          .forBot(botId)
+          .info(
+            `[${botId}] ${chalk.bold(key.charAt(0).toUpperCase() + key.slice(1))} ${
+              webhook ? `${webhook} ` : ''
+            }webhook ${chalk.dim(
+              `${process.EXTERNAL_URL}/api/v1/messaging/webhooks${
+                channels[key].version === '1.0.0' ? '/v1' : ''
+              }/${botId}/${key}${webhook ? `/${webhook}` : ''}`
+            )}`
+          )
+      }
     }
   }
 


### PR DESCRIPTION
Goes with https://github.com/botpress/messaging/pull/417

Improves the server's interaction with messaging when doing sync calls by reducing the amount of point of failures. We no longer send over the bot name when doing a sync call, and instead the proxy to messaging resolves the bot ids to client ids.

TODO
- Move the printing of webhook paths to core instead of messaging  (messaging can't print these paths because it doesn't know the bot id anymore)

Closes DEV-2192