### PR TITLE
docs: Update README to Include one-click deployment options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,12 @@ tilt ci
 pnpm run check
 ```
 
+## One-Click Deployment
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploy.png)](https://repocloud.io/details/?app_id=170)
+
+[![Deploy on Elastio](https://pub-da36157c854648669813f3f76c526c2b.r2.dev/deploy-on-elestio-black.png)](https://elest.io/open-source/botpress)
+
 ## Licensing
 
 All packages in this repository are open-source software and licensed under the [MIT License](LICENSE). By contributing in this repository, you agree to release your code under this license as well.


### PR DESCRIPTION
This pull request introduces updates to the Botpress README file, adding one-click deployment buttons for RepoCloud and Elastio. These enhancements are designed to provide options to users with one-click solutions for deploying Botpress instances