### PR TITLE
chore: bump messaging to v1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "version": "0.0.51"
   },
   "messaging": {
-    "version": "1.2.0"
+    "version": "1.2.3"
   },
   "scripts": {
     "postinstall": "yarn cmd postinstall",


### PR DESCRIPTION
Self-explanatory

# Changelog

### [1.2.3](https://github.com/botpress/messaging/compare/v1.2.2...v1.2.3) (2022-05-25)
### Features
* messenger: allow receiving file content elements (https://github.com/botpress/messaging/issues/480) ([cfab6a1](https://github.com/botpress/messaging/commit/cfab6a175a36dbf1589e41cee804f43b17f79e2d))

### [1.2.2](https://github.com/botpress/messaging/compare/v1.2.1...v1.2.2) (2022-04-19)
### Bug Fixes
* shutdown: fix channels not being cleared correctly (https://github.com/botpress/messaging/issues/444) ([95fde0f](https://github.com/botpress/messaging/commit/95fde0ff690a0b47f1f0cde3721c1ff44da320f0))

### [1.2.1](https://github.com/botpress/messaging/compare/v1.2.0...v1.2.1) (2022-04-12)
### Features

* channels: channel validation (https://github.com/botpress/messaging/issues/437) ([23a6990](https://github.com/botpress/messaging/commit/23a69901f1ad7e1f128bc97cb4466d1c0a4993c4))