### PR TITLE
fix(web-channel): race condition from visit event

### DIFF
--- a/modules/channel-web/src/backend/api.ts
+++ b/modules/channel-web/src/backend/api.ts
@@ -226,26 +226,10 @@ export default async (bp: typeof sdk, db: Database) => {
     asyncMiddleware(async (req: ChatRequest, res: Response) => {
       const { botId, userId } = req
 
-      const user = await bp.users.getOrCreateUser('web', userId, botId)
       const payload = req.body.payload || {}
 
       if (!SUPPORTED_MESSAGES.includes(payload.type)) {
         return res.status(400).send(ERR_MSG_TYPE)
-      }
-
-      if (payload.type === 'visit') {
-        const { timezone, language } = payload
-        const isValidTimezone = _.isNumber(timezone) && timezone >= -12 && timezone <= 14 && timezone % 0.5 === 0
-        const isValidLanguage = language.length < 4 && !_.get(user, 'result.attributes.language')
-
-        const newAttributes = {
-          ...(isValidTimezone && { timezone }),
-          ...(isValidLanguage && { language })
-        }
-
-        if (Object.getOwnPropertyNames(newAttributes).length) {
-          await bp.users.updateAttributes('web', userId, newAttributes)
-        }
       }
 
       if (!req.conversationId) {

--- a/modules/channel-web/src/hooks/before_incoming_middleware/00_user_attributes.js
+++ b/modules/channel-web/src/hooks/before_incoming_middleware/00_user_attributes.js
@@ -1,0 +1,22 @@
+const _ = require('lodash')
+
+async function visitEvent() {
+  if (event.type === 'visit') {
+    const user = await bp.users.getOrCreateUser('web', event.target, event.botId)
+
+    const { timezone, language } = event.payload
+    const isValidTimezone = _.isNumber(timezone) && timezone >= -12 && timezone <= 14 && timezone % 0.5 === 0
+    const isValidLanguage = language.length < 4 && !_.get(user, 'result.attributes.language')
+
+    const newAttributes = {
+      ...(isValidTimezone && { timezone }),
+      ...(isValidLanguage && { language })
+    }
+
+    if (Object.getOwnPropertyNames(newAttributes).length) {
+      event.state.user = { ...event.state.user, ...newAttributes }
+    }
+  }
+}
+
+return visitEvent()

--- a/modules/channel-web/src/views/lite/core/constants.tsx
+++ b/modules/channel-web/src/views/lite/core/constants.tsx
@@ -1,6 +1,6 @@
 export default {
   /** These types are sent using the /message/ endpoint */
-  MESSAGE_TYPES: ['text', 'quick_reply', 'form', 'login_prompt', 'visit', 'postback'],
+  MESSAGE_TYPES: ['text', 'quick_reply', 'form', 'login_prompt', 'postback'],
   /** The duration of the hide / show chat */
   ANIM_DURATION: 300,
   MIN_TIME_BETWEEN_SOUNDS: 1000,

--- a/packages/bp/src/core/dialog/state-manager.ts
+++ b/packages/bp/src/core/dialog/state-manager.ts
@@ -164,12 +164,13 @@ export class StateManager {
     }
 
     const batchCount = this.batch.length >= BATCH_SIZE ? BATCH_SIZE : this.batch.length
-    const elements = this.batch.splice(0, batchCount)
+    const elements = this.batch.slice(0, batchCount)
 
     this.currentPromise = this.knex
       .transaction(async trx => {
         for (const { event, ignoreContext } of elements) {
           await this._saveState(event, ignoreContext, trx)
+          _.remove(this.batch, { event })
         }
       })
       .finally(() => {


### PR DESCRIPTION
The visit event today is being intercepted by the web-channel backend; in the handler, we update some user variables using `bp.users.updateAttributes`, which creates a race condition if there is a proactive hook and the flow changes some user variables in an action or an entry node, for example. This isn't easy to reproduce but has been happening for some managed clients, but happens in one of 50 interactions.

I could reproduce it by using a puppeteer automated test with a proactive hook + 3 new events sent by the front end simultaneously (events that change the user variable).

![image](https://user-images.githubusercontent.com/13484138/209865429-8d55118b-04f9-4fa0-a97e-8ac4f8dcd3d2.png)

![image](https://user-images.githubusercontent.com/13484138/209865628-f8db6b9d-703f-4c1b-ac98-3d30705805e9.png)

![image](https://user-images.githubusercontent.com/13484138/209865491-73bd684b-6b62-41aa-925a-46b06fb7e3c1.png)

![image](https://user-images.githubusercontent.com/13484138/209865580-a6b387da-e0ae-41be-9380-57435e1b0348.png)

What happens is that when the issue occurs, the isSet4 variable gets overwritten by the `bp.users.updateAttributes` call. I was able to fix it by converting the visit message event to a data event and handling the user state update in a hook, this way, the visit event is sent to the event queue and gets executed sequentially.
