### PR TITLE
feat(telegram): storing user name and pictureUrl on message received

### DIFF
--- a/integrations/telegram/src/const.ts
+++ b/integrations/telegram/src/const.ts
@@ -1,0 +1,1 @@
+export const PICTURE_LIMIT_SIZE = 100_000

--- a/integrations/telegram/src/const.ts
+++ b/integrations/telegram/src/const.ts
@@ -1,1 +1,1 @@
-export const PICTURE_LIMIT_SIZE = 20_000
+export const PICTURE_LIMIT_SIZE = 25_000

--- a/integrations/telegram/src/const.ts
+++ b/integrations/telegram/src/const.ts
@@ -1,1 +1,1 @@
-export const PICTURE_LIMIT_SIZE = 100_000
+export const PICTURE_LIMIT_SIZE = 20_000

--- a/integrations/telegram/src/const.ts
+++ b/integrations/telegram/src/const.ts
@@ -1,1 +1,1 @@
-export const PICTURE_LIMIT_SIZE = 25_000
+export const USER_PICTURE_MAX_SIZE_BYTES = 25_000

--- a/integrations/telegram/src/index.ts
+++ b/integrations/telegram/src/index.ts
@@ -8,6 +8,8 @@ import type { Update, User } from 'telegraf/typings/core/types/typegram'
 import { getUserPictureDataUri, getUserNameFromTelegramUser } from './misc/utils'
 import * as bp from '.botpress'
 
+export type IntegrationLogger = Parameters<bp.IntegrationProps['handler']>[0]['logger']
+
 type Card = bp.channels.channel.card.Card
 
 const prefixedId = `${name}:id` as const
@@ -157,12 +159,13 @@ const integration = new bp.Integration({
     })
 
     const userFieldsToUpdate = {
-      pictureUrl:
-        user.pictureUrl ||
-        (await getUserPictureDataUri({
-          botToken: ctx.configuration.botToken,
-          telegramUserId: userId,
-        })),
+      pictureUrl: !user.pictureUrl
+        ? await getUserPictureDataUri({
+            botToken: ctx.configuration.botToken,
+            telegramUserId: userId,
+            logger,
+          })
+        : undefined,
       name: user.name !== userName ? userName : undefined,
     }
 

--- a/integrations/telegram/src/index.ts
+++ b/integrations/telegram/src/index.ts
@@ -155,7 +155,7 @@ const integration = new bp.Integration({
       tags: {
         [prefixedId]: `${userId}`,
       },
-      name: userName || userId,
+      ...(userName && { name: userName }),
     })
 
     const userFieldsToUpdate = {

--- a/integrations/telegram/src/index.ts
+++ b/integrations/telegram/src/index.ts
@@ -156,6 +156,24 @@ const integration = new bp.Integration({
       name: userName || userId,
     })
 
+    const userFieldsToUpdate = {
+      pictureUrl:
+        user.pictureUrl ||
+        (await getUserPictureDataUri({
+          botToken: ctx.configuration.botToken,
+          telegramUserId: userId,
+        })),
+      name: user.name !== userName ? userName : undefined,
+    }
+
+    if (userFieldsToUpdate.pictureUrl || userFieldsToUpdate.name) {
+      await client.updateUser({
+        ...user,
+        ...(userFieldsToUpdate.pictureUrl && { pictureUrl: userFieldsToUpdate.pictureUrl }),
+        ...(userFieldsToUpdate.name && { name: userFieldsToUpdate.name }),
+      })
+    }
+
     const messageId = data.message.message_id
 
     if (!messageId) {
@@ -170,19 +188,6 @@ const integration = new bp.Integration({
       conversationId: conversation.id,
       payload: { text: data.message.text },
     })
-
-    // doing this after creating the message to avoid latency
-    const userFieldsToUpdate = {
-      pictureUrl: await getUserPictureDataUri({
-        botToken: ctx.configuration.botToken,
-        telegramUserId: userId,
-      }),
-      name: user.name !== userName ? userName : undefined,
-    }
-
-    if (userFieldsToUpdate.pictureUrl || userFieldsToUpdate.name) {
-      await client.updateUser({ ...user, ...userFieldsToUpdate })
-    }
   },
   createUser: async ({ client, tags, ctx }) => {
     const userId = Number(tags[prefixedId])

--- a/integrations/telegram/src/misc/utils.ts
+++ b/integrations/telegram/src/misc/utils.ts
@@ -1,0 +1,53 @@
+import { axios } from '@botpress/client'
+import { PICTURE_LIMIT_SIZE } from 'src/const'
+import { Telegraf } from 'telegraf'
+import { PhotoSize, User } from 'telegraf/typings/core/types/typegram'
+
+export const getUserNameFromTelegramUser = (telegramUser: User) => {
+  if (telegramUser.last_name) {
+    return `${telegramUser.first_name} ${telegramUser.last_name}`
+  } else if (telegramUser.username) {
+    return `${telegramUser.first_name} (username: ${telegramUser.username})`
+  }
+  return `${telegramUser.first_name} (id: ${telegramUser.id})`
+}
+
+export const getUserPictureDataUri = async ({
+  botToken,
+  telegramUserId,
+}: {
+  botToken: string
+  telegramUserId: number
+}): Promise<string | null> => {
+  try {
+    const telegraf = new Telegraf(botToken)
+    const res = await telegraf.telegram.getUserProfilePhotos(telegramUserId)
+
+    const photoToUse = res.photos?.[0]?.reduce<PhotoSize | null>((finalPicture, currentPicture) => {
+      const isSizeBelowLimit = !!currentPicture.file_size && currentPicture.file_size < PICTURE_LIMIT_SIZE
+      const isSizeAbovePrevious =
+        !!currentPicture.file_size && !!finalPicture?.file_size && currentPicture.file_size > finalPicture.file_size
+      // here we want to use the picture with the best resolution below PICTURE_LIMIT_SIZE
+      if (isSizeBelowLimit && (!finalPicture || isSizeAbovePrevious)) {
+        return currentPicture
+      }
+      return finalPicture
+    }, null)
+
+    if (photoToUse) {
+      const fileLink = await telegraf.telegram.getFileLink(photoToUse.file_id)
+
+      const fileExtension = fileLink.href.substring(fileLink.href.lastIndexOf('.') + 1)
+
+      const { data } = await axios.default.get(fileLink.href, { responseType: 'arraybuffer' })
+
+      const base64File = Buffer.from(data, 'binary').toString('base64')
+
+      return `data:image/${fileExtension};base64,${base64File}`
+    }
+    return null
+  } catch (error) {
+    console.error("Couldn't convert Telegram profile picture to base64 Data URI: ", error)
+    return null
+  }
+}

--- a/integrations/telegram/src/misc/utils.ts
+++ b/integrations/telegram/src/misc/utils.ts
@@ -22,8 +22,8 @@ const getDataUriFromImgHref = async (imgHref: string): Promise<string> => {
   return `data:image/${fileExtension};base64,${base64File}`
 }
 
-export const getBestPhotoSize = (photos: PhotoSize[][] | undefined): PhotoSize | null =>
-  photos?.[0]?.reduce((finalPicture: PhotoSize | null, currentPicture: PhotoSize) => {
+const getBestPhotoSize = (photos: PhotoSize[]): PhotoSize | null =>
+  photos.reduce((finalPicture: PhotoSize | null, currentPicture: PhotoSize) => {
     const isSizeBelowLimit = !!currentPicture.file_size && currentPicture.file_size < PICTURE_LIMIT_SIZE
     const isSizeAbovePrevious =
       !!currentPicture.file_size && !!finalPicture?.file_size && currentPicture.file_size > finalPicture.file_size
@@ -46,7 +46,10 @@ export const getUserPictureDataUri = async ({
     const telegraf = new Telegraf(botToken)
     const res = await telegraf.telegram.getUserProfilePhotos(telegramUserId)
 
-    const photoToUse = getBestPhotoSize(res.photos)
+    if (!res.photos[0]) {
+      return null
+    }
+    const photoToUse = getBestPhotoSize(res.photos[0])
 
     if (photoToUse) {
       const fileLink = await telegraf.telegram.getFileLink(photoToUse.file_id)

--- a/integrations/telegram/src/misc/utils.ts
+++ b/integrations/telegram/src/misc/utils.ts
@@ -5,12 +5,12 @@ import { Telegraf } from 'telegraf'
 import { PhotoSize, User } from 'telegraf/typings/core/types/typegram'
 
 export const getUserNameFromTelegramUser = (telegramUser: User) => {
-  if (telegramUser.last_name) {
+  if (telegramUser.first_name && telegramUser.last_name) {
     return `${telegramUser.first_name} ${telegramUser.last_name}`
   } else if (telegramUser.username) {
-    return `${telegramUser.first_name} (username: ${telegramUser.username})`
+    return telegramUser.username
   }
-  return `${telegramUser.first_name} (id: ${telegramUser.id})`
+  return null
 }
 
 const getMimeTypeFromExtension = (extension: string): string => {


### PR DESCRIPTION
We currently don't store informations on Telegram users, making it hard to identify them when needed.

![Screenshot 2023-11-08 at 3 48 59 PM](https://github.com/botpress/botpress/assets/5313741/67570ea4-cf6d-4952-9d5a-c6accf5fc112)

Solution: when a message is received by the Telegram integration, we want to store the user name and a pictureUrl if possible.