### PR TITLE
fix(llm): put back optional model in llm action input

### DIFF
--- a/integrations/groq/src/index.ts
+++ b/integrations/groq/src/index.ts
@@ -14,6 +14,7 @@ export default new bp.Integration({
     generateContent: async ({ input, logger }) => {
       return await llm.openai.generateContent(<llm.GenerateContentInput>input, groqClient, logger, {
         provider: 'groq',
+        defaultModel: 'mixtral-8x7b-32768',
         modelCosts: {
           // Source: https://wow.groq.com/
           'llama3-8b-8192': { inputCostPer1MTokens: 0.05, outputCostPer1MTokens: 0.08 },

--- a/integrations/openai/src/index.ts
+++ b/integrations/openai/src/index.ts
@@ -13,6 +13,7 @@ export default new bp.Integration({
     generateContent: async ({ input, logger }) => {
       return await llm.openai.generateContent(<llm.GenerateContentInput>input, openAIClient, logger, {
         provider: 'openai',
+        defaultModel: 'gpt-4o-2024-05-13',
         modelCosts: {
           // Source: https://openai.com/api/pricing/
           // Only full model names should be supported here, as the short model names can be pointed to a newer model with different pricing by OpenAI at any time.

--- a/packages/common/src/llm/openai.ts
+++ b/packages/common/src/llm/openai.ts
@@ -19,12 +19,15 @@ type ModelCost = {
   outputCostPer1MTokens: number
 }
 
+type NoInfer<T> = [T][T extends any ? 0 : never]
+
 export async function generateContent<M extends string>(
   input: GenerateContentInput,
   openAIClient: OpenAI,
   logger: IntegrationLogger,
   params: {
     provider: string
+    defaultModel: NoInfer<M>
     modelCosts: {
       [key in M]: ModelCost
     }
@@ -49,7 +52,7 @@ export async function generateContent<M extends string>(
   }
 
   const response = await openAIClient.chat.completions.create({
-    model: input.model,
+    model: input.model ?? params.defaultModel,
     max_tokens: input.maxTokens || undefined, // note: ignore a zero value as the Studio doesn't support empty number inputs and defaults this to 0
     temperature: input.temperature,
     top_p: input.topP,

--- a/packages/sdk/src/interfaces/llm.ts
+++ b/packages/sdk/src/interfaces/llm.ts
@@ -41,7 +41,8 @@ const MessageSchema = z.object({
 })
 
 const GenerateContentInputSchema = z.object({
-  model: z.string().describe('Model to use for content generation'),
+  // optional because an llm integration should have a default model
+  model: z.string().optional().describe('Model to use for content generation'),
   systemPrompt: z.string().optional().describe('Optional system prompt to guide the model'),
   messages: z.array(MessageSchema).describe('Array of messages for the model to process').min(1),
   responseFormat: z


### PR DESCRIPTION
The previous version of these integrations had a `.default()` model id