### PR TITLE
fix(google-speech): allow multiline SSML content

### DIFF
--- a/modules/google-speech/src/backend/client.ts
+++ b/modules/google-speech/src/backend/client.ts
@@ -205,7 +205,7 @@ export class GoogleSpeechClient {
   ): Promise<Uint8Array | string | undefined> {
     debugTextToSpeech(`Received text to convert into audio: ${text}`)
 
-    const hasSSML = !!text.match(/<speak>.*<\/speak>/g)?.length
+    const hasSSML = !!text.match(/<speak>(.|\n)*<\/speak>/g)?.length
 
     const request: ISynthesizeSpeechRequest = {
       input: hasSSML ? { ssml: text } : { text },


### PR DESCRIPTION
This change will allow SSML content to have multi lines

Example: 
```
<speak>
   Content
</speak>
```