### PR TITLE
fix(whatsapp): remove tag prefixes from message handler as it's causing issues

### DIFF
--- a/integrations/whatsapp/src/index.ts
+++ b/integrations/whatsapp/src/index.ts
@@ -7,7 +7,7 @@ import * as carousel from './message-types/carousel'
 import * as choice from './message-types/choice'
 import * as dropdown from './message-types/dropdown'
 import * as outgoing from './outgoing-message'
-import { Integration, IntegrationProps, secrets, Client } from '.botpress'
+import { Integration, IntegrationProps, secrets } from '.botpress'
 
 // TODO: Export these types publicly from the SDK and import them here.
 export type CreateConversationPayload = {
@@ -16,6 +16,7 @@ export type CreateConversationPayload = {
 }
 export type IntegrationLogger = Parameters<IntegrationProps['handler']>[0]['logger']
 export type IntegrationContext = Parameters<IntegrationProps['handler']>[0]['ctx']
+export type Client = Parameters<IntegrationProps['handler']>[0]['client']
 
 sentryHelpers.init({
   dsn: secrets.SENTRY_DSN,
@@ -176,16 +177,16 @@ async function handleMessage(
     const { conversation } = await client.getOrCreateConversation({
       channel: 'channel',
       tags: {
-        ['whatsapp:userPhone']: message.from,
-        ['whatsapp:phoneNumberId']: value.metadata.phone_number_id,
+        userPhone: message.from,
+        phoneNumberId: value.metadata.phone_number_id,
       },
     })
 
     if (value.contacts.length > 0) {
       const { user } = await client.getOrCreateUser({
         tags: {
-          ['whatsapp:userId']: value.contacts[0] ? value.contacts[0].wa_id : '',
-          ['whatsapp:name']: value.contacts[0] ? value.contacts[0]?.profile.name : '',
+          userId: value.contacts[0] ? value.contacts[0].wa_id : '',
+          name: value.contacts[0] ? value.contacts[0]?.profile.name : '',
         },
       })
 
@@ -193,7 +194,7 @@ async function handleMessage(
         logger.forBot().debug('Received text message from Whatsapp:', message.text.body)
 
         await client.createMessage({
-          tags: { ['whatsapp:id']: message.id },
+          tags: { id: message.id },
           type: 'text',
           payload: { text: message.text.body },
           userId: user.id,
@@ -204,7 +205,7 @@ async function handleMessage(
           logger.forBot().debug('Received button reply from Whatsapp:', message.interactive.button_reply)
 
           await client.createMessage({
-            tags: { ['whatsapp:id']: message.id },
+            tags: { id: message.id },
             type: 'text',
             payload: {
               text: message.interactive.button_reply?.id!,
@@ -218,7 +219,7 @@ async function handleMessage(
           logger.forBot().debug('Received list reply from Whatsapp:', message.interactive.list_reply)
 
           await client.createMessage({
-            tags: { ['whatsapp:id']: message.id },
+            tags: { id: message.id },
             type: 'text',
             payload: {
               text: message.interactive.list_reply?.id!,


### PR DESCRIPTION
Fixes: https://discord.com/channels/1108396290624213082/1141701643457527890

Tested this with a text, button_reply, and list_reply Whatsapp messages and it all works after removing the prefixes.