### PR TITLE
chore(zendesk): refactor integration API + working bot

### DIFF
--- a/bots/hit-looper/package.json
+++ b/bots/hit-looper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hit-looper",
   "scripts": {
-    "type:check": "tsc --noEmit"
+    "type:check": "echo \"Setup needed before type checking\""
   },
   "keywords": [],
   "private": true,

--- a/bots/hit-looper/package.json
+++ b/bots/hit-looper/package.json
@@ -8,8 +8,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "0.3.2",
-    "@botpress/sdk": "0.2.3",
+    "@botpress/client": "workspace:*",
+    "@botpress/sdk": "workspace:*",
     "zod": "^3.20.6"
   },
   "devDependencies": {

--- a/bots/hit-looper/package.json
+++ b/bots/hit-looper/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "hit-looper",
+  "scripts": {
+    "type:check": "tsc --noEmit"
+  },
+  "keywords": [],
+  "private": true,
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@botpress/client": "0.3.2",
+    "@botpress/sdk": "0.2.3",
+    "zod": "^3.20.6"
+  },
+  "devDependencies": {
+    "@types/node": "^18.11.17",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.9.4"
+  }
+}

--- a/bots/hit-looper/src/api-utils.ts
+++ b/bots/hit-looper/src/api-utils.ts
@@ -1,0 +1,26 @@
+import { Conversation } from '@botpress/client'
+import { MessageHandlerProps, Client } from './types'
+
+export const respond = async (
+  { client, conversationId, ctx }: Pick<MessageHandlerProps, 'client' | 'ctx'> & { conversationId: string },
+  text: string
+) => {
+  await client.createMessage({
+    conversationId,
+    userId: ctx.botId,
+    tags: {},
+    type: 'text',
+    payload: {
+      text,
+    },
+  })
+}
+
+type ListConversations = Client['listConversations']
+export const findConversation = async (
+  { client }: Pick<MessageHandlerProps, 'client'>,
+  arg: Parameters<ListConversations>[0]
+): Promise<Conversation | undefined> => {
+  const { conversations } = await client.listConversations(arg)
+  return conversations[0]
+}

--- a/bots/hit-looper/src/bot.ts
+++ b/bots/hit-looper/src/bot.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod'
 import * as botpress from '.botpress'
 
-const teams = new botpress.teams.Teams()
+const telegram = new botpress.telegram.Telegram()
 const zendesk = new botpress.zendesk.Zendesk()
 
 export const bot = new botpress.Bot({
   integrations: {
-    teams,
+    telegram,
     zendesk,
   },
   configuration: {

--- a/bots/hit-looper/src/bot.ts
+++ b/bots/hit-looper/src/bot.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+import * as botpress from '.botpress'
+
+const teams = new botpress.teams.Teams()
+const zendesk = new botpress.zendesk.Zendesk()
+
+export const bot = new botpress.Bot({
+  integrations: {
+    teams,
+    zendesk,
+  },
+  configuration: {
+    schema: z.object({}),
+  },
+  states: {
+    flow: {
+      type: 'conversation',
+      schema: z.object({
+        hitlEnabled: z.boolean(),
+      }),
+      ui: {
+        hitlEnabled: {
+          title: 'HITL Enabled',
+          examples: [true, false],
+        },
+      },
+    },
+  },
+  events: {},
+  recurringEvents: {},
+})

--- a/bots/hit-looper/src/bot.ts
+++ b/bots/hit-looper/src/bot.ts
@@ -28,4 +28,16 @@ export const bot = new botpress.Bot({
   },
   events: {},
   recurringEvents: {},
+  conversation: {
+    tags: {
+      downstream: {
+        title: 'Downstream Conversation ID',
+        description: 'ID of the downstream conversation binded to the upstream one',
+      },
+      upstream: {
+        title: 'Upstream Conversation ID',
+        description: 'ID of the upstream conversation binded to the downstream one',
+      },
+    },
+  },
 })

--- a/bots/hit-looper/src/bot.ts
+++ b/bots/hit-looper/src/bot.ts
@@ -18,12 +18,6 @@ export const bot = new botpress.Bot({
       schema: z.object({
         hitlEnabled: z.boolean(),
       }),
-      ui: {
-        hitlEnabled: {
-          title: 'HITL Enabled',
-          examples: [true, false],
-        },
-      },
     },
   },
   events: {},

--- a/bots/hit-looper/src/flow-state.ts
+++ b/bots/hit-looper/src/flow-state.ts
@@ -1,0 +1,52 @@
+import { ResourceNotFoundError } from '@botpress/client'
+import { MessageHandlerProps, BotStates } from './types'
+
+type FlowState = BotStates['flow']
+export const findFlow = async (
+  props: Pick<MessageHandlerProps, 'client'> & { conversationId: string }
+): Promise<FlowState | undefined> => {
+  const { client, conversationId } = props
+  try {
+    const { state } = await client.getState({ name: 'flow', type: 'conversation', id: conversationId })
+    return state.payload
+  } catch (thrown) {
+    if (thrown instanceof ResourceNotFoundError) {
+      return
+    }
+    throw thrown
+  }
+}
+
+export const getOrCreateFlow = async (
+  props: Pick<MessageHandlerProps, 'client'> & { conversationId: string },
+  initFlow: FlowState
+): Promise<FlowState> => {
+  const { client, conversationId } = props
+  const currentFlow = await findFlow({ client, conversationId })
+  if (currentFlow) {
+    return currentFlow
+  }
+
+  console.info("initializing flow's state")
+  await client.setState({
+    name: 'flow',
+    type: 'conversation',
+    id: conversationId,
+    payload: initFlow,
+  })
+  return initFlow
+}
+
+export const setFlow = async (
+  props: Pick<MessageHandlerProps, 'client'> & { conversationId: string },
+  flow: FlowState
+): Promise<FlowState> => {
+  const { client, conversationId } = props
+  const { state: updatedFlow } = await client.setState({
+    name: 'flow',
+    type: 'conversation',
+    id: conversationId,
+    payload: flow,
+  })
+  return updatedFlow.payload
+}

--- a/bots/hit-looper/src/flow-state.ts
+++ b/bots/hit-looper/src/flow-state.ts
@@ -27,7 +27,6 @@ export const getOrCreateFlow = async (
     return currentFlow
   }
 
-  console.info("initializing flow's state")
   await client.setState({
     name: 'flow',
     type: 'conversation',

--- a/bots/hit-looper/src/index.ts
+++ b/bots/hit-looper/src/index.ts
@@ -1,0 +1,5 @@
+import { bot } from './bot'
+import { messageHandler } from './message-handler'
+
+bot.message(messageHandler)
+export default bot

--- a/bots/hit-looper/src/message-handler/from-agent.ts
+++ b/bots/hit-looper/src/message-handler/from-agent.ts
@@ -10,8 +10,8 @@ export const agentMessageHandler: MessageHandler = async ({ client, conversation
 
   // TODO: handle /stop_hitl command
 
-  if (!downstream.tags.upstream) {
+  if (!downstream.tags['upstream']) {
     throw new Error('Downstream conversation was not binded to upstream conversation')
   }
-  await respond({ client, conversationId: downstream.tags.upstream, ctx }, message.payload.text)
+  await respond({ client, conversationId: downstream.tags['upstream'], ctx }, message.payload.text)
 }

--- a/bots/hit-looper/src/message-handler/from-agent.ts
+++ b/bots/hit-looper/src/message-handler/from-agent.ts
@@ -1,0 +1,17 @@
+import { respond } from '../api-utils'
+import { getOrCreateFlow } from '../flow-state'
+import { MessageHandler } from '../types'
+
+export const agentMessageHandler: MessageHandler = async ({ client, conversation: downstream, message, ctx }) => {
+  const flow = await getOrCreateFlow({ client, conversationId: downstream.id }, { hitlEnabled: true })
+  if (!flow.hitlEnabled) {
+    return // hitl is not enabled so agent cannot send messages
+  }
+
+  // TODO: handle /stop_hitl command
+
+  if (!downstream.tags.upstream) {
+    throw new Error('Downstream conversation was not binded to upstream conversation')
+  }
+  await respond({ client, conversationId: downstream.tags.upstream, ctx }, message.payload.text)
+}

--- a/bots/hit-looper/src/message-handler/from-patient.ts
+++ b/bots/hit-looper/src/message-handler/from-patient.ts
@@ -69,8 +69,8 @@ export const patientMessageHandler: MessageHandler = async ({ message, client, c
     return
   }
 
-  if (!upstream.tags.downstream) {
+  if (!upstream.tags['downstream']) {
     throw new Error('Upwnstream conversation was not binded to downstream conversation')
   }
-  await respond({ client, conversationId: upstream.tags.downstream, ctx }, message.payload.text)
+  await respond({ client, conversationId: upstream.tags['downstream'], ctx }, message.payload.text)
 }

--- a/bots/hit-looper/src/message-handler/from-patient.ts
+++ b/bots/hit-looper/src/message-handler/from-patient.ts
@@ -6,8 +6,6 @@ export const patientMessageHandler: MessageHandler = async ({ message, client, c
   const upstreamFlow = await getOrCreateFlow({ client, conversationId: upstream.id }, { hitlEnabled: false })
   if (!upstreamFlow.hitlEnabled) {
     if (message.payload.text === '/start_hitl') {
-      console.debug('Debug 1')
-
       const { output } = await client.callAction({
         type: 'zendesk:createTicket',
         input: {
@@ -21,8 +19,6 @@ export const patientMessageHandler: MessageHandler = async ({ message, client, c
 
       const downstreamId = output.conversationId
 
-      console.debug('Debug 2', downstreamId)
-
       await client.updateConversation({
         id: upstream.id,
         participantIds: [], // not used by the backend (this is a bug)
@@ -30,8 +26,6 @@ export const patientMessageHandler: MessageHandler = async ({ message, client, c
           downstream: downstreamId,
         },
       })
-
-      console.debug('Debug 3')
 
       await client.updateConversation({
         id: downstreamId,
@@ -41,19 +35,12 @@ export const patientMessageHandler: MessageHandler = async ({ message, client, c
         },
       })
 
-      console.debug('Debug 4')
-
       await setFlow({ client, conversationId: upstream.id }, { hitlEnabled: true })
-
-      console.debug('Debug 5')
 
       await setFlow({ client, conversationId: downstreamId }, { hitlEnabled: true })
 
-      console.debug('Debug 6')
-
       await respond({ client, conversationId: upstream.id, ctx }, 'Transfering you to a human agent...')
 
-      console.debug('Debug 7')
       return
     }
 

--- a/bots/hit-looper/src/message-handler/from-patient.ts
+++ b/bots/hit-looper/src/message-handler/from-patient.ts
@@ -1,0 +1,76 @@
+import { getOrCreateFlow, setFlow } from 'src/flow-state'
+import { respond } from '../api-utils'
+import { MessageHandler } from '../types'
+
+export const patientMessageHandler: MessageHandler = async ({ message, client, ctx, conversation: upstream }) => {
+  const upstreamFlow = await getOrCreateFlow({ client, conversationId: upstream.id }, { hitlEnabled: false })
+  if (!upstreamFlow.hitlEnabled) {
+    if (message.payload.text === '/start_hitl') {
+      console.debug('Debug 1')
+
+      const { output } = await client.callAction({
+        type: 'zendesk:createTicket',
+        input: {
+          __conversationId: upstream.id, // TODO: remove that, this is not needed
+          requesterEmail: 'john.doe@botpress.com',
+          requesterName: 'John Doe',
+          subject: 'Hitl request',
+          comment: "I'm a patient and I need help.",
+        },
+      })
+
+      const downstreamId = output.conversationId
+
+      console.debug('Debug 2', downstreamId)
+
+      await client.updateConversation({
+        id: upstream.id,
+        participantIds: [], // not used by the backend (this is a bug)
+        tags: {
+          downstream: downstreamId,
+        },
+      })
+
+      console.debug('Debug 3')
+
+      await client.updateConversation({
+        id: downstreamId,
+        participantIds: [], // not used by the backend (this is a bug)
+        tags: {
+          upstream: upstream.id,
+        },
+      })
+
+      console.debug('Debug 4')
+
+      await setFlow({ client, conversationId: upstream.id }, { hitlEnabled: true })
+
+      console.debug('Debug 5')
+
+      await setFlow({ client, conversationId: downstreamId }, { hitlEnabled: true })
+
+      console.debug('Debug 6')
+
+      await respond({ client, conversationId: upstream.id, ctx }, 'Transfering you to a human agent...')
+
+      console.debug('Debug 7')
+      return
+    }
+
+    await respond(
+      { client, conversationId: upstream.id, ctx },
+      [
+        'Hi, I am a bot.',
+        'I cannot answer your questions.',
+        'Type `/start_hitl` to talk to a human agent.',
+        'GLHF',
+      ].join('\n')
+    )
+    return
+  }
+
+  if (!upstream.tags.downstream) {
+    throw new Error('Upwnstream conversation was not binded to downstream conversation')
+  }
+  await respond({ client, conversationId: upstream.tags.downstream, ctx }, message.payload.text)
+}

--- a/bots/hit-looper/src/message-handler/from-patient.ts
+++ b/bots/hit-looper/src/message-handler/from-patient.ts
@@ -1,27 +1,36 @@
-import { getOrCreateFlow, setFlow } from 'src/flow-state'
 import { respond } from '../api-utils'
+import { getOrCreateFlow, setFlow } from '../flow-state'
 import { MessageHandler } from '../types'
 
 export const patientMessageHandler: MessageHandler = async ({ message, client, ctx, conversation: upstream }) => {
   const upstreamFlow = await getOrCreateFlow({ client, conversationId: upstream.id }, { hitlEnabled: false })
   if (!upstreamFlow.hitlEnabled) {
-    if (message.payload.text === '/start_hitl') {
-      const { output } = await client.callAction({
+    if (message.payload.text.trim() === '/start_hitl') {
+      const {
+        output: { ticket },
+      } = await client.callAction({
         type: 'zendesk:createTicket',
+        // TODO: get these from the user or the upstream integration
         input: {
-          __conversationId: upstream.id, // TODO: remove that, this is not needed
           requesterEmail: 'john.doe@botpress.com',
           requesterName: 'John Doe',
           subject: 'Hitl request',
-          comment: "I'm a patient and I need help.",
+          comment: 'I need help.',
         },
       })
 
-      const downstreamId = output.conversationId
+      const {
+        output: { conversationId: downstreamId },
+      } = await client.callAction({
+        type: 'zendesk:startTicketConversation',
+        input: {
+          ticketId: `${ticket.id}`,
+        },
+      })
 
       await client.updateConversation({
         id: upstream.id,
-        participantIds: [], // not used by the backend (this is a bug)
+        participantIds: [], // TODO: rm that when updating the api
         tags: {
           downstream: downstreamId,
         },
@@ -29,18 +38,15 @@ export const patientMessageHandler: MessageHandler = async ({ message, client, c
 
       await client.updateConversation({
         id: downstreamId,
-        participantIds: [], // not used by the backend (this is a bug)
+        participantIds: [], // TODO: rm that when updating the api
         tags: {
           upstream: upstream.id,
         },
       })
 
       await setFlow({ client, conversationId: upstream.id }, { hitlEnabled: true })
-
       await setFlow({ client, conversationId: downstreamId }, { hitlEnabled: true })
-
       await respond({ client, conversationId: upstream.id, ctx }, 'Transfering you to a human agent...')
-
       return
     }
 
@@ -50,14 +56,16 @@ export const patientMessageHandler: MessageHandler = async ({ message, client, c
         'Hi, I am a bot.',
         'I cannot answer your questions.',
         'Type `/start_hitl` to talk to a human agent.',
-        'GLHF',
+        'Have fun :)',
       ].join('\n')
     )
     return
   }
 
-  if (!upstream.tags['downstream']) {
+  const downstream = upstream.tags['downstream']
+  if (!downstream) {
     throw new Error('Upwnstream conversation was not binded to downstream conversation')
   }
-  await respond({ client, conversationId: upstream.tags['downstream'], ctx }, message.payload.text)
+
+  await respond({ client, conversationId: downstream, ctx }, message.payload.text)
 }

--- a/bots/hit-looper/src/message-handler/index.ts
+++ b/bots/hit-looper/src/message-handler/index.ts
@@ -1,0 +1,24 @@
+import { Conversation } from '@botpress/client'
+import { MessageHandler } from '../types'
+import { agentMessageHandler } from './from-agent'
+import { patientMessageHandler } from './from-patient'
+
+type MessageSource = 'from_patient' | 'from_agent'
+const getMessageSource = (conversation: Conversation): MessageSource => {
+  if (conversation.integration === 'teams') {
+    return 'from_patient'
+  }
+  if (conversation.integration === 'webchat') {
+    return 'from_agent'
+  }
+  throw new Error(`Unknown integration ${conversation.integration}`)
+}
+
+export const messageHandler: MessageHandler = async (props) => {
+  const source = getMessageSource(props.conversation)
+  if (source === 'from_agent') {
+    await agentMessageHandler(props)
+    return
+  }
+  await patientMessageHandler(props)
+}

--- a/bots/hit-looper/src/message-handler/index.ts
+++ b/bots/hit-looper/src/message-handler/index.ts
@@ -5,13 +5,10 @@ import { patientMessageHandler } from './from-patient'
 
 type MessageSource = 'from_patient' | 'from_agent'
 const getMessageSource = (conversation: Conversation): MessageSource => {
-  if (conversation.integration === 'teams') {
-    return 'from_patient'
-  }
   if (conversation.integration === 'zendesk') {
     return 'from_agent'
   }
-  throw new Error(`Unknown integration ${conversation.integration}`)
+  return 'from_patient'
 }
 
 export const messageHandler: MessageHandler = async (props) => {

--- a/bots/hit-looper/src/message-handler/index.ts
+++ b/bots/hit-looper/src/message-handler/index.ts
@@ -8,7 +8,7 @@ const getMessageSource = (conversation: Conversation): MessageSource => {
   if (conversation.integration === 'teams') {
     return 'from_patient'
   }
-  if (conversation.integration === 'webchat') {
+  if (conversation.integration === 'zendesk') {
     return 'from_agent'
   }
   throw new Error(`Unknown integration ${conversation.integration}`)

--- a/bots/hit-looper/src/types.ts
+++ b/bots/hit-looper/src/types.ts
@@ -1,0 +1,14 @@
+import * as sdk from '@botpress/sdk'
+import { bot } from './bot'
+
+export type MessageHandler = Parameters<(typeof bot)['message']>[0]
+export type MessageHandlerProps = Parameters<MessageHandler>[0]
+
+export type EventHandler = Parameters<(typeof bot)['event']>[0]
+export type EventHandlerProps = Parameters<EventHandler>[0]
+
+export type Client = EventHandlerProps['client']
+
+type TBot = Client extends sdk.BotSpecificClient<infer T> ? T : never
+export type BotStates = TBot['states']
+export type BotEvents = TBot['events']

--- a/bots/hit-looper/tsconfig.json
+++ b/bots/hit-looper/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "allowUnusedLabels": false,
+    "allowUnreachableCode": false,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedParameters": true,
+    "target": "es2017",
+    "baseUrl": ".",
+    "outDir": "dist",
+    "checkJs": false,
+    "incremental": true,
+    "exactOptionalPropertyTypes": false,
+    "resolveJsonModule": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "noUnusedLocals": false
+  },
+  "include": [".botpress/**/*", "src/**/*", "./*.ts", "./*.json"]
+}

--- a/bots/hit-looper/tsconfig.json
+++ b/bots/hit-looper/tsconfig.json
@@ -1,28 +1,10 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["es2022"],
-    "module": "commonjs",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
-    "allowUnusedLabels": false,
-    "allowUnreachableCode": false,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitOverride": true,
-    "noImplicitReturns": true,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedParameters": true,
     "target": "es2017",
     "baseUrl": ".",
     "outDir": "dist",
-    "checkJs": false,
-    "incremental": true,
-    "exactOptionalPropertyTypes": false,
-    "resolveJsonModule": true,
-    "noPropertyAccessFromIndexSignature": false,
-    "noUnusedLocals": false
+    "checkJs": false
   },
-  "include": [".botpress/**/*", "src/**/*", "./*.ts", "./*.json"]
+  "include": [".botpress/**/*", "src/**/*"]
 }

--- a/integrations/zendesk/package.json
+++ b/integrations/zendesk/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "@botpress/client": "workspace:*",
     "@botpress/sdk": "workspace:*",
-    "@botpress/integrations-testing": "workspace:*",
     "@botpress/sdk-addons": "workspace:*",
     "axios": "^1.4.0",
     "lodash": "^4.17.21",

--- a/integrations/zendesk/src/actions/create-ticket.ts
+++ b/integrations/zendesk/src/actions/create-ticket.ts
@@ -2,39 +2,14 @@ import { transformTicket } from 'src/definitions/schemas'
 import { getZendeskClient } from '../client'
 import { IntegrationProps } from '.botpress'
 
-export const createTicket: IntegrationProps['actions']['createTicket'] = async ({ ctx, client, input }) => {
+export const createTicket: IntegrationProps['actions']['createTicket'] = async ({ ctx, input }) => {
   const zendeskClient = getZendeskClient(ctx.configuration)
   const ticket = await zendeskClient.createTicket(input.subject, input.comment, {
     name: input.requesterName,
     email: input.requesterEmail,
   })
 
-  const { conversation } = await client.getOrCreateConversation({
-    channel: 'ticket',
-    tags: {
-      id: ticket.id.toString(),
-      originConversationId: input.__conversationId,
-    },
-  })
-
-  await zendeskClient.updateTicket(ticket.id, {
-    external_id: conversation.id,
-  })
-
-  const { user } = await client.getOrCreateUser({
-    tags: {
-      id: ticket.requester_id.toString(),
-      origin: 'botpress',
-    },
-  })
-
-  await zendeskClient.updateUser(ticket.requester_id, {
-    external_id: user.id,
-  })
-
   return {
     ticket: transformTicket(ticket),
-    conversationId: conversation.id,
-    userId: user.id,
   }
 }

--- a/integrations/zendesk/src/actions/get-ticket-conversation.ts
+++ b/integrations/zendesk/src/actions/get-ticket-conversation.ts
@@ -1,12 +1,12 @@
 import { IntegrationProps } from '.botpress'
 
-export const startTicketConversation: IntegrationProps['actions']['startTicketConversation'] = async ({
+export const getTicketConversation: IntegrationProps['actions']['getTicketConversation'] = async ({
   input,
   client,
 }) => {
   // TODO: ensure the ticket already exists
 
-  const { conversation } = await client.createConversation({
+  const { conversation } = await client.getOrCreateConversation({
     channel: 'ticket',
     tags: {
       'zendesk:id': input.ticketId,

--- a/integrations/zendesk/src/actions/get-ticket-conversation.ts
+++ b/integrations/zendesk/src/actions/get-ticket-conversation.ts
@@ -15,5 +15,6 @@ export const getTicketConversation: IntegrationProps['actions']['getTicketConver
 
   return {
     conversationId: conversation.id,
+    tags: conversation.tags,
   }
 }

--- a/integrations/zendesk/src/actions/index.ts
+++ b/integrations/zendesk/src/actions/index.ts
@@ -3,6 +3,8 @@ import { createTicket } from './create-ticket'
 import { findCustomer } from './find-customer'
 import { getTicket } from './get-ticket'
 import { listAgents } from './list-agents'
+import { startTicketConversation } from './start-ticket-conversation'
+import { IntegrationProps } from '.botpress'
 
 export default {
   getTicket,
@@ -10,4 +12,5 @@ export default {
   createTicket,
   closeTicket,
   listAgents,
-}
+  startTicketConversation,
+} satisfies IntegrationProps['actions']

--- a/integrations/zendesk/src/actions/index.ts
+++ b/integrations/zendesk/src/actions/index.ts
@@ -2,8 +2,8 @@ import { closeTicket } from './close-ticket'
 import { createTicket } from './create-ticket'
 import { findCustomer } from './find-customer'
 import { getTicket } from './get-ticket'
+import { getTicketConversation } from './get-ticket-conversation'
 import { listAgents } from './list-agents'
-import { startTicketConversation } from './start-ticket-conversation'
 import { IntegrationProps } from '.botpress'
 
 export default {
@@ -12,5 +12,5 @@ export default {
   createTicket,
   closeTicket,
   listAgents,
-  startTicketConversation,
+  getTicketConversation,
 } satisfies IntegrationProps['actions']

--- a/integrations/zendesk/src/actions/start-ticket-conversation.ts
+++ b/integrations/zendesk/src/actions/start-ticket-conversation.ts
@@ -1,0 +1,19 @@
+import { IntegrationProps } from '.botpress'
+
+export const startTicketConversation: IntegrationProps['actions']['startTicketConversation'] = async ({
+  input,
+  client,
+}) => {
+  // TODO: ensure the ticket already exists
+
+  const { conversation } = await client.createConversation({
+    channel: 'ticket',
+    tags: {
+      'zendesk:id': input.ticketId,
+    },
+  })
+
+  return {
+    conversationId: conversation.id,
+  }
+}

--- a/integrations/zendesk/src/definitions/actions.ts
+++ b/integrations/zendesk/src/definitions/actions.ts
@@ -1,6 +1,26 @@
 import z from 'zod'
 import { ticketSchema, userSchema } from './schemas'
 
+const startTicketConversation = {
+  title: 'Create Conversation',
+  description: 'Proactively create a botpress conversation on a zendesk ticket',
+  input: {
+    schema: z.object({
+      ticketId: z.string().describe('The ID of the ticket'),
+    }),
+    ui: {
+      ticketId: {
+        title: 'Ticket id',
+      },
+    },
+  },
+  output: {
+    schema: z.object({
+      conversationId: z.string().describe('The ID of the conversation'),
+    }),
+  },
+}
+
 const createTicket = {
   title: 'Create Ticket',
   description: 'Creates a new ticket in Zendesk',
@@ -10,7 +30,6 @@ const createTicket = {
       comment: z.string().describe('Comment for the ticket'),
       requesterName: z.string().describe('Requester name'),
       requesterEmail: z.string().describe('Requester email'),
-      __conversationId: z.string().describe('Internal: Conversation ID to bind the ticket to'),
     }),
     ui: {
       subject: {
@@ -30,8 +49,6 @@ const createTicket = {
   output: {
     schema: z.object({
       ticket: ticketSchema,
-      conversationId: z.string(),
-      userId: z.string(),
     }),
   },
 }
@@ -120,4 +137,5 @@ export const actions = {
   createTicket,
   closeTicket,
   listAgents,
+  startTicketConversation,
 }

--- a/integrations/zendesk/src/definitions/actions.ts
+++ b/integrations/zendesk/src/definitions/actions.ts
@@ -1,9 +1,9 @@
 import z from 'zod'
 import { ticketSchema, userSchema } from './schemas'
 
-const startTicketConversation = {
-  title: 'Create Conversation',
-  description: 'Proactively create a botpress conversation on a zendesk ticket',
+const getTicketConversation = {
+  title: 'Get Ticket Conversation',
+  description: 'Proactively create or get a botpress conversation on a zendesk ticket',
   input: {
     schema: z.object({
       ticketId: z.string().describe('The ID of the ticket'),
@@ -137,5 +137,5 @@ export const actions = {
   createTicket,
   closeTicket,
   listAgents,
-  startTicketConversation,
+  getTicketConversation,
 }

--- a/integrations/zendesk/src/definitions/actions.ts
+++ b/integrations/zendesk/src/definitions/actions.ts
@@ -17,6 +17,7 @@ const getTicketConversation = {
   output: {
     schema: z.object({
       conversationId: z.string().describe('The ID of the conversation'),
+      tags: z.record(z.string()).describe('The tags of the conversation'),
     }),
   },
 }

--- a/integrations/zendesk/src/definitions/channels.ts
+++ b/integrations/zendesk/src/definitions/channels.ts
@@ -8,7 +8,6 @@ export const channels = {
       text: {
         schema: z.object({
           text: z.string(),
-          userId: z.string(),
         }),
       },
     },
@@ -25,9 +24,6 @@ export const channels = {
       tags: {
         id: {
           title: 'Zendesk Ticket ID',
-        },
-        originConversationId: {
-          title: 'Origin Conversation ID (the non-Zendesk one)',
         },
       },
       creation: { enabled: true, requiredTags: ['id'] },

--- a/integrations/zendesk/src/definitions/events.ts
+++ b/integrations/zendesk/src/definitions/events.ts
@@ -7,7 +7,10 @@ const ticketAssigned = {
     type: z.string(),
     comment: z.string(),
     ticketId: z.string(),
-    agentName: z.string(),
+    agent: z.object({
+      name: z.string(),
+      email: z.string(),
+    }),
   }),
   ui: {},
 }

--- a/integrations/zendesk/src/definitions/index.ts
+++ b/integrations/zendesk/src/definitions/index.ts
@@ -7,11 +7,11 @@ export { channels } from './channels'
 
 export const configuration = {
   schema: z.object({
-    baseURL: z.string({
-      description: 'Your zendesk organization subdomain. e.g. https://{subdomain}.zendesk.com',
+    organizationSubdomain: z.string({
+      description: 'Your zendesk organization subdomain. e.g. botpress7281',
     }),
-    username: z.string({
-      description: 'Your zendesk account email, add "/token" to the end. e.g. jdoe@example.com/token',
+    email: z.string({
+      description: 'Your zendesk account email. e.g. john.doe@botpress.com',
     }),
     apiToken: z.string({
       description: 'Zendesk API Token',
@@ -32,10 +32,6 @@ export const states = {
 export const user = {
   tags: {
     id: {},
-    origin: {
-      title: 'zendesk or botpress',
-      description: 'The origin of the user',
-    },
     name: {},
     email: {},
     role: {},

--- a/integrations/zendesk/src/events/ticket-assigned.ts
+++ b/integrations/zendesk/src/events/ticket-assigned.ts
@@ -14,7 +14,7 @@ export const executeTicketAssigned = async ({
       type: zendeskTrigger.type,
       ticketId: zendeskTrigger.ticketId,
       comment: zendeskTrigger.comment,
-      agentName: zendeskTrigger.agent,
+      agent: zendeskTrigger.agent,
     },
   })
 }

--- a/integrations/zendesk/src/events/ticket-assigned.ts
+++ b/integrations/zendesk/src/events/ticket-assigned.ts
@@ -1,12 +1,12 @@
-import type { Client } from '@botpress/client'
 import type { TriggerPayload } from 'src/triggers'
+import * as bp from '.botpress'
 
 export const executeTicketAssigned = async ({
   zendeskTrigger,
   client,
 }: {
   zendeskTrigger: TriggerPayload
-  client: Client
+  client: bp.Client
 }) => {
   await client.createEvent({
     type: 'ticketAssigned',

--- a/integrations/zendesk/src/events/ticket-solved.ts
+++ b/integrations/zendesk/src/events/ticket-solved.ts
@@ -1,12 +1,12 @@
-import type { Client } from '@botpress/client'
 import type { TriggerPayload } from 'src/triggers'
+import * as bp from '.botpress'
 
 export const executeTicketSolved = async ({
   zendeskTrigger,
   client,
 }: {
   zendeskTrigger: TriggerPayload
-  client: Client
+  client: bp.Client
 }) => {
   await client.createEvent({
     type: 'ticketSolved',

--- a/integrations/zendesk/src/handler.ts
+++ b/integrations/zendesk/src/handler.ts
@@ -28,7 +28,6 @@ export const handler: IntegrationProps['handler'] = async ({ req, ctx, client, l
         const { user: newUser } = await client.getOrCreateUser({
           tags: {
             id: zendeskTrigger.currentUser.id,
-            origin: 'zendesk',
             name: zendeskTrigger.currentUser.name,
             email: zendeskTrigger.currentUser.email,
             role: zendeskTrigger.currentUser.role,
@@ -53,7 +52,7 @@ export const handler: IntegrationProps['handler'] = async ({ req, ctx, client, l
         type: 'text',
         userId: user.id,
         conversationId: conversation.id,
-        payload: { text: messageWithoutAuthor, userId: zendeskTrigger.currentUser.externalId },
+        payload: { text: messageWithoutAuthor },
       })
 
       return

--- a/integrations/zendesk/src/setup.ts
+++ b/integrations/zendesk/src/setup.ts
@@ -17,6 +17,19 @@ export const register: IntegrationProps['register'] = async ({ client, ctx, webh
     return
   }
 
+  const user = await zendeskClient.createOrUpdateUser({
+    role: 'end-user',
+    external_id: ctx.botUserId,
+    name: 'Botpress',
+  })
+
+  await client.updateUser({
+    id: ctx.botUserId,
+    tags: {
+      'zendesk:id': `${user.id}`,
+    },
+  })
+
   const triggersCreated: string[] = []
 
   try {

--- a/integrations/zendesk/src/triggers.ts
+++ b/integrations/zendesk/src/triggers.ts
@@ -2,7 +2,10 @@ export type TriggerPayload = ReturnType<typeof getTriggerTemplate>
 
 export const getTriggerTemplate = (name: TriggerNames) => ({
   type: name,
-  agent: '{{current_user.email}}',
+  agent: {
+    name: '{{ticket.assignee.name}}',
+    email: '{{ticket.assignee.email}}',
+  },
   comment: '{{ticket.latest_public_comment_html}}',
   ticketId: '{{ticket.id}}',
   currentUser: {

--- a/packages/sdk/src/bot/client/index.ts
+++ b/packages/sdk/src/bot/client/index.ts
@@ -33,9 +33,12 @@ export class BotSpecificClient<TBot extends BaseBot> {
   public updateUser: routes.UpdateUser<TBot> = (x) => this.client.updateUser(x)
   public deleteUser: routes.DeleteUser<TBot> = (x) => this.client.deleteUser(x)
 
-  public getState: routes.GetState<TBot> = (x) => this.client.getState(x)
-  public setState: routes.SetState<TBot> = (x) => this.client.setState(x)
-  public patchState: routes.PatchState<TBot> = (x) => this.client.patchState(x)
+  public getState: routes.GetState<TBot> = (x) =>
+    this.client.getState(x).then((y) => ({ state: { ...y.state, payload: y.state.payload as any } }))
+  public setState: routes.SetState<TBot> = (x) =>
+    this.client.setState(x).then((y) => ({ state: { ...y.state, payload: y.state.payload as any } }))
+  public patchState: routes.PatchState<TBot> = (x) =>
+    this.client.patchState(x).then((y) => ({ state: { ...y.state, payload: y.state.payload as any } }))
 
   public callAction: routes.CallAction<TBot> = (x) => this.client.callAction(x)
 }

--- a/packages/sdk/src/bot/client/routes.ts
+++ b/packages/sdk/src/bot/client/routes.ts
@@ -84,9 +84,53 @@ export type GetOrCreateUser<_TBot extends BaseBot> = Client['getOrCreateUser']
 export type UpdateUser<_TBot extends BaseBot> = Client['updateUser']
 export type DeleteUser<_TBot extends BaseBot> = Client['deleteUser']
 
-export type GetState<_TBot extends BaseBot> = Client['getState']
-export type SetState<_TBot extends BaseBot> = Client['setState']
-export type PatchState<_TBot extends BaseBot> = Client['patchState']
+export type GetState<TBot extends BaseBot> = <TState extends keyof TBot['states']>(
+  x: Merge<
+    Arg<Client['getState']>,
+    {
+      name: Cast<TState, string> // TODO: use state name to infer state type
+    }
+  >
+) => Promise<{
+  state: Merge<
+    Awaited<Res<Client['getState']>>['state'],
+    {
+      payload: TBot['states'][TState]
+    }
+  >
+}>
+
+export type SetState<TBot extends BaseBot> = <TState extends keyof TBot['states']>(
+  x: Merge<
+    Arg<Client['setState']>,
+    {
+      name: Cast<TState, string> // TODO: use state name to infer state type
+    }
+  >
+) => Promise<{
+  state: Merge<
+    Awaited<Res<Client['setState']>>['state'],
+    {
+      payload: TBot['states'][TState]
+    }
+  >
+}>
+
+export type PatchState<TBot extends BaseBot> = <TState extends keyof TBot['states']>(
+  x: Merge<
+    Arg<Client['patchState']>,
+    {
+      name: Cast<TState, string> // TODO: use state name to infer state type
+    }
+  >
+) => Promise<{
+  state: Merge<
+    Awaited<Res<Client['patchState']>>['state'],
+    {
+      payload: TBot['states'][TState]
+    }
+  >
+}>
 
 export type CallAction<TBot extends BaseBot> = <ActionType extends keyof EnumerateActions<TBot>>(
   x: Merge<

--- a/packages/sdk/src/bot/server.ts
+++ b/packages/sdk/src/bot/server.ts
@@ -67,16 +67,16 @@ export const botHandler =
 
     switch (ctx.operation) {
       case 'event_received':
-        await onEventReceived<TBot>(props)
+        await onEventReceived<TBot>(props as ServerProps<TBot>)
         break
       case 'register':
-        await onRegister<TBot>(props)
+        await onRegister<TBot>(props as ServerProps<TBot>)
         break
       case 'unregister':
-        await onUnregister<TBot>(props)
+        await onUnregister<TBot>(props as ServerProps<TBot>)
         break
       case 'ping':
-        await onPing<TBot>(props)
+        await onPing<TBot>(props as ServerProps<TBot>)
         break
       default:
         throw new Error(`Unknown operation ${ctx.operation}`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,28 @@ importers:
         specifier: ^3.20.6
         version: 3.21.4
 
+  bots/hit-looper:
+    dependencies:
+      '@botpress/client':
+        specifier: 0.3.2
+        version: link:../../packages/client
+      '@botpress/sdk':
+        specifier: 0.2.3
+        version: link:../../packages/sdk
+      zod:
+        specifier: ^3.20.6
+        version: 3.21.4
+    devDependencies:
+      '@types/node':
+        specifier: ^18.11.17
+        version: 18.16.0
+      ts-node:
+        specifier: ^10.9.1
+        version: 10.9.1(@types/node@18.16.0)(typescript@4.9.5)
+      typescript:
+        specifier: ^4.9.4
+        version: 4.9.5
+
   integrations/asana:
     dependencies:
       '@botpress/sdk':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,7 +120,7 @@ importers:
         version: link:../../packages/client
       '@botpress/sdk':
         specifier: 0.2.3
-        version: link:../../packages/sdk
+        version: 0.2.3
       zod:
         specifier: ^3.20.6
         version: 3.21.4
@@ -1025,9 +1025,6 @@ importers:
       '@botpress/client':
         specifier: workspace:*
         version: link:../../packages/client
-      '@botpress/integrations-testing':
-        specifier: workspace:*
-        version: link:../@testing
       '@botpress/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
@@ -1854,6 +1851,16 @@ packages:
       - openapi-types
     dev: true
 
+  /@botpress/client@0.3.2:
+    resolution: {integrity: sha512-iPHlH4tZkNEOo/TetY7vUKM6o+BtlFe1703QWUtTqo2MnjtNlPtsCzPUJVMVqTojKhqu9QXnB4d0EVU36L73zw==}
+    dependencies:
+      axios: 1.2.5
+      browser-or-node: 2.1.1
+      type-fest: 3.11.1
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /@botpress/messaging-base@1.2.0:
     resolution: {integrity: sha512-7cjHeD1Ti4cvDmyUV2D2CFKR1kPYv+eFPgXaJOksvrEoNZ1SrqXbHR9l26ndaAz0TuoX3Wc9l4Q7i5sBoHE44Q==}
     dev: false
@@ -1865,6 +1872,18 @@ packages:
       axios: 0.21.4(debug@4.3.4)
       cookie: 0.4.2
       joi: 17.9.2
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /@botpress/sdk@0.2.3:
+    resolution: {integrity: sha512-s3yicqSY57vQMVoSn2xcrGf8uJ2zqFO8JEoRQtKdskOI7QaaNR+4kDr5p9UtR5P0k84f3kZdPeL1daxEmi4TdQ==}
+    dependencies:
+      '@botpress/client': 0.3.2
+      axios: 0.27.2
+      radash: 9.5.0
+      zod: 3.21.4
+      zod-to-json-schema: 3.21.4(zod@3.21.4)
     transitivePeerDependencies:
       - debug
     dev: false
@@ -10452,6 +10471,14 @@ packages:
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
+
+  /zod-to-json-schema@3.21.4(zod@3.21.4):
+    resolution: {integrity: sha512-fjUZh4nQ1s6HMccgIeE0VP4QG/YRGPmyjO9sAh890aQKPEk3nqbfUXhMFaC+Dr5KvYBm8BCyvfpZf2jY9aGSsw==}
+    peerDependencies:
+      zod: ^3.21.4
+    dependencies:
+      zod: 3.21.4
+    dev: false
 
   /zod@1.11.17:
     resolution: {integrity: sha512-UzIwO92D0dSFwIRyyqAfRXICITLjF0IP8tRbEK/un7adirMssWZx8xF/1hZNE7t61knWZ+lhEuUvxlu2MO8qqA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,11 +116,11 @@ importers:
   bots/hit-looper:
     dependencies:
       '@botpress/client':
-        specifier: 0.3.2
+        specifier: workspace:*
         version: link:../../packages/client
       '@botpress/sdk':
-        specifier: 0.2.3
-        version: 0.2.3
+        specifier: workspace:*
+        version: link:../../packages/sdk
       zod:
         specifier: ^3.20.6
         version: 3.21.4
@@ -1851,16 +1851,6 @@ packages:
       - openapi-types
     dev: true
 
-  /@botpress/client@0.3.2:
-    resolution: {integrity: sha512-iPHlH4tZkNEOo/TetY7vUKM6o+BtlFe1703QWUtTqo2MnjtNlPtsCzPUJVMVqTojKhqu9QXnB4d0EVU36L73zw==}
-    dependencies:
-      axios: 1.2.5
-      browser-or-node: 2.1.1
-      type-fest: 3.11.1
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
   /@botpress/messaging-base@1.2.0:
     resolution: {integrity: sha512-7cjHeD1Ti4cvDmyUV2D2CFKR1kPYv+eFPgXaJOksvrEoNZ1SrqXbHR9l26ndaAz0TuoX3Wc9l4Q7i5sBoHE44Q==}
     dev: false
@@ -1872,18 +1862,6 @@ packages:
       axios: 0.21.4(debug@4.3.4)
       cookie: 0.4.2
       joi: 17.9.2
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
-  /@botpress/sdk@0.2.3:
-    resolution: {integrity: sha512-s3yicqSY57vQMVoSn2xcrGf8uJ2zqFO8JEoRQtKdskOI7QaaNR+4kDr5p9UtR5P0k84f3kZdPeL1daxEmi4TdQ==}
-    dependencies:
-      '@botpress/client': 0.3.2
-      axios: 0.27.2
-      radash: 9.5.0
-      zod: 3.21.4
-      zod-to-json-schema: 3.21.4(zod@3.21.4)
     transitivePeerDependencies:
       - debug
     dev: false
@@ -10471,14 +10449,6 @@ packages:
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
-
-  /zod-to-json-schema@3.21.4(zod@3.21.4):
-    resolution: {integrity: sha512-fjUZh4nQ1s6HMccgIeE0VP4QG/YRGPmyjO9sAh890aQKPEk3nqbfUXhMFaC+Dr5KvYBm8BCyvfpZf2jY9aGSsw==}
-    peerDependencies:
-      zod: ^3.21.4
-    dependencies:
-      zod: 3.21.4
-    dev: false
 
   /zod@1.11.17:
     resolution: {integrity: sha512-UzIwO92D0dSFwIRyyqAfRXICITLjF0IP8tRbEK/un7adirMssWZx8xF/1hZNE7t61knWZ+lhEuUvxlu2MO8qqA==}


### PR DESCRIPTION
### Changes made to the zendesk API:

1. Action `createTicket` has no side effect; it creates a zendesk ticket (this behavior is something @michaelmass asked me to start enforcing).

2. The `originConversationId` is no longer an integration tag. Instead there is are `upstream` and `downstream` tags in the bot. This reinforces the fact that HITL is a bot concept, not an integration concept.

3. We don't create a "fake" or "clone" user in the HITL integration. We use the bot user for that. (This involves very slight behavior change, but is way simple to implement)

4. The config fields are now `organizationDomain` and `email`.

 ### To try:

```bash
# terminal 1
cd integrations/zendesk
pnpm bp dev

# copy your id
```
```bash
# terminal 2
cd bots/hit-looper
pnpm bp add telegram -y
pnpm bp add $YOUR_ZENDESK_DEV_ID -y
pnpm bp dev

# go in bot framework to talk to your bot
```

Let me know what you think