### PR TITLE
Fix #12669 - Broadcast module filters are now working

### DIFF
--- a/modules/broadcast/src/backend/daemon.ts
+++ b/modules/broadcast/src/backend/daemon.ts
@@ -35,7 +35,12 @@ export default async (botId: string, bp: typeof sdk, db: Database) => {
             bp.logger.warn('Filter returned something other ' + 'than a boolean (or a Promise of a boolean)')
           }
 
-          return typeof v !== 'undefined' && v !== null
+          if(typeof v == 'undefined' || v == null){
+            return true;
+            }
+          else {
+            return v;
+          }
         })
       })
     }


### PR DESCRIPTION
This pull request fixes issue botpress/v12#1739.

PS. In order to build it I had to update the module-builder Babel version to `^7.20` or I would get this error https://github.com/babel/babel/issues/15089 -- Let me know If you want me to also add that change here. 