### PR TITLE
feat(linear): custom bot name & add tags

### DIFF
--- a/integrations/linear/src/actions/create-issue.ts
+++ b/integrations/linear/src/actions/create-issue.ts
@@ -1,4 +1,4 @@
-import { getLinearClient, getTeam } from '../misc/utils'
+import { getIssueTags, getLinearClient, getTeam } from '../misc/utils'
 import { getIssueFields } from './get-issue'
 import { IntegrationProps } from '.botpress'
 
@@ -25,6 +25,8 @@ export const createIssue: IntegrationProps['actions']['createIssue'] = async ({
     teamId: team.id,
     labelIds,
     projectId,
+    createAsUser: ctx.configuration.botName,
+    displayIconUrl: ctx.configuration.botAvatarUrl,
   })
 
   const fullIssue = await issueFetch
@@ -33,12 +35,11 @@ export const createIssue: IntegrationProps['actions']['createIssue'] = async ({
   }
 
   const issue = getIssueFields(fullIssue)
+  const issueTags = await getIssueTags(fullIssue)
 
   await client.getOrCreateConversation({
     channel: 'issue',
-    tags: {
-      id: fullIssue.id,
-    },
+    tags: issueTags,
   })
 
   return {

--- a/integrations/linear/src/actions/create-issue.ts
+++ b/integrations/linear/src/actions/create-issue.ts
@@ -25,8 +25,8 @@ export const createIssue: IntegrationProps['actions']['createIssue'] = async ({
     teamId: team.id,
     labelIds,
     projectId,
-    createAsUser: ctx.configuration.botName,
-    displayIconUrl: ctx.configuration.botAvatarUrl,
+    createAsUser: ctx.configuration.displayName,
+    displayIconUrl: ctx.configuration.avatarUrl,
   })
 
   const fullIssue = await issueFetch

--- a/integrations/linear/src/const.ts
+++ b/integrations/linear/src/const.ts
@@ -1,3 +1,4 @@
 export const INTEGRATION_NAME = 'linear'
 
 export const idTag = `${INTEGRATION_NAME}:id` as const
+export const urlTag = `${INTEGRATION_NAME}:url` as const

--- a/integrations/linear/src/definitions/index.ts
+++ b/integrations/linear/src/definitions/index.ts
@@ -11,8 +11,8 @@ export const configuration = {
     linkTemplateScript: 'linkTemplate.vrl',
   },
   schema: z.object({
-    displayName: z.string().optional().describe('Name used when sending messages'),
-    avatarUrl: z.string().optional().describe('URL of the bot avatar'),
+    displayName: z.string().optional().describe('The name displayed in message transmissions'),
+    avatarUrl: z.string().optional().describe('The web address for the profile picture'),
   }),
 } satisfies IntegrationDefinitionProps['configuration']
 

--- a/integrations/linear/src/definitions/index.ts
+++ b/integrations/linear/src/definitions/index.ts
@@ -11,8 +11,8 @@ export const configuration = {
     linkTemplateScript: 'linkTemplate.vrl',
   },
   schema: z.object({
-    botName: z.string().optional().describe('Name used when the bot sends messages'),
-    botAvatarUrl: z.string().optional().describe('URL of the bot avatar'),
+    displayName: z.string().optional().describe('Name used when sending messages'),
+    avatarUrl: z.string().optional().describe('URL of the bot avatar'),
   }),
 } satisfies IntegrationDefinitionProps['configuration']
 

--- a/integrations/linear/src/definitions/index.ts
+++ b/integrations/linear/src/definitions/index.ts
@@ -31,6 +31,11 @@ export const channels = {
       },
       tags: {
         id: {},
+        title: {},
+        url: {},
+        parentId: {},
+        parentTitle: {},
+        parentUrl: {},
       },
     },
   },

--- a/integrations/linear/src/definitions/index.ts
+++ b/integrations/linear/src/definitions/index.ts
@@ -10,7 +10,10 @@ export const configuration = {
   identifier: {
     linkTemplateScript: 'linkTemplate.vrl',
   },
-  schema: z.object({}),
+  schema: z.object({
+    botName: z.string().optional().describe('Name used when the bot sends messages'),
+    botAvatarUrl: z.string().optional().describe('URL of the bot avatar'),
+  }),
 } satisfies IntegrationDefinitionProps['configuration']
 
 export const channels = {

--- a/integrations/linear/src/definitions/schemas.ts
+++ b/integrations/linear/src/definitions/schemas.ts
@@ -62,8 +62,12 @@ export const LinearIssue = z.object({
   number: z.number().describe('The issue number on Linear, such as "123" in XXX-123'),
   teamName: z
     .string()
+    .optional()
     .describe('The name of the Linear team the issue currently belongs to, such as "Customer Support"'),
-  teamKey: z.string().describe('The key of the Linear team the issue currently belongs to, such as "XXX" in XXX-123'),
+  teamKey: z
+    .string()
+    .optional()
+    .describe('The key of the Linear team the issue currently belongs to, such as "XXX" in XXX-123'),
   createdAt: z.string().datetime().describe('The ISO date the issue was created'),
   updatedAt: z.string().datetime().describe('The ISO date the issue was last updated'),
   status: z.string().describe('The issue State name (such as "In Progress"'),

--- a/integrations/linear/src/events/issueCreated.ts
+++ b/integrations/linear/src/events/issueCreated.ts
@@ -1,9 +1,10 @@
 import { IssueCreated } from '../definitions/events'
+import { LinearIssueEvent } from '../misc/linear'
 
 import { getUserAndConversation } from '../misc/utils'
 import { Client } from '.botpress'
 
-export const fireIssueCreated = async ({ linearEvent, client }: { linearEvent: any; client: Client }) => {
+export const fireIssueCreated = async ({ linearEvent, client }: { linearEvent: LinearIssueEvent; client: Client }) => {
   const payload = {
     title: linearEvent.data.title,
     priority: linearEvent.data.priority,

--- a/integrations/linear/src/events/issueCreated.ts
+++ b/integrations/linear/src/events/issueCreated.ts
@@ -41,8 +41,8 @@ export const fireIssueCreated = async ({ linearEvent, client, ctx }: IssueProps)
   const { conversationId, userId } = await getUserAndConversation({
     linearIssueId: linearEvent.data.id,
     linearUserId: linearEvent.data.creatorId,
-    client,
     integrationId: ctx.integrationId,
+    client,
   })
 
   await client.createEvent({

--- a/integrations/linear/src/events/issueCreated.ts
+++ b/integrations/linear/src/events/issueCreated.ts
@@ -1,10 +1,18 @@
+import { IntegrationContext } from '@botpress/sdk'
 import { IssueCreated } from '../definitions/events'
 import { LinearIssueEvent } from '../misc/linear'
 
 import { getUserAndConversation } from '../misc/utils'
+import * as bp from '.botpress'
 import { Client } from '.botpress'
 
-export const fireIssueCreated = async ({ linearEvent, client }: { linearEvent: LinearIssueEvent; client: Client }) => {
+type IssueProps = {
+  linearEvent: LinearIssueEvent
+  client: Client
+  ctx: IntegrationContext<bp.configuration.Configuration>
+}
+
+export const fireIssueCreated = async ({ linearEvent, client, ctx }: IssueProps) => {
   const payload = {
     title: linearEvent.data.title,
     priority: linearEvent.data.priority,
@@ -30,13 +38,12 @@ export const fireIssueCreated = async ({ linearEvent, client }: { linearEvent: L
     },
   } satisfies Omit<IssueCreated, 'conversationId' | 'userId'>
 
-  const { conversationId, userId } = await getUserAndConversation(
-    {
-      linearIssueId: linearEvent.data.id,
-      linearUserId: linearEvent.data.creatorId,
-    },
-    client
-  )
+  const { conversationId, userId } = await getUserAndConversation({
+    linearIssueId: linearEvent.data.id,
+    linearUserId: linearEvent.data.creatorId,
+    client,
+    integrationId: ctx.integrationId,
+  })
 
   await client.createEvent({
     type: 'issueCreated',

--- a/integrations/linear/src/events/issueUpdated.ts
+++ b/integrations/linear/src/events/issueUpdated.ts
@@ -1,9 +1,10 @@
+import { LinearIssueEvent } from 'src/misc/linear'
 import { IssueUpdated } from '../definitions/events'
 
 import { getUserAndConversation } from '../misc/utils'
 import { Client } from '.botpress'
 
-export const fireIssueUpdated = async ({ linearEvent, client }: { linearEvent: any; client: Client }) => {
+export const fireIssueUpdated = async ({ linearEvent, client }: { linearEvent: LinearIssueEvent; client: Client }) => {
   const payload = {
     title: linearEvent.data.title,
     priority: linearEvent.data.priority,

--- a/integrations/linear/src/events/issueUpdated.ts
+++ b/integrations/linear/src/events/issueUpdated.ts
@@ -41,6 +41,7 @@ export const fireIssueUpdated = async ({ linearEvent, client, ctx }: IssueProps)
     linearIssueId: linearEvent.data.id,
     linearUserId: linearEvent.data.creatorId,
     integrationId: ctx.integrationId,
+    forceUpdate: true,
     client,
   })
 

--- a/integrations/linear/src/events/issueUpdated.ts
+++ b/integrations/linear/src/events/issueUpdated.ts
@@ -9,10 +9,9 @@ type IssueProps = {
   linearEvent: LinearIssueEvent
   client: Client
   ctx: IntegrationContext<bp.configuration.Configuration>
-  logger: any
 }
 
-export const fireIssueUpdated = async ({ linearEvent, client, logger, ctx }: IssueProps) => {
+export const fireIssueUpdated = async ({ linearEvent, client, ctx }: IssueProps) => {
   const payload = {
     title: linearEvent.data.title,
     priority: linearEvent.data.priority,
@@ -44,7 +43,6 @@ export const fireIssueUpdated = async ({ linearEvent, client, logger, ctx }: Iss
     integrationId: ctx.integrationId,
     forceUpdate: true,
     client,
-    logger,
   })
 
   await client.createEvent({

--- a/integrations/linear/src/events/issueUpdated.ts
+++ b/integrations/linear/src/events/issueUpdated.ts
@@ -9,9 +9,10 @@ type IssueProps = {
   linearEvent: LinearIssueEvent
   client: Client
   ctx: IntegrationContext<bp.configuration.Configuration>
+  logger: any
 }
 
-export const fireIssueUpdated = async ({ linearEvent, client, ctx }: IssueProps) => {
+export const fireIssueUpdated = async ({ linearEvent, client, logger, ctx }: IssueProps) => {
   const payload = {
     title: linearEvent.data.title,
     priority: linearEvent.data.priority,
@@ -43,6 +44,7 @@ export const fireIssueUpdated = async ({ linearEvent, client, ctx }: IssueProps)
     integrationId: ctx.integrationId,
     forceUpdate: true,
     client,
+    logger,
   })
 
   await client.createEvent({

--- a/integrations/linear/src/events/issueUpdated.ts
+++ b/integrations/linear/src/events/issueUpdated.ts
@@ -1,10 +1,17 @@
-import { LinearIssueEvent } from 'src/misc/linear'
+import { IntegrationContext } from '@botpress/sdk'
 import { IssueUpdated } from '../definitions/events'
-
+import { LinearIssueEvent } from '../misc/linear'
 import { getUserAndConversation } from '../misc/utils'
+import * as bp from '.botpress'
 import { Client } from '.botpress'
 
-export const fireIssueUpdated = async ({ linearEvent, client }: { linearEvent: LinearIssueEvent; client: Client }) => {
+type IssueProps = {
+  linearEvent: LinearIssueEvent
+  client: Client
+  ctx: IntegrationContext<bp.configuration.Configuration>
+}
+
+export const fireIssueUpdated = async ({ linearEvent, client, ctx }: IssueProps) => {
   const payload = {
     title: linearEvent.data.title,
     priority: linearEvent.data.priority,
@@ -30,13 +37,12 @@ export const fireIssueUpdated = async ({ linearEvent, client }: { linearEvent: L
     },
   } satisfies Omit<IssueUpdated, 'conversationId' | 'userId'>
 
-  const { conversationId, userId } = await getUserAndConversation(
-    {
-      linearIssueId: linearEvent.data.id,
-      linearUserId: linearEvent.data.creatorId,
-    },
-    client
-  )
+  const { conversationId, userId } = await getUserAndConversation({
+    linearIssueId: linearEvent.data.id,
+    linearUserId: linearEvent.data.creatorId,
+    client,
+    integrationId: ctx.integrationId,
+  })
 
   await client.createEvent({
     type: 'issueUpdated',

--- a/integrations/linear/src/events/issueUpdated.ts
+++ b/integrations/linear/src/events/issueUpdated.ts
@@ -22,7 +22,7 @@ export const fireIssueUpdated = async ({ linearEvent, client, ctx }: IssueProps)
     createdAt: linearEvent.data.createdAt,
     teamKey: linearEvent.data.team?.key,
     teamName: linearEvent.data.team?.name,
-    labels: linearEvent.data.labels?.map((x: any) => x.name) ?? [],
+    labels: linearEvent.data.labels?.map((x) => x.name) ?? [],
     linearIds: {
       creatorId: linearEvent.data.creatorId,
       labelIds: linearEvent.data.labelIds ?? [],

--- a/integrations/linear/src/events/issueUpdated.ts
+++ b/integrations/linear/src/events/issueUpdated.ts
@@ -40,8 +40,8 @@ export const fireIssueUpdated = async ({ linearEvent, client, ctx }: IssueProps)
   const { conversationId, userId } = await getUserAndConversation({
     linearIssueId: linearEvent.data.id,
     linearUserId: linearEvent.data.creatorId,
-    client,
     integrationId: ctx.integrationId,
+    client,
   })
 
   await client.createEvent({

--- a/integrations/linear/src/handler.ts
+++ b/integrations/linear/src/handler.ts
@@ -71,7 +71,7 @@ export const handler: bp.IntegrationProps['handler'] = async ({ req, ctx, client
       logger,
     })
 
-    console.info('linearUser', linearUser)
+    console.info('linear User', linearUser)
 
     await client.setState({
       id: userId,

--- a/integrations/linear/src/handler.ts
+++ b/integrations/linear/src/handler.ts
@@ -39,7 +39,7 @@ export const handler: bp.IntegrationProps['handler'] = async ({ req, ctx, client
   }
 
   if (linearEvent.type === 'issue' && linearEvent.action === 'update') {
-    await fireIssueUpdated({ linearEvent, client, ctx })
+    await fireIssueUpdated({ linearEvent, client, ctx, logger })
     return
   }
 

--- a/integrations/linear/src/handler.ts
+++ b/integrations/linear/src/handler.ts
@@ -61,7 +61,8 @@ export const handler: bp.IntegrationProps['handler'] = async ({ req, ctx, client
         linearIssueId: issueConversationId,
         linearUserId,
       },
-      client
+      client,
+      logger
     )
 
     if (created) {

--- a/integrations/linear/src/handler.ts
+++ b/integrations/linear/src/handler.ts
@@ -56,15 +56,12 @@ export const handler: bp.IntegrationProps['handler'] = async ({ req, ctx, client
     const issueConversationId = linearEvent.data.issueId || linearEvent.data.issue.id
     const content = linearEvent.data.body
 
-    const { userId, conversationId } = await getUserAndConversation(
-      {
-        linearIssueId: issueConversationId,
-        linearUserId,
-        client,
-        integrationId: ctx.integrationId,
-      },
-      logger
-    )
+    const { userId, conversationId } = await getUserAndConversation({
+      linearIssueId: issueConversationId,
+      linearUserId,
+      integrationId: ctx.integrationId,
+      client,
+    })
 
     const linearUser = await getUser({
       client,

--- a/integrations/linear/src/handler.ts
+++ b/integrations/linear/src/handler.ts
@@ -56,12 +56,15 @@ export const handler: bp.IntegrationProps['handler'] = async ({ req, ctx, client
     const issueConversationId = linearEvent.data.issueId || linearEvent.data.issue.id
     const content = linearEvent.data.body
 
-    const { userId, conversationId } = await getUserAndConversation({
-      linearIssueId: issueConversationId,
-      linearUserId,
-      client,
-      integrationId: ctx.integrationId,
-    })
+    const { userId, conversationId } = await getUserAndConversation(
+      {
+        linearIssueId: issueConversationId,
+        linearUserId,
+        client,
+        integrationId: ctx.integrationId,
+      },
+      logger
+    )
 
     const linearUser = await getUser({
       client,
@@ -70,8 +73,6 @@ export const handler: bp.IntegrationProps['handler'] = async ({ req, ctx, client
       type: 'getUser',
       logger,
     })
-
-    console.info('linear User', linearUser)
 
     await client.setState({
       id: userId,

--- a/integrations/linear/src/handler.ts
+++ b/integrations/linear/src/handler.ts
@@ -39,7 +39,7 @@ export const handler: bp.IntegrationProps['handler'] = async ({ req, ctx, client
   }
 
   if (linearEvent.type === 'issue' && linearEvent.action === 'update') {
-    await fireIssueUpdated({ linearEvent, client, ctx, logger })
+    await fireIssueUpdated({ linearEvent, client, ctx })
     return
   }
 

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -5,6 +5,65 @@ import queryString from 'query-string'
 import { z } from 'zod'
 import * as bp from '.botpress'
 
+type BaseEvent = {
+  action: 'create' | 'update'
+  type: string
+  webhookTimestamp: number
+  data: {
+    issueId?: string
+    userId?: string
+    user?: {
+      id: string
+    }
+  }
+}
+
+export type LinearIssueEvent = {
+  type: 'issue'
+  data: {
+    id: string
+    creatorId: string
+    labelIds?: string[]
+    number: number
+    title: string
+    updatedAt: string
+    createdAt: string
+    description: string
+    priority: number
+    labels: {
+      name: string
+    }[]
+    subscriberIds: string[]
+    assignee?: {
+      id: string
+    }
+    team?: {
+      id: string
+      key: string
+      name: string
+    }
+    state: {
+      name: string
+    }
+    project: {
+      id: string
+    }
+  }
+} & BaseEvent
+
+export type LinearCommentEvent = {
+  type: 'comment'
+  data: {
+    id: string
+    body: string
+    issue: {
+      id: string
+    }
+  }
+} & BaseEvent
+
+export type LinearEvent = LinearCommentEvent | LinearIssueEvent
+
 const linearEndpoint = 'https://api.linear.app'
 
 const oauthHeaders = {

--- a/integrations/linear/src/misc/utils.ts
+++ b/integrations/linear/src/misc/utils.ts
@@ -121,11 +121,7 @@ export const getUserAndConversation = async (
     const existingIssue = await linearClient.issue(props.linearIssueId)
     const newTags = await getIssueTags(existingIssue)
 
-    logger?.forBot().info('set tags', conversation.id, newTags)
-
-    await props.client.updateConversation(conversation.id, { tags: newTags }).catch((err: any) => {
-      console.log('error updating conversation', err)
-    })
+    await props.client.updateConversation({ id: conversation.id, tags: newTags })
   }
 
   const { user } = await props.client.getOrCreateUser({ tags: { id: props.linearUserId }, name: 'test' })

--- a/integrations/linear/src/misc/utils.ts
+++ b/integrations/linear/src/misc/utils.ts
@@ -130,7 +130,13 @@ export const getUserAndConversation = async (props: {
 
   if (!user.name) {
     const linearUser = await linearClient.user(props.linearUserId)
-    await props.client.updateUser({ id: user.id, name: linearUser.name, pictureUrl: linearUser.avatarUrl })
+
+    await props.client.updateUser({
+      id: user.id,
+      name: linearUser.name,
+      pictureUrl: linearUser.avatarUrl,
+      tags: user.tags,
+    })
   }
 
   return {

--- a/integrations/linear/src/misc/utils.ts
+++ b/integrations/linear/src/misc/utils.ts
@@ -117,7 +117,8 @@ export const updateConversationTags = async (props: {
 
 export const getUserAndConversation = async (
   props: { linearUserId: string; linearIssueId: string },
-  client: Client
+  client: Client,
+  logger?: any
 ) => {
   const { conversation } = await client.getOrCreateConversation({
     channel: 'issue',
@@ -126,10 +127,11 @@ export const getUserAndConversation = async (
     },
   })
 
+  logger?.forBot().info(conversation)
   console.info(conversation)
 
-  const { user } = await client.getOrCreateUser({ tags: { id: props.linearUserId } })
-
+  const { user } = await client.getOrCreateUser({ tags: { id: props.linearUserId }, name: 'test' })
+  logger?.forBot().info(user)
   // sync the user from linear to botpress profile
 
   // TODO: when we create users and conversations based on linear entities, add the tags and properties to them

--- a/integrations/linear/src/misc/utils.ts
+++ b/integrations/linear/src/misc/utils.ts
@@ -96,9 +96,9 @@ export const getIssueTags = async (issue: Issue) => {
     id: issue.id,
     url: issue.url,
     title: issue.title,
-    parentId: parent?.id || null,
+    parentId: parent?.id || '',
     parentTitle: parent?.title || '',
-    parentUrl: parent?.url,
+    parentUrl: parent?.url || '',
   }
 }
 
@@ -108,7 +108,6 @@ export const getUserAndConversation = async (props: {
   client: Client
   integrationId: string
   forceUpdate?: boolean
-  logger?: any
 }) => {
   const { conversation } = await props.client.getOrCreateConversation({
     channel: 'issue',
@@ -124,7 +123,6 @@ export const getUserAndConversation = async (props: {
     const existingIssue = await linearClient.issue(props.linearIssueId)
     const newTags = await getIssueTags(existingIssue)
 
-    props.logger?.forBot().info('new tags', newTags)
     await props.client.updateConversation({ id: conversation.id, tags: newTags })
   }
 

--- a/integrations/linear/src/misc/utils.ts
+++ b/integrations/linear/src/misc/utils.ts
@@ -130,7 +130,7 @@ export const getUserAndConversation = async (props: {
 
   if (!user.name) {
     const linearUser = await linearClient.user(props.linearUserId)
-    await props.client.updateUser({ id: user.id, name: linearUser.name, avatarUrl: linearUser.avatarUrl })
+    await props.client.updateUser({ id: user.id, name: linearUser.name, pictureUrl: linearUser.avatarUrl })
   }
 
   return {

--- a/integrations/linear/src/misc/utils.ts
+++ b/integrations/linear/src/misc/utils.ts
@@ -96,8 +96,8 @@ export const getIssueTags = async (issue: Issue) => {
     id: issue.id,
     url: issue.url,
     title: issue.title,
-    parentId: parent?.id,
-    parentTitle: parent?.title,
+    parentId: parent?.id || null,
+    parentTitle: parent?.title || '',
     parentUrl: parent?.url,
   }
 }
@@ -119,13 +119,11 @@ export const getUserAndConversation = async (props: {
 
   const linearClient = await getLinearClient(props.client, props.integrationId)
 
-  props.logger?.forBot().info('getUserAndConversation', props.forceUpdate, conversation.tags[urlTag])
   // TODO: better way to know if the conversation was just created
   if (props.forceUpdate || !conversation.tags[urlTag]) {
     const existingIssue = await linearClient.issue(props.linearIssueId)
     const newTags = await getIssueTags(existingIssue)
 
-    props.logger?.forBot().info('parent', await existingIssue.parent)
     props.logger?.forBot().info('new tags', newTags)
     await props.client.updateConversation({ id: conversation.id, tags: newTags })
   }

--- a/integrations/linear/src/misc/utils.ts
+++ b/integrations/linear/src/misc/utils.ts
@@ -104,7 +104,6 @@ export const getIssueTags = async (issue: Issue) => {
 
 export const getUserAndConversation = async (
   props: { linearUserId: string; linearIssueId: string; client: Client; integrationId: string },
-
   logger?: any
 ) => {
   const { conversation } = await props.client.getOrCreateConversation({
@@ -122,9 +121,11 @@ export const getUserAndConversation = async (
     const existingIssue = await linearClient.issue(props.linearIssueId)
     const newTags = await getIssueTags(existingIssue)
 
-    logger?.forBot().info('set tags', newTags)
+    logger?.forBot().info('set tags', conversation.id, newTags)
 
-    // await props.client.updateConversation(conversation.id, { tags: newTags })
+    await props.client.updateConversation(conversation.id, { tags: newTags }).catch((err: any) => {
+      console.log('error updating conversation', err)
+    })
   }
 
   const { user } = await props.client.getOrCreateUser({ tags: { id: props.linearUserId }, name: 'test' })

--- a/integrations/linear/src/misc/utils.ts
+++ b/integrations/linear/src/misc/utils.ts
@@ -102,19 +102,6 @@ export const getIssueTags = async (issue: Issue) => {
   }
 }
 
-export const updateConversationTags = async (props: {
-  linearIssueId: string
-  conversationId: string
-  integrationId: string
-  client: Client
-}) => {
-  const linearClient = await getLinearClient(props.client, props.integrationId)
-  const existingIssue = await linearClient.issue(props.linearIssueId)
-  const newTags = await getIssueTags(existingIssue)
-
-  await props.client.updateConversation(props.conversationId, { tags: newTags })
-}
-
 export const getUserAndConversation = async (
   props: { linearUserId: string; linearIssueId: string; client: Client; integrationId: string },
 
@@ -136,7 +123,8 @@ export const getUserAndConversation = async (
     const newTags = await getIssueTags(existingIssue)
 
     logger?.forBot().info('set tags', newTags)
-    await props.client.updateConversation(conversation.id, { tags: newTags })
+
+    // await props.client.updateConversation(conversation.id, { tags: newTags })
   }
 
   const { user } = await props.client.getOrCreateUser({ tags: { id: props.linearUserId }, name: 'test' })

--- a/integrations/linear/src/misc/utils.ts
+++ b/integrations/linear/src/misc/utils.ts
@@ -107,6 +107,7 @@ export const getUserAndConversation = async (props: {
   linearIssueId: string
   client: Client
   integrationId: string
+  forceUpdate?: boolean
 }) => {
   const { conversation } = await props.client.getOrCreateConversation({
     channel: 'issue',
@@ -118,7 +119,7 @@ export const getUserAndConversation = async (props: {
   const linearClient = await getLinearClient(props.client, props.integrationId)
 
   // TODO: better way to know if the conversation was just created
-  if (!conversation.tags[urlTag]) {
+  if (props.forceUpdate || !conversation.tags[urlTag]) {
     const existingIssue = await linearClient.issue(props.linearIssueId)
     const newTags = await getIssueTags(existingIssue)
 

--- a/integrations/linear/src/misc/utils.ts
+++ b/integrations/linear/src/misc/utils.ts
@@ -118,7 +118,7 @@ export const getUserAndConversation = async (
 
   const linearClient = await getLinearClient(props.client, props.integrationId)
 
-  if (!conversation.tags?.['linear:url']) {
+  if (!conversation.tags['linear:url']) {
     const existingIssue = await linearClient.issue(props.linearIssueId)
     const newTags = await getIssueTags(existingIssue)
 

--- a/integrations/linear/src/misc/utils.ts
+++ b/integrations/linear/src/misc/utils.ts
@@ -108,6 +108,7 @@ export const getUserAndConversation = async (props: {
   client: Client
   integrationId: string
   forceUpdate?: boolean
+  logger?: any
 }) => {
   const { conversation } = await props.client.getOrCreateConversation({
     channel: 'issue',
@@ -118,11 +119,14 @@ export const getUserAndConversation = async (props: {
 
   const linearClient = await getLinearClient(props.client, props.integrationId)
 
+  props.logger?.forBot().info('getUserAndConversation', props.forceUpdate, conversation.tags[urlTag])
   // TODO: better way to know if the conversation was just created
   if (props.forceUpdate || !conversation.tags[urlTag]) {
     const existingIssue = await linearClient.issue(props.linearIssueId)
     const newTags = await getIssueTags(existingIssue)
 
+    props.logger?.forBot().info('parent', await existingIssue.parent)
+    props.logger?.forBot().info('new tags', newTags)
     await props.client.updateConversation({ id: conversation.id, tags: newTags })
   }
 

--- a/integrations/linear/src/misc/utils.ts
+++ b/integrations/linear/src/misc/utils.ts
@@ -60,8 +60,8 @@ export async function createComment({ ctx, client, conversation, ack, content }:
   const res = await linearClient.createComment({
     issueId,
     body: content,
-    createAsUser: ctx.configuration.botName,
-    displayIconUrl: ctx.configuration.botAvatarUrl,
+    createAsUser: ctx.configuration.displayName,
+    displayIconUrl: ctx.configuration.avatarUrl,
   })
   const comment = await res.comment
   if (!comment) {


### PR DESCRIPTION
1. Add `displayName` and `avatarUrl` to change how the bot responds in linear
2. Copy user name/avatar to botpress user when missing
3. Added tags `title`, `url`, `parentId`, `parentTitle`, `parentUrl` on the conversation

![image](https://github.com/botpress/botpress/assets/42552874/a481c6f8-36bd-420c-84bf-991d2da2ae92)
