### PR TITLE
fix(admin): fix nps hidden by console

### DIFF
--- a/packages/ui-admin/src/app/NetPromoterScore/NetPromotingScore/style.scss
+++ b/packages/ui-admin/src/app/NetPromoterScore/NetPromotingScore/style.scss
@@ -9,6 +9,7 @@
   display: flex;
   align-items: flex-start;
   flex-direction: row-reverse;
+  z-index: 1;
 }
 .animated {
   animation-duration: 2s;


### PR DESCRIPTION
A quick PR to fix a Z-index problem with the NPS tab.

![npsPannelZIndex](https://user-images.githubusercontent.com/23468320/160019615-8a70e13d-614f-4f92-951d-cc4f154f5da3.gif)

Closes botpress/v12#1607 