### PR TITLE
fix(client): add bundle export

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -5,6 +5,10 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.cjs",
+    "./bundle": "./dist/bundle.cjs"
+  },
   "license": "MIT",
   "scripts": {
     "build:type": "tsc --emitDeclarationOnly --declaration --target es2019 --module commonjs --moduleResolution node --lib es2019",


### PR DESCRIPTION
Just so we can resolve '@botpress/client/bundle' correctly without this small hack:

![image](https://github.com/botpress/botpress/assets/42552874/227236c7-f8c5-4942-9430-5b61b31c2f66)
