### PR TITLE
fix(misunderstood): unselect amended items to prevent incorrect status

### DIFF
--- a/modules/misunderstood/src/views/full/index.tsx
+++ b/modules/misunderstood/src/views/full/index.tsx
@@ -199,6 +199,9 @@ export default class MisunderstoodMainView extends React.Component<Props, State>
       FLAGGED_MESSAGE_STATUS.pending,
       resolutionData
     )
+
+    await this.setStateP({ checkedEventIds: [], selectAllChecked: false })
+
     return this.alterEventsList(
       FLAGGED_MESSAGE_STATUS.new,
       FLAGGED_MESSAGE_STATUS.pending,


### PR DESCRIPTION
If you amend and then delete some items, since the checked list was not cleared, it would move the amended items to the deleted