### PR TITLE
feat(slack): add name & avatar url to config

### DIFF
--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -29,6 +29,8 @@ export default new IntegrationDefinition({
     schema: z.object({
       botToken: z.string().optional(), // TODO revert once the multiple configuration is available
       signingSecret: z.string().optional(), // TODO revert once the multiple configuration is available
+      botAvatarUrl: z.string().optional(),
+      botName: z.string().optional(),
     }),
   },
   states: {

--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -26,10 +26,18 @@ export default new IntegrationDefinition({
     identifier: {
       linkTemplateScript: 'linkTemplate.vrl',
     },
+    ui: {
+      botName: {
+        title: 'Bot Name (Name displayed as the sender in Slack conversations)',
+      },
+      botAvatarUrl: {
+        title: "Bot Avatar URL (URL for the image used as the Slack bot's avatar)",
+      },
+    },
     schema: z.object({
       botToken: z.string().optional(), // TODO revert once the multiple configuration is available
       signingSecret: z.string().optional(), // TODO revert once the multiple configuration is available
-      botAvatarUrl: z.string().optional(),
+      botAvatarUrl: z.string().url().optional(),
       botName: z.string().optional(),
     }),
   },

--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -28,7 +28,7 @@ export default new IntegrationDefinition({
     },
     ui: {
       botName: {
-        title: 'Bot Name (Name displayed as the sender in Slack conversations)',
+        title: 'Bot Name (displayed as the sender in Slack conversations)',
       },
       botAvatarUrl: {
         title: "Bot Avatar URL (URL for the image used as the Slack bot's avatar)",

--- a/integrations/slack/src/channels.ts
+++ b/integrations/slack/src/channels.ts
@@ -1,186 +1,209 @@
 import { textSchema } from './definitions/schemas'
 import { renderCard } from './misc/renderer'
 import { Channels } from './misc/types'
-import { getAccessToken, getSlackTarget, notEmpty, sendSlackMessage } from './misc/utils'
+import { getSlackTarget, notEmpty, sendSlackMessage } from './misc/utils'
 
 const defaultMessages: Channels['channel']['messages'] = {
   text: async ({ client, payload, ctx, conversation, ack, logger }) => {
     const parsed = textSchema.parse(payload)
     logger.forBot().debug('Sending text message to Slack chat:', payload)
-    const accessToken = await getAccessToken(client, ctx)
-    await sendSlackMessage(accessToken, ack, {
-      ...getSlackTarget(conversation),
-      ...parsed,
-    })
+    await sendSlackMessage(
+      { ack, ctx, client },
+      {
+        ...getSlackTarget(conversation),
+        ...parsed,
+      }
+    )
   },
   image: async ({ client, payload, ctx, conversation, ack, logger }) => {
     logger.forBot().debug('Sending image message to Slack chat:', payload)
-    const accessToken = await getAccessToken(client, ctx)
-    await sendSlackMessage(accessToken, ack, {
-      ...getSlackTarget(conversation),
-      blocks: [
-        {
-          type: 'image',
-          image_url: payload.imageUrl,
-          alt_text: 'image',
-        },
-      ],
-    })
+    await sendSlackMessage(
+      { ack, ctx, client },
+      {
+        ...getSlackTarget(conversation),
+        blocks: [
+          {
+            type: 'image',
+            image_url: payload.imageUrl,
+            alt_text: 'image',
+          },
+        ],
+      }
+    )
   },
   markdown: async ({ ctx, conversation, ack, client, payload, logger }) => {
     logger.forBot().debug('Sending markdown message to Slack chat:', payload)
-    const accessToken = await getAccessToken(client, ctx)
-    await sendSlackMessage(accessToken, ack, {
-      ...getSlackTarget(conversation),
-      text: payload.markdown,
-      blocks: [
-        {
-          type: 'section',
-          text: { type: 'mrkdwn', text: payload.markdown },
-        },
-      ],
-    })
+
+    await sendSlackMessage(
+      { ack, ctx, client },
+      {
+        ...getSlackTarget(conversation),
+        text: payload.markdown,
+        blocks: [
+          {
+            type: 'section',
+            text: { type: 'mrkdwn', text: payload.markdown },
+          },
+        ],
+      }
+    )
   },
   audio: async ({ ctx, conversation, ack, client, payload, logger }) => {
     logger.forBot().debug('Sending audio message to Slack chat:', payload)
-    const accessToken = await getAccessToken(client, ctx)
-    await sendSlackMessage(accessToken, ack, {
-      ...getSlackTarget(conversation),
-      text: 'audio',
-      blocks: [
-        {
-          type: 'section',
-          text: { type: 'mrkdwn', text: `<${payload.audioUrl}|audio>` },
-        },
-      ],
-    })
+    await sendSlackMessage(
+      { ack, ctx, client },
+      {
+        ...getSlackTarget(conversation),
+        text: 'audio',
+        blocks: [
+          {
+            type: 'section',
+            text: { type: 'mrkdwn', text: `<${payload.audioUrl}|audio>` },
+          },
+        ],
+      }
+    )
   },
   video: async ({ ctx, conversation, ack, client, payload, logger }) => {
     logger.forBot().debug('Sending video message to Slack chat:', payload)
-    const accessToken = await getAccessToken(client, ctx)
-    await sendSlackMessage(accessToken, ack, {
-      ...getSlackTarget(conversation),
-      text: 'video',
-      blocks: [
-        {
-          type: 'section',
-          text: { type: 'mrkdwn', text: `<${payload.videoUrl}|video>` },
-        },
-      ],
-    })
+    await sendSlackMessage(
+      { ack, ctx, client },
+      {
+        ...getSlackTarget(conversation),
+        text: 'video',
+        blocks: [
+          {
+            type: 'section',
+            text: { type: 'mrkdwn', text: `<${payload.videoUrl}|video>` },
+          },
+        ],
+      }
+    )
   },
   file: async ({ ctx, conversation, ack, client, payload, logger }) => {
     logger.forBot().debug('Sending file message to Slack chat:', payload)
-    const accessToken = await getAccessToken(client, ctx)
-    await sendSlackMessage(accessToken, ack, {
-      ...getSlackTarget(conversation),
-      text: 'file',
-      blocks: [
-        {
-          type: 'section',
-          text: { type: 'mrkdwn', text: `<${payload.fileUrl}|file>` },
-        },
-      ],
-    })
+    await sendSlackMessage(
+      { ack, ctx, client },
+      {
+        ...getSlackTarget(conversation),
+        text: 'file',
+        blocks: [
+          {
+            type: 'section',
+            text: { type: 'mrkdwn', text: `<${payload.fileUrl}|file>` },
+          },
+        ],
+      }
+    )
   },
   location: async ({ ctx, conversation, ack, client, payload, logger }) => {
     const googleMapsLink = `https://www.google.com/maps/search/?api=1&query=${payload.latitude},${payload.longitude}`
     logger.forBot().debug('Sending location message to Slack chat:', payload)
-    const accessToken = await getAccessToken(client, ctx)
-    await sendSlackMessage(accessToken, ack, {
-      ...getSlackTarget(conversation),
-      text: 'location',
-      blocks: [
-        {
-          type: 'section',
-          text: { type: 'mrkdwn', text: `<${googleMapsLink}|location>` },
-        },
-      ],
-    })
+    await sendSlackMessage(
+      { ack, ctx, client },
+      {
+        ...getSlackTarget(conversation),
+        text: 'location',
+        blocks: [
+          {
+            type: 'section',
+            text: { type: 'mrkdwn', text: `<${googleMapsLink}|location>` },
+          },
+        ],
+      }
+    )
   },
   carousel: async ({ ctx, conversation, ack, client, payload, logger }) => {
     logger.forBot().debug('Sending carousel message to Slack chat:', payload)
-    const accessToken = await getAccessToken(client, ctx)
-    await sendSlackMessage(accessToken, ack, {
-      ...getSlackTarget(conversation),
-      text: 'carousel',
-      blocks: payload.items.flatMap(renderCard).filter(notEmpty),
-    })
+    await sendSlackMessage(
+      { ack, ctx, client },
+      {
+        ...getSlackTarget(conversation),
+        text: 'carousel',
+        blocks: payload.items.flatMap(renderCard).filter(notEmpty),
+      }
+    )
   },
   card: async ({ ctx, conversation, ack, client, payload, logger }) => {
     logger.forBot().debug('Sending card message to Slack chat:', payload)
-    const accessToken = await getAccessToken(client, ctx)
-    await sendSlackMessage(accessToken, ack, {
-      ...getSlackTarget(conversation),
-      text: 'card',
-      blocks: renderCard(payload),
-    })
+    await sendSlackMessage(
+      { ack, ctx, client },
+      {
+        ...getSlackTarget(conversation),
+        text: 'card',
+        blocks: renderCard(payload),
+      }
+    )
   },
   dropdown: async ({ ctx, conversation, ack, client, payload, logger }) => {
     logger.forBot().debug('Sending dropdown message to Slack chat:', payload)
-    const accessToken = await getAccessToken(client, ctx)
-    await sendSlackMessage(accessToken, ack, {
-      ...getSlackTarget(conversation),
-      text: payload.text,
-      blocks:
-        payload.options?.length > 0
-          ? [
-              {
-                type: 'actions',
-                elements: [
-                  {
-                    type: 'static_select',
-                    action_id: 'option_selected',
-                    placeholder: {
-                      type: 'plain_text',
-                      text: payload.text,
+    await sendSlackMessage(
+      { ack, ctx, client },
+      {
+        ...getSlackTarget(conversation),
+        text: payload.text,
+        blocks:
+          payload.options?.length > 0
+            ? [
+                {
+                  type: 'actions',
+                  elements: [
+                    {
+                      type: 'static_select',
+                      action_id: 'option_selected',
+                      placeholder: {
+                        type: 'plain_text',
+                        text: payload.text,
+                      },
+                      options: payload.options
+                        .filter((o) => o.label.length > 0)
+                        .map((choice) => ({
+                          text: {
+                            type: 'plain_text',
+                            text: choice.label,
+                          },
+                          value: choice.value,
+                        })),
                     },
-                    options: payload.options
-                      .filter((o) => o.label.length > 0)
-                      .map((choice) => ({
-                        text: {
-                          type: 'plain_text',
-                          text: choice.label,
-                        },
-                        value: choice.value,
-                      })),
-                  },
-                ],
-              },
-            ]
-          : undefined,
-    })
+                  ],
+                },
+              ]
+            : undefined,
+      }
+    )
   },
   choice: async ({ ctx, conversation, ack, client, payload, logger }) => {
     logger.forBot().debug('Sending choice message to Slack chat:', payload)
-    const accessToken = await getAccessToken(client, ctx)
-    await sendSlackMessage(accessToken, ack, {
-      ...getSlackTarget(conversation),
-      text: payload.text,
-      blocks:
-        payload.options?.length > 0
-          ? [
-              {
-                type: 'section',
-                text: {
-                  type: 'plain_text',
-                  text: payload.text,
+    await sendSlackMessage(
+      { ack, ctx, client },
+      {
+        ...getSlackTarget(conversation),
+        text: payload.text,
+        blocks:
+          payload.options?.length > 0
+            ? [
+                {
+                  type: 'section',
+                  text: {
+                    type: 'plain_text',
+                    text: payload.text,
+                  },
                 },
-              },
-              {
-                type: 'actions',
-                elements: payload.options
-                  .filter((o) => o.label.length > 0)
-                  .map((choice, i) => ({
-                    type: 'button',
-                    text: { type: 'plain_text', text: choice.label },
-                    value: choice.value,
-                    action_id: `quick_reply_${i}`,
-                  })),
-              },
-            ]
-          : undefined,
-    })
+                {
+                  type: 'actions',
+                  elements: payload.options
+                    .filter((o) => o.label.length > 0)
+                    .map((choice, i) => ({
+                      type: 'button',
+                      text: { type: 'plain_text', text: choice.label },
+                      value: choice.value,
+                      action_id: `quick_reply_${i}`,
+                    })),
+                },
+              ]
+            : undefined,
+      }
+    )
   },
 }
 

--- a/integrations/slack/src/channels.ts
+++ b/integrations/slack/src/channels.ts
@@ -8,7 +8,7 @@ const defaultMessages: Channels['channel']['messages'] = {
     const parsed = textSchema.parse(payload)
     logger.forBot().debug('Sending text message to Slack chat:', payload)
     await sendSlackMessage(
-      { ack, ctx, client },
+      { ack, ctx, client, logger },
       {
         ...getSlackTarget(conversation),
         ...parsed,
@@ -18,7 +18,7 @@ const defaultMessages: Channels['channel']['messages'] = {
   image: async ({ client, payload, ctx, conversation, ack, logger }) => {
     logger.forBot().debug('Sending image message to Slack chat:', payload)
     await sendSlackMessage(
-      { ack, ctx, client },
+      { ack, ctx, client, logger },
       {
         ...getSlackTarget(conversation),
         blocks: [
@@ -35,7 +35,7 @@ const defaultMessages: Channels['channel']['messages'] = {
     logger.forBot().debug('Sending markdown message to Slack chat:', payload)
 
     await sendSlackMessage(
-      { ack, ctx, client },
+      { ack, ctx, client, logger },
       {
         ...getSlackTarget(conversation),
         text: payload.markdown,
@@ -51,7 +51,7 @@ const defaultMessages: Channels['channel']['messages'] = {
   audio: async ({ ctx, conversation, ack, client, payload, logger }) => {
     logger.forBot().debug('Sending audio message to Slack chat:', payload)
     await sendSlackMessage(
-      { ack, ctx, client },
+      { ack, ctx, client, logger },
       {
         ...getSlackTarget(conversation),
         text: 'audio',
@@ -67,7 +67,7 @@ const defaultMessages: Channels['channel']['messages'] = {
   video: async ({ ctx, conversation, ack, client, payload, logger }) => {
     logger.forBot().debug('Sending video message to Slack chat:', payload)
     await sendSlackMessage(
-      { ack, ctx, client },
+      { ack, ctx, client, logger },
       {
         ...getSlackTarget(conversation),
         text: 'video',
@@ -83,7 +83,7 @@ const defaultMessages: Channels['channel']['messages'] = {
   file: async ({ ctx, conversation, ack, client, payload, logger }) => {
     logger.forBot().debug('Sending file message to Slack chat:', payload)
     await sendSlackMessage(
-      { ack, ctx, client },
+      { ack, ctx, client, logger },
       {
         ...getSlackTarget(conversation),
         text: 'file',
@@ -100,7 +100,7 @@ const defaultMessages: Channels['channel']['messages'] = {
     const googleMapsLink = `https://www.google.com/maps/search/?api=1&query=${payload.latitude},${payload.longitude}`
     logger.forBot().debug('Sending location message to Slack chat:', payload)
     await sendSlackMessage(
-      { ack, ctx, client },
+      { ack, ctx, client, logger },
       {
         ...getSlackTarget(conversation),
         text: 'location',
@@ -116,7 +116,7 @@ const defaultMessages: Channels['channel']['messages'] = {
   carousel: async ({ ctx, conversation, ack, client, payload, logger }) => {
     logger.forBot().debug('Sending carousel message to Slack chat:', payload)
     await sendSlackMessage(
-      { ack, ctx, client },
+      { ack, ctx, client, logger },
       {
         ...getSlackTarget(conversation),
         text: 'carousel',
@@ -127,7 +127,7 @@ const defaultMessages: Channels['channel']['messages'] = {
   card: async ({ ctx, conversation, ack, client, payload, logger }) => {
     logger.forBot().debug('Sending card message to Slack chat:', payload)
     await sendSlackMessage(
-      { ack, ctx, client },
+      { ack, ctx, client, logger },
       {
         ...getSlackTarget(conversation),
         text: 'card',
@@ -138,7 +138,7 @@ const defaultMessages: Channels['channel']['messages'] = {
   dropdown: async ({ ctx, conversation, ack, client, payload, logger }) => {
     logger.forBot().debug('Sending dropdown message to Slack chat:', payload)
     await sendSlackMessage(
-      { ack, ctx, client },
+      { ack, ctx, client, logger },
       {
         ...getSlackTarget(conversation),
         text: payload.text,
@@ -175,7 +175,7 @@ const defaultMessages: Channels['channel']['messages'] = {
   choice: async ({ ctx, conversation, ack, client, payload, logger }) => {
     logger.forBot().debug('Sending choice message to Slack chat:', payload)
     await sendSlackMessage(
-      { ack, ctx, client },
+      { ack, ctx, client, logger },
       {
         ...getSlackTarget(conversation),
         text: payload.text,

--- a/integrations/slack/src/misc/utils.ts
+++ b/integrations/slack/src/misc/utils.ts
@@ -131,9 +131,19 @@ export const getSlackTarget = (conversation: Conversation) => {
   return { channel, thread_ts: thread }
 }
 
-export async function sendSlackMessage(botToken: string, ack: AckFunction, payload: ChatPostMessageArguments) {
-  const client = new WebClient(botToken)
-  const response = await client.chat.postMessage(payload)
+export async function sendSlackMessage(
+  { client, ctx, ack }: { client: Client; ctx: IntegrationCtx; ack: AckFunction },
+  payload: ChatPostMessageArguments
+) {
+  const accessToken = await getAccessToken(client, ctx)
+  const slackClient = new WebClient(accessToken)
+
+  const botOptionalProps = {
+    icon_url: ctx.configuration.botAvatarUrl,
+    username: ctx.configuration.botName,
+  }
+
+  const response = await slackClient.chat.postMessage({ ...payload, ...botOptionalProps })
   const message = response.message
 
   if (!(response.ok && message)) {

--- a/integrations/slack/src/misc/utils.ts
+++ b/integrations/slack/src/misc/utils.ts
@@ -153,7 +153,7 @@ const getOptionalProps = (ctx: IntegrationCtx, logger: IntegrationLogger) => {
   }
 
   return {
-    username: ctx.configuration.botName,
+    username: ctx.configuration.botName?.trim() !== '' ? ctx.configuration.botName : undefined,
   }
 }
 

--- a/integrations/slack/src/misc/utils.ts
+++ b/integrations/slack/src/misc/utils.ts
@@ -141,15 +141,15 @@ const isValidUrl = (str: string) => {
 }
 
 const getOptionalProps = (ctx: IntegrationCtx, logger: IntegrationLogger) => {
-  if (ctx.configuration.botAvatarUrl && isValidUrl(ctx.configuration.botAvatarUrl)) {
-    return {
-      username: ctx.configuration.botName,
-      icon_url: ctx.configuration.botAvatarUrl,
+  if (ctx.configuration.botAvatarUrl) {
+    if (isValidUrl(ctx.configuration.botAvatarUrl)) {
+      return {
+        username: ctx.configuration.botName,
+        icon_url: ctx.configuration.botAvatarUrl,
+      }
+    } else {
+      logger.forBot().warn('Invalid bot avatar URL')
     }
-  }
-
-  if (ctx.configuration.botAvatarUrl && !isValidUrl(ctx.configuration.botAvatarUrl)) {
-    logger.forBot().warn('Invalid bot avatar URL')
   }
 
   return {


### PR DESCRIPTION
## Overview

This pull request introduces a new feature that allows users to configure the Slack bot's avatar URL and name directly from the interface. This enhancement aims to provide greater flexibility and personalization for users configuring the Slack bot.

## Changes

- Added fields in the user interface for setting the Slack bot's avatar URL and bot name.
- Ensured that the Slack bot sends the fields `icon_url` and `username` when a `.postMessage()` is used.

## TODO -> DONE ✅ 

[This documentation](https://botpress.com/docs/cloud/channels/slack) must be updated, [chat:write.customize](https://api.slack.com/scopes/chat:write.customize) should also be added as a scope for this feature to work.

<img width="848" alt="Screenshot 2023-11-22 at 5 21 34 PM" src="https://github.com/botpress/botpress/assets/5313741/f6866db3-cb4a-40fa-91b5-a95914173b2f">
