### PR TITLE
fix(code-editor): allow creating hooks with hook type as name

### DIFF
--- a/modules/code-editor/src/backend/definitions.ts
+++ b/modules/code-editor/src/backend/definitions.ts
@@ -55,7 +55,7 @@ export const FileTypes: { [type: string]: FileDefinition } = {
       baseDir: '/hooks',
       dirListingAddFields: (filepath: string) => ({ hookType: filepath.substr(0, filepath.indexOf('/')) }),
       upsertLocation: (file: EditableFile) => `/hooks/${file.hookType}`,
-      upsertFilename: (file: EditableFile) => file.location.replace(file.hookType, ''),
+      upsertFilename: (file: EditableFile) => file.location.replace(`${file.hookType}/`, ''),
       shouldSyncToDisk: true
     },
     validate: async (file: EditableFile, isWriting?: boolean) => {

--- a/modules/code-editor/src/backend/definitions.ts
+++ b/modules/code-editor/src/backend/definitions.ts
@@ -55,7 +55,7 @@ export const FileTypes: { [type: string]: FileDefinition } = {
       baseDir: '/hooks',
       dirListingAddFields: (filepath: string) => ({ hookType: filepath.substr(0, filepath.indexOf('/')) }),
       upsertLocation: (file: EditableFile) => `/hooks/${file.hookType}`,
-      upsertFilename: (file: EditableFile) => file.location.replace(file.hookType, ''),
+      upsertFilename: (file: EditableFile) => file.location,
       shouldSyncToDisk: true
     },
     validate: async (file: EditableFile, isWriting?: boolean) => {

--- a/modules/code-editor/src/backend/definitions.ts
+++ b/modules/code-editor/src/backend/definitions.ts
@@ -55,7 +55,7 @@ export const FileTypes: { [type: string]: FileDefinition } = {
       baseDir: '/hooks',
       dirListingAddFields: (filepath: string) => ({ hookType: filepath.substr(0, filepath.indexOf('/')) }),
       upsertLocation: (file: EditableFile) => `/hooks/${file.hookType}`,
-      upsertFilename: (file: EditableFile) => file.location,
+      upsertFilename: (file: EditableFile) => file.location.replace(file.hookType, ''),
       shouldSyncToDisk: true
     },
     validate: async (file: EditableFile, isWriting?: boolean) => {

--- a/modules/code-editor/src/backend/editor.ts
+++ b/modules/code-editor/src/backend/editor.ts
@@ -75,9 +75,9 @@ export default class Editor {
 
   async saveFile(file: EditableFile): Promise<void> {
     const shouldSyncToDisk = FileTypes[file.type].ghost.shouldSyncToDisk
-    const { folder, filename } = getFileLocation(file)
+    const { folder } = getFileLocation(file)
 
-    return this._getGhost(file).upsertFile(folder, filename, file.content, {
+    return this._getGhost(file).upsertFile(folder, file.location, file.content, {
       syncDbToDisk: shouldSyncToDisk
     })
   }

--- a/modules/code-editor/src/backend/editor.ts
+++ b/modules/code-editor/src/backend/editor.ts
@@ -75,9 +75,9 @@ export default class Editor {
 
   async saveFile(file: EditableFile): Promise<void> {
     const shouldSyncToDisk = FileTypes[file.type].ghost.shouldSyncToDisk
-    const { folder } = getFileLocation(file)
+    const { folder, filename } = getFileLocation(file)
 
-    return this._getGhost(file).upsertFile(folder, file.location, file.content, {
+    return this._getGhost(file).upsertFile(folder, filename, file.content, {
       syncDbToDisk: shouldSyncToDisk
     })
   }


### PR DESCRIPTION
This PR adds the possibility to create a hook with the name of the hook type. Before this change, the resulting filename would be `.js` since we were removing the hook type from its name (not sure why as there seems to be no impact of doing so).  

e.g. Creating an `after_incoming_middleware` hook named: `after_incoming_middleware.js`

Closes https://github.com/botpress/v12/issues/1580