### PR TITLE
feat(cli): show error context on `bp build` failures

### DIFF
--- a/packages/cli/src/command-implementations/project-command.ts
+++ b/packages/cli/src/command-implementations/project-command.ts
@@ -118,8 +118,8 @@ export abstract class ProjectCommand<C extends ProjectCommandDefinition> extends
         return { type: 'interface', definition: interfaceDefinition }
       }
       return { type: 'bot', definition: null }
-    } catch (readError: unknown) {
-      throw new errors.BotpressCLIError(`Error while reading project definition: ${(readError as Error).message}`)
+    } catch (thrown: unknown) {
+      throw errors.BotpressCLIError.wrap(thrown, 'Error while reading project definition')
     }
   }
 

--- a/packages/cli/src/utils/require-utils.test.ts
+++ b/packages/cli/src/utils/require-utils.test.ts
@@ -12,3 +12,26 @@ test('require js code should do as its name suggests', () => {
 
   expect(result.foo).toBe('bar')
 })
+
+const getError = (fn: () => void): Error | undefined => {
+  try {
+    fn()
+    return
+  } catch (thrown: unknown) {
+    return thrown instanceof Error ? thrown : new Error(`${thrown}`)
+  }
+}
+
+test('require js code should indicate issue in stack trace', () => {
+  const code = `
+    var foo = undefined
+    module.exports = {
+      bar: foo.bar
+    }
+  `
+
+  const error = getError(() => requireUtils.requireJsCode(code))
+
+  expect(error).toBeDefined()
+  expect(error?.message).toContain('bar: foo.bar')
+})


### PR DESCRIPTION
Currently, if `bp build` fails to import the transpiled code after the esbuild stage, it will only print the error message, without any context to help diagnose it. For instance, see the following `bp build` output:

```
> bp build

🤖 Botpress CLI v0.9.3
✖ Cannot read properties of undefined (reading 'shape')
```

This message would be helpful if there was a single instance of property access for this property. However, since my integration includes [`.shape`](https://zod.dev/?id=shape) 221 times, this error message is not very helpful.

---

This PR adds more context to error messages:

```
> bp build

🤖 Botpress CLI v0.9.3
✖ Error while reading project definition: Cannot read properties of undefined (reading 'shape')

Offending code:

  [TRELLO_EVENTS.addMemberToCard]: {
    title: "Member added to card",
    description: "Triggered when a member is added to a card",
    schema: addMemberToCardEventSchema.shape.action.shape.data
                                       ^
  },
  [TRELLO_EVENTS.commentCard]: {
    title: "Comment added to card",
```

The caret `^` character shows the exact location of the error