### PR TITLE
feat(integrations): use const for integration name (part 3)

### DIFF
--- a/integrations/sunco/integration.definition.ts
+++ b/integrations/sunco/integration.definition.ts
@@ -1,9 +1,10 @@
 import { IntegrationDefinition, messages } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { z } from 'zod'
+import { INTEGRATION_NAME } from './src/const'
 
 export default new IntegrationDefinition({
-  name: 'sunco',
+  name: INTEGRATION_NAME,
   version: '0.2.0',
   title: 'Sunshine Conversations',
   description: 'This integration allows your bot to interact with Sunshine Conversations.',

--- a/integrations/sunco/src/const.ts
+++ b/integrations/sunco/src/const.ts
@@ -1,0 +1,3 @@
+export const INTEGRATION_NAME = 'sunco'
+
+export const idTag = `${INTEGRATION_NAME}:id` as const

--- a/integrations/sunco/src/index.ts
+++ b/integrations/sunco/src/index.ts
@@ -1,4 +1,5 @@
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
+import { idTag } from './const'
 import * as bp from '.botpress'
 const SunshineConversationsClient = require('sunshine-conversations-client')
 
@@ -128,18 +129,18 @@ const integration = new bp.Integration({
       const { conversation } = await client.getOrCreateConversation({
         channel: 'channel',
         tags: {
-          'sunco:id': payload.conversation.id,
+          [idTag]: payload.conversation.id,
         },
       })
 
       const { user } = await client.getOrCreateUser({
         tags: {
-          'sunco:id': payload.message.author.userId,
+          [idTag]: payload.message.author.userId,
         },
       })
 
       await client.createMessage({
-        tags: { 'sunco:id': payload.message.id },
+        tags: { [idTag]: payload.message.id },
         type: 'text',
         userId: user.id,
         conversationId: conversation.id,
@@ -148,7 +149,7 @@ const integration = new bp.Integration({
     }
   },
   createUser: async ({ client, tags, ctx }) => {
-    const userId = tags['sunco:id']
+    const userId = tags[idTag]
 
     if (!userId) {
       return
@@ -157,7 +158,7 @@ const integration = new bp.Integration({
     const suncoClient = createClient(ctx.configuration.keyId, ctx.configuration.keySecret)
     const suncoUser = await suncoClient.users.getUser(ctx.configuration.appId, userId)
 
-    const { user } = await client.getOrCreateUser({ tags: { 'sunco:id': `${suncoUser.user?.id}` } })
+    const { user } = await client.getOrCreateUser({ tags: { [idTag]: `${suncoUser.user?.id}` } })
 
     return {
       body: JSON.stringify({ user: { id: user.id } }),
@@ -166,7 +167,7 @@ const integration = new bp.Integration({
     }
   },
   createConversation: async ({ client, channel, tags, ctx }) => {
-    const conversationId = tags['sunco:id']
+    const conversationId = tags[idTag]
 
     if (!conversationId) {
       return
@@ -177,7 +178,7 @@ const integration = new bp.Integration({
 
     const { conversation } = await client.getOrCreateConversation({
       channel,
-      tags: { 'sunco:id': `${suncoConversation.conversation?.id}` },
+      tags: { [idTag]: `${suncoConversation.conversation?.id}` },
     })
 
     return {
@@ -251,7 +252,7 @@ const sendCarousel = async (props: SendMessageProps, payload: Carousel) => {
 }
 
 function getConversationId(conversation: SendMessageProps['conversation']) {
-  const conversationId = conversation.tags['sunco:id']
+  const conversationId = conversation.tags[idTag]
 
   if (!conversationId) {
     throw new Error('Conversation does not have a sunco identifier')
@@ -294,7 +295,7 @@ async function sendMessage({ conversation, ctx, ack }: SendMessageProps, payload
     throw new Error('Message not sent')
   }
 
-  await ack({ tags: { 'sunco:id': message.id } })
+  await ack({ tags: { [idTag]: message.id } })
 
   if (messages.length > 1) {
     console.warn('More than one message was sent')

--- a/integrations/trello/integration.definition.ts
+++ b/integrations/trello/integration.definition.ts
@@ -1,9 +1,10 @@
 import { IntegrationDefinition } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
+import { INTEGRATION_NAME } from './src/const'
 import { configuration, states, user, actions } from './src/definitions'
 
 export default new IntegrationDefinition({
-  name: 'trello',
+  name: INTEGRATION_NAME,
   version: '0.2.0',
   title: 'Trello',
   readme: 'hub.md',

--- a/integrations/trello/src/const.ts
+++ b/integrations/trello/src/const.ts
@@ -1,0 +1,1 @@
+export const INTEGRATION_NAME = 'trello'

--- a/integrations/twilio/integration.definition.ts
+++ b/integrations/twilio/integration.definition.ts
@@ -1,9 +1,10 @@
 import { IntegrationDefinition, messages } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { z } from 'zod'
+import { INTEGRATION_NAME } from './src/const'
 
 export default new IntegrationDefinition({
-  name: 'twilio',
+  name: INTEGRATION_NAME,
   version: '0.2.0',
   title: 'Twilio',
   description: 'This integration allows your bot to interact with Twilio.',

--- a/integrations/twilio/src/const.ts
+++ b/integrations/twilio/src/const.ts
@@ -1,0 +1,5 @@
+export const INTEGRATION_NAME = 'twilio'
+
+export const idTag = `${INTEGRATION_NAME}:id` as const
+export const userPhoneTag = `${INTEGRATION_NAME}:userPhone` as const
+export const activePhoneTag = `${INTEGRATION_NAME}:activePhone` as const

--- a/integrations/viber/integration.definition.ts
+++ b/integrations/viber/integration.definition.ts
@@ -1,9 +1,10 @@
 import { IntegrationDefinition, messages } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { z } from 'zod'
+import { INTEGRATION_NAME } from './src/const'
 
 export default new IntegrationDefinition({
-  name: 'viber',
+  name: INTEGRATION_NAME,
   version: '0.2.0',
   title: 'Viber',
   description: 'This integration allows your bot to interact with Viber.',

--- a/integrations/viber/src/const.ts
+++ b/integrations/viber/src/const.ts
@@ -1,0 +1,3 @@
+export const INTEGRATION_NAME = 'viber'
+
+export const idTag = `${INTEGRATION_NAME}:id` as const

--- a/integrations/viber/src/index.ts
+++ b/integrations/viber/src/index.ts
@@ -1,6 +1,7 @@
 import type { IntegrationContext } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import axios from 'axios'
+import { idTag } from './const'
 import * as bp from '.botpress'
 
 type Channels = bp.Integration['channels']
@@ -175,20 +176,20 @@ const integration = new bp.Integration({
       const { conversation } = await client.getOrCreateConversation({
         channel: 'channel',
         tags: {
-          'viber:id': data.sender.id,
+          [idTag]: data.sender.id,
         },
       })
 
       const { user } = await client.getOrCreateUser({
         tags: {
-          'viber:id': data.sender.id,
+          [idTag]: data.sender.id,
         },
       })
 
       switch (data.message.type) {
         case 'text':
           await client.createMessage({
-            tags: { 'viber:id': data.message_token.toString() },
+            tags: { [idTag]: data.message_token.toString() },
             type: 'text',
             userId: user.id,
             conversationId: conversation.id,
@@ -197,7 +198,7 @@ const integration = new bp.Integration({
           break
         case 'picture':
           await client.createMessage({
-            tags: { 'viber:id': data.message_token.toString() },
+            tags: { [idTag]: data.message_token.toString() },
             type: 'image',
             userId: user.id,
             conversationId: conversation.id,
@@ -210,7 +211,7 @@ const integration = new bp.Integration({
           break
         case 'video':
           await client.createMessage({
-            tags: { 'viber:id': data.message_token.toString() },
+            tags: { [idTag]: data.message_token.toString() },
             type: 'video',
             userId: user.id,
             conversationId: conversation.id,
@@ -223,7 +224,7 @@ const integration = new bp.Integration({
           break
         case 'file':
           await client.createMessage({
-            tags: { 'viber:id': data.message_token.toString() },
+            tags: { [idTag]: data.message_token.toString() },
             type: 'file',
             userId: user.id,
             conversationId: conversation.id,
@@ -237,7 +238,7 @@ const integration = new bp.Integration({
           break
         case 'location':
           await client.createMessage({
-            tags: { 'viber:id': data.message_token.toString() },
+            tags: { [idTag]: data.message_token.toString() },
             type: 'location',
             userId: user.id,
             conversationId: conversation.id,
@@ -253,7 +254,7 @@ const integration = new bp.Integration({
     return
   },
   createUser: async ({ client, tags, ctx }) => {
-    const userId = tags['viber:id']
+    const userId = tags[idTag]
 
     if (!userId) {
       return
@@ -261,7 +262,7 @@ const integration = new bp.Integration({
 
     const userDetails = await getUserDetails({ ctx, id: userId })
 
-    const { user } = await client.getOrCreateUser({ tags: { 'viber:id': `${userDetails.id}` } })
+    const { user } = await client.getOrCreateUser({ tags: { [idTag]: `${userDetails.id}` } })
 
     return {
       body: JSON.stringify({ user: { id: user.id } }),
@@ -270,7 +271,7 @@ const integration = new bp.Integration({
     }
   },
   createConversation: async ({ client, channel, tags, ctx }) => {
-    const userId = tags['viber:id']
+    const userId = tags[idTag]
 
     if (!userId) {
       return
@@ -280,7 +281,7 @@ const integration = new bp.Integration({
 
     const { conversation } = await client.getOrCreateConversation({
       channel,
-      tags: { 'viber:id': `${userDetails.id}` },
+      tags: { [idTag]: `${userDetails.id}` },
     })
 
     return {
@@ -318,7 +319,7 @@ export async function setViberWebhook(webhookUrl: string | undefined, token: str
 }
 
 export async function sendViberMessage({ conversation, ctx, ack, payload }: SendMessageProps) {
-  const target = conversation.tags['viber:id']
+  const target = conversation.tags[idTag]
   const { data } = await axios.post(
     'https://chatapi.viber.com/pa/send_message',
     {
@@ -346,7 +347,7 @@ export async function sendViberMessage({ conversation, ctx, ack, payload }: Send
   }
   await ack({
     tags: {
-      ['viber:id']: data.message_token.toString(),
+      [idTag]: data.message_token.toString(),
     },
   })
   return data

--- a/integrations/vonage/integration.definition.ts
+++ b/integrations/vonage/integration.definition.ts
@@ -1,9 +1,10 @@
 import { IntegrationDefinition, messages } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { z } from 'zod'
+import { INTEGRATION_NAME } from './src/const'
 
 export default new IntegrationDefinition({
-  name: 'vonage',
+  name: INTEGRATION_NAME,
   version: '0.2.0',
   title: 'Vonage',
   description: 'This integration allows your bot to interact with Vonage.',

--- a/integrations/vonage/src/const.ts
+++ b/integrations/vonage/src/const.ts
@@ -1,0 +1,6 @@
+export const INTEGRATION_NAME = 'vonage'
+
+export const idTag = `${INTEGRATION_NAME}:id` as const
+export const channelTag = `${INTEGRATION_NAME}:channel` as const
+export const channelIdTag = `${INTEGRATION_NAME}:channelId` as const
+export const userIdTag = `${INTEGRATION_NAME}:userId` as const

--- a/integrations/vonage/src/index.ts
+++ b/integrations/vonage/src/index.ts
@@ -1,5 +1,6 @@
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import axios from 'axios'
+import { idTag, channelIdTag, channelTag, userIdTag } from './const'
 import * as bp from '.botpress'
 
 type Channels = bp.Integration['channels']
@@ -84,21 +85,21 @@ const integration = new bp.Integration({
     const { conversation } = await client.getOrCreateConversation({
       channel: 'channel',
       tags: {
-        'vonage:channel': data.channel,
-        'vonage:channelId': data.to,
-        'vonage:userId': data.from,
+        [channelTag]: data.channel,
+        [channelIdTag]: data.to,
+        [userIdTag]: data.from,
       },
     })
 
     const { user } = await client.getOrCreateUser({
       tags: {
-        'vonage:channel': data.channel,
-        'vonage:userId': data.from,
+        [channelTag]: data.channel,
+        [userIdTag]: data.from,
       },
     })
 
     await client.createMessage({
-      tags: { 'vonage:id': data.message_uuid },
+      tags: { [idTag]: data.message_uuid },
       type: 'text',
       userId: user.id,
       conversationId: conversation.id,
@@ -106,8 +107,8 @@ const integration = new bp.Integration({
     })
   },
   createUser: async ({ client, tags }) => {
-    const vonageChannel = tags['vonage:channel']
-    const userId = tags['vonage:userId']
+    const vonageChannel = tags[channelTag]
+    const userId = tags[userIdTag]
 
     if (!(vonageChannel && userId)) {
       return
@@ -115,8 +116,8 @@ const integration = new bp.Integration({
 
     const { user } = await client.getOrCreateUser({
       tags: {
-        'vonage:channel': vonageChannel,
-        'vonage:userId': userId,
+        [channelTag]: vonageChannel,
+        [userIdTag]: userId,
       },
     })
 
@@ -127,9 +128,9 @@ const integration = new bp.Integration({
     }
   },
   createConversation: async ({ client, channel, tags }) => {
-    const vonageChannel = tags['vonage:channel']
-    const channelId = tags['vonage:channelId']
-    const userId = tags['vonage:userId']
+    const vonageChannel = tags[channelTag]
+    const channelId = tags[channelIdTag]
+    const userId = tags[userIdTag]
 
     if (!(vonageChannel && channelId && userId)) {
       return
@@ -138,9 +139,9 @@ const integration = new bp.Integration({
     const { conversation } = await client.getOrCreateConversation({
       channel,
       tags: {
-        'vonage:channel': vonageChannel,
-        'vonage:channelId': channelId,
-        'vonage:userId': userId,
+        [channelTag]: vonageChannel,
+        [channelIdTag]: channelId,
+        [userIdTag]: userId,
       },
     })
 
@@ -159,9 +160,9 @@ export default sentryHelpers.wrapIntegration(integration, {
 })
 
 function getRequestMetadata(conversation: SendMessageProps['conversation']) {
-  const channel = conversation.tags?.['vonage:channel']
-  const channelId = conversation.tags?.['vonage:channelId']
-  const userId = conversation.tags?.['vonage:userId']
+  const channel = conversation.tags?.[channelTag]
+  const channelId = conversation.tags?.[channelIdTag]
+  const userId = conversation.tags?.[userIdTag]
 
   if (!channelId) {
     throw new Error('Invalid channel id')
@@ -331,5 +332,5 @@ async function sendMessage({ conversation, ctx, ack }: SendMessageProps, payload
       auth: { username: ctx.configuration.apiKey, password: ctx.configuration.apiSecret },
     }
   )
-  await ack({ tags: { 'vonage:id': response.data.message_uuid } })
+  await ack({ tags: { [idTag]: response.data.message_uuid } })
 }

--- a/integrations/webhook/integration.definition.ts
+++ b/integrations/webhook/integration.definition.ts
@@ -1,9 +1,10 @@
 import { IntegrationDefinition } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { z } from 'zod'
+import { INTEGRATION_NAME } from './src/const'
 
 export default new IntegrationDefinition({
-  name: 'webhook',
+  name: INTEGRATION_NAME,
   version: '0.2.0',
   title: 'Webhook',
   description: 'This integration allows your bot to interact with Webhook.',

--- a/integrations/webhook/src/const.ts
+++ b/integrations/webhook/src/const.ts
@@ -1,0 +1,1 @@
+export const INTEGRATION_NAME = 'webhook'

--- a/integrations/zapier/integration.definition.ts
+++ b/integrations/zapier/integration.definition.ts
@@ -1,10 +1,11 @@
 import { IntegrationDefinition } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { z } from 'zod'
+import { INTEGRATION_NAME } from './src/const'
 import { TriggerSchema, EventSchema, ZapierTriggersStateName, ZapierTriggersStateSchema } from './src/types'
 
 export default new IntegrationDefinition({
-  name: 'zapier',
+  name: INTEGRATION_NAME,
   version: '0.2.0',
   title: 'Zapier',
   description: 'This integration allows your bot to interact with Zapier.',

--- a/integrations/zapier/src/const.ts
+++ b/integrations/zapier/src/const.ts
@@ -1,0 +1,1 @@
+export const INTEGRATION_NAME = 'zapier'

--- a/integrations/zendesk/src/actions/get-ticket-conversation.ts
+++ b/integrations/zendesk/src/actions/get-ticket-conversation.ts
@@ -1,4 +1,5 @@
 import { getZendeskClient } from 'src/client'
+import { idTag } from 'src/const'
 import { IntegrationProps } from '.botpress'
 
 type ZendeskClient = ReturnType<typeof getZendeskClient>
@@ -26,7 +27,7 @@ export const getTicketConversation: IntegrationProps['actions']['getTicketConver
   const { conversation } = await client.getOrCreateConversation({
     channel: 'ticket',
     tags: {
-      'zendesk:id': input.ticketId,
+      [idTag]: input.ticketId,
     },
   })
 

--- a/integrations/zendesk/src/actions/set-conversation-requester.ts
+++ b/integrations/zendesk/src/actions/set-conversation-requester.ts
@@ -1,4 +1,5 @@
 import { getZendeskClient } from 'src/client'
+import { requesterIdTag } from 'src/const'
 import { IntegrationProps } from '.botpress'
 
 type ZendeskClient = ReturnType<typeof getZendeskClient>
@@ -26,7 +27,7 @@ export const setConversationRequester: IntegrationProps['actions']['setConversat
   await client.updateConversation({
     id: input.conversationId,
     tags: {
-      'zendesk:requesterId': input.requesterId,
+      [requesterIdTag]: input.requesterId,
     },
   })
 

--- a/integrations/zendesk/src/channels.ts
+++ b/integrations/zendesk/src/channels.ts
@@ -1,7 +1,7 @@
 import '@botpress/client'
 import { IntegrationLogger } from '@botpress/sdk/dist/integration/logger'
 import { getZendeskClient } from './client'
-import { INTEGRATION_NAME } from './const'
+import { idTag, requesterIdTag } from './const'
 import { IntegrationProps } from '.botpress'
 
 class TagStore<T extends Record<string, string>> {
@@ -27,7 +27,7 @@ export default {
     messages: {
       text: async ({ client, ...props }) => {
         const conversationTags = new TagStore(props.conversation, props.logger)
-        const ticketId = conversationTags.get(`${INTEGRATION_NAME}:id`)
+        const ticketId = conversationTags.get(idTag)
 
         const { user } = await client.getUser({
           id: props.user.id,
@@ -35,8 +35,7 @@ export default {
 
         const userTags = new TagStore(user, props.logger)
 
-        const zendeskAuthorId =
-          conversationTags.find(`${INTEGRATION_NAME}:requesterId`) ?? userTags.get(`${INTEGRATION_NAME}:id`)
+        const zendeskAuthorId = conversationTags.find(requesterIdTag) ?? userTags.get(idTag)
 
         return await getZendeskClient(props.ctx.configuration).createComment(
           ticketId,

--- a/integrations/zendesk/src/const.ts
+++ b/integrations/zendesk/src/const.ts
@@ -1,1 +1,4 @@
 export const INTEGRATION_NAME = 'zendesk'
+
+export const idTag = `${INTEGRATION_NAME}:id` as const
+export const requesterIdTag = `${INTEGRATION_NAME}:requesterId` as const

--- a/integrations/zendesk/src/setup.ts
+++ b/integrations/zendesk/src/setup.ts
@@ -1,5 +1,6 @@
 import { IntegrationProps } from '../.botpress/implementation'
 import { getZendeskClient } from './client'
+import { idTag } from './const'
 import { Triggers } from './triggers'
 
 export const register: IntegrationProps['register'] = async ({ client, ctx, webhookUrl, logger }) => {
@@ -26,7 +27,7 @@ export const register: IntegrationProps['register'] = async ({ client, ctx, webh
   await client.updateUser({
     id: ctx.botUserId,
     tags: {
-      'zendesk:id': `${user.id}`,
+      [idTag]: `${user.id}`,
     },
   })
 


### PR DESCRIPTION
We want to avoid having the name of the integration hard-coded in multiple files, instead we export a constant from a const.ts file.

- sunco
- trello
- twilio
- viber
- vonage
- webhook
- zapier
- zendesk