### PR TITLE
fix(webchat): improve descriptions & examples

### DIFF
--- a/integrations/webchat/src/definitions/actions.ts
+++ b/integrations/webchat/src/definitions/actions.ts
@@ -4,7 +4,6 @@ import z from 'zod'
 const conversationId = z
   .string()
   .describe('The conversation id of the webchat instance. Usually {{event.conversationId}}')
-  .default('{{event.conversationId}}')
 
 const getUserData = {
   title: 'Get User Data',
@@ -12,12 +11,11 @@ const getUserData = {
     "Get the user's information that was provided when the webchat is initialized with the property \"userData\", for example: window.botpressWebChat.init({ userData: { name: 'John Doe' } })",
   input: {
     schema: z.object({
-      userId: z
-        .string()
-        .uuid()
-        .describe('The ID of the user. Usually you can access it using {{event.userId}}')
-        .default('{{event.userId}}'),
+      userId: z.string().uuid().describe('The ID of the user. Usually you can access it using {{event.userId}}'),
     }),
+    ui: {
+      userId: { title: 'User ID', examples: ['{{event.userId}}'] },
+    },
   },
   output: {
     schema: z.object({
@@ -68,8 +66,19 @@ const configWebchat = {
   input: {
     schema: z.object({
       conversationId,
-      config: z.string().describe('An config as JSON'),
+      config: z
+        .string()
+        .describe(
+          'A JSON string representing the new configuration. You can use {{JSON.stringify(workflow.someVariable)}} to convert an object to JSON'
+        ),
     }),
+    ui: {
+      conversationId: { title: 'Conversation ID', examples: ['{{event.conversationId}}'] },
+      config: {
+        title: 'JSON Configuration',
+        examples: ['{ "emailAddress": "some@mail.com" }', '{{JSON.stringify(workflow.someVariable)}}'],
+      },
+    },
   },
   output: {
     schema: z.object({}),
@@ -84,6 +93,10 @@ const customEvent = {
       conversationId,
       event: z.string().describe('An event as JSON to send to the webchat instance'),
     }),
+    ui: {
+      conversationId: { title: 'Conversation ID', examples: ['{{event.conversationId}}'] },
+      event: { title: 'JSON Payload', examples: ['{ "emailAddress": "some@mail.com" }'] },
+    },
   },
   output: {
     schema: z.object({}),

--- a/integrations/webchat/src/definitions/actions.ts
+++ b/integrations/webchat/src/definitions/actions.ts
@@ -99,7 +99,8 @@ const configWebchat = {
 
 const customEvent = {
   title: 'Send Custom Event',
-  description: 'Use this action to send a custom event to the webchat. You must handle this event on your web page.',
+  description:
+    "Initiate this action to dispatch a custom event to the webchat. Please ensure to appropriately handle this event within your webpage's code. \n\n window.botpressWebChat.onEvent(event => {}, ['TRIGGER'])",
   input: {
     schema: z.object({
       conversationId,

--- a/integrations/webchat/src/definitions/actions.ts
+++ b/integrations/webchat/src/definitions/actions.ts
@@ -4,6 +4,7 @@ import z from 'zod'
 const conversationId = z
   .string()
   .describe('The conversation id of the webchat instance. Usually {{event.conversationId}}')
+  .default('{{event.conversationId}}')
 
 const getUserData = {
   title: 'Get User Data',
@@ -11,7 +12,11 @@ const getUserData = {
     "Get the user's information that was provided when the webchat is initialized with the property \"userData\", for example: window.botpressWebChat.init({ userData: { name: 'John Doe' } })",
   input: {
     schema: z.object({
-      userId: z.string().uuid().describe('The ID of the user. Usually you can access it using {{event.userId}}'),
+      userId: z
+        .string()
+        .uuid()
+        .describe('The ID of the user. Usually you can access it using {{event.userId}}')
+        .default('{{event.userId}}'),
     }),
   },
   output: {
@@ -73,6 +78,7 @@ const configWebchat = {
 
 const customEvent = {
   title: 'Send Custom Event',
+  description: 'Use this action to send a custom event to the webchat. You must handle this event on your web page.',
   input: {
     schema: z.object({
       conversationId,

--- a/integrations/webchat/src/definitions/actions.ts
+++ b/integrations/webchat/src/definitions/actions.ts
@@ -26,10 +26,14 @@ const getUserData = {
 
 const showWebchat = {
   title: 'Show Webchat',
+  description: 'Show the webchat widget',
   input: {
     schema: z.object({
       conversationId,
     }),
+    ui: {
+      conversationId: { title: 'Conversation ID', examples: ['{{event.conversationId}}'] },
+    },
   },
   output: {
     schema: z.object({}),
@@ -38,10 +42,14 @@ const showWebchat = {
 
 const hideWebchat = {
   title: 'Hide Webchat',
+  description: 'Hide the webchat widget',
   input: {
     schema: z.object({
       conversationId,
     }),
+    ui: {
+      conversationId: { title: 'Conversation ID', examples: ['{{event.conversationId}}'] },
+    },
   },
   output: {
     schema: z.object({}),
@@ -50,10 +58,14 @@ const hideWebchat = {
 
 const toggleWebchat = {
   title: 'Toggle Webchat',
+  description: 'Toggle the visibility of the webchat widget',
   input: {
     schema: z.object({
       conversationId,
     }),
+    ui: {
+      conversationId: { title: 'Conversation ID', examples: ['{{event.conversationId}}'] },
+    },
   },
   output: {
     schema: z.object({}),

--- a/integrations/webchat/src/definitions/actions.ts
+++ b/integrations/webchat/src/definitions/actions.ts
@@ -100,7 +100,7 @@ const configWebchat = {
 const customEvent = {
   title: 'Send Custom Event',
   description:
-    "Initiate this action to dispatch a custom event to the webchat. Please ensure to appropriately handle this event within your webpage's code. \n\n window.botpressWebChat.onEvent(event => {}, ['TRIGGER'])",
+    "Initiate this action to dispatch a custom event to the webchat. Please ensure to appropriately handle this event within your webpage's code. Usage: \n\nwindow.botpressWebChat.onEvent(event => {}, ['TRIGGER'])",
   input: {
     schema: z.object({
       conversationId,

--- a/integrations/webchat/src/definitions/events.ts
+++ b/integrations/webchat/src/definitions/events.ts
@@ -19,7 +19,8 @@ export type Trigger = z.infer<typeof trigger.schema>
 
 export const trigger = {
   title: 'Custom Trigger (advanced)',
-  description: "Triggered when a custom event is sent from the user's browser",
+  description:
+    'This event occurs when a payload is sent from the browser using: "window.botpressWebChat.sendPayload({ type: \'trigger\', payload: {} })". That payload will be available in {{event.payload}}',
   schema: TriggerSchema,
   ui: {},
 }

--- a/integrations/webchat/src/definitions/events.ts
+++ b/integrations/webchat/src/definitions/events.ts
@@ -11,14 +11,14 @@ const conversationStartedSchema = z.object({
 const conversationStarted = {
   schema: conversationStartedSchema,
   title: 'Conversation Started',
-  description: 'Triggered when a new conversation is started',
+  description: 'This event occurs when a user activates the webchat widget, prompting the chat interface to appear.',
   ui: {},
 }
 
 export type Trigger = z.infer<typeof trigger.schema>
 
 export const trigger = {
-  title: 'Trigger',
+  title: 'Custom Trigger (advanced)',
   description: "Triggered when a custom event is sent from the user's browser",
   schema: TriggerSchema,
   ui: {},

--- a/integrations/webchat/src/definitions/events.ts
+++ b/integrations/webchat/src/definitions/events.ts
@@ -20,7 +20,7 @@ export type Trigger = z.infer<typeof trigger.schema>
 export const trigger = {
   title: 'Custom Trigger (advanced)',
   description:
-    "This event occurs when a payload is sent from the browser. That payload will be available in {{event.payload}}.\n\n Usage: window.botpressWebChat.sendPayload({ type: 'trigger', payload: {} })",
+    "This event occurs when a payload is sent from the browser. That payload will be available in {{event.payload}}. Usage: \n\nwindow.botpressWebChat.sendPayload({ type: 'trigger', payload: {} })",
   schema: TriggerSchema,
   ui: {},
 }

--- a/integrations/webchat/src/definitions/events.ts
+++ b/integrations/webchat/src/definitions/events.ts
@@ -20,7 +20,7 @@ export type Trigger = z.infer<typeof trigger.schema>
 export const trigger = {
   title: 'Custom Trigger (advanced)',
   description:
-    'This event occurs when a payload is sent from the browser using: "window.botpressWebChat.sendPayload({ type: \'trigger\', payload: {} })". That payload will be available in {{event.payload}}',
+    "This event occurs when a payload is sent from the browser. That payload will be available in {{event.payload}}.\n\n Usage: window.botpressWebChat.sendPayload({ type: 'trigger', payload: {} })",
   schema: TriggerSchema,
   ui: {},
 }


### PR DESCRIPTION
Added descriptions for everything so the page feels less empty on the studio with some examples & better labels
ex:
![image](https://github.com/botpress/botpress/assets/42552874/9fadf13c-d17b-4aeb-8c4e-198e23edf337)
