### PR TITLE
fix(channel-web): carousel after reopening chat

### DIFF
--- a/modules/channel-web/assets/default.css
+++ b/modules/channel-web/assets/default.css
@@ -400,8 +400,11 @@ body {
 
 .bpw-bubble-carousel {
   background: none;
+  border: 0px;
+  padding: 0px;
   margin: 10px 0;
-  width: 100%;
+  text-align: left;
+  width: 250px; /* Magic number so that it fits properly in the web */
 }
 
 .bpw-bubble-file {

--- a/modules/channel-web/package.json
+++ b/modules/channel-web/package.json
@@ -52,7 +52,7 @@
     "react-linkify": "^0.2.2",
     "react-scroll-to-bottom": "^4.2.0",
     "react-select": "^2.4.2",
-    "react-slick": "^0.24.0",
+    "react-slick": "0.29.0",
     "slick-carousel": "^1.8.1",
     "snarkdown": "^1.2.2",
     "uuid": "^3.1.0"

--- a/modules/channel-web/src/views/lite/components/messages/renderer/Carousel.tsx
+++ b/modules/channel-web/src/views/lite/components/messages/renderer/Carousel.tsx
@@ -6,6 +6,18 @@ import '../../../../../../assets/slick/slick-theme.css'
 import '../../../../../../assets/slick/slick.css'
 import { Renderer } from '../../../typings'
 
+const CarouselSkeleton = () => {
+  const common = { width: '100%', borderRadius: 5, padding: 10 }
+  const button = { height: 30, backgroundColor: '#ecebeb', marginTop: 10, ...common }
+  return (
+    <div className="bpw-carousel-skeleton" style={{ height: 380, backgroundColor: '#f3f3f3', ...common }}>
+      <div style={{ height: 280, backgroundColor: '#ecebeb', ...common }} />
+      <div style={button} />
+      <div style={button} />
+    </div>
+  )
+}
+
 export class Carousel extends React.Component<ICarouselProps, ICarouselState> {
   private ref
 
@@ -14,7 +26,8 @@ export class Carousel extends React.Component<ICarouselProps, ICarouselState> {
   }
 
   componentDidMount() {
-    this.setState({ adjustedWidth: this.ref.offsetWidth - window.innerWidth })
+    // Delay this to avoid incorrect values when closing-opening the webchat
+    setTimeout(() => this.setState({ adjustedWidth: this.ref.offsetWidth - window.innerWidth }), 300)
   }
 
   renderCarousel() {
@@ -51,7 +64,7 @@ export class Carousel extends React.Component<ICarouselProps, ICarouselState> {
   render() {
     return (
       <div ref={el => (this.ref = el)} style={{ width: '100%', ...this.props.style }}>
-        {this.state.adjustedWidth && this.renderCarousel()}
+        {(this.state.adjustedWidth && this.renderCarousel()) || <CarouselSkeleton />}
       </div>
     )
   }

--- a/modules/channel-web/yarn.lock
+++ b/modules/channel-web/yarn.lock
@@ -1252,10 +1252,10 @@ react-select@^2.4.2:
     react-input-autosize "^2.2.1"
     react-transition-group "^2.2.1"
 
-react-slick@^0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/react-slick/-/react-slick-0.24.0.tgz#1a4e078a82de4e9458255d9ce26aa6f3b17b168b"
-  integrity sha512-Pvo0B74ohumQdYOf0qP+pdQpj9iUbAav7+2qiF3uTc5XeQp/Y/cnIeDBM2tB3txthfSe05jKIqLMJTS6qVvt5g==
+react-slick@0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/react-slick/-/react-slick-0.29.0.tgz#0bed5ea42bf75a23d40c0259b828ed27627b51bb"
+  integrity sha512-TGdOKE+ZkJHHeC4aaoH85m8RnFyWqdqRfAGkhd6dirmATXMZWAxOpTLmw2Ll/jPTQ3eEG7ercFr/sbzdeYCJXA==
   dependencies:
     classnames "^2.2.5"
     enquire.js "^2.1.6"


### PR DESCRIPTION
This fixes an issue with the carousel when closing and reopening the webchat; we give the web channel enough time to open before mounting the component.

Before: 

https://user-images.githubusercontent.com/13484138/211102945-d31a9609-818a-4281-bfb5-9d79cb6db6b7.mp4

After:

https://user-images.githubusercontent.com/13484138/211102735-9d4bf7a3-b7f1-44d2-bb16-81f357265345.mp4

