### PR TITLE
fix(core): fix export with dotted folder

### DIFF
--- a/packages/bp/src/core/bpfs/drivers/disk-driver.ts
+++ b/packages/bp/src/core/bpfs/drivers/disk-driver.ts
@@ -138,7 +138,8 @@ export class DiskStorageDriver implements StorageDriver {
     const ghostIgnorePatterns = await this._getGhostIgnorePatterns(this.resolvePath('data/.ghostignore'))
     const globOptions: glob.IOptions = {
       cwd: this.resolvePath(folder),
-      dot: options.includeDotFiles
+      dot: options.includeDotFiles,
+      nodir: true
     }
 
     // options.excludes can either be a string or an array of strings or undefined


### PR DESCRIPTION
Small fix to fix the bot export. If you have a folder starting with a dot, it was considered as a file, which caused an error when exporting to an archive: 
![image](https://user-images.githubusercontent.com/42552874/166290282-57df8972-28ba-4ef4-af07-d572729b3d96.png)

Folder is considered as a file :
![image](https://user-images.githubusercontent.com/42552874/166290321-e51240c4-7622-47b9-9c93-898eb309f7d9.png)
