### PR TITLE
fix(whatsapp): file extension should be extracted correctly for URLs with query strings

### DIFF
--- a/integrations/whatsapp/src/index.ts
+++ b/integrations/whatsapp/src/index.ts
@@ -72,7 +72,8 @@ const integration = new bp.Integration({
           })
         },
         file: async ({ payload, ...props }) => {
-          const extension = payload.fileUrl.includes('.') ? payload.fileUrl.split('.').pop()?.toLowerCase() ?? '' : ''
+          const url = new URL(payload.fileUrl)
+          const extension = url.pathname.includes('.') ? url.pathname.split('.').pop()?.toLowerCase() ?? '' : ''
           const filename = 'file' + (extension ? `.${extension}` : '')
 
           await outgoing.send({


### PR DESCRIPTION
Addresses the following issue: https://discord.com/channels/1108396290624213082/1218049759554834512/1218232620442193948