### PR TITLE
feat(channel-web): allow choices below message

### DIFF
--- a/modules/builtin/src/content-types/single_choice.js
+++ b/modules/builtin/src/content-types/single_choice.js
@@ -56,6 +56,11 @@ module.exports = {
         title: 'module.builtin.disableFreeText',
         default: false
       },
+      displayInMessage: {
+        type: 'boolean',
+        title: 'module.builtin.types.singleChoice.displayInMessageTitle',
+        default: false
+      },
       ...base.typingIndicators
     }
   },

--- a/modules/builtin/src/translations/en.json
+++ b/modules/builtin/src/translations/en.json
@@ -47,7 +47,8 @@
       "description": "Suggest choices to the user with the intention of picking only one (with an optional message)",
       "itemTitle": "The title of the choice (this is what gets shown to the user)",
       "itemValue": "The value that your bot gets when the user picks this choice (usually hidden from the user)",
-      "title": "Single Choice"
+      "title": "Single Choice",
+      "displayInMessageTitle": "Display below the message"
     },
     "text": {
       "alternatives": "Alternates",

--- a/modules/builtin/src/translations/es.json
+++ b/modules/builtin/src/translations/es.json
@@ -47,7 +47,8 @@
       "description": "Sugerir opciones al usuario con la intención de seleccionar solo una (con un mensaje opcional)",
       "itemTitle": "El título de la elección (esto es lo que se muestra al usuario)",
       "itemValue": "El valor que obtiene el bot cuando el usuario elige esta opción (normalmente oculto al usuario)",
-      "title": "Elección única"
+      "title": "Elección única",
+      "displayInMessageTitle": "Mostrar debajo del mensaje"
     },
     "text": {
       "alternatives": "Alternativas (opcional)",

--- a/modules/builtin/src/translations/fr.json
+++ b/modules/builtin/src/translations/fr.json
@@ -47,7 +47,8 @@
       "description": "Suggérer un choix à l'utilisateur avec l'intention de n'en sélectionner qu'un (avec un message optionnel)",
       "itemTitle": "Le titre du choix (ce que verra l'utilisateur)",
       "itemValue": "La valeur que recevra le bot lorsque l'utilisateur choisi cet item (habituellement caché de l'utilisateur)",
-      "title": "Choix Unique"
+      "title": "Choix Unique",
+      "displayInMessageTitle": "Afficher sous le message"
     },
     "text": {
       "alternatives": "Alternatives",

--- a/modules/channel-web/assets/default-emulator.css
+++ b/modules/channel-web/assets/default-emulator.css
@@ -526,6 +526,14 @@
     margin-bottom: 0;
   }
 
+  .bpw-in-message-quick_reply {
+    padding-top: 10px;
+  }
+
+  .bpw-in-message-quick_reply > button {
+    margin: 2px;
+  }
+
   .bpw-quick_reply-buttons-container {
     width: 100%;
     white-space: nowrap;

--- a/modules/channel-web/assets/default.css
+++ b/modules/channel-web/assets/default.css
@@ -452,6 +452,14 @@ body {
   border-top: 1px solid #dcdcdc;
 }
 
+.bpw-in-message-quick_reply {
+  padding-top: 10px;
+}
+
+.bpw-in-message-quick_reply > button {
+  margin: 2px;
+}
+
 /* CAROUSEL  */
 .slick-arrow {
   background-color: #fff !important;

--- a/modules/channel-web/src/views/lite/components/messages/renderer/QuickReplies.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/renderer/QuickReplies.tsx
@@ -51,10 +51,25 @@ export class QuickReplies extends Component<Renderer.QuickReply> {
 
   render() {
     const buttons = this.props.buttons || this.props.quick_replies
-    const kbd = <div className={'bpw-keyboard-quick_reply'}>{buttons && this.renderKeyboard(buttons)}</div>
+    const kbd = (
+      <div className={this.props.displayInMessage ? 'bpw-in-message-quick_reply' : 'bpw-keyboard-quick_reply'}>
+        {buttons && this.renderKeyboard(buttons)}
+      </div>
+    )
+
+    const visible = this.props.isLastGroup && this.props.isLastOfGroup
+
+    if (this.props.displayInMessage && visible) {
+      return (
+        <div>
+          {this.props.children}
+          {kbd}
+        </div>
+      )
+    }
 
     return (
-      <Keyboard.Prepend keyboard={kbd} visible={this.props.isLastGroup && this.props.isLastOfGroup}>
+      <Keyboard.Prepend keyboard={kbd} visible={visible}>
         {this.props.children}
       </Keyboard.Prepend>
     )

--- a/modules/channel-web/src/views/lite/typings.d.ts
+++ b/modules/channel-web/src/views/lite/typings.d.ts
@@ -91,6 +91,7 @@ export namespace Renderer {
     buttons: any
     quick_replies: any
     disableFreeText: boolean
+    displayInMessage?: boolean
   } & Message
 
   export type QuickReplyButton = {

--- a/modules/hitlnext/assets/webchat-theme.css
+++ b/modules/hitlnext/assets/webchat-theme.css
@@ -464,6 +464,14 @@
     margin-bottom: 0;
   }
 
+  .bpw-in-message-quick_reply {
+    padding-top: 10px;
+  }
+
+  .bpw-in-message-quick_reply > button {
+    margin: 2px;
+  }
+
   .bpw-quick_reply-buttons-container {
     width: 100%;
     white-space: nowrap;

--- a/packages/ui-shared-lite/Payloads/index.ts
+++ b/packages/ui-shared-lite/Payloads/index.ts
@@ -5,6 +5,7 @@ interface ExtraChoiceProperties {
   isDropdown: boolean
   dropdownPlaceholder: string
   disableFreeText: boolean
+  displayInMessage: boolean
 }
 
 interface ExtraDropdownProperties {
@@ -73,7 +74,8 @@ const renderChoicePayload = (content: sdk.ChoiceContent & ExtraChoiceProperties)
       options: content.choices.map(c => ({ label: c.title, value: c.value.toUpperCase() })),
       width: 300,
       placeholderText: content.dropdownPlaceholder,
-      disableFreeText: content.disableFreeText
+      disableFreeText: content.disableFreeText,
+      displayInMessage: content.displayInMessage
     }
   }
   return {
@@ -88,7 +90,8 @@ const renderChoicePayload = (content: sdk.ChoiceContent & ExtraChoiceProperties)
     wrapped: {
       type: 'text',
       ...omit(content, 'choices', 'type')
-    }
+    },
+    displayInMessage: content.displayInMessage
   }
 }
 


### PR DESCRIPTION
This adds the option to display choices below the message on the single-choice content type

![image](https://user-images.githubusercontent.com/13484138/199111164-e308cac9-4519-463c-9431-a4d34c1765b9.png)

![image](https://user-images.githubusercontent.com/13484138/199111336-a28c5bf2-7fc4-4760-bce6-27a520c394c8.png)

![image](https://user-images.githubusercontent.com/13484138/199111576-1ceb37b4-f04d-4437-ad29-6de00f21ec43.png)
