### PR TITLE
feat(sdk): expose simple health check

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -48,7 +48,7 @@
     "zod": "^3.20.6"
   },
   "devDependencies": {
-    "@botpress/sdk": "0.5.5",
+    "@botpress/sdk": "0.5.6",
     "@bpinternal/log4bot": "^0.0.4",
     "@types/bluebird": "^3.5.38",
     "@types/json-schema": "^7.0.11",

--- a/packages/cli/templates/echo-bot/package.json
+++ b/packages/cli/templates/echo-bot/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "@botpress/client": "0.9.1",
-    "@botpress/sdk": "0.5.5",
+    "@botpress/sdk": "0.5.6",
     "zod": "^3.20.6"
   },
   "devDependencies": {

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "dependencies": {
     "@botpress/client": "0.9.1",
-    "@botpress/sdk": "0.5.5",
+    "@botpress/sdk": "0.5.6",
     "zod": "^3.20.6"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Botpress SDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/sdk/src/serve.ts
+++ b/packages/sdk/src/serve.ts
@@ -33,6 +33,10 @@ export async function serve(
   const server = createServer(async (req, res) => {
     try {
       const request = await mapIncomingMessageToRequest(req)
+      if (request.path === '/health') {
+        res.writeHead(200).end('ok')
+        return
+      }
       const response = await handler(request)
       res.writeHead(response?.status ?? 200, response?.headers ?? {}).end(response?.body ?? '{}')
     } catch (e: any) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1262,7 +1262,7 @@ importers:
         version: 3.21.4
     devDependencies:
       '@botpress/sdk':
-        specifier: 0.5.5
+        specifier: 0.5.6
         version: link:../sdk
       '@bpinternal/log4bot':
         specifier: ^0.0.4
@@ -1304,7 +1304,7 @@ importers:
         specifier: 0.9.1
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.5.5
+        specifier: 0.5.6
         version: link:../../../sdk
       zod:
         specifier: ^3.20.6
@@ -1326,7 +1326,7 @@ importers:
         specifier: 0.9.1
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.5.5
+        specifier: 0.5.6
         version: link:../../../sdk
       zod:
         specifier: ^3.20.6


### PR DESCRIPTION
usefull in a tilt environment to probe that an integration is running without formatting to whole request like:

```bash
curl -X POST -d "{}" \
  -H "x-bot-id: lol" \
  -H "x-bot-user-id: lol" \
  -H "x-integration-id: lol" \
  -H "x-webhook-id: lol" \
  -H "x-bp-configuration: e30=" \
  -H "x-bp-operation: ping" 
  http://localhost:8089/
```

instead you get:

```bash
curl http://localhost:8089/health
```