### PR TITLE
chore(next): bump to 12.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bp_main",
-  "version": "12.26.13",
+  "version": "12.27.0",
   "description": "The world's most powerful conversational engine",
   "engines": {
     "node": "^12"

--- a/packages/bp/e2e/studio/ui.test.ts
+++ b/packages/bp/e2e/studio/ui.test.ts
@@ -36,21 +36,24 @@ describe('Studio - UI', () => {
 
   it('Toggle Bottom Panel using shortcut', async () => {
     await page.focus('#mainLayout')
-    await triggerKeyboardShortcut('j', true, true)
     const bottomPanel = await page.$('div[data-tab-id="debugger"]')
 
-    expect(await bottomPanel?.isIntersectingViewport()).toBe(true)
     await triggerKeyboardShortcut('j', true, true)
+    expect(await bottomPanel?.isIntersectingViewport()).toBe(true)
+
+    await triggerKeyboardShortcut('j', true, true)
+    expect(await bottomPanel?.isIntersectingViewport()).toBe(false)
   })
 
   it('Toggles bottom panel using click toolbar menu', async () => {
     await page.focus('#mainLayout')
-    await clickOn('#botpress-tooltip-2-trigger')
-
     const bottomPanel = await page.$('div[data-tab-id="debugger"]')
+
+    await clickOn('#botpress-tooltip-2-trigger')
     expect(await bottomPanel?.isIntersectingViewport()).toBe(true)
 
     await clickOn('#botpress-tooltip-2-trigger')
+    expect(await bottomPanel?.isIntersectingViewport()).toBe(false)
   })
 
   // Uncomment once the analytics v2 is enabled by default


### PR DESCRIPTION
This PR bumps the next branch to 12.27 which Is the version `next` represents.

This will make sure that nightly next binaries will be saved as `botpress_12_27_0...` instead of 12.26.13 which is misleading.