### PR TITLE
chore(whatsapp): upgrade Whatsapp API JS dependency to v1.0.5

### DIFF
--- a/integrations/whatsapp/package.json
+++ b/integrations/whatsapp/package.json
@@ -18,7 +18,7 @@
     "@botpress/sdk": "workspace:*",
     "@botpress/sdk-addons": "workspace:*",
     "query-string": "^6.14.1",
-    "whatsapp-api-js": "^0.8.2",
+    "whatsapp-api-js": "^1.0.5",
     "zod": "^3.20.6"
   },
   "devDependencies": {

--- a/integrations/whatsapp/src/const.ts
+++ b/integrations/whatsapp/src/const.ts
@@ -1,4 +1,4 @@
-export const INTEGRATION_NAME = 'whatsapp'
+export const INTEGRATION_NAME = 'whatsappabe'
 
 export const PhoneNumberIdTag = 'phoneNumberId'
 export const UserPhoneTag = 'userPhone'

--- a/integrations/whatsapp/src/const.ts
+++ b/integrations/whatsapp/src/const.ts
@@ -1,4 +1,4 @@
-export const INTEGRATION_NAME = 'whatsappabe'
+export const INTEGRATION_NAME = 'whatsapp'
 
 export const PhoneNumberIdTag = 'phoneNumberId'
 export const UserPhoneTag = 'userPhone'

--- a/integrations/whatsapp/src/conversation.ts
+++ b/integrations/whatsapp/src/conversation.ts
@@ -94,12 +94,12 @@ export async function startConversation(
 
   const language = new Language(templateLanguage)
 
-  const bodyParams = templateVariables.map((variable) => ({
+  const bodyParams: BodyParameter[] = templateVariables.map((variable) => ({
     type: 'text',
     text: variable.toString(),
-  })) as AtLeastOne<BodyParameter>
+  }))
 
-  const body = new BodyComponent(...bodyParams)
+  const body = new BodyComponent(...(bodyParams as AtLeastOne<BodyParameter>))
 
   const template = new Template(templateName, language, body)
 

--- a/integrations/whatsapp/src/conversation.ts
+++ b/integrations/whatsapp/src/conversation.ts
@@ -1,8 +1,10 @@
 import { Conversation, RuntimeError } from '@botpress/client'
-import { IntegrationContext } from '@botpress/sdk'
-import { WhatsAppAPI, Types } from 'whatsapp-api-js'
+import WhatsAppAPI from 'whatsapp-api-js'
+import { AtLeastOne } from 'whatsapp-api-js/lib/types/utils'
+import { BodyComponent, BodyParameter, Language, Template } from 'whatsapp-api-js/messages'
+import { ServerErrorResponse, ServerMessageResponse } from 'whatsapp-api-js/types'
 import z from 'zod'
-import { IntegrationLogger } from '.'
+import { IntegrationCtx, IntegrationLogger } from '.'
 import {
   PhoneNumberIdTag,
   UserPhoneTag,
@@ -14,10 +16,6 @@ import {
 } from './const'
 import * as botpress from '.botpress'
 import { Channels } from '.botpress/implementation/channels'
-
-const {
-  Template: { Template, Language },
-} = Types
 
 const TemplateVariablesSchema = z.array(z.string().or(z.number()))
 
@@ -32,8 +30,7 @@ export async function startConversation(
   },
   dependencies: {
     client: botpress.Client
-
-    ctx: IntegrationContext
+    ctx: IntegrationCtx
     logger: IntegrationLogger
   }
 ): Promise<Pick<Conversation, 'id'>> {
@@ -93,24 +90,26 @@ export async function startConversation(
     },
   })
 
-  const whatsapp = new WhatsAppAPI(ctx.configuration.accessToken)
+  const whatsapp = new WhatsAppAPI({ token: ctx.configuration.accessToken, secure: false })
 
   const language = new Language(templateLanguage)
 
-  const template = new Template(templateName, language, {
-    type: 'body',
-    parameters: templateVariables.map((variable) => ({
-      type: 'text',
-      text: variable,
-    })),
-  })
+  const bodyParams = templateVariables.map((variable) => ({
+    type: 'text',
+    text: variable.toString(),
+  })) as AtLeastOne<BodyParameter>
 
-  const response = await whatsapp.sendMessage(phoneNumberId, userPhone, template)
+  const body = new BodyComponent(...bodyParams)
 
-  if (response?.error) {
+  const template = new Template(templateName, language, body)
+
+  const response = (await whatsapp.sendMessage(phoneNumberId, userPhone, template)) as ServerMessageResponse
+  const errorResponse = response as ServerErrorResponse
+
+  if (errorResponse?.error) {
     logForBotAndThrow(
       `Failed to start Whatsapp conversation using template "${templateName}" and language "${templateLanguage}" - Error: ${JSON.stringify(
-        response.error
+        errorResponse?.error
       )}`,
       logger
     )

--- a/integrations/whatsapp/src/index.ts
+++ b/integrations/whatsapp/src/index.ts
@@ -2,7 +2,8 @@ import { IntegrationContext } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { channel } from 'integration.definition'
 import queryString from 'query-string'
-import { WhatsAppAPI, Types } from 'whatsapp-api-js'
+import WhatsAppAPI from 'whatsapp-api-js'
+import { Audio, Document, Image, Location, Text, Video } from 'whatsapp-api-js/messages'
 import { createConversationHandler as createConversation, startConversation } from './conversation'
 import { handleIncomingMessage } from './incoming-message'
 import * as card from './message-types/card'
@@ -16,8 +17,6 @@ import { Configuration } from '.botpress/implementation/configuration'
 
 export type IntegrationLogger = Parameters<bp.IntegrationProps['handler']>[0]['logger']
 export type IntegrationCtx = IntegrationContext<Configuration>
-
-const { Text, Media, Location } = Types
 
 const integration = new bp.Integration({
   register: async () => {},
@@ -51,7 +50,7 @@ const integration = new bp.Integration({
         image: async ({ payload, ...props }) => {
           await outgoing.send({
             ...props,
-            message: new Media.Image(payload.imageUrl, false),
+            message: new Image(payload.imageUrl, false),
           })
         },
         markdown: async ({ payload, ...props }) => {
@@ -63,13 +62,13 @@ const integration = new bp.Integration({
         audio: async ({ payload, ...props }) => {
           await outgoing.send({
             ...props,
-            message: new Media.Audio(payload.audioUrl, false),
+            message: new Audio(payload.audioUrl, false),
           })
         },
         video: async ({ payload, ...props }) => {
           await outgoing.send({
             ...props,
-            message: new Media.Video(payload.videoUrl, false),
+            message: new Video(payload.videoUrl, false),
           })
         },
         file: async ({ payload, ...props }) => {
@@ -78,7 +77,7 @@ const integration = new bp.Integration({
 
           await outgoing.send({
             ...props,
-            message: new Media.Document(payload.fileUrl, false, payload.title, filename),
+            message: new Document(payload.fileUrl, false, payload.title, filename),
           })
         },
         location: async ({ payload, ...props }) => {
@@ -178,7 +177,7 @@ const integration = new bp.Integration({
 
           for (const message of change.value.messages) {
             const accessToken = ctx.configuration.accessToken
-            const whatsapp = new WhatsAppAPI(accessToken)
+            const whatsapp = new WhatsAppAPI({ token: accessToken, secure: false })
 
             const phoneNumberId = change.value.metadata.phone_number_id
 

--- a/integrations/whatsapp/src/interactive/body.ts
+++ b/integrations/whatsapp/src/interactive/body.ts
@@ -1,6 +1,4 @@
-import { Types } from 'whatsapp-api-js'
-
-const { Body } = Types.Interactive
+import { Body } from 'whatsapp-api-js/messages'
 
 const MAX_LENGTH = 1024
 

--- a/integrations/whatsapp/src/interactive/button.ts
+++ b/integrations/whatsapp/src/interactive/button.ts
@@ -1,8 +1,8 @@
-import { Types } from 'whatsapp-api-js'
+import { Button } from 'whatsapp-api-js/messages'
 
 const ID_MAX_LENGTH = 256
 const TITLE_MAX_LENGTH = 20
 
 export function create({ id, title }: { id: string; title: string }) {
-  return new Types.Interactive.Button(id.substring(0, ID_MAX_LENGTH), title.substring(0, TITLE_MAX_LENGTH))
+  return new Button(id.substring(0, ID_MAX_LENGTH), title.substring(0, TITLE_MAX_LENGTH))
 }

--- a/integrations/whatsapp/src/interactive/footer.ts
+++ b/integrations/whatsapp/src/interactive/footer.ts
@@ -1,6 +1,4 @@
-import { Types } from 'whatsapp-api-js'
-
-const { Footer } = Types.Interactive
+import { Footer } from 'whatsapp-api-js/messages'
 
 const MAX_LENGTH = 60
 

--- a/integrations/whatsapp/src/message-types/card.ts
+++ b/integrations/whatsapp/src/message-types/card.ts
@@ -90,9 +90,9 @@ function isNotActionUrl(action: Action): action is ActionSay | ActionPostback {
 function* generateInteractiveMessages(card: Card, nonURLActions: Action[]) {
   const [firstChunk, ...followingChunks] = chunkArray(nonURLActions, INTERACTIVE_MAX_BUTTONS_COUNT)
   if (firstChunk) {
-    const buttons = createButtons(firstChunk) as AtLeastOne<Button>
+    const buttons: Button[] = createButtons(firstChunk)
     yield new Interactive(
-      new ActionButtons(...buttons),
+      new ActionButtons(...(buttons as AtLeastOne<Button>)),
       body.create(card.title),
       card.imageUrl ? new Header(new Image(card.imageUrl, false)) : undefined,
       card.subtitle ? footer.create(card.subtitle) : undefined
@@ -101,8 +101,8 @@ function* generateInteractiveMessages(card: Card, nonURLActions: Action[]) {
 
   if (followingChunks) {
     for (const chunk of followingChunks) {
-      const buttons = createButtons(chunk) as AtLeastOne<Button>
-      yield new Interactive(new ActionButtons(...buttons), body.create(card.title))
+      const buttons: Button[] = createButtons(chunk)
+      yield new Interactive(new ActionButtons(...(buttons as AtLeastOne<Button>)), body.create(card.title))
     }
   }
 }

--- a/integrations/whatsapp/src/message-types/card.ts
+++ b/integrations/whatsapp/src/message-types/card.ts
@@ -1,5 +1,5 @@
-import { Types } from 'whatsapp-api-js'
-import type { Button } from 'whatsapp-api-js/types/messages/interactive'
+import { AtLeastOne } from 'whatsapp-api-js/lib/types/utils'
+import { Text, Interactive, ActionButtons, Header, Image, Button } from 'whatsapp-api-js/messages'
 import * as body from '../interactive/body'
 import * as button from '../interactive/button'
 import * as footer from '../interactive/footer'
@@ -14,10 +14,6 @@ type ActionSay = SDKAction & { action: 'say' }
 type ActionPostback = SDKAction & { action: 'postback' }
 
 type Action = ActionSay | ActionURL | ActionPostback
-type NonUrlAction = ActionPostback | ActionSay
-
-const { Text, Media } = Types
-const { ActionButtons, Interactive, Header } = Types.Interactive
 
 const POSTBACK_PREFIX = 'p:'
 const SAY_PREFIX = 's:'
@@ -73,7 +69,7 @@ export function* generateOutgoingMessages(card: Card) {
 
 function* generateHeader(card: Card) {
   if (card.imageUrl) {
-    yield new Media.Image(card.imageUrl, false, card.title)
+    yield new Image(card.imageUrl, false, card.title)
   } else {
     yield new Text(card.title)
   }
@@ -91,25 +87,27 @@ function isNotActionUrl(action: Action): action is ActionSay | ActionPostback {
   return !isActionURL(action)
 }
 
-function* generateInteractiveMessages(card: Card, nonURLActions: NonUrlAction[]) {
+function* generateInteractiveMessages(card: Card, nonURLActions: Action[]) {
   const [firstChunk, ...followingChunks] = chunkArray(nonURLActions, INTERACTIVE_MAX_BUTTONS_COUNT)
   if (firstChunk) {
+    const buttons = createButtons(firstChunk) as AtLeastOne<Button>
     yield new Interactive(
-      new ActionButtons(...createButtons(firstChunk)),
+      new ActionButtons(...buttons),
       body.create(card.title),
-      card.imageUrl ? new Header(new Media.Image(card.imageUrl, false)) : undefined,
+      card.imageUrl ? new Header(new Image(card.imageUrl, false)) : undefined,
       card.subtitle ? footer.create(card.subtitle) : undefined
     )
   }
 
   if (followingChunks) {
     for (const chunk of followingChunks) {
-      yield new Interactive(new ActionButtons(...createButtons(chunk)), body.create(card.title), undefined, undefined)
+      const buttons = createButtons(chunk) as AtLeastOne<Button>
+      yield new Interactive(new ActionButtons(...buttons), body.create(card.title))
     }
   }
 }
 
-function createButtons(nonURLActions: NonUrlAction[]) {
+function createButtons(nonURLActions: Action[]) {
   const buttons: Button[] = []
   for (const action of nonURLActions) {
     switch (action.action) {
@@ -119,6 +117,9 @@ function createButtons(nonURLActions: NonUrlAction[]) {
       case 'say':
         buttons.push(button.create({ id: `${SAY_PREFIX}${action.value}`, title: action.label }))
         break
+      case 'url':
+        // TODO implement support for URL actions
+        throw new Error('URL actions not implemented yet')
       default:
         throw new UnreachableCaseError(action)
     }

--- a/integrations/whatsapp/src/message-types/choice.ts
+++ b/integrations/whatsapp/src/message-types/choice.ts
@@ -33,8 +33,8 @@ export function* generateOutgoingMessages({
     }
 
     for (const chunk of chunks) {
-      const buttons = chunk.map(createButton) as AtLeastOne<Button>
-      yield new Interactive(new ActionButtons(...buttons), body.create(text))
+      const buttons: Button[] = chunk.map(createButton)
+      yield new Interactive(new ActionButtons(...(buttons as AtLeastOne<Button>)), body.create(text))
     }
   }
 }

--- a/integrations/whatsapp/src/message-types/choice.ts
+++ b/integrations/whatsapp/src/message-types/choice.ts
@@ -1,12 +1,10 @@
-import { Types } from 'whatsapp-api-js'
+import { AtLeastOne } from 'whatsapp-api-js/lib/types/utils'
+import { Text, Interactive, ActionButtons, Button } from 'whatsapp-api-js/messages'
 import { IntegrationLogger } from '..'
 import * as body from '../interactive/body'
 import * as button from '../interactive/button'
 import { chunkArray, truncate } from '../util'
 import type { channels } from '.botpress'
-
-const { Text } = Types
-const { Interactive, ActionButtons } = Types.Interactive
 
 type Choice = channels.channel.choice.Choice
 type Option = Choice['options'][number]
@@ -35,7 +33,8 @@ export function* generateOutgoingMessages({
     }
 
     for (const chunk of chunks) {
-      yield new Interactive(new ActionButtons(...chunk.map(createButton)), body.create(text))
+      const buttons = chunk.map(createButton) as AtLeastOne<Button>
+      yield new Interactive(new ActionButtons(...buttons), body.create(text))
     }
   }
 }

--- a/integrations/whatsapp/src/message-types/dropdown.ts
+++ b/integrations/whatsapp/src/message-types/dropdown.ts
@@ -31,12 +31,12 @@ export function* generateOutgoingMessages({
     }
 
     for (const chunk of chunks) {
-      const rows = chunk.map(
+      const rows: Row[] = chunk.map(
         (o) => new Row(o.value.substring(0, 200), truncate(o.label, ACTION_LABEL_MAX_LENGTH), ' ')
-      ) as AtLeastOne<Row>
+      )
       const section = new ListSection(
         truncate(text, ACTION_LABEL_MAX_LENGTH),
-        ...rows // NOTE: The description parameter is optional as per Whatsapp's documentation, but they have a bug that actually enforces the description to be a non-empty string.
+        ...(rows as AtLeastOne<Row>) // NOTE: The description parameter is optional as per Whatsapp's documentation, but they have a bug that actually enforces the description to be a non-empty string.
       )
       const actionList = new ActionList('Choose...', section)
 

--- a/integrations/whatsapp/src/message-types/dropdown.ts
+++ b/integrations/whatsapp/src/message-types/dropdown.ts
@@ -1,11 +1,9 @@
-import { Types } from 'whatsapp-api-js'
+import { AtLeastOne } from 'whatsapp-api-js/lib/types/utils'
+import { Text, Interactive, ActionList, ListSection, Row } from 'whatsapp-api-js/messages'
 import { IntegrationLogger } from '..'
 import * as body from '../interactive/body'
 import { chunkArray, truncate } from '../util'
 import type { channels } from '.botpress'
-
-const { Text } = Types
-const { Interactive, ActionList, ListSection, Row } = Types.Interactive
 
 type Dropdown = channels.channel.dropdown.Dropdown
 
@@ -33,9 +31,12 @@ export function* generateOutgoingMessages({
     }
 
     for (const chunk of chunks) {
+      const rows = chunk.map(
+        (o) => new Row(o.value.substring(0, 200), truncate(o.label, ACTION_LABEL_MAX_LENGTH), ' ')
+      ) as AtLeastOne<Row>
       const section = new ListSection(
         truncate(text, ACTION_LABEL_MAX_LENGTH),
-        ...chunk.map((o) => new Row(o.value.substring(0, 200), truncate(o.label, ACTION_LABEL_MAX_LENGTH), ' ')) // NOTE: The description parameter is optional as per Whatsapp's documentation, but they have a bug that actually enforces the description to be a non-empty string.
+        ...rows // NOTE: The description parameter is optional as per Whatsapp's documentation, but they have a bug that actually enforces the description to be a non-empty string.
       )
       const actionList = new ActionList('Choose...', section)
 

--- a/integrations/whatsapp/src/util.ts
+++ b/integrations/whatsapp/src/util.ts
@@ -1,5 +1,6 @@
 import { IntegrationCtx } from 'src'
-import { WhatsAppAPI } from 'whatsapp-api-js'
+import WhatsAppAPI from 'whatsapp-api-js'
+import { ServerErrorResponse, ServerMediaRetrieveResponse } from 'whatsapp-api-js/types'
 
 export class UnreachableCaseError extends Error {
   constructor(val: never) {
@@ -33,7 +34,7 @@ export function truncate(input: string, maxLength: number) {
 }
 
 export async function getWhatsAppMediaUrl(whatsappMediaId: string, ctx: IntegrationCtx): Promise<string> {
-  const whatsapp = new WhatsAppAPI(ctx.configuration.accessToken)
+  const whatsapp = new WhatsAppAPI({ token: ctx.configuration.accessToken, secure: false })
   const media = await whatsapp.retrieveMedia(whatsappMediaId)
-  return media.url
+  return (media as Exclude<ServerMediaRetrieveResponse, ServerErrorResponse>).url
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1166,8 +1166,8 @@ importers:
         specifier: ^6.14.1
         version: 6.14.1
       whatsapp-api-js:
-        specifier: ^0.8.2
-        version: 0.8.2
+        specifier: ^1.0.5
+        version: 1.0.5
       zod:
         specifier: ^3.20.6
         version: 3.20.6
@@ -4873,6 +4873,7 @@ packages:
     engines: {node: '>=10.16.0'}
     dependencies:
       streamsearch: 1.1.0
+    dev: true
 
   /bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -9910,6 +9911,7 @@ packages:
   /streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+    dev: true
 
   /strict-uri-encode@2.0.0:
     resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
@@ -10604,6 +10606,7 @@ packages:
     engines: {node: '>=14.0'}
     dependencies:
       busboy: 1.6.0
+    dev: true
 
   /unfetch@4.2.0:
     resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
@@ -10990,11 +10993,9 @@ packages:
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
-  /whatsapp-api-js@0.8.2:
-    resolution: {integrity: sha512-n/Wt7VO7D+8InLchNmQ6LmqFC6kLnyRgu6Slo8v0kVt3JgvnZsPrp178OpsxVn50jFECxasKqEaZXBF/SIN36g==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      undici: 5.22.1
+  /whatsapp-api-js@1.0.5:
+    resolution: {integrity: sha512-cuxRRf1pi/ztICjpqw52yHycpoaLF2M74+2A8YMq1lDyuNsy0+4tIXNxoxDMJZxCBkSV8sDMsPK4F7oHjPFYzw==}
+    engines: {node: '>14.21'}
     dev: false
 
   /whatwg-url@5.0.0:


### PR DESCRIPTION
This dependency needs to be upgraded in order to support URL actions on cards. That feature will come in a follow-up PR.

The latest version of this dependency is 2.x but it's less risky to do it in 2 steps and first upgrade to 1.x. We'll test this upgrade first and the 2.x upgrade can be done after this upgrade has been stable for several days (already tested in staging with a Whatsapp test bot I made).