### PR TITLE
fix(whatsapp): safer handler of choices values and multiple messages

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -2,7 +2,7 @@ import { IntegrationDefinition, messages } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { z } from 'zod'
 
-export const name = 'whatsapp'
+export const name = 'whatsappabe'
 
 export default new IntegrationDefinition({
   name,

--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -2,7 +2,7 @@ import { IntegrationDefinition, messages } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { z } from 'zod'
 
-export const name = 'whatsappabe'
+export const name = 'whatsapp'
 
 export default new IntegrationDefinition({
   name,

--- a/integrations/whatsapp/src/message-types/choice.ts
+++ b/integrations/whatsapp/src/message-types/choice.ts
@@ -41,5 +41,6 @@ export function* generateOutgoingMessages({
 }
 
 function createButton(option: Option) {
-  return button.create({ id: option.value, title: truncate(option.label, BUTTON_LABEL_MAX_LENGTH) })
+  const safeValue = option.value.trim() // Whatsapp doesn't allow trailing spaces in button IDs
+  return button.create({ id: safeValue, title: truncate(option.label, BUTTON_LABEL_MAX_LENGTH) })
 }

--- a/integrations/whatsapp/src/outgoing-message.ts
+++ b/integrations/whatsapp/src/outgoing-message.ts
@@ -88,10 +88,14 @@ export async function sendMany({
   generator: Generator<OutgoingMessage, void, unknown>
   logger: IntegrationLogger
 }) {
-  for (const message of generator) {
-    // Sending multiple messages in sequence does not guarantee delivery order on the client-side.
-    // In order for messages to appear in order on the client side, adding some sleep in between each seems to work.
-    await sleep(1000)
-    await send({ ctx, conversation, ack, message, logger })
+  try {
+    for (const message of generator) {
+      // Sending multiple messages in sequence does not guarantee delivery order on the client-side.
+      // In order for messages to appear in order on the client side, adding some sleep in between each seems to work.
+      await sleep(1000)
+      await send({ ctx, conversation, ack, message, logger })
+    }
+  } catch (err) {
+    logger.forBot().error('Failed to generate messages for sending to Whatsapp. Reason:', err)
   }
 }


### PR DESCRIPTION
This prevents the following unhandled error from happening when the choice values contain trailing spaces:

`2023-08-24T21:41:24.585Z	ed5d865a-dd08-4b38-9944-5d549e881d8c	ERROR	Invoke Error 	{"errorType":"Error","errorMessage":"Button id cannot have leading or trailing spaces","stack":["Error: Button id cannot have leading or trailing spaces","    at new Button (/var/task/customer_code.js:34:43730)","    at create (/var/task/customer_code.js:81:158520)","    at createButton (/var/task/customer_code.js:81:161014)","    at Array.map (<anonymous>)","    at generateOutgoingMessages (/var/task/customer_code.js:81:160940)","    at gL.next (<anonymous>)","    at sendMany (/var/task/customer_code.js:81:163756)","    at choice (/var/task/customer_code.js:81:165711)","    at /var/task/customer_code.js:81:101419","    at be (/var/task/customer_code.js:8:84257)"]}`

Also, errors happening in the generators of multiple messages (like the one above) will be correctly handled and directly surfaced in the bot logs.