### PR TITLE
fix(channel-web): dropdown should disable composer

### DIFF
--- a/packages/ui-shared-lite/Payloads/index.ts
+++ b/packages/ui-shared-lite/Payloads/index.ts
@@ -72,7 +72,8 @@ const renderChoicePayload = (content: sdk.ChoiceContent & ExtraChoiceProperties)
       displayInKeyboard: true,
       options: content.choices.map(c => ({ label: c.title, value: c.value.toUpperCase() })),
       width: 300,
-      placeholderText: content.dropdownPlaceholder
+      placeholderText: content.dropdownPlaceholder,
+      disableFreeText: content.disableFreeText
     }
   }
   return {


### PR DESCRIPTION
This fixes an issue where the composer would not be disabled if the single choice is using dropdowns while having the Disable free text option enabled.

![image](https://user-images.githubusercontent.com/13484138/186751329-231512cf-4832-4f89-acf0-be719f5dc4c2.png)

Before: 

![image](https://user-images.githubusercontent.com/13484138/186751519-ea79ffd8-d184-466c-9277-6d3c37cc5c62.png)

After:

![image](https://user-images.githubusercontent.com/13484138/186751670-76f47d41-2f55-4629-9475-31dd91c68ea3.png)


https://github.com/botpress/v12/issues/1632