### PR TITLE
fix(core): improved timeout behavior

### DIFF
--- a/packages/bp/src/core/dialog/dialog-engine.ts
+++ b/packages/bp/src/core/dialog/dialog-engine.ts
@@ -314,12 +314,15 @@ export class DialogEngine {
       }
     }
 
-    if (!timeoutNode || !timeoutFlow) {
-      throw new TimeoutNodeNotFound(`Could not find any timeout node or flow for session "${sessionId}"`)
+    if (timeoutNode && timeoutFlow) {
+      // There is a timeout node and flow, we jump to it
+      this.fillContextForTransition(event, { currentFlow, currentNode, nextFlow: timeoutFlow, nextNode: timeoutNode })
+    } else if (!event.state.context?.hasJumped) {
+      // If there was no jump, we just return the event to have it's state changes persisted
+      return event
     }
 
-    this.fillContextForTransition(event, { currentFlow, currentNode, nextFlow: timeoutFlow, nextNode: timeoutNode })
-
+    // Process the event with the new context, return to persist state changes
     return this.processEvent(sessionId, event)
   }
 

--- a/packages/bp/src/core/dialog/dialog-engine.ts
+++ b/packages/bp/src/core/dialog/dialog-engine.ts
@@ -414,7 +414,7 @@ export class DialogEngine {
 
   protected async _transition(sessionId: string, event: IO.IncomingEvent, transitionTo: string) {
     let context: IO.DialogContext = event.state.context || {}
-    this._detectInfiniteLoop(event.state.__stacktrace, event.botId)
+    this.detectInfiniteLoop(event.state.__stacktrace, event.botId)
 
     context.jumpPoints = context.jumpPoints?.filter(x => !x.used)
 
@@ -556,7 +556,7 @@ export class DialogEngine {
     this._flowsByBot.set(botId, flows)
   }
 
-  private _detectInfiniteLoop(stacktrace: IO.JumpPoint[], botId: string) {
+  public detectInfiniteLoop(stacktrace: IO.JumpPoint[], botId: string) {
     // find the first node that gets repeated at least 3 times
     const loop = _.chain(stacktrace)
       .groupBy(x => `${x.flow}|${x.node}`)

--- a/packages/bp/src/core/dialog/janitor.ts
+++ b/packages/bp/src/core/dialog/janitor.ts
@@ -106,7 +106,11 @@ export class DialogJanitor extends Janitor {
 
       const { result: user } = await this.userRepo.getOrCreate(channel, target, botId)
 
-      fakeEvent.state.context = session.context as IO.DialogContext
+      // We clean the queue because that processTimeout will return the same event context
+      // if there is no jump, so we don't want the timeout event to process the previous queue
+      // The reason to return the event is to persist any changes made to session state or context
+      // in the session timeout hook
+      fakeEvent.state.context = { ...session.context, queue: undefined } as IO.DialogContext
       fakeEvent.state.session = session.session_data as IO.CurrentSession
       fakeEvent.state.user = user.attributes
       fakeEvent.state.temp = session.temp_data
@@ -141,6 +145,9 @@ export class DialogJanitor extends Janitor {
     if (update.resetSession) {
       session.context = {}
       session.temp_data = {}
+    } else {
+      session.context = update.event?.state.context || session.context
+      session.temp_data = update.event?.state.temp
     }
 
     session.context_expiry = expiry.context

--- a/packages/bp/src/core/dialog/janitor.ts
+++ b/packages/bp/src/core/dialog/janitor.ts
@@ -93,6 +93,8 @@ export class DialogJanitor extends Janitor {
       const { channel, target, threadId } = SessionIdFactory.extractDestinationFromId(sessionId)
       const session = await this.sessionRepo.get(sessionId)
 
+      this.dialogEngine.detectInfiniteLoop(session.context.jumpPoints || [], botId)
+
       // This event only exists so that processTimeout can call processEvent
       const fakeEvent = Event({
         type: 'timeout',


### PR DESCRIPTION
This PR fixes the conversation timeout behavior with the following items:

- Saves the state and context so if there are any jumps during the timeout flow or timeout hook the conversation can be continued (If there is no jump, only the state will be persisted)

![image](https://user-images.githubusercontent.com/13484138/213593023-de961519-fbe3-4fe7-b45b-7e98aa714ab5.png)

- Allows timeout hook to be executed even if there is no timeout flow (I think this is a bug)

![image](https://user-images.githubusercontent.com/13484138/213593351-75c975c9-68b8-401e-80af-0956bf8a59ea.png)

- Adds infinite loop detection for timeout (Easily reproducible when using timeout nodes)

![2023-01-19_21-34](https://user-images.githubusercontent.com/13484138/213592711-0dff7d15-3a87-49ad-b662-2aededd1a21e.png)

![image](https://user-images.githubusercontent.com/13484138/213592405-64877b87-b536-433b-9bf3-9ae85867024d.png)
