### PR TITLE
fix(core): qna with transitions source details

### DIFF
--- a/packages/bp/src/core/dialog/decision-engine.ts
+++ b/packages/bp/src/core/dialog/decision-engine.ts
@@ -137,15 +137,17 @@ export class DecisionEngine {
       (!sendSuggestionResult || sendSuggestionResult!.executeFlows)
     ) {
       try {
-        Object.assign(event, {
-          decision: <IO.Suggestion>{
-            decision: { reason: 'no suggestion matched', status: 'elected' },
-            confidence: 1,
-            payloads: [],
-            source: 'decisionEngine',
-            sourceDetails: 'execute default flow'
-          }
-        })
+        if (!sendSuggestionResult?.executeFlows) {
+          Object.assign(event, {
+            decision: <IO.Suggestion>{
+              decision: { reason: 'no suggestion matched', status: 'elected' },
+              confidence: 1,
+              payloads: [],
+              source: 'decisionEngine',
+              sourceDetails: 'execute default flow'
+            }
+          })
+        }
         const processedEvent = await this.dialogEngine.processEvent(sessionId, event)
         // In case there are no unknown errors, remove skills/ flow from the stacktrace
         processedEvent.state.__stacktrace = processedEvent.state.__stacktrace.filter(x => !x.flow.startsWith('skills/'))

--- a/packages/bp/src/core/dialog/decision-engine.ts
+++ b/packages/bp/src/core/dialog/decision-engine.ts
@@ -137,7 +137,7 @@ export class DecisionEngine {
       (!sendSuggestionResult || sendSuggestionResult!.executeFlows)
     ) {
       try {
-        if (!sendSuggestionResult?.executeFlows) {
+        if (!sendSuggestionResult?.executeFlows || !event?.decision) {
           Object.assign(event, {
             decision: <IO.Suggestion>{
               decision: { reason: 'no suggestion matched', status: 'elected' },


### PR DESCRIPTION
This fixes the core behavior that would change decision details if the QNA has any transition, resulting in an incorrect QNA feedback entry

Fixes: https://github.com/botpress/v12/issues/1637