### PR TITLE
chore(cli): prevent special characters in action and event names + standardize codegen naming

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "0.8.21",
+  "version": "0.8.22",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -21,7 +21,7 @@
   "main": "dist/index.js",
   "dependencies": {
     "@botpress/client": "0.19.0",
-    "@botpress/sdk": "0.8.17",
+    "@botpress/sdk": "0.8.18",
     "@bpinternal/const": "^0.0.20",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/src/code-generation/integration-schemas/actions-module.ts
+++ b/packages/cli/src/code-generation/integration-schemas/actions-module.ts
@@ -1,7 +1,7 @@
 import bluebird from 'bluebird'
-import { casing } from '../../utils'
 import { jsonSchemaToTypeScriptType } from '../generators'
 import { Module, ModuleDef, ReExportTypeModule } from '../module'
+import * as strings from '../strings'
 import type * as types from '../typings'
 
 type ActionInput = types.ActionDefinition['input']
@@ -11,10 +11,11 @@ export class ActionInputModule extends Module {
   public static async create(input: ActionInput): Promise<ActionInputModule> {
     const schema = input.schema
     const name = 'input'
+    const exportName = strings.typeName(name)
     const def: ModuleDef = {
       path: `${name}.ts`,
-      exportName: 'Input',
-      content: await jsonSchemaToTypeScriptType(schema, name),
+      exportName,
+      content: await jsonSchemaToTypeScriptType(schema, exportName),
     }
     return new ActionInputModule(def)
   }
@@ -24,10 +25,11 @@ export class ActionOutputModule extends Module {
   public static async create(output: ActionOutput): Promise<ActionOutputModule> {
     const schema = output.schema
     const name = 'output'
+    const exportName = strings.typeName(name)
     const def: ModuleDef = {
       path: `${name}.ts`,
-      exportName: 'Output',
-      content: await jsonSchemaToTypeScriptType(schema, name),
+      exportName,
+      content: await jsonSchemaToTypeScriptType(schema, exportName),
     }
     return new ActionOutputModule(def)
   }
@@ -39,7 +41,7 @@ export class ActionModule extends ReExportTypeModule {
     const outputModule = await ActionOutputModule.create(action.output)
 
     const inst = new ActionModule({
-      exportName: `Action${casing.to.pascalCase(actionName)}`,
+      exportName: strings.typeName(actionName),
     })
 
     inst.pushDep(inputModule)
@@ -57,7 +59,7 @@ export class ActionsModule extends ReExportTypeModule {
     })
 
     const inst = new ActionsModule({
-      exportName: 'Actions',
+      exportName: strings.typeName('actions'),
     })
 
     inst.pushDep(...actionModules)

--- a/packages/cli/src/code-generation/integration-schemas/configuration-module.ts
+++ b/packages/cli/src/code-generation/integration-schemas/configuration-module.ts
@@ -1,6 +1,7 @@
 import { INDEX_FILE } from '../const'
 import { jsonSchemaToTypeScriptType } from '../generators'
 import { Module } from '../module'
+import * as strings from '../strings'
 import type * as types from '../typings'
 
 export class ConfigurationModule extends Module {
@@ -15,10 +16,12 @@ export class ConfigurationModule extends Module {
     }
 
     const name = 'configuration'
+
+    const exportName = strings.typeName(name)
     return new ConfigurationModule({
       path: INDEX_FILE,
-      exportName: 'Configuration',
-      content: await jsonSchemaToTypeScriptType(schema, name),
+      exportName,
+      content: await jsonSchemaToTypeScriptType(schema, exportName),
     })
   }
 }

--- a/packages/cli/src/code-generation/integration-schemas/events-module.ts
+++ b/packages/cli/src/code-generation/integration-schemas/events-module.ts
@@ -1,16 +1,18 @@
 import bluebird from 'bluebird'
-import { casing } from '../../utils'
 import { jsonSchemaToTypeScriptType } from '../generators'
 import { Module, ModuleDef, ReExportTypeModule } from '../module'
+import * as strings from '../strings'
 import type * as types from '../typings'
 
 export class EventModule extends Module {
   public static async create(name: string, event: types.EventDefinition): Promise<EventModule> {
+    const eventName = name
     const schema = event.schema
+    const exportName = strings.typeName(eventName)
     const def: ModuleDef = {
       path: `${name}.ts`,
-      exportName: casing.to.pascalCase(name),
-      content: await jsonSchemaToTypeScriptType(schema, name),
+      exportName,
+      content: await jsonSchemaToTypeScriptType(schema, exportName),
     }
     return new EventModule(def)
   }
@@ -23,7 +25,7 @@ export class EventsModule extends ReExportTypeModule {
     )
 
     const inst = new EventsModule({
-      exportName: 'Events',
+      exportName: strings.typeName('events'),
     })
     inst.pushDep(...eventModules)
     return inst

--- a/packages/cli/src/code-generation/integration-schemas/states-module.ts
+++ b/packages/cli/src/code-generation/integration-schemas/states-module.ts
@@ -1,16 +1,17 @@
 import bluebird from 'bluebird'
-import { casing } from '../../utils'
 import { jsonSchemaToTypeScriptType } from '../generators'
 import { Module, ModuleDef, ReExportTypeModule } from '../module'
+import * as strings from '../strings'
 import type * as types from '../typings'
 
 export class StateModule extends Module {
   public static async create(name: string, state: types.StateDefinition): Promise<StateModule> {
     const schema = state.schema
+    const exportName = strings.typeName(name)
     const def: ModuleDef = {
       path: `${name}.ts`,
-      exportName: casing.to.pascalCase(name),
-      content: await jsonSchemaToTypeScriptType(schema, name),
+      exportName,
+      content: await jsonSchemaToTypeScriptType(schema, exportName),
     }
     return new StateModule(def)
   }
@@ -23,7 +24,7 @@ export class StatesModule extends ReExportTypeModule {
     )
 
     const inst = new StatesModule({
-      exportName: 'States',
+      exportName: strings.typeName('states'),
     })
     inst.pushDep(...stateModules)
     return inst

--- a/packages/cli/src/code-generation/map-integration.ts
+++ b/packages/cli/src/code-generation/map-integration.ts
@@ -5,36 +5,38 @@ import * as utils from '../utils'
 import * as types from './typings'
 
 export namespace from {
-  export const sdk = (i: sdk.IntegrationDefinition): types.IntegrationDefinition => ({
-    id: null,
-    name: i.name,
-    version: i.version,
-    user: {
-      tags: i.user?.tags ?? {},
-      creation: i.user?.creation ?? { enabled: false, requiredTags: [] },
-    },
-    configuration: i.configuration ? _mapSchema(i.configuration) : { schema: {} },
-    events: i.events ? utils.records.mapValues(i.events, _mapSchema) : {},
-    states: i.states ? utils.records.mapValues(i.states, _mapSchema) : {},
-    actions: i.actions
-      ? utils.records.mapValues(i.actions, (a) => ({
-          input: _mapSchema(a.input),
-          output: _mapSchema(a.output),
-        }))
-      : {},
-    channels: i.channels
-      ? utils.records.mapValues(i.channels, (c) => ({
-          conversation: {
-            tags: c.conversation?.tags ?? {},
-            creation: c.conversation?.creation ?? { enabled: false, requiredTags: [] },
-          },
-          message: {
-            tags: c.message?.tags ?? {},
-          },
-          messages: utils.records.mapValues(c.messages, _mapSchema),
-        }))
-      : {},
-  })
+  export const sdk = (i: sdk.IntegrationDefinition): types.IntegrationDefinition => {
+    return {
+      id: null,
+      name: i.name,
+      version: i.version,
+      user: {
+        tags: i.user?.tags ?? {},
+        creation: i.user?.creation ?? { enabled: false, requiredTags: [] },
+      },
+      configuration: i.configuration ? _mapSchema(i.configuration) : { schema: {} },
+      events: i.events ? utils.records.mapValues(i.events, _mapSchema) : {},
+      states: i.states ? utils.records.mapValues(i.states, _mapSchema) : {},
+      actions: i.actions
+        ? utils.records.mapValues(i.actions, (a) => ({
+            input: _mapSchema(a.input),
+            output: _mapSchema(a.output),
+          }))
+        : {},
+      channels: i.channels
+        ? utils.records.mapValues(i.channels, (c) => ({
+            conversation: {
+              tags: c.conversation?.tags ?? {},
+              creation: c.conversation?.creation ?? { enabled: false, requiredTags: [] },
+            },
+            message: {
+              tags: c.message?.tags ?? {},
+            },
+            messages: utils.records.mapValues(c.messages, _mapSchema),
+          }))
+        : {},
+    }
+  }
 
   export const client = (i: client.Integration): types.IntegrationDefinition => {
     const { id, name, version, configuration, channels, states, events, actions, user } = i

--- a/packages/cli/src/code-generation/strings.ts
+++ b/packages/cli/src/code-generation/strings.ts
@@ -1,0 +1,19 @@
+import * as utils from '../utils'
+type StrTransform = (str: string) => string
+
+const apply = (str: string, ...transforms: StrTransform[]) => transforms.reduce((acc, transform) => transform(acc), str)
+
+/**
+ *
+ * @param input any string
+ * @returns the input string with all non-alphanumeric characters (excluding underscore) replaced
+ */
+const sanitize =
+  (replace?: string) =>
+  (input: string): string => {
+    const pattern = /[^a-zA-Z0-9_]/g
+    return input.replace(pattern, replace || '')
+  }
+
+export const typeName = (name: string) => apply(name, sanitize(''), utils.casing.to.pascalCase)
+export const importAlias = (name: string) => apply(name, utils.casing.to.camelCase, sanitize('_'))

--- a/packages/cli/src/code-generation/strings.ts
+++ b/packages/cli/src/code-generation/strings.ts
@@ -3,17 +3,5 @@ type StrTransform = (str: string) => string
 
 const apply = (str: string, ...transforms: StrTransform[]) => transforms.reduce((acc, transform) => transform(acc), str)
 
-/**
- *
- * @param input any string
- * @returns the input string with all non-alphanumeric characters (excluding underscore) replaced
- */
-const sanitize =
-  (replace?: string) =>
-  (input: string): string => {
-    const pattern = /[^a-zA-Z0-9_]/g
-    return input.replace(pattern, replace || '')
-  }
-
-export const typeName = (name: string) => apply(name, sanitize(''), utils.casing.to.pascalCase)
-export const importAlias = (name: string) => apply(name, utils.casing.to.camelCase, sanitize('_'))
+export const typeName = (name: string) => apply(name, utils.casing.to.pascalCase)
+export const importAlias = (name: string) => apply(name, utils.casing.to.camelCase)

--- a/packages/cli/src/command-implementations/deploy-command.ts
+++ b/packages/cli/src/command-implementations/deploy-command.ts
@@ -322,7 +322,7 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
         throw new errors.BotpressCLIError(workspaceHandleIsMandatoryMsg)
       }
       const newName = `${remoteHandle}/${localName}`
-      return { ...integration, name: newName }
+      return integration.clone({ name: newName })
     }
 
     if (localHandle && !remoteHandle) {
@@ -371,7 +371,7 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
 
     this.logger.success(`Handle "${claimedHandle}" is yours!`)
     const newName = `${claimedHandle}/${localName}`
-    return { ...integration, name: newName }
+    return integration.clone({ name: newName })
   }
 
   private _parseIntegrationName = (integrationName: string): { name: string; workspaceHandle?: string } => {

--- a/packages/cli/src/utils/case-utils.test.ts
+++ b/packages/cli/src/utils/case-utils.test.ts
@@ -1,11 +1,11 @@
 import { test, expect } from 'vitest'
 import * as caseUtils from './case-utils'
 
-const pascalCase = 'HelloWorld'
-const kebabCase = 'hello-world'
-const snakeCase = 'hello_world'
-const screamingSnakeCase = 'HELLO_WORLD'
-const camelCase = 'helloWorld'
+const pascalCase = 'HelloLittleWorld'
+const kebabCase = 'hello-little-world'
+const snakeCase = 'hello_little_world'
+const screamingSnakeCase = 'HELLO_LITTLE_WORLD'
+const camelCase = 'helloLittleWorld'
 
 test('case utils should convert from pascal case to all other cases', () => {
   expect(caseUtils.to.kebabCase(pascalCase)).toBe(kebabCase)

--- a/packages/cli/src/utils/case-utils.test.ts
+++ b/packages/cli/src/utils/case-utils.test.ts
@@ -41,3 +41,19 @@ test('case utils should convert from camel case to all other cases', () => {
   expect(caseUtils.to.snakeCase(camelCase)).toBe(snakeCase)
   expect(caseUtils.to.screamingSnakeCase(camelCase)).toBe(screamingSnakeCase)
 })
+
+test('case utils should split special characters when converting', () => {
+  expect(caseUtils.to.pascalCase(`${pascalCase}.2`)).toBe(`${pascalCase}2`)
+  expect(caseUtils.to.kebabCase(`${kebabCase}.2`)).toBe(`${kebabCase}-2`)
+  expect(caseUtils.to.snakeCase(`${snakeCase}.2`)).toBe(`${snakeCase}_2`)
+  expect(caseUtils.to.screamingSnakeCase(`${screamingSnakeCase}.2`)).toBe(`${screamingSnakeCase}_2`)
+  expect(caseUtils.to.camelCase(`${camelCase}.2`)).toBe(`${camelCase}2`)
+})
+
+test('case utils should prevent special characters when checking', () => {
+  expect(caseUtils.is.pascalCase(`${pascalCase}.2`)).toBe(false)
+  expect(caseUtils.is.kebabCase(`${kebabCase}.2`)).toBe(false)
+  expect(caseUtils.is.snakeCase(`${snakeCase}.2`)).toBe(false)
+  expect(caseUtils.is.screamingSnakeCase(`${screamingSnakeCase}.2`)).toBe(false)
+  expect(caseUtils.is.camelCase(`${camelCase}.2`)).toBe(false)
+})

--- a/packages/cli/src/utils/case-utils.ts
+++ b/packages/cli/src/utils/case-utils.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 
-const specialChars = /[^a-zA-Z0-9\/_-]/g
+const specialChars = /[^a-zA-Z0-9_-]/g
 
 const capitalizeFirstLetter = (text: string) => text.charAt(0).toUpperCase() + text.slice(1).toLowerCase()
 
@@ -8,7 +8,7 @@ const splitChar = (char: string) => (tokens: string[]) => tokens.flatMap((token)
 const splitRegex = (regex: RegExp) => (tokens: string[]) => tokens.flatMap((token) => token.split(regex))
 const splitCaseChange = (tokens: string[]) => tokens.flatMap((token) => token.split(/(?<=[a-z])(?=[A-Z])/))
 const splitTokens = (tokens: string[]) => {
-  return [splitRegex(specialChars), splitChar('/'), splitChar('-'), splitChar('_'), splitCaseChange].reduce(
+  return [splitRegex(specialChars), splitChar('-'), splitChar('_'), splitCaseChange].reduce(
     (acc, step) => step(acc),
     tokens
   )

--- a/packages/cli/src/utils/case-utils.ts
+++ b/packages/cli/src/utils/case-utils.ts
@@ -1,11 +1,23 @@
 import _ from 'lodash'
 
+const specialChars = /[^a-zA-Z0-9\/_-]/g
+
 const capitalizeFirstLetter = (text: string) => text.charAt(0).toUpperCase() + text.slice(1).toLowerCase()
 
 const splitChar = (char: string) => (tokens: string[]) => tokens.flatMap((token) => token.split(char))
+const splitRegex = (regex: RegExp) => (tokens: string[]) => tokens.flatMap((token) => token.split(regex))
 const splitCaseChange = (tokens: string[]) => tokens.flatMap((token) => token.split(/(?<=[a-z])(?=[A-Z])/))
 const splitTokens = (tokens: string[]) => {
-  return [splitChar('/'), splitChar('-'), splitChar('_'), splitCaseChange].reduce((acc, step) => step(acc), tokens)
+  return [splitRegex(specialChars), splitChar('/'), splitChar('-'), splitChar('_'), splitCaseChange].reduce(
+    (acc, step) => step(acc),
+    tokens
+  )
+}
+
+const filterOutEmpty = (tokens: string[]) => tokens.filter((token) => token.length > 0)
+const filterOutRegex = (regex: RegExp) => (tokens: string[]) => tokens.filter((token) => !regex.test(token))
+const filterTokens = (tokens: string[]) => {
+  return [filterOutEmpty, filterOutRegex(specialChars)].reduce((acc, step) => step(acc), tokens)
 }
 
 type SupportedCase = `${'pascal' | 'kebab' | 'snake' | 'screamingSnake' | 'camel'}Case`
@@ -30,7 +42,8 @@ const fromTokens = {
 } as Record<SupportedCase, (tokens: string[]) => string>
 
 export const to = _.mapValues(fromTokens, (fn) => (text: string) => {
-  const tokens = splitTokens([text])
+  let tokens = splitTokens([text])
+  tokens = filterTokens(tokens)
   return fn(tokens)
 }) satisfies Record<SupportedCase, (text: string) => string>
 

--- a/packages/cli/src/utils/record-utils.ts
+++ b/packages/cli/src/utils/record-utils.ts
@@ -41,6 +41,17 @@ export const mapValues = <A, B>(record: Record<string, A>, fn: (value: A, key: s
   return newRecord
 }
 
+export const mapKeys = <A>(record: Record<string, A>, fn: (value: A, key: string) => string): Record<string, A> => {
+  const newRecord: Record<string, A> = {}
+
+  for (const [key, value] of Object.entries(record)) {
+    const newKey = fn(value, key) as string
+    newRecord[newKey] = value
+  }
+
+  return newRecord
+}
+
 export function filterValues<A, B extends A>(
   record: Record<string, A>,
   fn: (value: A, key: string) => value is B

--- a/packages/cli/templates/echo-bot/package.json
+++ b/packages/cli/templates/echo-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.19.0",
-    "@botpress/sdk": "0.8.17"
+    "@botpress/sdk": "0.8.18"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.19.0",
-    "@botpress/sdk": "0.8.17"
+    "@botpress/sdk": "0.8.18"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.19.0",
-    "@botpress/sdk": "0.8.17"
+    "@botpress/sdk": "0.8.18"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.19.0",
-    "@botpress/sdk": "0.8.17",
+    "@botpress/sdk": "0.8.18",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "0.8.17",
+  "version": "0.8.18",
   "description": "Botpress SDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/sdk/src/integration/definition.ts
+++ b/packages/sdk/src/integration/definition.ts
@@ -151,6 +151,15 @@ export class IntegrationDefinition<
   public readonly identifier: this['props']['identifier']
   public readonly entities: this['props']['entities']
 
+  public clone(
+    props: Partial<IntegrationDefinitionProps<TConfig, TEvents, TActions, TChannels, TStates, TEntities>>
+  ): IntegrationDefinition<TConfig, TEvents, TActions, TChannels, TStates, TEntities> {
+    return new IntegrationDefinition<TConfig, TEvents, TActions, TChannels, TStates, TEntities>({
+      ...this,
+      ...props,
+    })
+  }
+
   public constructor(
     public readonly props: IntegrationDefinitionProps<TConfig, TEvents, TActions, TChannels, TStates, TEntities>
   ) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1242,7 +1242,7 @@ importers:
         specifier: 0.19.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 0.8.17
+        specifier: 0.8.18
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.0.20
@@ -1357,7 +1357,7 @@ importers:
         specifier: 0.19.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.8.17
+        specifier: 0.8.18
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1376,7 +1376,7 @@ importers:
         specifier: 0.19.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.8.17
+        specifier: 0.8.18
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1395,7 +1395,7 @@ importers:
         specifier: 0.19.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.8.17
+        specifier: 0.8.18
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1414,7 +1414,7 @@ importers:
         specifier: 0.19.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.8.17
+        specifier: 0.8.18
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
this PR:
- ensures special characters are not allowed in action names, 
- but also prepares the field for if we want to support some special characters in the future
- make all generated types have more uniform names
