### PR TITLE
feat(slack): implement start dm & list active users

### DIFF
--- a/integrations/slack/package.json
+++ b/integrations/slack/package.json
@@ -6,8 +6,7 @@
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
     "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\"",
-    "bp": "bp"
+    "test": "echo \"Tests not implemented yet.\""
   },
   "keywords": [],
   "author": "",

--- a/integrations/slack/package.json
+++ b/integrations/slack/package.json
@@ -6,7 +6,8 @@
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
     "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "test": "echo \"Tests not implemented yet.\"",
+    "bp": "bp"
   },
   "keywords": [],
   "author": "",
@@ -18,6 +19,7 @@
     "@slack/web-api": "^6.8.0",
     "axios": "^1.3.4",
     "fuse.js": "^6.6.2",
+    "lodash": "^4.17.21",
     "query-string": "^6.14.1",
     "verror": "^1.10.1",
     "zod": "^3.20.6"
@@ -26,6 +28,7 @@
     "@botpress/cli": "workspace:*",
     "@botpress/client": "workspace:*",
     "@sentry/cli": "^2.18.1",
+    "@types/lodash": "^4.14.191",
     "@types/node": "^18.11.17",
     "@types/verror": "^1.10.6",
     "typescript": "^4.9.4"

--- a/integrations/slack/src/actions/find-target.ts
+++ b/integrations/slack/src/actions/find-target.ts
@@ -27,7 +27,9 @@ export const findTarget: Implementation['actions']['findTarget'] = async ({ clie
     const users = (list.members || [])
       .filter((x) => !x.deleted)
       .map<Target>((member) => ({
-        displayName: member.real_name || member.name || '',
+        displayName: member.name!,
+        name: member.profile?.real_name ?? '',
+        email: member.profile?.email ?? '',
         tags: { id: member.id! },
         channel: 'dm',
       }))

--- a/integrations/slack/src/actions/index.ts
+++ b/integrations/slack/src/actions/index.ts
@@ -3,6 +3,7 @@ import { findTarget } from './find-target'
 import { listActiveMembers } from './list-users'
 import { retrieveMessage } from './retreive-message'
 import { startDmConversation } from './start-dm'
+
 import * as bp from '.botpress'
 
 export default {

--- a/integrations/slack/src/actions/index.ts
+++ b/integrations/slack/src/actions/index.ts
@@ -1,10 +1,14 @@
 import { addReaction } from './add-reaction'
 import { findTarget } from './find-target'
+import { listActiveMembers } from './list-users'
 import { retrieveMessage } from './retreive-message'
+import { startDmConversation } from './start-dm'
 import * as bp from '.botpress'
 
 export default {
   addReaction,
   findTarget,
   retrieveMessage,
+  listActiveMembers,
+  startDmConversation,
 } satisfies bp.IntegrationProps['actions']

--- a/integrations/slack/src/actions/list-users.ts
+++ b/integrations/slack/src/actions/list-users.ts
@@ -1,0 +1,63 @@
+import { isApiError } from '@botpress/client'
+import { WebClient } from '@slack/web-api'
+import { Member } from '@slack/web-api/dist/response/UsersListResponse'
+import { mapKeys, isEqual } from 'lodash'
+import { getAccessToken } from 'src/misc/utils'
+import * as botpress from '.botpress'
+
+const syncSlackUserToBotpressUser = async (member: Member, botpressClient: botpress.Client) => {
+  try {
+    const { user } = await botpressClient.getOrCreateUser({
+      tags: {
+        id: member.id,
+      },
+    })
+
+    const latestTags = mapKeys(user.tags, (v, k) => k.split(':')[1])
+    const tags = { ...member.profile }
+
+    if (isEqual(latestTags, tags)) {
+      return user
+    }
+
+    const { user: updatedUser } = await botpressClient.updateUser({
+      name: member.name,
+      pictureUrl: member.profile?.image_512,
+      tags,
+    } as any)
+
+    return updatedUser
+  } catch (err) {
+    if (isApiError(err) && err.type === 'RateLimited') {
+      await new Promise((resolve) => setTimeout(resolve, 10 * 1000))
+      await syncSlackUserToBotpressUser(member, botpressClient)
+    }
+  }
+}
+
+export const listActiveMembers: botpress.IntegrationProps['actions']['listActiveMembers'] = async ({
+  client: botpressClient,
+  ctx,
+}) => {
+  const accessToken = await getAccessToken(botpressClient, ctx)
+  const client = new WebClient(accessToken)
+  const slackMembers: Member[] = []
+
+  const getAllMembers = async (cursor?: string) => {
+    const res = await client.users.list({ cursor })
+    slackMembers.push(...(res.members || []).filter((x) => !x.deleted))
+
+    if (res.response_metadata?.next_cursor) {
+      await getAllMembers(res.response_metadata.next_cursor)
+    }
+  }
+  await getAllMembers()
+
+  const users = []
+  for (const slackMember of slackMembers) {
+    const user = await syncSlackUserToBotpressUser(slackMember, botpressClient)
+    users.push(user)
+  }
+
+  return { users }
+}

--- a/integrations/slack/src/actions/start-dm.ts
+++ b/integrations/slack/src/actions/start-dm.ts
@@ -12,12 +12,12 @@ export const startDmConversation: botpress.IntegrationProps['actions']['startDmC
 
   const { user } = await client.getOrCreateUser({
     tags: {
-      id: input.userId,
+      id: input.slackUserId,
     },
   })
 
   const { ok, channel } = await slackClient.conversations.open({
-    users: input.userId,
+    users: input.slackUserId,
   })
 
   if (!ok || !channel) {

--- a/integrations/slack/src/actions/start-dm.ts
+++ b/integrations/slack/src/actions/start-dm.ts
@@ -1,0 +1,45 @@
+import { WebClient } from '@slack/web-api'
+import { getAccessToken } from '../misc/utils'
+import type * as botpress from '.botpress'
+
+export const startDmConversation: botpress.IntegrationProps['actions']['startDmConversation'] = async ({
+  ctx,
+  client,
+  input,
+}) => {
+  const accessToken = await getAccessToken(client, ctx)
+  const slackClient = new WebClient(accessToken)
+
+  const { user } = await client.getOrCreateUser({
+    tags: {
+      id: input.userId,
+    },
+  })
+
+  const { ok, channel } = await slackClient.conversations.open({
+    users: input.userId,
+  })
+
+  if (!ok || !channel) {
+    throw new Error('Could not open conversation')
+  }
+
+  const { conversation } = await client.getOrCreateConversation({
+    channel: 'dm',
+    tags: {
+      id: channel.id,
+    },
+  })
+
+  await client.updateConversation({
+    id: conversation.id,
+    tags: {
+      title: `DM with ${user.name}`,
+    },
+  } as any)
+
+  return {
+    conversationId: conversation.id,
+    userId: user.id,
+  }
+}

--- a/integrations/slack/src/definitions/actions.ts
+++ b/integrations/slack/src/definitions/actions.ts
@@ -90,8 +90,44 @@ const retrieveMessage = {
   },
 }
 
+const listActiveMembers = {
+  title: 'List Active Members',
+  description: 'Retrieve the list of active members from Slack',
+  input: {
+    schema: z.object({}),
+  },
+  output: {
+    schema: z.object({
+      users: z.array(z.object({})), //TODO z array or botpress user
+    }),
+  },
+}
+
+const startDmConversation = {
+  title: 'Start DM Conversation',
+  description: 'Initiate a conversation with a user in a DM',
+  input: {
+    schema: z.object({
+      userId: z.string().describe('The ID of the user to initiate the conversation with'),
+    }),
+    ui: {
+      userId: {
+        title: 'User Id',
+      },
+    },
+  },
+  output: {
+    schema: z.object({
+      userId: z.string(),
+      conversationId: z.string(),
+    }),
+  },
+}
+
 export const actions = {
   addReaction,
   findTarget,
   retrieveMessage,
+  listActiveMembers,
+  startDmConversation,
 } satisfies IntegrationDefinitionProps['actions']

--- a/integrations/slack/src/definitions/actions.ts
+++ b/integrations/slack/src/definitions/actions.ts
@@ -108,7 +108,7 @@ const startDmConversation = {
   description: 'Initiate a conversation with a user in a DM',
   input: {
     schema: z.object({
-      userId: z.string().describe('The ID of the user to initiate the conversation with'),
+      slackUserId: z.string().describe('The ID of the user to initiate the conversation with'),
     }),
     ui: {
       userId: {

--- a/integrations/slack/src/definitions/channels.ts
+++ b/integrations/slack/src/definitions/channels.ts
@@ -8,13 +8,18 @@ const messages = {
   },
 }
 
+const convoTags = {
+  id: {},
+  title: {},
+} as const
+
 export const channels = {
   channel: {
     title: 'Channel',
     messages,
     message: { tags: { ts: {} } },
     conversation: {
-      tags: { id: {} },
+      tags: { ...convoTags },
       creation: { enabled: true, requiredTags: ['id'] },
     },
   },
@@ -23,7 +28,7 @@ export const channels = {
     messages,
     message: { tags: { ts: {} } },
     conversation: {
-      tags: { id: {} },
+      tags: { ...convoTags },
       creation: { enabled: true, requiredTags: ['id'] },
     },
   },
@@ -32,7 +37,7 @@ export const channels = {
     messages,
     message: { tags: { ts: {} } },
     conversation: {
-      tags: { id: {}, thread: {} },
+      tags: { ...convoTags, thread: {} },
       creation: { enabled: true, requiredTags: ['id'] },
     },
   },

--- a/integrations/slack/src/definitions/index.ts
+++ b/integrations/slack/src/definitions/index.ts
@@ -31,6 +31,23 @@ export const states = {
 } satisfies IntegrationDefinitionProps['states']
 
 export const user = {
-  tags: { id: {} },
+  tags: {
+    id: {},
+    avatar_hash: {},
+    status_text: {},
+    status_emoji: {},
+    real_name: {},
+    display_name: {},
+    real_name_normalized: {},
+    display_name_normalized: {},
+    email: {},
+    image_24: {},
+    image_32: {},
+    image_48: {},
+    image_72: {},
+    image_192: {},
+    image_512: {},
+    team: {},
+  },
   creation: { enabled: true, requiredTags: ['id'] },
 } satisfies IntegrationDefinitionProps['user']

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,6 +632,9 @@ importers:
       fuse.js:
         specifier: ^6.6.2
         version: 6.6.2
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       query-string:
         specifier: ^6.14.1
         version: 6.14.1
@@ -651,6 +654,9 @@ importers:
       '@sentry/cli':
         specifier: ^2.18.1
         version: 2.18.1
+      '@types/lodash':
+        specifier: ^4.14.191
+        version: 4.14.195
       '@types/node':
         specifier: ^18.11.17
         version: 18.16.16


### PR DESCRIPTION
This PR adds 2 features and fixes 1 issue:

1- **feat:** list active members : this lists all active slack members of a slack workspace & syncs all the user attributes to the corresponding botpress user if any change

2- **feat:** start dm: opens a dm conversation with a user

**fix:** better search when finding a user, we add all the possible slack member properties that can make sens instead of one of them
 