### PR TITLE
chore(botpress): bump to v12.28.0

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botpress",
-  "version": "12.27.0",
+  "version": "12.28.0",
   "description": "The world's most powerful conversational engine",
   "main": "index.js",
   "bin": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bp_main",
-  "version": "12.27.0",
+  "version": "12.28.0",
   "description": "The world's most powerful conversational engine",
   "engines": {
     "node": "^12"


### PR DESCRIPTION
Bump Botpress to v12.28.0 in preparation for the new release.