### PR TITLE
fix(hitlnext): expire cache while updating tags

### DIFF
--- a/modules/hitlnext/src/backend/api.ts
+++ b/modules/hitlnext/src/backend/api.ts
@@ -198,8 +198,7 @@ export default async (bp: typeof sdk, state: StateType, repository: Repository) 
 
       Joi.attempt(payload, UpdateHandoffSchema)
 
-      const handoff = await repository.updateHandoff(botId, id, payload)
-      state.cacheHandoff(botId, handoff.userThreadId, handoff)
+      const handoff = await service.updateHandoff(id, botId, payload)
 
       service.sendPayload(botId, {
         resource: 'handoff',


### PR DESCRIPTION
If there is a call to the tags route after the handoff is resolved, it will be cached again. This also makes it possible to invalidate the cache for custom solutions.