### PR TITLE
chore: health now returns data for only specified workspace

### DIFF
--- a/packages/bp/src/admin/workspace/bots/bots-router.ts
+++ b/packages/bp/src/admin/workspace/bots/bots-router.ts
@@ -262,7 +262,7 @@ class BotsRouter extends CustomAdminRouter {
       '/health',
       this.needPermissions('read', this.resource),
       this.asyncMiddleware(async (req, res) => {
-        return sendSuccess(res, 'Retrieved bot health', await this.botService.getBotHealth())
+        return sendSuccess(res, 'Retrieved bot health', await this.botService.getBotHealth(req.workspace || 'default'))
       })
     )
 


### PR DESCRIPTION
I use a simple filter, using _.pick with the botIds that are in the workspace. simple enough