### PR TITLE
chore(server): bump studio to v0.0.54 and prepare for patch release

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botpress",
-  "version": "12.28.0",
+  "version": "12.28.1",
   "description": "The world's most powerful conversational engine",
   "main": "index.js",
   "bin": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bp_main",
-  "version": "12.28.0",
+  "version": "12.28.1",
   "description": "The world's most powerful conversational engine",
   "engines": {
     "node": "^12"
@@ -14,7 +14,7 @@
     "version": "1.0.1"
   },
   "studio": {
-    "version": "0.0.52"
+    "version": "0.0.53"
   },
   "messaging": {
     "version": "1.2.3"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "version": "1.0.1"
   },
   "studio": {
-    "version": "0.0.53"
+    "version": "0.0.54"
   },
   "messaging": {
     "version": "1.2.3"

--- a/packages/bp/src/core/realtime/realtime-service.ts
+++ b/packages/bp/src/core/realtime/realtime-service.ts
@@ -1,4 +1,4 @@
-import { createAdapter, RedisAdapter } from '@socket.io/redis-adapter'
+dimport { createAdapter, RedisAdapter } from '@socket.io/redis-adapter'
 import { Logger } from 'botpress/sdk'
 import cookie from 'cookie'
 import { TYPES } from 'core/app/types'
@@ -129,6 +129,7 @@ export class RealtimeService {
       path: `${process.ROOT_PATH}/socket.io`,
       cors: { origin: '*' },
       serveClient: false,
+      allowEIO3: true,
       transports
     })
 


### PR DESCRIPTION
Bumps the studio bin to its latest version ([v0.0.54](https://github.com/botpress/studio/releases/tag/v0.0.54)) and prepares Botpress for the next patch release.