### PR TITLE
feat(sdk): expose files operations in sdk clients

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "0.8.28",
+  "version": "0.8.29",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -21,7 +21,7 @@
   "main": "dist/index.js",
   "dependencies": {
     "@botpress/client": "0.21.0",
-    "@botpress/sdk": "0.8.23",
+    "@botpress/sdk": "0.8.24",
     "@bpinternal/const": "^0.0.20",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/templates/echo-bot/package.json
+++ b/packages/cli/templates/echo-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.21.0",
-    "@botpress/sdk": "0.8.23"
+    "@botpress/sdk": "0.8.24"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.21.0",
-    "@botpress/sdk": "0.8.23"
+    "@botpress/sdk": "0.8.24"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.21.0",
-    "@botpress/sdk": "0.8.23"
+    "@botpress/sdk": "0.8.24"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.21.0",
-    "@botpress/sdk": "0.8.23",
+    "@botpress/sdk": "0.8.24",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "description": "Botpress SDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/sdk/src/bot/client/index.ts
+++ b/packages/sdk/src/bot/client/index.ts
@@ -49,6 +49,13 @@ export class BotSpecificClient<TBot extends BaseBot> {
 
   public callAction: routes.CallAction<TBot> = (x) => this.client.callAction(x)
 
+  public upsertFile: routes.UpsertFile<TBot> = (x) => this.client.upsertFile(x)
+  public deleteFile: routes.DeleteFile<TBot> = (x) => this.client.deleteFile(x)
+  public listFiles: routes.ListFiles<TBot> = (x) => this.client.listFiles(x)
+  public getFile: routes.GetFile<TBot> = (x) => this.client.getFile(x)
+  public updateFileMetadata: routes.UpdateFileMetadata<TBot> = (x) => this.client.updateFileMetadata(x)
+  public searchFiles: routes.SearchFiles<TBot> = (x) => this.client.searchFiles(x)
+
   /**
    * @deprecated Use `callAction` to delegate the conversation creation to an integration.
    */

--- a/packages/sdk/src/bot/client/routes.ts
+++ b/packages/sdk/src/bot/client/routes.ts
@@ -135,3 +135,10 @@ export type CallAction<TBot extends BaseBot> = <ActionType extends keyof types.E
 ) => Promise<{
   output: Cast<types.EnumerateActions<TBot>[ActionType], types.IntegrationInstanceActionDefinition>['output']
 }>
+
+export type UpsertFile<_TBot extends BaseBot> = Client['upsertFile']
+export type DeleteFile<_TBot extends BaseBot> = Client['deleteFile']
+export type ListFiles<_TBot extends BaseBot> = Client['listFiles']
+export type GetFile<_TBot extends BaseBot> = Client['getFile']
+export type UpdateFileMetadata<_TBot extends BaseBot> = Client['updateFileMetadata']
+export type SearchFiles<_TBot extends BaseBot> = Client['searchFiles']

--- a/packages/sdk/src/integration/client/index.ts
+++ b/packages/sdk/src/integration/client/index.ts
@@ -67,4 +67,10 @@ export class IntegrationSpecificClient<TIntegration extends BaseIntegration> {
     this.client.patchState(x)) as routes.PatchState<TIntegration>
 
   public configureIntegration: routes.ConfigureIntegration<TIntegration> = (x) => this.client.configureIntegration(x)
+
+  public upsertFile: routes.UpsertFile<TIntegration> = (x) => this.client.upsertFile(x)
+  public deleteFile: routes.DeleteFile<TIntegration> = (x) => this.client.deleteFile(x)
+  public listFiles: routes.ListFiles<TIntegration> = (x) => this.client.listFiles(x)
+  public getFile: routes.GetFile<TIntegration> = (x) => this.client.getFile(x)
+  public updateFileMetadata: routes.UpdateFileMetadata<TIntegration> = (x) => this.client.updateFileMetadata(x)
 }

--- a/packages/sdk/src/integration/client/routes.ts
+++ b/packages/sdk/src/integration/client/routes.ts
@@ -267,3 +267,9 @@ export type PatchState<TIntegration extends BaseIntegration> = <TState extends k
 ) => Promise<StateResponse<TIntegration, TState>>
 
 export type ConfigureIntegration<_TIntegration extends BaseIntegration> = Client['configureIntegration']
+
+export type UpsertFile<_TIntegration extends BaseIntegration> = Client['upsertFile']
+export type DeleteFile<_TIntegration extends BaseIntegration> = Client['deleteFile']
+export type ListFiles<_TIntegration extends BaseIntegration> = Client['listFiles']
+export type GetFile<_TIntegration extends BaseIntegration> = Client['getFile']
+export type UpdateFileMetadata<_TIntegration extends BaseIntegration> = Client['updateFileMetadata']

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1242,7 +1242,7 @@ importers:
         specifier: 0.21.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 0.8.23
+        specifier: 0.8.24
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.0.20
@@ -1357,7 +1357,7 @@ importers:
         specifier: 0.21.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.8.23
+        specifier: 0.8.24
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1376,7 +1376,7 @@ importers:
         specifier: 0.21.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.8.23
+        specifier: 0.8.24
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1395,7 +1395,7 @@ importers:
         specifier: 0.21.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.8.23
+        specifier: 0.8.24
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1414,7 +1414,7 @@ importers:
         specifier: 0.21.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.8.23
+        specifier: 0.8.24
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
This feature enhances the SDK by providing direct access to the Files API for integrations and bots _as code_. While it was previously possible to interact with the Files API, this update simplifies the process by incorporating it directly into the SDK clients.

**For Bots:**
This addition is a necessary enhancement, streamlining file operations for bot functionalities.

**For Integrations:**
Despite initial reservations due to potential downsides, such as the risk of unexpected billing caused by integrations creating files, we have chosen to implement this feature.

Our goal is to enable webchat users to upload files seamlessly, and this approach offers the simplest and most straightforward solution.

There are multiple workarounds to mitigate the risks associated with this feature, such as implementing a permission system for integrations, so we are confident that the benefits outweigh the potential downsides.