### PR TITLE
fix(nlu): trainset hash is computed from sorted datastructure

### DIFF
--- a/modules/nlu/src/backend/application/bot/bot-state.ts
+++ b/modules/nlu/src/backend/application/bot/bot-state.ts
@@ -9,6 +9,7 @@ import { NLUClient } from '../nlu-client'
 import { mapTrainSet } from '../nlu-client/api-mapper'
 
 import { BotDefinition } from '../typings'
+import { orderKeys } from './order-keys'
 
 export class BotState {
   private _botId: string
@@ -92,7 +93,12 @@ export class BotState {
   }
 
   private _hashTrainSet = (ts: StanTrainInput): string => {
-    const content = [...ts.entities, ...ts.intents]
+    const { entities, intents } = ts
+    const content = orderKeys({
+      entities: _.orderBy(entities, e => e.name),
+      intents: _.orderBy(intents, i => i.name)
+    })
+
     return crypto
       .createHash('sha1')
       .update(JSON.stringify(content))

--- a/modules/nlu/src/backend/application/bot/order-keys.test.ts
+++ b/modules/nlu/src/backend/application/bot/order-keys.test.ts
@@ -1,0 +1,66 @@
+import { orderKeys } from './order-keys'
+
+test('order keys with primitive types return input', () => {
+  for (const x of [1, '2', true]) {
+    expect(orderKeys(x)).toBe(x)
+  }
+})
+
+test('order keys with flat objects works', () => {
+  expect(orderKeys({ d: 'd', b: 'b', a: 'a', c: 'c' })).toEqual({ a: 'a', b: 'b', c: 'c', d: 'd' })
+  expect(orderKeys({ a3: 'a', a1: 'b', a5: 'c', a2: 'd' })).toEqual({ a1: 'b', a2: 'd', a3: 'a', a5: 'c' })
+})
+
+test('order keys with nested objects works with simple example', () => {
+  const x = {
+    c: 0,
+    a: {
+      c: ['c', 'a', 'b'],
+      a: 0,
+      b: 0
+    },
+    b: 0
+  }
+
+  const expected = {
+    a: {
+      a: 0,
+      b: 0,
+      c: ['c', 'a', 'b']
+    },
+    b: 0,
+    c: 0
+  }
+
+  const actual = orderKeys(x)
+  expect(actual).toEqual(expected)
+})
+
+test('order keys with nested objects works with complex example', () => {
+  const x = {
+    d: 'd',
+    b: 'b',
+    a: {
+      a2: 'd',
+      a3: [1, 2, 3, 4, { zozo: 69, yaya: 42 }],
+      a5: 'c',
+      a1: 'b'
+    },
+    c: 'c'
+  }
+
+  const expected = {
+    a: {
+      a1: 'b',
+      a2: 'd',
+      a3: [1, 2, 3, 4, { yaya: 42, zozo: 69 }],
+      a5: 'c'
+    },
+    b: 'b',
+    c: 'c',
+    d: 'd'
+  }
+
+  const actual = orderKeys(x)
+  expect(actual).toEqual(expected)
+})

--- a/modules/nlu/src/backend/application/bot/order-keys.ts
+++ b/modules/nlu/src/backend/application/bot/order-keys.ts
@@ -1,0 +1,21 @@
+import _ from 'lodash'
+
+export const orderKeys = <T>(x: T): T => {
+  if (typeof x !== 'object') {
+    return x
+  }
+
+  for (const k in x) {
+    x[k] = orderKeys(x[k])
+  }
+
+  if (_.isArray(x)) {
+    return x
+  }
+
+  return _(x)
+    .toPairs()
+    .sortBy(0)
+    .fromPairs()
+    .value() as T
+}


### PR DESCRIPTION
This fixes the following issue:

1. use botpress with pg
2. navigate to the qna page in studio
3. open a qna, click on an utterance and click outside
4. the model appears dirty