### PR TITLE
fix: skills rendering

### DIFF
--- a/modules/basic-skills/package.json
+++ b/modules/basic-skills/package.json
@@ -8,10 +8,8 @@
   "main": "dist/backend/index.js",
   "webpack": {
     "externals": {
-      "reactstrap": "Reactstrap",
       "react-select": "ReactSelect",
-      "botpress/select-action-dropdown": "SelectActionDropdown",
-      "botpress/tooltip": "BotpressTooltip"
+      "botpress/select-action-dropdown": "SelectActionDropdown"
     }
   },
   "scripts": {
@@ -24,8 +22,7 @@
   "devDependencies": {
     "@babel/helpers": "^7.4.3",
     "@types/nodemailer": "^6.2.1",
-    "@types/react-bootstrap": "^0.32.20",
-    "@types/reactstrap": "^8.4.1"
+    "@types/react-bootstrap": "^0.32.20"
   },
   "dependencies": {
     "bluebird": "^3.5.3",

--- a/modules/basic-skills/package.json
+++ b/modules/basic-skills/package.json
@@ -21,8 +21,7 @@
   "license": "AGPL-3.0-only",
   "devDependencies": {
     "@babel/helpers": "^7.4.3",
-    "@types/nodemailer": "^6.2.1",
-    "@types/react-bootstrap": "^0.32.20"
+    "@types/nodemailer": "^6.2.1"
   },
   "dependencies": {
     "bluebird": "^3.5.3",

--- a/modules/basic-skills/src/views/full/TipLabel.tsx
+++ b/modules/basic-skills/src/views/full/TipLabel.tsx
@@ -1,0 +1,21 @@
+import { Label, Tooltip, Position, Icon } from '@blueprintjs/core'
+import React from 'react'
+
+import style from './style.scss'
+
+interface Props {
+  htmlFor: string
+  labelText: string
+  tooltipText: string
+}
+
+export const TipLabel = (props: Props) => (
+  <Label htmlFor={props.htmlFor}>
+    <span>
+      {props.labelText}&nbsp;
+      <Tooltip className={style.skillToolTipPopover} content={props.tooltipText} position={Position.TOP} usePortal>
+        <Icon icon="info-sign" iconSize={14} />
+      </Tooltip>
+    </span>
+  </Label>
+)

--- a/modules/basic-skills/src/views/full/TipLabel.tsx
+++ b/modules/basic-skills/src/views/full/TipLabel.tsx
@@ -1,4 +1,4 @@
-import { Label, Tooltip, Position, Icon } from '@blueprintjs/core'
+import { Tooltip, Position, Icon } from '@blueprintjs/core'
 import React from 'react'
 
 import style from './style.scss'
@@ -10,12 +10,12 @@ interface Props {
 }
 
 export const TipLabel = (props: Props) => (
-  <Label htmlFor={props.htmlFor}>
+  <label htmlFor={props.htmlFor} className={style.tipLabel}>
     <span>
       {props.labelText}&nbsp;
-      <Tooltip className={style.skillToolTipPopover} content={props.tooltipText} position={Position.TOP} usePortal>
+      <Tooltip className={style.skillToolTipPopover} content={props.tooltipText} position={Position.RIGHT} usePortal>
         <Icon icon="info-sign" iconSize={14} />
       </Tooltip>
     </span>
-  </Label>
+  </label>
 )

--- a/modules/basic-skills/src/views/full/callApi.jsx
+++ b/modules/basic-skills/src/views/full/callApi.jsx
@@ -1,10 +1,10 @@
-import { Tab, Tabs, Callout, Label, Classes, TextArea, Tooltip, Icon, Position } from '@blueprintjs/core'
+import { Tab, Tabs, Callout, Label, Classes, TextArea, Icon } from '@blueprintjs/core'
 import classnames from 'classnames'
 import { nanoid } from 'nanoid'
 import React from 'react'
 import Select from 'react-select'
 
-import { TipLabel } from './Tiplabel'
+import { TipLabel } from './TipLabel'
 import style from './style.scss'
 
 const methodOptions = [

--- a/modules/basic-skills/src/views/full/callApi.jsx
+++ b/modules/basic-skills/src/views/full/callApi.jsx
@@ -132,7 +132,7 @@ export class CallAPI extends React.Component {
             />
           </div>
         </div>
-        <Tabs id="requestOptionsTabs" animate={false} defaultSelectedTabId="body">
+        <Tabs id="requestOptionsTabs" animate={false} defaultSelectedTabId="body" className={style.callApiTabs}>
           <Tab
             id="body"
             title="Body"
@@ -191,7 +191,9 @@ export class CallAPI extends React.Component {
                 </Callout>
                 <div style={{ display: 'flex', justifyContent: 'space-between' }}>
                   <div style={{ flex: `${2 / 12}` }}>
-                    <Label htmlFor="storageSelect">Memory type</Label>
+                    <label htmlFor="storageSelect" className={style.tipLabel}>
+                      Memory type
+                    </label>
                     <Select
                       name="storageSelect"
                       id="storageSelect"

--- a/modules/basic-skills/src/views/full/callApi.jsx
+++ b/modules/basic-skills/src/views/full/callApi.jsx
@@ -3,6 +3,8 @@ import classnames from 'classnames'
 import { nanoid } from 'nanoid'
 import React from 'react'
 import Select from 'react-select'
+
+import { TipLabel } from './Tiplabel'
 import style from './style.scss'
 
 const methodOptions = [
@@ -107,7 +109,7 @@ export class CallAPI extends React.Component {
   render() {
     return (
       <div className={style.modalContent}>
-        <div className={style.callApiSection}>
+        <div className={style.skillSection}>
           <div style={{ flex: `${2 / 12}` }}>
             <Select
               id="method"
@@ -199,18 +201,11 @@ export class CallAPI extends React.Component {
                     />
                   </div>
                   <div style={{ flex: `${9.5 / 12}` }}>
-                    <Label htmlFor="variable">
-                      <Tooltip
-                        content="The response body will be assigned to this variable"
-                        position={Position.TOP_LEFT}
-                        className={style.skillToolTipPopover}
-                      >
-                        <span>
-                          Variable&nbsp;
-                          <Icon icon="info-sign" iconSize={14} />
-                        </span>
-                      </Tooltip>
-                    </Label>
+                    <TipLabel
+                      htmlFor="variable"
+                      labelText="Variable"
+                      tooltipText="The response body will be assigned to this variable"
+                    />
                     <input
                       type="text"
                       className={classnames(Classes.INPUT, Classes.LARGE, Classes.FILL)}

--- a/modules/basic-skills/src/views/full/callApi.jsx
+++ b/modules/basic-skills/src/views/full/callApi.jsx
@@ -1,11 +1,9 @@
+import { Tab, Tabs, Callout, Label, Classes, TextArea, Tooltip, Icon, Position } from '@blueprintjs/core'
+import classnames from 'classnames'
+import { nanoid } from 'nanoid'
 import React from 'react'
-import { Input, Label } from 'reactstrap'
-import { Tabs, Tab, Row, Col, Alert } from 'react-bootstrap'
 import Select from 'react-select'
 import style from './style.scss'
-import { BotpressTooltip } from 'botpress/tooltip'
-import { LinkDocumentationProvider } from 'botpress/documentation'
-import { nanoid } from 'nanoid'
 
 const methodOptions = [
   { label: 'Get', value: 'get' },
@@ -107,12 +105,10 @@ export class CallAPI extends React.Component {
   }
 
   render() {
-    const paramsHelp = <LinkDocumentationProvider file="main/memory" />
-
     return (
       <div className={style.modalContent}>
-        <Row className={style.callApiSection}>
-          <Col md={2}>
+        <div className={style.callApiSection}>
+          <div style={{ flex: `${2 / 12}` }}>
             <Select
               id="method"
               default
@@ -121,9 +117,10 @@ export class CallAPI extends React.Component {
               value={this.state.selectedMethod}
               onChange={this.handleMethodChange}
             />
-          </Col>
-          <Col md={10}>
-            <Input
+          </div>
+          <div style={{ flex: `${9.5 / 12}` }}>
+            <input
+              className={classnames(Classes.INPUT, Classes.FILL, Classes.LARGE)}
               id="url"
               name="url"
               type="text"
@@ -131,70 +128,102 @@ export class CallAPI extends React.Component {
               value={this.state.url}
               onChange={this.handleInputChange}
             />
-          </Col>
-        </Row>
-
-        <Row className={style.callApiSection}>
-          <Col md={12}>
-            <Tabs id="requestOptionsTabs" defaultActiveKey="body" animation={false}>
-              <Tab eventKey="body" title="Body">
-                <Alert className={style.callApiNote} bsStyle="info">
+          </div>
+        </div>
+        <Tabs id="requestOptionsTabs" animate={false} defaultSelectedTabId="body">
+          <Tab
+            id="body"
+            title="Body"
+            panel={
+              <div>
+                <Callout className={style.callApiNote}>
                   Send a request body. Enter the raw payload of the request. Make sure it has proper formatting based on
                   your Content-Type. E.g. application/json content type should respect the JSON format.
-                </Alert>
-                <Input
-                  type="textarea"
-                  rows="4"
+                </Callout>
+                <TextArea
+                  fill
+                  growVertically
                   id="body"
                   name="body"
+                  className={style.callApiTextArea}
                   value={this.state.body}
                   onChange={this.handleInputChange}
                 />
-              </Tab>
-              <Tab eventKey="headers" title="Headers">
-                <Alert className={style.callApiNote} bsStyle="info">
-                  Send request headers. Write in JSON format.
-                </Alert>
-                {this.state.invalidJson && (
-                  <div className={style.callApiWarning}>
-                    <i className="material-icons">warning</i>
-                    Invalid JSON format
-                  </div>
-                )}
-                <Input
-                  type="textarea"
-                  rows="5"
+              </div>
+            }
+          />
+          <Tab
+            id="headers"
+            title="Headers"
+            panel={
+              <div>
+                <Callout className={style.callApiNote}>Send request headers. Write in JSON format.</Callout>
+                <TextArea
+                  fill
+                  growVertically
                   id="headers"
+                  name="headers"
+                  className={style.callApiTextArea}
                   placeholder={headersPlaceholder}
                   value={this.state.headers}
                   onChange={this.handleHeadersChange}
                 />
-              </Tab>
-              <Tab eventKey="variable" title="Memory">
-                <Alert className={style.callApiNote} bsStyle="info">
+                {this.state.invalidJson && (
+                  <div className={style.callApiWarning}>
+                    <Icon icon="warning-sign" />
+                    Invalid JSON format
+                  </div>
+                )}
+              </div>
+            }
+          />
+          <Tab
+            id="variable"
+            title="Memory"
+            panel={
+              <div>
+                <Callout className={style.callApiNote}>
                   {
                     'Store the response body in {{temp.response}} by default. You can change the memory type and the variable here.'
                   }
-                </Alert>
-                <Col md={6}>
-                  <Label>Memory type</Label>
-                  {paramsHelp}
-                  <Select
-                    id="storageSelect"
-                    options={memoryOptions}
-                    value={this.state.selectedMemory}
-                    onChange={this.handleMemoryChange}
-                  />
-                </Col>
-                <Col md={6}>
-                  <Label>Variable</Label>
-                  <BotpressTooltip message="The response body will be assigned to this variable" />
-                  <Input type="text" name="variable" value={this.state.variable} onChange={this.handleInputChange} />
-                </Col>
-              </Tab>
-            </Tabs>
-          </Col>
-        </Row>
+                </Callout>
+                <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                  <div style={{ flex: `${2 / 12}` }}>
+                    <Label htmlFor="storageSelect">Memory type</Label>
+                    <Select
+                      name="storageSelect"
+                      id="storageSelect"
+                      options={memoryOptions}
+                      value={this.state.selectedMemory}
+                      onChange={this.handleMemoryChange}
+                    />
+                  </div>
+                  <div style={{ flex: `${9.5 / 12}` }}>
+                    <Label htmlFor="variable">
+                      <Tooltip
+                        content="The response body will be assigned to this variable"
+                        position={Position.TOP_LEFT}
+                        className={style.skillToolTipPopover}
+                      >
+                        <span>
+                          Variable&nbsp;
+                          <Icon icon="info-sign" iconSize={14} />
+                        </span>
+                      </Tooltip>
+                    </Label>
+                    <input
+                      type="text"
+                      className={classnames(Classes.INPUT, Classes.LARGE, Classes.FILL)}
+                      name="variable"
+                      value={this.state.variable}
+                      onChange={this.handleInputChange}
+                    />
+                  </div>
+                </div>
+              </div>
+            }
+          />
+        </Tabs>
       </div>
     )
   }

--- a/modules/basic-skills/src/views/full/email.jsx
+++ b/modules/basic-skills/src/views/full/email.jsx
@@ -1,8 +1,10 @@
 import React from 'react'
-import { Row, Col, Label, Input } from 'reactstrap'
 import ContentPickerWidget from 'botpress/content-picker'
-import { BotpressTooltip } from 'botpress/tooltip'
+import { Classes } from '@blueprintjs/core'
+import classnames from 'classnames'
 import _ from 'lodash'
+import { TipLabel } from './TipLabel'
+import style from './style.scss'
 
 export class Email extends React.Component {
   state = {
@@ -59,13 +61,16 @@ export class Email extends React.Component {
 
   render() {
     return (
-      <div>
-        <Row>
-          <Col md={12}>
-            <Label for="fromAddress">From</Label>
-            &nbsp;
-            <BotpressTooltip message="The address from which the email will be sent" />
-            <Input
+      <>
+        <div className={style.skillSection}>
+          <div style={{ width: '45%' }}>
+            <TipLabel
+              htmlFor="fromAddress"
+              labelText="From"
+              tooltipText="The address from which the email will be sent"
+            />
+            <input
+              className={classnames(Classes.INPUT, Classes.FILL)}
               id="fromAddress"
               name="fromAddress"
               type="text"
@@ -73,14 +78,11 @@ export class Email extends React.Component {
               placeholder="your@email.com"
               onChange={event => this.setState({ fromAddress: event.target.value })}
             />
-          </Col>
-        </Row>
-        <Row>
-          <Col md={12}>
-            <Label for="toAddress">To</Label>
-            &nbsp;
-            <BotpressTooltip message="The address to which the email will be sent" />
-            <Input
+          </div>
+          <div style={{ width: '45%' }}>
+            <TipLabel htmlFor="toAddress" labelText="To" tooltipText="The address to which the email will be sent" />
+            <input
+              className={classnames(Classes.INPUT, Classes.FILL)}
               id="toAddress"
               name="toAddress"
               type="text"
@@ -88,14 +90,15 @@ export class Email extends React.Component {
               placeholder="your@email.com"
               onChange={event => this.setState({ toAddress: event.target.value })}
             />
-          </Col>
-        </Row>
-        <Row>
-          <Col md={6}>
-            <Label for="ccAddress">CC</Label>
-            &nbsp;
-            <BotpressTooltip message="CC the email to these email addresses. This field can be empty." />
-            <Input
+          </div>
+          <div style={{ width: '45%' }}>
+            <TipLabel
+              htmlFor="ccAddress"
+              labelText="CC"
+              tooltipText="CC the email to these email addresses. This field can be empty."
+            />
+            <input
+              className={classnames(Classes.INPUT, Classes.FILL)}
               id="ccAddress"
               name="ccAddress"
               type="text"
@@ -103,12 +106,15 @@ export class Email extends React.Component {
               placeholder="your@email.com"
               onChange={event => this.setState({ ccAddress: event.target.value })}
             />
-          </Col>
-          <Col md={6}>
-            <Label for="fromAddress">BCC</Label>
-            &nbsp;
-            <BotpressTooltip message="BCC the email to these email addresses. This field can be empty." />
-            <Input
+          </div>
+          <div style={{ width: '45%' }}>
+            <TipLabel
+              htmlFor="fromAddress"
+              labelText="BCC"
+              tooltipText="BCC the email to these email addresses. This field can be empty."
+            />
+            <input
+              className={classnames(Classes.INPUT, Classes.FILL)}
               id="bccAddress"
               name="bccAddress"
               type="text"
@@ -116,40 +122,39 @@ export class Email extends React.Component {
               placeholder="your@email.com"
               onChange={event => this.setState({ bccAddress: event.target.value })}
             />
-          </Col>
-        </Row>
-        <hr />
-        <Row>
-          <Col md={12}>
-            <Label for="subjectPicker">Subject Line</Label>
-            &nbsp;
-            <BotpressTooltip message="The email's subject line (pick a CMS element)" />
-            <ContentPickerWidget
-              style={{ zIndex: 0 }}
-              name="subjectPicker"
-              id="subjectPicker"
-              itemId={this.state.subjectElement}
-              onChange={this.handleSubjectChange}
-              placeholder="Pick Subject Line"
-            />
-          </Col>
-        </Row>
-        <Row>
-          <Col md={12}>
-            <Label for="contentPicker">Email Content</Label>
-            &nbsp;
-            <BotpressTooltip message="The email's actual content (pick a CMS element)" />
-            <ContentPickerWidget
-              style={{ zIndex: 0 }}
-              name="contentPicker"
-              id="contentPicker"
-              itemId={this.state.contentElement}
-              onChange={this.handleContentChange}
-              placeholder="Pick Email Content"
-            />
-          </Col>
-        </Row>
-      </div>
+          </div>
+        </div>
+        <div>
+          <TipLabel
+            htmlFor="subjectPicker"
+            labelText="Subject Line"
+            tooltipText="The email's subject line (pick a CMS element)"
+          />
+          <ContentPickerWidget
+            style={{ zIndex: 0 }}
+            name="subjectPicker"
+            id="subjectPicker"
+            itemId={this.state.subjectElement}
+            onChange={this.handleSubjectChange}
+            placeholder="Pick Subject Line"
+          />
+        </div>
+        <div>
+          <TipLabel
+            htmlFor="contentPicker"
+            labelText="Email Content"
+            tooltipText="The email's actual content (pick a CMS element)"
+          />
+          <ContentPickerWidget
+            style={{ zIndex: 0 }}
+            name="contentPicker"
+            id="contentPicker"
+            itemId={this.state.contentElement}
+            onChange={this.handleContentChange}
+            placeholder="Pick Email Content"
+          />
+        </div>
+      </>
     )
   }
 }

--- a/modules/basic-skills/src/views/full/slot.jsx
+++ b/modules/basic-skills/src/views/full/slot.jsx
@@ -1,13 +1,11 @@
-import React from 'react'
-import { Row, Col, Label } from 'reactstrap'
+import { NumericInput, Label, Tooltip, Callout, Position, Icon } from '@blueprintjs/core'
 import ContentPickerWidget from 'botpress/content-picker'
 import SelectActionDropdown from 'botpress/select-action-dropdown'
+import _ from 'lodash'
+import React from 'react'
 import Select from 'react-select'
 import style from './style.scss'
-import { Alert } from 'react-bootstrap'
-import { BotpressTooltip } from 'botpress/tooltip'
-import { NumericInput } from '@blueprintjs/core'
-import _ from 'lodash'
+import { TipLabel } from './Tiplabel'
 
 const MAX_RETRIES = 10
 const DEFAULT_RETRY_ATTEMPTS = 3
@@ -24,10 +22,10 @@ export class Slot extends React.Component {
     actions: [],
     maxRetryAttempts: DEFAULT_RETRY_ATTEMPTS,
     error: undefined,
+
     errorField: undefined,
     turnExpiry: DEFAULT_TURN_EXP
   }
-
   componentDidMount() {
     this.fetchActions()
     this.fetchIntents().then(() => this.setStateFromProps())
@@ -89,7 +87,7 @@ export class Slot extends React.Component {
   }
 
   fetchActions = () => {
-    this.props.bp.axios.get(`/actions`, { baseURL: window.STUDIO_API_PATH }).then(({ data }) => {
+    this.props.bp.axios.get('/actions', { baseURL: window.STUDIO_API_PATH }).then(({ data }) => {
       this.setState({
         actions: data
           .filter(action => !action.hidden)
@@ -226,9 +224,9 @@ export class Slot extends React.Component {
 
     return (
       <React.Fragment>
-        <Row style={{ marginBottom: 10 }}>
-          <Col md={5}>
-            <Label>Choose an intent</Label>
+        <div className={style.skillSection}>
+          <div style={{ flex: 0.3 }}>
+            <Label htmlFor="intent">Choose an intent</Label>
             <Select
               id="intent"
               name="intent"
@@ -239,8 +237,8 @@ export class Slot extends React.Component {
               value={this.state.selectedIntentOption}
               options={intentsOptions}
             />
-          </Col>
-          <Col md={4}>
+          </div>
+          <div style={{ flex: 0.3 }}>
             <Label for="slot">Choose a slot to fill</Label>
             <Select
               id="slot"
@@ -252,14 +250,18 @@ export class Slot extends React.Component {
               value={this.state.selectedSlotOption}
               options={slotOptions}
             />
-          </Col>
-          <Col md={3}>
-            <Label for="turnExpiry">Expires after X turns</Label>
-            &nbsp;
-            <BotpressTooltip message="The information stored in the slot will be deleted after this number of turns. Set to -1 to never expire." />
+          </div>
+          <div style={{ flex: 0.3 }}>
+            <TipLabel
+              htmlFor="turnExpiry"
+              labelText="Expires after X turns"
+              tooltipText="The information stored in the slot will be deleted after this number of turns. Set to -1 to never expire."
+            />
             <NumericInput
               id="turnExpiry"
               name="turnExpiry"
+              fill
+              large
               defaultValue={_.get(this.props, 'initialData.turnExpiry', DEFAULT_TURN_EXP)}
               selectAllOnFocus
               clampValueOnBlur
@@ -269,13 +271,15 @@ export class Slot extends React.Component {
               stepSize={1}
               onValueChange={this.handleTurnExpiryChange}
             />
-          </Col>
-        </Row>
-        <Row>
-          <Col md={9}>
-            <Label for="contentPicker">Bot will ask...</Label>
-            &nbsp;
-            <BotpressTooltip message="The bot should ask a question specific about the slot to fill. (e.g. What is your email?)" />
+          </div>
+        </div>
+        <div className={style.skillSection}>
+          <div style={{ width: '66%' }}>
+            <TipLabel
+              htmlFor="contentPicker"
+              labelText="Bot will ask..."
+              tooltipText="The bot should ask a question specific about the slot to fill. (e.g. What is your email?)"
+            />
             <ContentPickerWidget
               style={{ zIndex: 0 }}
               name="contentPicker"
@@ -284,31 +288,36 @@ export class Slot extends React.Component {
               onChange={this.handleContentChange}
               placeholder="Pick content"
             />
-          </Col>
-        </Row>
-        <Row>
-          <Col md="9">
-            <Label>Message to send when user input is invalid</Label>
-            &nbsp;
-            <BotpressTooltip message="This message will appear to the user when the information he has given is invalid. (e.g. Your email is invalid)" />
+          </div>
+
+          <div style={{ width: '66%' }}>
+            <TipLabel
+              htmlFor="notFoundElement"
+              labelText="Message to send when user input is invalid"
+              tooltipText="This message will appear to the user when the information he has given is invalid. (e.g. Your email is invalid)"
+            />
             <ContentPickerWidget
               style={{ zIndex: 0 }}
               id="notFoundElement"
+              name="notFoundElement"
               itemId={this.state.notFoundElement}
               onChange={this.handleNotFoundChange}
               placeholder="Pick content to display when the slot is not found"
             />
-          </Col>
-          <Col md="3">
-            <Label for="retryAttempts">Max retry attempts</Label>
-            &nbsp;
-            <BotpressTooltip message="This is the maximum number of times the bot will try to extract the slot. When the limit is reached, the bot will execute the 'On not found' transition." />
+          </div>
+          <div style={{ width: '30%' }}>
+            <TipLabel
+              htmlfor="retryAttempts"
+              labelText="Max retry attempts"
+              tooltipText="This is the maximum number of times the bot will try to extract the slot. When the limit is reached, the bot will execute the 'On not found' transition."
+            />
             <NumericInput
               id="retryAttempts"
               name="retryAttempts"
               defaultValue={_.get(this.props, 'initialData.retryAttempts', DEFAULT_RETRY_ATTEMPTS)}
               selectAllOnFocus
               clampValueOnBlur
+              fill
               majorStepSize={1}
               minorStepSize={1}
               stepSize={1}
@@ -316,15 +325,13 @@ export class Slot extends React.Component {
               max={MAX_RETRIES}
               onValueChange={this.handleMaxRetryAttemptsChange}
             />
-          </Col>
-        </Row>
-        <Row>
-          <Col md={12}>
-            <Label for="validationCheck">
-              <small>Custom Input Validation (optional)</small>
-            </Label>
-            &nbsp;
-            <BotpressTooltip message="You can add custom validation for your slot with an action. It should assign a boolean value to the temp.valid variable." />
+          </div>
+          <div style={{ width: '100%' }}>
+            <TipLabel
+              htmlfor="validationCheck"
+              labelText="Custom Input Validation (optional)"
+              tooltipText="You can add custom validation for your slot with an action. It should assign a boolean value to the temp.valid variable."
+            />
             <SelectActionDropdown
               className={style.actionSelect}
               value={this.state.selectedActionOption}
@@ -332,13 +339,11 @@ export class Slot extends React.Component {
               onChange={this.handleActionChange}
               isClearable={true}
             />
-          </Col>
-        </Row>
-        <Row>
-          <Col className={style.errorContainer} md={12}>
-            {this.state.error && <Alert bsStyle="danger">{this.state.error}</Alert>}
-          </Col>
-        </Row>
+          </div>
+        </div>
+        <div className={style.errorContainer}>
+          {this.state.error && <Callout intent="danger">{this.state.error}</Callout>}
+        </div>
       </React.Fragment>
     )
   }

--- a/modules/basic-skills/src/views/full/slot.jsx
+++ b/modules/basic-skills/src/views/full/slot.jsx
@@ -1,11 +1,11 @@
-import { NumericInput, Label, Tooltip, Callout, Position, Icon } from '@blueprintjs/core'
+import { NumericInput, Label, Callout } from '@blueprintjs/core'
 import ContentPickerWidget from 'botpress/content-picker'
 import SelectActionDropdown from 'botpress/select-action-dropdown'
 import _ from 'lodash'
 import React from 'react'
 import Select from 'react-select'
 import style from './style.scss'
-import { TipLabel } from './Tiplabel'
+import { TipLabel } from './TipLabel'
 
 const MAX_RETRIES = 10
 const DEFAULT_RETRY_ATTEMPTS = 3

--- a/modules/basic-skills/src/views/full/style.scss
+++ b/modules/basic-skills/src/views/full/style.scss
@@ -50,6 +50,12 @@
   min-height: 120px;
 }
 
+.callApiTabs {
+  :global(.bp3-tab[aria-selected='true']) {
+    box-shadow: none;
+  }
+}
+
 .skillToolTipPopover {
   display: inline-block !important;
   margin: 0 !important;

--- a/modules/basic-skills/src/views/full/style.scss
+++ b/modules/basic-skills/src/views/full/style.scss
@@ -34,6 +34,11 @@
   margin: 10px 0 10px 0;
 }
 
+.tipLabel {
+  margin-bottom: var(--spacing-small);
+  margin-top: var(--spacing-medium);
+}
+
 .skillSection {
   display: flex;
   flex-wrap: wrap;

--- a/modules/basic-skills/src/views/full/style.scss
+++ b/modules/basic-skills/src/views/full/style.scss
@@ -34,8 +34,9 @@
   margin: 10px 0 10px 0;
 }
 
-.callApiSection {
+.skillSection {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   margin-bottom: 20px;
 }
@@ -45,6 +46,7 @@
 }
 
 .skillToolTipPopover {
+  display: inline-block !important;
   margin: 0 !important;
 }
 

--- a/modules/basic-skills/src/views/full/style.scss
+++ b/modules/basic-skills/src/views/full/style.scss
@@ -35,7 +35,17 @@
 }
 
 .callApiSection {
-  margin-top: 10px;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.callApiTextArea {
+  min-height: 120px;
+}
+
+.skillToolTipPopover {
+  margin: 0 !important;
 }
 
 .callApiWarning {

--- a/modules/basic-skills/src/views/full/style.scss.d.ts
+++ b/modules/basic-skills/src/views/full/style.scss.d.ts
@@ -15,6 +15,7 @@ interface CssExports {
   'skillSection': string;
   'skillToolTipPopover': string;
   'slotSelect': string;
+  'tipLabel': string;
   'warning': string;
 }
 declare var cssExports: CssExports;

--- a/modules/basic-skills/src/views/full/style.scss.d.ts
+++ b/modules/basic-skills/src/views/full/style.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'actionSelect': string;
   'callApiNote': string;
+  'callApiTabs': string;
   'callApiTextArea': string;
   'callApiWarning': string;
   'contentPicker': string;

--- a/modules/basic-skills/src/views/full/style.scss.d.ts
+++ b/modules/basic-skills/src/views/full/style.scss.d.ts
@@ -4,6 +4,7 @@ interface CssExports {
   'actionSelect': string;
   'callApiNote': string;
   'callApiSection': string;
+  'callApiTextArea': string;
   'callApiWarning': string;
   'contentPicker': string;
   'errorContainer': string;
@@ -12,6 +13,7 @@ interface CssExports {
   'modalContent': string;
   'notFoundSelect': string;
   'padded': string;
+  'skillToolTipPopover': string;
   'slotSelect': string;
   'warning': string;
 }

--- a/modules/basic-skills/src/views/full/style.scss.d.ts
+++ b/modules/basic-skills/src/views/full/style.scss.d.ts
@@ -3,7 +3,6 @@
 interface CssExports {
   'actionSelect': string;
   'callApiNote': string;
-  'callApiSection': string;
   'callApiTextArea': string;
   'callApiWarning': string;
   'contentPicker': string;
@@ -13,6 +12,7 @@ interface CssExports {
   'modalContent': string;
   'notFoundSelect': string;
   'padded': string;
+  'skillSection': string;
   'skillToolTipPopover': string;
   'slotSelect': string;
   'warning': string;

--- a/modules/basic-skills/yarn.lock
+++ b/modules/basic-skills/yarn.lock
@@ -110,26 +110,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/prop-types@*":
-  version "15.7.3"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
-  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
-
-"@types/react-bootstrap@^0.32.20":
-  version "0.32.20"
-  resolved "https://registry.yarnpkg.com/@types/react-bootstrap/-/react-bootstrap-0.32.20.tgz#8d90e625a1b2d92d169de27e40b3d20057efa1ae"
-  integrity sha512-lc7bUHGMfVkbH9B7EKPD/9AYtgtFYP5go5D3tqIUN4O0znPX1UwBY4wUeicJPONaMpYtmVUGSdbDDqK9lXUCFQ==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react@*":
-  version "16.9.4"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.4.tgz#de8cf5e5e2838659fb78fa93181078469eeb19fc"
-  integrity sha512-ItGNmJvQ0IvWt8rbk5PLdpdQhvBVxAaXI9hDlx7UMd8Ie1iMIuwMNiKeTfmVN517CdplpyXvA22X4zm4jGGZnw==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
-
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -185,11 +165,6 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
-
-csstype@^2.2.0:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.6.tgz#c34f8226a94bbb10c32cc0d714afdf942291fc41"
-  integrity sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==
 
 debug@^4.1.0:
   version "4.1.1"

--- a/modules/basic-skills/yarn.lock
+++ b/modules/basic-skills/yarn.lock
@@ -130,14 +130,6 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
-"@types/reactstrap@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@types/reactstrap/-/reactstrap-8.4.1.tgz#6dff4d1fdf59233877925e3caec406272050b632"
-  integrity sha512-7c0JDBTizNmKbf9yeqqO8eTmuqEW/RKuhJXnp7bDhF1SVfairXaHI69xRFT0GNHRuXrBkWQV4V+9BduNq6MJjg==
-  dependencies:
-    "@types/react" "*"
-    popper.js "^1.14.1"
-
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -336,11 +328,6 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
-
-popper.js@^1.14.1:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.0.tgz#2e1816bcbbaa518ea6c2e15a466f4cb9c6e2fbb3"
-  integrity sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw==
 
 rimraf@2:
   version "2.7.1"


### PR DESCRIPTION
reactstrap was taken away from the studio and was required as an external dependency from basic skill module (only)

## Api call Skill
**before**
![Screen Shot 2022-08-31 at 4 27 52 PM](https://user-images.githubusercontent.com/955524/187776613-be775155-622a-4d1d-bea0-defb188fa46c.png)

**after**
![Screen Shot 2022-08-31 at 4 27 49 PM](https://user-images.githubusercontent.com/955524/187776616-ba50b6bd-59ae-4cc7-8893-9116abe80b11.png)

## Slot Filling Skill
**before**
![Screen Shot 2022-08-31 at 4 29 28 PM](https://user-images.githubusercontent.com/955524/187776655-d871bbf8-9da4-4b5a-92ca-2d8dedc40c45.png)

**after**
![Screen Shot 2022-08-31 at 4 29 15 PM](https://user-images.githubusercontent.com/955524/187776665-70fae4ad-714b-4645-bd5b-5a16dee3a85b.png)

## Email Skill
**before**
![Screen Shot 2022-08-31 at 4 29 44 PM](https://user-images.githubusercontent.com/955524/187776694-39f2e541-3535-4ffb-847a-a831be193bce.png)

**after**
![Screen Shot 2022-08-31 at 4 29 37 PM](https://user-images.githubusercontent.com/955524/187776705-71908771-da2a-452c-ba03-6d560972d058.png)
