### PR TITLE
fix(cli): prevent updating a public integration of another workspace

### DIFF
--- a/packages/cli/src/api/paging.ts
+++ b/packages/cli/src/api/paging.ts
@@ -1,0 +1,21 @@
+export type PageLister<R extends object> = (t: { nextToken?: string }) => Promise<R & { meta: { nextToken?: string } }>
+
+export async function listAllPages<R extends object>(lister: PageLister<R>): Promise<R[]>
+export async function listAllPages<R extends object, M>(lister: PageLister<R>, mapper?: (r: R) => M[]): Promise<M[]>
+export async function listAllPages<R extends object, M>(lister: PageLister<R>, mapper?: (r: R) => M[]) {
+  let nextToken: string | undefined
+  const all: R[] = []
+
+  do {
+    const { meta, ...r } = await lister({ nextToken })
+    all.push(r as R)
+    nextToken = meta.nextToken
+  } while (nextToken)
+
+  if (!mapper) {
+    return all
+  }
+
+  const mapped: M[] = all.flatMap((r) => mapper(r))
+  return mapped
+}

--- a/packages/cli/src/command-implementations/deploy-command.ts
+++ b/packages/cli/src/command-implementations/deploy-command.ts
@@ -53,7 +53,7 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
     const integration = await api.findIntegration({ type: 'name', name, version })
     if (integration && !integration.workspaceId) {
       throw new errors.BotpressCLIError(
-        `Integration ${integrationDef.name} v${integrationDef.version} is already deployed publicly in another workspace.`
+        `Public integration ${integrationDef.name} v${integrationDef.version} is already deployed in another workspace.`
       )
     }
 

--- a/packages/cli/src/command-implementations/deploy-command.ts
+++ b/packages/cli/src/command-implementations/deploy-command.ts
@@ -51,6 +51,11 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
     const readmeFileContent = await this._readMediaFile('readme', readmeRelativeFilePath)
 
     const integration = await api.findIntegration({ type: 'name', name, version })
+    if (integration && !integration.workspaceId) {
+      throw new errors.BotpressCLIError(
+        `Integration ${integrationDef.name} v${integrationDef.version} is already deployed publicly in another workspace.`
+      )
+    }
 
     let message: string
     if (integration) {

--- a/packages/cli/src/command-implementations/login-command.ts
+++ b/packages/cli/src/command-implementations/login-command.ts
@@ -1,3 +1,5 @@
+import * as bpclient from '@botpress/client'
+import * as paging from '../api/paging'
 import type commandDefinitions from '../command-definitions'
 import * as errors from '../errors'
 import { GlobalCommand } from './global-command'
@@ -18,9 +20,9 @@ export class LoginCommand extends GlobalCommand<LoginCommandDefinition> {
     })
 
     const promptedWorkspaceId = await this.globalCache.sync('workspaceId', this.argv.workspaceId, async (defaultId) => {
-      const tmpApi = this.api.newClient({ apiUrl: this.argv.apiUrl, token: promptedToken }, this.logger) // no workspaceId yet
-      const userWorkspaces = await tmpApi
-        .listAllPages(tmpApi.client.listWorkspaces, (r) => r.workspaces)
+      const tmpClient = new bpclient.Client({ apiUrl: this.argv.apiUrl, token: promptedToken }) // no workspaceId yet
+      const userWorkspaces = await paging
+        .listAllPages(tmpClient.listWorkspaces, (r) => r.workspaces)
         .catch((thrown) => {
           throw errors.BotpressCLIError.wrap(thrown, 'Could not list workspaces')
         })


### PR DESCRIPTION
closes CLS-1187

### Problem:

1. a user is logged in in his own workspace
2. he tries deploying integration `telegram`
3. integration `telegram` is already deployed publicly in another workspace (our own)
4. the cli checks if it already exists (it does) and calls `client.updateIntegration`
5. the user gets the error `Could not update integration "telegram": Integration "238f88e8-107e-4f78-92ed-affe32ef6ad7" doesn't exist`
6. the problem is that it does exist, but not in the current workspace

### Solution: 

we throw an error earlier with a clear error message that the integration is not yours to update

### Bonus: 

I also checked what happens if a user try to create an integration with a name already taken by another **private** integration of another workspace. We get this:

`Could not create integration "qwerty": Integration name "qwerty" is already reserved by another workspace`

So I believe all possible paths work now