### PR TITLE
fix(whatsapp): post release fixes

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -32,7 +32,7 @@ export const INTEGRATION_NAME = 'whatsapp'
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '2.0.5',
+  version: '2.0.6',
   title: 'WhatsApp',
   description: 'This integration allows your bot to interact with WhatsApp.',
   icon: 'icon.svg',

--- a/integrations/whatsapp/src/index.ts
+++ b/integrations/whatsapp/src/index.ts
@@ -1,6 +1,6 @@
 import { RuntimeError } from '@botpress/client'
-import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { IntegrationContext, Request } from '@botpress/sdk'
+import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { channel, INTEGRATION_NAME } from 'integration.definition'
 import * as crypto from 'node:crypto'
 import queryString from 'query-string'
@@ -192,7 +192,7 @@ const integration = new bp.Integration({
 
     const secret = getSecret(ctx)
     // For testing purposes, if you send the secret in the header it's possible to disable signature check
-    if (secret?.length && req.headers['x-secret'] !== secret) {
+    if (secret && req.headers['x-secret'] !== secret) {
       const signature = req.headers['x-hub-signature-256']
 
       if (!signature) {

--- a/integrations/whatsapp/src/index.ts
+++ b/integrations/whatsapp/src/index.ts
@@ -204,7 +204,7 @@ const integration = new bp.Integration({
         const expectedHash = crypto.createHmac('sha256', secret).update(req.body).digest('hex')
         if (signatureHash !== expectedHash) {
           const errorMessage =
-            "Couldn't validate the request signature, please verify the client secret configuration property!"
+            "Couldn't validate the request signature, please verify the client secret configuration property."
           logger.forBot().error(errorMessage)
           return { status: 401, body: errorMessage }
         }

--- a/integrations/whatsapp/src/misc/whatsapp.ts
+++ b/integrations/whatsapp/src/misc/whatsapp.ts
@@ -145,12 +145,15 @@ export const getAccessToken = async (client: bp.Client, ctx: IntegrationContext)
   return accessToken
 }
 
-export const getSecret = (ctx: IntegrationContext) => {
+export const getSecret = (ctx: IntegrationContext): string | undefined => {
+  let value
   if (ctx.configuration.useManualConfiguration) {
-    return ctx.configuration.clientSecret
+    value = ctx.configuration.clientSecret
+  } else {
+    value = bp.secrets.CLIENT_SECRET
   }
 
-  return bp.secrets.CLIENT_SECRET
+  return value?.length && value
 }
 
 export const getPhoneNumberId = async (client: bp.Client, ctx: IntegrationContext) => {


### PR DESCRIPTION
This PR will address the following non critical issues:

-  After the oAuth update, I noticed some people are not filling the client secret config variable and saying that the integration stopped working; this will make sure that the client secret is optional
- prevent a possible configuration reset using the wizard route