### PR TITLE
feat(runtime): prefix Action and Hook logs with botId

### DIFF
--- a/packages/bp/src/core/user-code/action-service.ts
+++ b/packages/bp/src/core/user-code/action-service.ts
@@ -337,17 +337,12 @@ export class ScopedActionService {
 
     const vm = new NodeVM({
       wrapper: 'none',
-      console: 'redirect',
       sandbox: args,
       require: {
         external: true,
         mock: modRequire
       },
       timeout: 5000
-    })
-
-    vm.on('console.log', (data) => {
-      console.log(`botid=${this.botId} ${data}`)
     })
 
     const runner = new VmRunner()

--- a/packages/bp/src/core/user-code/action-service.ts
+++ b/packages/bp/src/core/user-code/action-service.ts
@@ -328,7 +328,6 @@ export class ScopedActionService {
   }
 
   private async _runInVm(code: string, dirPath: string, args: any, _require: Function) {
-    console.log('SPG RUNNING')
     const modRequire = new Proxy(
       {},
       {

--- a/packages/bp/src/core/user-code/action-service.ts
+++ b/packages/bp/src/core/user-code/action-service.ts
@@ -328,6 +328,7 @@ export class ScopedActionService {
   }
 
   private async _runInVm(code: string, dirPath: string, args: any, _require: Function) {
+    console.log('SPG RUNNING')
     const modRequire = new Proxy(
       {},
       {
@@ -337,12 +338,17 @@ export class ScopedActionService {
 
     const vm = new NodeVM({
       wrapper: 'none',
+      console: 'redirect',
       sandbox: args,
       require: {
         external: true,
         mock: modRequire
       },
       timeout: 5000
+    })
+
+    vm.on('console.log', (data) => {
+      console.log(`botid=${this.botId} ${data}`)
     })
 
     const runner = new VmRunner()

--- a/packages/runtime/src/runtime/user-code/action-service.ts
+++ b/packages/runtime/src/runtime/user-code/action-service.ts
@@ -30,7 +30,8 @@ import {
   isTrustedAction,
   prepareRequire,
   prepareRequireTester,
-  runOutsideVm
+  runOutsideVm,
+  interceptConsole
 } from './utils'
 import { VmRunner } from './vm'
 
@@ -61,7 +62,7 @@ export class ActionService {
     @inject(TYPES.Logger)
     @tagged('name', 'ActionService')
     private logger: Logger
-  ) {}
+  ) { }
 
   public forBot(botId: string): ScopedActionService {
     if (this._scopedActions.has(botId)) {
@@ -99,7 +100,7 @@ export class ScopedActionService {
     private botId: string,
     private tasksRepository: TasksRepository,
     private workspaceId: string
-  ) {}
+  ) { }
 
   public clearRequireCache() {
     this._scriptsCache.clear()
@@ -318,6 +319,7 @@ export class ScopedActionService {
     )
 
     const vm = new NodeVM({
+      console: 'redirect',
       wrapper: 'none',
       sandbox: args,
       require: {
@@ -326,6 +328,8 @@ export class ScopedActionService {
       },
       timeout: 5000
     })
+
+    interceptConsole(vm, this.botId)
 
     const runner = new VmRunner()
     return runner.runInVm(vm, code, dirPath)

--- a/packages/runtime/src/runtime/user-code/utils.ts
+++ b/packages/runtime/src/runtime/user-code/utils.ts
@@ -73,3 +73,21 @@ export const actionServerIdRegex = /^[a-zA-Z0-9]*$/
 export const runOutsideVm = (scope: ActionScope): boolean => {
   return (process.DISABLE_GLOBAL_SANDBOX && scope === 'global') || (process.DISABLE_BOT_SANDBOX && scope !== 'global')
 }
+
+export const interceptConsole = (vm, botId: string) => {
+  const formatLine = (data: any) => `botid=${botId} ${data}`
+
+  vm.on('console.log', data => {
+    // eslint-disable-next-line no-console
+    console.log(formatLine(data))
+  })
+  vm.on('console.info', data => {
+    console.info(formatLine(data))
+  })
+  vm.on('console.warn', data => {
+    console.warn(formatLine(data))
+  })
+  vm.on('console.error', data => {
+    console.error(formatLine(data))
+  })
+}


### PR DESCRIPTION
Adds a `botid=${botid}` prefix to log lines for Actions and hooks
This will be useful to retrieve logs in the Cloud for the current bot