### PR TITLE
feat(whatsapp): provide media URL in payload when a media message is received

### DIFF
--- a/integrations/whatsapp/src/incoming-message.ts
+++ b/integrations/whatsapp/src/incoming-message.ts
@@ -102,7 +102,6 @@ export async function handleIncomingMessage(
             document: {
               documentUrl,
               filename: message.document.filename,
-              mime_type: message.document.mime_type,
             },
           },
           userId: user.id,

--- a/integrations/whatsapp/src/incoming-message.ts
+++ b/integrations/whatsapp/src/incoming-message.ts
@@ -1,11 +1,13 @@
 /* eslint-disable max-lines-per-function */
-import { IntegrationLogger } from 'src'
+import { IntegrationCtx, IntegrationLogger } from 'src'
+import { getWhatsAppMediaUrl } from './util'
 import { WhatsAppMessage, WhatsAppValue } from './whatsapp-types'
 import * as bp from '.botpress'
 
 export async function handleIncomingMessage(
   message: WhatsAppMessage,
   value: WhatsAppValue,
+  ctx: IntegrationCtx,
   client: bp.Client,
   logger: IntegrationLogger
 ) {
@@ -67,48 +69,40 @@ export async function handleIncomingMessage(
       } else if (message.image) {
         logger.forBot().debug('Received image message from Whatsapp:', message.button)
 
+        const imageUrl = await getWhatsAppMediaUrl(message.image.id, ctx)
+
         await client.createMessage({
           tags: { id: message.id },
-          type: 'whatsappImage' as any, // Note: We cast this to avoid defining a custom message type which would involve having to support it as an outgoing message as well.
-          payload: {
-            image: {
-              id: message.image.id,
-              mime_type: message.image.mime_type,
-              sha256: message.image.sha256,
-            },
-          },
+          type: 'image',
+          payload: { imageUrl },
           userId: user.id,
           conversationId: conversation.id,
         })
       } else if (message.audio) {
         logger.forBot().debug('Received audio message from Whatsapp:', message.button)
 
+        const audioUrl = await getWhatsAppMediaUrl(message.audio.id, ctx)
+
         await client.createMessage({
           tags: { id: message.id },
-          type: 'whatsappAudio' as any,
-          payload: {
-            audio: {
-              id: message.audio.id,
-              voice: message.audio.voice,
-              mime_type: message.audio.mime_type,
-              sha256: message.audio.sha256,
-            },
-          },
+          type: 'audio',
+          payload: { audioUrl },
           userId: user.id,
           conversationId: conversation.id,
         })
       } else if (message.document) {
         logger.forBot().debug('Received document message from Whatsapp:', message.button)
 
+        const documentUrl = await getWhatsAppMediaUrl(message.document.id, ctx)
+
         await client.createMessage({
           tags: { id: message.id },
-          type: 'whatsappDocument' as any,
+          type: 'document' as any, // Note: We cast this to avoid defining a custom message type which would involve having to support it as an outgoing message as well.
           payload: {
             document: {
-              id: message.document.id,
+              documentUrl,
               filename: message.document.filename,
               mime_type: message.document.mime_type,
-              sha256: message.document.sha256,
             },
           },
           userId: user.id,

--- a/integrations/whatsapp/src/index.ts
+++ b/integrations/whatsapp/src/index.ts
@@ -1,3 +1,4 @@
+import { IntegrationContext } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { channel } from 'integration.definition'
 import queryString from 'query-string'
@@ -11,8 +12,10 @@ import * as dropdown from './message-types/dropdown'
 import * as outgoing from './outgoing-message'
 import { WhatsAppPayload } from './whatsapp-types'
 import * as bp from '.botpress'
+import { Configuration } from '.botpress/implementation/configuration'
 
 export type IntegrationLogger = Parameters<bp.IntegrationProps['handler']>[0]['logger']
+export type IntegrationCtx = IntegrationContext<Configuration>
 
 const { Text, Media, Location } = Types
 
@@ -181,7 +184,7 @@ const integration = new bp.Integration({
 
             await whatsapp.markAsRead(phoneNumberId, message.id)
 
-            await handleIncomingMessage(message, change.value, client, logger)
+            await handleIncomingMessage(message, change.value, ctx, client, logger)
           }
         }
       }

--- a/integrations/whatsapp/src/util.ts
+++ b/integrations/whatsapp/src/util.ts
@@ -1,3 +1,6 @@
+import { IntegrationCtx } from 'src'
+import { WhatsAppAPI } from 'whatsapp-api-js'
+
 export class UnreachableCaseError extends Error {
   constructor(val: never) {
     super(`Unreachable case: ${val}`)
@@ -27,4 +30,10 @@ export function truncate(input: string, maxLength: number) {
     truncated = truncated.substring(0, maxLength - 1) + '…'
   }
   return truncated
+}
+
+export async function getWhatsAppMediaUrl(whatsappMediaId: string, ctx: IntegrationCtx): Promise<string> {
+  const whatsapp = new WhatsAppAPI(ctx.configuration.accessToken)
+  const media = await whatsapp.retrieveMedia(whatsappMediaId)
+  return media.url
 }


### PR DESCRIPTION
This is an improvement of https://github.com/botpress/botpress/pull/12944

User still has to retrieve the media from the URL passing their access token in the `Authorization` header as [documented here](https://developers.facebook.com/docs/whatsapp/cloud-api/reference/media/#download-media) but this change will allow us to reuse the existing `image` and `audio` messages types in the SDK, provide a simpler payload, and save the user the step of fetching the URL.

Closes CLS-1539