### PR TITLE
fix(security): only Super Admins can reboot the server

### DIFF
--- a/packages/bp/src/admin/management/management-router.ts
+++ b/packages/bp/src/admin/management/management-router.ts
@@ -71,6 +71,7 @@ class ManagementRouter extends CustomAdminRouter {
 
     this.router.post(
       '/rebootServer',
+      assertSuperAdmin,
       this.asyncMiddleware(async (req, res) => {
         const user = req.tokenUser!.email
         const config = await this.configProvider.getBotpressConfig()


### PR DESCRIPTION
This PR improves the security by only allowing the Super Admins to reboot the server.

To test: 
- First, run this branch. 
- Then create an admin, a developer, a content editor, or an agent. 
- Login as the user and fetch its token
- Make a POST call to `http://localhost:3000/api/v1/admin/server/rebootServer` using the token to authenticate and see the 403 error code returned.