### PR TITLE
fix(admin): fix bot workspace scoping

### DIFF
--- a/packages/bp/src/admin/workspace/bots/bots-router.ts
+++ b/packages/bp/src/admin/workspace/bots/bots-router.ts
@@ -81,11 +81,22 @@ class BotsRouter extends CustomAdminRouter {
       })
     )
 
+    const checkBotInWorkspace = async (botId: string, workspaceId?: string) => {
+      const botExists = (await this.botService.getBotsIds()).includes(botId)
+      const isBotInCurrentWorkspace = (await this.workspaceService.getBotRefs(workspaceId)).includes(botId)
+
+      if (botExists && !isBotInCurrentWorkspace) {
+        throw new ConflictError(`Bot "${botId}" already exists in another workspace. Bot ID are unique server-wide`)
+      }
+    }
+
     router.post(
       '/',
       this.needPermissions('write', this.resource),
       this.asyncMiddleware(async (req, res) => {
         const bot = <BotConfig>_.pick(req.body, ['id', 'name', 'category', 'defaultLanguage'])
+
+        await checkBotInWorkspace(bot.id, req.workspace)
 
         const botExists = (await this.botService.getBotsIds()).includes(bot.id)
         const botLinked = (await this.workspaceService.getBotRefs()).includes(bot.id)
@@ -204,6 +215,8 @@ class BotsRouter extends CustomAdminRouter {
         }
 
         const botId = await this.botService.makeBotId(req.params.botId, req.workspace!)
+
+        await checkBotInWorkspace(botId, req.workspace)
 
         const buffers: any[] = []
         req.on('data', chunk => buffers.push(chunk))

--- a/packages/bp/src/admin/workspace/bots/bots-router.ts
+++ b/packages/bp/src/admin/workspace/bots/bots-router.ts
@@ -81,7 +81,7 @@ class BotsRouter extends CustomAdminRouter {
       })
     )
 
-    const checkBotInWorkspace = async (botId: string, workspaceId?: string) => {
+    const assertBotInWorkspace = async (botId: string, workspaceId?: string) => {
       const botExists = (await this.botService.getBotsIds()).includes(botId)
       const isBotInCurrentWorkspace = (await this.workspaceService.getBotRefs(workspaceId)).includes(botId)
 
@@ -96,7 +96,7 @@ class BotsRouter extends CustomAdminRouter {
       this.asyncMiddleware(async (req, res) => {
         const bot = <BotConfig>_.pick(req.body, ['id', 'name', 'category', 'defaultLanguage'])
 
-        await checkBotInWorkspace(bot.id, req.workspace)
+        await assertBotInWorkspace(bot.id, req.workspace)
 
         const botExists = (await this.botService.getBotsIds()).includes(bot.id)
         const botLinked = (await this.workspaceService.getBotRefs()).includes(bot.id)
@@ -216,7 +216,7 @@ class BotsRouter extends CustomAdminRouter {
 
         const botId = await this.botService.makeBotId(req.params.botId, req.workspace!)
 
-        await checkBotInWorkspace(botId, req.workspace)
+        await assertBotInWorkspace(botId, req.workspace)
 
         const buffers: any[] = []
         req.on('data', chunk => buffers.push(chunk))


### PR DESCRIPTION
Bot ID are unique server-wide. If a user has access to workspace A and also to workspace B, he could create/import a bot in the other workspace with the same id. This would overwrite the original bot, but would also display its ID in both workspace. 

Only the latest copy existed however, so anyone deleting the bot from either workspace would delete it from both.