### PR TITLE
feat(cli): allow installing integration from local path

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -101,7 +101,8 @@ local_resource(
   dir='packages/client',
   cmd='pnpm build',
   labels=['client'],
-  resource_deps=['generate-client']
+  resource_deps=['generate-client'],
+  deps=["./packages/client"]
 )
 
 ## build sdk
@@ -112,7 +113,8 @@ local_resource(
   dir='packages/sdk',
   cmd='pnpm build',
   labels=['sdk'],
-  resource_deps=['build-client']
+  resource_deps=['build-client'],
+  deps=["./packages/sdk"]
 )
 
 ## build cli
@@ -123,7 +125,8 @@ local_resource(
   dir='packages/cli',
   cmd='pnpm build',
   labels=['cli'],
-  resource_deps=['build-sdk']
+  resource_deps=['build-sdk'],
+  deps=["./packages/cli"]
 )
 
 ## build integrations
@@ -133,7 +136,8 @@ local_resource(
   allow_parallel=True,
   cmd='pnpm -r --stream -F @botpresshub/* exec bp build --source-map',
   labels=['integrations'],
-  resource_deps=['build-cli']
+  resource_deps=['build-cli'],
+  deps=["./integrations"]
 )
 
 ## build bots
@@ -145,7 +149,8 @@ local_resource(
   allow_parallel=True,
   cmd='pnpm -r --stream -F "%s" run integrations' % bot_filter,
   labels=['bots'],
-  resource_deps=['build-integrations']
+  resource_deps=['build-integrations'],
+  deps=["./bots"]
 )
 
 local_resource(
@@ -153,6 +158,7 @@ local_resource(
   allow_parallel=True,
   cmd='pnpm -r --stream -F "%s" exec bp build --source-map' % bot_filter,
   labels=['bots'],
-  resource_deps=['add-integrations']
+  resource_deps=['add-integrations'],
+  deps=["./bots"]
 )
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -9,7 +9,7 @@ READINESS_PORT = 8082
 
 GENERATE_CLIENT_RESSOURCES = ['pnpm-install', 'openapi-generator-server', 'readiness', 'generate-client']
 BUILD_PACKAGES_RESSOURCES = GENERATE_CLIENT_RESSOURCES + ['build-client', 'build-sdk', 'build-cli']
-BUILD_ALL_RESSOURCES = BUILD_PACKAGES_RESSOURCES + ['build-integrations', 'build-bots']
+BUILD_ALL_RESSOURCES = BUILD_PACKAGES_RESSOURCES + ['build-integrations', 'add-integrations', 'build-bots']
 
 COMMAND_RESSOURCES = {
   'generate-client': GENERATE_CLIENT_RESSOURCES,
@@ -138,11 +138,21 @@ local_resource(
 
 ## build bots
 
+bot_filter = ".\\bots\\*" if os.name == 'nt' else './bots/*'
+
+local_resource(
+  name='add-integrations',
+  allow_parallel=True,
+  cmd='pnpm -r --stream -F "%s" run integrations' % bot_filter,
+  labels=['bots'],
+  resource_deps=['build-integrations']
+)
+
 local_resource(
   name='build-bots',
   allow_parallel=True,
-  cmd='pnpm -r --stream -F hello-world exec bp build --source-map',
+  cmd='pnpm -r --stream -F "%s" exec bp build --source-map' % bot_filter,
   labels=['bots'],
-  resource_deps=['build-integrations']
+  resource_deps=['add-integrations']
 )
 

--- a/bots/bugbuster/integrations.ts
+++ b/bots/bugbuster/integrations.ts
@@ -1,0 +1,13 @@
+import * as pathlib from 'path'
+import { $ } from 'shellby'
+
+const integrations = ['linear', 'github']
+
+const rootDir = pathlib.resolve(__dirname, '..', '..')
+const integrationsDir = pathlib.join(rootDir, 'integrations')
+
+for (const integration of integrations) {
+  console.info(`Installing integration "${integration}"`)
+  const integrationPath = pathlib.join(integrationsDir, integration)
+  $(`pnpm bp add ${integrationPath} -y`)
+}

--- a/bots/bugbuster/package.json
+++ b/bots/bugbuster/package.json
@@ -1,7 +1,8 @@
 {
   "name": "bugbuster",
   "scripts": {
-    "type:check": "echo \"Setup needed before type checking\""
+    "type:check": "tsc --noEmit",
+    "integrations": "ts-node -T ./integrations.ts"
   },
   "keywords": [],
   "private": true,
@@ -15,6 +16,7 @@
   "devDependencies": {
     "@botpress/cli": "workspace:*",
     "@types/node": "^18.11.17",
+    "shellby": "workspace:*",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"
   }

--- a/bots/hit-looper/integrations.ts
+++ b/bots/hit-looper/integrations.ts
@@ -1,0 +1,13 @@
+import * as pathlib from 'path'
+import { $ } from 'shellby'
+
+const integrations = ['zendesk', 'telegram']
+
+const rootDir = pathlib.resolve(__dirname, '..', '..')
+const integrationsDir = pathlib.join(rootDir, 'integrations')
+
+for (const integration of integrations) {
+  console.info(`Installing integration "${integration}"`)
+  const integrationPath = pathlib.join(integrationsDir, integration)
+  $(`pnpm bp add ${integrationPath} -y`)
+}

--- a/bots/hit-looper/package.json
+++ b/bots/hit-looper/package.json
@@ -1,7 +1,8 @@
 {
   "name": "hit-looper",
   "scripts": {
-    "type:check": "echo \"Setup needed before type checking\""
+    "type:check": "tsc --noEmit",
+    "integrations": "ts-node -T ./integrations.ts"
   },
   "keywords": [],
   "private": true,
@@ -14,6 +15,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.11.17",
+    "shellby": "workspace:*",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"
   }

--- a/bots/hit-looper/src/message-handler/from-patient.ts
+++ b/bots/hit-looper/src/message-handler/from-patient.ts
@@ -22,7 +22,7 @@ export const patientMessageHandler: MessageHandler = async ({ message, client, c
       const {
         output: { conversationId: downstreamId },
       } = await client.callAction({
-        type: 'zendesk:startTicketConversation',
+        type: 'zendesk:getTicketConversation',
         input: {
           ticketId: `${ticket.id}`,
         },
@@ -30,7 +30,6 @@ export const patientMessageHandler: MessageHandler = async ({ message, client, c
 
       await client.updateConversation({
         id: upstream.id,
-        participantIds: [], // TODO: rm that when updating the api
         tags: {
           downstream: downstreamId,
         },
@@ -38,7 +37,6 @@ export const patientMessageHandler: MessageHandler = async ({ message, client, c
 
       await client.updateConversation({
         id: downstreamId,
-        participantIds: [], // TODO: rm that when updating the api
         tags: {
           upstream: upstream.id,
         },

--- a/packages/cli/src/api/client.ts
+++ b/packages/cli/src/api/client.ts
@@ -1,6 +1,6 @@
 import * as bpclient from '@botpress/client'
 import _ from 'lodash'
-import { formatIntegrationRef, IntegrationRef } from '../integration-ref'
+import { formatIntegrationRef, ApiIntegrationRef as IntegrationRef } from '../integration-ref'
 import type { Logger } from '../logger'
 import * as paging from './paging'
 

--- a/packages/cli/src/code-generation/integration-implementation.ts
+++ b/packages/cli/src/code-generation/integration-implementation.ts
@@ -1,6 +1,3 @@
-import * as bpsdk from '@botpress/sdk'
-import { z } from 'zod'
-import * as utils from '../utils'
 import { GENERATED_HEADER, INDEX_FILE } from './const'
 import { stringifySingleLine } from './generators'
 import { ActionsModule } from './integration-schemas/actions-module'
@@ -12,11 +9,7 @@ import { Module, ModuleDef } from './module'
 import * as types from './typings'
 
 export class IntegrationImplementationIndexModule extends Module {
-  public static async create(
-    sdkIntegration: bpsdk.IntegrationDefinition
-  ): Promise<IntegrationImplementationIndexModule> {
-    const integration = this._mapIntegration(sdkIntegration)
-
+  public static async create(integration: types.IntegrationDefinition): Promise<IntegrationImplementationIndexModule> {
     const configModule = await ConfigurationModule.create(integration.configuration ?? { schema: {} })
     configModule.unshift('configuration')
 
@@ -112,41 +105,4 @@ export class IntegrationImplementationIndexModule extends Module {
 
     return content
   }
-
-  private static _mapIntegration = (i: bpsdk.IntegrationDefinition): types.IntegrationDefinition => ({
-    name: i.name,
-    version: i.version,
-    user: {
-      tags: i.user?.tags ?? {},
-      creation: i.user?.creation ?? { enabled: false, requiredTags: [] },
-    },
-    configuration: i.configuration ? this._mapSchema(i.configuration) : { schema: {} },
-    events: i.events ? utils.records.mapValues(i.events, this._mapSchema) : {},
-    states: i.states ? utils.records.mapValues(i.states, this._mapSchema) : {},
-    actions: i.actions
-      ? utils.records.mapValues(i.actions, (a) => ({
-          input: this._mapSchema(a.input),
-          output: this._mapSchema(a.output),
-        }))
-      : {},
-    channels: i.channels
-      ? utils.records.mapValues(i.channels, (c) => ({
-          conversation: {
-            tags: c.conversation?.tags ?? {},
-            creation: c.conversation?.creation ?? { enabled: false, requiredTags: [] },
-          },
-          message: {
-            tags: c.message?.tags ?? {},
-          },
-          messages: utils.records.mapValues(c.messages, this._mapSchema),
-        }))
-      : {},
-  })
-
-  private static _mapSchema = <T extends { schema: z.ZodObject<any> }>(
-    x: T
-  ): utils.types.Merge<T, { schema: ReturnType<typeof utils.schema.mapZodToJsonSchema> }> => ({
-    ...x,
-    schema: utils.schema.mapZodToJsonSchema(x),
-  })
 }

--- a/packages/cli/src/code-generation/integration-instance.ts
+++ b/packages/cli/src/code-generation/integration-instance.ts
@@ -1,4 +1,3 @@
-import type { Integration } from '@botpress/client'
 import { casing } from '../utils'
 import { GENERATED_HEADER, INDEX_FILE } from './const'
 import { stringifySingleLine } from './generators'
@@ -8,9 +7,10 @@ import { ConfigurationModule } from './integration-schemas/configuration-module'
 import { EventsModule } from './integration-schemas/events-module'
 import { StatesModule } from './integration-schemas/states-module'
 import { Module, ModuleDef } from './module'
+import * as types from './typings'
 
 export class IntegrationInstanceIndexModule extends Module {
-  public static async create(integration: Integration): Promise<IntegrationInstanceIndexModule> {
+  public static async create(integration: types.IntegrationDefinition): Promise<IntegrationInstanceIndexModule> {
     const { name } = integration
 
     const configModule = await ConfigurationModule.create(integration.configuration ?? { schema: {} })
@@ -54,7 +54,7 @@ export class IntegrationInstanceIndexModule extends Module {
   }
 
   private constructor(
-    private integration: Integration,
+    private integration: types.IntegrationDefinition,
     private configModule: ConfigurationModule,
     private actionsModule: ActionsModule,
     private channelsModule: ChannelsModule,
@@ -77,6 +77,8 @@ export class IntegrationInstanceIndexModule extends Module {
     const { name, version, id } = integration
     const className = casing.to.pascalCase(name)
     const propsName = `${className}Props`
+
+    const integrationId = id === null ? 'null' : `'${id}'`
 
     const lines = [
       GENERATED_HEADER,
@@ -113,7 +115,7 @@ export class IntegrationInstanceIndexModule extends Module {
       '',
       `  public readonly name = '${name}'`,
       `  public readonly version = '${version}'`,
-      `  public readonly id = '${id}'`,
+      `  public readonly id = ${integrationId}`,
       '',
       '  public readonly enabled?: boolean',
       `  public readonly configuration?: ${configModule.name}.${configModule.exports}`,

--- a/packages/cli/src/code-generation/map-integration.ts
+++ b/packages/cli/src/code-generation/map-integration.ts
@@ -1,0 +1,50 @@
+import * as bpclient from '@botpress/client'
+import * as bpsdk from '@botpress/sdk'
+import { z } from 'zod'
+import * as utils from '../utils'
+import * as types from './typings'
+
+export namespace from {
+  export const sdk = (i: bpsdk.IntegrationDefinition): types.IntegrationDefinition => ({
+    id: null,
+    name: i.name,
+    version: i.version,
+    user: {
+      tags: i.user?.tags ?? {},
+      creation: i.user?.creation ?? { enabled: false, requiredTags: [] },
+    },
+    configuration: i.configuration ? _mapSchema(i.configuration) : { schema: {} },
+    events: i.events ? utils.records.mapValues(i.events, _mapSchema) : {},
+    states: i.states ? utils.records.mapValues(i.states, _mapSchema) : {},
+    actions: i.actions
+      ? utils.records.mapValues(i.actions, (a) => ({
+          input: _mapSchema(a.input),
+          output: _mapSchema(a.output),
+        }))
+      : {},
+    channels: i.channels
+      ? utils.records.mapValues(i.channels, (c) => ({
+          conversation: {
+            tags: c.conversation?.tags ?? {},
+            creation: c.conversation?.creation ?? { enabled: false, requiredTags: [] },
+          },
+          message: {
+            tags: c.message?.tags ?? {},
+          },
+          messages: utils.records.mapValues(c.messages, _mapSchema),
+        }))
+      : {},
+  })
+
+  export const client = (i: bpclient.Integration): types.IntegrationDefinition => {
+    const { id, name, version, configuration, channels, states, events, actions, user } = i
+    return { id, name, version, configuration, channels, states, events, actions, user }
+  }
+
+  const _mapSchema = <T extends { schema: z.ZodObject<any> }>(
+    x: T
+  ): utils.types.Merge<T, { schema: ReturnType<typeof utils.schema.mapZodToJsonSchema> }> => ({
+    ...x,
+    schema: utils.schema.mapZodToJsonSchema(x),
+  })
+}

--- a/packages/cli/src/code-generation/typings.ts
+++ b/packages/cli/src/code-generation/typings.ts
@@ -5,7 +5,9 @@ export type File = { path: string; content: string }
 export type IntegrationDefinition = Pick<
   Integration,
   'name' | 'version' | 'configuration' | 'channels' | 'states' | 'events' | 'actions' | 'user'
->
+> & {
+  id: string | null
+}
 
 type Def<T> = NonNullable<T>
 

--- a/packages/cli/src/command-implementations/deploy-command.ts
+++ b/packages/cli/src/command-implementations/deploy-command.ts
@@ -72,7 +72,7 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
     }
 
     const createBody: CreateIntegrationBody = {
-      ...this.parseIntegrationDefinition(integrationDef),
+      ...this.prepareIntegrationDefinition(integrationDef),
       icon: iconFileContent,
       readme: readmeFileContent,
       code,
@@ -147,7 +147,8 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
       {
         id: bot.id,
         code,
-        ...this.parseBot(botImpl),
+        ...this.prepareBot(botImpl),
+        ...(await this.prepareBotIntegrationInstances(botImpl, api)),
       },
       bot
     )

--- a/packages/cli/src/command-implementations/dev-command.ts
+++ b/packages/cli/src/command-implementations/dev-command.ts
@@ -218,7 +218,7 @@ export class DevCommand extends ProjectCommand<DevCommandDefinition> {
     line.started(`Deploying dev integration ${chalk.bold(integrationDef.name)}...`)
 
     const integrationBody: CreateIntegrationBody = {
-      ...this.parseIntegrationDefinition(integrationDef),
+      ...this.prepareIntegrationDefinition(integrationDef),
       url: externalUrl,
     }
 
@@ -292,7 +292,8 @@ export class DevCommand extends ProjectCommand<DevCommandDefinition> {
       {
         id: bot.id,
         url: externalUrl,
-        ...this.parseBot(botImpl),
+        ...this.prepareBot(botImpl),
+        ...(await this.prepareBotIntegrationInstances(botImpl, api)),
       },
       bot
     )

--- a/packages/cli/src/command-implementations/integration-commands.ts
+++ b/packages/cli/src/command-implementations/integration-commands.ts
@@ -14,6 +14,9 @@ export class GetIntegrationCommand extends GlobalCommand<GetIntegrationCommandDe
     if (!parsedRef) {
       throw new errors.InvalidIntegrationReferenceError(this.argv.integrationRef)
     }
+    if (parsedRef.type === 'path') {
+      throw new errors.BotpressCLIError('Cannot get local integration')
+    }
 
     try {
       const integration = await api.findIntegration(parsedRef)
@@ -61,6 +64,9 @@ export class DeleteIntegrationCommand extends GlobalCommand<DeleteIntegrationCom
     const parsedRef = parseIntegrationRef(this.argv.integrationRef)
     if (!parsedRef) {
       throw new errors.InvalidIntegrationReferenceError(this.argv.integrationRef)
+    }
+    if (parsedRef.type === 'path') {
+      throw new errors.BotpressCLIError('Cannot delete local integration')
     }
 
     let integration: bpclient.Integration | undefined

--- a/packages/cli/src/integration-ref.test.ts
+++ b/packages/cli/src/integration-ref.test.ts
@@ -1,0 +1,115 @@
+import { describe } from 'node:test'
+import { test, expect } from 'vitest'
+import { formatIntegrationRef, IntegrationRef, parseIntegrationRef } from './integration-ref'
+
+const path = '/my/path'
+const uuid = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
+const name = 'myintegration'
+
+describe('parseIntegrationRef', () => {
+  test('parse empty string should return undefined', () => {
+    // arrange
+    const ref = ''
+    // act
+    const result = parseIntegrationRef(ref)
+    // assert
+    expect(result).toBeUndefined()
+  })
+
+  test('parse with invalid version should return undefined', () => {
+    // arrange
+    const ref0 = `${name}@lol`
+    const ref1 = `${name}@1`
+    const ref2 = `${name}@1.0`
+    // act
+    const result0 = parseIntegrationRef(ref0)
+    const result1 = parseIntegrationRef(ref1)
+    const result2 = parseIntegrationRef(ref2)
+    // assert
+    expect(result0).toBeUndefined()
+    expect(result1).toBeUndefined()
+    expect(result2).toBeUndefined()
+  })
+
+  test('parse with an absolute path should return path', () => {
+    // arrange
+    const ref = path
+    // act
+    const result = parseIntegrationRef(ref)
+    // assert
+    const expected: IntegrationRef = { type: 'path', path: ref }
+    expect(result).toEqual(expected)
+  })
+
+  test('parse with a uuid return uuid', () => {
+    // arrange
+    const ref = uuid
+    // act
+    const result = parseIntegrationRef(ref)
+    // assert
+    const expected: IntegrationRef = { type: 'id', id: ref }
+    expect(result).toEqual(expected)
+  })
+
+  test('parse with a name and version should return name and version', () => {
+    // arrange
+    const version = '1.0.0'
+    const ref = `${name}@${version}`
+    // act
+    const result = parseIntegrationRef(ref)
+    // assert
+    const expected: IntegrationRef = { type: 'name', name, version }
+    expect(result).toEqual(expected)
+  })
+
+  test('parse with a name and latest should return name and latest', () => {
+    // arrange
+    const version = 'latest'
+    const ref = `${name}@${version}`
+    // act
+    const result = parseIntegrationRef(ref)
+    // assert
+    const expected: IntegrationRef = { type: 'name', name, version }
+    expect(result).toEqual(expected)
+  })
+
+  test('parse with only a name should return name and latest', () => {
+    // arrange
+    const ref = name
+    // act
+    const result = parseIntegrationRef(ref)
+    // assert
+    const expected: IntegrationRef = { type: 'name', name, version: 'latest' }
+    expect(result).toEqual(expected)
+  })
+})
+
+describe('formatIntegrationRef', () => {
+  test('format with a path should return path', () => {
+    // arrange
+    const ref: IntegrationRef = { type: 'path', path }
+    // act
+    const result = formatIntegrationRef(ref)
+    // assert
+    expect(result).toEqual(ref.path)
+  })
+
+  test('format with a uuid should return uuid', () => {
+    // arrange
+    const ref: IntegrationRef = { type: 'id', id: uuid }
+    // act
+    const result = formatIntegrationRef(ref)
+    // assert
+    expect(result).toEqual(ref.id)
+  })
+
+  test('format with a name and version should return name and version', () => {
+    // arrange
+    const version = '1.0.0'
+    const ref: IntegrationRef = { type: 'name', name, version }
+    // act
+    const result = formatIntegrationRef(ref)
+    // assert
+    expect(result).toEqual(`${name}@${version}`)
+  })
+})

--- a/packages/cli/src/integration-ref.ts
+++ b/packages/cli/src/integration-ref.ts
@@ -1,5 +1,6 @@
 import semver from 'semver'
 import * as uuid from 'uuid'
+import * as utils from './utils'
 
 export type UUIDIntegrationRef = {
   type: 'id'
@@ -12,11 +13,20 @@ export type NameIntegrationRef = {
   version: string
 }
 
-export type IntegrationRef = UUIDIntegrationRef | NameIntegrationRef
+export type LocalPathIntegrationRef = {
+  type: 'path'
+  path: utils.path.AbsolutePath
+}
+
+export type ApiIntegrationRef = UUIDIntegrationRef | NameIntegrationRef
+export type IntegrationRef = ApiIntegrationRef | LocalPathIntegrationRef
 
 const LATEST_TAG = 'latest'
 
 export const formatIntegrationRef = (ref: IntegrationRef): string => {
+  if (ref.type === 'path') {
+    return ref.path
+  }
   if (ref.type === 'id') {
     return ref.id
   }
@@ -24,8 +34,16 @@ export const formatIntegrationRef = (ref: IntegrationRef): string => {
 }
 
 export const parseIntegrationRef = (ref: string): IntegrationRef | undefined => {
+  if (!ref) {
+    return
+  }
+
   if (uuid.validate(ref)) {
     return { type: 'id', id: ref }
+  }
+
+  if (utils.path.isAbsolute(ref)) {
+    return { type: 'path', path: ref }
   }
 
   if (!ref.includes('@')) {

--- a/packages/sdk/src/bot/integration-instance.ts
+++ b/packages/sdk/src/bot/integration-instance.ts
@@ -1,5 +1,5 @@
 export type IntegrationInstance<TName extends string> = {
-  id: string
+  id: string | null
   enabled?: boolean
   configuration?: Record<string, any>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@types/node':
         specifier: ^18.11.17
         version: 18.16.0
+      shellby:
+        specifier: workspace:*
+        version: link:../../scripts/shellby
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@types/node@18.16.0)(typescript@4.9.5)
@@ -128,6 +131,9 @@ importers:
       '@types/node':
         specifier: ^18.11.17
         version: 18.16.0
+      shellby:
+        specifier: workspace:*
+        version: link:../../scripts/shellby
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@types/node@18.16.0)(typescript@4.9.5)
@@ -1359,6 +1365,12 @@ importers:
       yaml:
         specifier: ^2.3.1
         version: 2.3.1
+
+  scripts/shellby:
+    dependencies:
+      typescript:
+        specifier: ^4.9.4
+        version: 4.9.5
 
 packages:
 

--- a/scripts/shellby/package.json
+++ b/scripts/shellby/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "shellby",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Just a function to run shell commands without having to handle the child_process API",
+  "main": "src/index.ts",
+  "scripts": {
+    "type:check": "tsc --noEmit"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "typescript": "^4.9.4"
+  }
+}

--- a/scripts/shellby/readme.md
+++ b/scripts/shellby/readme.md
@@ -1,0 +1,3 @@
+# Shellby
+
+Just a function to run shell commands without having to handle the `child_process` API.

--- a/scripts/shellby/src/index.ts
+++ b/scripts/shellby/src/index.ts
@@ -2,15 +2,12 @@ import * as childProcess from 'child_process'
 
 const parseCommand = (cmd: string): { command: string; args: string[] } => {
   const [command, ...args] = cmd.split(' ')
-  if (command) {
-    return {
-      command,
-      args,
-    }
+  if (!command) {
+    throw new Error('Command is empty')
   }
   return {
-    command: cmd,
-    args: [],
+    command,
+    args,
   }
 }
 

--- a/scripts/shellby/src/index.ts
+++ b/scripts/shellby/src/index.ts
@@ -1,0 +1,23 @@
+import * as childProcess from 'child_process'
+
+const parseCommand = (cmd: string): { command: string; args: string[] } => {
+  const [command, ...args] = cmd.split(' ')
+  if (command) {
+    return {
+      command,
+      args,
+    }
+  }
+  return {
+    command: cmd,
+    args: [],
+  }
+}
+
+export const $ = (cmd: string) => {
+  const { command, args } = parseCommand(cmd)
+  return childProcess.spawnSync(command, args, {
+    stdio: 'inherit',
+  })
+}
+export default $

--- a/scripts/shellby/tsconfig.json
+++ b/scripts/shellby/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
closes CLS-1136

# The Feature

## What

```sh
# before
bp install telegram
bp install telegram@0.2.0
bp install telegram@latest
bp install 238f88e8-107e-4f78-92ed-affe32ef6ad7

# now
bp install "$(pwd)/integrations/telegram"
```

## Why

Previously, calling the add command would query the API to find the integration to install. This was problematic because we need to install integrations to get proper typings, but we need to login to Botpress Cloud to install an integration. This meant we had to login to Botpress Cloud just to run type checking.

# The Code

When deploying a bot, we need to index integrations by their Id. The problem is that when we install an integration from a local path we don't know its Id yet (it's chosen by Botpress Cloud). 

The solution presented here is:
1. when an integration is installed from a local path, its id is null
2. when deploying the bot, if an id is null, we fetch the API to get the actual integration id from its name and version

# Reviewing

I believe this PR can be reviewed by commit

1. feat(cli): allow installing integration from local path
2. chore: install integrations and build bots in tilt file
3. chore: fix typings in hit-looper

The first commit implements the feature. The second one add some scripting to the repo so that bots are type checked by the CI. The third one fixes typing mistakes in `hit-looper` that were missed before.