### PR TITLE
fix(hitlnext): fix error when creating handoff from converse

### DIFF
--- a/modules/hitlnext/src/backend/api.ts
+++ b/modules/hitlnext/src/backend/api.ts
@@ -56,7 +56,7 @@ export default async (bp: typeof sdk, state: StateType, repository: Repository) 
     return (req: BPRequest, res: Response, next) => {
       Promise.resolve(fn(req as BPRequest, res, next)).catch(err => {
         if (err instanceof Joi.ValidationError) {
-          throw new UnprocessableEntityError(formatValidationError(err))
+          next(new UnprocessableEntityError(formatValidationError(err)))
         } else {
           next(err)
         }


### PR DESCRIPTION
This PR fixes an issue where creating a handoff from the Converse API would result in the request never being sent back and the server receiving an unhandled exception. 

The reason is that the Converse API first creates an event with no conversation ID, which then makes the call to create a handoff fail its validation. The middleware that handles the errors would then throw instead of passing the error to the next middleware. With Express V4.X, when an exception is thrown in a handler, a unhandledRejection error is then sent to the main process which results in the error above with no further details:

![Screenshot from 2022-06-28 16-22-07](https://user-images.githubusercontent.com/9640576/176277764-4627e119-d88c-4fce-80a3-6c815331fa9c.png)

To reproduce the issue, create an empty bot called `test` and add a single node that calls the HITLNext action to create a new handoff, and call the bot using the Converse API like so:

```curl
POST http://localhost:3000/api/v1/bots/test/converse/12345
{
	"type": "text",
	"text": "<img src=x onerror=alert('XSS-from-public')>"
}
```

As you will notice after testing this bugfix, it doesn't solve the whole problem where the Converse API does not create an event with a thread id. This will be fixed in another PR.
