### PR TITLE
fix(api): update api & integration logging

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "0.8.57",
+  "version": "0.8.58",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -20,8 +20,8 @@
   },
   "main": "dist/index.js",
   "dependencies": {
-    "@botpress/client": "0.29.0",
-    "@botpress/sdk": "0.10.9",
+    "@botpress/client": "0.29.1",
+    "@botpress/sdk": "0.10.10",
     "@bpinternal/const": "^0.0.20",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/templates/echo-bot/package.json
+++ b/packages/cli/templates/echo-bot/package.json
@@ -5,8 +5,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.29.0",
-    "@botpress/sdk": "0.10.9"
+    "@botpress/client": "0.29.1",
+    "@botpress/sdk": "0.10.10"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.29.0",
-    "@botpress/sdk": "0.10.9"
+    "@botpress/client": "0.29.1",
+    "@botpress/sdk": "0.10.10"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.29.0",
-    "@botpress/sdk": "0.10.9"
+    "@botpress/client": "0.29.1",
+    "@botpress/sdk": "0.10.10"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.29.0",
-    "@botpress/sdk": "0.10.9",
+    "@botpress/client": "0.29.1",
+    "@botpress/sdk": "0.10.10",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -31,7 +31,7 @@
     "type-fest": "^3.4.0"
   },
   "devDependencies": {
-    "@botpress/api": "0.39.0",
+    "@botpress/api": "0.39.1",
     "@types/qs": "^6.9.7",
     "esbuild": "^0.16.12",
     "lodash": "^4.17.21",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "description": "Botpress SDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "@bpinternal/zui": "0.9.3",
-    "@botpress/client": "0.29.0"
+    "@botpress/client": "0.29.1"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/sdk/src/integration/server.ts
+++ b/packages/sdk/src/integration/server.ts
@@ -188,6 +188,17 @@ export const integrationHandler =
         const runtimeError = new RuntimeError(thrown.message, thrown)
         return { status: runtimeError.code, body: JSON.stringify(runtimeError.toJSON()) }
       }
+
+      if (thrown instanceof Error) {
+        // prints the error in the integration logs
+        console.error(thrown)
+
+        const runtimeError = new RuntimeError(
+          'An unexpected error occurred in the integration. Bot owners: Check logs for more informations. Integration owners: throw a RuntimeError to return a custom error message instead.'
+        )
+        return { status: 400, body: JSON.stringify(runtimeError.toJSON()) }
+      }
+
       throw thrown
     }
   }

--- a/packages/sdk/src/integration/server.ts
+++ b/packages/sdk/src/integration/server.ts
@@ -189,17 +189,13 @@ export const integrationHandler =
         return { status: runtimeError.code, body: JSON.stringify(runtimeError.toJSON()) }
       }
 
-      if (thrown instanceof Error) {
-        // prints the error in the integration logs
-        console.error(thrown)
+      // prints the error in the integration logs
+      console.error(thrown)
 
-        const runtimeError = new RuntimeError(
-          'An unexpected error occurred in the integration. Bot owners: Check logs for more informations. Integration owners: throw a RuntimeError to return a custom error message instead.'
-        )
-        return { status: 400, body: JSON.stringify(runtimeError.toJSON()) }
-      }
-
-      throw thrown
+      const runtimeError = new RuntimeError(
+        'An unexpected error occurred in the integration. Bot owners: Check logs for more informations. Integration owners: throw a RuntimeError to return a custom error message instead.'
+      )
+      return { status: runtimeError.code, body: JSON.stringify(runtimeError.toJSON()) }
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1559,10 +1559,10 @@ importers:
   packages/cli:
     dependencies:
       '@botpress/client':
-        specifier: 0.29.0
+        specifier: 0.29.1
         version: link:../client
       '@botpress/sdk':
-        specifier: 0.10.9
+        specifier: 0.10.10
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.0.20
@@ -1674,10 +1674,10 @@ importers:
   packages/cli/templates/echo-bot:
     dependencies:
       '@botpress/client':
-        specifier: 0.29.0
+        specifier: 0.29.1
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.10.9
+        specifier: 0.10.10
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1693,10 +1693,10 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 0.29.0
+        specifier: 0.29.1
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.10.9
+        specifier: 0.10.10
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1712,10 +1712,10 @@ importers:
   packages/cli/templates/hello-world:
     dependencies:
       '@botpress/client':
-        specifier: 0.29.0
+        specifier: 0.29.1
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.10.9
+        specifier: 0.10.10
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1731,10 +1731,10 @@ importers:
   packages/cli/templates/webhook-message:
     dependencies:
       '@botpress/client':
-        specifier: 0.29.0
+        specifier: 0.29.1
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.10.9
+        specifier: 0.10.10
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8
@@ -1769,8 +1769,8 @@ importers:
         version: 3.11.1
     devDependencies:
       '@botpress/api':
-        specifier: 0.39.0
-        version: 0.39.0(openapi-types@12.1.3)
+        specifier: 0.39.1
+        version: 0.39.1(openapi-types@12.1.3)
       '@types/qs':
         specifier: ^6.9.7
         version: 6.9.7
@@ -1815,7 +1815,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 0.29.0
+        specifier: 0.29.1
         version: link:../client
       '@bpinternal/zui':
         specifier: 0.9.3
@@ -2384,10 +2384,10 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@botpress/api@0.39.0(openapi-types@12.1.3):
-    resolution: {integrity: sha512-/ykf8s2qydvZh8Tj4qe2DI5mmcFU/8kY4r/YO088CnM/o5qD+XoDBmslrzt6r19c1MfceN2J53NBnwfoFUrZng==}
+  /@botpress/api@0.39.1(openapi-types@12.1.3):
+    resolution: {integrity: sha512-paTfxw5vN6FwHgSLBLwLzVPzYbbtuMD7jUDjWz7P017L2OzpFlBzkc2ijwGqkNLXGHehlb3S1X30Vu8oUfN9Lw==}
     dependencies:
-      '@bpinternal/opapi': 0.10.20(openapi-types@12.1.3)
+      '@bpinternal/opapi': 0.10.22(openapi-types@12.1.3)
     transitivePeerDependencies:
       - debug
       - openapi-types
@@ -2459,8 +2459,8 @@ packages:
       regex-parser: 2.2.11
     dev: true
 
-  /@bpinternal/opapi@0.10.20(openapi-types@12.1.3):
-    resolution: {integrity: sha512-plTaVl+FvRCdMlsju5HMGEY0kHcXv3RZAHCAImaAaR0mwEjpUBB4sJFsptx+BaCyyyau4Ty8s+xdgbxh6IB+iQ==}
+  /@bpinternal/opapi@0.10.22(openapi-types@12.1.3):
+    resolution: {integrity: sha512-Un1H3WteDK5PqyvtG5KFw/pe6t5w9eTvhC7j/j8uQnEJR6OreaSj29a5QnEbI2MB375ti6OIUgF0ipbV8KeQIw==}
     engines: {node: '>=16.0.0', pnpm: 9.1.0}
     dependencies:
       '@anatine/zod-openapi': 1.12.1(openapi3-ts@2.0.2)(zod@3.22.4)


### PR DESCRIPTION
Currently when an integration `throw new Error()`, the message is printed in the integration logs, and the lambda fails with status code 502 (which is technically a bad gateway), and there is a log displayed in the bridge for each of those requests.

Previously:
<img width="536" alt="image" src="https://github.com/user-attachments/assets/f9df4bec-9cce-4fbf-b487-ad932483ffe7">

The change I am proposing would instead return thrown errors as RuntimeErrors, but with a generic error message with a bit more information. Being considered a runtime error would stop displaying them in the bridge (it's an error the integration decided to throw, pretty much a runtime error then), 

Here:

So for example, the error would show in the integration log but return a generic message
<img width="315" alt="image" src="https://github.com/user-attachments/assets/bd4e0267-3f3a-41a2-98d3-4f5239ca74b2">

<img width="662" alt="image" src="https://github.com/user-attachments/assets/55104e79-18ff-424c-b195-17441fbd4970">

<img width="575" alt="image" src="https://github.com/user-attachments/assets/cdfa4fae-0ae8-4dd7-9794-41b636240b5d">

And the runtime error (no logs, just the response):
<img width="233" alt="image" src="https://github.com/user-attachments/assets/20bbd0b9-c5ac-4617-82f5-1923ea6f508a">
