### PR TITLE
fix(hitl-next): updates for second conversation

### DIFF
--- a/modules/hitlnext/src/views/full/app/components/ConversationContainer.tsx
+++ b/modules/hitlnext/src/views/full/app/components/ConversationContainer.tsx
@@ -133,7 +133,7 @@ const ConversationContainer: FC<Props> = ({ api, bp }) => {
     ].filter(Boolean)
 
   const content = shouldRenderLiveChat ? (
-    <LiveChat handoff={selectedHandoff} currentAgent={state.currentAgent} />
+    <LiveChat key={selectedHandoff.userThreadId} handoff={selectedHandoff} currentAgent={state.currentAgent} />
   ) : (
     <ConversationHistory bp={bp} api={api} conversationId={selectedHandoff.userThreadId} />
   )


### PR DESCRIPTION
This fixes an issue where if you are handling two conversations, updates for one of the conversations would not be received even if you are looking at the chat (including agent messages)

It occurred because, when switching the conversation, because the LiveChat component didn't have a distinct key, not all required effects would be triggered.