### PR TITLE
feat(cli): throw error when deploying integration if icon is not an SVG

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/command-implementations/deploy-command.ts
+++ b/packages/cli/src/command-implementations/deploy-command.ts
@@ -54,6 +54,10 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
       configuration,
     } = integrationDef
 
+    if (iconRelativeFilePath && !iconRelativeFilePath.toLowerCase().endsWith('.svg')) {
+      throw new errors.BotpressCLIError('Icon must be an SVG file')
+    }
+
     const iconFileContent = await this._readMediaFile('icon', iconRelativeFilePath)
     const readmeFileContent = await this._readMediaFile('readme', readmeRelativeFilePath)
     const identifierExtractScriptFileContent = await this._readFile(identifier?.extractScript)


### PR DESCRIPTION
We could validate this on the backend too but it's tricky as we don't receive an icon filename there but the actual file contents, so we should validate early in the CLI.