### PR TITLE
fix(slack): user sync was broken

### DIFF
--- a/integrations/slack/src/actions/index.ts
+++ b/integrations/slack/src/actions/index.ts
@@ -1,6 +1,6 @@
 import { addReaction } from './add-reaction'
 import { findTarget } from './find-target'
-import { listActiveMembers } from './list-users'
+import { syncMembers } from './list-users'
 import { retrieveMessage } from './retreive-message'
 import { startDmConversation } from './start-dm'
 
@@ -10,6 +10,6 @@ export default {
   addReaction,
   findTarget,
   retrieveMessage,
-  listActiveMembers,
+  syncMembers,
   startDmConversation,
 } satisfies bp.IntegrationProps['actions']

--- a/integrations/slack/src/actions/list-users.ts
+++ b/integrations/slack/src/actions/list-users.ts
@@ -1,12 +1,12 @@
-import { isApiError } from '@botpress/client'
+import { User, isApiError } from '@botpress/client'
 import { WebClient } from '@slack/web-api'
 import { Member } from '@slack/web-api/dist/response/UsersListResponse'
-import { mapKeys, isEqual } from 'lodash'
-import { getAccessToken } from 'src/misc/utils'
+import { chain, mapKeys, isEqual } from 'lodash'
+import { getAccessToken, getSyncState, saveSyncState } from 'src/misc/utils'
+import { user as userDef } from '../definitions/index'
 import * as botpress from '.botpress'
 
-type SyncedUser = NonNullable<Awaited<ReturnType<typeof syncSlackUserToBotpressUser>>>
-const syncSlackUserToBotpressUser = async (member: Member, botpressClient: botpress.Client) => {
+const syncSlackUserToBotpressUser = async (member: Member, botpressClient: botpress.Client): Promise<User> => {
   try {
     const { user } = await botpressClient.getOrCreateUser({
       tags: {
@@ -15,9 +15,30 @@ const syncSlackUserToBotpressUser = async (member: Member, botpressClient: botpr
     })
 
     const latestTags = mapKeys(user.tags, (_v, k) => k.split(':')[1])
-    const tags = { ...member.profile }
+    const updatedTags: Record<keyof (typeof userDef)['tags'], string | undefined> = {
+      id: member.id,
+      avatar_hash: member.profile?.avatar_hash,
+      display_name: member.profile?.display_name,
+      display_name_normalized: member.profile?.display_name_normalized,
+      email: member.profile?.email,
+      image_24: member.profile?.image_24,
+      image_48: member.profile?.image_48,
+      image_192: member.profile?.image_192,
+      image_512: member.profile?.image_512,
+      image_1024: member.profile?.image_1024,
+      is_admin: member.is_admin?.toString(),
+      is_bot: member.is_bot?.toString(),
+      phone: member.profile?.phone,
+      real_name: member.profile?.real_name,
+      real_name_normalized: member.profile?.real_name_normalized,
+      status_emoji: member.profile?.status_emoji,
+      status_text: member.profile?.status_text,
+      team: member.team_id,
+      title: member.profile?.title,
+      tz: member.tz,
+    }
 
-    if (isEqual(latestTags, tags)) {
+    if (isEqual(latestTags, updatedTags)) {
       return user
     }
 
@@ -25,42 +46,63 @@ const syncSlackUserToBotpressUser = async (member: Member, botpressClient: botpr
       id: user.id,
       name: member.name,
       pictureUrl: member.profile?.image_512,
-      tags,
+      tags: updatedTags,
     })
 
     return updatedUser
   } catch (err) {
     if (isApiError(err) && err.type === 'RateLimited') {
       await new Promise((resolve) => setTimeout(resolve, 10 * 1000))
-      await syncSlackUserToBotpressUser(member, botpressClient)
+      return syncSlackUserToBotpressUser(member, botpressClient)
     }
-    return
+    throw err
   }
 }
 
-export const listActiveMembers: botpress.IntegrationProps['actions']['listActiveMembers'] = async ({
+export const syncMembers: botpress.IntegrationProps['actions']['syncMembers'] = async ({
   client: botpressClient,
   ctx,
+  logger,
 }) => {
+  let { usersLastSyncTs } = await getSyncState(botpressClient, ctx)
+  logger.forBot().debug(`Last sync timestamp for Slack users: ${usersLastSyncTs}`)
+
   const accessToken = await getAccessToken(botpressClient, ctx)
   const client = new WebClient(accessToken)
-  const slackMembers: Member[] = []
 
+  const allMembers: Member[] = []
   const getAllMembers = async (cursor?: string) => {
     const res = await client.users.list({ cursor })
-    slackMembers.push(...(res.members || []).filter((x) => !x.deleted))
-
+    allMembers.push(...(res.members ?? []))
     if (res.response_metadata?.next_cursor) {
+      logger.forBot().debug(`Fetching next page of Slack members... (${allMembers.length}/?)`)
       await getAllMembers(res.response_metadata.next_cursor)
     }
   }
+
   await getAllMembers()
 
-  const users: SyncedUser[] = []
-  for (const slackMember of slackMembers) {
-    const user = await syncSlackUserToBotpressUser(slackMember, botpressClient)
-    user && users.push(user)
+  const membersToSync = chain(allMembers)
+    .sortBy((x) => x.updated, 'asc')
+    .filter((x) => !x.deleted)
+    .filter((x) => (x.updated ?? 0) > (usersLastSyncTs ?? -1))
+    .value()
+
+  logger.forBot().debug(`Found ${membersToSync.length}/${allMembers.length} members to sync in Slack workspace`)
+
+  for (const slackMember of membersToSync) {
+    logger.forBot().debug('Syncing Slack user to Botpress...', { user: slackMember.name, updated: slackMember.updated })
+    try {
+      const user = await syncSlackUserToBotpressUser(slackMember, botpressClient)
+      logger.forBot().debug(`Synced Slack user ${user.name} (${user.id})`)
+      usersLastSyncTs = Math.max(usersLastSyncTs ?? 0, slackMember.updated ?? 0)
+      await saveSyncState(botpressClient, ctx, { usersLastSyncTs })
+    } catch (err) {
+      logger.forBot().error(`Failed to sync Slack user ${slackMember.name}`, err)
+    }
   }
 
-  return { users }
+  logger.forBot().debug(`Synced ${membersToSync.length} Slack users to Botpress`)
+
+  return { syncedCount: membersToSync.length }
 }

--- a/integrations/slack/src/actions/list-users.ts
+++ b/integrations/slack/src/actions/list-users.ts
@@ -3,7 +3,7 @@ import { WebClient } from '@slack/web-api'
 import { Member } from '@slack/web-api/dist/response/UsersListResponse'
 import { chain, mapKeys, isEqual } from 'lodash'
 import { getAccessToken, getSyncState, saveSyncState } from 'src/misc/utils'
-import { user as userDef } from '../definitions/index'
+import { userTags } from '../definitions/index'
 import * as botpress from '.botpress'
 
 const syncSlackUserToBotpressUser = async (member: Member, botpressClient: botpress.Client): Promise<User> => {
@@ -15,7 +15,8 @@ const syncSlackUserToBotpressUser = async (member: Member, botpressClient: botpr
     })
 
     const latestTags = mapKeys(user.tags, (_v, k) => k.split(':')[1])
-    const updatedTags: Record<keyof (typeof userDef)['tags'], string | undefined> = {
+    const updatedTags: Record<keyof typeof userTags, string | undefined> = {
+      dm_conversation_id: user.tags.dm_conversation_id,
       id: member.id,
       avatar_hash: member.profile?.avatar_hash,
       display_name: member.profile?.display_name,

--- a/integrations/slack/src/actions/start-dm.ts
+++ b/integrations/slack/src/actions/start-dm.ts
@@ -16,6 +16,13 @@ export const startDmConversation: botpress.IntegrationProps['actions']['startDmC
     },
   })
 
+  if (user.tags.dm_conversation_id) {
+    return {
+      conversationId: user.tags.dm_conversation_id,
+      userId: user.id,
+    }
+  }
+
   const { ok, channel } = await slackClient.conversations.open({
     users: input.slackUserId,
   })
@@ -37,6 +44,13 @@ export const startDmConversation: botpress.IntegrationProps['actions']['startDmC
       title: `DM with ${user.name}`,
     },
   } as any)
+
+  await client.updateUser({
+    id: user.id,
+    tags: {
+      dm_conversation_id: conversation.id,
+    },
+  })
 
   return {
     conversationId: conversation.id,

--- a/integrations/slack/src/definitions/actions.ts
+++ b/integrations/slack/src/definitions/actions.ts
@@ -90,16 +90,15 @@ const retrieveMessage = {
   },
 }
 
-const listActiveMembers = {
-  title: 'List Active Members',
-  description: 'Retrieve the list of active members from Slack',
+const syncMembers = {
+  title: 'Sync Members',
+  description:
+    'Sync Slack workspace members to Botpress users. This action keeps track of the last sync timestamp and will only sync updated members since the last sync.',
   input: {
     schema: z.object({}),
   },
   output: {
-    schema: z.object({
-      users: z.array(z.object({})), //TODO z array or botpress user
-    }),
+    schema: z.object({ syncedCount: z.number() }),
   },
 }
 
@@ -128,6 +127,6 @@ export const actions = {
   addReaction,
   findTarget,
   retrieveMessage,
-  listActiveMembers,
+  syncMembers,
   startDmConversation,
 } satisfies IntegrationDefinitionProps['actions']

--- a/integrations/slack/src/definitions/index.ts
+++ b/integrations/slack/src/definitions/index.ts
@@ -22,6 +22,12 @@ export const states = {
       botUserId: z.string().optional(),
     }),
   },
+  sync: {
+    type: 'integration',
+    schema: z.object({
+      usersLastSyncTs: z.number().optional(),
+    }),
+  },
   credentials: {
     type: 'integration',
     schema: z.object({
@@ -33,21 +39,25 @@ export const states = {
 export const user = {
   tags: {
     id: {},
-    avatar_hash: {},
-    status_text: {},
-    status_emoji: {},
+    tz: {},
+    is_bot: {},
+    is_admin: {},
+    title: {},
+    phone: {},
+    email: {},
     real_name: {},
     display_name: {},
     real_name_normalized: {},
     display_name_normalized: {},
-    email: {},
+    avatar_hash: {},
+    status_text: {},
+    status_emoji: {},
     image_24: {},
-    image_32: {},
     image_48: {},
-    image_72: {},
     image_192: {},
     image_512: {},
+    image_1024: {},
     team: {},
-  },
+  } as const,
   creation: { enabled: true, requiredTags: ['id'] },
-} satisfies IntegrationDefinitionProps['user']
+} as const satisfies IntegrationDefinitionProps['user']

--- a/integrations/slack/src/definitions/index.ts
+++ b/integrations/slack/src/definitions/index.ts
@@ -36,28 +36,40 @@ export const states = {
   },
 } satisfies IntegrationDefinitionProps['states']
 
+export const userTags = {
+  dm_conversation_id: {
+    title: 'DM Conversation ID',
+    description: 'The ID of the conversation used to DM the user (created by calling the `startDmConversation` action)',
+  },
+  id: {
+    title: 'ID',
+    description: 'The Slack ID of the user (U0000XXXXXX)',
+  },
+  tz: {},
+  is_bot: {},
+  is_admin: {},
+  title: {},
+  phone: {},
+  email: {},
+  real_name: {},
+  display_name: {},
+  real_name_normalized: {},
+  display_name_normalized: {},
+  avatar_hash: {},
+  status_text: {},
+  status_emoji: {},
+  image_24: {},
+  image_48: {},
+  image_192: {},
+  image_512: {},
+  image_1024: {},
+  team: {
+    title: 'Team',
+    description: 'The Slack ID of the team (T0000XXXXXX)',
+  },
+} as const
+
 export const user = {
-  tags: {
-    id: {},
-    tz: {},
-    is_bot: {},
-    is_admin: {},
-    title: {},
-    phone: {},
-    email: {},
-    real_name: {},
-    display_name: {},
-    real_name_normalized: {},
-    display_name_normalized: {},
-    avatar_hash: {},
-    status_text: {},
-    status_emoji: {},
-    image_24: {},
-    image_48: {},
-    image_192: {},
-    image_512: {},
-    image_1024: {},
-    team: {},
-  } as const,
+  tags: userTags,
   creation: { enabled: true, requiredTags: ['id'] },
-} as const satisfies IntegrationDefinitionProps['user']
+} satisfies IntegrationDefinitionProps['user']

--- a/integrations/slack/src/misc/utils.ts
+++ b/integrations/slack/src/misc/utils.ts
@@ -240,7 +240,7 @@ export const getConfig = async (client: Client, ctx: IntegrationCtx): Promise<Co
   const {
     state: { payload },
   } = await client.getState({ type: 'integration', name: 'configuration', id: ctx.integrationId }).catch(() => ({
-    state: { payload: {} },
+    state: { payload: {} as any },
   }))
 
   return payload as Configuration
@@ -254,7 +254,7 @@ export const getSyncState = async (client: Client, ctx: IntegrationCtx): Promise
   const {
     state: { payload },
   } = await client.getState({ type: 'integration', name: 'sync', id: ctx.integrationId }).catch(() => ({
-    state: { payload: {} },
+    state: { payload: {} as any },
   }))
 
   return payload as SyncState
@@ -268,7 +268,7 @@ export const getAccessToken = async (client: Client, ctx: IntegrationCtx) => {
   const { state } = await client
     .getState({ type: 'integration', name: 'credentials', id: ctx.integrationId })
     .catch(() => ({
-      state: { payload: {} },
+      state: { payload: {} as any },
     }))
 
   return state.payload.accessToken

--- a/integrations/slack/src/misc/utils.ts
+++ b/integrations/slack/src/misc/utils.ts
@@ -5,7 +5,7 @@ import axios from 'axios'
 import queryString from 'query-string'
 import VError from 'verror'
 import { INTEGRATION_NAME } from '../const'
-import { Configuration } from '../setup'
+import { Configuration, SyncState } from '../setup'
 import { Client, IntegrationCtx } from './types'
 import * as bp from '.botpress'
 
@@ -239,9 +239,25 @@ export const saveConfig = async (client: Client, ctx: IntegrationCtx, config: Co
 export const getConfig = async (client: Client, ctx: IntegrationCtx): Promise<Configuration> => {
   const {
     state: { payload },
-  } = await client.getState({ type: 'integration', name: 'configuration', id: ctx.integrationId })
+  } = await client.getState({ type: 'integration', name: 'configuration', id: ctx.integrationId }).catch(() => ({
+    state: { payload: {} },
+  }))
 
   return payload as Configuration
+}
+
+export const saveSyncState = async (client: Client, ctx: IntegrationCtx, state: SyncState) => {
+  await client.setState({ type: 'integration', name: 'sync', id: ctx.integrationId, payload: state })
+}
+
+export const getSyncState = async (client: Client, ctx: IntegrationCtx): Promise<SyncState> => {
+  const {
+    state: { payload },
+  } = await client.getState({ type: 'integration', name: 'sync', id: ctx.integrationId }).catch(() => ({
+    state: { payload: {} },
+  }))
+
+  return payload as SyncState
 }
 
 export const getAccessToken = async (client: Client, ctx: IntegrationCtx) => {
@@ -249,7 +265,11 @@ export const getAccessToken = async (client: Client, ctx: IntegrationCtx) => {
     return ctx.configuration.botToken
   }
 
-  const { state } = await client.getState({ type: 'integration', name: 'credentials', id: ctx.integrationId })
+  const { state } = await client
+    .getState({ type: 'integration', name: 'credentials', id: ctx.integrationId })
+    .catch(() => ({
+      state: { payload: {} },
+    }))
 
   return state.payload.accessToken
 }

--- a/integrations/slack/src/setup.ts
+++ b/integrations/slack/src/setup.ts
@@ -2,6 +2,7 @@ import { WebClient } from '@slack/web-api'
 import { CreateConversationFunction, CreateUserFunction, RegisterFunction, UnregisterFunction } from './misc/types'
 import { getAccessToken, getDirectMessageForUser, getTag, isUserId, saveConfig } from './misc/utils'
 
+export type SyncState = { usersLastSyncTs?: number }
 export type Configuration = { botUserId?: string }
 
 export const register: RegisterFunction = async ({ client, ctx }) => {


### PR DESCRIPTION
Fixes the method introduced here which didn't work: https://github.com/botpress/botpress/pull/12858

This new implementation keeps track of the last synced TS and will only sync changed users since then.
It also fixes the tags that never synced (TBH I don't know how this could have ever worked the way it was implemented before)
Also fixes getState() throwing when state doesn't exist (which is always the case the first time you use it since we don't have `getOrCreateState`)