### PR TITLE
fix(channel-web): use avatar from last message

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
@@ -1,5 +1,6 @@
 import { ResizeObserver } from '@juggle/resize-observer'
 import differenceInMinutes from 'date-fns/difference_in_minutes'
+import _ from 'lodash'
 import debounce from 'lodash/debounce'
 import { observe } from 'mobx'
 import { inject, observer } from 'mobx-react'
@@ -173,7 +174,7 @@ class MessageList extends React.Component<MessageListProps, State> {
             !groups[i - 1] ||
             differenceInMinutes(new Date(groupDate), new Date(lastDate)) > constants.TIME_BETWEEN_DATES
 
-          const [{ authorId, payload }] = group
+          const { authorId, payload } = _.last(group)
 
           const avatar = authorId
             ? this.props.showUserAvatar &&


### PR DESCRIPTION
This change will ensure that we use the payload from the last message within a message group to decide which avatar to use in the channel web.

Fixes https://github.com/botpress/v12/issues/1673

Before:

![image](https://user-images.githubusercontent.com/13484138/195674428-41f46a75-a1b8-4b7d-b3c8-69ef2ab05ee9.png)

After:

![image](https://user-images.githubusercontent.com/13484138/195673986-4c29d8f8-7115-4836-b4eb-6119a47d25bc.png)
