### PR TITLE
fix(core): fix SAML SLO config as environment variables

### DIFF
--- a/packages/bp/src/core/config/botpress.config.ts
+++ b/packages/bp/src/core/config/botpress.config.ts
@@ -528,7 +528,7 @@ export interface AuthStrategySaml {
    */
   acceptedClockSkewMs: number
   /**
-   * Logout URL fro SAML SLO provided by the IDP.
+   * Logout URL for SAML SLO provided by the IDP.
    */
   logoutUrl: string
   /**

--- a/packages/bp/src/core/config/botpress.config.ts
+++ b/packages/bp/src/core/config/botpress.config.ts
@@ -527,6 +527,15 @@ export interface AuthStrategySaml {
    * @default 5000
    */
   acceptedClockSkewMs: number
+  /**
+   * Logout URL fro SAML SLO provided by the IDP.
+   */
+  logoutUrl: string
+  /**
+   * The logout callback URL for SAML SLO. The path provided here is absolute.
+   * For example, http://localhost:3000/api/v1/auth/logout-callback/saml/saml
+   */
+  logoutCallbackUrl: string
 }
 
 export interface AuthStrategyOauth2 {


### PR DESCRIPTION
Right now is not possible to use BP_CONFIG_AUTHSTRATEGIES_SAML_OPTIONS_LOGOUTCALLBACKURL or BP_CONFIG_AUTHSTRATEGIES_SAML_OPTIONS_LOGOUTURL to set SAML SLO configurations as environment variables, this PR fixes this issue