### PR TITLE
chore(ci_cd): allow to bump server version without releasing

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -5,6 +5,7 @@ on:
       - master
 jobs:
   create_draft_release:
+    if: "${{ startsWith(github.event.head_commit.message, 'chore(server): release v') == true }}"
     name: Create Draft-Release
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +31,6 @@ jobs:
           echo "Latest Tag: ${{ steps.release_details.outputs.latest_tag }}"
 
       - name: Release
-        if: ${{ steps.release_details.outputs.is_new_release == 'true' }}
         uses: softprops/action-gh-release@v1
         with:
           prerelease: false

--- a/build/package.json
+++ b/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botpress",
-  "version": "12.26.12",
+  "version": "12.26.13",
   "description": "The world's most powerful conversational engine",
   "main": "index.js",
   "bin": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bp_main",
-  "version": "12.26.12",
+  "version": "12.26.13",
   "description": "The world's most powerful conversational engine",
   "engines": {
     "node": "^12"


### PR DESCRIPTION
This PR allows anyone to bump the version of Botpress without creating a new release when merged on master. To trigger a release, we have to use the single provided path of manually calling the `Create Release Pull Request` action. 

This change will greatly improve the development process as it will allow developers to run migrations automatically as if it was the new version. No more "you need to run `yarn start migrate up -t <version>`" :100: 