### PR TITLE
chore(server): bump botpress to 12.28.2 and add missing messaging mig

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botpress",
-  "version": "12.28.1",
+  "version": "12.28.2",
   "description": "The world's most powerful conversational engine",
   "main": "index.js",
   "bin": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bp_main",
-  "version": "12.28.1",
+  "version": "12.28.2",
   "description": "The world's most powerful conversational engine",
   "engines": {
     "node": "^12"

--- a/packages/bp/src/migrations/v12_28_0-1662113636-bump_messaging.ts
+++ b/packages/bp/src/migrations/v12_28_0-1662113636-bump_messaging.ts
@@ -1,0 +1,21 @@
+import * as sdk from 'botpress/sdk'
+import { Migration, MigrationOpts } from 'core/migration'
+import { runMessagingMigration } from 'orchestrator/messaging-server'
+
+const migration: Migration = {
+  info: {
+    description: 'Migrates the messaging database from 1.2.0 to 1.2.3',
+    target: 'core',
+    type: 'database'
+  },
+
+  up: async ({ metadata }: MigrationOpts): Promise<sdk.MigrationResult> => {
+    return runMessagingMigration('up', '1.2.3', metadata.isDryRun)
+  },
+
+  down: async ({ metadata }: MigrationOpts): Promise<sdk.MigrationResult> => {
+    return runMessagingMigration('down', '1.2.0', metadata.isDryRun)
+  }
+}
+
+export default migration


### PR DESCRIPTION
This PR bumps the Botpress server to its next patch release version and also adds a missing Messaging migration that was supposed to be added with 12.28.0