### PR TITLE
feat(integrations): use const for integration name (part 1)

### DIFF
--- a/integrations/instagram/src/const.ts
+++ b/integrations/instagram/src/const.ts
@@ -1,0 +1,2 @@
+export const INTEGRATION_NAME = 'instagram'
+export const idTag = `${INTEGRATION_NAME}:id` as const

--- a/integrations/instagram/src/index.ts
+++ b/integrations/instagram/src/index.ts
@@ -2,6 +2,7 @@ import { IntegrationContext } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { MessengerClient, MessengerTypes } from 'messaging-api-messenger'
 import queryString from 'query-string'
+import { idTag } from './const'
 import * as bp from '.botpress'
 
 type Channels = bp.Integration['channels']
@@ -10,8 +11,6 @@ type MessageHandler = Messages[keyof Messages]
 type MessageHandlerProps = Parameters<MessageHandler>[0]
 type IntegrationLogger = Parameters<bp.IntegrationProps['handler']>[0]['logger']
 type InstagramUserProfile = MessengerTypes.User & { username: string }
-
-const idTag = 'instagram:id'
 
 const integration = new bp.Integration({
   register: async () => {},

--- a/integrations/messenger/src/const.ts
+++ b/integrations/messenger/src/const.ts
@@ -1,0 +1,2 @@
+export const INTEGRATION_NAME = 'messenger'
+export const idTag = `${INTEGRATION_NAME}:id` as const

--- a/integrations/messenger/src/index.ts
+++ b/integrations/messenger/src/index.ts
@@ -2,6 +2,7 @@ import { IntegrationContext } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { MessengerClient, MessengerTypes } from 'messaging-api-messenger'
 import queryString from 'query-string'
+import { idTag } from './const'
 import * as bp from '.botpress'
 
 type Channels = bp.Integration['channels']
@@ -9,8 +10,6 @@ type Messages = Channels[keyof Channels]['messages']
 type MessageHandler = Messages[keyof Messages]
 type MessageHandlerProps = Parameters<MessageHandler>[0]
 type IntegrationLogger = Parameters<bp.IntegrationProps['handler']>[0]['logger']
-
-const idTag = 'messenger:id'
 
 const integration = new bp.Integration({
   register: async () => {},

--- a/integrations/teams/src/channels.ts
+++ b/integrations/teams/src/channels.ts
@@ -9,6 +9,7 @@ import {
   MessageFactory,
 } from 'botbuilder'
 import '@botpress/client'
+import { idTag } from './const'
 import * as botpress from '.botpress'
 
 type Messages = botpress.Integration['channels']['channel']['messages']
@@ -50,7 +51,7 @@ const renderTeams = async ({ ctx, ack, conversation, client }: RenderProps, acti
     }
 
     await turnContext.sendActivity(activity)
-    await ack({ tags: { ['teams:id']: turnContext.activity.id } })
+    await ack({ tags: { [idTag]: turnContext.activity.id } })
   })
 }
 

--- a/integrations/teams/src/const.ts
+++ b/integrations/teams/src/const.ts
@@ -1,0 +1,2 @@
+export const INTEGRATION_NAME = 'teams'
+export const idTag = `${INTEGRATION_NAME}:id`

--- a/integrations/telegram/integration.definition.ts
+++ b/integrations/telegram/integration.definition.ts
@@ -1,11 +1,10 @@
 import { IntegrationDefinition, messages } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
+import { INTEGRATION_NAME } from 'src/const'
 import { z } from 'zod'
 
-export const name = 'telegram'
-
 export default new IntegrationDefinition({
-  name,
+  name: INTEGRATION_NAME,
   version: '0.2.0',
   title: 'Telegram',
   description: 'This integration allows your bot to interact with Telegram.',

--- a/integrations/telegram/src/const.ts
+++ b/integrations/telegram/src/const.ts
@@ -1,1 +1,3 @@
 export const USER_PICTURE_MAX_SIZE_BYTES = 25_000
+export const INTEGRATION_NAME = 'telegram'
+export const idTag = `${INTEGRATION_NAME}:id` as const

--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -1,15 +1,16 @@
 import { IntegrationDefinition, messages } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { z } from 'zod'
+import {
+  INTEGRATION_NAME,
+  PhoneNumberIdTag,
+  TemplateLanguageTag,
+  TemplateNameTag,
+  TemplateVariablesTag,
+  UserPhoneTag,
+} from './src/const'
 
-export const name = 'whatsapp'
 export const channel = 'channel' // TODO: Rename to "whatsapp" once support for integration versioning is finished.
-
-export const PhoneNumberIdTag = 'phoneNumberId'
-export const UserPhoneTag = 'userPhone'
-export const TemplateNameTag = 'templateName'
-export const TemplateLanguageTag = 'templateLanguage'
-export const TemplateVariablesTag = 'templateVariables'
 
 const TagsForCreatingConversation = {
   [PhoneNumberIdTag]: {
@@ -37,7 +38,7 @@ const TagsForCreatingConversation = {
 }
 
 export default new IntegrationDefinition({
-  name,
+  name: INTEGRATION_NAME,
   version: '0.2.0',
   title: 'WhatsApp',
   description: 'This integration allows your bot to interact with WhatsApp.',

--- a/integrations/whatsapp/src/const.ts
+++ b/integrations/whatsapp/src/const.ts
@@ -1,0 +1,13 @@
+export const INTEGRATION_NAME = 'whatsapp'
+
+export const PhoneNumberIdTag = 'phoneNumberId'
+export const UserPhoneTag = 'userPhone'
+export const TemplateNameTag = 'templateName'
+export const TemplateLanguageTag = 'templateLanguage'
+export const TemplateVariablesTag = 'templateVariables'
+
+export const phoneNumberIdTag = `${INTEGRATION_NAME}:${PhoneNumberIdTag}` as const
+export const userPhoneTag = `${INTEGRATION_NAME}:${UserPhoneTag}` as const
+export const templateNameTag = `${INTEGRATION_NAME}:${TemplateNameTag}` as const
+export const templateLanguageTag = `${INTEGRATION_NAME}:${TemplateLanguageTag}` as const
+export const templateVariablesTag = `${INTEGRATION_NAME}:${TemplateVariablesTag}` as const

--- a/integrations/whatsapp/src/conversation.ts
+++ b/integrations/whatsapp/src/conversation.ts
@@ -1,16 +1,17 @@
 import { Conversation, RuntimeError } from '@botpress/client'
 import { IntegrationContext } from '@botpress/sdk'
-import {
-  PhoneNumberIdTag,
-  UserPhoneTag,
-  TemplateNameTag,
-  name,
-  TemplateLanguageTag,
-  TemplateVariablesTag,
-} from 'integration.definition'
 import { WhatsAppAPI, Types } from 'whatsapp-api-js'
 import z from 'zod'
 import { IntegrationLogger } from '.'
+import {
+  PhoneNumberIdTag,
+  UserPhoneTag,
+  phoneNumberIdTag,
+  userPhoneTag,
+  templateLanguageTag,
+  templateNameTag,
+  templateVariablesTag,
+} from './const'
 import * as botpress from '.botpress'
 import { Channels } from '.botpress/implementation/channels'
 
@@ -138,11 +139,11 @@ export const createConversationHandler: botpress.IntegrationProps['createConvers
   ctx,
   logger,
 }) => {
-  const phoneNumberId = tags[`${name}:${PhoneNumberIdTag}`] || ctx.configuration.phoneNumberId
-  const userPhone = tags[`${name}:${UserPhoneTag}`]!
-  const templateName = tags[`${name}:${TemplateNameTag}`]!
-  const templateLanguage = tags[`${name}:${TemplateLanguageTag}`]
-  const templateVariablesJson = tags[`${name}:${TemplateVariablesTag}`]
+  const phoneNumberId = tags[phoneNumberIdTag] || ctx.configuration.phoneNumberId
+  const userPhone = tags[userPhoneTag] || ''
+  const templateName = tags[templateNameTag] || ''
+  const templateLanguage = tags[templateLanguageTag]
+  const templateVariablesJson = tags[templateVariablesTag]
 
   const conversation = await startConversation(
     { channel, phoneNumberId, userPhone, templateName, templateLanguage, templateVariablesJson },

--- a/integrations/whatsapp/src/outgoing-message.ts
+++ b/integrations/whatsapp/src/outgoing-message.ts
@@ -1,6 +1,5 @@
 import type { Conversation } from '@botpress/client'
 import type { IntegrationContext, AckFunction } from '@botpress/sdk'
-import { PhoneNumberIdTag, UserPhoneTag, name } from 'integration.definition'
 import { WhatsAppAPI } from 'whatsapp-api-js'
 import type { Contacts } from 'whatsapp-api-js/types/messages/contacts'
 import type { Interactive } from 'whatsapp-api-js/types/messages/interactive'
@@ -10,6 +9,7 @@ import type Reaction from 'whatsapp-api-js/types/messages/reaction'
 import type { Template } from 'whatsapp-api-js/types/messages/template'
 import type Text from 'whatsapp-api-js/types/messages/text'
 import { IntegrationLogger } from '.'
+import { INTEGRATION_NAME, phoneNumberIdTag, userPhoneTag } from './const'
 import { sleep } from './util'
 
 export type OutgoingMessage =
@@ -39,8 +39,8 @@ export async function send({
   logger: IntegrationLogger
 }) {
   const whatsapp = new WhatsAppAPI(ctx.configuration.accessToken)
-  const phoneNumberId = conversation.tags[`${name}:${PhoneNumberIdTag}`]
-  const to = conversation.tags[`${name}:${UserPhoneTag}`]
+  const phoneNumberId = conversation.tags[phoneNumberIdTag]
+  const to = conversation.tags[userPhoneTag]
   const messageType = message._
 
   if (!phoneNumberId) {
@@ -70,7 +70,7 @@ export async function send({
 
   if (messageId) {
     logger.forBot().debug(`Successfully sent ${messageType} message from bot to Whatsapp:`, message)
-    await ack({ tags: { [`${name}:id`]: messageId } })
+    await ack({ tags: { [`${INTEGRATION_NAME}:id`]: messageId } })
   } else {
     logger
       .forBot()


### PR DESCRIPTION
We want to avoid having the name of the integration hard-coded in multiple files, instead we export a constant from a const.ts file.

- instagram
- whatsapp
- telegram
- messenger
- teams
- slack