### PR TITLE
fix(integrations): improve error logs

### DIFF
--- a/integrations/anthropic/integration.definition.ts
+++ b/integrations/anthropic/integration.definition.ts
@@ -4,7 +4,7 @@ import { modelId } from 'src/schemas'
 export default new IntegrationDefinition({
   name: 'anthropic',
   title: 'Anthropic',
-  version: '3.1.0',
+  version: '3.1.1',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/fireworks-ai/integration.definition.ts
+++ b/integrations/fireworks-ai/integration.definition.ts
@@ -4,7 +4,7 @@ import { languageModelId } from 'src/schemas'
 export default new IntegrationDefinition({
   name: 'fireworks-ai',
   title: 'Fireworks AI',
-  version: '0.2.0',
+  version: '0.2.1',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/webhook/integration.definition.ts
+++ b/integrations/webhook/integration.definition.ts
@@ -3,7 +3,7 @@ import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 
 export default new IntegrationDefinition({
   name: 'webhook',
-  version: '0.4.1',
+  version: '0.4.2',
   title: 'Webhook',
   description:
     'Connect your chatbot to your systems with webhooks. Send and receive data from external systems and trigger workflows effortlessly.',

--- a/integrations/webhook/src/index.ts
+++ b/integrations/webhook/src/index.ts
@@ -1,3 +1,4 @@
+import { RuntimeError } from '@botpress/client'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import qs from 'qs'
 import * as bp from '.botpress'
@@ -15,12 +16,12 @@ const isMethod = (method: string): method is Method => method in methods
 const integration = new bp.Integration({
   handler: async ({ req, client, ctx }) => {
     if (ctx.configuration.secret && req.headers['x-bp-secret'] !== ctx.configuration.secret) {
-      throw new Error('Invalid secret')
+      throw new RuntimeError('The provided secret is invalid.')
     }
 
     const method = req.method.toUpperCase()
     if (!isMethod(method)) {
-      throw new Error('Invalid method')
+      throw new RuntimeError('Only GET and POST methods are supported.')
     }
 
     const query = req.query ? qs.parse(req.query) : {}

--- a/packages/common/src/llm/openai.ts
+++ b/packages/common/src/llm/openai.ts
@@ -1,4 +1,4 @@
-import { InvalidPayloadError } from '@botpress/client'
+import { InvalidPayloadError, RuntimeError } from '@botpress/client'
 import { z, IntegrationLogger, interfaces } from '@botpress/sdk'
 import assert from 'assert'
 import OpenAI from 'openai'
@@ -107,15 +107,13 @@ export async function generateContent<M extends string>(
         const message = `${props.provider} error ${err.status} (${err.type}:${err.code}): ${
           parsedError.data.error?.message ?? err.message
         }`
-        logger.forBot().error(message)
 
-        throw err
+        throw new RuntimeError(message)
       }
     }
 
     // Fallback
-    logger.forBot().error(err.message)
-    throw err
+    throw new RuntimeError(err.message)
   } finally {
     if (input.debug && response) {
       logger.forBot().info(`Response received from ${props.provider}: ` + JSON.stringify(response, null, 2))

--- a/packages/sdk/src/integration/server.ts
+++ b/packages/sdk/src/integration/server.ts
@@ -186,6 +186,8 @@ export const integrationHandler =
     } catch (thrown) {
       if (isApiError(thrown)) {
         const runtimeError = new RuntimeError(thrown.message, thrown)
+        integrationLogger.forBot().error(runtimeError.message)
+
         return { status: runtimeError.code, body: JSON.stringify(runtimeError.toJSON()) }
       }
 
@@ -195,6 +197,7 @@ export const integrationHandler =
       const runtimeError = new RuntimeError(
         'An unexpected error occurred in the integration. Bot owners: Check logs for more informations. Integration owners: throw a RuntimeError to return a custom error message instead.'
       )
+      integrationLogger.forBot().error(runtimeError.message)
       return { status: runtimeError.code, body: JSON.stringify(runtimeError.toJSON()) }
     }
   }


### PR DESCRIPTION
When integrations throw a RuntimeError, the error is returned in the payload AND is also in the bot logs. Previously the payload returned an unhandled error but the details were in the bot logs, which might be confusing.