### PR TITLE
chore: use generated integration context instead of exported sdk types

### DIFF
--- a/integrations/instagram/src/misc/incoming-message.ts
+++ b/integrations/instagram/src/misc/incoming-message.ts
@@ -1,15 +1,10 @@
-import { IntegrationContext } from '@botpress/sdk'
 import { InstagramMessage, IntegrationLogger } from './types'
 import { getUserProfile } from './utils'
 import * as bp from '.botpress'
 
 export async function handleMessage(
   message: InstagramMessage,
-  {
-    client,
-    ctx,
-    logger,
-  }: { client: bp.Client; ctx: IntegrationContext<bp.configuration.Configuration>; logger: IntegrationLogger }
+  { client, ctx, logger }: { client: bp.Client; ctx: bp.Context; logger: IntegrationLogger }
 ) {
   if (message?.message?.text) {
     logger.forBot().debug('Received text message from Instagram:', message.message.text)

--- a/integrations/linear/src/events/issueUpdated.ts
+++ b/integrations/linear/src/events/issueUpdated.ts
@@ -1,4 +1,3 @@
-import { IntegrationContext } from '@botpress/sdk'
 import { LinearIssueEvent } from '../misc/linear'
 import { getUserAndConversation } from '../misc/utils'
 import * as bp from '.botpress'
@@ -7,7 +6,7 @@ import { Client } from '.botpress'
 type IssueProps = {
   linearEvent: LinearIssueEvent
   client: Client
-  ctx: IntegrationContext<bp.configuration.Configuration>
+  ctx: bp.Context
 }
 
 type IssueUpdated = bp.events.issueUpdated.IssueUpdated

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -1,4 +1,4 @@
-import { z, IntegrationContext, Request } from '@botpress/sdk'
+import { z, Request } from '@botpress/sdk'
 import { LinearClient } from '@linear/sdk'
 import axios from 'axios'
 import queryString from 'query-string'
@@ -137,7 +137,7 @@ export class LinearOauthClient {
   }
 }
 
-export const handleOauth = async (req: Request, client: bp.Client, ctx: IntegrationContext) => {
+export const handleOauth = async (req: Request, client: bp.Client, ctx: bp.Context) => {
   const linearOauthClient = new LinearOauthClient()
 
   const query = queryString.parse(req.query)

--- a/integrations/messenger/src/misc/incoming-message.ts
+++ b/integrations/messenger/src/misc/incoming-message.ts
@@ -1,4 +1,3 @@
-import { IntegrationContext } from '@botpress/sdk'
 import { MessengerMessage } from './types'
 import { getMessengerClient } from './utils'
 import * as bp from '.botpress'
@@ -7,11 +6,7 @@ type IntegrationLogger = bp.Logger
 
 export async function handleMessage(
   message: MessengerMessage,
-  {
-    client,
-    ctx,
-    logger,
-  }: { client: bp.Client; ctx: IntegrationContext<bp.configuration.Configuration>; logger: IntegrationLogger }
+  { client, ctx, logger }: { client: bp.Client; ctx: bp.Context; logger: IntegrationLogger }
 ) {
   const { sender, recipient, message: textMessage, postback } = message
 

--- a/integrations/notion/src/notion/notion.ts
+++ b/integrations/notion/src/notion/notion.ts
@@ -1,14 +1,12 @@
-import type { IntegrationContext } from '@botpress/sdk'
 import { Client } from '@notionhq/client'
 import type { GetDatabaseResponse } from '@notionhq/client/build/src/api-endpoints'
 import { NOTION_PROPERTY_STRINGIFIED_TYPE_MAP } from './notion.constants'
 import type { NotionPagePropertyTypes } from './notion.types'
-import { configuration } from '.botpress'
+import * as bp from '.botpress'
 
 // TODO: Write a decorator to achieve this
-type BotpressIntegrationContext = IntegrationContext<configuration.Configuration>
 
-export function getNotionClient(integrationContext: BotpressIntegrationContext) {
+export function getNotionClient(integrationContext: bp.Context) {
   return new Client({
     auth: integrationContext.configuration.authToken,
   })
@@ -22,7 +20,7 @@ export function getNotionClient(integrationContext: BotpressIntegrationContext) 
  * @returns
  */
 export function addPageToDb(
-  integrationContext: BotpressIntegrationContext,
+  integrationContext: bp.Context,
   databaseId: string,
   properties: Record<NotionPagePropertyTypes, any>
 ) {
@@ -40,7 +38,7 @@ export function addPageToDb(
  * @param messageBody
  * @returns
  */
-export function addCommentToPage(integrationContext: BotpressIntegrationContext, blockId: string, messageBody: string) {
+export function addCommentToPage(integrationContext: bp.Context, blockId: string, messageBody: string) {
   const notion = getNotionClient(integrationContext)
   return notion.comments.create({
     parent: { page_id: blockId },
@@ -55,11 +53,7 @@ export function addCommentToPage(integrationContext: BotpressIntegrationContext,
   })
 }
 
-export function addCommentToDiscussion(
-  integrationContext: BotpressIntegrationContext,
-  discussionId: string,
-  messageBody: string
-) {
+export function addCommentToDiscussion(integrationContext: bp.Context, discussionId: string, messageBody: string) {
   const notion = getNotionClient(integrationContext)
   return notion.comments.create({
     discussion_id: discussionId,
@@ -74,7 +68,7 @@ export function addCommentToDiscussion(
   })
 }
 
-export function getAllCommentsForBlock(integrationContext: BotpressIntegrationContext, blockId: string) {
+export function getAllCommentsForBlock(integrationContext: bp.Context, blockId: string) {
   const notion = getNotionClient(integrationContext)
   return notion.comments.list({ block_id: blockId })
 }
@@ -85,12 +79,12 @@ export function getAllCommentsForBlock(integrationContext: BotpressIntegrationCo
  * - a page
  * - a block
  */
-export function deleteBlock(integrationContext: BotpressIntegrationContext, blockId: string) {
+export function deleteBlock(integrationContext: bp.Context, blockId: string) {
   const notion = getNotionClient(integrationContext)
   return notion.blocks.delete({ block_id: blockId })
 }
 
-export function getDb(integrationContext: BotpressIntegrationContext, databaseId: string) {
+export function getDb(integrationContext: bp.Context, databaseId: string) {
   const notion = getNotionClient(integrationContext)
   return notion.databases.retrieve({ database_id: databaseId })
 }

--- a/integrations/slack/src/misc/utils.ts
+++ b/integrations/slack/src/misc/utils.ts
@@ -1,4 +1,4 @@
-import type { IntegrationContext, Request } from '@botpress/sdk'
+import type { Request } from '@botpress/sdk'
 import { ChatPostMessageArguments, WebClient } from '@slack/web-api'
 import axios from 'axios'
 import * as crypto from 'crypto'
@@ -86,7 +86,7 @@ export class SlackOauthClient {
   }
 }
 
-export async function onOAuth(req: Request, client: bp.Client, ctx: IntegrationContext) {
+export async function onOAuth(req: Request, client: bp.Client, ctx: bp.Context) {
   const slackOAuthClient = new SlackOauthClient()
 
   const query = queryString.parse(req.query)

--- a/integrations/viber/src/index.ts
+++ b/integrations/viber/src/index.ts
@@ -1,5 +1,4 @@
 import { RuntimeError } from '@botpress/client'
-import type { IntegrationContext } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import axios from 'axios'
 import * as bp from '.botpress'
@@ -349,7 +348,7 @@ export async function sendViberMessage({ conversation, ctx, ack, payload }: Send
   return data
 }
 
-async function getUserDetails({ ctx, id }: { ctx: IntegrationContext; id: string }) {
+async function getUserDetails({ ctx, id }: { ctx: bp.Context; id: string }) {
   const { data } = await axios.post(
     'https://chatapi.viber.com/pa/get_user_details',
     { id },

--- a/integrations/whatsapp/src/index.ts
+++ b/integrations/whatsapp/src/index.ts
@@ -1,5 +1,5 @@
 import { RuntimeError } from '@botpress/client'
-import { IntegrationContext, Request } from '@botpress/sdk'
+import { Request } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { channel, INTEGRATION_NAME } from 'integration.definition'
 import * as crypto from 'node:crypto'
@@ -253,7 +253,7 @@ export const getGlobalWebhookUrl = () => {
   return `${process.env.BP_WEBHOOK_URL}/integration/global/${INTEGRATION_NAME}`
 }
 
-export const detectIdentifierIssue = (req: Request, ctx: IntegrationContext) => {
+export const detectIdentifierIssue = (req: Request, ctx: bp.Context) => {
   /* because of the wizard, we need to accept the query param "state" as an identifier
    * but we need to prevent anyone of using anything other than the webhookId there for security reasons
    */

--- a/integrations/whatsapp/src/misc/whatsapp.ts
+++ b/integrations/whatsapp/src/misc/whatsapp.ts
@@ -1,4 +1,4 @@
-import { IntegrationContext, z } from '@botpress/sdk'
+import { z } from '@botpress/sdk'
 import axios from 'axios'
 import { getGlobalWebhookUrl } from '../index'
 import * as bp from '.botpress'
@@ -131,9 +131,9 @@ export class MetaOauthClient {
   }
 }
 
-export const getAccessToken = async (client: bp.Client, ctx: IntegrationContext) => {
+export const getAccessToken = async (client: bp.Client, ctx: bp.Context): Promise<string> => {
   if (ctx.configuration.useManualConfiguration) {
-    return ctx.configuration.accessToken
+    return ctx.configuration.accessToken as string
   }
 
   const {
@@ -142,21 +142,21 @@ export const getAccessToken = async (client: bp.Client, ctx: IntegrationContext)
     },
   } = await client.getState({ type: 'integration', name: 'credentials', id: ctx.integrationId })
 
-  return accessToken
+  return accessToken as string
 }
 
-export const getSecret = (ctx: IntegrationContext): string | undefined => {
-  let value
+export const getSecret = (ctx: bp.Context): string | undefined => {
+  let value: string | undefined
   if (ctx.configuration.useManualConfiguration) {
     value = ctx.configuration.clientSecret
   } else {
     value = bp.secrets.CLIENT_SECRET
   }
 
-  return value?.length && value
+  return value?.length ? value : undefined
 }
 
-export const getPhoneNumberId = async (client: bp.Client, ctx: IntegrationContext) => {
+export const getPhoneNumberId = async (client: bp.Client, ctx: bp.Context) => {
   if (ctx.configuration.useManualConfiguration) {
     return ctx.configuration.phoneNumberId
   }

--- a/integrations/whatsapp/src/misc/wizard.ts
+++ b/integrations/whatsapp/src/misc/wizard.ts
@@ -1,4 +1,4 @@
-import { IntegrationContext, Request } from '@botpress/sdk'
+import { Request } from '@botpress/sdk'
 import queryString from 'query-string'
 import * as bp from '../../.botpress'
 import { getOAuthConfigId } from '../../integration.definition'
@@ -6,7 +6,7 @@ import { getGlobalWebhookUrl } from '../index'
 import { generateButtonDialog, generateSelectDialog, getInterstitialUrl, redirectTo } from './html-utils'
 import { MetaOauthClient } from './whatsapp'
 
-export const handleWizard = async (req: Request, client: bp.Client, ctx: IntegrationContext, logger: bp.Logger) => {
+export const handleWizard = async (req: Request, client: bp.Client, ctx: bp.Context, logger: bp.Logger) => {
   const query = queryString.parse(req.query)
 
   let wizardStep = query['wizard-step'] || (query['code'] && 'get-access-token') || 'get-access-token'
@@ -141,7 +141,7 @@ export const handleWizard = async (req: Request, client: bp.Client, ctx: Integra
 // client.patchState is not working correctly
 const patchCredentialsState = async (
   client: bp.Client,
-  ctx: IntegrationContext,
+  ctx: bp.Context,
   newState: Partial<typeof bp.states.credentials>
 ) => {
   const currentState = await getCredentialsState(client, ctx)
@@ -157,7 +157,7 @@ const patchCredentialsState = async (
   })
 }
 
-const getCredentialsState = async (client: bp.Client, ctx: IntegrationContext) => {
+const getCredentialsState = async (client: bp.Client, ctx: bp.Context) => {
   try {
     return (
       (

--- a/integrations/zapier/src/helpers.ts
+++ b/integrations/zapier/src/helpers.ts
@@ -1,4 +1,4 @@
-import { z, IntegrationContext, isApiError } from '@botpress/sdk'
+import { z, isApiError } from '@botpress/sdk'
 import {
   TriggerSubscriber,
   ZapierTriggersStateName,
@@ -6,25 +6,21 @@ import {
   ZapierTriggersState,
   Client,
 } from './types'
-import type { Configuration } from '.botpress/implementation/configuration'
+import * as bp from '.botpress'
 
-export async function unsubscribeZapierHook(url: string, ctx: IntegrationContext<Configuration>, client: Client) {
+export async function unsubscribeZapierHook(url: string, ctx: bp.Context, client: Client) {
   let subscribers = await getTriggerSubscribers(ctx, client)
   subscribers = subscribers.filter((x) => x.url !== url)
   await saveTriggerSubscribers(subscribers, ctx, client)
   console.info(`Zapier hook ${url} was unsubscribed`)
 }
 
-export async function getTriggerSubscribers(ctx: IntegrationContext<Configuration>, client: Client) {
+export async function getTriggerSubscribers(ctx: bp.Context, client: Client) {
   const state = await getTriggersState(ctx, client)
   return state.subscribers
 }
 
-export async function saveTriggerSubscribers(
-  subscribers: TriggerSubscriber[],
-  ctx: IntegrationContext<Configuration>,
-  client: Client
-) {
+export async function saveTriggerSubscribers(subscribers: TriggerSubscriber[], ctx: bp.Context, client: Client) {
   await client.setState({
     type: 'integration',
     name: ZapierTriggersStateName,
@@ -33,7 +29,7 @@ export async function saveTriggerSubscribers(
   })
 }
 
-export async function getTriggersState(ctx: IntegrationContext<Configuration>, client: Client) {
+export async function getTriggersState(ctx: bp.Context, client: Client) {
   const defaultState = buildTriggersState()
 
   return await client

--- a/integrations/zapier/src/index.ts
+++ b/integrations/zapier/src/index.ts
@@ -1,8 +1,6 @@
-import type { IntegrationContext } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import axios, { isAxiosError } from 'axios'
 import { constants } from 'http2'
-import type { Configuration } from '../.botpress/implementation/configuration'
 import { getTriggerSubscribers, saveTriggerSubscribers, unsubscribeZapierHook } from './helpers'
 import { Client, TriggerRequestBody, IntegrationEvent, IntegrationEventSchema, EventSchema, Event } from './types'
 import * as bp from '.botpress'
@@ -75,7 +73,7 @@ export default sentryHelpers.wrapIntegration(integration, {
   release: bp.secrets.SENTRY_RELEASE,
 })
 
-async function handleIntegrationEvent(event: IntegrationEvent, ctx: IntegrationContext<Configuration>, client: Client) {
+async function handleIntegrationEvent(event: IntegrationEvent, ctx: bp.Context, client: Client) {
   console.info('Received integration event: ', event)
 
   let subscribers = await getTriggerSubscribers(ctx, client)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "0.8.62",
+  "version": "0.8.63",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -21,7 +21,7 @@
   "main": "dist/index.js",
   "dependencies": {
     "@botpress/client": "0.29.2",
-    "@botpress/sdk": "0.10.13",
+    "@botpress/sdk": "0.10.14",
     "@bpinternal/const": "^0.0.20",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/templates/echo-bot/package.json
+++ b/packages/cli/templates/echo-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.29.2",
-    "@botpress/sdk": "0.10.13"
+    "@botpress/sdk": "0.10.14"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.29.2",
-    "@botpress/sdk": "0.10.13"
+    "@botpress/sdk": "0.10.14"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.29.2",
-    "@botpress/sdk": "0.10.13"
+    "@botpress/sdk": "0.10.14"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.29.2",
-    "@botpress/sdk": "0.10.13",
+    "@botpress/sdk": "0.10.14",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "description": "Botpress SDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -11,7 +11,6 @@ export {
   IntegrationDefinitionProps,
   IntegrationImplementation as Integration,
   IntegrationImplementationProps as IntegrationProps,
-  IntegrationContext,
   IntegrationLogger,
   IntegrationSpecificClient,
   InterfaceDeclaration,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -11,6 +11,7 @@ export {
   IntegrationDefinitionProps,
   IntegrationImplementation as Integration,
   IntegrationImplementationProps as IntegrationProps,
+  IntegrationContext,
   IntegrationLogger,
   IntegrationSpecificClient,
   InterfaceDeclaration,

--- a/packages/sdk/src/integration/context.ts
+++ b/packages/sdk/src/integration/context.ts
@@ -7,6 +7,7 @@ import {
   operationHeader,
   webhookIdHeader,
 } from '../const'
+import { BaseIntegration } from './generic'
 
 export const integrationOperationSchema = z.enum([
   'webhook_received',
@@ -21,16 +22,18 @@ export const integrationOperationSchema = z.enum([
 
 export type IntegrationOperation = z.infer<typeof integrationOperationSchema>
 
-export type IntegrationContext<Configuration = any> = {
+export type IntegrationContext<TIntegration extends BaseIntegration = BaseIntegration> = {
   botId: string
   botUserId: string
   integrationId: string
   webhookId: string
   operation: IntegrationOperation
-  configuration: Configuration
+  configuration: TIntegration['configuration']
 }
 
-export const extractContext = (headers: Record<string, string | undefined>): IntegrationContext => {
+export const extractContext = <TIntegration extends BaseIntegration>(
+  headers: Record<string, string | undefined>
+): IntegrationContext<TIntegration> => {
   const botId = headers[botIdHeader]
   const botUserId = headers[botUserIdHeader]
   const integrationId = headers[integrationIdHeader]

--- a/packages/sdk/src/integration/server.ts
+++ b/packages/sdk/src/integration/server.ts
@@ -9,7 +9,7 @@ import { BaseIntegration } from './generic'
 import { IntegrationLogger, integrationLogger } from './logger'
 
 type CommonArgs<TIntegration extends BaseIntegration> = {
-  ctx: IntegrationContext<TIntegration['configuration']>
+  ctx: IntegrationContext<TIntegration>
   client: IntegrationSpecificClient<TIntegration>
   logger: IntegrationLogger
 }
@@ -135,7 +135,7 @@ type ServerProps<TIntegration extends BaseIntegration> = CommonArgs<TIntegration
 export const integrationHandler =
   <TIntegration extends BaseIntegration>(instance: IntegrationHandlers<TIntegration>) =>
   async (req: Request): Promise<Response | void> => {
-    const ctx = extractContext(req.headers)
+    const ctx = extractContext<TIntegration>(req.headers)
 
     const vanillaClient = new Client({
       botId: ctx.botId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1541,7 +1541,7 @@ importers:
         specifier: 0.29.2
         version: link:../client
       '@botpress/sdk':
-        specifier: 0.10.13
+        specifier: 0.10.14
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.0.20
@@ -1656,7 +1656,7 @@ importers:
         specifier: 0.29.2
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.10.13
+        specifier: 0.10.14
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1675,7 +1675,7 @@ importers:
         specifier: 0.29.2
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.10.13
+        specifier: 0.10.14
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1694,7 +1694,7 @@ importers:
         specifier: 0.29.2
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.10.13
+        specifier: 0.10.14
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1713,7 +1713,7 @@ importers:
         specifier: 0.29.2
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 0.10.13
+        specifier: 0.10.14
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
no need to bump version of integrations, we'll just redeploy current versions