### PR TITLE
chore(client): increase version to v0.3.0

### DIFF
--- a/bots/bugbuster/package.json
+++ b/bots/bugbuster/package.json
@@ -8,12 +8,12 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "0.2.0",
-    "@botpress/sdk": "0.2.0",
+    "@botpress/client": "0.3.0",
+    "@botpress/sdk": "0.2.1",
     "zod": "^3.20.6"
   },
   "devDependencies": {
-    "@botpress/cli": "0.2.6",
+    "@botpress/cli": "0.2.7",
     "@types/node": "^18.11.17",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -20,7 +20,7 @@
   },
   "main": "dist/index.js",
   "dependencies": {
-    "@botpress/client": "0.2.0",
+    "@botpress/client": "0.3.0",
     "@bpinternal/tunnel": "^0.1.0",
     "@bpinternal/yargs-extra": "^0.0.3",
     "@parcel/watcher": "^2.1.0",
@@ -47,7 +47,7 @@
     "zod-to-json-schema": "^3.20.1"
   },
   "devDependencies": {
-    "@botpress/sdk": "0.2.0",
+    "@botpress/sdk": "0.2.1",
     "@bpinternal/log4bot": "^0.0.4",
     "@types/bluebird": "^3.5.38",
     "@types/prompts": "^2.0.14",

--- a/packages/cli/templates/echo-bot/package.json
+++ b/packages/cli/templates/echo-bot/package.json
@@ -8,8 +8,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "0.2.0",
-    "@botpress/sdk": "0.2.0",
+    "@botpress/client": "0.3.0",
+    "@botpress/sdk": "0.2.1",
     "zod": "^3.20.6"
   },
   "devDependencies": {

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -8,8 +8,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "0.2.0",
-    "@botpress/sdk": "0.2.0",
+    "@botpress/client": "0.3.0",
+    "@botpress/sdk": "0.2.1",
     "zod": "^3.20.6"
   },
   "devDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Botpress SDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -14,7 +14,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "0.2.0",
+    "@botpress/client": "0.3.0",
     "axios": "0.27.2",
     "radash": "^9.5.0",
     "zod": "^3.20.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,17 +57,17 @@ importers:
   bots/bugbuster:
     dependencies:
       '@botpress/client':
-        specifier: 0.2.0
+        specifier: 0.3.0
         version: link:../../packages/client
       '@botpress/sdk':
-        specifier: 0.2.0
+        specifier: 0.2.1
         version: link:../../packages/sdk
       zod:
         specifier: ^3.20.6
         version: 3.21.4
     devDependencies:
       '@botpress/cli':
-        specifier: 0.2.6
+        specifier: 0.2.7
         version: link:../../packages/cli
       '@types/node':
         specifier: ^18.11.17
@@ -961,7 +961,7 @@ importers:
   packages/cli:
     dependencies:
       '@botpress/client':
-        specifier: 0.2.0
+        specifier: 0.3.0
         version: link:../client
       '@bpinternal/tunnel':
         specifier: ^0.1.0
@@ -1037,7 +1037,7 @@ importers:
         version: 3.21.1(zod@3.21.4)
     devDependencies:
       '@botpress/sdk':
-        specifier: 0.2.0
+        specifier: 0.2.1
         version: link:../sdk
       '@bpinternal/log4bot':
         specifier: ^0.0.4
@@ -1073,10 +1073,10 @@ importers:
   packages/cli/templates/echo-bot:
     dependencies:
       '@botpress/client':
-        specifier: 0.2.0
+        specifier: 0.3.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.2.0
+        specifier: 0.2.1
         version: link:../../../sdk
       zod:
         specifier: ^3.20.6
@@ -1095,10 +1095,10 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 0.2.0
+        specifier: 0.3.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.2.0
+        specifier: 0.2.1
         version: link:../../../sdk
       zod:
         specifier: ^3.20.6
@@ -1136,7 +1136,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 0.2.0
+        specifier: 0.3.0
         version: link:../client
       axios:
         specifier: 0.27.2


### PR DESCRIPTION
Needed to integrate new `getAuditRecords` operation with the BP Cloud dashboard.

Public API version has already been updated with this addition.