### PR TITLE
feat(slack): storing user name and pictureUrl on message received

### DIFF
--- a/integrations/slack/src/events/message-received.ts
+++ b/integrations/slack/src/events/message-received.ts
@@ -1,17 +1,36 @@
 import { GenericMessageEvent } from '@slack/bolt'
-import { Client } from '../misc/types'
-import { getUserAndConversation } from '../misc/utils'
+import { Client, IntegrationCtx } from '../misc/types'
+import { getAccessToken, getSlackUserProfile, getUserAndConversation } from '../misc/utils'
 
 export const executeMessageReceived = async ({
   slackEvent,
   client,
+  ctx,
 }: {
   slackEvent: GenericMessageEvent
   client: Client
+  ctx: IntegrationCtx
 }) => {
   // prevents the bot from answering itself
   if (slackEvent.bot_id) {
     return
+  }
+
+  const { user, userId, conversationId } = await getUserAndConversation(
+    { slackUserId: slackEvent.user, slackChannelId: slackEvent.channel, slackThreadId: slackEvent.thread_ts },
+    client
+  )
+
+  if (!user.pictureUrl || !user.name) {
+    const accessToken = await getAccessToken(client, ctx)
+    const userProfile = await getSlackUserProfile(accessToken, slackEvent.user)
+    const fieldsToUpdate = {
+      pictureUrl: userProfile?.image_192,
+      name: userProfile?.real_name,
+    }
+    if (fieldsToUpdate.pictureUrl || fieldsToUpdate.name) {
+      await client.updateUser({ ...user, ...fieldsToUpdate })
+    }
   }
 
   await client.createMessage({
@@ -27,9 +46,7 @@ export const executeMessageReceived = async ({
       //   channel: { id: slackEvent.channel },
       // },
     },
-    ...(await getUserAndConversation(
-      { slackUserId: slackEvent.user, slackChannelId: slackEvent.channel, slackThreadId: slackEvent.thread_ts },
-      client
-    )),
+    userId,
+    conversationId,
   })
 }

--- a/integrations/slack/src/events/reaction-added.ts
+++ b/integrations/slack/src/events/reaction-added.ts
@@ -10,6 +10,11 @@ export const executeReactionAdded = async ({
   slackEvent: ReactionAddedEvent
   client: Client
 }) => {
+  const { userId, conversationId } = await getUserAndConversation(
+    { slackUserId: slackEvent.user, slackChannelId: slackEvent.item.channel },
+    client
+  )
+
   await client.createEvent({
     type: 'reactionAdded',
     payload: {
@@ -19,10 +24,8 @@ export const executeReactionAdded = async ({
         thread: 'ts' in slackEvent.item ? { id: slackEvent.item.channel, thread: slackEvent.item.ts } : undefined,
         channel: { id: slackEvent.item.channel },
       },
-      ...(await getUserAndConversation(
-        { slackUserId: slackEvent.user, slackChannelId: slackEvent.item.channel },
-        client
-      )),
+      userId,
+      conversationId,
     },
   })
 }

--- a/integrations/slack/src/handler.ts
+++ b/integrations/slack/src/handler.ts
@@ -36,11 +36,17 @@ export const handler: botpress.IntegrationProps['handler'] = async ({ req, ctx, 
       throw Error(`Interaction type ${body.type} is not supported yet`)
     }
 
+    const { userId, conversationId } = await getUserAndConversation(
+      { slackUserId: body.user.id, slackChannelId: body.channel.id },
+      client
+    )
+
     await client.createMessage({
       tags: { ts: body.message.ts },
       type: 'text',
       payload: { text: actionValue },
-      ...(await getUserAndConversation({ slackUserId: body.user.id, slackChannelId: body.channel.id }, client)),
+      userId,
+      conversationId,
     })
 
     return

--- a/integrations/slack/src/handler.ts
+++ b/integrations/slack/src/handler.ts
@@ -60,7 +60,7 @@ export const handler: botpress.IntegrationProps['handler'] = async ({ req, ctx, 
 
   switch (event.type) {
     case 'message':
-      return executeMessageReceived({ slackEvent: event, client })
+      return executeMessageReceived({ slackEvent: event, client, ctx })
 
     case 'reaction_added':
       if (event.user !== botUserId) {

--- a/integrations/slack/src/handler.ts
+++ b/integrations/slack/src/handler.ts
@@ -60,7 +60,7 @@ export const handler: botpress.IntegrationProps['handler'] = async ({ req, ctx, 
 
   switch (event.type) {
     case 'message':
-      return executeMessageReceived({ slackEvent: event, client, ctx })
+      return executeMessageReceived({ slackEvent: event, client, ctx, logger })
 
     case 'reaction_added':
       if (event.user !== botUserId) {

--- a/integrations/slack/src/misc/types.ts
+++ b/integrations/slack/src/misc/types.ts
@@ -18,3 +18,5 @@ export type UnregisterFunction = botpress.IntegrationProps['unregister']
 export type CreateConversationFunction = botpress.IntegrationProps['createConversation']
 export type CreateUserFunction = botpress.IntegrationProps['createUser']
 export type Channels = botpress.IntegrationProps['channels']
+
+export type IntegrationLogger = Parameters<botpress.IntegrationProps['handler']>[0]['logger']

--- a/integrations/slack/src/misc/utils.ts
+++ b/integrations/slack/src/misc/utils.ts
@@ -190,7 +190,11 @@ export const getTag = (tags: Record<string, string>, name: string) => {
 }
 
 export const getUserAndConversation = async (
-  props: { slackUserId: string; slackChannelId: string; slackThreadId?: string },
+  props: {
+    slackUserId: string
+    slackChannelId: string
+    slackThreadId?: string
+  },
   client: Client
 ) => {
   let conversation: Conversation
@@ -210,12 +214,22 @@ export const getUserAndConversation = async (
     conversation = resp.conversation
   }
 
-  const { user } = await client.getOrCreateUser({ tags: { id: props.slackUserId } })
+  const { user } = await client.getOrCreateUser({
+    tags: { id: props.slackUserId },
+  })
 
   return {
+    user,
     userId: user.id,
     conversationId: conversation.id,
   }
+}
+
+export const getSlackUserProfile = async (botToken: string, slackUserId: string) => {
+  const slackClient = new WebClient(botToken)
+  const { profile } = await slackClient.users.profile.get({ user: slackUserId })
+
+  return profile
 }
 
 export const saveConfig = async (client: Client, ctx: IntegrationCtx, config: Configuration) => {


### PR DESCRIPTION
We currently don't store informations on Slack users, making it hard to identify them when needed.

Solution: when a message is received by the Slack integration, we want to store the user name and a pictureUrl if possible.