### PR TITLE
chore(downloader): better error handling when packaging botpress

### DIFF
--- a/build/downloader/src/index.ts
+++ b/build/downloader/src/index.ts
@@ -65,7 +65,7 @@ yargs
           type: 'string'
         })
         .positional('toolVersion', {
-          describe: 'When ommitted, the latest version is installed',
+          describe: 'When omitted, the latest version is installed',
           type: 'string'
         })
 

--- a/build/gulp.package.js
+++ b/build/gulp.package.js
@@ -92,25 +92,36 @@ const makeTempPackage = () => {
   }
 }
 
-const fetchExternalBinaries = () => {
+const fetchExternalBinaries = async () => {
   const binOut = path.resolve(__dirname, '../packages/bp/binaries')
 
-  systems.forEach(({ osName, platform }) =>
-    execAsync(`yarn bpd init --output ${path.resolve(binOut, osName)} --platform ${platform}`)
-  )
+  for (const { osName, platform } of systems) {
+    // Since bpd does not exit when there is an error, we must read stderr to know if something went wrong
+    const command = `yarn bpd init --output ${path.resolve(binOut, osName)} --platform ${platform}`
+    const { stderr } = await execAsync(command)
+
+    if (stderr) {
+      const err = new Error()
+      err.cmd = command
+      err.stderr = stderr
+
+      throw err
+    }
+  }
 }
 
 const packageAll = async () => {
   const tempPackage = makeTempPackage()
 
   try {
-    fetchExternalBinaries()
+    await fetchExternalBinaries()
 
     await execAsync(`cross-env pkg --options max_old_space_size=16384 --output ../binaries/bp ./package.json`, {
       cwd: path.resolve(__dirname, '../packages/bp/dist')
     })
   } catch (err) {
-    console.error('Error running: ', err.cmd, '\nMessage: ', err.stderr, err)
+    // We don´t want to create an archive if there was something wrong in the steps above
+    return console.error('Error running:', err.cmd, '\nMessage:', err.stderr)
   } finally {
     tempPackage.remove()
   }

--- a/build/gulp.package.js
+++ b/build/gulp.package.js
@@ -121,7 +121,8 @@ const packageAll = async () => {
     })
   } catch (err) {
     // We don´t want to create an archive if there was something wrong in the steps above
-    return console.error('Error running:', err.cmd, '\nMessage:', err.stderr)
+    console.error('Error running:', err.cmd, '\nMessage:', err.stderr)
+    process.exit(1)
   } finally {
     tempPackage.remove()
   }


### PR DESCRIPTION
This PR improves the error handling of the downloader (`bpd`) when creating an archive of Botpress. Since the bpd utility does not exit when there is an error, we have to read from the stdout to know if something went wrong and then cancel the process of creating the archive.

This will prevent us from creating invalid Botpress binaries that would be missing some of its dependencies (nlu, messaging, studio) 

Closes DEV-2557