### PR TITLE
Remove enterprise support portal link

### DIFF
--- a/docs/src/components/WebDevCards/index.tsx
+++ b/docs/src/components/WebDevCards/index.tsx
@@ -13,15 +13,6 @@ import Link from '@docusaurus/Link';
 
 const WebDevCards = [
   {
-    name: 'Botpress Support Portal',
-    url: {
-      page: 'https://support.botpress.com/support/login',
-      name: 'Go to Botpress Support Portal',
-    },
-    description:
-      'Engineer-to-engineer support directly from the Botpress team',
-  },
-  {
     name: 'Community Support',
     url: {
       page: 'https://github.com/botpress/botpress/discussions',


### PR DESCRIPTION
support.botpress.com is just for enterprise customers and requires an account to access. It might be confusing for community members looking for support to be turned away at this link.