### PR TITLE
fix(channel-web): escape html chars from messages

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/Message.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/Message.tsx
@@ -33,6 +33,7 @@ class Message extends Component<MessageProps> {
         intl={this.props.intl}
         maxLength={this.props.payload.trimLength}
         escapeHTML={this.props.store.escapeHTML}
+        isBotMessage={this.props.isBotMessage}
       />
     )
   }

--- a/modules/channel-web/src/views/lite/components/messages/renderer/Text.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/renderer/Text.tsx
@@ -28,8 +28,10 @@ export const Text = (props: Renderer.Text) => {
 
   let message
   if (markdown) {
-    // we always escape user messages
-    const html = renderUnsafeHTML(text, props.isBotMessage ? escapeHTML : true)
+    const isUserMessage = !props.isBotMessage
+    const shouldEscapeHTML = isUserMessage || escapeHTML
+    const html = renderUnsafeHTML(text, shouldEscapeHTML)
+
     message = <div dangerouslySetInnerHTML={{ __html: truncateIfRequired(html) }} />
   } else {
     message = <p>{truncateIfRequired(text)}</p>

--- a/modules/channel-web/src/views/lite/components/messages/renderer/Text.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/renderer/Text.tsx
@@ -26,14 +26,11 @@ export const Text = (props: Renderer.Text) => {
     return hasShowMore && !showMore ? truncate(message, maxLength) : message
   }
 
-  const escapeHtmlChars = (str: string) => {
-    return str.replace(/>/g, '&gt;').replace(/</g, '&lt;')
-  }
-
   let message
   if (markdown) {
-    const html = renderUnsafeHTML(text, escapeHTML)
-    message = <div dangerouslySetInnerHTML={{ __html: truncateIfRequired(escapeHtmlChars(html)) }} />
+    // we always escape user messages
+    const html = renderUnsafeHTML(text, props.isBotMessage ? escapeHTML : true)
+    message = <div dangerouslySetInnerHTML={{ __html: truncateIfRequired(html) }} />
   } else {
     message = <p>{truncateIfRequired(text)}</p>
   }

--- a/modules/channel-web/src/views/lite/components/messages/renderer/Text.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/renderer/Text.tsx
@@ -26,10 +26,14 @@ export const Text = (props: Renderer.Text) => {
     return hasShowMore && !showMore ? truncate(message, maxLength) : message
   }
 
+  const escapeHtmlChars = (str: string) => {
+    return str.replace(/>/g, '&gt;').replace(/</g, '&lt;')
+  }
+
   let message
   if (markdown) {
     const html = renderUnsafeHTML(text, escapeHTML)
-    message = <div dangerouslySetInnerHTML={{ __html: truncateIfRequired(html) }} />
+    message = <div dangerouslySetInnerHTML={{ __html: truncateIfRequired(escapeHtmlChars(html)) }} />
   } else {
     message = <p>{truncateIfRequired(text)}</p>
   }


### PR DESCRIPTION
This PR makes sure that we escape HTML chars from the channel-web when displaying text entries