### PR TITLE
feat(client): add list utils to the client

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "0.8.55",
+  "version": "0.8.56",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -20,8 +20,8 @@
   },
   "main": "dist/index.js",
   "dependencies": {
-    "@botpress/client": "0.27.0",
-    "@botpress/sdk": "0.10.7",
+    "@botpress/client": "0.28.0",
+    "@botpress/sdk": "0.10.8",
     "@bpinternal/const": "^0.0.20",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/templates/echo-bot/package.json
+++ b/packages/cli/templates/echo-bot/package.json
@@ -5,8 +5,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.27.0",
-    "@botpress/sdk": "0.10.7"
+    "@botpress/client": "0.28.0",
+    "@botpress/sdk": "0.10.8"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.27.0",
-    "@botpress/sdk": "0.10.7"
+    "@botpress/client": "0.28.0",
+    "@botpress/sdk": "0.10.8"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.27.0",
-    "@botpress/sdk": "0.10.7"
+    "@botpress/client": "0.28.0",
+    "@botpress/sdk": "0.10.8"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.27.0",
-    "@botpress/sdk": "0.10.7",
+    "@botpress/client": "0.28.0",
+    "@botpress/sdk": "0.10.8",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/client/readme.md
+++ b/packages/client/readme.md
@@ -13,24 +13,33 @@ pnpm add @botpress/client # for pnpm
 ## Usage
 
 ```ts
-import { Client, ClientOutputs } from '@botpress/client'
+import { Client } from '@botpress/client'
 
-type Bot = ClientOutputs['listBots']['bots'][number]
+// 0. Type definitions for each operation's IO
+type GetBotInput = ClientInputs['getBot']
+type GetBotOutput = ClientOutputs['getBot']
 
 const main = async () => {
   const token = 'your-token'
   const workspaceId = 'your-workspace-id'
-  const client = new Client({ token, workspaceId })
+  const botId = 'your-bot-id'
+  const client = new Client({ token, workspaceId, botId })
 
-  const allBots: Bot[] = []
-  let nextToken: string | undefined
-  do {
-    const resp = await client.listBots({ nextToken })
-    nextToken = resp.meta.nextToken
-    allBots.push(...resp.bots)
-  } while (nextToken)
+  // 1. plain operations
+  const { bot } = await client.getBot({ id: botId })
+  console.log('### bot', bot)
 
-  console.log(allBots)
+  // 2. list utils with `.collect()` function
+  const [latestConversation] = await client.list
+    .conversations({ sortField: 'createdAt', sortDirection: 'desc', integrationName: 'telegram' })
+    .collect({ limit: 1 })
+  console.log('### latestConversation', latestConversation)
+
+  // 3. list utils with async generator and `for await` syntax
+  for await (const message of client.list.messages({ conversationId: latestConversation.id })) {
+    console.log(`### [${message.userId}]`, message.payload)
+  }
 }
+
 void main()
 ```

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -5,6 +5,7 @@ import https from 'https'
 import * as config from './config'
 import * as errors from './errors'
 import * as gen from './gen'
+import { Lister } from './lister'
 import * as types from './types'
 
 const _100mb = 100 * 1024 * 1024
@@ -30,6 +31,10 @@ export class Client extends gen.Client implements types.IClient {
     super(axiosInstance)
 
     this.config = clientConfig
+  }
+
+  public get list() {
+    return new Lister(this)
   }
 
   /**

--- a/packages/client/src/lister.ts
+++ b/packages/client/src/lister.ts
@@ -23,10 +23,16 @@ class AsyncCollection<T> {
     } while (nextToken)
   }
 
-  public async collect() {
+  public async collect(props: { limit?: number } = {}) {
+    const limit = props.limit ?? Number.POSITIVE_INFINITY
     const arr: T[] = []
+    let count = 0
     for await (const item of this) {
       arr.push(item)
+      count++
+      if (count >= limit) {
+        break
+      }
     }
     return arr
   }

--- a/packages/client/src/lister.ts
+++ b/packages/client/src/lister.ts
@@ -1,0 +1,107 @@
+import * as gen from './gen'
+import * as types from './types'
+
+type ListOperation = keyof {
+  [K in types.Operation as types.ClientInputs[K] extends { nextToken?: string | undefined } ? K : never]: null
+}
+type ListInputs = {
+  [K in ListOperation]: Omit<types.ClientInputs[K], 'nextToken'>
+}
+type PageLister<R> = (t: { nextToken?: string }) => Promise<{ items: R[]; meta: { nextToken?: string } }>
+
+class AsyncCollection<T> {
+  public constructor(private _list: PageLister<T>) {}
+
+  public async *[Symbol.asyncIterator]() {
+    let nextToken: string | undefined
+    do {
+      const { items, meta } = await this._list({ nextToken })
+      nextToken = meta.nextToken
+      for (const item of items) {
+        yield item
+      }
+    } while (nextToken)
+  }
+
+  public async collect() {
+    const arr: T[] = []
+    for await (const item of this) {
+      arr.push(item)
+    }
+    return arr
+  }
+}
+
+// lots of repeated code here, but I prefer using vertical selection than to make the code more complex - fleur
+
+export class Lister {
+  public constructor(private client: gen.Client) {}
+  public readonly conversations = (props: ListInputs['listConversations']) =>
+    new AsyncCollection(({ nextToken }) =>
+      this.client.listConversations({ nextToken, ...props }).then((r) => ({ ...r, items: r.conversations }))
+    )
+  public readonly participants = (props: ListInputs['listParticipants']) =>
+    new AsyncCollection(({ nextToken }) =>
+      this.client.listParticipants({ nextToken, ...props }).then((r) => ({ ...r, items: r.participants }))
+    )
+  public readonly events = (props: ListInputs['listEvents']) =>
+    new AsyncCollection(({ nextToken }) =>
+      this.client.listEvents({ nextToken, ...props }).then((r) => ({ ...r, items: r.events }))
+    )
+  public readonly messages = (props: ListInputs['listMessages']) =>
+    new AsyncCollection(({ nextToken }) =>
+      this.client.listMessages({ nextToken, ...props }).then((r) => ({ ...r, items: r.messages }))
+    )
+  public readonly users = (props: ListInputs['listUsers']) =>
+    new AsyncCollection(({ nextToken }) =>
+      this.client.listUsers({ nextToken, ...props }).then((r) => ({ ...r, items: r.users }))
+    )
+  public readonly tasks = (props: ListInputs['listTasks']) =>
+    new AsyncCollection(({ nextToken }) =>
+      this.client.listTasks({ nextToken, ...props }).then((r) => ({ ...r, items: r.tasks }))
+    )
+  public readonly publicIntegrations = (props: ListInputs['listPublicIntegrations']) =>
+    new AsyncCollection(({ nextToken }) =>
+      this.client.listPublicIntegrations({ nextToken, ...props }).then((r) => ({ ...r, items: r.integrations }))
+    )
+  public readonly bots = (props: ListInputs['listBots']) =>
+    new AsyncCollection(({ nextToken }) =>
+      this.client.listBots({ nextToken, ...props }).then((r) => ({ ...r, items: r.bots }))
+    )
+  public readonly botIssues = (props: ListInputs['listBotIssues']) =>
+    new AsyncCollection(({ nextToken }) =>
+      this.client.listBotIssues({ nextToken, ...props }).then((r) => ({ ...r, items: r.issues }))
+    )
+  public readonly workspaces = (props: ListInputs['listWorkspaces']) =>
+    new AsyncCollection(({ nextToken }) =>
+      this.client.listWorkspaces({ nextToken, ...props }).then((r) => ({ ...r, items: r.workspaces }))
+    )
+  public readonly publicWorkspaces = (props: ListInputs['listPublicWorkspaces']) =>
+    new AsyncCollection(({ nextToken }) =>
+      this.client.listPublicWorkspaces({ nextToken, ...props }).then((r) => ({ ...r, items: r.workspaces }))
+    )
+  public readonly workspaceMembers = (props: ListInputs['listWorkspaceMembers']) =>
+    new AsyncCollection(({ nextToken }) =>
+      this.client.listWorkspaceMembers({ nextToken, ...props }).then((r) => ({ ...r, items: r.members }))
+    )
+  public readonly integrations = (props: ListInputs['listIntegrations']) =>
+    new AsyncCollection(({ nextToken }) =>
+      this.client.listIntegrations({ nextToken, ...props }).then((r) => ({ ...r, items: r.integrations }))
+    )
+  public readonly interfaces = (props: ListInputs['listInterfaces']) =>
+    new AsyncCollection(({ nextToken }) =>
+      this.client.listInterfaces({ nextToken, ...props }).then((r) => ({ ...r, items: r.interfaces }))
+    )
+  public readonly activities = (props: ListInputs['listActivities']) =>
+    new AsyncCollection(({ nextToken }) =>
+      this.client.listActivities({ nextToken, ...props }).then((r) => ({ ...r, items: r.activities }))
+    )
+  public readonly files = (props: ListInputs['listFiles']) =>
+    new AsyncCollection(({ nextToken }) =>
+      this.client.listFiles({ nextToken, ...props }).then((r) => ({ ...r, items: r.files }))
+    )
+  public readonly filePassages = (props: ListInputs['listFilePassages']) =>
+    new AsyncCollection(({ nextToken }) =>
+      this.client.listFilePassages({ nextToken, ...props }).then((r) => ({ ...r, items: r.passages }))
+    )
+}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Botpress SDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "@bpinternal/zui": "0.9.3",
-    "@botpress/client": "0.27.0"
+    "@botpress/client": "0.28.0"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1559,10 +1559,10 @@ importers:
   packages/cli:
     dependencies:
       '@botpress/client':
-        specifier: 0.27.0
+        specifier: 0.28.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 0.10.7
+        specifier: 0.10.8
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.0.20
@@ -1674,10 +1674,10 @@ importers:
   packages/cli/templates/echo-bot:
     dependencies:
       '@botpress/client':
-        specifier: 0.27.0
+        specifier: 0.28.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.10.7
+        specifier: 0.10.8
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1693,10 +1693,10 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 0.27.0
+        specifier: 0.28.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.10.7
+        specifier: 0.10.8
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1712,10 +1712,10 @@ importers:
   packages/cli/templates/hello-world:
     dependencies:
       '@botpress/client':
-        specifier: 0.27.0
+        specifier: 0.28.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.10.7
+        specifier: 0.10.8
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1731,10 +1731,10 @@ importers:
   packages/cli/templates/webhook-message:
     dependencies:
       '@botpress/client':
-        specifier: 0.27.0
+        specifier: 0.28.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.10.7
+        specifier: 0.10.8
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8
@@ -1812,7 +1812,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 0.27.0
+        specifier: 0.28.0
         version: link:../client
       '@bpinternal/zui':
         specifier: 0.9.3


### PR DESCRIPTION
fixes CLS-2041

Here's how to use:
```ts
import { Client } from '@botpress/client'

const main = async () => {
  const client = new Client({ ... })

  // 0. by using for-await
  const allBots: ClientOutputs['listBots']['bots'] = []
  for await (const bot of client.list.bots({ dev: false })) {
    allBots.push(bot)
  }

  // 1. by using collect to get all items
  const allConv = await client.list.conversations({ integrationName: 'telegram' }).collect()

  // 2. by using collect with limit
  const topConv = await client.list.conversations({ integrationName: 'telegram' }).collect({ limit: 2 })

  console.log({ allConv, topConv, allBots })
}

void main()
```

I added the `.collect()` function since its seems the [Array.fromAsync](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fromAsync) function is still early and not supported in all environments

Instead of looping through pages, the async iterator loops through items directly to prevent the need for a double for loop when consuming. 