### PR TITLE
fix(core): resolve 'undefined' workspace

### DIFF
--- a/packages/bp/src/core/security/router-security.ts
+++ b/packages/bp/src/core/security/router-security.ts
@@ -183,7 +183,7 @@ const checkPermissions = (workspaceService: WorkspaceService) => (
     return new ForbiddenError('Unauthorized')
   }
 
-  if (!req.workspace && req.params.botId) {
+  if ((!req.workspace || req.workspace === 'undefined') && req.params.botId) {
     req.workspace = await workspaceService.getBotWorkspaceId(req.params.botId)
   }
 


### PR DESCRIPTION
Sometimes the frontend sends an 'undefined' workspace in the header; this ensures that those situations will be handled.