### PR TITLE
fix(integrations): use JSON.stringify() for debug logging in LLM integrations

### DIFF
--- a/integrations/anthropic/src/actions/generate-content.ts
+++ b/integrations/anthropic/src/actions/generate-content.ts
@@ -77,7 +77,7 @@ export async function generateContent<M extends string>(
   }
 
   if (input.debug) {
-    logger.forBot().info('Request being sent to Anthropic:', request)
+    logger.forBot().info('Request being sent to Anthropic: ' + JSON.stringify(request, null, 2))
   }
 
   try {
@@ -100,7 +100,7 @@ export async function generateContent<M extends string>(
     throw err
   } finally {
     if (input.debug && response) {
-      logger.forBot().info('Response received from Anthropic:', response)
+      logger.forBot().info('Response received from Anthropic: ' + JSON.stringify(response, null, 2))
     }
   }
 

--- a/packages/common/src/llm/openai.ts
+++ b/packages/common/src/llm/openai.ts
@@ -80,7 +80,7 @@ export async function generateContent<M extends string>(
   }
 
   if (input.debug) {
-    logger.forBot().info(`Request being sent to ${props.provider}:`, request)
+    logger.forBot().info(`Request being sent to ${props.provider}: ` + JSON.stringify(request, null, 2))
   }
 
   try {
@@ -101,7 +101,7 @@ export async function generateContent<M extends string>(
     throw err
   } finally {
     if (input.debug && response) {
-      logger.forBot().info(`Response received from ${props.provider}:`, response)
+      logger.forBot().info(`Response received from ${props.provider}: ` + JSON.stringify(response, null, 2))
     }
   }
 


### PR DESCRIPTION
The logger doesn't serialize child properties when passing an object so we'll use JSON.stringify() with pretty printing instead.