### PR TITLE
Update package.json

### DIFF
--- a/modules/ndu/package.json
+++ b/modules/ndu/package.json
@@ -21,7 +21,7 @@
     "moment": "^2.24.0",
     "ms": "^2.1.2",
     "nanoid": "^3.1.31",
-    "@botpress/node-svm": "0.0.3",
+    "@botpress/node-svm": "^0.0.4",
     "seedrandom": "^3.0.5",
     "numeric": "^1.2.6"
   },


### PR DESCRIPTION
Fixing the build error: botpress/v12#1729 
The error message suggests that there is an issue with fetching the node-svm package from the yarnpkg registry. The request to fetch the package returned a "404 Not Found" error, which means that the package was not found in the registry.

To fix this issue, updating the version of the node-svm package in  package.json file to a version that exists in the yarnpkg registry. Also can  try running yarn install to ensure that all dependencies are up-to-date and installed correctly.