### PR TITLE
chore(messaging): add bp.messaging to runtime

### DIFF
--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -7,7 +7,6 @@ The botpress runtime is a lightweight version of botpress that runs on the cloud
 1. Edit the file `dist/.env` and configure the following elements:
 
 ```js
-ENABLE_EXPERIMENTAL_CONVERSE=true
 MESSAGING_ENDPOINT=http://localhost:3100
 ```
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.6",
-    "@botpress/messaging-client": "1.1.5",
     "@botpress/nlu-client": "1.0.0-rc.2",
     "axios": "^0.21.1",
     "bluebird-global": "^1.0.1",

--- a/packages/runtime/src/runtime/app/api.ts
+++ b/packages/runtime/src/runtime/app/api.ts
@@ -15,6 +15,7 @@ import { EventEngine, EventRepository, Event } from '../events'
 import { KeyValueStore, KvsService } from '../kvs'
 import { LoggerProvider } from '../logger'
 import * as logEnums from '../logger/enums'
+import { MessagingService } from '../messaging'
 import { getMessageSignature } from '../security'
 import { ChannelUserRepository } from '../users'
 
@@ -93,6 +94,12 @@ const kvs = (kvs: KeyValueStore): typeof sdk.kvs => {
   }
 }
 
+const messaging = (messagingService: MessagingService): typeof sdk.messaging => {
+  return {
+    forBot: botId => messagingService.lifetime.getHttpClient(botId)
+  }
+}
+
 const security = (): typeof sdk.security => {
   return {
     getMessageSignature
@@ -145,6 +152,7 @@ export class BotpressRuntimeAPIProvider {
   bots: typeof sdk.bots
   ghost: typeof sdk.ghost
   cms: typeof sdk.cms
+  messaging: typeof sdk.messaging
   security: typeof sdk.security
 
   constructor(
@@ -157,7 +165,8 @@ export class BotpressRuntimeAPIProvider {
     @inject(TYPES.GhostService) ghostService: GhostService,
     @inject(TYPES.CMSService) cmsService: CMSService,
     @inject(TYPES.EventRepository) eventRepo: EventRepository,
-    @inject(TYPES.StateManager) stateManager: StateManager
+    @inject(TYPES.StateManager) stateManager: StateManager,
+    @inject(TYPES.MessagingService) messagingService: MessagingService
   ) {
     this.events = event(eventEngine, eventRepo)
     this.dialog = dialog(dialogEngine, stateManager)
@@ -166,6 +175,7 @@ export class BotpressRuntimeAPIProvider {
     this.bots = bots(botService)
     this.ghost = ghost(ghostService)
     this.cms = cms(cmsService)
+    this.messaging = messaging(messagingService)
     this.security = security()
   }
 
@@ -188,6 +198,7 @@ export class BotpressRuntimeAPIProvider {
       ghost: this.ghost,
       bots: this.bots,
       cms: this.cms,
+      messaging: this.messaging,
       security: this.security,
       ButtonAction: renderEnums.ButtonAction
     }

--- a/packages/runtime/src/runtime/app/botpress.ts
+++ b/packages/runtime/src/runtime/app/botpress.ts
@@ -236,7 +236,7 @@ export class Botpress {
         this.eventCollector.storeEvent(event)
       }
 
-      this.messagingService.informProcessingDone(event)
+      this.messagingService.collector.informProcessingDone(event)
       await converseApiEvents.emitAsync(`done.${buildUserKey(event.botId, event.target)}`, event)
     }
 

--- a/packages/runtime/src/runtime/bots/bot-service.ts
+++ b/packages/runtime/src/runtime/bots/bot-service.ts
@@ -268,7 +268,7 @@ export class BotService {
         throw new Error('Supported languages must include the default language of the bot')
       }
 
-      await this.messagingService.loadMessagingForBot(botId)
+      await this.messagingService.lifetime.loadMessagingForBot(botId)
       await this.cms.loadContentTypesFromFiles(botId)
 
       await this.cms.loadElementsForBot(botId)
@@ -309,7 +309,7 @@ export class BotService {
     }
 
     await this.cms.clearElementsFromCache(botId)
-    await this.messagingService.unloadMessagingForBot(botId)
+    await this.messagingService.lifetime.unloadMessagingForBot(botId)
     await this.nluInferenceService.unmountBot(botId)
 
     const api = await createForGlobalHooks()

--- a/packages/runtime/src/runtime/cloud/messaging.ts
+++ b/packages/runtime/src/runtime/cloud/messaging.ts
@@ -1,5 +1,5 @@
 import { MessagingChannel, MessagingChannelOptions, uuid } from '@botpress/messaging-client'
-import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
+import axios, { AxiosRequestConfig } from 'axios'
 import { CloudConfig } from 'botpress/runtime-sdk'
 import { VError } from 'verror'
 import { cache } from './cache'
@@ -50,10 +50,9 @@ const getClientIdFromRequestConfig = (config: AxiosRequestConfig) => {
 const getToken = async (clientId: uuid, clientIdToCloudConfig: ClientIdToCloudConfig) => {
   let auth = authByMessagingClientId[clientId]
   if (!auth) {
-    const { oauthUrl, clientId: oauthClientId, clientSecret } = clientIdToCloudConfig[clientId]
+    const { clientId: oauthClientId, clientSecret } = clientIdToCloudConfig[clientId]
     auth = cache(
       createOauthTokenClient(axios.create(), {
-        oauthUrl,
         clientId: oauthClientId,
         clientSecret,
         scopes: ['messaging']

--- a/packages/runtime/src/runtime/cloud/nlu.ts
+++ b/packages/runtime/src/runtime/cloud/nlu.ts
@@ -8,8 +8,8 @@ export class CloudNluClient extends Client {
   constructor(props: Props) {
     super({ ...props, validateStatus: () => true })
 
-    const { oauthUrl, clientId, clientSecret } = props
+    const { clientId, clientSecret } = props
 
-    authenticateOAuth({ axiosInstance: this.axios, oauthUrl, clientId, clientSecret, scopes: ['nlu'] })
+    authenticateOAuth({ axiosInstance: this.axios, clientId, clientSecret, scopes: ['nlu'] })
   }
 }

--- a/packages/runtime/src/runtime/cloud/oauth.ts
+++ b/packages/runtime/src/runtime/cloud/oauth.ts
@@ -5,7 +5,6 @@ import { cache } from './cache'
 type Scope = 'messaging' | 'nlu'
 
 export interface CloudClientProps {
-  oauthUrl: string
   clientId: string
   clientSecret: string
 }
@@ -28,10 +27,9 @@ export const authenticateOAuth = (
     axiosInstance: AxiosInstance
   } & OauthTokenClientProps
 ) => {
-  const { axiosInstance, oauthUrl, clientId, clientSecret, scopes } = props
+  const { axiosInstance, clientId, clientSecret, scopes } = props
 
   const oauthTokenClient = createOauthTokenClient(axios.create(), {
-    oauthUrl,
     clientId,
     clientSecret,
     scopes
@@ -50,9 +48,9 @@ export const createOauthTokenClient = (
   axios: AxiosInstance,
   oauthTokenClientProps: OauthTokenClientProps
 ) => async () => {
-  const { oauthUrl, clientId, clientSecret, scopes } = oauthTokenClientProps
+  const { clientId, clientSecret, scopes } = oauthTokenClientProps
   const res = await axios.post(
-    oauthUrl,
+    process.OAUTH_ENDPOINT!,
     qs.stringify({
       client_id: clientId,
       client_secret: clientSecret,

--- a/packages/runtime/src/runtime/cloud/oauth.ts
+++ b/packages/runtime/src/runtime/cloud/oauth.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig } from 'axios'
 import qs from 'querystring'
+import VError from 'verror'
 import { cache } from './cache'
 
 type Scope = 'messaging' | 'nlu'
@@ -49,8 +50,13 @@ export const createOauthTokenClient = (
   oauthTokenClientProps: OauthTokenClientProps
 ) => async () => {
   const { clientId, clientSecret, scopes } = oauthTokenClientProps
+
+  if (!process.OAUTH_ENDPOINT) {
+    throw new VError('OAUTH_ENDPOINT must be defined')
+  }
+
   const res = await axios.post(
-    process.OAUTH_ENDPOINT!,
+    process.OAUTH_ENDPOINT,
     qs.stringify({
       client_id: clientId,
       client_secret: clientSecret,

--- a/packages/runtime/src/runtime/messaging/messaging-router.ts
+++ b/packages/runtime/src/runtime/messaging/messaging-router.ts
@@ -10,6 +10,6 @@ export class MessagingRouter extends CustomRouter {
   }
 
   public setupRoutes() {
-    this.messagingService.messaging.setup(this.router, '/receive')
+    this.messagingService.interactor.client.setup(this.router, '/receive')
   }
 }

--- a/packages/runtime/src/runtime/messaging/messaging-service.ts
+++ b/packages/runtime/src/runtime/messaging/messaging-service.ts
@@ -1,236 +1,46 @@
-import { ConversationStartedEvent, MessageNewEvent, MessagingChannel, uuid } from '@botpress/messaging-client'
-import { IO, Logger, MessagingConfig } from 'botpress/runtime-sdk'
-import { inject, injectable } from 'inversify'
-import LRUCache from 'lru-cache'
-import ms from 'ms'
-import { VError } from 'verror'
-import yn from 'yn'
-
-import { formatUrl } from '../../common/url'
-import { ClientIdToCloudConfig, CloudMessagingChannel } from '../cloud/messaging'
+import { Logger } from 'botpress/sdk'
+import { inject, injectable, tagged } from 'inversify'
 import { ConfigProvider } from '../config'
-import { WellKnownFlags } from '../dialog'
-import { EventEngine, Event } from '../events'
+import { EventEngine, EventRepository } from '../events'
 import { TYPES } from '../types'
+import { MessagingCollector } from './subservices/collector'
+import { MessagingInteractor } from './subservices/interactor'
+import { MessagingLifetime } from './subservices/lifetime'
+import { MessagingListener } from './subservices/listener'
+import { MessagingMiddleware } from './subservices/middleware'
 
 @injectable()
 export class MessagingService {
-  public messaging!: MessagingChannel
-  private botIdToClientId: { [botId: string]: uuid } = {}
-  private clientIdToBotId: { [clientId: uuid]: string } = {}
-  private clientIdToCloudConfig: ClientIdToCloudConfig = {}
-  private channelNames = ['messenger', 'slack', 'smooch', 'teams', 'telegram', 'twilio', 'vonage']
-  private newUsers: number = 0
-  private collectingCache: LRUCache<string, uuid>
+  public readonly interactor: MessagingInteractor
+  public readonly lifetime: MessagingLifetime
+  public readonly collector: MessagingCollector
+  public readonly listener: MessagingListener
+  public readonly middleware: MessagingMiddleware
 
   constructor(
     @inject(TYPES.EventEngine) private eventEngine: EventEngine,
+    @inject(TYPES.EventRepository) private eventRepo: EventRepository,
     @inject(TYPES.ConfigProvider) private configProvider: ConfigProvider,
-    @inject(TYPES.Logger) private logger: Logger
+    @inject(TYPES.Logger)
+    @tagged('name', 'Messaging')
+    private logger: Logger
   ) {
-    this.collectingCache = new LRUCache<string, uuid>({ max: 5000, maxAge: ms('5m') })
-
-    const messagingUrl = process.MESSAGING_ENDPOINT
-    if (!messagingUrl) {
-      throw new VError('messagingUrl must be defined')
-    }
-
-    this.messaging = new CloudMessagingChannel({
-      url: messagingUrl,
-      sessionCookieName: process.MESSAGING_SESSION_COOKIE_NAME,
-      logger: {
-        info: this.logger.info.bind(this.logger),
-        debug: this.logger.debug.bind(this.logger),
-        warn: this.logger.warn.bind(this.logger),
-        error: (e, msg, data) => {
-          this.logger.attachError(e).error(msg || '', data)
-        }
-      },
-      clientIdToCloudConfig: this.clientIdToCloudConfig
-    })
-    // use this to test converse from messaging
-    if (yn(process.env.ENABLE_EXPERIMENTAL_CONVERSE)) {
-      this.channelNames.push('messaging')
-    }
+    this.interactor = new MessagingInteractor(this.logger)
+    this.lifetime = new MessagingLifetime(this.configProvider, this.interactor)
+    this.collector = new MessagingCollector(this.logger, this.eventEngine, this.interactor, this.lifetime)
+    this.listener = new MessagingListener(
+      this.eventEngine,
+      this.eventRepo,
+      this.interactor,
+      this.lifetime,
+      this.collector
+    )
+    this.middleware = new MessagingMiddleware(this.eventEngine, this.interactor, this.lifetime, this.collector)
   }
 
   async initialize() {
-    this.eventEngine.register({
-      name: 'messaging.fixUrl',
-      description: 'Fix payload url before sending them',
-      order: 99,
-      direction: 'outgoing',
-      handler: this.fixOutgoingUrls.bind(this)
-    })
-
-    if (!process.MESSAGING_ENDPOINT) {
-      this.logger.warn('No messaging endpoint provided, some features will not work as expected.')
-      return
-    }
-
-    this.eventEngine.register({
-      name: 'messaging.sendOut',
-      description: 'Sends outgoing messages to external messaging',
-      order: 20000,
-      direction: 'outgoing',
-      handler: this.handleOutgoingEvent.bind(this)
-    })
-
-    this.messaging.on('user', this.handleUserNewEvent.bind(this))
-    this.messaging.on('started', this.handleConversationStartedEvent.bind(this))
-    this.messaging.on('message', this.handleMessageNewEvent.bind(this))
-  }
-
-  async loadMessagingForBot(botId: string) {
-    const config = await this.configProvider.getBotConfig(botId)
-    const cloud = config.cloud
-    if (!cloud) {
-      throw new VError(`cloud config undefined for bot ${botId}`)
-    }
-
-    const messaging = (config.messaging || {}) as Partial<MessagingConfig>
-    const messagingId = messaging.id
-    if (!messagingId) {
-      throw new VError(`could not find messaging id in botConfig for bot: ${botId}`)
-    }
-
-    this.clientIdToBotId[messagingId] = botId
-    this.botIdToClientId[botId] = messagingId
-    this.clientIdToCloudConfig[messagingId] = cloud
-
-    this.messaging.start(messagingId, { clientToken: messaging.token })
-    const { webhooks } = await this.messaging.sync(messagingId, {
-      channels: messaging.channels,
-      webhooks: [{ url: `${process.EXTERNAL_URL}/api/v1/chat/receive` }]
-    })
-    this.messaging.start(messagingId, { clientToken: messaging.token, webhookToken: webhooks[0].token })
-  }
-
-  async unloadMessagingForBot(botId: string) {
-    const config = await this.configProvider.getBotConfig(botId)
-    if (!config.messaging?.id) {
-      return
-    }
-
-    delete this.clientIdToBotId[config.messaging.id]
-    delete this.botIdToClientId[botId]
-  }
-
-  informProcessingDone(event: IO.IncomingEvent) {
-    if (this.collectingCache.get(event.id!)) {
-      // We don't want the waiting for the queue to be empty to freeze other messages
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this.sendProcessingDone(event)
-    }
-  }
-
-  getNewUsersCount({ resetCount }: { resetCount: boolean }) {
-    const count = this.newUsers
-    if (resetCount) {
-      this.newUsers = 0
-    }
-    return count
-  }
-
-  private handleUserNewEvent() {
-    this.newUsers++
-  }
-
-  private async handleConversationStartedEvent(clientId: uuid, data: ConversationStartedEvent) {
-    if (!this.channelNames.includes(data.channel)) {
-      return
-    }
-
-    const event = Event({
-      direction: 'incoming',
-      type: 'proactive-trigger',
-      payload: {},
-      channel: data.channel,
-      threadId: data.conversationId,
-      target: data.userId,
-      botId: this.clientIdToBotId[clientId]
-    })
-    event.setFlag(WellKnownFlags.SKIP_DIALOG_ENGINE, true)
-
-    return this.eventEngine.sendEvent(event)
-  }
-
-  private async handleMessageNewEvent(clientId: uuid, data: MessageNewEvent) {
-    if (!this.channelNames.includes(data.channel)) {
-      return
-    }
-
-    const event = Event({
-      direction: 'incoming',
-      type: data.message.payload.type,
-      payload: data.message.payload,
-      channel: data.channel,
-      threadId: data.conversationId,
-      target: data.userId,
-      messageId: data.message.id,
-      botId: this.clientIdToBotId[clientId]
-    })
-
-    if (data.collect) {
-      this.collectingCache.set(event.id, data.message.id)
-    }
-
-    return this.eventEngine.sendEvent(event)
-  }
-
-  private async fixOutgoingUrls(event: IO.OutgoingEvent, next: IO.MiddlewareNextCallback) {
-    this.fixPayloadUrls(event.payload)
-    next()
-  }
-
-  private async handleOutgoingEvent(event: IO.OutgoingEvent, next: IO.MiddlewareNextCallback) {
-    if (!this.channelNames.includes(event.channel)) {
-      return next(undefined, false, true)
-    }
-
-    const collecting = event.incomingEventId && this.collectingCache.get(event.incomingEventId)
-    const message = await this.messaging.createMessage(
-      this.botIdToClientId[event.botId],
-      event.threadId!,
-      undefined,
-      event.payload,
-      collecting ? { incomingId: collecting } : undefined
-    )
-    event.messageId = message.id
-
-    return next(undefined, true, false)
-  }
-
-  private async sendProcessingDone(event: IO.IncomingEvent) {
-    try {
-      await this.eventEngine.waitOutgoingQueueEmpty(event)
-      await this.messaging.endTurn(this.botIdToClientId[event.botId], event.messageId!)
-    } catch (e) {
-      this.logger.attachError(e).error('Failed to inform messaging of completed processing')
-    } finally {
-      this.collectingCache.del(event.id!)
-    }
-  }
-
-  private fixPayloadUrls(payload: any) {
-    if (typeof payload !== 'object' || payload === null) {
-      if (typeof payload === 'string') {
-        payload = payload.replace('BOT_URL', process.EXTERNAL_URL)
-      }
-
-      return formatUrl(process.EXTERNAL_URL, payload, process.env.MEDIA_URL)
-    }
-
-    for (const [key, value] of Object.entries(payload)) {
-      if (Array.isArray(value)) {
-        for (let i = 0; i < value.length; i++) {
-          value[i] = this.fixPayloadUrls(value[i])
-        }
-      } else {
-        payload[key] = this.fixPayloadUrls(value)
-      }
-    }
-
-    return payload
+    await this.interactor.setup()
+    await this.listener.setup()
+    await this.middleware.setup()
   }
 }

--- a/packages/runtime/src/runtime/messaging/subservices/collector.ts
+++ b/packages/runtime/src/runtime/messaging/subservices/collector.ts
@@ -23,7 +23,7 @@ export class MessagingCollector {
   }
 
   get(eventId: string) {
-    return this.collectingCache[eventId]
+    return this.collectingCache.get(eventId)
   }
 
   informProcessingDone(event: IO.IncomingEvent) {

--- a/packages/runtime/src/runtime/messaging/subservices/collector.ts
+++ b/packages/runtime/src/runtime/messaging/subservices/collector.ts
@@ -1,0 +1,47 @@
+import { uuid } from '@botpress/messaging-client'
+import { IO, Logger } from 'botpress/sdk'
+import LRUCache from 'lru-cache'
+import ms from 'ms'
+import { EventEngine } from '../../events'
+import { MessagingInteractor } from './interactor'
+import { MessagingLifetime } from './lifetime'
+
+export class MessagingCollector {
+  private collectingCache: LRUCache<string, uuid>
+
+  constructor(
+    private logger: Logger,
+    private eventEngine: EventEngine,
+    private interactor: MessagingInteractor,
+    private lifetime: MessagingLifetime
+  ) {
+    this.collectingCache = new LRUCache<string, uuid>({ max: 5000, maxAge: ms('5m') })
+  }
+
+  set(eventId: string, messageId: uuid) {
+    this.collectingCache.set(eventId, messageId)
+  }
+
+  get(eventId: string) {
+    return this.collectingCache[eventId]
+  }
+
+  informProcessingDone(event: IO.IncomingEvent) {
+    if (this.collectingCache.get(event.id!)) {
+      // We don't want the waiting for the queue to be empty to freeze other messages
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this.sendProcessingDone(event)
+    }
+  }
+
+  private async sendProcessingDone(event: IO.IncomingEvent) {
+    try {
+      await this.eventEngine.waitOutgoingQueueEmpty(event)
+      await this.interactor.client.endTurn(this.lifetime.getClientId(event.botId), event.messageId!)
+    } catch (e) {
+      this.logger.attachError(e).error('Failed to inform messaging of completed processing')
+    } finally {
+      this.collectingCache.del(event.id!)
+    }
+  }
+}

--- a/packages/runtime/src/runtime/messaging/subservices/interactor.ts
+++ b/packages/runtime/src/runtime/messaging/subservices/interactor.ts
@@ -1,6 +1,6 @@
 import { MessagingChannel, MessagingClient } from '@botpress/messaging-client'
 import { Logger } from 'botpress/sdk'
-import { CloudMessagingChannel } from 'src/runtime/cloud/messaging'
+import { CloudMessagingChannel } from '../../cloud/messaging'
 
 export class MessagingInteractor {
   public readonly client: MessagingChannel

--- a/packages/runtime/src/runtime/messaging/subservices/interactor.ts
+++ b/packages/runtime/src/runtime/messaging/subservices/interactor.ts
@@ -1,0 +1,41 @@
+import { MessagingChannel, MessagingClient } from '@botpress/messaging-client'
+import { Logger } from 'botpress/sdk'
+
+export class MessagingInteractor {
+  public readonly client: MessagingChannel
+
+  constructor(private logger: Logger) {
+    this.client = new MessagingChannel(this.getOptions())
+  }
+
+  async setup() {
+    if (!process.MESSAGING_ENDPOINT) {
+      this.logger.warn('No messaging endpoint provided, some features will not work as expected.')
+      return
+    }
+  }
+
+  public createHttpClientForBot(clientId: string, clientToken: string, webhookToken: string) {
+    return new MessagingClient({
+      ...this.getOptions(),
+      clientId,
+      clientToken,
+      webhookToken
+    })
+  }
+
+  private getOptions() {
+    return {
+      url: process.MESSAGING_ENDPOINT!,
+      sessionCookieName: process.MESSAGING_SESSION_COOKIE_NAME,
+      logger: {
+        info: this.logger.info.bind(this.logger),
+        debug: this.logger.debug.bind(this.logger),
+        warn: this.logger.warn.bind(this.logger),
+        error: (e, msg, data) => {
+          this.logger.attachError(e).error(msg || '', data)
+        }
+      }
+    }
+  }
+}

--- a/packages/runtime/src/runtime/messaging/subservices/interactor.ts
+++ b/packages/runtime/src/runtime/messaging/subservices/interactor.ts
@@ -1,11 +1,14 @@
 import { MessagingChannel, MessagingClient } from '@botpress/messaging-client'
 import { Logger } from 'botpress/sdk'
+import { CloudMessagingChannel } from 'src/runtime/cloud/messaging'
 
 export class MessagingInteractor {
   public readonly client: MessagingChannel
 
   constructor(private logger: Logger) {
-    this.client = new MessagingChannel(this.getOptions())
+    this.client = process.OAUTH_ENDPOINT
+      ? new CloudMessagingChannel(this.getOptions())
+      : new MessagingChannel(this.getOptions())
   }
 
   async setup() {

--- a/packages/runtime/src/runtime/messaging/subservices/lifetime.ts
+++ b/packages/runtime/src/runtime/messaging/subservices/lifetime.ts
@@ -1,0 +1,48 @@
+import { MessagingClient, uuid } from '@botpress/messaging-client'
+import { ConfigProvider } from '../../config'
+import { MessagingInteractor } from './interactor'
+
+export class MessagingLifetime {
+  private botIdToClientId: { [botId: string]: uuid } = {}
+  private clientIdToBotId: { [clientId: uuid]: string } = {}
+  private httpClients: { [botId: string]: MessagingClient } = {}
+
+  constructor(private configProvider: ConfigProvider, private interactor: MessagingInteractor) {}
+
+  getClientId(botId: string) {
+    return this.botIdToClientId[botId]
+  }
+
+  getBotId(clientId: uuid) {
+    return this.clientIdToBotId[clientId]
+  }
+
+  getHttpClient(botId: string): MessagingClient {
+    return this.httpClients[botId]
+  }
+
+  async loadMessagingForBot(botId: string) {
+    const botConfig = await this.configProvider.getBotConfig(botId)
+    if (!botConfig.messaging) {
+      throw new Error(`Bot ${botId} does not have a messaging config`)
+    }
+
+    const { clientId, clientToken, webhookToken } = botConfig.messaging
+
+    this.clientIdToBotId[clientId] = botId
+    this.botIdToClientId[botId] = clientId
+    this.httpClients[botId] = this.interactor.createHttpClientForBot(clientId, clientToken, webhookToken)
+
+    this.interactor.client.start(clientId, { clientToken, webhookToken })
+  }
+
+  async unloadMessagingForBot(botId: string) {
+    const clientId = this.botIdToClientId[botId]
+
+    delete this.clientIdToBotId[clientId]
+    delete this.botIdToClientId[botId]
+    delete this.httpClients[botId]
+
+    this.interactor.client.stop(clientId)
+  }
+}

--- a/packages/runtime/src/runtime/messaging/subservices/lifetime.ts
+++ b/packages/runtime/src/runtime/messaging/subservices/lifetime.ts
@@ -1,6 +1,6 @@
 import { MessagingClient, uuid } from '@botpress/messaging-client'
 import { BotConfig } from 'botpress/runtime-sdk'
-import { CloudMessagingChannel } from 'src/runtime/cloud/messaging'
+import { CloudMessagingChannel } from '../../cloud/messaging'
 import { ConfigProvider } from '../../config'
 import { MessagingInteractor } from './interactor'
 

--- a/packages/runtime/src/runtime/messaging/subservices/lifetime.ts
+++ b/packages/runtime/src/runtime/messaging/subservices/lifetime.ts
@@ -1,5 +1,6 @@
 import { MessagingClient, uuid } from '@botpress/messaging-client'
 import { BotConfig } from 'botpress/runtime-sdk'
+import { VError } from 'verror'
 import { CloudMessagingChannel } from '../../cloud/messaging'
 import { ConfigProvider } from '../../config'
 import { MessagingInteractor } from './interactor'
@@ -34,7 +35,7 @@ export class MessagingLifetime {
   }
   private loadClientId(botId: string, config: BotConfig) {
     if (!config.messaging) {
-      throw new Error(`Bot ${botId} does not have a messaging config`)
+      throw new VError(`Bot ${botId} does not have a messaging config`)
     }
 
     const { clientId, clientToken, webhookToken } = config.messaging
@@ -47,7 +48,7 @@ export class MessagingLifetime {
   private loadOAuth(botId: string, config: BotConfig) {
     const cloud = config.cloud
     if (!cloud) {
-      throw new Error(`Bot ${botId} does not have a cloud config`)
+      throw new VError(`Bot ${botId} does not have a cloud config`)
     }
 
     const cloudMessaging = this.interactor.client as CloudMessagingChannel

--- a/packages/runtime/src/runtime/messaging/subservices/listener.ts
+++ b/packages/runtime/src/runtime/messaging/subservices/listener.ts
@@ -1,0 +1,95 @@
+import { ConversationStartedEvent, MessageFeedbackEvent, MessageNewEvent, uuid } from '@botpress/messaging-client'
+import { WellKnownFlags } from '../../dialog'
+import { EventEngine, Event, EventRepository } from '../../events'
+import { MessagingCollector } from './collector'
+import { MessagingInteractor } from './interactor'
+import { MessagingLifetime } from './lifetime'
+
+export class MessagingListener {
+  private newUsers: number = 0
+  private newMessages: number = 0
+
+  constructor(
+    private eventEngine: EventEngine,
+    private eventRepo: EventRepository,
+    private interactor: MessagingInteractor,
+    private lifetime: MessagingLifetime,
+    private collector: MessagingCollector
+  ) {}
+
+  async setup() {
+    this.interactor.client.on('user', this.handleUserNewEvent.bind(this))
+    this.interactor.client.on('started', this.handleConversationStartedEvent.bind(this))
+    this.interactor.client.on('message', this.handleMessageNewEvent.bind(this))
+    this.interactor.client.on('feedback', this.handleMessageFeedback.bind(this))
+  }
+
+  getNewMessagesCount({ resetCount }: { resetCount: boolean }) {
+    const count = this.newMessages
+    if (resetCount) {
+      this.newMessages = 0
+    }
+    return count
+  }
+
+  getNewUsersCount({ resetCount }: { resetCount: boolean }) {
+    const count = this.newUsers
+    if (resetCount) {
+      this.newUsers = 0
+    }
+    return count
+  }
+
+  private handleUserNewEvent() {
+    this.newUsers++
+  }
+
+  private async handleConversationStartedEvent(clientId: uuid, data: ConversationStartedEvent) {
+    const event = Event({
+      direction: 'incoming',
+      type: 'proactive-trigger',
+      payload: {},
+      channel: data.channel,
+      threadId: data.conversationId,
+      target: data.userId,
+      botId: this.lifetime.getBotId(clientId)
+    })
+    event.setFlag(WellKnownFlags.SKIP_DIALOG_ENGINE, true)
+
+    return this.eventEngine.sendEvent(event)
+  }
+
+  private async handleMessageNewEvent(clientId: uuid, data: MessageNewEvent) {
+    if (!data.message.authorId) {
+      return
+    }
+
+    const event = Event({
+      direction: 'incoming',
+      type: data.message.payload.type,
+      payload: data.message.payload,
+      channel: data.channel,
+      threadId: data.conversationId,
+      target: data.userId,
+      messageId: data.message.id,
+      botId: this.lifetime.getBotId(clientId)
+    })
+
+    if (data.collect) {
+      this.collector.set(event.id, data.message.id)
+    }
+
+    this.newMessages++
+
+    return this.eventEngine.sendEvent(event)
+  }
+
+  private async handleMessageFeedback(clientId: uuid, data: MessageFeedbackEvent) {
+    const botId = this.lifetime.getBotId(clientId)
+    const [event] = await this.eventRepo.findEvents({ botId, messageId: data.messageId })
+
+    if (event?.incomingEventId) {
+      await this.eventRepo.saveUserFeedback(event.incomingEventId, data.userId, data.feedback, 'qna')
+    }
+  }
+}

--- a/packages/runtime/src/runtime/messaging/subservices/middleware.ts
+++ b/packages/runtime/src/runtime/messaging/subservices/middleware.ts
@@ -1,0 +1,73 @@
+import { IO } from 'botpress/sdk'
+import { EventEngine } from '../../events'
+import { MessagingCollector } from './collector'
+import { MessagingInteractor } from './interactor'
+import { MessagingLifetime } from './lifetime'
+
+export class MessagingMiddleware {
+  constructor(
+    private eventEngine: EventEngine,
+    private interactor: MessagingInteractor,
+    private lifetime: MessagingLifetime,
+    private collector: MessagingCollector
+  ) {}
+
+  async setup() {
+    this.eventEngine.register({
+      name: 'messaging.fixUrl',
+      description: 'Fix payload url before sending them',
+      order: 99,
+      direction: 'outgoing',
+      handler: this.fixOutgoingUrls.bind(this)
+    })
+
+    this.eventEngine.register({
+      name: 'messaging.sendOut',
+      description: 'Sends outgoing messages to external messaging',
+      order: 20000,
+      direction: 'outgoing',
+      handler: this.handleOutgoingEvent.bind(this)
+    })
+  }
+
+  private async handleOutgoingEvent(event: IO.OutgoingEvent, next: IO.MiddlewareNextCallback) {
+    const collecting = event.incomingEventId && this.collector.get(event.incomingEventId)
+    const message = await this.interactor.client.createMessage(
+      this.lifetime.getClientId(event.botId),
+      event.threadId!,
+      undefined,
+      event.payload,
+      collecting ? { incomingId: collecting } : undefined
+    )
+    event.messageId = message.id
+
+    return next(undefined, true, false)
+  }
+
+  private async fixOutgoingUrls(event: IO.OutgoingEvent, next: IO.MiddlewareNextCallback) {
+    this.fixPayloadUrls(event.payload)
+    next()
+  }
+
+  private fixPayloadUrls(payload: any) {
+    if (typeof payload !== 'object' || payload === null) {
+      if (typeof payload === 'string') {
+        payload = payload.replace('BOT_URL', process.EXTERNAL_URL)
+      }
+
+      return payload
+    }
+
+    for (const [key, value] of Object.entries(payload)) {
+      if (Array.isArray(value)) {
+        for (let i = 0; i < value.length; i++) {
+          value[i] = this.fixPayloadUrls(value[i])
+        }
+      } else {
+        payload[key] = this.fixPayloadUrls(value)
+      }
+    }
+
+    return payload
+  }
+}

--- a/packages/runtime/src/runtime/telemetry/stats/user-stats.ts
+++ b/packages/runtime/src/runtime/telemetry/stats/user-stats.ts
@@ -32,7 +32,7 @@ export class UserStats extends TelemetryStats {
   }
 
   protected async getStats() {
-    const newUsers = this.messagingService.getNewUsersCount({ resetCount: true })
+    const newUsers = this.messagingService.listener.getNewUsersCount({ resetCount: true })
 
     return {
       ...buildSchema(await this.getServerStats(), 'server'),

--- a/packages/runtime/src/startup/misc.ts
+++ b/packages/runtime/src/startup/misc.ts
@@ -76,6 +76,7 @@ export const loadEnvVars = () => {
   process.ASSERT_LICENSED = () => {}
   process.BPFS_STORAGE = process.runtime_env.BPFS_STORAGE || 'disk'
   process.CLUSTER_ENABLED = yn(process.runtime_env.CLUSTER_ENABLED)
+  process.OAUTH_ENDPOINT = process.runtime_env.OAUTH_ENDPOINT
   process.NLU_ENDPOINT = process.runtime_env.NLU_ENDPOINT
   process.MESSAGING_ENDPOINT = process.runtime_env.MESSAGING_ENDPOINT
   process.MESSAGING_SESSION_COOKIE_NAME = process.runtime_env.MESSAGING_SESSION_COOKIE_NAME

--- a/packages/runtime/src/typings/global.d.ts
+++ b/packages/runtime/src/typings/global.d.ts
@@ -52,6 +52,7 @@ declare namespace NodeJS {
     // The internal password is used for inter-process communication
     INTERNAL_PASSWORD: string
 
+    OAUTH_ENDPOINT?: string
     /** These two endpoints may either be provided as environment variables (when standalone) or from the main process */
     NLU_ENDPOINT?: string
     MESSAGING_ENDPOINT?: string
@@ -78,6 +79,9 @@ declare interface RuntimeEnvironmentVariables {
 
   /** A custom URL where bot medias will be served. Format: MEDIA_URL/botId/assetName */
   readonly MEDIA_URL?: string
+
+  /** The URL used to reach OAuth */
+  readonly OAUTH_ENDPOINT?: string
 
   /** The URL used to reach an external Messaging server */
   readonly MESSAGING_ENDPOINT?: string

--- a/packages/typings/sdk/botpress.runtime.d.ts
+++ b/packages/typings/sdk/botpress.runtime.d.ts
@@ -734,19 +734,9 @@ declare module 'botpress/runtime-sdk' {
   }
 
   export interface MessagingConfig {
-    /**
-     * Client id used to identify the bot on the messaging server
-     */
-    id: string
-    /**
-     * Client token used to authenticate requests made to the messaging server
-     */
-    token: string
-    /**
-     * Configurations of channels to be sent to the messaging server
-     * You can find more about channel configurations here : https://botpress.com/docs/channels/faq
-     */
-    channels: { [channelName: string]: any }
+    clientId: string
+    clientToken: string
+    webhookToken: string
   }
 
   /**

--- a/packages/typings/sdk/botpress.runtime.d.ts
+++ b/packages/typings/sdk/botpress.runtime.d.ts
@@ -1097,6 +1097,145 @@ declare module 'botpress/runtime-sdk' {
     extend(duration: number): Promise<void>
   }
 
+  export type uuid = string
+
+  export interface Conversation {
+    id: uuid
+    clientId: uuid
+    userId: uuid
+    createdOn: Date
+  }
+
+  export interface MessagingUser {
+    id: uuid
+    clientId: uuid
+  }
+
+  export interface Message {
+    id: uuid
+    conversationId: uuid
+    authorId: uuid | undefined
+    sentOn: Date
+    payload: any
+  }
+
+  export interface Endpoint {
+    channel:
+      | {
+          name: string
+          version: string
+        }
+      | string
+    identity: string
+    sender: string
+    thread: string
+  }
+
+  export interface MessagingClient {
+    /** Client id configured for this instance */
+    readonly clientId: uuid
+
+    /** Client token of to authenticate requests made with the client id */
+    readonly clientToken: string | undefined
+
+    /** Webhook token to validate webhook events that are received */
+    readonly webhookToken: string | undefined
+
+    /**
+     * Creates a new messaging user
+     * @returns info of the newly created user
+     */
+    createUser(): Promise<MessagingUser>
+
+    /**
+     * Fetches a messaging user
+     * @param id id of the user to fetch
+     * @returns info of the user or `undefined` if not found
+     */
+    getUser(id: uuid): Promise<MessagingUser | undefined>
+
+    /**
+     * Creates a new messaging conversation
+     * @param userId id of the user that starts this conversation
+     * @returns info of the newly created conversation
+     */
+    createConversation(userId: uuid): Promise<Conversation>
+    /**
+     * Fetches a messaging conversation
+     * @param id id of the conversation to fetch
+     * @returns info of the conversation or `undefined` if not found
+     */
+    getConversation(id: uuid): Promise<Conversation | undefined>
+
+    /**
+     * Lists the conversations that a user participates in
+     * @param userId id of the user that participates in the conversations
+     * @param limit max amount of conversations to list (default 20)
+     * @returns an array of conversations
+     */
+    listConversations(userId: uuid, limit?: number): Promise<Conversation[]>
+
+    /**
+     * Sends a message to the messaging server
+     * @param conversationId id of the conversation to post the message to
+     * @param authorId id of the message autor. `undefined` if bot
+     * @param payload content of the message
+     * @param flags message flags
+     * @returns info of the created message
+     */
+    createMessage(
+      conversationId: uuid,
+      authorId: uuid | undefined,
+      payload: any,
+      flags?: {
+        incomingId: uuid
+      }
+    ): Promise<Message>
+    /**
+     * Fetches a message
+     * @param id id of the message to fetch
+     * @returns info of the message or `undefined` if not found
+     */
+    getMessage(id: uuid): Promise<Message | undefined>
+
+    /**
+     * Lists the messages of a conversation
+     * @param conversationId id of the conversation that owns the messages
+     * @param limit max amount of messages to list (default 20)
+     * @returns an array of conversations
+     */
+    listMessages(conversationId: uuid, limit?: number): Promise<Message[]>
+
+    /**
+     * Deletes a message
+     * @param id id of the message to delete
+     * @returns `true` if a message was deleted
+     */
+    deleteMessage(id: uuid): Promise<boolean>
+
+    /**
+     * Deletes all messages of a conversation
+     * @param conversationId id of the conversation that owns the messages
+     * @returns amount of messages deleted
+     */
+    deleteMessagesByConversation(conversationId: uuid): Promise<number>
+
+    /**
+     * Maps an endpoint to a conversation id. Calling this function with the
+     * same endpoint always returns the same conversation id
+     * @param endpoint endpoint to be mapped
+     * @returns a conversation id associated to the endpoint
+     */
+    mapEndpoint(endpoint: Endpoint): Promise<uuid>
+
+    /**
+     * Lists the endpoints associated to a conversation
+     * @param conversationId id of the conversation that is associated with the endpoints
+     * @returns an array of endpoints that are linked to the provided conversation
+     */
+    listEndpoints(conversationId: uuid): Promise<Endpoint[]>
+  }
+
   /**
    * Events is the base communication channel of the bot. Messages and payloads are a part of it,
    * and it is the only way to receive or send information. Each event goes through the whole middleware chain (incoming or outgoing)
@@ -1325,6 +1464,10 @@ declare module 'botpress/runtime-sdk' {
      * @param context Variables to use for the template rendering
      */
     export function renderTemplate(item: TemplateItem, context): TemplateItem
+  }
+
+  export namespace messaging {
+    export function forBot(botId: string): MessagingClient
   }
 
   /**

--- a/packages/typings/sdk/botpress.runtime.d.ts
+++ b/packages/typings/sdk/botpress.runtime.d.ts
@@ -672,7 +672,6 @@ declare module 'botpress/runtime-sdk' {
   }
 
   export interface CloudConfig {
-    oauthUrl: string
     clientId: string
     clientSecret: string
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2416,25 +2416,10 @@
     classnames "^2.2"
     tslib "~1.13.0"
 
-"@botpress/messaging-base@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@botpress/messaging-base/-/messaging-base-1.1.0.tgz#0a266f8748f45afdcb93e158e72c03dc5d7c3035"
-  integrity sha512-mIQ90leVlYw+DuYixPa1pGWt/Sc/EU/r8k6IjS/BUl0XalvlgmeWIJsZ8xTh9B2H6f6xidlJO63tsgiPcimf7Q==
-
 "@botpress/messaging-base@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@botpress/messaging-base/-/messaging-base-1.1.1.tgz#8e599c5bcd61b44f62b89952439294b14268e1ba"
   integrity sha512-b6GNEILgn236RNX3HCJykfwkLiFr74gpwmMwBgwAmizH6oYi2h7yAI4sN4w3deXNiCcxi3RoDInhV+QiWtIK6Q==
-
-"@botpress/messaging-client@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@botpress/messaging-client/-/messaging-client-1.1.5.tgz#f5dd7264833831a826cfdce48e4865fb52228f9b"
-  integrity sha512-nKnEl3bNPa0ipYuihy3/2C3XsGRjA01FWTAZrjTiAt0Ex2pvb0ZLtU+egvKGXmEoEUAwKyUQlpg9+2/1VGpBlw==
-  dependencies:
-    "@botpress/messaging-base" "1.1.0"
-    axios "^0.21.4"
-    cookie "^0.4.2"
-    joi "^17.6.0"
 
 "@botpress/messaging-client@1.1.8":
   version "1.1.8"


### PR DESCRIPTION
Rewrite of the messaging service (mostly the same rewrite as the one in the core with the stuff that doesn't apply to runtime removed). Adds bp.messaging to sdk

Also removes sync call from runtime. Runtime now expects to get clientId, clientToken and webhookToken in botConfig.messaging

Must now provide OAUTH_URL as env var, we no longer accept it from botConfig (changed for NLU and Messaging)

Closes DEV-2522