### PR TITLE
feat(integrations/whatsapp): support for creating conversations

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -2,8 +2,10 @@ import { IntegrationDefinition, messages } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { z } from 'zod'
 
+export const name = 'whatsapp'
+
 export default new IntegrationDefinition({
-  name: 'whatsapp',
+  name,
   version: '0.2.0',
   title: 'WhatsApp',
   description: 'This integration allows your bot to interact with WhatsApp.',
@@ -25,9 +27,32 @@ export default new IntegrationDefinition({
         },
       },
       conversation: {
+        creation: {
+          enabled: true,
+          requiredTags: ['userPhone', 'templateName'],
+        },
         tags: {
-          userPhone: {},
-          phoneNumberId: {},
+          userPhone: {
+            title: 'User phone number',
+            description: 'Phone number of the Whatsapp user to start the conversation with.',
+          },
+          phoneNumberId: {
+            title: 'Phone number ID',
+            description: 'ID of the Whatsapp phone number to use as sender.',
+          },
+          templateName: {
+            title: 'Message template name',
+            description: 'Name of Message Template to start the conversation with.',
+          },
+          templateLanguage: {
+            title: 'Message template language (optional)',
+            description:
+              'Language of Message Template to start the conversation with. Defaults to "en_US" (U.S. English).',
+          },
+          templateVariables: {
+            title: 'Message template variables (optional)',
+            description: 'JSON array representation of variable values to pass to the Message Template.',
+          },
         },
       },
     },

--- a/integrations/whatsapp/package.json
+++ b/integrations/whatsapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpresshub/whatsapp",
   "version": "0.2.0",
-  "description": "Instagram integration for Botpress",
+  "description": "Whatsapp integration for Botpress",
   "private": true,
   "scripts": {
     "start": "pnpm bp serve",
@@ -19,7 +19,7 @@
     "@botpress/sdk-addons": "workspace:*",
     "query-string": "^6.14.1",
     "whatsapp-api-js": "^0.8.2",
-    "zod": "^3.20.6"
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@botpress/cli": "workspace:*",

--- a/integrations/whatsapp/src/conversation.ts
+++ b/integrations/whatsapp/src/conversation.ts
@@ -1,0 +1,106 @@
+import { Client, RuntimeError } from '@botpress/client'
+import { CreateConversationPayload, IntegrationContext } from '@botpress/sdk/dist/integration'
+import { name } from 'integration.definition'
+import { WhatsAppAPI, Types } from 'whatsapp-api-js'
+import z from 'zod'
+import { Configuration } from '.botpress/implementation/configuration'
+
+const {
+  Template: { Template, Language },
+} = Types
+
+export async function createConversation({
+  client,
+  channel,
+  tags,
+  ctx,
+}: {
+  ctx: IntegrationContext<Configuration>
+  client: Client
+} & CreateConversationPayload) {
+  const phoneNumberId = ctx.configuration.phoneNumberId
+  if (!phoneNumberId) {
+    throw new RuntimeError('Phone number ID is not configured')
+  }
+
+  const userPhoneTag = `${name}:userPhone`
+  const userPhone = tags[userPhoneTag]
+  if (!userPhone) {
+    throw new RuntimeError(`A Whatsapp recipient phone number needs to be provided in the '${userPhoneTag}' tag`)
+  }
+
+  /*
+  Whatsapp only allows using Message Templates for proactively starting conversations with users.
+  See: https://developers.facebook.com/docs/whatsapp/pricing#opening-conversations
+  */
+  const templateNameTag = `${name}:templateName`
+  const templateName = tags[templateNameTag]
+  if (!templateName) {
+    throw new RuntimeError(`A Whatsapp template name needs to be provided in the '${templateNameTag}' tag`)
+  }
+
+  const templateLanguageTag = `${name}:templateLanguage`
+  const templateLanguage = tags[templateLanguageTag] || 'en_US'
+
+  const templateVariablesTag = `${name}:templateVariables`
+  const templateVariablesSchema = z.array(z.string().or(z.number()))
+  let templateVariables: z.infer<typeof templateVariablesSchema> = []
+
+  if (templateVariablesTag in tags) {
+    let templateVariablesRaw = []
+
+    try {
+      templateVariablesRaw = JSON.parse(tags[templateVariablesTag]!)
+    } catch (err) {
+      throw new RuntimeError(
+        `Template variables received isn't valid JSON (error: ${(err as Error)?.message ?? ''}). Received: ${
+          tags[templateVariablesTag]
+        }})`
+      )
+    }
+
+    const validationResult = templateVariablesSchema.safeParse(templateVariablesRaw)
+    if (!validationResult.success) {
+      throw new RuntimeError(
+        `Template variables should be an array of strings or numbers (error: ${validationResult.error}))`
+      )
+    }
+
+    templateVariables = validationResult.data
+  }
+
+  const { conversation } = await client.getOrCreateConversation({
+    channel,
+    tags: {
+      [`${name}:phoneNumberId`]: phoneNumberId,
+      [userPhoneTag]: userPhone,
+      [templateNameTag]: templateName,
+    },
+  })
+
+  const whatsapp = new WhatsAppAPI(ctx.configuration.accessToken)
+
+  const template = new Template(templateName, new Language(templateLanguage), {
+    type: 'body',
+    parameters: templateVariables.map((variable) => ({
+      type: 'text',
+      text: variable,
+    })),
+  })
+
+  const response = await whatsapp.sendMessage(phoneNumberId, userPhone, template)
+
+  if (response?.error) {
+    throw new RuntimeError(
+      `Failed to start Whatsapp conversation using template "${templateName}" and language "${templateLanguage}" - Error: ${JSON.stringify(
+        response.error
+      )}`
+    )
+  }
+
+  return {
+    body: JSON.stringify({ conversation: { id: conversation.id } }),
+    headers: {},
+    statusCode: 200,
+  }
+}

--- a/integrations/whatsapp/src/index.ts
+++ b/integrations/whatsapp/src/index.ts
@@ -1,8 +1,9 @@
-import type { Client } from '@botpress/client'
+import { type Client } from '@botpress/client'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
+import { name } from 'integration.definition'
 import queryString from 'query-string'
-
 import { WhatsAppAPI, Types } from 'whatsapp-api-js'
+import { createConversation } from './conversation'
 import * as card from './message-types/card'
 import * as carousel from './message-types/carousel'
 import * as choice from './message-types/choice'
@@ -24,6 +25,7 @@ const integration = new Integration({
   register: async () => {},
   unregister: async () => {},
   actions: {},
+  createConversation,
   channels: {
     channel: {
       messages: {
@@ -149,22 +151,22 @@ async function handleMessage(message: WhatsAppMessage, value: WhatsAppValue, cli
     const { conversation } = await client.getOrCreateConversation({
       channel: 'channel',
       tags: {
-        'whatsapp:userPhone': message.from,
-        'whatsapp:phoneNumberId': value.metadata.phone_number_id,
+        [`${name}:userPhone`]: message.from,
+        [`${name}:phoneNumberId`]: value.metadata.phone_number_id,
       },
     })
 
     if (value.contacts.length > 0) {
       const { user } = await client.getOrCreateUser({
         tags: {
-          'whatsapp:userId': value.contacts[0] ? value.contacts[0].wa_id : '',
-          'whatsapp:name': value.contacts[0] ? value.contacts[0]?.profile.name : '',
+          [`${name}:userId`]: value.contacts[0] ? value.contacts[0].wa_id : '',
+          [`${name}:name`]: value.contacts[0] ? value.contacts[0]?.profile.name : '',
         },
       })
 
       if (message.text) {
         await client.createMessage({
-          tags: { 'whatsapp:id': message.id },
+          tags: { [`${name}:id`]: message.id },
           type: 'text',
           payload: { text: message.text.body },
           userId: user.id,
@@ -173,7 +175,7 @@ async function handleMessage(message: WhatsAppMessage, value: WhatsAppValue, cli
       } else if (message.interactive) {
         if (message.interactive.type === 'button_reply') {
           await client.createMessage({
-            tags: { 'whatsapp:id': message.id },
+            tags: { [`${name}:id`]: message.id },
             type: 'text',
             payload: {
               text: message.interactive.button_reply?.id,
@@ -184,7 +186,7 @@ async function handleMessage(message: WhatsAppMessage, value: WhatsAppValue, cli
           })
         } else if (message.interactive.type === 'list_reply') {
           await client.createMessage({
-            tags: { 'whatsapp:id': message.id },
+            tags: { [`${name}:id'`]: message.id },
             type: 'text',
             payload: {
               text: message.interactive.list_reply?.id,

--- a/integrations/whatsapp/src/index.ts
+++ b/integrations/whatsapp/src/index.ts
@@ -1,4 +1,4 @@
-import { type Client } from '@botpress/client'
+import type { Client } from '@botpress/client'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { name } from 'integration.definition'
 import queryString from 'query-string'

--- a/integrations/whatsapp/src/outgoing-message.ts
+++ b/integrations/whatsapp/src/outgoing-message.ts
@@ -1,5 +1,6 @@
 import type { Conversation } from '@botpress/client'
 import type { IntegrationContext, AckFunction } from '@botpress/sdk'
+import { name } from 'integration.definition'
 import { WhatsAppAPI } from 'whatsapp-api-js'
 import type { Contacts } from 'whatsapp-api-js/types/messages/contacts'
 import type { Interactive } from 'whatsapp-api-js/types/messages/interactive'
@@ -38,14 +39,13 @@ export async function send({
 }) {
   const whatsapp = new WhatsAppAPI(ctx.configuration.accessToken)
   const phoneNumberId = ctx.configuration.phoneNumberId
-  const to = conversation.tags['whatsapp:userPhone']
+  const to = conversation.tags[`${name}:userPhone`]
 
   if (!to) {
-    log.error('No phone number found')
+    log.error("The phone number ID isn't configured yet.")
     return
   }
 
-  // Create a bot that can send messages
   const feedback = await whatsapp.sendMessage(phoneNumberId, to, message)
 
   if (feedback?.error) {
@@ -53,10 +53,12 @@ export async function send({
     return
   }
 
-  const messageId = feedback?.message?.[0]?.id
+  const messageId = feedback?.messages?.[0]?.id
 
   if (messageId) {
-    await ack({ tags: { 'whatsapp:id': messageId } })
+    await ack({ tags: { [`${name}:id`]: messageId } })
+  } else {
+    log.error(`Could not detect message ID. Whatsapp API response: ${JSON.stringify(feedback)}`)
   }
 }
 

--- a/integrations/whatsapp/tsconfig.json
+++ b/integrations/whatsapp/tsconfig.json
@@ -6,5 +6,5 @@
     "outDir": "dist",
     "checkJs": false
   },
-  "include": [".botpress/**/*", "src/**/*"]
+  "include": [".botpress/**/*", "src/**/*", "integration.definition.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -850,7 +850,7 @@ importers:
         specifier: ^0.8.2
         version: 0.8.2
       zod:
-        specifier: ^3.20.6
+        specifier: ^3.21.4
         version: 3.21.4
     devDependencies:
       '@botpress/cli':


### PR DESCRIPTION
A Whatsapp conversation can be proactively created with a user only by using [Message Templates](https://developers.facebook.com/docs/whatsapp/message-templates/guidelines/) as outlined in the [documentation](https://developers.facebook.com/docs/whatsapp/pricing#opening-conversations).

Here's a code example of how to start a conversation from a bot:

```ts
const conversation = await client.createConversation({
  integrationName: 'whatsapp',
  channel: 'channel',
  tags: {
    'whatsapp:userPhone': '+1 504 123 456 78',
    'whatsapp:templateName': 'test_message',
    'whatsapp:templateLanguage': 'en_US', // Optional (defaults to `en_US`)
    'whatsapp:templateVariables': JSON.stringify(['John']), // Optional (only needed if your message template uses variables)
  },
})
```