### PR TITLE
chore(ci_cd): use gh-actions v2

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -12,6 +12,6 @@ jobs:
         uses: actions/checkout@master
 
       - name: Close PR Issues
-        uses: botpress/gh-actions/close_pull_request_issues@next
+        uses: botpress/gh-actions/close_pull_request_issues@v2
         with:
           comment: Available on ${{ github.event.release.tag_name }}

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -13,11 +13,11 @@ jobs:
 
       - name: Get Release Details
         id: release_details
-        uses: botpress/gh-actions/get_release_details@next
+        uses: botpress/gh-actions/get_release_details@v2
 
       - name: Fetch Dependencies Changelogs
         id: fetch_dependencies_changelogs
-        uses: botpress/gh-actions/fetch_release_changelogs@next
+        uses: botpress/gh-actions/fetch_release_changelogs@v2
         with:
           repos: '[ "studio", "messaging", "nlu" ]'
 

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Get Release Details
         id: release_details
-        uses: botpress/gh-actions/get_release_details@next
+        uses: botpress/gh-actions/get_release_details@v2
 
       - uses: tibdex/github-app-token@v1
         id: generate-token


### PR DESCRIPTION
This PR updates the actions from gh-actions to its latest version v2.

Note: next was simply merged into v2