### PR TITLE
fix(google-speech): error when detecting SSML

### DIFF
--- a/modules/google-speech/src/backend/client.ts
+++ b/modules/google-speech/src/backend/client.ts
@@ -205,7 +205,7 @@ export class GoogleSpeechClient {
   ): Promise<Uint8Array | string | undefined> {
     debugTextToSpeech(`Received text to convert into audio: ${text}`)
 
-    const hasSSML = !!text.match(/<speak>.*<\/speak>/g).length
+    const hasSSML = !!text.match(/<speak>.*<\/speak>/g)
 
     const request: ISynthesizeSpeechRequest = {
       input: hasSSML ? { ssml: text } : { text },

--- a/modules/google-speech/src/backend/client.ts
+++ b/modules/google-speech/src/backend/client.ts
@@ -205,7 +205,7 @@ export class GoogleSpeechClient {
   ): Promise<Uint8Array | string | undefined> {
     debugTextToSpeech(`Received text to convert into audio: ${text}`)
 
-    const hasSSML = !!text.match(/<speak>.*<\/speak>/g)
+    const hasSSML = !!text.match(/<speak>.*<\/speak>/g)?.length
 
     const request: ISynthesizeSpeechRequest = {
       input: hasSSML ? { ssml: text } : { text },


### PR DESCRIPTION
This fixes an issue with SSML detection, text.match will return null instead of an empty array if nothing matches