### PR TITLE
feat(slack): verify requests signature

### DIFF
--- a/.github/actions/deploy-integrations/action.yml
+++ b/.github/actions/deploy-integrations/action.yml
@@ -103,7 +103,7 @@ runs:
         echo "### Deploying integration @botpresshub/notion ###"
         pnpm -r --stream -F @botpresshub/notion -c exec -- 'bp deploy -v -y --noBuild'
         echo "### Deploying integration @botpresshub/slack ###"
-        pnpm -r --stream -F @botpresshub/slack -c exec -- 'dsn=$(cat .sentryclirc | grep dsn | sed "s/dsn=//"); bp deploy -v -y --noBuild --secrets SENTRY_DSN="$dsn" --secrets SENTRY_ENVIRONMENT="$SENTRY_ENVIRONMENT" --secrets SENTRY_RELEASE="$SENTRY_RELEASE" --secrets CLIENT_ID="${{ inputs.slack_client_id }}" --secrets CLIENT_SECRET="${{ inputs.slack_client_secret }}"'
+        pnpm -r --stream -F @botpresshub/slack -c exec -- 'dsn=$(cat .sentryclirc | grep dsn | sed "s/dsn=//"); bp deploy -v -y --noBuild --secrets SENTRY_DSN="$dsn" --secrets SENTRY_ENVIRONMENT="$SENTRY_ENVIRONMENT" --secrets SENTRY_RELEASE="$SENTRY_RELEASE" --secrets CLIENT_ID="${{ inputs.slack_client_id }}" --secrets CLIENT_SECRET="${{ inputs.slack_client_secret }}" --secrets SIGNING_SECRET="${{ inputs.slack_signing_secret }}"'
         echo "### Deploying integration @botpresshub/sunco ###"
         pnpm -r --stream -F @botpresshub/sunco -c exec -- 'dsn=$(cat .sentryclirc | grep dsn | sed "s/dsn=//"); bp deploy -v -y --noBuild --secrets SENTRY_DSN="$dsn" --secrets SENTRY_ENVIRONMENT="$SENTRY_ENVIRONMENT" --secrets SENTRY_RELEASE="$SENTRY_RELEASE"'
         echo "### Deploying integration @botpresshub/teams ###"

--- a/.github/workflows/deploy-integrations-production.yml
+++ b/.github/workflows/deploy-integrations-production.yml
@@ -28,3 +28,4 @@ jobs:
           linear_webhook_signing_secret: ${{ secrets.PRODUCTION_LINEAR_WEBHOOK_SIGNING_SECRET }}
           slack_client_id: ${{ secrets.PRODUCTION_SLACK_CLIENT_ID }}
           slack_client_secret: ${{ secrets.PRODUCTION_SLACK_CLIENT_SECRET }}
+          slack_signing_secret: ${{ secrets.PRODUCTION_SLACK_SIGNING_SECRET }}

--- a/.github/workflows/deploy-integrations-staging.yml
+++ b/.github/workflows/deploy-integrations-staging.yml
@@ -33,3 +33,4 @@ jobs:
           linear_webhook_signing_secret: ${{ secrets.STAGING_LINEAR_WEBHOOK_SIGNING_SECRET }}
           slack_client_id: ${{ secrets.STAGING_SLACK_CLIENT_ID }}
           slack_client_secret: ${{ secrets.STAGING_SLACK_CLIENT_SECRET }}
+          slack_signing_secret: ${{ secrets.STAGING_SLACK_SIGNING_SECRET }}

--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -97,6 +97,9 @@ export default new IntegrationDefinition({
     CLIENT_SECRET: {
       description: 'The client secret of your Slack OAuth app.',
     },
+    SIGNING_SECRET: {
+      description: 'The signing secret of your Slack OAuth app used to verify requests signature.',
+    },
     ...sentryHelpers.COMMON_SECRET_NAMES,
   },
   user: {

--- a/integrations/slack/linkTemplate.vrl
+++ b/integrations/slack/linkTemplate.vrl
@@ -1,4 +1,11 @@
 webhookId = to_string!(.webhookId)
 webhookUrl = to_string!(.webhookUrl)
+isDevMode = to_bool!(.isDevMode)
 
-"https://slack.com/oauth/v2/authorize?client_id=327679845109.4960499297143&state={{ webhookId }}&redirect_uri={{ webhookUrl }}/oauth&scope=channels:history,channels:read,chat:write,files:read,files:write,groups:history,groups:read,im:read,links:read,links:write,metadata.message:read,mpim:history,mpim:read,team:read,usergroups:read,users:read&user_scope="
+clientId = "327679845109.4960499297143"
+
+if $isDevMode {
+  clientId = "327679845109.6306488448308"
+}
+
+"https://slack.com/oauth/v2/authorize?client_id={{ clientId }}&state={{ webhookId }}&redirect_uri={{ webhookUrl }}/oauth&scope=channels:history,channels:read,chat:write,files:read,files:write,groups:history,groups:read,im:read,links:read,links:write,metadata.message:read,mpim:history,mpim:read,team:read,usergroups:read,users:read&user_scope="

--- a/integrations/slack/linkTemplate.vrl
+++ b/integrations/slack/linkTemplate.vrl
@@ -1,11 +1,11 @@
 webhookId = to_string!(.webhookId)
 webhookUrl = to_string!(.webhookUrl)
-isDevMode = to_bool!(.isDevMode)
+env = to_string!(.env)
 
-clientId = "327679845109.4960499297143"
+clientId = "327679845109.6306488448308"
 
-if $isDevMode {
-  clientId = "327679845109.6306488448308"
+if env == "production" {
+  clientId = "327679845109.4960499297143"
 }
 
 "https://slack.com/oauth/v2/authorize?client_id={{ clientId }}&state={{ webhookId }}&redirect_uri={{ webhookUrl }}/oauth&scope=channels:history,channels:read,chat:write,files:read,files:write,groups:history,groups:read,im:read,links:read,links:write,metadata.message:read,mpim:history,mpim:read,team:read,usergroups:read,users:read&user_scope="

--- a/integrations/slack/linkTemplate.vrl
+++ b/integrations/slack/linkTemplate.vrl
@@ -8,5 +8,4 @@ if env == "production" {
   clientId = "327679845109.4960499297143"
 }
 
-"https://slack.com/oauth/v2/authorize?client_id={{ clientId }}&state={{ webhookId }}&redirect_uri={{ webhookUrl }}/oauth&scope=channels:history,channels:read,chat:write,files:read,files:write,groups:history,groups:read,im:read,links:read,links:write,metadata.message:read,mpim:history,mpim:read,team:read,usergroups:read,users:read,users.profile:read,users.profile:read,reactions.read,reactions.write,mpim:write,mpim:write.invites,mpim:write.topic,im:write,im:history,groups:write.topic,groups:write.invites,groups:write,dnd:read,chat:write.customize,channels:join,channels:manage,channels:write.invites,channels:write.topic&user_scope="
-
+"https://slack.com/oauth/v2/authorize?client_id={{ clientId }}&state={{ webhookId }}&redirect_uri={{ webhookUrl }}/oauth&scope=channels:history,channels:read,chat:write,files:read,files:write,groups:history,groups:read,im:read,links:read,links:write,metadata.message:read,mpim:history,mpim:read,team:read,usergroups:read,users:read,users.profile:read,users.profile:read,reactions:read,reactions:write,mpim:write,mpim:write.invites,mpim:write.topic,im:write,im:history,groups:write.topic,groups:write.invites,groups:write,dnd:read,chat:write.customize,channels:join,channels:manage,channels:write.invites,channels:write.topic&user_scope="

--- a/integrations/slack/src/const.ts
+++ b/integrations/slack/src/const.ts
@@ -1,4 +1,4 @@
-export const INTEGRATION_NAME = 'slack'
+export const INTEGRATION_NAME = 'slacktest'
 
 export const userIdTag = `${INTEGRATION_NAME}:userId` as const
 export const channelIdTag = `${INTEGRATION_NAME}:channelId` as const

--- a/integrations/slack/src/const.ts
+++ b/integrations/slack/src/const.ts
@@ -1,4 +1,4 @@
-export const INTEGRATION_NAME = 'slacktest'
+export const INTEGRATION_NAME = 'slack'
 
 export const userIdTag = `${INTEGRATION_NAME}:userId` as const
 export const channelIdTag = `${INTEGRATION_NAME}:channelId` as const

--- a/integrations/slack/src/handler.ts
+++ b/integrations/slack/src/handler.ts
@@ -36,8 +36,6 @@ export const handler: botpress.IntegrationProps['handler'] = async ({ req, ctx, 
     return
   }
 
-  const data = JSON.parse(req.body)
-
   const { botUserId } = await getConfig(client, ctx)
 
   if (isInteractiveRequest(req)) {
@@ -66,6 +64,8 @@ export const handler: botpress.IntegrationProps['handler'] = async ({ req, ctx, 
 
     return
   }
+
+  const data = JSON.parse(req.body)
 
   if (data.type === 'url_verification') {
     logger.forBot().debug('Handler received request of type url_verification')

--- a/integrations/slack/src/handler.ts
+++ b/integrations/slack/src/handler.ts
@@ -17,6 +17,14 @@ import {
 import * as botpress from '.botpress'
 
 export const handler: botpress.IntegrationProps['handler'] = async ({ req, ctx, client, logger }) => {
+  logger.forBot().debug('Handler received request from Slack with payload:', req.body)
+  if (req.path.startsWith('/oauth')) {
+    return onOAuth(req, client, ctx).catch((err) => {
+      logger.forBot().error('Error while processing OAuth', err.response?.data || err.message)
+      throw err
+    })
+  }
+
   const isOAuthConfigured = !!(await getOAuthAccessToken(client, ctx))
 
   if (isOAuthConfigured) {
@@ -28,14 +36,6 @@ export const handler: botpress.IntegrationProps['handler'] = async ({ req, ctx, 
     }
   } else {
     logger.forBot().debug('OAuth is not configured, skipping signature validation')
-  }
-
-  logger.forBot().debug('Handler received request from Slack with payload:', req.body)
-  if (req.path.startsWith('/oauth')) {
-    return onOAuth(req, client, ctx).catch((err) => {
-      logger.forBot().error('Error while processing OAuth', err.response?.data || err.message)
-      throw err
-    })
   }
 
   if (!req.body) {

--- a/integrations/slack/src/handler.ts
+++ b/integrations/slack/src/handler.ts
@@ -11,16 +11,23 @@ import {
   getUserAndConversation,
   getConfig,
   validateRequestSignature,
+  getOAuthAccessToken,
 } from './misc/utils'
 
 import * as botpress from '.botpress'
 
 export const handler: botpress.IntegrationProps['handler'] = async ({ req, ctx, client, logger }) => {
-  const isSignatureValid = validateRequestSignature({ req, logger })
+  const isOAuthConfigured = !!(await getOAuthAccessToken(client, ctx))
 
-  if (!isSignatureValid) {
-    logger.forBot().error('Handler received a request with an invalid signature')
-    return
+  if (isOAuthConfigured) {
+    const isSignatureValid = validateRequestSignature({ req, logger })
+
+    if (!isSignatureValid) {
+      logger.forBot().error('Handler received a request with an invalid signature')
+      return
+    }
+  } else {
+    logger.forBot().debug('OAuth is not configured, skipping signature validation')
   }
 
   logger.forBot().debug('Handler received request from Slack with payload:', req.body)

--- a/integrations/slack/src/handler.ts
+++ b/integrations/slack/src/handler.ts
@@ -10,11 +10,19 @@ import {
   respondInteractive,
   getUserAndConversation,
   getConfig,
+  validateRequestSignature,
 } from './misc/utils'
 
 import * as botpress from '.botpress'
 
 export const handler: botpress.IntegrationProps['handler'] = async ({ req, ctx, client, logger }) => {
+  const isSignatureValid = validateRequestSignature({ req, logger })
+
+  if (!isSignatureValid) {
+    logger.forBot().error('Handler received a request with an invalid signature')
+    return
+  }
+
   logger.forBot().debug('Handler received request from Slack with payload:', req.body)
   if (req.path.startsWith('/oauth')) {
     return onOAuth(req, client, ctx).catch((err) => {
@@ -28,10 +36,13 @@ export const handler: botpress.IntegrationProps['handler'] = async ({ req, ctx, 
     return
   }
 
+  const data = JSON.parse(req.body)
+
   const { botUserId } = await getConfig(client, ctx)
 
   if (isInteractiveRequest(req)) {
     const body = parseInteractiveBody(req)
+
     const actionValue = await respondInteractive(body)
 
     if (body.type !== 'block_actions') {
@@ -55,8 +66,6 @@ export const handler: botpress.IntegrationProps['handler'] = async ({ req, ctx, 
 
     return
   }
-
-  const data = JSON.parse(req.body)
 
   if (data.type === 'url_verification') {
     logger.forBot().debug('Handler received request of type url_verification')

--- a/integrations/slack/src/misc/utils.ts
+++ b/integrations/slack/src/misc/utils.ts
@@ -294,11 +294,7 @@ export const getSyncState = async (client: Client, ctx: IntegrationCtx): Promise
   return payload as SyncState
 }
 
-export const getAccessToken = async (client: Client, ctx: IntegrationCtx) => {
-  if (ctx.configuration.botToken) {
-    return ctx.configuration.botToken
-  }
-
+export const getOAuthAccessToken = async (client: Client, ctx: IntegrationCtx) => {
   const { state } = await client
     .getState({ type: 'integration', name: 'credentials', id: ctx.integrationId })
     .catch(() => ({
@@ -306,6 +302,14 @@ export const getAccessToken = async (client: Client, ctx: IntegrationCtx) => {
     }))
 
   return state.payload.accessToken
+}
+
+export const getAccessToken = async (client: Client, ctx: IntegrationCtx) => {
+  if (ctx.configuration.botToken) {
+    return ctx.configuration.botToken
+  }
+
+  return getOAuthAccessToken(client, ctx)
 }
 
 export const validateRequestSignature = ({ req, logger }: { req: Request; logger: IntegrationLogger }): boolean => {

--- a/integrations/slack/src/misc/utils.ts
+++ b/integrations/slack/src/misc/utils.ts
@@ -331,7 +331,7 @@ export const validateRequestSignature = ({ req, logger }: { req: Request; logger
     return false
   }
 
-  const sigBasestring = `v0:${timestamp}:${JSON.stringify(req.body)}`
+  const sigBasestring = `v0:${timestamp}:${req.body}`
   const mySignature = 'v0=' + crypto.createHmac('sha256', signingSecret).update(sigBasestring).digest('hex')
 
   try {

--- a/integrations/slack/src/misc/validateRequestSignature.test.ts
+++ b/integrations/slack/src/misc/validateRequestSignature.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { validateRequestSignature } from './utils'
 import * as crypto from 'crypto'
 
-const generateSlackSignature = (secret: string, timestamp: string, body: string) => {
+const generateSlackSignature = (secret: string, timestamp: string, body: any) => {
   const sigBasestring = `v0:${timestamp}:${body}`
   return 'v0=' + crypto.createHmac('sha256', secret).update(sigBasestring).digest('hex')
 }
@@ -19,7 +19,7 @@ describe('validateRequestSignature', () => {
   it('validates a legitimate Slack request', () => {
     const timestamp = Math.floor(Date.now() / 1000).toString()
     const body = {}
-    const signature = generateSlackSignature('valid-signing-secret', timestamp, JSON.stringify(body))
+    const signature = generateSlackSignature('valid-signing-secret', timestamp, body)
 
     const mockRequest = {
       headers: {
@@ -35,7 +35,7 @@ describe('validateRequestSignature', () => {
   it('invalidates a 6 min old legitimate Slack request', () => {
     const timestamp = (Math.floor(Date.now() / 1000) - 60 * 6).toString()
     const body = {}
-    const signature = generateSlackSignature('valid-signing-secret', timestamp, JSON.stringify(body))
+    const signature = generateSlackSignature('valid-signing-secret', timestamp, body)
 
     const mockRequest = {
       headers: {
@@ -51,7 +51,7 @@ describe('validateRequestSignature', () => {
   it('invalidates a request with an incorrect signature', () => {
     const timestamp = Math.floor(Date.now() / 1000).toString()
     const body = {}
-    const invalidSignature = generateSlackSignature('invalid-secret', timestamp, JSON.stringify(body))
+    const invalidSignature = generateSlackSignature('invalid-secret', timestamp, body)
 
     const mockRequest = {
       headers: {

--- a/integrations/slack/src/misc/validateRequestSignature.test.ts
+++ b/integrations/slack/src/misc/validateRequestSignature.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest'
+import { validateRequestSignature } from './utils'
+import * as crypto from 'crypto'
+
+const generateSlackSignature = (secret: string, timestamp: string, body: string) => {
+  const sigBasestring = `v0:${timestamp}:${body}`
+  return 'v0=' + crypto.createHmac('sha256', secret).update(sigBasestring).digest('hex')
+}
+
+const mockedLogger = { forBot: () => ({ error: console.error }) } as any
+
+vi.mock('.botpress', () => ({
+  secrets: {
+    SIGNING_SECRET: 'valid-signing-secret',
+  },
+}))
+
+describe('validateRequestSignature', () => {
+  it('validates a legitimate Slack request', () => {
+    const timestamp = Math.floor(Date.now() / 1000).toString()
+    const body = {}
+    const signature = generateSlackSignature('valid-signing-secret', timestamp, JSON.stringify(body))
+
+    const mockRequest = {
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': signature,
+      },
+      body,
+    }
+
+    expect(validateRequestSignature({ req: mockRequest as any, logger: mockedLogger })).toBe(true)
+  })
+
+  it('invalidates a 6 min old legitimate Slack request', () => {
+    const timestamp = (Math.floor(Date.now() / 1000) - 60 * 6).toString()
+    const body = {}
+    const signature = generateSlackSignature('valid-signing-secret', timestamp, JSON.stringify(body))
+
+    const mockRequest = {
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': signature,
+      },
+      body,
+    }
+
+    expect(validateRequestSignature({ req: mockRequest as any, logger: mockedLogger })).toBe(false)
+  })
+
+  it('invalidates a request with an incorrect signature', () => {
+    const timestamp = Math.floor(Date.now() / 1000).toString()
+    const body = {}
+    const invalidSignature = generateSlackSignature('invalid-secret', timestamp, JSON.stringify(body))
+
+    const mockRequest = {
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': invalidSignature,
+      },
+      body,
+    }
+
+    expect(validateRequestSignature({ req: mockRequest as any, logger: mockedLogger })).toBe(false)
+  })
+
+  it('with a signature of a different length', () => {
+    const timestamp = Math.floor(Date.now() / 1000).toString()
+    const body = {}
+
+    const mockRequest = {
+      headers: {
+        'x-slack-request-timestamp': timestamp,
+        'x-slack-signature': '90f4j8032j04392jf043fj9f4230j2f4',
+      },
+      body,
+    }
+
+    expect(validateRequestSignature({ req: mockRequest as any, logger: mockedLogger })).toBe(false)
+  })
+})


### PR DESCRIPTION
We want to ensure that the webhook requests have the right signature for OAuth authenticated Slack integrations.

[Implementation details](https://api.slack.com/authentication/verifying-requests-from-slack#making__validating-a-request)