### PR TITLE
fix(cli): build before deploying in dev command

### DIFF
--- a/packages/cli/src/command-implementations/dev-command.ts
+++ b/packages/cli/src/command-implementations/dev-command.ts
@@ -81,8 +81,8 @@ export class DevCommand extends ProjectCommand<DevCommandDefinition> {
     })
     await supervisor.start()
 
-    await this._deploy(api, httpTunnelUrl)
     await this._runBuild()
+    await this._deploy(api, httpTunnelUrl)
     const worker = await this._spawnWorker(env, port)
 
     try {
@@ -119,8 +119,6 @@ export class DevCommand extends ProjectCommand<DevCommandDefinition> {
   }
 
   private _restart = async (api: ApiClient, worker: Worker, tunnelUrl: string) => {
-    await this._deploy(api, tunnelUrl)
-
     try {
       await this._runBuild()
     } catch (thrown) {
@@ -129,6 +127,7 @@ export class DevCommand extends ProjectCommand<DevCommandDefinition> {
       return
     }
 
+    await this._deploy(api, tunnelUrl)
     await worker.reload()
   }
 


### PR DESCRIPTION
this allows running command `bp dev` on a bot without running `bp build` first