### PR TITLE
feat(whatsapp): support multiple senders by using phone number ID stored in the conversation tags instead of the configuration

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -13,24 +13,25 @@ export const TemplateVariablesTag = 'templateVariables'
 
 const TagsForCreatingConversation = {
   [PhoneNumberIdTag]: {
-    title: 'Phone number ID',
-    description: 'ID of the Whatsapp phone number to use as sender.',
+    title: 'Phone Number ID',
+    description:
+      'Whatsapp Phone Number ID to use as sender. If not provided it defaults to the one set in the configuration.',
   },
   [UserPhoneTag]: {
     title: 'User phone number',
     description: 'Phone number of the Whatsapp user to start the conversation with.',
   },
   [TemplateNameTag]: {
-    title: 'Message template name',
+    title: 'Message Template name',
     description: 'Name of the Whatsapp Message Template to start the conversation with.',
   },
   [TemplateLanguageTag]: {
-    title: 'Message template language (optional)',
+    title: 'Message Template language (optional)',
     description:
       'Language of the Whatsapp Message Template to start the conversation with. Defaults to "en_US" (U.S. English).',
   },
   [TemplateVariablesTag]: {
-    title: 'Message template variables (optional)',
+    title: 'Message Template variables (optional)',
     description: 'JSON array representation of variable values to pass to the Whatsapp Message Template.',
   },
 }
@@ -43,10 +44,15 @@ export default new IntegrationDefinition({
   icon: 'icon.svg',
   readme: 'hub.md',
   configuration: {
+    ui: {
+      phoneNumberId: {
+        title: 'Default Phone Number ID for starting conversations',
+      },
+    },
     schema: z.object({
       verifyToken: z.string(),
-      phoneNumberId: z.string(),
       accessToken: z.string(),
+      phoneNumberId: z.string(),
     }),
   },
   channels: {
@@ -76,7 +82,7 @@ export default new IntegrationDefinition({
     startConversation: {
       title: 'Start Conversation',
       description:
-        "Starts a conversation with a user's Whatsapp phone number by sending them a message using a Whatsapp Message Template.",
+        "Proactively starts a conversation with a user's Whatsapp phone number by sending them a message using a Whatsapp Message Template.",
       input: {
         schema: z.object({
           userPhone: z.string().describe(TagsForCreatingConversation.userPhone.description),
@@ -86,6 +92,7 @@ export default new IntegrationDefinition({
             .string()
             .optional()
             .describe(TagsForCreatingConversation.templateVariables.description),
+          senderPhoneNumberId: z.string().optional().describe(TagsForCreatingConversation.phoneNumberId.description),
         }),
       },
       output: {

--- a/integrations/whatsapp/src/conversation.ts
+++ b/integrations/whatsapp/src/conversation.ts
@@ -44,7 +44,7 @@ export async function startConversation(
   let templateVariables: z.infer<typeof TemplateVariablesSchema> = []
 
   if (!phoneNumberId) {
-    logForBotAndThrow('Phone number ID was not provided', logger)
+    logForBotAndThrow('Whatsapp Phone number ID to use as sender was not provided', logger)
   }
 
   if (!userPhone) {
@@ -138,7 +138,7 @@ export const createConversationHandler: botpress.IntegrationProps['createConvers
   ctx,
   logger,
 }) => {
-  const phoneNumberId = ctx.configuration.phoneNumberId
+  const phoneNumberId = tags[`${name}:${PhoneNumberIdTag}`] || ctx.configuration.phoneNumberId
   const userPhone = tags[`${name}:${UserPhoneTag}`]!
   const templateName = tags[`${name}:${TemplateNameTag}`]!
   const templateLanguage = tags[`${name}:${TemplateLanguageTag}`]

--- a/integrations/whatsapp/src/index.ts
+++ b/integrations/whatsapp/src/index.ts
@@ -22,7 +22,7 @@ const integration = new bp.Integration({
       const conversation = await startConversation(
         {
           channel,
-          phoneNumberId: ctx.configuration.phoneNumberId,
+          phoneNumberId: input.senderPhoneNumberId || ctx.configuration.phoneNumberId,
           userPhone: input.userPhone,
           templateName: input.templateName,
           templateLanguage: input.templateLanguage,

--- a/integrations/whatsapp/src/outgoing-message.ts
+++ b/integrations/whatsapp/src/outgoing-message.ts
@@ -1,6 +1,6 @@
 import type { Conversation } from '@botpress/client'
 import type { IntegrationContext, AckFunction } from '@botpress/sdk'
-import { name } from 'integration.definition'
+import { PhoneNumberIdTag, UserPhoneTag, name } from 'integration.definition'
 import { WhatsAppAPI } from 'whatsapp-api-js'
 import type { Contacts } from 'whatsapp-api-js/types/messages/contacts'
 import type { Interactive } from 'whatsapp-api-js/types/messages/interactive'
@@ -39,9 +39,16 @@ export async function send({
   logger: IntegrationLogger
 }) {
   const whatsapp = new WhatsAppAPI(ctx.configuration.accessToken)
-  const phoneNumberId = ctx.configuration.phoneNumberId
-  const to = conversation.tags[`${name}:userPhone`]
+  const phoneNumberId = conversation.tags[`${name}:${PhoneNumberIdTag}`]
+  const to = conversation.tags[`${name}:${UserPhoneTag}`]
   const messageType = message._
+
+  if (!phoneNumberId) {
+    logger
+      .forBot()
+      .error("Cannot send message to Whatsapp because the phone number ID wasn't set in the conversation tags.")
+    return
+  }
 
   if (!to) {
     logger


### PR DESCRIPTION
Note: This approach is secure as Whatsapp verifies the phone number ID used against the access token set in the configuration, which prevents impersonation attempts of a bot trying to change the sender ID set in the conversation tags.