### PR TITLE
feat(whatsapp): support for media messages

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -58,38 +58,7 @@ export default new IntegrationDefinition({
   },
   channels: {
     [channel]: {
-      messages: {
-        ...messages.defaults,
-        // whatsappImage: {
-        //   schema: z.object({
-        //     image: z.object({
-        //       id: z.string(),
-        //       mime_type: z.string(),
-        //       sha256: z.string(),
-        //     }),
-        //   }),
-        // },
-        // whatsappAudio: {
-        //   schema: z.object({
-        //     audio: z.object({
-        //       id: z.string(),
-        //       voice: z.boolean(),
-        //       mime_type: z.string(),
-        //       sha256: z.string(),
-        //     }),
-        //   }),
-        // },
-        // whatsappDocument: {
-        //   schema: z.object({
-        //     document: z.object({
-        //       id: z.string(),
-        //       filename: z.string(),
-        //       mime_type: z.string(),
-        //       sha256: z.string(),
-        //     }),
-        //   }),
-        // },
-      },
+      messages: messages.defaults,
       message: {
         tags: {
           id: {},

--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -60,35 +60,35 @@ export default new IntegrationDefinition({
     [channel]: {
       messages: {
         ...messages.defaults,
-        whatsappImage: {
-          schema: z.object({
-            image: z.object({
-              id: z.string(),
-              mime_type: z.string(),
-              sha256: z.string(),
-            }),
-          }),
-        },
-        whatsappAudio: {
-          schema: z.object({
-            audio: z.object({
-              id: z.string(),
-              voice: z.boolean(),
-              mime_type: z.string(),
-              sha256: z.string(),
-            }),
-          }),
-        },
-        whatsappDocument: {
-          schema: z.object({
-            document: z.object({
-              id: z.string(),
-              filename: z.string(),
-              mime_type: z.string(),
-              sha256: z.string(),
-            }),
-          }),
-        },
+        // whatsappImage: {
+        //   schema: z.object({
+        //     image: z.object({
+        //       id: z.string(),
+        //       mime_type: z.string(),
+        //       sha256: z.string(),
+        //     }),
+        //   }),
+        // },
+        // whatsappAudio: {
+        //   schema: z.object({
+        //     audio: z.object({
+        //       id: z.string(),
+        //       voice: z.boolean(),
+        //       mime_type: z.string(),
+        //       sha256: z.string(),
+        //     }),
+        //   }),
+        // },
+        // whatsappDocument: {
+        //   schema: z.object({
+        //     document: z.object({
+        //       id: z.string(),
+        //       filename: z.string(),
+        //       mime_type: z.string(),
+        //       sha256: z.string(),
+        //     }),
+        //   }),
+        // },
       },
       message: {
         tags: {

--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -58,7 +58,38 @@ export default new IntegrationDefinition({
   },
   channels: {
     [channel]: {
-      messages: messages.defaults,
+      messages: {
+        ...messages.defaults,
+        whatsappImage: {
+          schema: z.object({
+            image: z.object({
+              id: z.string(),
+              mime_type: z.string(),
+              sha256: z.string(),
+            }),
+          }),
+        },
+        whatsappAudio: {
+          schema: z.object({
+            audio: z.object({
+              id: z.string(),
+              voice: z.boolean(),
+              mime_type: z.string(),
+              sha256: z.string(),
+            }),
+          }),
+        },
+        whatsappDocument: {
+          schema: z.object({
+            document: z.object({
+              id: z.string(),
+              filename: z.string(),
+              mime_type: z.string(),
+              sha256: z.string(),
+            }),
+          }),
+        },
+      },
       message: {
         tags: {
           id: {},

--- a/integrations/whatsapp/src/incoming-message.ts
+++ b/integrations/whatsapp/src/incoming-message.ts
@@ -69,7 +69,7 @@ export async function handleIncomingMessage(
 
         await client.createMessage({
           tags: { id: message.id },
-          type: 'whatsappImage' as any, // Note: We cast this to avoid defining a custom message type which involves supporting it as an outgoing message as well.
+          type: 'whatsappImage' as any, // Note: We cast this to avoid defining a custom message type which would involve having to support it as an outgoing message as well.
           payload: {
             image: {
               id: message.image.id,

--- a/integrations/whatsapp/src/incoming-message.ts
+++ b/integrations/whatsapp/src/incoming-message.ts
@@ -69,7 +69,7 @@ export async function handleIncomingMessage(
 
         await client.createMessage({
           tags: { id: message.id },
-          type: 'whatsappImage',
+          type: 'whatsappImage' as any, // Note: We cast this to avoid defining a custom message type which involves supporting it as an outgoing message as well.
           payload: {
             image: {
               id: message.image.id,
@@ -85,7 +85,7 @@ export async function handleIncomingMessage(
 
         await client.createMessage({
           tags: { id: message.id },
-          type: 'whatsappAudio',
+          type: 'whatsappAudio' as any,
           payload: {
             audio: {
               id: message.audio.id,
@@ -102,7 +102,7 @@ export async function handleIncomingMessage(
 
         await client.createMessage({
           tags: { id: message.id },
-          type: 'whatsappDocument',
+          type: 'whatsappDocument' as any,
           payload: {
             document: {
               id: message.document.id,

--- a/integrations/whatsapp/src/incoming-message.ts
+++ b/integrations/whatsapp/src/incoming-message.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import { IntegrationLogger } from 'src'
 import { WhatsAppMessage, WhatsAppValue } from './whatsapp-types'
 import * as bp from '.botpress'
@@ -59,6 +60,56 @@ export async function handleIncomingMessage(
             longitude: Number(message.location.longitude),
             address: message.location.address,
             title: message.location.name,
+          },
+          userId: user.id,
+          conversationId: conversation.id,
+        })
+      } else if (message.image) {
+        logger.forBot().debug('Received image message from Whatsapp:', message.button)
+
+        await client.createMessage({
+          tags: { id: message.id },
+          type: 'whatsappImage',
+          payload: {
+            image: {
+              id: message.image.id,
+              mime_type: message.image.mime_type,
+              sha256: message.image.sha256,
+            },
+          },
+          userId: user.id,
+          conversationId: conversation.id,
+        })
+      } else if (message.audio) {
+        logger.forBot().debug('Received audio message from Whatsapp:', message.button)
+
+        await client.createMessage({
+          tags: { id: message.id },
+          type: 'whatsappAudio',
+          payload: {
+            audio: {
+              id: message.audio.id,
+              voice: message.audio.voice,
+              mime_type: message.audio.mime_type,
+              sha256: message.audio.sha256,
+            },
+          },
+          userId: user.id,
+          conversationId: conversation.id,
+        })
+      } else if (message.document) {
+        logger.forBot().debug('Received document message from Whatsapp:', message.button)
+
+        await client.createMessage({
+          tags: { id: message.id },
+          type: 'whatsappDocument',
+          payload: {
+            document: {
+              id: message.document.id,
+              filename: message.document.filename,
+              mime_type: message.document.mime_type,
+              sha256: message.document.sha256,
+            },
           },
           userId: user.id,
           conversationId: conversation.id,


### PR DESCRIPTION
## Origin

https://discord.com/channels/1108396290624213082/1113036358957666324/1191359176807551006

## Proposal

Until we have a public file storage API and we natively support media messages in all integrations we can provide significant value for users building Whatsapp bots (the most popular integration after webchat) by providing them the raw Whatsapp media object so they can manually fetch it in their bot using the Whatsapp API.

## Precedent

We already do this for WhatsApp location messages [here](https://github.com/botpress/botpress/blob/master/integrations/whatsapp/src/incoming-message.ts#L51). The only difference in this PR is that we use a custom message type to provide the raw media object rather than changing the SDK's general image/audio message types to support this.