### PR TITLE
fix(redis): improved error handling when redis is down

### DIFF
--- a/packages/bp/package.json
+++ b/packages/bp/package.json
@@ -21,7 +21,7 @@
     "@babel/parser": "^7.11.2",
     "@babel/traverse": "^7.11.0",
     "@microsoft/recognizers-text-suite": "^1.3.0",
-    "@socket.io/redis-adapter": "^7.0.1",
+    "@socket.io/redis-adapter": "^7.2.0",
     "axios": "^0.21.1",
     "bluebird-global": "^1.0.1",
     "bluebird-retry": "^0.11.0",

--- a/packages/bp/src/core/realtime/realtime-service.ts
+++ b/packages/bp/src/core/realtime/realtime-service.ts
@@ -134,8 +134,17 @@ export class RealtimeService {
 
     if (this.useRedis) {
       const redisFactory = this.monitoringService.getRedisFactory()
-
-      if (redisFactory) {
+      if (redisFactory('commands')) {
+        // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! NOTE !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        // If Redis is down for some amount of time while using the adapter, some command will reach
+        // the maximum number of retry (maxRetriesPerRequest) which will cause the redis client to throw
+        // an error. Since redis @socket.io/redis-adapter and socket.io doesn't seem to handle those errors,
+        // t's possible the we get an unhandledRejection error that is only catched at the process level!
+        // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        //
+        // TODO: There's a conflict between the typings caused by some peer dependencies
+        // Related issue: https://github.com/socketio/socket.io-redis-adapter/issues/419
+        // @ts-ignore
         io.adapter(createAdapter(redisFactory('commands'), redisFactory('socket')))
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3481,14 +3481,14 @@
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz#8863915676f837d9dad7b76f50cb500c1e9422e9"
   integrity sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==
 
-"@socket.io/redis-adapter@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@socket.io/redis-adapter/-/redis-adapter-7.0.1.tgz#e39dac4a75f48b4f77a96770c625038b167b9ad3"
-  integrity sha512-0pJRwRW7lH9FCeyMfjOry8qXemhGan2HsapkoKGzh4VkGOP/aVr1ukd5WyUOaIRSsVjBVXnYU0FJNmWAzPqaQw==
+"@socket.io/redis-adapter@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@socket.io/redis-adapter/-/redis-adapter-7.2.0.tgz#d0a1c406631bf52556073cc37b764c318efe690f"
+  integrity sha512-/r6oF6Myz0K9uatB/pfCi0BhKg/KRMh1OokrqcjlNz6aq40WiXdFLRbHJQuwGHq/KvB+D6141K+IynbVxZGvhw==
   dependencies:
     debug "~4.3.1"
     notepack.io "~2.2.0"
-    socket.io-adapter "~2.3.0"
+    socket.io-adapter "^2.4.0"
     uid2 "0.0.3"
 
 "@surma/rollup-plugin-off-main-thread@^1.1.1":
@@ -21304,7 +21304,12 @@ snarkdown@^1.2.2:
   resolved "https://registry.npmjs.org/snarkdown/-/snarkdown-1.2.2.tgz#0cfe2f3012b804de120fc0c9f7791e869c59cc74"
   integrity sha1-DP4vMBK4BN4SD8DJ93kehpxZzHQ=
 
-socket.io-adapter@~2.3.0, socket.io-adapter@~2.3.2:
+socket.io-adapter@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz#b50a4a9ecdd00c34d4c8c808224daa1a786152a6"
+  integrity sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==
+
+socket.io-adapter@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.3.2.tgz#039cd7c71a52abad984a6d57da2c0b7ecdd3c289"
   integrity sha512-PBZpxUPYjmoogY0aoaTmo1643JelsaS1CiAwNjRVdrI0X9Seuc19Y2Wife8k88avW6haG8cznvwbubAZwH4Mtg==


### PR DESCRIPTION
This PR aims at improving the error handling when Redis goes down. The behavior we had prior to this PR was that the web worker would crash in loop because errors were only caught by the `uncaughtException` process handler ([which calls `process.exit(1)`](https://github.com/botpress/botpress/blob/master/packages/bp/src/index.ts#L69)).

Closes botpress/v12#1633

Related PR on botpress-pro: https://github.com/botpress/botpress-pro/pull/72