### PR TITLE
chore(nlu): bump nlu to v0.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "AGPL-3.0",
   "private": true,
   "nlu": {
-    "version": "0.1.9"
+    "version": "0.1.10"
   },
   "studio": {
     "version": "0.0.49"


### PR DESCRIPTION
release info are here: https://github.com/botpress/nlu/releases/tag/v0.1.10

This patch only includes one fix. Here's how to reproduce the issue on `master`:

1. using Botpress latest version, do a training on any bot and locate the following log in your terminal: `[NLU] Engine Training worker successfully started on process with pid 92926.`
2. once the training is done, run `kill -9 92926` with the pid displayed in the log above
3. try training again, this should fail

If you try the same scenario on this branch, you'll get the following warning log
```
[NLU] Engine The following workers have died since last usage: [92926]
```

This indicates that the nlu engine is aware that pid 92926 is no longer available and won't try reusing it.