### PR TITLE
Updated Make integration

### DIFF
--- a/integrations/make/integration.definition.ts
+++ b/integrations/make/integration.definition.ts
@@ -24,7 +24,7 @@ export default new IntegrationDefinition({
       input: {
         schema: z
           .object({
-            data: z.string().min(1, { message: 'Must not me empty' }).describe('JSON string of data to send'),
+            data: z.string().min(1, { message: 'Must not be empty' }).describe('JSON string of data to send'),
           })
           .describe('Input schema for sending data'),
       },
@@ -33,13 +33,10 @@ export default new IntegrationDefinition({
           .object({
             success: z.boolean().describe('True if the data was sent successfully'),
             response: z
-              .object({
-                data: z
                   .any()
                   .describe(
                     'Data received from Make.com, will be the string `Accepted` if successful and no data is returned'
-                  ),
-              })
+                  )
               .nullable(),
           })
           .describe('Output schema after sending data, expecting any JSON structure'),


### PR DESCRIPTION
All edits were done in the integration.definition.ts file

Fixed a typo in line 27.

Updated the output schema so that it can now take responses from Make.com that aren't just objects.

I have tested this with every scenario that I could think of, and it works like its supposed to now.

There were multiple issues with it before, because of the output schema.