### PR TITLE
fix(core): fix dialog timeout loop detection

### DIFF
--- a/packages/bp/src/core/dialog/dialog-engine.ts
+++ b/packages/bp/src/core/dialog/dialog-engine.ts
@@ -253,7 +253,7 @@ export class DialogEngine {
       nextFlow,
       nextNode
     }: {
-      currentFlow: FlowWithParent
+      currentFlow?: FlowWithParent
       currentNode?: FlowNode
       nextFlow: FlowWithParent
       nextNode: FlowNode
@@ -264,13 +264,16 @@ export class DialogEngine {
       currentNode: nextNode.name,
       currentFlow: nextFlow.name,
       queue: undefined,
-      previousFlow: currentFlow.name,
+      previousFlow: currentFlow?.name ?? '',
       previousNode: currentNode?.name ?? '',
-      hasJumped: true,
-      jumpPoints: [
+      hasJumped: true
+    }
+
+    if (currentFlow) {
+      event.state.context.jumpPoints = [
         ...(event.state.context?.jumpPoints || []),
         {
-          flow: currentFlow.name,
+          flow: currentFlow?.name,
           node: currentNode?.name as string
         }
       ]
@@ -285,7 +288,7 @@ export class DialogEngine {
 
     await this._loadFlows(botId)
 
-    const currentFlow = this._findFlow(botId, event.state.context?.currentFlow)
+    const currentFlow = this.findFlowWithoutError(botId, event.state.context?.currentFlow)
     const currentNode = this.findNodeWithoutError(botId, currentFlow, event.state.context?.currentNode)
 
     // Check for a timeout property in the current node

--- a/packages/bp/src/core/dialog/janitor.ts
+++ b/packages/bp/src/core/dialog/janitor.ts
@@ -2,18 +2,20 @@ import { BotConfig, IO, Logger } from 'botpress/sdk'
 import { TYPES } from 'core/app/types'
 import { BotService } from 'core/bots'
 import { BotpressConfig, ConfigProvider } from 'core/config'
-import { SessionRepository, createExpiry, SessionIdFactory } from 'core/dialog/sessions'
+import { SessionRepository, createExpiry, SessionIdFactory, DialogSession } from 'core/dialog/sessions'
 import { JobService } from 'core/distributed'
-import { Event } from 'core/events'
+import { Event, EventRepository } from 'core/events'
+import { EventCollector } from 'core/events/event-collector'
 import { Janitor } from 'core/services/janitor'
 import { ChannelUserRepository } from 'core/users'
 import { inject, injectable, tagged } from 'inversify'
 import _ from 'lodash'
 import { Memoize } from 'lodash-decorators'
+import moment from 'moment'
 import ms from 'ms'
 
 import { DialogEngine } from './dialog-engine'
-import { TimeoutNodeNotFound } from './errors'
+import { TimeoutNodeNotFound, InfiniteLoopError } from './errors'
 
 const debug = DEBUG('janitor')
 const dialogDebug = debug.sub('dialog')
@@ -34,7 +36,9 @@ export class DialogJanitor extends Janitor {
     @inject(TYPES.BotService) private botService: BotService,
     @inject(TYPES.SessionRepository) private sessionRepo: SessionRepository,
     @inject(TYPES.UserRepository) private userRepo: ChannelUserRepository,
-    @inject(TYPES.JobService) private jobService: JobService
+    @inject(TYPES.JobService) private jobService: JobService,
+    @inject(TYPES.EventCollector) private eventCollector: EventCollector,
+    @inject(TYPES.EventRepository) private eventRepository: EventRepository
   ) {
     super(logger)
   }
@@ -93,18 +97,21 @@ export class DialogJanitor extends Janitor {
       const { channel, target, threadId } = SessionIdFactory.extractDestinationFromId(sessionId)
       const session = await this.sessionRepo.get(sessionId)
 
-      this.dialogEngine.detectInfiniteLoop(session.context.jumpPoints || [], botId)
+      await this.detectTimeoutInfiniteLoop(session, botId)
 
-      // This event only exists so that processTimeout can call processEvent
-      const fakeEvent = Event({
+      // Used to call processEvent and it's also saved for loop detection
+      const InternalEvent = Event({
         type: 'timeout',
         channel,
         target,
         threadId,
-        direction: 'incoming',
+        direction: 'internal',
         payload: '',
         botId
-      }) as IO.IncomingEvent
+      }) as IO.InternalEvent
+
+      // Store the timeout event so we can detect loops
+      this.eventCollector.storeEvent(InternalEvent)
 
       const { result: user } = await this.userRepo.getOrCreate(channel, target, botId)
 
@@ -112,12 +119,12 @@ export class DialogJanitor extends Janitor {
       // if there is no jump, so we don't want the timeout event to process the previous queue
       // The reason to return the event is to persist any changes made to session state or context
       // in the session timeout hook
-      fakeEvent.state.context = { ...session.context, queue: undefined } as IO.DialogContext
-      fakeEvent.state.session = session.session_data as IO.CurrentSession
-      fakeEvent.state.user = user.attributes
-      fakeEvent.state.temp = session.temp_data
+      InternalEvent.state.context = { ...session.context, queue: undefined } as IO.DialogContext
+      InternalEvent.state.session = session.session_data as IO.CurrentSession
+      InternalEvent.state.user = user.attributes
+      InternalEvent.state.temp = session.temp_data
 
-      update.event = await this.dialogEngine.processTimeout(botId, sessionId, fakeEvent)
+      update.event = await this.dialogEngine.processTimeout(botId, threadId || target, InternalEvent)
 
       if (_.get(update.event, 'state.context.queue.instructions.length', 0) > 0) {
         // if after processing the timeout handling we still have instructions queued, we're not clearing the context
@@ -159,5 +166,57 @@ export class DialogJanitor extends Janitor {
     await this.sessionRepo.update(session)
 
     dialogDebug.forBot(botId, `New expiry set for ${session.context_expiry}`, sessionId)
+  }
+
+  public async detectTimeoutInfiniteLoop(session: DialogSession, botId: string) {
+    try {
+      const botpressConfig = await this.getBotpressConfig()
+      const botConfig = await this.configProvider.getBotConfig(botId)
+      const { threadId, target } = SessionIdFactory.extractDestinationFromId(session.id)
+
+      const limit = 5
+      const dialogTimeout = _.get(botConfig, 'dialog.timeoutInterval', botpressConfig.dialog.timeoutInterval) as string
+      const from = moment(moment().valueOf() - ms(dialogTimeout) * (limit * 2))
+
+      // We get the last 5 timeout events ( limiting the creation time by now - 2 * the timeout interval * 5 )
+      const timeoutEvents = await this.eventRepository.findEvents(
+        { botId, ...(threadId && { threadId }), target, type: 'timeout' },
+        { count: limit, sortOrder: [{ column: 'createdOn', desc: true }], createdOn: { from: from.toDate() } }
+      )
+
+      // Not enought timeout events
+      if (timeoutEvents.length < limit) {
+        return
+      }
+
+      // We get all the events that happened after in the oldest timeout event
+      const eventsAfterTimeout = await this.eventRepository.findEvents(
+        { botId, ...(threadId && { threadId }), target },
+        {
+          sortOrder: [{ column: 'createdOn', desc: true }],
+          createdOn: { from: moment(timeoutEvents[limit - 1].createdOn).toDate() }
+        }
+      )
+
+      // Even if we have enough timeout events, if there is an incoming event after the oldest timeout event
+      // Then there is no loop
+      if (!eventsAfterTimeout.find(item => item.direction === 'incoming')) {
+        const recurringPath: string[] = []
+        const stacktrace = session.context.jumpPoints || []
+
+        const { node, flow } = stacktrace[0]
+        for (const jump of stacktrace.slice(0, 16)) {
+          recurringPath.push(`${jump.flow} (${jump.node})`)
+        }
+
+        throw new InfiniteLoopError(recurringPath, botId, flow, node)
+      }
+    } catch (err) {
+      if (err instanceof InfiniteLoopError) {
+        throw err
+      } else {
+        this.logger.forBot(botId).error(`Error verifying infinite loop on dialog timeout. ${err.message}`)
+      }
+    }
   }
 }

--- a/packages/bp/src/core/dialog/janitor.ts
+++ b/packages/bp/src/core/dialog/janitor.ts
@@ -184,7 +184,7 @@ export class DialogJanitor extends Janitor {
         { count: limit, sortOrder: [{ column: 'createdOn', desc: true }], createdOn: { from: from.toDate() } }
       )
 
-      // Not enought timeout events
+      // Not enough timeout events
       if (timeoutEvents.length < limit) {
         return
       }

--- a/packages/bp/src/core/dialog/janitor.ts
+++ b/packages/bp/src/core/dialog/janitor.ts
@@ -124,7 +124,7 @@ export class DialogJanitor extends Janitor {
       InternalEvent.state.user = user.attributes
       InternalEvent.state.temp = session.temp_data
 
-      update.event = await this.dialogEngine.processTimeout(botId, threadId || target, InternalEvent)
+      update.event = await this.dialogEngine.processTimeout(botId, sessionId, InternalEvent)
 
       if (_.get(update.event, 'state.context.queue.instructions.length', 0) > 0) {
         // if after processing the timeout handling we still have instructions queued, we're not clearing the context

--- a/packages/bp/src/core/dialog/janitor.ts
+++ b/packages/bp/src/core/dialog/janitor.ts
@@ -181,7 +181,7 @@ export class DialogJanitor extends Janitor {
       // We get the last 5 timeout events ( limiting the creation time by now - 2 * the timeout interval * 5 )
       const timeoutEvents = await this.eventRepository.findEvents(
         { botId, ...(threadId && { threadId }), target, type: 'timeout' },
-        { count: limit, sortOrder: [{ column: 'createdOn', desc: true }], createdOn: { from: from.toDate() } }
+        { count: limit, sortOrder: [{ column: 'createdOn', desc: true }], createdOn: { after: from.toDate() } }
       )
 
       // Not enough timeout events
@@ -194,7 +194,7 @@ export class DialogJanitor extends Janitor {
         { botId, ...(threadId && { threadId }), target },
         {
           sortOrder: [{ column: 'createdOn', desc: true }],
-          createdOn: { from: moment(timeoutEvents[limit - 1].createdOn).toDate() }
+          createdOn: { after: moment(timeoutEvents[limit - 1].createdOn).toDate() }
         }
       )
 

--- a/packages/bp/src/core/events/event-repository.ts
+++ b/packages/bp/src/core/events/event-repository.ts
@@ -32,11 +32,11 @@ export class EventRepository {
     query = query.where(fields)
 
     if (params.createdOn) {
-      if (params.createdOn.from) {
-        query = query.andWhere(this.database.knex.date.isAfterOrOn('createdOn', params.createdOn.from))
+      if (params.createdOn.after) {
+        query = query.andWhere(this.database.knex.date.isAfterOrOn('createdOn', params.createdOn.after))
       }
-      if (params.createdOn.to) {
-        query = query.andWhere(this.database.knex.date.isBeforeOrOn('createdOn', params.createdOn.to))
+      if (params.createdOn.before) {
+        query = query.andWhere(this.database.knex.date.isBeforeOrOn('createdOn', params.createdOn.before))
       }
     }
 
@@ -85,7 +85,7 @@ export class EventRepository {
     const storedEvent = events[0]
     const incomingEvent = storedEvent.event as sdk.IO.IncomingEvent
 
-    await this.updateEvent(storedEvent.id, {feedback})
+    await this.updateEvent(storedEvent.id, { feedback })
 
     if (type) {
       const details = incomingEvent.decision?.sourceDetails

--- a/packages/bp/src/core/events/event-repository.ts
+++ b/packages/bp/src/core/events/event-repository.ts
@@ -6,7 +6,8 @@ import { inject, injectable } from 'inversify'
 export const DefaultSearchParams: sdk.EventSearchParams = {
   sortOrder: [{ column: 'createdOn' }],
   from: 0,
-  count: 10
+  count: 10,
+  createdOn: undefined
 }
 
 const UNLIMITED_ELEMENTS = -1
@@ -29,6 +30,15 @@ export class EventRepository {
 
     let query = this.database.knex(this.TABLE_NAME)
     query = query.where(fields)
+
+    if (params.createdOn) {
+      if (params.createdOn.from) {
+        query = query.andWhere(this.database.knex.date.isAfterOrOn('createdOn', params.createdOn.from))
+      }
+      if (params.createdOn.to) {
+        query = query.andWhere(this.database.knex.date.isBeforeOrOn('createdOn', params.createdOn.to))
+      }
+    }
 
     sortOrder &&
       sortOrder.forEach(sort => {

--- a/packages/bp/src/sdk/botpress.d.ts
+++ b/packages/bp/src/sdk/botpress.d.ts
@@ -1709,7 +1709,7 @@ declare module 'botpress/sdk' {
     count?: number
     /** An array of columns with direction to sort results */
     sortOrder?: SortOrder[]
-    createdOn?: { from?: Date; to?: Date }
+    createdOn?: { after?: Date; before?: Date }
   }
 
   export interface Filter {

--- a/packages/bp/src/sdk/botpress.d.ts
+++ b/packages/bp/src/sdk/botpress.d.ts
@@ -443,7 +443,7 @@ declare module 'botpress/sdk' {
   }
 
   export namespace IO {
-    export type EventDirection = 'incoming' | 'outgoing'
+    export type EventDirection = 'incoming' | 'outgoing' | 'internal'
     export namespace WellKnownFlags {
       /** When this flag is active, the dialog engine will ignore those events */
       export const SKIP_DIALOG_ENGINE: symbol
@@ -585,6 +585,12 @@ declare module 'botpress/sdk' {
       /* HITL module has possibility to pause conversation */
       readonly isPause?: boolean
       readonly ndu?: NDU.DialogUnderstanding
+    }
+
+    export interface InternalEvent extends Event {
+      direction: 'internal'
+      /** Contains data related to the state of the event */
+      state: EventState
     }
 
     export interface OutgoingEvent extends Event {
@@ -806,7 +812,7 @@ declare module 'botpress/sdk' {
    * An outgoing event will register itself into the outgoing middleware chain.
    * @see MiddlewareDefinition to learn more about middleware.
    */
-  export type EventDirection = 'incoming' | 'outgoing'
+  export type EventDirection = 'incoming' | 'outgoing' | 'internal'
 
   export interface UpsertOptions {
     /** Whether or not to record a revision @default true */
@@ -1703,6 +1709,7 @@ declare module 'botpress/sdk' {
     count?: number
     /** An array of columns with direction to sort results */
     sortOrder?: SortOrder[]
+    createdOn?: { from?: Date; to?: Date }
   }
 
   export interface Filter {


### PR DESCRIPTION
This is an additional PR to https://github.com/botpress/botpress/pull/12470

The previous approach to detect dialog timeout loops was not reliable on edge cases, this PR creates an internal event that gets stored in the events table, we use that to verify for loops instead