### PR TITLE
fix(workspaces): display warning if workspace has no authStrategies

### DIFF
--- a/packages/bp/src/core/users/workspace-service.ts
+++ b/packages/bp/src/core/users/workspace-service.ts
@@ -48,10 +48,20 @@ export class WorkspaceService {
   ) {}
 
   async initialize(): Promise<void> {
-    await this.getWorkspaces().catch(async () => {
+    try {
+      const workspaces = await this.getWorkspaces()
+
+      for (const workspace of workspaces) {
+        if (workspace.authStrategies.length === 0) {
+          this.logger.warn(
+            `Workspace [${workspace.name}] does not contain any Authentication Strategies ('authStrategies'). This can result in unwanted behavior.`
+          )
+        }
+      }
+    } catch {
       await this.save([defaultWorkspace])
       this.logger.info('Created workspace')
-    })
+    }
   }
 
   async getWorkspaces(): Promise<Workspace[]> {

--- a/packages/bp/src/core/users/workspace-service.ts
+++ b/packages/bp/src/core/users/workspace-service.ts
@@ -52,7 +52,7 @@ export class WorkspaceService {
       const workspaces = await this.getWorkspaces()
 
       for (const workspace of workspaces) {
-        if (workspace.authStrategies.length === 0) {
+        if ((workspace.authStrategies || []).length === 0) {
           this.logger.warn(
             `Workspace [${workspace.name}] does not contain any Authentication Strategies ('authStrategies'). This can result in unwanted behavior.`
           )


### PR DESCRIPTION
This PR fixes an issue or rather recommends the user to add authStrategies to its workspaces when none is set. 

The result of having no authentication strategy set in a workspace is that you won't be able to list available users for the workspace. Meaning that when adding a user to the workspace, you won't be provided suggestions of already existing users and get an error if you try to re-create it.

Closes https://github.com/botpress/v12/issues/1609