### PR TITLE
chore(config): display warning when using invalid timeout configs

### DIFF
--- a/packages/bp/src/core/bots/bot-service.ts
+++ b/packages/bp/src/core/bots/bot-service.ts
@@ -646,6 +646,15 @@ export class BotService {
         throw new Error('Supported languages must include the default language of the bot')
       }
 
+      const botpressConfig = await this.configProvider.getBotpressConfig()
+      if (botpressConfig.dialog.sessionTimeoutInterval < (config.dialog?.timeoutInterval || 0)) {
+        this.logger
+          .forBot(botId)
+          .warn(
+            `[${botId}] Your timeout interval (source: bot.config) is greater than your session timeout (source: botpress.config). This will prevent 'before_session_timeout' hooks and Timeout flows from being executed.`
+          )
+      }
+
       await this.messagingService.lifetime.loadMessagingForBot(botId)
       await this.cms.loadElementsForBot(botId)
       await this.moduleLoader.loadModulesForBot(botId)


### PR DESCRIPTION
This PR adds a warning in the console if the user set invalid timeout configs in its bot and botpress config files.

See this comment for more details: https://github.com/botpress/v12/issues/1597

**Screenshot**
![Screenshot from 2022-03-29 13-51-32](https://user-images.githubusercontent.com/9640576/160674584-f09fb839-c579-462d-8b63-4fabfba309a2.png)

Closes https://github.com/botpress/v12/issues/1597