### PR TITLE
fix(web-channel): crash on empty message list

### DIFF
--- a/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/MessageList.tsx
@@ -76,13 +76,13 @@ const Content = observer(props => {
   const [sticky] = useSticky()
 
   useEffect(() => {
-    const stateUpdate = { ...state, messagesLength: props.currentMessages.length }
-    if (!sticky && state.messagesLength !== props.currentMessages.length) {
+    const stateUpdate = { ...state, messagesLength: props.currentMessages?.length }
+    if (!sticky && state.messagesLength !== props.currentMessages?.length) {
       setState({ ...stateUpdate, showNewMessageIndicator: true })
     } else {
       setState({ ...stateUpdate, showNewMessageIndicator: false })
     }
-  }, [props.currentMessages.length, sticky])
+  }, [props.currentMessages?.length, sticky])
 
   const shouldDisplayMessage = (m: Message): boolean => {
     return m.payload.type !== 'postback'
@@ -191,7 +191,7 @@ const Content = observer(props => {
         <div className="bpw-new-messages-indicator" onClick={e => scrollToBottom()}>
           <span>
             {props.intl.formatMessage({
-              id: `messages.newMessage${props.currentMessages.length === 1 ? '' : 's'}`
+              id: `messages.newMessage${props.currentMessages?.length === 1 ? '' : 's'}`
             })}
           </span>
         </div>


### PR DESCRIPTION
This fixes an issue when creating a new session while using the emulator

![image](https://user-images.githubusercontent.com/13484138/199112938-29761a40-3d08-4dd0-a5b0-3d059685f852.png)
