### PR TITLE
fix(integrations/slack)!: bump major version

### DIFF
--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -28,7 +28,7 @@ export default new IntegrationDefinition({
   name: 'slack',
   title: 'Slack',
   description: 'This integration allows your bot to interact with Slack.',
-  version: '0.6.0',
+  version: '1.0.0',
   icon: 'icon.svg',
   readme: 'hub.md',
   configuration: {


### PR DESCRIPTION
BREAKING CHANGE: the `credentials` state is no longer compatible, as it introduces a new `signingSecret` key

This PR fixes pipeline https://github.com/botpress/botpress/actions/runs/10994735807/job/30523947937 following the merge of #13288 