### PR TITLE
feat(integrations): use const for integration name (part 2)

### DIFF
--- a/integrations/asana/integration.definition.ts
+++ b/integrations/asana/integration.definition.ts
@@ -1,10 +1,11 @@
 import { IntegrationDefinition } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 
+import { INTEGRATION_NAME } from './src/const'
 import { configuration, states, user, channels, actions } from './src/definitions'
 
 export default new IntegrationDefinition({
-  name: 'asana',
+  name: INTEGRATION_NAME,
   version: '0.2.0',
   title: 'Asana',
   readme: 'hub.md',

--- a/integrations/asana/src/const.ts
+++ b/integrations/asana/src/const.ts
@@ -1,0 +1,1 @@
+export const INTEGRATION_NAME = 'asana'

--- a/integrations/discord/integration.definition.ts
+++ b/integrations/discord/integration.definition.ts
@@ -1,9 +1,10 @@
 import { IntegrationDefinition, messages } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { z } from 'zod'
+import { INTEGRATION_NAME } from './src/const'
 
 export default new IntegrationDefinition({
-  name: 'discord',
+  name: INTEGRATION_NAME,
   version: '0.2.0',
   readme: 'hub.md',
   configuration: {

--- a/integrations/discord/src/const.ts
+++ b/integrations/discord/src/const.ts
@@ -1,0 +1,1 @@
+export const INTEGRATION_NAME = 'discord'

--- a/integrations/gmail/integration.definition.ts
+++ b/integrations/gmail/integration.definition.ts
@@ -1,9 +1,10 @@
 import { IntegrationDefinition, messages } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { z } from 'zod'
+import { INTEGRATION_NAME } from './src/const'
 
 export default new IntegrationDefinition({
-  name: 'gmail',
+  name: INTEGRATION_NAME,
   version: '0.2.0',
   title: 'Gmail',
   description: 'This integration allows your bot to interact with Gmail.',

--- a/integrations/gmail/src/const.ts
+++ b/integrations/gmail/src/const.ts
@@ -1,0 +1,7 @@
+export const INTEGRATION_NAME = 'gmail'
+
+export const idTag = `${INTEGRATION_NAME}:id` as const
+export const subjectTag = `${INTEGRATION_NAME}:subject` as const
+export const emailTag = `${INTEGRATION_NAME}:email` as const
+export const referencesTag = `${INTEGRATION_NAME}:references` as const
+export const ccTag = `${INTEGRATION_NAME}:cc` as const

--- a/integrations/gsheets/integration.definition.ts
+++ b/integrations/gsheets/integration.definition.ts
@@ -1,9 +1,10 @@
 import { IntegrationDefinition } from '@botpress/sdk'
 
+import { INTEGRATION_NAME } from './src/const'
 import { configuration, actions } from './src/definitions'
 
 export default new IntegrationDefinition({
-  name: 'gsheets',
+  name: INTEGRATION_NAME,
   version: '0.2.0',
   description: 'This integration allows your bot to interact with Google Sheets.',
   title: 'Google Sheets',

--- a/integrations/gsheets/src/const.ts
+++ b/integrations/gsheets/src/const.ts
@@ -1,0 +1,1 @@
+export const INTEGRATION_NAME = 'gsheets'

--- a/integrations/intercom/src/const.ts
+++ b/integrations/intercom/src/const.ts
@@ -1,1 +1,4 @@
 export const INTEGRATION_NAME = 'intercom'
+
+export const idTag = `${INTEGRATION_NAME}:id` as const
+export const emailTag = `${INTEGRATION_NAME}:email` as const

--- a/integrations/intercom/src/index.ts
+++ b/integrations/intercom/src/index.ts
@@ -3,7 +3,7 @@ import type { AckFunction } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { Client, ReplyToConversationMessageType } from 'intercom-client'
 import { z } from 'zod'
-import { INTEGRATION_NAME } from './const'
+import { emailTag, idTag } from './const'
 import * as html from './html.utils'
 import * as bp from '.botpress'
 
@@ -208,7 +208,7 @@ const integration = new bp.Integration({
     const { conversation } = await client.getOrCreateConversation({
       channel: 'channel',
       tags: {
-        [`${INTEGRATION_NAME}:id`]: `${conversationId}`,
+        [idTag]: `${conversationId}`,
       },
     })
 
@@ -235,13 +235,13 @@ const integration = new bp.Integration({
 
       const { user } = await client.getOrCreateUser({
         tags: {
-          [`${INTEGRATION_NAME}:id`]: `${authorId}`,
-          [`${INTEGRATION_NAME}:email`]: `${email}`,
+          [idTag]: `${authorId}`,
+          [emailTag]: `${email}`,
         },
       })
 
       await client.createMessage({
-        tags: { [`${INTEGRATION_NAME}:id`]: `${messageId}` },
+        tags: { [idTag]: `${messageId}` },
         type: 'text',
         userId: user.id,
         conversationId: conversation.id,
@@ -261,7 +261,7 @@ const integration = new bp.Integration({
     return
   },
   createUser: async ({ client, tags, ctx }) => {
-    const userId = tags[`${INTEGRATION_NAME}:id`]
+    const userId = tags[idTag]
 
     if (!userId) {
       return
@@ -271,7 +271,7 @@ const integration = new bp.Integration({
     const contact = await intercomClient.contacts.find({ id: userId })
 
     const { user } = await client.getOrCreateUser({
-      tags: { [`${INTEGRATION_NAME}:id`]: `${contact.id}`, [`${INTEGRATION_NAME}:email`]: `${contact.email}` },
+      tags: { [idTag]: `${contact.id}`, [emailTag]: `${contact.email}` },
     })
 
     return {
@@ -281,7 +281,7 @@ const integration = new bp.Integration({
     }
   },
   createConversation: async ({ client, channel, tags, ctx }) => {
-    const conversationId = tags[`${INTEGRATION_NAME}:id`]
+    const conversationId = tags[idTag]
 
     if (!conversationId) {
       return
@@ -292,7 +292,7 @@ const integration = new bp.Integration({
 
     const { conversation } = await client.getOrCreateConversation({
       channel,
-      tags: { [`${INTEGRATION_NAME}:id`]: `${chat.id}` },
+      tags: { [idTag]: `${chat.id}` },
     })
 
     return {
@@ -322,14 +322,14 @@ async function sendMessage(props: {
   const {
     conversation_parts: { conversation_parts: conversationParts },
   } = await client.conversations.replyByIdAsAdmin({
-    id: conversation.tags[`${INTEGRATION_NAME}:id`] ?? '',
+    id: conversation.tags[idTag] ?? '',
     adminId: configuration.adminId,
     messageType: ReplyToConversationMessageType.COMMENT,
     body,
     attachmentUrls,
   })
 
-  await ack({ tags: { [`${INTEGRATION_NAME}:id`]: `${conversationParts.at(-1)?.id ?? ''}` } })
+  await ack({ tags: { [idTag]: `${conversationParts.at(-1)?.id ?? ''}` } })
 }
 
 function composeMessage(...parts: string[]) {

--- a/integrations/line/integration.definition.ts
+++ b/integrations/line/integration.definition.ts
@@ -1,9 +1,10 @@
 import { IntegrationDefinition, messages } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { z } from 'zod'
+import { INTEGRATION_NAME } from './src/const'
 
 export default new IntegrationDefinition({
-  name: 'line',
+  name: INTEGRATION_NAME,
   version: '0.2.0',
   title: 'Line',
   description: 'This integration allows your bot to interact with Line.',

--- a/integrations/line/src/const.ts
+++ b/integrations/line/src/const.ts
@@ -1,0 +1,5 @@
+export const INTEGRATION_NAME = 'line'
+
+export const msgIdTag = `${INTEGRATION_NAME}:msgId` as const
+export const usrIdTag = `${INTEGRATION_NAME}:usrId` as const
+export const destIdTag = `${INTEGRATION_NAME}:destId` as const

--- a/integrations/line/src/index.ts
+++ b/integrations/line/src/index.ts
@@ -1,6 +1,7 @@
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import * as line from '@line/bot-sdk'
 import crypto from 'crypto'
+import { INTEGRATION_NAME, destIdTag, msgIdTag, usrIdTag } from './const'
 import * as bp from '.botpress'
 
 type Channels = bp.Integration['channels']
@@ -10,7 +11,7 @@ type MessageHandlerProps = Parameters<MessageHandler>[0]
 
 type ReplyLineProps = Pick<MessageHandlerProps, 'ctx' | 'conversation' | 'client' | 'ack'>
 
-console.info('starting integration line')
+console.info(`starting integration ${INTEGRATION_NAME}`)
 
 const replyLineMessage = async (props: ReplyLineProps, messageObj: line.Message) => {
   const { ctx, conversation, client, ack } = props
@@ -31,7 +32,7 @@ const replyLineMessage = async (props: ReplyLineProps, messageObj: line.Message)
     const lineResponse = await lineClient.replyMessage(stateRes.state.payload.replyToken, messageObj)
 
     if (lineResponse?.['x-line-request-id']) {
-      await ack({ tags: { ['line:msgId']: lineResponse['x-line-request-id'] } })
+      await ack({ tags: { [msgIdTag]: lineResponse['x-line-request-id'] } })
     }
   } catch (e: any) {
     console.error(`Error: ${e.originalError.message}`)
@@ -402,7 +403,7 @@ const integration = new bp.Integration({
     return
   },
   createUser: async ({ client, tags, ctx }) => {
-    const userId = tags['line:usrId']
+    const userId = tags[usrIdTag]
 
     if (!userId) {
       return
@@ -414,7 +415,7 @@ const integration = new bp.Integration({
     })
     const profile = await lineClient.getProfile(userId)
 
-    const { user } = await client.getOrCreateUser({ tags: { 'line:usrId': `${profile.userId}` } })
+    const { user } = await client.getOrCreateUser({ tags: { [usrIdTag]: `${profile.userId}` } })
 
     return {
       body: JSON.stringify({ user: { id: user.id } }),
@@ -423,8 +424,8 @@ const integration = new bp.Integration({
     }
   },
   createConversation: async ({ client, channel, tags, ctx }) => {
-    const usrId = tags['line:usrId']
-    const destId = tags['line:destId']
+    const usrId = tags[usrIdTag]
+    const destId = tags[destIdTag]
 
     if (!(usrId && destId)) {
       return
@@ -438,7 +439,7 @@ const integration = new bp.Integration({
 
     const { conversation } = await client.getOrCreateConversation({
       channel,
-      tags: { 'line:usrId': `${profile.userId}`, 'line:destId': destId },
+      tags: { [usrIdTag]: `${profile.userId}`, [destIdTag]: destId },
     })
 
     return {
@@ -461,8 +462,8 @@ async function handleMessage(events: LineEvents, destination: string, client: bp
     const { conversation } = await client.getOrCreateConversation({
       channel: 'channel',
       tags: {
-        ['line:usrId']: events.source.userId,
-        ['line:destId']: destination,
+        [usrIdTag]: events.source.userId,
+        [destIdTag]: destination,
       },
     })
 
@@ -475,13 +476,13 @@ async function handleMessage(events: LineEvents, destination: string, client: bp
 
     const { user } = await client.getOrCreateUser({
       tags: {
-        ['line:usrId']: events.source.userId,
+        [usrIdTag]: events.source.userId,
       },
     })
 
     if (message.type === 'text') {
       await client.createMessage({
-        tags: { ['line:msgId']: message.id },
+        tags: { [msgIdTag]: message.id },
         type: 'text',
         userId: user.id,
         conversationId: conversation.id,

--- a/integrations/linear/src/const.ts
+++ b/integrations/linear/src/const.ts
@@ -1,1 +1,3 @@
 export const INTEGRATION_NAME = 'linear'
+
+export const idTag = `${INTEGRATION_NAME}:id` as const

--- a/integrations/linear/src/misc/utils.ts
+++ b/integrations/linear/src/misc/utils.ts
@@ -1,7 +1,7 @@
 import type { Conversation } from '@botpress/client'
 import type { AckFunction } from '@botpress/sdk'
 import { Comment, Issue, IssueLabel, LinearClient, Team } from '@linear/sdk'
-import { INTEGRATION_NAME } from '../const'
+import { idTag } from '../const'
 import { LinearOauthClient } from './linear'
 import { Client } from '.botpress'
 
@@ -76,7 +76,7 @@ export function getCardContent(card: any) {
 }
 
 export function getIssueId(conversation: Conversation): string {
-  const issueId = conversation.tags[`${INTEGRATION_NAME}:id`]
+  const issueId = conversation.tags[idTag]
 
   if (!issueId) {
     throw Error(`No issue found for conversation ${conversation.id}`)

--- a/integrations/notion/integration.definition.ts
+++ b/integrations/notion/integration.definition.ts
@@ -1,11 +1,12 @@
 import { IntegrationDefinition } from '@botpress/sdk'
 import { z } from 'zod'
+import { INTEGRATION_NAME } from './src/const'
 
 const emptyObject = z.object({})
 const anyObject = z.object({}).passthrough()
 
 export default new IntegrationDefinition({
-  name: 'notion',
+  name: INTEGRATION_NAME,
   description: 'Notion integration for Botpress',
   title: 'Notion',
   version: '0.2.0',

--- a/integrations/notion/src/const.ts
+++ b/integrations/notion/src/const.ts
@@ -1,0 +1,1 @@
+export const INTEGRATION_NAME = 'notion'


### PR DESCRIPTION
We want to avoid having the name of the integration hard-coded in multiple files, instead we export a constant from a const.ts file.

- Asana
- Discord
- GitHub
- Gmail
- GSheet
- Intercom
- Line
- Linear
- Notion