### PR TITLE
feat(hitlnext): add skill, fix lang & expired handoff

### DIFF
--- a/modules/hitlnext/src/actions/check_agents.js
+++ b/modules/hitlnext/src/actions/check_agents.js
@@ -1,0 +1,13 @@
+const axios = require('axios')
+
+/**
+ * @hidden true
+ */
+const check_agents = async event => {
+  const axiosConfig = await bp.http.getAxiosConfigForBot(event.botId, { localUrl: true })
+  const { data } = await axios.get('/mod/hitlnext/agents', axiosConfig)
+
+  temp['hitlnext-noAgent'] = data.filter(x => x.online).length === 0
+}
+
+return check_agents(event)

--- a/modules/hitlnext/src/actions/handoff.js
+++ b/modules/hitlnext/src/actions/handoff.js
@@ -8,17 +8,18 @@ const axios = require('axios')
  * @description Transfers control of the conversation to an agent
  * @author Botpress, Inc.
  */
-const escalate = async event => {
+const escalate = async (event, timeoutDelay) => {
   const axiosConfig = await bp.http.getAxiosConfigForBot(event.botId, { localUrl: true })
   await axios.post(
     '/mod/hitlnext/handoffs',
     {
       userThreadId: event.threadId,
       userId: event.target,
-      userChannel: event.channel
+      userChannel: event.channel,
+      timeoutDelay
     },
     axiosConfig
   )
 }
 
-return escalate(event)
+return escalate(event, args.timeoutDelay)

--- a/modules/hitlnext/src/backend/api.ts
+++ b/modules/hitlnext/src/backend/api.ts
@@ -15,7 +15,7 @@ import { HandoffStatus, IAgent, IComment, IHandoff } from './../types'
 import { UnprocessableEntityError } from './errors'
 import { extendAgentSession, formatValidationError, makeAgentId } from './helpers'
 import Repository, { CollectionConditions } from './repository'
-import Service, { toBpDestination } from './service'
+import Service, { toEventDestination } from './service'
 import Socket from './socket'
 import {
   AgentOnlineValidation,
@@ -231,7 +231,7 @@ export default async (bp: typeof sdk, state: StateType, repository: Repository) 
         const attributes = await bp.users.getAttributes(handoff.userChannel, handoff.userId)
         const language = attributes.language
 
-        const eventDestination = toBpDestination(req.params.botId, handoff)
+        const eventDestination = toEventDestination(req.params.botId, handoff)
 
         await service.sendMessageToUser(configs.assignMessage, eventDestination, language, {
           agentName: agentName(agent)

--- a/modules/hitlnext/src/backend/api.ts
+++ b/modules/hitlnext/src/backend/api.ts
@@ -15,6 +15,7 @@ import { HandoffStatus, IAgent, IComment, IHandoff } from './../types'
 import { UnprocessableEntityError } from './errors'
 import { extendAgentSession, formatValidationError, makeAgentId } from './helpers'
 import Repository, { CollectionConditions } from './repository'
+import Service, { toBpDestination } from './service'
 import Socket from './socket'
 import {
   AgentOnlineValidation,
@@ -29,6 +30,7 @@ import {
 export default async (bp: typeof sdk, state: StateType, repository: Repository) => {
   const router = bp.http.createRouterForBot(MODULE_NAME)
   const realtime = Socket(bp)
+  const service = new Service(bp, state, repository, realtime)
 
   // Enforces for an agent to be 'online' before executing an action
   const agentOnlineMiddleware = async (req: BPRequest, res: Response, next) => {
@@ -158,33 +160,7 @@ export default async (bp: typeof sdk, state: StateType, repository: Repository) 
         return res.sendStatus(200)
       }
 
-      const configs: Config = await bp.config.getModuleConfigForBot(MODULE_NAME, req.params.botId)
-
-      const handoff = await repository.createHandoff(req.params.botId, payload).then(handoff => {
-        state.cacheHandoff(req.params.botId, handoff.userThreadId, handoff)
-        return handoff
-      })
-
-      const eventDestination = {
-        botId: req.params.botId,
-        target: handoff.userId,
-        threadId: handoff.userThreadId,
-        channel: handoff.userChannel
-      }
-
-      if (configs.transferMessage) {
-        bp.events.replyToEvent(
-          eventDestination,
-          await bp.cms.renderElement('@builtin_text', { type: 'text', text: configs.transferMessage }, eventDestination)
-        )
-      }
-
-      realtime.sendPayload(req.params.botId, {
-        resource: 'handoff',
-        type: 'create',
-        id: handoff.id,
-        payload: handoff
-      })
+      const handoff = await service.createHandoff(req.params.botId, payload, req.body.timeoutDelay)
 
       res.status(201).send(handoff)
     })
@@ -252,20 +228,14 @@ export default async (bp: typeof sdk, state: StateType, repository: Repository) 
       const configs: Config = await bp.config.getModuleConfigForBot(MODULE_NAME, req.params.botId)
 
       if (configs.assignMessage) {
-        const eventDestination = {
-          botId: req.params.botId,
-          target: handoff.userId,
-          threadId: handoff.userThreadId,
-          channel: handoff.userChannel
-        }
+        const attributes = await bp.users.getAttributes(handoff.userChannel, handoff.userId)
+        const language = attributes.language
 
-        // TODO replace this by render service
-        const assignedPayload = await bp.cms.renderElement(
-          '@builtin_text',
-          { type: 'text', text: configs.assignMessage, agentName: agentName(agent) },
-          eventDestination
-        )
-        bp.events.replyToEvent(eventDestination, assignedPayload)
+        const eventDestination = toBpDestination(req.params.botId, handoff)
+
+        await service.sendMessageToUser(configs.assignMessage, eventDestination, language, {
+          agentName: agentName(agent)
+        })
       }
 
       // TODO replace this by messaging api once all channels have been ported
@@ -325,8 +295,7 @@ export default async (bp: typeof sdk, state: StateType, repository: Repository) 
 
       const agentId = makeAgentId(strategy, email)
 
-      let handoff
-      handoff = await repository.findHandoff(req.params.botId, req.params.id)
+      const handoff = await repository.findHandoff(req.params.botId, req.params.id)
 
       const payload: Pick<IHandoff, 'status' | 'resolvedAt'> = {
         status: 'resolved',
@@ -341,21 +310,10 @@ export default async (bp: typeof sdk, state: StateType, repository: Repository) 
         throw new UnprocessableEntityError(formatValidationError(e))
       }
 
-      handoff = await repository.updateHandoff(req.params.botId, req.params.id, payload).then(handoff => {
-        state.expireHandoff(req.params.botId, handoff.userThreadId)
-        return handoff
-      })
-
+      const updated = await service.resolveHandoff(handoff, req.params.botId, payload)
       await extendAgentSession(repository, realtime, req.params.botId, agentId)
 
-      realtime.sendPayload(req.params.botId, {
-        resource: 'handoff',
-        type: 'update',
-        id: handoff.id,
-        payload: handoff
-      })
-
-      res.send(handoff)
+      res.send(updated)
     })
   )
 

--- a/modules/hitlnext/src/backend/flowBuilder.ts
+++ b/modules/hitlnext/src/backend/flowBuilder.ts
@@ -1,0 +1,78 @@
+import * as sdk from 'botpress/sdk'
+import { ExitTypes, SkillData } from 'src/types'
+
+const makeExit = (exitType: ExitTypes) => `temp['hitlnext-${exitType}'] === true`
+
+const generateFlow = async (data: SkillData): Promise<sdk.FlowGenerationResult> => {
+  const nodes: sdk.SkillFlowNode[] = []
+
+  if (data.redirectNoAgent) {
+    nodes.push({
+      name: 'entry',
+      onEnter: [
+        {
+          type: sdk.NodeActionType.RunAction,
+          name: 'hitlnext/check_agents',
+          args: data
+        }
+      ],
+      next: [
+        { condition: makeExit('noAgent'), node: '#' },
+        { condition: 'true', node: 'hitl' }
+      ]
+    })
+  }
+
+  nodes.push(
+    {
+      name: 'hitl',
+      onEnter: [
+        {
+          type: sdk.NodeActionType.RunAction,
+          name: 'hitlnext/handoff',
+          args: data
+        }
+      ],
+      next: [{ condition: 'true', node: 'wait' }]
+    },
+    {
+      name: 'wait',
+      onEnter: [],
+      onReceive: [],
+      next: [
+        { condition: makeExit('noAgent'), node: '#' },
+        { condition: makeExit('timedOutWaitingAgent'), node: '#' },
+        { condition: makeExit('handoffResolved'), node: '#' },
+        { condition: 'true', node: 'wait' }
+      ]
+    }
+  )
+
+  return {
+    transitions: createTransitions(data),
+    flow: {
+      nodes,
+      catchAll: {
+        next: []
+      }
+    }
+  }
+}
+
+const createTransitions = (data: SkillData) => {
+  const transitions: sdk.NodeTransition[] = [
+    { caption: 'Handoff Resolved', condition: makeExit('handoffResolved'), node: '' }
+  ]
+
+  if (data.redirectNoAgent) {
+    transitions.push({ caption: 'No Agent Available', condition: makeExit('noAgent'), node: '' })
+  }
+
+  if (data.timeoutDelay > 0) {
+    transitions.push({ caption: 'Timed Out Waiting Agent', condition: makeExit('timedOutWaitingAgent'), node: '' })
+  }
+
+  return transitions
+}
+
+export default { generateFlow }

--- a/modules/hitlnext/src/backend/index.ts
+++ b/modules/hitlnext/src/backend/index.ts
@@ -6,6 +6,7 @@ import en from '../translations/en.json'
 import fr from '../translations/fr.json'
 
 import api from './api'
+import flowBuilder from './flowBuilder'
 import { registerMiddleware, unregisterMiddleware } from './middleware'
 import migrate from './migrate'
 import Repository from './repository'
@@ -36,11 +37,21 @@ const onModuleUnmount = async (bp: typeof sdk) => {
   await unregisterMiddleware(bp)
 }
 
+const skills: sdk.Skill[] = [
+  {
+    id: 'HitlNext',
+    icon: 'person',
+    name: 'HITL',
+    flowGenerator: flowBuilder.generateFlow
+  }
+]
+
 const entryPoint: sdk.ModuleEntryPoint = {
   onServerStarted,
   onServerReady,
   onModuleUnmount,
   translations: { en, fr },
+  skills,
   definition: {
     name: MODULE_NAME,
     menuIcon: 'headset',

--- a/modules/hitlnext/src/backend/middleware.ts
+++ b/modules/hitlnext/src/backend/middleware.ts
@@ -14,6 +14,15 @@ import Socket from './socket'
 
 const debug = DEBUG(MODULE_NAME)
 
+const updateHitlStatus = event => {
+  if (event.type === 'hitlnext' && event.payload) {
+    const { exitType, agentName } = event.payload
+
+    _.set(event, 'state.temp.agentName', agentName)
+    _.set(event, `state.temp.hitlnext-${exitType}`, true)
+  }
+}
+
 const registerMiddleware = async (bp: typeof sdk, state: StateType) => {
   const handoffCache = new LRU<string, string>({ max: 1000, maxAge: ms('1 day') })
   const repository = new Repository(bp, state.timeouts)
@@ -103,6 +112,8 @@ const registerMiddleware = async (bp: typeof sdk, state: StateType) => {
   }
 
   const incomingHandler = async (event: sdk.IO.IncomingEvent, next: sdk.IO.MiddlewareNextCallback) => {
+    updateHitlStatus(event)
+
     // TODO we might want to handle other types
     if (event.type !== 'text') {
       return next(undefined, false, true)

--- a/modules/hitlnext/src/backend/service.ts
+++ b/modules/hitlnext/src/backend/service.ts
@@ -1,0 +1,100 @@
+import * as sdk from 'botpress/sdk'
+import _ from 'lodash'
+
+import { Config } from '../config'
+import { MODULE_NAME } from '../constants'
+import { ExitTypes, IHandoff } from '../types'
+import { StateType } from '.'
+import Repository from './repository'
+
+export const toBpDestination = (botId: string, handoff: Pick<IHandoff, 'userId' | 'userThreadId' | 'userChannel'>) => {
+  return { botId, target: handoff.userId, threadId: handoff.userThreadId, channel: handoff.userChannel }
+}
+
+class Service {
+  constructor(private bp: typeof sdk, private state: StateType, private repository: Repository, private realtime) {}
+
+  async createHandoff(
+    botId: string,
+    dest: Pick<IHandoff, 'userId' | 'userThreadId' | 'userChannel' | 'status'>,
+    timeoutDelay: number
+  ) {
+    const config: Config = await this.bp.config.getModuleConfigForBot(MODULE_NAME, botId)
+    const eventDestination = toBpDestination(botId, dest)
+    const attributes = await this.bp.users.getAttributes(dest.userChannel, dest.userId)
+    const language = attributes.language
+
+    const handoff = await this.repository.createHandoff(botId, dest).then(handoff => {
+      this.state.cacheHandoff(botId, handoff.userThreadId, handoff)
+      return handoff
+    })
+
+    if (config.transferMessage) {
+      await this.sendMessageToUser(config.transferMessage, eventDestination, language)
+    }
+
+    this.realtime.sendPayload(botId, { resource: 'handoff', type: 'create', id: handoff.id, payload: handoff })
+
+    if (timeoutDelay !== undefined && timeoutDelay > 0) {
+      setTimeout(async () => {
+        const userHandoff = await this.repository.getHandoff(handoff.id)
+
+        if (userHandoff.status === 'pending') {
+          await this.updateHandoff(userHandoff, botId, { status: 'expired' })
+          await this.transferToBot(eventDestination, 'timedOutWaitingAgent')
+        }
+      }, timeoutDelay * 1000)
+    }
+
+    return handoff
+  }
+
+  async resolveHandoff(handoff: IHandoff, botId: string, payload) {
+    const eventDestination = toBpDestination(botId, handoff)
+    const updated = await this.updateHandoff(handoff, botId, payload)
+    await this.transferToBot(eventDestination, 'handoffResolved')
+
+    return updated
+  }
+
+  async updateHandoff(handoff: Partial<IHandoff>, botId: string, payload: any) {
+    const updated = await this.repository.updateHandoff(botId, handoff.id, payload)
+    this.state.expireHandoff(botId, handoff.userThreadId)
+    this.updateRealtimeHandoff(botId, updated)
+
+    return updated
+  }
+
+  async sendMessageToUser(
+    text: { [lang: string]: string },
+    eventDestination: sdk.IO.EventDestination,
+    language: string,
+    args?: any
+  ) {
+    const event = { state: { user: { language } } }
+    const message = await this.bp.cms.renderElement(
+      '@builtin_text',
+      { type: 'text', text, event, ...args },
+      eventDestination
+    )
+    this.bp.events.replyToEvent(eventDestination, message)
+  }
+
+  updateRealtimeHandoff(botId: string, handoff: Partial<IHandoff>) {
+    return this.realtime.sendPayload(botId, { resource: 'handoff', type: 'update', id: handoff.id, payload: handoff })
+  }
+
+  async transferToBot(event: sdk.IO.EventDestination, exitType: ExitTypes, agentName?: string) {
+    const stateUpdate = this.bp.IO.Event({
+      ..._.pick(event, ['botId', 'channel', 'target', 'threadId']),
+      direction: 'incoming',
+      payload: { exitType, agentName },
+      preview: 'none',
+      type: 'hitlnext'
+    })
+
+    await this.bp.events.sendEvent(stateUpdate)
+  }
+}
+
+export default Service

--- a/modules/hitlnext/src/translations/en.json
+++ b/modules/hitlnext/src/translations/en.json
@@ -9,7 +9,8 @@
     "unassigned": "Unassigned",
     "assignedMe": "Assigned to Me",
     "assignedOther": "Assigned to Others",
-    "resolved": "Resolved"
+    "resolved": "Resolved",
+    "expired": "Expired"
   },
   "sortBy": "Sort By",
   "filterBy": "Filter By",
@@ -30,7 +31,8 @@
     "status": {
       "pending": "pending",
       "assigned": "assigned",
-      "resolved": "resolved"
+      "resolved": "resolved",
+      "expired": "expired"
     },
     "assignedToAgent": "You've been assigned to an agent",
     "assignedToYou": "Conversation Handed to You",

--- a/modules/hitlnext/src/translations/fr.json
+++ b/modules/hitlnext/src/translations/fr.json
@@ -9,7 +9,8 @@
     "unassigned": "Non-assigné",
     "assignedMe": "Assigné à moi",
     "assignedOther": "Assigné à d'autres",
-    "resolved": "Résolue"
+    "resolved": "Résolue",
+    "expired": "Expiré"
   },
   "sortBy": "Trier Par",
   "filterBy": "Filtrer Par",
@@ -30,7 +31,8 @@
     "status": {
       "pending": "en attente",
       "assigned": "assignée",
-      "resolved": "résolue"
+      "resolved": "résolue",
+      "expired": "expiré"
     },
     "assignedToAgent": "Vous avez été assigné à un agent",
     "assignedToYou": "La conversation vous a été assigné",

--- a/modules/hitlnext/src/types.d.ts
+++ b/modules/hitlnext/src/types.d.ts
@@ -15,7 +15,7 @@ export type IAgent = sdk.WorkspaceUserWithAttributes & {
 
 export type AgentWithPermissions = IAgent & UserProfile
 
-export type HandoffStatus = 'pending' | 'assigned' | 'resolved'
+export type HandoffStatus = 'pending' | 'assigned' | 'resolved' | 'expired'
 export interface IHandoff {
   id: string
   botId: string
@@ -66,4 +66,22 @@ export interface ISocketMessage {
   resource: string
   type: string
   id: string
+}
+
+export type ExitTypes = 'timedOutWaitingAgent' | 'handoffResolved' | 'noAgent'
+
+export interface SkillData {
+  redirectNoAgent: boolean
+  timeoutDelay: number
+}
+
+// These are properties provided by the studio
+export interface SkillProps<T> {
+  initialData: T
+  onDataChanged: (data: T) => void
+  onValidChanged: (canSubmit: boolean) => void
+  resizeBuilderWindow: (newSize: 'normal' | 'large' | 'small') => void
+  contentLang: string
+  defaultLanguage: string
+  languages: string[]
 }

--- a/modules/hitlnext/src/views/full/Skill.tsx
+++ b/modules/hitlnext/src/views/full/Skill.tsx
@@ -37,7 +37,7 @@ const Skill: FC<SkillProps<SkillData>> = ({ onDataChanged, onValidChanged, initi
 
       <FormGroup>
         <Checkbox
-          label="Send user to another node if no agents are online"
+          label="Send user to another node if no agent is online"
           checked={redirectNoAgent}
           onChange={e => setRedirectNoAgent(e.currentTarget.checked)}
         ></Checkbox>

--- a/modules/hitlnext/src/views/full/Skill.tsx
+++ b/modules/hitlnext/src/views/full/Skill.tsx
@@ -1,0 +1,49 @@
+import { FormGroup, NumericInput, Checkbox } from '@blueprintjs/core'
+
+import _ from 'lodash'
+import React, { useState, FC, useEffect } from 'react'
+import { SkillData, SkillProps } from '../../types'
+
+const Skill: FC<SkillProps<SkillData>> = ({ onDataChanged, onValidChanged, initialData }) => {
+  const [timeoutDelay, setTimeoutDelay] = useState(0)
+  const [redirectNoAgent, setRedirectNoAgent] = useState(false)
+
+  useEffect(() => {
+    if (_.isEmpty(initialData)) {
+      return
+    }
+
+    setTimeoutDelay(initialData.timeoutDelay)
+    setRedirectNoAgent(initialData.redirectNoAgent)
+  }, [])
+
+  useEffect(() => {
+    onDataChanged({
+      timeoutDelay,
+      redirectNoAgent
+    })
+
+    onValidChanged(true)
+  }, [timeoutDelay, redirectNoAgent])
+
+  return (
+    <div>
+      <FormGroup
+        label="Delay before the user times out waiting for an agent (in seconds)"
+        helperText="Once this delay is exceeded, the agent request is aborted (0 = never timeouts)"
+      >
+        <NumericInput min={0} max={9999999} onValueChange={value => setTimeoutDelay(value)} value={timeoutDelay} />
+      </FormGroup>
+
+      <FormGroup>
+        <Checkbox
+          label="Send user to another node if no agents are online"
+          checked={redirectNoAgent}
+          onChange={e => setRedirectNoAgent(e.currentTarget.checked)}
+        ></Checkbox>
+      </FormGroup>
+    </div>
+  )
+}
+
+export default Skill

--- a/modules/hitlnext/src/views/full/app/components/HandoffList.tsx
+++ b/modules/hitlnext/src/views/full/app/components/HandoffList.tsx
@@ -25,6 +25,7 @@ const HandoffList: FC<Props> = ({ tags, handoffs, loading }) => {
     unassigned: true,
     assignedMe: true,
     assignedOther: false,
+    expired: false,
     resolved: false,
     tags: []
   })
@@ -32,9 +33,10 @@ const HandoffList: FC<Props> = ({ tags, handoffs, loading }) => {
 
   function filterBy(item: IHandoff): boolean {
     const conditions = {
-      unassigned: item.agentId == null,
+      unassigned: item.agentId == null && item.status !== 'expired',
       assignedMe: item.status === 'assigned' && item.agentId === state.currentAgent?.agentId,
       assignedOther: item.status === 'assigned' && item.agentId !== state.currentAgent?.agentId,
+      expired: item.status === 'expired',
       resolved: item.status === 'resolved'
     }
 

--- a/modules/hitlnext/src/views/full/app/components/HandoffListHeader.tsx
+++ b/modules/hitlnext/src/views/full/app/components/HandoffListHeader.tsx
@@ -10,6 +10,7 @@ export interface FilterType {
   assignedMe: boolean
   assignedOther: boolean
   resolved: boolean
+  expired: boolean
   tags: string[]
 }
 
@@ -66,6 +67,15 @@ const HandoffListHeader: FC<Props> = ({
           checked={filterOptions.resolved}
           label={lang.tr('module.hitlnext.filter.resolved')}
           onChange={() => setFilterOptions({ ...filterOptions, resolved: !filterOptions.resolved })}
+        />
+      )
+    },
+    {
+      content: (
+        <Checkbox
+          checked={filterOptions.expired}
+          label={lang.tr('module.hitlnext.filter.expired')}
+          onChange={() => setFilterOptions({ ...filterOptions, expired: !filterOptions.expired })}
         />
       )
     }

--- a/modules/hitlnext/src/views/full/index.tsx
+++ b/modules/hitlnext/src/views/full/index.tsx
@@ -1,3 +1,6 @@
 import App from './App'
 
 export default App
+
+import HitlNext from './Skill'
+export { HitlNext }

--- a/modules/hitlnext/src/views/full/typings.d.ts
+++ b/modules/hitlnext/src/views/full/typings.d.ts
@@ -1,0 +1,10 @@
+// These are properties provided by the studio
+export interface SkillProps<T> {
+  initialData: T
+  onDataChanged: (data: T) => void
+  onValidChanged: (canSubmit: boolean) => void
+  resizeBuilderWindow: (newSize: 'normal' | 'large' | 'small') => void
+  contentLang: string
+  defaultLanguage: string
+  languages: string[]
+}


### PR DESCRIPTION
Adds some features to hitl next. A skill was added so we have more control on the conversation.
- If no agent are online, redirect the user
- If the wait time is too long, redirect the user
- Fix messages not sent in the correct language
- Auto close handoff when no agent answer in the specified time

Moved some of the logic from the api file to a service file, there was way too much stuff happening there and it was hard to keep track of it...

Took inspiration from zenchat for the skill implementation so we have similar code.