### PR TITLE
feat(admin): validate botpress cloud keys

### DIFF
--- a/packages/bp/src/admin/workspace/bots/bots-router.ts
+++ b/packages/bp/src/admin/workspace/bots/bots-router.ts
@@ -64,18 +64,19 @@ class BotsRouter extends CustomAdminRouter {
 
         bot.id = await this.botService.makeBotId(bot.id, req.workspace!)
 
-        if (bot.isCloudBot) {
+        if (!!bot.isCloudBot) {
           if (!bot.cloud) {
             throw new BadRequestError('Cloud enabled bots require cloud configuration')
           }
+
           const localBotMatching = await this.botService.findBotFromCloudConfigs(bot.cloud)
           if (localBotMatching) {
             throw new ConflictError(`Bot ${localBotMatching.id} is already using provided cloud api key pair`)
           }
-        }
 
-        if (!(await this.botService.botExistOnCloud(bot.cloud!))) {
-          throw new BadRequestError('Provided cloud api key pair are invalid')
+          if (!(await this.botService.botExistOnCloud(bot.cloud!))) {
+            throw new BadRequestError('Provided cloud api key pair are invalid')
+          }
         }
 
         if (botExists && botLinkedToWorkspace) {

--- a/packages/bp/src/index.ts
+++ b/packages/bp/src/index.ts
@@ -88,6 +88,7 @@ try {
   process.ASSERT_LICENSED = () => {}
   process.BOTPRESS_VERSION = metadataContent.version
   process.BPFS_STORAGE = process.core_env.BPFS_STORAGE || 'disk'
+  process.CONTROLLERAPI_ENDPOINT = process.env.CONTROLLERAPI_ENDPOINT || 'https://controllerapi.botpress.dev'
 
   const configPath = path.join(process.PROJECT_LOCATION, '/data/global/botpress.config.json')
 

--- a/packages/bp/src/typings/global.d.ts
+++ b/packages/bp/src/typings/global.d.ts
@@ -65,6 +65,7 @@ declare namespace NodeJS {
     USE_JWT_COOKIES: boolean
     // The internal password is used for inter-process communication
     INTERNAL_PASSWORD: string
+    CONTROLLERAPI_ENDPOINT: string
   }
 }
 

--- a/packages/bp/src/typings/global.d.ts
+++ b/packages/bp/src/typings/global.d.ts
@@ -65,6 +65,7 @@ declare namespace NodeJS {
     USE_JWT_COOKIES: boolean
     // The internal password is used for inter-process communication
     INTERNAL_PASSWORD: string
+    // The botpress cloud acces point.
     CONTROLLERAPI_ENDPOINT: string
   }
 }

--- a/packages/bp/src/typings/global.d.ts
+++ b/packages/bp/src/typings/global.d.ts
@@ -65,7 +65,7 @@ declare namespace NodeJS {
     USE_JWT_COOKIES: boolean
     // The internal password is used for inter-process communication
     INTERNAL_PASSWORD: string
-    // The botpress cloud acces point.
+    // The Botpress cloud access point.
     CONTROLLERAPI_ENDPOINT: string
   }
 }


### PR DESCRIPTION
This addresses the case where a user tries to create cloud enabled chatbot with keys already used or keys that are invalid.

**already used keys**
<img width="537" alt="Screen Shot 2022-03-22 at 4 51 47 PM" src="https://user-images.githubusercontent.com/955524/159578892-04065121-47db-4ab0-8593-b3239d61cb6c.png">

**invalid keys**
<img width="571" alt="Screen Shot 2022-03-22 at 4 52 07 PM" src="https://user-images.githubusercontent.com/955524/159578896-b4d3300e-284c-4901-8d38-2a0aa9509ed9.png">






closes : DEV-2456