### PR TITLE
chore: ensure ci supports integration versioning

### DIFF
--- a/.github/actions/deploy-integrations/action.yml
+++ b/.github/actions/deploy-integrations/action.yml
@@ -82,57 +82,17 @@ runs:
 
         # deploy
 
-        echo "### Deploying integration @botpresshub/dalle ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/dalle -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/discord ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/discord -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/googlecalendar ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/googlecalendar -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/github ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/github -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/gmail ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/gmail -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/gsheets ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/gsheets -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/instagram ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/instagram -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/intercom ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/intercom -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/line ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/line -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/linear ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/linear -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/make ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/make -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/messenger ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/messenger -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/mailchimp ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/mailchimp -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/notion ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/notion -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/slack ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/slack -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/sunco ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/sunco -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/teams ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/teams -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/telegram ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/telegram -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/twilio ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/twilio -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/viber ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/viber -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/vonage ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/vonage -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/webchat ###"
-        echo "webchat disabled"
-        echo "### Deploying integration @botpresshub/webhook ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/webhook -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/whatsapp ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/whatsapp -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/zapier ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/zapier -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/zendesk ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/zendesk -c exec -- 'bp deploy -v -y --noBuild'
-        echo "### Deploying integration @botpresshub/stripe ###"
-        pnpm retry -n 3 -- pnpm -r --stream -F @botpresshub/stripe -c exec -- 'bp deploy -v -y --noBuild'
+        list_cmd='pnpm list -F "@botpresshub/*" -F "!asana" -F "!trello" -F "!webchat" --json'
+        integration_paths=$(eval $list_cmd | jq -r "map(".path") | .[]")
+
+        for integration_path in $integration_paths; do
+            integration=$(basename $integration_path)
+            exists=$(./.github/scripts/integration-exists.sh $integration)
+            
+            if [ $exists -eq 0 ]; then
+                echo -e "\nDeploying integration: ### $integration ###\n"
+                pnpm retry -n 2 -- pnpm -r --stream -F $integration -c exec -- 'bp deploy -v -y --noBuild'
+            else
+                echo -e "\nSkipping integration: ### $integration ###\n"
+            fi
+        done

--- a/.github/actions/deploy-integrations/action.yml
+++ b/.github/actions/deploy-integrations/action.yml
@@ -82,8 +82,7 @@ runs:
 
         # deploy
 
-        list_cmd='pnpm list -F "@botpresshub/*" -F "!asana" -F "!trello" -F "!webchat" --json'
-        integration_paths=$(eval $list_cmd | jq -r "map(".path") | .[]")
+        integration_paths=$(pnpm list -F "@botpresshub/*" -F "!asana" -F "!trello" -F "!webchat" --json | jq -r "map(".path") | .[]")
 
         for integration_path in $integration_paths; do
             integration=$(basename $integration_path)

--- a/.github/scripts/integration-exists.sh
+++ b/.github/scripts/integration-exists.sh
@@ -1,0 +1,14 @@
+if [ -z "$1" ]; then
+  echo "Error: integration name is not provided" >&2 
+  exit 1
+fi
+integration=$1
+            
+integration_path="integrations/$integration"
+integration_def=$(pnpm bp read --work-dir $integration_path --json)
+
+name=$(echo $integration_def | jq -r ".name")
+version=$(echo $integration_def | jq -r ".version")
+
+exists=$(pnpm bp integrations ls --name $name --version-number $version --json | jq '[ .[] | select(.public) ] | length') # 0 if not exists
+echo $exists

--- a/.github/workflows/check-integration-versions.yml
+++ b/.github/workflows/check-integration-versions.yml
@@ -1,4 +1,4 @@
-name: Check Integrations Version
+name: Check Integration Versions
 
 on: pull_request
 
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 jobs:
-  check-integrations-version:
+  check-integration-versions:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/check-integrations-version.yml
+++ b/.github/workflows/check-integrations-version.yml
@@ -1,0 +1,41 @@
+name: Check Integrations Version
+
+on: pull_request
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  check-integrations-version:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Tilt
+        uses: ./.github/actions/setup-tilt
+        with:
+          tilt_cmd: 'build-packages'
+      - name: Login to Botpress
+        run: pnpm bp login -y --token ${{ secrets.PRODUCTION_TOKEN_CLOUD_OPS_ACCOUNT }} --workspace-id ${{ secrets.PRODUCTION_CLOUD_OPS_WORKSPACE_ID }}
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v43
+        with:
+          files: 'integrations/**/*.{ts,md,svg}'
+          separator: '\n'
+      - name: List modified integrations
+        run: |
+          echo -e "Changed files: ${{ steps.changed-files.outputs.all_changed_files }}"
+          modified_integrations=$(echo -e "${{ steps.changed-files.outputs.all_changed_files }}" | awk -F'/' '{print $2}' | sort -u)
+
+          for integration in $modified_integrations; do
+            echo "Checking $integration"
+            exists=$(./.github/scripts/integration-exists.sh $integration)
+
+            if [ $exists -ne 0 ]; then
+              echo "Integration $integration is already deployed publicly with the same version. Please update the version of your integration."
+              exit 1
+            fi
+
+          done

--- a/integrations/asana/hub.md
+++ b/integrations/asana/hub.md
@@ -11,7 +11,3 @@ Before activating the Botpress Asana Integration, please ensure the availability
 - Authorized access to an existing Asana workspace.
 
 - A valid API token generated from Asana (Personal Access Token).
-
-## Functionality
-
-Once the integration is operational, you can initiate interactions with Asana directly from your Botpress chatbot. The integration introduces actions such as `createTask`, `updateTask`, `findUser`, and `addCommentToTask`, streamlining the management of tasks and users.


### PR DESCRIPTION
This PR does 2 things:

1. On every PR, it checks if you have a *.ts, *.md or *.svg change in an integration. If so, you have to its version to merge.
2. When deploying all integrations, it only deploys the integrations that have changed

In a future PR:

3. add a CLI argument `--public` 