### PR TITLE
chore: use pnpm 8.6.2 to synchronize repositories

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@v2.2.4
       with:
-        version: 8.6.0
+        version: 8.6.2
     - uses: actions/setup-node@v3
       with:
         node-version: '18.x'

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-pnpm 8.6.0
+pnpm 8.6.2
 nodejs 18.13.0

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "typescript": "^4.9.4",
     "vitest": "^0.33.0"
   },
-  "packageManager": "pnpm@8.6.0"
+  "packageManager": "pnpm@8.6.2"
 }


### PR DESCRIPTION
this is to sync with:
- [botpress/documentation](https://github.com/botpress/documentation/blob/master/package.json)
- [botpress/skynet](https://github.com/botpress/skynet/blob/master/package.json)