### PR TITLE
chore(core): added internal routes to mount and unmount bot

### DIFF
--- a/packages/bp/src/core/app/internal-router.ts
+++ b/packages/bp/src/core/app/internal-router.ts
@@ -68,6 +68,28 @@ export class InternalRouter extends CustomRouter {
     )
 
     router.post(
+      '/unmountBot',
+      this.asyncMiddleware(async (req, res) => {
+        const { botId } = req.body
+
+        await this.botService.unmountBot(botId)
+
+        res.sendStatus(200)
+      })
+    )
+
+    router.post(
+      '/mountBot',
+      this.asyncMiddleware(async (req, res) => {
+        const { botId } = req.body
+
+        await this.botService.mountBot(botId)
+
+        res.sendStatus(200)
+      })
+    )
+
+    router.post(
       '/invalidateCmsForBot',
       this.asyncMiddleware(async (req, res) => {
         const { botId } = req.body


### PR DESCRIPTION
This PR adds to internal routes that allow the studio to tell the core to mount or unmount a certain bot. Related to:  https://github.com/botpress/studio/pull/322