### PR TITLE
chore: use new script naming pattern

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup
         uses: ./.github/actions/setup
-      - run: pnpm run format:check
-      - run: pnpm run lint:check
-      - run: pnpm run type:check
-      - run: pnpm run dep:check
+      - run: pnpm run check:format
+      - run: pnpm run check:lint
+      - run: pnpm run check:type
+      - run: pnpm run check:dep
       - run: pnpm run test

--- a/.github/workflows/run-cli-tests.yml
+++ b/.github/workflows/run-cli-tests.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           filter: '@botpress/cli'
       - run: |
-          pnpm run -F cli e2e:test -v \
+          pnpm run -F cli test:e2e -v \
             --api-url https://api.botpress.dev \
             --workspace-id ${{ secrets.STAGING_E2E_TESTS_WORKSPACE_ID }} \
             --workspace-handle clitests \

--- a/.github/workflows/run-client-tests.yml
+++ b/.github/workflows/run-client-tests.yml
@@ -20,4 +20,4 @@ jobs:
           filter: '@botpress/client'
       - run: |
           pnpm -F client exec puppeteer browsers install chrome
-          pnpm -F client run e2e:test
+          pnpm -F client run test:e2e

--- a/bots/bugbuster/package.json
+++ b/bots/bugbuster/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bp-bots/bugbuster",
   "scripts": {
-    "type:check": "tsc --noEmit",
+    "check:type": "tsc --noEmit",
     "integrations": "es-node ./integrations.ts"
   },
   "keywords": [],

--- a/bots/hello-world/package.json
+++ b/bots/hello-world/package.json
@@ -3,7 +3,7 @@
   "description": "Hello-world bot",
   "private": true,
   "scripts": {
-    "type:check": "tsc --noEmit"
+    "check:type": "tsc --noEmit"
   },
   "dependencies": {
     "@botpress/cli": "workspace:*",

--- a/bots/hit-looper/package.json
+++ b/bots/hit-looper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bp-bots/hit-looper",
   "scripts": {
-    "type:check": "tsc --noEmit",
+    "check:type": "tsc --noEmit",
     "integrations": "es-node ./integrations.ts"
   },
   "keywords": [],

--- a/bots/sheetzy/package.json
+++ b/bots/sheetzy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bp-bots/sheetzy",
   "scripts": {
-    "type:check": "tsc --noEmit",
+    "check:type": "tsc --noEmit",
     "integrations": "es-node ./integrations.ts"
   },
   "keywords": [],

--- a/integrations/asana/package.json
+++ b/integrations/asana/package.json
@@ -5,8 +5,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "private": true,

--- a/integrations/dalle/package.json
+++ b/integrations/dalle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpresshub/dalle",
   "scripts": {
-    "type:check": "tsc --noEmit",
+    "check:type": "tsc --noEmit",
     "version": "bp --version",
     "login": "bp login",
     "build": "bp build",

--- a/integrations/discord/package.json
+++ b/integrations/discord/package.json
@@ -6,8 +6,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/github/package.json
+++ b/integrations/github/package.json
@@ -5,8 +5,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/gmail/package.json
+++ b/integrations/gmail/package.json
@@ -6,8 +6,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/googlecalendar/package.json
+++ b/integrations/googlecalendar/package.json
@@ -5,8 +5,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/gsheets/package.json
+++ b/integrations/gsheets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpresshub/gsheets",
   "scripts": {
-    "type:check": "tsc --noEmit",
+    "check:type": "tsc --noEmit",
     "build": "pnpm bp build"
   },
   "keywords": [],

--- a/integrations/instagram/package.json
+++ b/integrations/instagram/package.json
@@ -6,8 +6,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/intercom/package.json
+++ b/integrations/intercom/package.json
@@ -6,8 +6,7 @@
     "start": "pnpm bp serve --port 7009",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/line/package.json
+++ b/integrations/line/package.json
@@ -6,8 +6,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/linear/package.json
+++ b/integrations/linear/package.json
@@ -5,7 +5,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "login": "pnpm bp login",
-    "type:check": "tsc --noEmit"
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/mailchimp/package.json
+++ b/integrations/mailchimp/package.json
@@ -4,8 +4,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "private": true,

--- a/integrations/make/package.json
+++ b/integrations/make/package.json
@@ -4,7 +4,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit"
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "private": true,

--- a/integrations/messenger/package.json
+++ b/integrations/messenger/package.json
@@ -6,8 +6,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/notion/package.json
+++ b/integrations/notion/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpresshub/notion",
   "scripts": {
-    "type:check": "tsc --noEmit",
+    "check:type": "tsc --noEmit",
     "build": "pnpm bp build"
   },
   "keywords": [],

--- a/integrations/slack/package.json
+++ b/integrations/slack/package.json
@@ -5,8 +5,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/stripe/package.json
+++ b/integrations/stripe/package.json
@@ -4,8 +4,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "private": true,

--- a/integrations/sunco/package.json
+++ b/integrations/sunco/package.json
@@ -6,8 +6,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/teams/package.json
+++ b/integrations/teams/package.json
@@ -6,8 +6,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/telegram/package.json
+++ b/integrations/telegram/package.json
@@ -7,8 +7,7 @@
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
     "login": "pnpm bp login",
-    "test": "echo \"Tests not implemented yet.\"",
-    "type:check": "tsc --noEmit"
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/trello/package.json
+++ b/integrations/trello/package.json
@@ -4,8 +4,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "private": true,

--- a/integrations/twilio/package.json
+++ b/integrations/twilio/package.json
@@ -6,8 +6,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/viber/package.json
+++ b/integrations/viber/package.json
@@ -6,8 +6,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/vonage/package.json
+++ b/integrations/vonage/package.json
@@ -6,8 +6,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/webchat/package.json
+++ b/integrations/webchat/package.json
@@ -5,8 +5,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/webhook/package.json
+++ b/integrations/webhook/package.json
@@ -7,8 +7,7 @@
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
     "login": "pnpm bp login",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/whatsapp/package.json
+++ b/integrations/whatsapp/package.json
@@ -6,8 +6,7 @@
     "start": "pnpm bp serve",
     "build": "pnpm bp build",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
-    "test": "echo \"Tests not implemented yet.\""
+    "check:type": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/integrations/zapier/package.json
+++ b/integrations/zapier/package.json
@@ -7,7 +7,7 @@
     "build": "pnpm bp build",
     "login": "pnpm bp login",
     "deploy": "pnpm bp deploy",
-    "type:check": "tsc --noEmit",
+    "check:type": "tsc --noEmit",
     "test": "jest"
   },
   "keywords": [],

--- a/integrations/zendesk/package.json
+++ b/integrations/zendesk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpresshub/zendesk",
   "scripts": {
-    "type:check": "tsc --noEmit",
+    "check:type": "tsc --noEmit",
     "build": "pnpm bp build"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -4,16 +4,16 @@
   "scripts": {
     "build": "turbo build",
     "bump": "depsynky bump && pnpm -w install",
-    "type:check": "pnpm -r --stream type:check",
-    "format:check": "prettier --check .",
-    "format:fix": "prettier --write .",
-    "lint:check": "eslint ./ --ext .ts --ext .tsx",
-    "lint:fix": "eslint --fix ./ --ext .ts --ext .tsx",
-    "dep:check": "depsynky check",
-    "dep:fix": "depsynky sync",
-    "check": "pnpm dep:check && pnpm format:check && pnpm lint:check && pnpm type:check",
     "test": "pnpm vitest --run",
-    "fix": "pnpm dep:fix && pnpm format:fix && pnpm lint:fix"
+    "check:type": "pnpm -r --stream check:type",
+    "check:format": "prettier --check .",
+    "fix:format": "prettier --write .",
+    "check:lint": "eslint ./ --ext .ts --ext .tsx",
+    "fix:lint": "eslint --fix ./ --ext .ts --ext .tsx",
+    "check:dep": "depsynky check",
+    "fix:dep": "depsynky sync",
+    "check": "pnpm check:dep && pnpm check:format && pnpm check:lint && pnpm check:type",
+    "fix": "pnpm fix:dep && pnpm fix:format && pnpm fix:lint"
   },
   "dependencies": {
     "@botpress/cli": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,11 +6,11 @@
     "build": "pnpm run bundle && pnpm run template:gen",
     "dev": "ts-node -T src/index.ts",
     "start": "node dist/index.js",
-    "type:check": "tsc --noEmit",
+    "check:type": "tsc --noEmit",
     "bundle": "ts-node -T build.ts",
     "template:gen": "pnpm -r --stream -F @bp-templates/* exec bp gen",
-    "e2e:test": "ts-node -T ./e2e",
-    "unit:test": "pnpm vitest --run"
+    "test:e2e": "ts-node -T ./e2e",
+    "test:unit": "pnpm vitest --run"
   },
   "keywords": [],
   "author": "",

--- a/packages/cli/templates/echo-bot/package.json
+++ b/packages/cli/templates/echo-bot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bp-templates/echo-bot",
   "scripts": {
-    "type:check": "tsc --noEmit"
+    "check:type": "tsc --noEmit"
   },
   "private": true,
   "dependencies": {

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -2,7 +2,7 @@
   "name": "@bp-templates/empty-integration",
   "integrationName": "empty-integration",
   "scripts": {
-    "type:check": "tsc --noEmit"
+    "check:type": "tsc --noEmit"
   },
   "private": true,
   "dependencies": {

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -2,7 +2,7 @@
   "name": "@bp-templates/hello-world",
   "integrationName": "hello-world",
   "scripts": {
-    "type:check": "tsc --noEmit"
+    "check:type": "tsc --noEmit"
   },
   "private": true,
   "dependencies": {

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -2,7 +2,7 @@
   "name": "@bp-templates/webhook-message",
   "integrationName": "webhook-message",
   "scripts": {
-    "type:check": "tsc --noEmit"
+    "check:type": "tsc --noEmit"
   },
   "private": true,
   "dependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,16 +12,16 @@
     "https": false
   },
   "scripts": {
-    "type:check": "tsc --noEmit",
+    "check:type": "tsc --noEmit",
     "build:type": "tsc --emitDeclarationOnly --declaration",
     "build:browser": "ts-node -T ./build.ts --browser",
     "build:node": "ts-node -T ./build.ts --node",
     "build:bundle": "ts-node -T ./build.ts --bundle",
     "build": "pnpm build:type && pnpm build:node && pnpm build:browser && pnpm build:bundle",
     "generate": "ts-node ./openapi.ts",
-    "test": "pnpm run e2e:test",
     "test:manual": "vitest tests/manual/file-upload",
-    "e2e:test": "ts-node -T ./tests/e2e/node.ts && ts-node -T ./tests/e2e/browser"
+    "test:e2e": "ts-node -T ./tests/e2e/node.ts && ts-node -T ./tests/e2e/browser",
+    "test": "pnpm run test:e2e"
   },
   "dependencies": {
     "axios": "^1.6.1",

--- a/packages/sdk-addons/package.json
+++ b/packages/sdk-addons/package.json
@@ -4,7 +4,7 @@
   "main": "./src/index.ts",
   "scripts": {
     "build": "tsc",
-    "type:check": "tsc --noEmit"
+    "check:type": "tsc --noEmit"
   },
   "dependencies": {
     "@sentry/node": "^7.53.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "type:check": "tsc --noEmit",
+    "check:type": "tsc --noEmit",
     "build:type": "tsc --emitDeclarationOnly --declaration",
     "build:node": "ts-node -T build.ts",
     "build": "pnpm build:type && pnpm build:node"


### PR DESCRIPTION
This is something I talked about with @AbrahamLopez10 and @michaelmass 

The goal is to define a uniform script naming pattern that can be used across all our repos.

The pattern goes as follows:
- `check:*` for static checks
- `fix:*` to automatically fix static checks
- `test:*` to run tests
- `build:*` to build/bundle a project
- `gen:*` to generate code

Here's a few examples:
```json
"scripts": {
  "check:type": "pnpm -r --stream type:check",
  "check:format": "prettier --check .",
  "fix:format": "prettier --write .",
  "check:lint": "eslint ./ --ext .ts --ext .tsx",
  "fix:lint": "eslint --fix ./ --ext .ts --ext .tsx",
  "check:dep": "depsynky check",
  "fix:dep": "depsynky sync",
  
  "check": "pnpm check:dep && pnpm check:format && pnpm check:lint && pnpm check:type",
  "fix": "pnpm dep:fix && pnpm format:fix && pnpm lint:fix"
}
```