### PR TITLE
feat(docker): configure botpress user for the docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,6 +63,7 @@ jobs:
           yarn run build --linux --prod --verbose
           yarn run package --linux
           cp build/docker/Dockerfile packages/bp/binaries/
+          cp build/docker/docker-entrypoint.sh packages/bp/binaries/
       - name: DockerHub Authentication
         uses: docker/login-action@v1
         if: ${{ steps.prep.outputs.release }}

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -18,8 +18,7 @@ RUN chmod +x duckling && \
 RUN groupadd -g 999 botpress && \
     useradd -m -r -u 999 -g botpress botpress
 
-RUN chgrp -R botpress /botpress && \
-	chmod -R g=u /botpress
+RUN chown -R botpress:botpress /botpress
 
 ENV BP_MODULE_NLU_DUCKLINGURL=http://localhost:8000
 ENV BP_IS_DOCKER=true

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -7,20 +7,26 @@ RUN apt update && \
 	apt install -y wget ca-certificates && \
 	update-ca-certificates && \
 	wget -O duckling https://s3.amazonaws.com/botpress-binaries/duckling-example-exe && \
-	chmod +x duckling && \
-	chmod +x bp && \
-	chgrp -R 0 /botpress && \
-	chmod -R g=u /botpress && \
 	apt install -y tzdata && \
 	ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
-	dpkg-reconfigure --frontend noninteractive tzdata && \
+	dpkg-reconfigure --frontend noninteractive tzdata
+
+RUN chmod +x duckling && \
+	chmod +x bp && \
 	./bp extract
 
+RUN groupadd -g 999 botpress && \
+    useradd -m -r -u 999 -g botpress botpress
+
+RUN chgrp -R botpress /botpress && \
+	chmod -R g=u /botpress
 
 ENV BP_MODULE_NLU_DUCKLINGURL=http://localhost:8000
 ENV BP_IS_DOCKER=true
 
 ENV LANG=C.UTF-8
 EXPOSE 3000
+
+USER botpress
 
 CMD ./duckling & ./bp

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,7 +1,12 @@
 FROM ubuntu:20.04
 
-ADD . /botpress
-WORKDIR /botpress
+ENV BP_WORKDIR=/botpress
+ENV BP_USER=botpress
+ENV BP_GROUP=botpress
+ENV BP_DATA_PATH $BP_WORKDIR/data
+
+ADD . $BP_WORKDIR
+WORKDIR $BP_WORKDIR
 
 RUN apt update && \
 	apt install -y wget ca-certificates && \
@@ -11,14 +16,16 @@ RUN apt update && \
 	ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
 	dpkg-reconfigure --frontend noninteractive tzdata
 
-RUN chmod +x duckling && \
-	chmod +x bp && \
-	./bp extract
+RUN chmod +x duckling && chmod +x bp
 
-RUN groupadd -g 999 botpress && \
-    useradd -m -r -u 999 -g botpress botpress
+RUN ./bp extract
 
-RUN chown -R botpress:botpress /botpress
+# Creates botpress user and group
+RUN groupadd -g 999 $BP_GROUP && \
+    useradd -m -r -u 999 -g $BP_GROUP $BP_USER
+
+# Sets ownership of the workdir to the botpress user
+RUN chown -R $BP_USER:$BP_GROUP $BP_WORKDIR
 
 ENV BP_MODULE_NLU_DUCKLINGURL=http://localhost:8000
 ENV BP_IS_DOCKER=true
@@ -26,6 +33,7 @@ ENV BP_IS_DOCKER=true
 ENV LANG=C.UTF-8
 EXPOSE 3000
 
-USER botpress
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
 
-CMD ./duckling & ./bp
+CMD su - botpress -c "$BP_WORKDIR/duckling & $BP_WORKDIR/bp"

--- a/build/docker/docker-entrypoint.sh
+++ b/build/docker/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Creates the Botpress data folder and sets botpress as the owner
+mkdir -p $BP_DATA_PATH;
+chown -R $BP_USER:$BP_GROUP $BP_DATA_PATH;
+
+# Executes the command (CMD) passed to the container
+exec "$@";

--- a/packages/bp/package.json
+++ b/packages/bp/package.json
@@ -51,6 +51,7 @@
     "https-proxy-agent": "^2.2.3",
     "intl-messageformat": "^2.2.0",
     "inversify": "^4.13.0",
+    "is-elevated": "^3.0.0",
     "json-schema-defaults": "^0.4.0",
     "jsonlint-mod": "^1.7.6",
     "jsonwebtoken": "^8.5.1",
@@ -106,6 +107,7 @@
     "joi": "^13.6.0"
   },
   "devDependencies": {
+    "@types/is-elevated": "^2.0.0",
     "@types/mustache": "^4.1.2"
   },
   "optionalDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3908,6 +3908,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/is-elevated@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/is-elevated/-/is-elevated-2.0.0.tgz#783a70e7226241a4e4f4918d3450f0e404f33c63"
+  integrity sha512-vhf0oGLj1/oGs8YnqSrmUJ+BGpNtiJlnNUj4P2ywiBRCkkWL/wrSF+ineCbonKtSVDmIjEIu6amLY1hYmD3mYQ==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -12863,6 +12868,13 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-admin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-admin/-/is-admin-3.0.0.tgz#5c6077fd235e056c3dbc0b6f1bbd23ff96e97135"
+  integrity sha512-wOa3CXFJAu8BZ2BDtG9xYOOrsq6oiSvc2jFPy4X/HINx5bmJUcW8e+apItVbU2E7GIfBVaFVO7Zit4oAWtTJcw==
+  dependencies:
+    execa "^1.0.0"
+
 is-any-array@^0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/is-any-array/-/is-any-array-0.0.3.tgz#cbdd8c7189d47b53b050969245f4ef7e55550b9b"
@@ -13020,6 +13032,14 @@ is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
   integrity sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=
+
+is-elevated@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-elevated/-/is-elevated-3.0.0.tgz#f0de684f89b5144179ae1729ba8af590b8e0cecb"
+  integrity sha512-wjcp6RkouU9jpg55zERl+BglvV5j4jx5c/EMvQ+d12j/+nIEenNWPu+qc0tCg3JkLodbKZMg1qhJzEwG4qjclg==
+  dependencies:
+    is-admin "^3.0.0"
+    is-root "^2.1.0"
 
 is-equal-shallow@^0.1.3:
   version "0.1.3"
@@ -13266,7 +13286,7 @@ is-retry-allowed@^2.2.0:
   resolved "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz#88f34cbd236e043e71b6932d09b0c65fb7b4d71d"
   integrity sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==
 
-is-root@2.1.0:
+is-root@2.1.0, is-root@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz#809e18129cf1129644302a4f8544035d51984a9c"
   integrity sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==


### PR DESCRIPTION
This PR adds the config to set and use the Botpress user inside the Dockerfile.

It also adds a warning in case a user is running Botpress as a privileged user:

![Screenshot from 2022-07-13 11-11-14](https://user-images.githubusercontent.com/9640576/178768606-0ef3bc04-ceb2-4a8e-bd3f-0cee3f5bbad4.png)

Related PR: https://github.com/botpress/documentation/pull/76