### PR TITLE
chore(studio): add typings for previewElements

### DIFF
--- a/packages/bp/src/core/dialog/skill-service.ts
+++ b/packages/bp/src/core/dialog/skill-service.ts
@@ -21,7 +21,11 @@ export class SkillService {
     }
 
     // TODO change when studio is updated, since actual doesn't support catchall
-    return { flow: completeFlow, transitions: partialFlow.transitions }
+    return {
+      flow: completeFlow,
+      transitions: partialFlow.transitions,
+      ...(partialFlow.previewElements && { preview: partialFlow.previewElements })
+    }
   }
 
   private parseActionQuery(nodes): string[] | undefined {

--- a/packages/bp/src/sdk/botpress.d.ts
+++ b/packages/bp/src/sdk/botpress.d.ts
@@ -1199,6 +1199,8 @@ declare module 'botpress/sdk' {
     flow: SkillFlow
     /** An array of possible transitions for the parent node */
     transitions: NodeTransition[]
+    /** Elements to be previewed in the skill node */
+    previewElements?: string[] | null
   }
 
   /**


### PR DESCRIPTION
Related to https://github.com/botpress/studio/pull/382

Add typings so its possible to compile custom modules without typing erros