### PR TITLE
fix(web-channel): prevent error on null choice

### DIFF
--- a/packages/ui-shared-lite/Payloads/index.ts
+++ b/packages/ui-shared-lite/Payloads/index.ts
@@ -70,7 +70,7 @@ const renderChoicePayload = (content: sdk.ChoiceContent & ExtraChoiceProperties)
       message: content.text,
       buttonText: '',
       displayInKeyboard: true,
-      options: content.choices.map(c => ({ label: c.title, value: c.value.toUpperCase() })),
+      options: content.choices.map(c => ({ label: c.title, value: c.value?.toUpperCase() })),
       width: 300,
       placeholderText: content.dropdownPlaceholder,
       disableFreeText: content.disableFreeText
@@ -82,7 +82,7 @@ const renderChoicePayload = (content: sdk.ChoiceContent & ExtraChoiceProperties)
     component: 'QuickReplies',
     quick_replies: content.choices.map(c => ({
       title: c.title,
-      payload: c.value.toUpperCase()
+      payload: c.value?.toUpperCase()
     })),
     disableFreeText: content.disableFreeText,
     wrapped: {


### PR DESCRIPTION
Prevents the error below when sending a choice with an undefined value

![image](https://user-images.githubusercontent.com/13484138/199300378-830567dc-cc64-4e03-95d1-73290636dd23.png)
