### PR TITLE
fix(channel-web): focus composer when single choice btn is clicked

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/renderer/QuickReplies.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/renderer/QuickReplies.tsx
@@ -16,13 +16,18 @@ import { Button } from './Button'
  */
 export class QuickReplies extends Component<Renderer.QuickReply> {
   handleButtonClicked = (title, payload) => {
+    this.props.store.view.setFocus('button')
+
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.props.onSendData?.({
       type: 'quick_reply',
       text: title,
       payload
     })
+
     this.props.store.composer.setLocked(false)
+    // Set focus back to composer input
+    this.props.store.view.setFocus('input')
   }
 
   renderKeyboard(buttons: Renderer.QuickReplyButton[]) {


### PR DESCRIPTION
This PR fixes an issue in the channel-web where the composer would lose focus after a button is clicked when selecting a choice. 

_Note that this issue would only happen when the composer is unlocked_ 

**Before**

https://user-images.githubusercontent.com/9640576/187728107-5774051e-7ce8-4995-b8fa-1cf7485b331b.mp4

**After**

https://user-images.githubusercontent.com/9640576/187728132-59a6079a-5cdf-454d-94ac-82b033cffe2a.mp4

