### PR TITLE
fix(hitlnext): issue with history and re-queue

### DIFF
--- a/modules/hitlnext/src/backend/api.ts
+++ b/modules/hitlnext/src/backend/api.ts
@@ -274,13 +274,13 @@ export default async (bp: typeof sdk, state: StateType, repository: Repository) 
       }
 
       await Promise.mapSeries(recentUserConversationEvents.reverse(), event => {
-        // @ts-ignore
-        const e = bp.IO.Event({
-          type: event.event.type,
-          payload: event.event.payload,
-          ...baseEvent
-        } as sdk.IO.EventCtorArgs)
-        return bp.events.sendEvent(e)
+        return bp.messaging
+          .forBot(handoff.botId)
+          .createMessage(
+            handoff.agentThreadId,
+            event.direction === 'incoming' ? undefined : event.target,
+            event.event.payload
+          )
       })
 
       await bp.events.sendEvent(

--- a/modules/hitlnext/src/backend/api.ts
+++ b/modules/hitlnext/src/backend/api.ts
@@ -1,4 +1,5 @@
 import Axios from 'axios'
+import Bluebird from 'bluebird'
 import * as sdk from 'botpress/sdk'
 import { BPRequest } from 'common/http'
 import { RequestWithUser } from 'common/typings'
@@ -273,14 +274,15 @@ export default async (bp: typeof sdk, state: StateType, repository: Repository) 
         threadId: handoff.agentThreadId
       }
 
-      await Promise.mapSeries(recentUserConversationEvents.reverse(), event => {
-        return bp.messaging
+      await Promise.mapSeries(recentUserConversationEvents.reverse(), async event => {
+        await bp.messaging
           .forBot(handoff.botId)
           .createMessage(
             handoff.agentThreadId,
             event.direction === 'incoming' ? undefined : event.target,
             event.event.payload
           )
+        await Bluebird.delay(5)
       })
 
       await bp.events.sendEvent(

--- a/modules/hitlnext/src/backend/service.ts
+++ b/modules/hitlnext/src/backend/service.ts
@@ -75,7 +75,13 @@ class Service {
 
   async updateHandoff(handoff: Partial<IHandoff>, botId: string, payload: any) {
     const updated = await this.repository.updateHandoff(botId, handoff.id, payload)
-    this.state.expireHandoff(botId, handoff.userThreadId)
+
+    if (updated.status !== 'pending') {
+      this.state.expireHandoff(botId, handoff.userThreadId)
+    } else {
+      this.state.cacheHandoff(botId, handoff.userThreadId, updated)
+    }
+
     this.updateRealtimeHandoff(botId, updated)
 
     return updated


### PR DESCRIPTION
So it's 2 small fixes. First one address an issue on hitlnext that was there since messaging was moved to its binary. The second one is just a safeguard (but it will help fix an upcoming feature)

1st fix: in api.ts, when the handoff was created, it took all the previous event of the user, and sent an event as if the bot sent those messages to the user, then messaging stored them. This looked as the user sent all the messages, including the incoming and outgoing ones. I just skipped one step and created them directly on messaging, specifying if the target was the user or a bot. 

2nd fix service.ts, when you update a handoff, currently the only operations means the handoff is ended, so any update would clear the cache of the user handoff. Problem is that it only added the handoff to the cache upon creating the handoff, so when the requeue updated it to pending, it was removed from the cache, so hitl didn't know it had to handle the user's message, so thats why the agent didn't receive them 

Basically, all the relevant messages are stored on the chat user's thread ID. Whenever a user speak with an agent, a new thread is started, and all the previous entries of the user's thread are "pushed" in the agent's thread. When you switch agent, the same process is repeated.
