### PR TITLE
fix(admin): log the user out when account is locked out on pass change

### DIFF
--- a/packages/bp/src/core/security/strategy-basic.ts
+++ b/packages/bp/src/core/security/strategy-basic.ts
@@ -172,14 +172,8 @@ export class StrategyBasic {
       debug('login failed; user does not exist %o', { email, ipAddress })
       throw new InvalidCredentialsError()
     }
-    const strategyOptions = _.get(await this.authService.getStrategy(strategy), 'options') as AuthStrategyBasic
-    if (!validateHash(password || '', user.password!, user.salt!)) {
-      debug('login failed; wrong password %o', { email, ipAddress })
-      // this.stats.track('auth', 'login', 'fail')
 
-      await this._incrementWrongPassword(user, strategyOptions)
-      throw new InvalidCredentialsError()
-    }
+    const strategyOptions = _.get(await this.authService.getStrategy(strategy), 'options') as AuthStrategyBasic
     const { locked_out, last_login_attempt, password_expiry_date, password_expired } = user.attributes
 
     if (locked_out) {
@@ -190,6 +184,14 @@ export class StrategyBasic {
         debug('login failed; user locked out %o', { email, ipAddress })
         throw new LockedOutError()
       }
+    }
+
+    if (!validateHash(password || '', user.password!, user.salt!)) {
+      debug('login failed; wrong password %o', { email, ipAddress })
+      // this.stats.track('auth', 'login', 'fail')
+
+      await this._incrementWrongPassword(user, strategyOptions)
+      throw new InvalidCredentialsError()
     }
 
     const isDateExpired = password_expiry_date && moment().isAfter(password_expiry_date)

--- a/packages/ui-admin/src/user/UpdatePassword.tsx
+++ b/packages/ui-admin/src/user/UpdatePassword.tsx
@@ -1,5 +1,5 @@
 import { Button, Classes, Dialog, FormGroup, InputGroup, Intent } from '@blueprintjs/core'
-import { lang, toast } from 'botpress/shared'
+import { lang, toast, auth } from 'botpress/shared'
 import { UserProfile } from 'common/typings'
 import React, { FC, useState } from 'react'
 import api from '~/app/api'
@@ -20,14 +20,25 @@ const UpdatePassword: FC<Props> = props => {
     event.preventDefault()
 
     const { strategyType, strategy, email } = props.profile
+    const client = api.getSecured()
 
     try {
-      await api.getSecured().post(`/admin/auth/login/${strategyType}/${strategy}`, { email, password, newPassword })
+      await client.post(`/admin/auth/login/${strategyType}/${strategy}`, { email, password, newPassword })
 
       props.toggle()
       toast.success(lang.tr('admin.passwordUpdatedSuccessfully'))
     } catch (err) {
-      toast.failure(lang.tr('admin.errorUpdatingPassword', { msg: err.message }))
+      const { errorCode, message } = err
+
+      toast.failure(lang.tr('admin.errorUpdatingPassword', { msg: message }))
+
+      // BP_0011 = LockedOutError
+      if (errorCode === 'BP_0011') {
+        // Let the user see the toast before logging him out
+        setTimeout(() => {
+          auth.logout(() => client)
+        }, 1000)
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes an issue where the user was not logged out when trying to update his password with the wrong current password too many times.

When `maxLoginAttemps` is set, we lock an account in case of multiple unsuccessful login attempts in a row. If this happens on the admin when the user updates his password, it makes sense to log the user out and invalidate his token.

**before**

https://user-images.githubusercontent.com/9640576/179610491-57ce599a-47ae-4cb0-aa30-f3ab2ad6c2c2.mp4

**after**

https://user-images.githubusercontent.com/9640576/179610189-de059fc2-cfc3-45a0-8706-5793a7be32bf.mp4

