### PR TITLE
fix(llm): return error message

### DIFF
--- a/integrations/anthropic/src/index.ts
+++ b/integrations/anthropic/src/index.ts
@@ -1,9 +1,9 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { llm } from '@botpress/common'
+import { interfaces } from '@botpress/sdk'
 import { generateContent } from './actions/generate-content'
 import { ModelId } from './schemas'
 import * as bp from '.botpress'
-import { interfaces } from '@botpress/sdk'
 
 const anthropic = new Anthropic({
   apiKey: bp.secrets.ANTHROPIC_API_KEY,
@@ -40,10 +40,15 @@ export default new bp.Integration({
   unregister: async () => {},
   actions: {
     generateContent: async ({ input, logger }) => {
-      return await generateContent<ModelId>(<llm.GenerateContentInput>input, anthropic, logger, {
-        models: languageModels,
-        defaultModel: 'claude-3-5-sonnet-20240620',
-      })
+      try {
+        return await generateContent<ModelId>(<llm.GenerateContentInput>input, anthropic, logger, {
+          models: languageModels,
+          defaultModel: 'claude-3-5-sonnet-20240620',
+        })
+      } catch (err: any) {
+        logger.forBot().error(err.message)
+        throw err
+      }
     },
     listLanguageModels: async ({}) => {
       return {

--- a/integrations/groq/src/index.ts
+++ b/integrations/groq/src/index.ts
@@ -1,8 +1,8 @@
 import { llm } from '@botpress/common'
+import { interfaces } from '@botpress/sdk'
 import OpenAI from 'openai'
 import { ModelId } from './schemas'
 import * as bp from '.botpress'
-import { interfaces } from '@botpress/sdk'
 
 const groqClient = new OpenAI({
   baseURL: 'https://api.groq.com/openai/v1',
@@ -75,11 +75,16 @@ export default new bp.Integration({
   unregister: async () => {},
   actions: {
     generateContent: async ({ input, logger }) => {
-      return await llm.openai.generateContent<ModelId>(<llm.GenerateContentInput>input, groqClient, logger, {
-        provider: 'groq',
-        models: languageModels,
-        defaultModel: 'mixtral-8x7b-32768',
-      })
+      try {
+        return await llm.openai.generateContent<ModelId>(<llm.GenerateContentInput>input, groqClient, logger, {
+          provider: 'groq',
+          models: languageModels,
+          defaultModel: 'mixtral-8x7b-32768',
+        })
+      } catch (err: any) {
+        logger.forBot().error(err.message)
+        throw err
+      }
     },
     listLanguageModels: async ({}) => {
       return {

--- a/integrations/openai/src/index.ts
+++ b/integrations/openai/src/index.ts
@@ -1,10 +1,10 @@
+import { InvalidPayloadError } from '@botpress/client'
 import { llm } from '@botpress/common'
 import { interfaces } from '@botpress/sdk'
 import OpenAI from 'openai'
+import { ImageGenerateParams, Images } from 'openai/resources'
 import { LanguageModelId, ImageModelId } from './schemas'
 import * as bp from '.botpress'
-import { InvalidPayloadError } from '@botpress/client'
-import { ImageGenerateParams, Images } from 'openai/resources'
 
 const openAIClient = new OpenAI({
   apiKey: bp.secrets.OPENAI_API_KEY,
@@ -114,11 +114,21 @@ export default new bp.Integration({
   unregister: async () => {},
   actions: {
     generateContent: async ({ input, logger }) => {
-      return await llm.openai.generateContent<LanguageModelId>(<llm.GenerateContentInput>input, openAIClient, logger, {
-        provider: 'openai',
-        models: languageModels,
-        defaultModel: DEFAULT_LANGUAGE_MODEL_ID,
-      })
+      try {
+        return await llm.openai.generateContent<LanguageModelId>(
+          <llm.GenerateContentInput>input,
+          openAIClient,
+          logger,
+          {
+            provider: 'openai',
+            models: languageModels,
+            defaultModel: DEFAULT_LANGUAGE_MODEL_ID,
+          }
+        )
+      } catch (err: any) {
+        logger.forBot().error(err.message)
+        throw err
+      }
     },
     generateImage: async ({ input, client }) => {
       const imageModelId = (input.model?.id ?? DEFAULT_IMAGE_MODEL_ID) as ImageModelId


### PR DESCRIPTION
There are some validations done in generateContent that throws errors but there's no logger for it (ex: wrong model, tokens, etc)