### PR TITLE
fix(code-editor): remove current value from env var typings

### DIFF
--- a/modules/code-editor/src/backend/utils.ts
+++ b/modules/code-editor/src/backend/utils.ts
@@ -110,16 +110,12 @@ export const buildRestrictedProcessVars = () => {
   declare var process: RestrictedProcess;
   interface RestrictedProcess {
     ${root.map(x => {
-      return `/** Current value: ${x.value} */
-${x.name}: ${x.type}
-`
+      return `${x.name}: ${x.type}`
     })}
 
     env: {
       ${exposed.map(x => {
-        return `/** Current value: ${x.value} */
-${x.name}: ${x.type}
-`
+        return `${x.name}: ${x.type}`
       })}
     }
   }`


### PR DESCRIPTION
This PR simply removes the current value from the typings of environment variables in the code editor.