### PR TITLE
Fix Broken Integration Documentation Link in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ _This step can be executed in any directory and git repository of your choice. Y
 
 You can then modify both the definition and implementation of your integration respectively located in the `integration.definition.ts` and `src/index.ts` files.
 
-For more information on how to develop an integration, please refer to the [Documentation](https://botpress.com/docs/developers/).
+For more information on how to develop an integration, please refer to the [Documentation](https://botpress.com/docs/getting-started-1).
 
 ### Integration Deployment
 


### PR DESCRIPTION
This pull request addresses the issue of a broken link in the `README.md` file that previously directed users to an incorrect URL for integration documentation. The outdated link (`https://botpress.com/docs/developers/`) has been updated to the correct URL (`https://botpress.com/docs/getting-started-1`) to ensure users are directed to the appropriate resources for developing integrations. This update improves the accuracy and usability of the documentation.