### PR TITLE
fix: bump client version

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "0.8.61",
+  "version": "0.8.62",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -20,8 +20,8 @@
   },
   "main": "dist/index.js",
   "dependencies": {
-    "@botpress/client": "0.29.1",
-    "@botpress/sdk": "0.10.12",
+    "@botpress/client": "0.29.2",
+    "@botpress/sdk": "0.10.13",
     "@bpinternal/const": "^0.0.20",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/templates/echo-bot/package.json
+++ b/packages/cli/templates/echo-bot/package.json
@@ -5,8 +5,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.29.1",
-    "@botpress/sdk": "0.10.12"
+    "@botpress/client": "0.29.2",
+    "@botpress/sdk": "0.10.13"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.29.1",
-    "@botpress/sdk": "0.10.12"
+    "@botpress/client": "0.29.2",
+    "@botpress/sdk": "0.10.13"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.29.1",
-    "@botpress/sdk": "0.10.12"
+    "@botpress/client": "0.29.2",
+    "@botpress/sdk": "0.10.13"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.29.1",
-    "@botpress/sdk": "0.10.12",
+    "@botpress/client": "0.29.2",
+    "@botpress/sdk": "0.10.13",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "description": "Botpress SDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "@bpinternal/zui": "0.10.0",
-    "@botpress/client": "0.29.1"
+    "@botpress/client": "0.29.2"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1538,10 +1538,10 @@ importers:
   packages/cli:
     dependencies:
       '@botpress/client':
-        specifier: 0.29.1
+        specifier: 0.29.2
         version: link:../client
       '@botpress/sdk':
-        specifier: 0.10.12
+        specifier: 0.10.13
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.0.20
@@ -1653,10 +1653,10 @@ importers:
   packages/cli/templates/echo-bot:
     dependencies:
       '@botpress/client':
-        specifier: 0.29.1
+        specifier: 0.29.2
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.10.12
+        specifier: 0.10.13
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1672,10 +1672,10 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 0.29.1
+        specifier: 0.29.2
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.10.12
+        specifier: 0.10.13
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1691,10 +1691,10 @@ importers:
   packages/cli/templates/hello-world:
     dependencies:
       '@botpress/client':
-        specifier: 0.29.1
+        specifier: 0.29.2
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.10.12
+        specifier: 0.10.13
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1710,10 +1710,10 @@ importers:
   packages/cli/templates/webhook-message:
     dependencies:
       '@botpress/client':
-        specifier: 0.29.1
+        specifier: 0.29.2
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.10.12
+        specifier: 0.10.13
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8
@@ -1794,7 +1794,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 0.29.1
+        specifier: 0.29.2
         version: link:../client
       '@bpinternal/zui':
         specifier: 0.10.0


### PR DESCRIPTION
I forgot to bump client version here: https://github.com/botpress/botpress/pull/13248/files

so SDK is currently broken.