### PR TITLE
chore(ci_cd): set permissions for actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,12 @@
 name: Build
 on: [pull_request]
+permissions:
+  contents: read
+
 jobs:
   botpress:
+    permissions:
+      contents: none
     name: Botpress
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -1,5 +1,8 @@
 name: Code Style
 on: [pull_request]
+permissions:
+  contents: read
+
 jobs:
   prettier:
     name: Prettier

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build_and_push_docker:
     name: Build and Push Docker Image

--- a/.github/workflows/module-builder.yml
+++ b/.github/workflows/module-builder.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+permissions:
+  contents: read
+
 jobs:
   test_module_builder:
     name: Test Module Builder Image

--- a/.github/workflows/publish-module-builder.yml
+++ b/.github/workflows/publish-module-builder.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [ closed ]
 
+permissions:
+  contents: read
+
 jobs:
   publish_module_builder:
     name: Build and publish module builder

--- a/.github/workflows/publish-reference.yml
+++ b/.github/workflows/publish-reference.yml
@@ -3,6 +3,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   publish_reference:
     name: Publish Reference

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -3,8 +3,13 @@ on:
     types: [created]
 
 name: Slack Notification Demo
+permissions:
+  contents: read
+
 jobs:
   slack_notification:
+    permissions:
+      contents: none
     name: Slack Notification
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: Tests
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   unit:
     name: Unit
@@ -75,6 +78,8 @@ jobs:
           PG_PORT: 5432
 
   e2e:
+    permissions:
+      contents: none
     name: E2E (ubuntu-latest)
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
