### PR TITLE
fix(hitlnext): do not to create a handoff when event comes from converse

### DIFF
--- a/modules/hitlnext/src/actions/handoff.js
+++ b/modules/hitlnext/src/actions/handoff.js
@@ -9,6 +9,18 @@ const axios = require('axios')
  * @author Botpress, Inc.
  */
 const escalate = async (event, timeoutDelay) => {
+  // The HITLNext module is not compatible with the Converse API since the
+  // former is asynchronous and the latter is synchronous.
+  if (event.channel === 'api') {
+    bp.logger
+      .forBot(event.botId)
+      .warn(
+        "HITLNext: The event was created by the Converse API, it will be discarded (no handoff will be created) since it's incompatible with the module."
+      )
+
+    return
+  }
+
   const axiosConfig = await bp.http.getAxiosConfigForBot(event.botId, { localUrl: true })
   await axios.post(
     '/mod/hitlnext/handoffs',

--- a/modules/hitlnext/src/backend/api.ts
+++ b/modules/hitlnext/src/backend/api.ts
@@ -56,7 +56,7 @@ export default async (bp: typeof sdk, state: StateType, repository: Repository) 
     return (req: BPRequest, res: Response, next) => {
       Promise.resolve(fn(req as BPRequest, res, next)).catch(err => {
         if (err instanceof Joi.ValidationError) {
-          throw new UnprocessableEntityError(formatValidationError(err))
+          next(new UnprocessableEntityError(formatValidationError(err)))
         } else {
           next(err)
         }


### PR DESCRIPTION
This PR fixes an issue where we would attempt to create a handoff when an event was created by the Converse API. This would result in the action throwing an error since an event created by the converse does not contain any `threadId`. Furthermore, the Converse API is simply incompatible with the module since the former is sync and the latter async.

Related to: https://github.com/botpress/botpress/pull/11921

To reproduce, follow the steps on [this PR](https://github.com/botpress/botpress/pull/11921)