### PR TITLE
feat(integrations/slack): update bot user with desired name and avatar

### DIFF
--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -18,7 +18,7 @@ export default new IntegrationDefinition({
   name: 'slack',
   title: 'Slack',
   description: 'This integration allows your bot to interact with Slack.',
-  version: '0.4.3',
+  version: '0.4.4',
   icon: 'icon.svg',
   readme: 'hub.md',
   configuration: {

--- a/integrations/slack/src/misc/utils.ts
+++ b/integrations/slack/src/misc/utils.ts
@@ -140,20 +140,20 @@ const isValidUrl = (str: string) => {
 }
 
 const getOptionalProps = (ctx: IntegrationCtx, logger: IntegrationLogger) => {
+  const props = {
+    username: ctx.configuration.botName?.trim(),
+    icon_url: undefined as string | undefined,
+  }
+
   if (ctx.configuration.botAvatarUrl) {
     if (isValidUrl(ctx.configuration.botAvatarUrl)) {
-      return {
-        username: ctx.configuration.botName,
-        icon_url: ctx.configuration.botAvatarUrl,
-      }
+      props.icon_url = ctx.configuration.botAvatarUrl
     } else {
       logger.forBot().warn('Invalid bot avatar URL')
     }
   }
 
-  return {
-    username: ctx.configuration.botName?.trim() !== '' ? ctx.configuration.botName : undefined,
-  }
+  return props
 }
 
 export async function sendSlackMessage(
@@ -336,4 +336,33 @@ export const validateRequestSignature = ({ req, logger }: { req: Request; logger
     logger.forBot().error('An error occurred while verifying the request signature')
     return false
   }
+}
+
+const updateBotpressBotName = async (client: Client, ctx: IntegrationCtx) => {
+  const { botName } = ctx.configuration
+  const trimmedName = botName?.trim()
+
+  if (trimmedName) {
+    await client.updateUser({
+      id: ctx.botUserId,
+      name: trimmedName,
+      tags: {},
+    })
+  }
+}
+
+const updateBotpressBotAvatar = async (client: Client, ctx: IntegrationCtx) => {
+  const { botAvatarUrl } = ctx.configuration
+
+  if (botAvatarUrl && isValidUrl(botAvatarUrl)) {
+    await client.updateUser({
+      id: ctx.botUserId,
+      pictureUrl: botAvatarUrl && isValidUrl(botAvatarUrl) ? botAvatarUrl?.trim() : undefined,
+      tags: {},
+    })
+  }
+}
+
+export const updateBotpressBotNameAndAvatar = (client: Client, ctx: IntegrationCtx) => {
+  return Promise.all([updateBotpressBotName(client, ctx), updateBotpressBotAvatar(client, ctx)])
 }

--- a/integrations/slack/src/setup.ts
+++ b/integrations/slack/src/setup.ts
@@ -1,6 +1,12 @@
 import { WebClient } from '@slack/web-api'
 import { CreateConversationFunction, CreateUserFunction, RegisterFunction, UnregisterFunction } from './misc/types'
-import { getAccessToken, getDirectMessageForUser, isUserId, saveConfig } from './misc/utils'
+import {
+  getAccessToken,
+  getDirectMessageForUser,
+  isUserId,
+  saveConfig,
+  updateBotpressBotNameAndAvatar,
+} from './misc/utils'
 
 export type SyncState = { usersLastSyncTs?: number }
 export type Configuration = { botUserId?: string }
@@ -19,6 +25,8 @@ export const register: RegisterFunction = async ({ client, ctx, logger }) => {
   const configuration: Configuration = { botUserId: identity.user_id }
 
   await saveConfig(client, ctx, configuration)
+
+  await updateBotpressBotNameAndAvatar(client, ctx)
 }
 
 export const unregister: UnregisterFunction = async () => {


### PR DESCRIPTION
When bot owners set a custom bot display name or avatar, these will now also be reflected on the Botpress side in the conversations view.

Does not directly depend upon #13288, but it might be best to merge this other PR first.