### PR TITLE
fix(dockerfile): revert workaround and use proper solution

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,7 +63,6 @@ jobs:
           yarn run build --linux --prod --verbose
           yarn run package --linux
           cp build/docker/Dockerfile packages/bp/binaries/
-          cp build/docker/docker-entrypoint.sh packages/bp/binaries/
       - name: DockerHub Authentication
         uses: docker/login-action@v1
         if: ${{ steps.prep.outputs.release }}

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -33,9 +33,6 @@ ENV BP_IS_DOCKER=true
 ENV LANG=C.UTF-8
 EXPOSE 3000
 
-COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+USER $BP_USER
 
-# '-p' preserves the environment variables when login in the new shell.
-# That's why we need to re-define the HOME and PWD variables.
-CMD su -p botpress -c "HOME=/home/$BP_USER; PWD=$BP_WORKDIR; $BP_WORKDIR/duckling & $BP_WORKDIR/bp"
+CMD ./duckling & ./bp

--- a/build/docker/docker-entrypoint.sh
+++ b/build/docker/docker-entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Creates the Botpress data folder and sets botpress as the owner
-mkdir -p $BP_DATA_PATH;
-chown -R $BP_USER:$BP_GROUP $BP_DATA_PATH;
-
-# Executes the command (CMD) passed to the container
-exec "$@";


### PR DESCRIPTION
This PR improves the Dockerfile for Botpress by using the `USER` command instead of the hack that starts a new shell with the botpress user.

 There is no difference for most users between the two solutions. Both are nonbreaking and simply improve the security of the image. *But* users that were using local mounts would need to follow a migration path before using the new images (this will be explained in the release note).