### PR TITLE
chore(ci_cd): publish next builds to latest directory

### DIFF
--- a/.github/workflows/publish-next-binaries.yml
+++ b/.github/workflows/publish-next-binaries.yml
@@ -62,3 +62,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           aws s3 sync packages/bp/archives s3://botpress-next-bins/${{ github.event.inputs.name ||  format('nightly-{0}', steps.date.outputs.date) }}
+          aws s3 sync packages/bp/archives s3://botpress-next-bins/latest


### PR DESCRIPTION
This PR adds a step to publish the next binaries to a `latest` folder on S3