### PR TITLE
fix(webchat): allow no text in choices

### DIFF
--- a/integrations/webchat/src/definitions/channels.ts
+++ b/integrations/webchat/src/definitions/channels.ts
@@ -6,8 +6,18 @@ const cardSchema = messages.defaults.card.schema.extend({
   imageUrl: z.string().optional(),
 })
 
+const choiceSchema = messages.defaults.choice.schema.extend({
+  text: z.string().optional(),
+})
+
+const dropdownSchema = messages.defaults.dropdown.schema.extend({
+  text: z.string().optional(),
+})
+
 const defaults = {
   ...messages.defaults,
+  choice: { schema: choiceSchema },
+  dropdown: { schema: dropdownSchema },
   carousel: { schema: z.object({ items: z.array(cardSchema) }) },
   card: { schema: cardSchema },
 } as const

--- a/integrations/webchat/src/definitions/channels.ts
+++ b/integrations/webchat/src/definitions/channels.ts
@@ -7,11 +7,11 @@ const cardSchema = messages.defaults.card.schema.extend({
 })
 
 const choiceSchema = messages.defaults.choice.schema.extend({
-  text: z.string().optional(),
+  text: z.string().min(0).optional(),
 })
 
 const dropdownSchema = messages.defaults.dropdown.schema.extend({
-  text: z.string().optional(),
+  text: z.string().min(0).optional(),
 })
 
 const defaults = {

--- a/integrations/webchat/src/misc/messaging/content-types.ts
+++ b/integrations/webchat/src/misc/messaging/content-types.ts
@@ -29,7 +29,7 @@ export const locationSchema = baseSchema.extend({
 })
 
 export const dropdownSchema = baseSchema.extend({
-  message: z.string(),
+  message: z.string().optional(),
   options: z.array(z.object({ label: z.string(), value: z.string() })),
   allowCreation: z.boolean().optional(),
   placeholderText: z.string().optional(),
@@ -41,7 +41,7 @@ export const dropdownSchema = baseSchema.extend({
 })
 
 export const singleChoiceSchema = baseSchema.extend({
-  text: z.string(),
+  text: z.string().optional(),
   disableFreeText: z.boolean().optional(),
   choices: z.array(z.object({ title: z.string(), value: z.string() })),
 })

--- a/packages/sdk/src/message.ts
+++ b/packages/sdk/src/message.ts
@@ -48,7 +48,7 @@ const cardSchema = z.object({
 })
 
 const choiceSchema = z.object({
-  text: NonEmptyString,
+  text: z.string().optional(),
   options: z.array(
     z.object({
       label: NonEmptyString,

--- a/packages/sdk/src/message.ts
+++ b/packages/sdk/src/message.ts
@@ -48,7 +48,7 @@ const cardSchema = z.object({
 })
 
 const choiceSchema = z.object({
-  text: z.string().optional(),
+  text: NonEmptyString,
   options: z.array(
     z.object({
       label: NonEmptyString,


### PR DESCRIPTION
It's OK to send choices without a text – frequently reported by the community as a bug