### PR TITLE
chore(cloud): environement defaults to production

### DIFF
--- a/packages/bp/src/index.ts
+++ b/packages/bp/src/index.ts
@@ -92,12 +92,12 @@ try {
   const localCloud = yn(process.env.CLOUD_LOCAL)
   process.CLOUD_CONTROLLER_ENDPOINT =
     process.env.CLOUD_CONTROLLER_ENDPOINT ||
-    (localCloud ? 'http://localhost:3600' : 'https://controllerapi.botpress.dev')
+    (localCloud ? 'http://localhost:3600' : 'https://controllerapi.botpress.cloud')
   process.CLOUD_OAUTH_ENDPOINT =
     process.env.CLOUD_OAUTH_ENDPOINT ||
-    (localCloud ? 'http://localhost:4444/oauth2/token' : 'https://oauth.botpress.dev/oauth2/token')
+    (localCloud ? 'http://localhost:4444/oauth2/token' : 'https://oauth.botpress.cloud/oauth2/token')
   process.CLOUD_NLU_ENDPOINT =
-    process.env.CLOUD_NLU_ENDPOINT || (localCloud ? 'http://localhost:3200' : 'https://nlu-builder.botpress.dev')
+    process.env.CLOUD_NLU_ENDPOINT || (localCloud ? 'http://localhost:3200' : 'https://nlu-builder.botpress.cloud')
 
   const configPath = path.join(process.PROJECT_LOCATION, '/data/global/botpress.config.json')
 

--- a/packages/ui-admin/src/app/translations/en.json
+++ b/packages/ui-admin/src/app/translations/en.json
@@ -286,7 +286,7 @@
           "template": "Bot Template",
           "cloud": "Botpress Cloud",
           "cloudCheckbox": "Enable Botpress Cloud",
-          "cloudHelper": "Cloud chatbots can then be deployed using the deploy button in the upper right section of the Studio.",
+          "cloudHelper": "Cloud chatbots are slightly different from traditional chatbots. Learn more here: https://www.botpress.com/docs/overview/cloud/try-the-beta",
           "cloudConfiguration": "Botpress Cloud Configuration",
           "cloudConfigurationHelper": "You can get your API Key and Secret by login into Botpress Cloud.",
           "clientIdPlaceholder": "API Key",

--- a/packages/ui-admin/src/app/translations/es.json
+++ b/packages/ui-admin/src/app/translations/es.json
@@ -268,7 +268,7 @@
           "template": "Plantilla de bot",
           "cloud": "Botpress Cloud",
           "cloudCheckbox": "Activar Botpress Cloud",
-          "cloudHelper": "Los chatbots de Botpress Cloud pueden desplegarse mediante el botón de despliegue situado en la parte superior derecha de Studio.",
+          "cloudHelper": "Los Botpress Cloud chatbots son diferentes de los chatbots tradicionales. Aprende más aquí: https://www.botpress.com/docs/overview/cloud/try-the-beta",
           "cloudConfiguration": "Configuración Botpress cloud",
           "cloudConfigurationHelper": "Puedes obtener tu API Key y secreto iniciando sesión en Botpress Cloud",
           "clientIdPlaceholder": "API key",

--- a/packages/ui-admin/src/app/translations/fr.json
+++ b/packages/ui-admin/src/app/translations/fr.json
@@ -279,7 +279,7 @@
           "template": "Modèle de bot",
           "cloud": "Botpress Cloud",
           "cloudCheckbox": "Activer Botpress Cloud",
-          "cloudHelper": "Ce chatbot pourra ėtre envoyé sur Botpress Cloud en utilisant le bouton dans le coins supérieur droit du studio.",
+          "cloudHelper": "Les chatbots Botpress Cloud sont légèrement différents des chatbots traditionels. Pour en savoir plus: https://www.botpress.com/docs/overview/cloud/try-the-beta",
           "cloudConfiguration": "Configurations Botpress Cloud",
           "cloudConfigurationHelper": "Vous pouvez obtenir ces clés en vous conectant sur Botpress Cloud",
           "clientIdPlaceholder": "Clé d'API ",

--- a/packages/ui-admin/src/app/translations/fr.json
+++ b/packages/ui-admin/src/app/translations/fr.json
@@ -279,7 +279,7 @@
           "template": "Modèle de bot",
           "cloud": "Botpress Cloud",
           "cloudCheckbox": "Activer Botpress Cloud",
-          "cloudHelper": "Les chatbots Botpress Cloud sont légèrement différents des chatbots traditionels. Pour en savoir plus: https://www.botpress.com/docs/overview/cloud/try-the-beta",
+          "cloudHelper": "Les chatbots Botpress Cloud sont légèrement différents des chatbots traditionnels. Pour en savoir plus: https://www.botpress.com/docs/overview/cloud/try-the-beta",
           "cloudConfiguration": "Configurations Botpress Cloud",
           "cloudConfigurationHelper": "Vous pouvez obtenir ces clés en vous conectant sur Botpress Cloud",
           "clientIdPlaceholder": "Clé d'API ",


### PR DESCRIPTION
I open this one with as a draft as I'm not sure we should do this. IMO as of now default should be staging env. We could / should override them on the build process when publishing binaries.

I'm seeking your opinion guys, if you want to move forward with this, same needs to be done in studio.