### PR TITLE
fix(slack): add some integration prefixed tags

### DIFF
--- a/integrations/slack/src/actions/start-dm.ts
+++ b/integrations/slack/src/actions/start-dm.ts
@@ -1,4 +1,5 @@
 import { WebClient } from '@slack/web-api'
+import { dmConversationIdTag, idTag, titleTag } from 'src/const'
 import { getAccessToken } from '../misc/utils'
 import type * as botpress from '.botpress'
 
@@ -42,6 +43,8 @@ export const startDmConversation: botpress.IntegrationProps['actions']['startDmC
     id: conversation.id,
     tags: {
       title: `DM with ${user.name}`,
+      [titleTag]: `DM with ${user.name}`,
+      [idTag]: channel.id,
     },
   } as any)
 
@@ -49,6 +52,8 @@ export const startDmConversation: botpress.IntegrationProps['actions']['startDmC
     id: user.id,
     tags: {
       dm_conversation_id: conversation.id,
+      [dmConversationIdTag]: conversation.id,
+      [idTag]: input.slackUserId,
     },
   })
 

--- a/integrations/slack/src/const.ts
+++ b/integrations/slack/src/const.ts
@@ -1,4 +1,8 @@
 export const INTEGRATION_NAME = 'slack'
 
+export const idTag = `${INTEGRATION_NAME}:id` as const
+export const titleTag = `${INTEGRATION_NAME}:title` as const
+export const tsTag = `${INTEGRATION_NAME}:ts` as const
 export const userIdTag = `${INTEGRATION_NAME}:userId` as const
 export const channelIdTag = `${INTEGRATION_NAME}:channelId` as const
+export const dmConversationIdTag = `${INTEGRATION_NAME}:dm_conversation_id` as const

--- a/integrations/slack/src/events/message-received.ts
+++ b/integrations/slack/src/events/message-received.ts
@@ -1,5 +1,5 @@
 import { GenericMessageEvent } from '@slack/bolt'
-import { channelIdTag, userIdTag } from 'src/const'
+import { channelIdTag, tsTag, userIdTag } from 'src/const'
 import { Client, IntegrationCtx, IntegrationLogger } from '../misc/types'
 import { getAccessToken, getSlackUserProfile, getUserAndConversation } from '../misc/utils'
 
@@ -42,7 +42,12 @@ export const executeMessageReceived = async ({
   }
 
   await client.createMessage({
-    tags: { ts: slackEvent.ts, [userIdTag]: slackEvent.user, [channelIdTag]: slackEvent.channel },
+    tags: {
+      ts: slackEvent.ts,
+      [tsTag]: slackEvent.ts,
+      [userIdTag]: slackEvent.user,
+      [channelIdTag]: slackEvent.channel,
+    },
     type: 'text',
     payload: {
       text: slackEvent.text!,


### PR DESCRIPTION
I can't update the `getOrCreate` operations since we would not find the existing users/conversations