### PR TITLE
fix(zendesk): added some HITL operations error logging

### DIFF
--- a/integrations/zendesk/src/actions/hitl.ts
+++ b/integrations/zendesk/src/actions/hitl.ts
@@ -10,10 +10,14 @@ export const startHitl: bp.IntegrationProps['actions']['startHitl'] = async ({ c
   })
 
   try {
-    const ticket = await zendeskClient.createTicket(input.title, input.description ?? '...', {
-      name: user.name ?? 'Unknown User',
-      email: user.tags.email ?? 'unknown@noemail.com',
-    })
+    const ticket = await zendeskClient.createTicket(
+      input.title ?? 'Untitled Ticket',
+      input.description ?? 'Someone opened a ticket using your Botpress chatbot',
+      {
+        name: user.name ?? 'Unknown User',
+        email: user.tags.email ?? 'unknown@noemail.com',
+      }
+    )
 
     const { conversation } = await client.getOrCreateConversation({
       channel: 'hitl',


### PR DESCRIPTION
Used this yesterday to debug an issue, thought it was useful to keep it. feel free to close if not useful.

Also added a default title as it's required by the zendesk api but not in the interface. A user could easily not specify any title or description and screw their bot