### PR TITLE
chore(admin): add help button

### DIFF
--- a/packages/ui-admin/src/app/Header/Help.tsx
+++ b/packages/ui-admin/src/app/Header/Help.tsx
@@ -12,8 +12,8 @@ export const HelpMenu = props => {
       <Popover
         content={
           <Menu>
-            <MenuItem icon="people" text={lang.tr('forum')} onClick={() => window.open(FORUM_LINK)} />
-            <MenuItem icon="book" text={lang.tr('docs')} onClick={() => window.open(DOCS_LINK)} />
+            <MenuItem icon="people" text={lang.tr('forum')} onClick={() => window.open(FORUM_LINK, '_blank')} />
+            <MenuItem icon="book" text={lang.tr('docs')} onClick={() => window.open(DOCS_LINK, '_blank')} />
           </Menu>
         }
         minimal

--- a/packages/ui-admin/src/app/Header/Help.tsx
+++ b/packages/ui-admin/src/app/Header/Help.tsx
@@ -7,8 +7,6 @@ const FORUM_LINK = 'https://github.com/botpress/botpress/discussions'
 const DOCS_LINK = 'https://v12.botpress.com/'
 
 export const HelpMenu = props => {
-  const [isHelpPopoverOpen, setHelpPopoverOpen] = useState(false)
-
   return (
     <div id="help_dropdown">
       <Popover
@@ -19,21 +17,20 @@ export const HelpMenu = props => {
           </Menu>
         }
         minimal
-        isOpen={isHelpPopoverOpen}
+        target={
+          <Tooltip content={<div className={style.tooltip}>{lang.tr('help')}</div>}>
+            <Button minimal>
+              <Icon color={Colors.BLACK} icon="help" iconSize={16} />
+            </Button>
+          </Tooltip>
+        }
         position={Position.TOP_RIGHT}
         canEscapeKeyClose
-        onClose={() => setHelpPopoverOpen(false)}
         fill
         modifiers={{
           preventOverflow: { enabled: true, boundariesElement: 'window' }
         }}
-      >
-        <Tooltip content={<div className={style.tooltip}>{lang.tr('help')}</div>}>
-          <Button onClick={() => setHelpPopoverOpen(!isHelpPopoverOpen)} minimal>
-            <Icon color={Colors.BLACK} icon="help" iconSize={16} />
-          </Button>
-        </Tooltip>
-      </Popover>
+      />
     </div>
   )
 }

--- a/packages/ui-admin/src/app/Header/Help.tsx
+++ b/packages/ui-admin/src/app/Header/Help.tsx
@@ -1,0 +1,39 @@
+import { Icon, Menu, MenuItem, Popover, Position, Button, Colors, Tooltip } from '@blueprintjs/core'
+import { lang } from 'botpress/shared'
+import React, { useState } from 'react'
+import style from './style.scss'
+
+const FORUM_LINK = 'https://github.com/botpress/botpress/discussions'
+const DOCS_LINK = 'https://v12.botpress.com/'
+
+export const HelpMenu = props => {
+  const [isHelpPopoverOpen, setHelpPopoverOpen] = useState(false)
+
+  return (
+    <div id="help_dropdown">
+      <Popover
+        content={
+          <Menu>
+            <MenuItem icon="people" text={lang.tr('forum')} onClick={() => window.open(FORUM_LINK)} />
+            <MenuItem icon="book" text={lang.tr('docs')} onClick={() => window.open(DOCS_LINK)} />
+          </Menu>
+        }
+        minimal
+        isOpen={isHelpPopoverOpen}
+        position={Position.TOP_RIGHT}
+        canEscapeKeyClose
+        onClose={() => setHelpPopoverOpen(false)}
+        fill
+        modifiers={{
+          preventOverflow: { enabled: true, boundariesElement: 'window' }
+        }}
+      >
+        <Tooltip content={<div className={style.tooltip}>{lang.tr('help')}</div>}>
+          <Button onClick={() => setHelpPopoverOpen(!isHelpPopoverOpen)} minimal>
+            <Icon color={Colors.BLACK} icon="help" iconSize={16} />
+          </Button>
+        </Tooltip>
+      </Popover>
+    </div>
+  )
+}

--- a/packages/ui-admin/src/app/Header/index.tsx
+++ b/packages/ui-admin/src/app/Header/index.tsx
@@ -9,6 +9,7 @@ import AccessControl from '~/auth/AccessControl'
 import UserDropdownMenu from '~/user/UserDropdownMenu'
 import { AppState } from '../rootReducer'
 import { toggleBottomPanel } from '../uiReducer'
+import { HelpMenu } from './Help'
 import style from './style.scss'
 
 type Props = ConnectedProps<typeof connector>
@@ -31,6 +32,8 @@ const Header: FC<Props> = props => {
         </Navbar.Group>
         <Navbar.Group align={Alignment.RIGHT}>
           <WorkspaceSelect />
+          <Navbar.Divider />
+          <HelpMenu />
           <Navbar.Divider />
           <AccessControl resource="admin.logs" operation="read">
             <Tooltip content={<div className={style.tooltip}>{lang.tr('bottomPanel.label')}</div>}>

--- a/packages/ui-admin/src/app/translations/en.json
+++ b/packages/ui-admin/src/app/translations/en.json
@@ -450,5 +450,8 @@
         "confUpdated": "Debug configuration updated successfully!"
       }
     }
-  }
+  },
+  "docs": "Documentation",
+  "forum": "Forum",
+  "help": "Help"
 }

--- a/packages/ui-admin/src/app/translations/es.json
+++ b/packages/ui-admin/src/app/translations/es.json
@@ -430,5 +430,8 @@
         "confUpdated": "¡Configuración de depuración actualizada correctamente!"
       }
     }
-  }
+  },
+  "docs": "Documentos",
+  "forum": "Foro",
+  "help": "Ayuda"
 }

--- a/packages/ui-admin/src/app/translations/fr.json
+++ b/packages/ui-admin/src/app/translations/fr.json
@@ -445,5 +445,8 @@
         "confUpdated": "La configuration de débogage a été mise à jour avec succès!"
       }
     }
-  }
+  },
+  "docs": "Documentation",
+  "forum": "Forum",
+  "help": "Aide"
 }


### PR DESCRIPTION
Add a help button to the admin panel as requested on https://linear.app/botpress/issue/GTM-309/add-buttons-to-v12-to-make-it-easier-for-users-to-get-help-in-the-v12

Related PR: https://github.com/botpress/studio/pull/411

![image](https://user-images.githubusercontent.com/13484138/225130964-0c58b03e-e0a5-4967-bcc7-a95b91371410.png)
