### PR TITLE
fix(testing): create new session before recording

### DIFF
--- a/modules/testing/src/views/full/index.tsx
+++ b/modules/testing/src/views/full/index.tsx
@@ -1,15 +1,18 @@
 import { Icon, Intent } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
 import { AxiosStatic } from 'axios'
-import { confirmDialog } from 'botpress/shared'
+import { confirmDialog, toast } from 'botpress/shared'
 import _ from 'lodash'
 import React from 'react'
 import { Grid, Row, Col, Button } from 'react-bootstrap'
+
 import { Preview, Scenario, Status } from '../../backend/typings'
 import NoScenarios from './NoScenarios'
 import ScenarioComponent from './Scenario'
 import ScenarioRecorder from './ScenarioRecorder'
 import style from './style.scss'
+
+const WEBCHAT_READY_TIMEOUT = 10000
 
 interface Props {
   bp: {
@@ -49,13 +52,43 @@ export default class Testing extends React.Component<Props, State> {
     await this.loadPreviews()
   }
 
-  startRecording = async () => {
-    this.setState({ isRecording: true })
+  resetWebchatSession = async () => {
+    // Fetches the emulator content window
+    const win: Window = document.querySelector('#bp-widget')?.['contentWindow']
+    if (win) {
+      const timeout = new Promise((_, reject) => {
+        setTimeout(() => reject('Timeout reached while waiting for the webchat to be ready'), WEBCHAT_READY_TIMEOUT)
+      })
 
-    const chatUserId = window.BP_STORAGE.get('bp/socket/studio/user') || window.__BP_VISITOR_ID
-    await this.props.bp.axios.post('/mod/testing/startRecording', { userId: chatUserId })
+      // Wait for the webchat to be ready
+      const wait = new Promise(resolve => {
+        window.addEventListener('message', event => {
+          if (event.data && event.data.name === 'webchatReady') {
+            resolve()
+          }
+        })
+      })
+
+      // Sends a request to the emulator to create a new session (new user, new socket connection, and new conversation)
+      win.postMessage({ action: 'new-session' }, '*')
+
+      await Promise.race([timeout, wait])
+    }
 
     window.botpressWebChat.sendEvent({ type: 'show' })
+  }
+
+  startRecording = async () => {
+    try {
+      await this.resetWebchatSession()
+
+      const chatUserId = window.BP_STORAGE.get('bp/socket/studio/user') || window.__BP_VISITOR_ID
+      await this.props.bp.axios.post('/mod/testing/startRecording', { userId: chatUserId })
+
+      this.setState({ isRecording: true })
+    } catch (err) {
+      toast.failure(`An error occurred while trying to record a new scenario: ${err}`, undefined, { timeout: 'medium' })
+    }
   }
 
   loadScenarios = async () => {

--- a/modules/testing/src/views/full/index.tsx
+++ b/modules/testing/src/views/full/index.tsx
@@ -74,8 +74,6 @@ export default class Testing extends React.Component<Props, State> {
 
       await Promise.race([timeout, wait])
     }
-
-    window.botpressWebChat.sendEvent({ type: 'show' })
   }
 
   startRecording = async () => {
@@ -84,6 +82,8 @@ export default class Testing extends React.Component<Props, State> {
 
       const chatUserId = window.BP_STORAGE.get('bp/socket/studio/user') || window.__BP_VISITOR_ID
       await this.props.bp.axios.post('/mod/testing/startRecording', { userId: chatUserId })
+
+      window.botpressWebChat.sendEvent({ type: 'show' })
 
       this.setState({ isRecording: true })
     } catch (err) {


### PR DESCRIPTION
This PR fixes an issue where recording a scenario starting from the middle of a flow would result in the scenario always failing. To solve the issue, I see two possibilities. 

1. First, the one which this PR implements, is to reset or create a new session just before we start recording the scenario.
2. We could simply save the state of the user's session before the recording starts and put this into the resulting scenario so that way we could restore the session before running the test. Since I see this option more as a feature than a fix, I opted for the simple one.

Closes: https://github.com/botpress/v12/issues/1087