### PR TITLE
chore(bots): fix warning comparing strings instead of numbers

### DIFF
--- a/packages/bp/src/core/bots/bot-service.ts
+++ b/packages/bp/src/core/bots/bot-service.ts
@@ -647,7 +647,7 @@ export class BotService {
       }
 
       const botpressConfig = await this.configProvider.getBotpressConfig()
-      if (botpressConfig.dialog.sessionTimeoutInterval < (config.dialog?.timeoutInterval || 0)) {
+      if (ms(botpressConfig.dialog.sessionTimeoutInterval) < ms(config.dialog?.timeoutInterval || '0s')) {
         this.logger
           .forBot(botId)
           .warn(


### PR DESCRIPTION
This PR fixes an obvious issue that was brought up by one of my last PRs. Since the sessionTimeoutInterval and timeoutInterval are string values (e.g. '5m'), we need to convert them to numbers before comparing the values.