### PR TITLE
Add guard clause in auth-service.ts

### DIFF
--- a/packages/bp/src/core/security/auth-service.ts
+++ b/packages/bp/src/core/security/auth-service.ts
@@ -107,6 +107,9 @@ export class AuthService {
 
   async generateSecureToken(email: string, strategy: string) {
     const config = await this.configProvider.getBotpressConfig()
+    if (!config.pro.collaboratorsAuthStrategies || !config.pro.collaboratorsAuthStrategies.length) {
+      throw new Error('There must be at least one collaborator authentication strategy configured.')
+    }
     const isGlobalStrategy = config.pro.collaboratorsAuthStrategies.includes(strategy)
     const user = await this.users.findUser(email, strategy)
 


### PR DESCRIPTION
Adding this Guard Clause should make the issue clearer -
Instead of throwing "TypeError: Cannot read property 'includes' of undefined"

Refs: https://support.botpress.com/support/tickets/3318 @ptrckbp please create a test release