### PR TITLE
feat(integrations/github)!: implement OAuth

### DIFF
--- a/integrations/github/extract.vrl
+++ b/integrations/github/extract.vrl
@@ -1,1 +1,8 @@
-parse_json!(.body).installation.organization.id
+# This is only used to extract the installation id if the integration was
+# installed using Botpress's own GitHub app
+
+# If the installation was done using a custom GitHub App or a PAT, the webhook
+# is configured by the bot owner and uses the Botpress-provided webhook URL, so
+# it does not use the /integration/global/github route
+
+to_string!(parse_json!(.body).installation.id)

--- a/integrations/github/hub.md
+++ b/integrations/github/hub.md
@@ -1,1 +1,126 @@
 Streamline your development workflow by seamlessly integrating GitHub with Botpress, the open-source conversational AI platform. This integration enables you to effortlessly manage and automate your GitHub repositories, issues, and pull requests directly from Botpress, empowering you to collaborate effectively, track progress, and ensure smooth development cycles. Take advantage of powerful features like real-time notifications, issue management, pull request merging, and more, all within the familiar Botpress environment. Boost productivity, streamline collaboration, and unleash the full potential of your conversational AI projects with the GitHub Integration for Botpress.
+
+## Migrating from version `0.x` to `1.x`
+
+Version `1.0` of the GitHub integration introduces several changes and improvements over the previous version. If you are migrating from version `0.x` to `1.x`, please note the following changes:
+
+> The integration now supports both GitHub Apps and personal access tokens for authentication. GitHub Apps are recommended for organizations, while personal access tokens are suitable for individual users. If you wish to continue using a personal access token, you must enable fine-grained personal access tokens for your organization on GitHub. For more information on setting up the integration with a personal access token, refer to the "[manual configuration with a personal access token](#manual-configuration-with-a-personal-access-token-not-recommended)" section.
+
+> The "Find Target" action now requires the `repo` field to be specified. This field should contain the name of the repository. Furthermore, the `discussion` channel was removed from this action, as it was not implemented and did nothing.
+
+> The `number` tag on channels has been removed. Instead, pull requests have a `pullRequestNumber` tag, and issues have an `issueNumber` tag.
+
+## Configuration
+
+### Automatic configuration with OAuth (recommended)
+
+This is the simplest way to set up the integration. To set up the GitHub integration using OAuth, click the authorization button and follow the instructions to connect your Botpress chatbot to GitHub. This method is recommended as it simplifies the configuration process and ensures secure communication between your chatbot and GitHub.
+
+When using this configuration mode, a Botpress-managed GitHub application will be used to connect to your GitHub organizations and repositories. The application will have the necessary permissions to listen to pull request and issue events and to create new comments on issues, pull requests and discussions. If you require more granular control over the permissions or prefer to use your own GitHub application, you can opt for the manual configuration mode instead.
+
+### Manual configuration with a custom GitHub App
+
+If you prefer to manually configure the integration, you can connect your own GitHub application to Botpress. To set up the GitHub integration manually, follow these steps:
+
+1. In the integration settings, copy the webhook URL provided to you by Botpress.
+2. On GitHub, navigate to your organization's settings page.
+3. Under the "Developer settings" section, click on "GitHub Apps" and then click the "New GitHub App" button.
+4. Fill in the required fields to create a new GitHub App. You can customize the app's name, description, homepage URL, and other settings as needed.
+5. In the "Webhook" section, paste the webhook URL provided by Botpress into the "Webhook URL" field.
+6. Use a password generator or other secure method to generate a high entropy string to be used as your GitHub App's webhook secret key. The secret key will be used to sign the payloads sent to your webhook URL. Make sure to keep this key secure and do not share it with others.
+7. Paste the secret key into the "Webhook Secret" field on GitHub. Make sure to keep this key secure and do not share it with others.
+8. Paste the same key into the "GitHub Webhook Secret" field in the Botpress integration settings.
+9. Configure the permissions for your GitHub App as needed:
+
+- Repository Permissions:
+  - `Discussions`: select the "Read & write" permission to allow the bot to read and create comments on discussions.
+  - `Issues`: select the "Read & write" permission to allow the bot to read and create comments on issues.
+  - `Pull requests`: select the "Read & write" permission to allow the bot to read and create comments on pull requests.
+- Organization Permissions:
+  - `Team discussions`: select the "Read & write" permission to allow the bot to read and create comments on team discussions.
+
+10. Depending on the permissions you choose to grant, you may now subscribe to webhook events as needed:
+
+- `Discussion`
+- `Discussion comment`
+- `Issues`
+- `Issue comment`
+- `Pull request`
+- `Pull request review`
+- `Pull request review comment`
+- `Pull request review thread`
+
+11. Save the changes on GitHub.
+12. In your newly created GitHub App, navigate to the "General" tab and generate a new private key. Save the private key to a secure location.
+13. In the integration settings, paste the contents of the private key file you downloaded from GitHub into the "GitHub App Private Key" field.
+14. On GitHub, in the "General" tab of your GitHub App, copy the App ID and paste it into the "GitHub App ID" field in the Botpress integration settings.
+15. Install the GitHub App on your organization's repositories as needed.
+16. Once the GitHub App is installed, navigate to your organization's installed GitHub Apps page and click on the newly installed GitHub App.
+17. The URL of the page should end with `/installations/:installation_id`. For example, in the URL `https://github.com/organizations/.../settings/installations/123456`, the installation ID is `123456`. Copy the installation ID and paste it into the "GitHub App Installation ID" field in the Botpress integration settings.
+18. Save the configuration in Botpress and enable the integration.
+
+## Manual configuration with a personal access token (not recommended)
+
+If you prefer to manually configure the integration, you can provide a personal access token to connect your personal GitHub account to Botpress. Keep in mind that when you use a personal access token, actions taken by the bot will be attributed to your personal GitHub account. If you wish for actions to be attributed to your organization instead of to your personal account, you must use a GitHub App. GitHub applications offer a lot of advantages over personal access tokens and do not consume a seat within your GitHub organization. As such, we do not recommend using personal access tokens.
+
+To set up the GitHub integration using a personal access token, follow these steps:
+
+### Enabling personal access tokens for your organization
+
+1. On GitHub, navigate to the settings page of your organization.
+2. Under the "Third-party Access" section, click on "Personal access tokens".
+3. In the setup page, select "Allow access via fine-grained personal access tokens".
+4. Go through the rest of the setup process to enable fine-grained personal access tokens for your organization. It is not necessary to enable _classic_ personal access tokens.
+
+### Subscribing to webhook events at the org level
+
+1. On Botpress, in the integration settings, copy the webhook URL provided to you by Botpress.
+2. Navigate to your organization's settings page on GitHub.
+3. Under the "Webhooks" section, click on "Add webhook".
+4. Paste the webhook URL provided by Botpress into the "Payload URL" field.
+5. Select the `application/json` content type.
+6. Use a password generator or other secure method to generate a high entropy string to be used as your webhook secret key. The secret key will be used to sign the payloads sent to your webhook URL. Make sure to keep this key secure and do not share it with others.
+7. Paste the secret key into the "Secret" field on GitHub
+8. Choose "Let me select individual events" and select the following events:
+
+- `Discussion`
+- `Discussion comment`
+- `Issues`
+- `Issue comment`
+- `Pull request`
+- `Pull request review`
+- `Pull request review comment`
+- `Pull request review thread`
+
+9. Save the webhook on GitHub.
+
+### Creating an organization-level personal access token
+
+1. On GitHub, navigate to your account settings page.
+2. Under the "Developer settings" section, click on "Personal access tokens" and then choose "Fine-grained tokens".
+3. Click the "Generate new token" button and provide a name and description for the token.
+4. Select your organization as the resource owner for the token.
+5. Choose a sufficient expiration date for the token. You will need to regenerate the token and update your integration settings accordingly when it expires.
+6. Under "Repository access", select the repositories you want the bot to have access to. Please note that if you choose "Public Repositories", the bot will not be able to reply to issues or pull requests.
+7. Configure the permissions for your personal access token as needed:
+
+- Repository Permissions:
+  - `Discussions`: select the "Read & write" permission to allow the bot to read and create comments on discussions.
+  - `Issues`: select the "Read & write" permission to allow the bot to read and create comments on issues.
+  - `Pull requests`: select the "Read & write" permission to allow the bot to read and create comments on pull requests.
+- Organization Permissions:
+  - `Team discussions`: select the "Read & write" permission to allow the bot to read and create comments on team discussions.
+
+8. Generate your personal access token and copy it to a secure location.
+
+### Configuring the integration in Botpress
+
+1. In the integration settings, paste the personal access token you generated into the "GitHub Personal Access Token" field.
+2. Paste the webhook secret key you generated into the "GitHub Webhook Secret" field.
+3. Save the configuration in Botpress and enable the integration.
+
+## Limitations
+
+Standard GitHub API limitations apply to the GitHub integration in Botpress. These limitations include rate limits, message size restrictions, and other constraints imposed by the GitHub platform. Ensure that your chatbot adheres to these limitations to maintain optimal performance and reliability.
+
+More details are available in the [GitHub API documentation](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api).

--- a/integrations/github/integration.definition.ts
+++ b/integrations/github/integration.definition.ts
@@ -2,20 +2,24 @@ import { IntegrationDefinition } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 
 import { INTEGRATION_NAME } from './src/const'
-import { actions, events, configuration, channels, user, states } from './src/definitions'
+import { actions, events, configuration, configurations, channels, user, secrets, states } from './src/definitions'
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   title: 'GitHub',
-  version: '0.3.3',
+  version: '1.0.0',
   icon: 'icon.svg',
   readme: 'hub.md',
   description: 'Github integration for Botpress',
   configuration,
+  configurations,
   actions,
   events,
   channels,
   user,
   states,
-  secrets: sentryHelpers.COMMON_SECRET_NAMES,
+  identifier: {
+    extractScript: 'extract.vrl',
+  },
+  secrets: { ...secrets, ...sentryHelpers.COMMON_SECRET_NAMES },
 })

--- a/integrations/github/linkTemplate.vrl
+++ b/integrations/github/linkTemplate.vrl
@@ -1,0 +1,10 @@
+webhookId = to_string!(.webhookId)
+env = to_string!(.env)
+
+appName = "botpress-staging"
+
+if env == "production" {
+  appName = "botpress"
+}
+
+"https://github.com/apps/{{ appName }}/installations/select_target?state={{ webhookId }}"

--- a/integrations/github/src/channels.ts
+++ b/integrations/github/src/channels.ts
@@ -1,92 +1,74 @@
-import { Octokit } from 'octokit'
-import { Channels } from './misc/types'
-import { ackMessage, getConversationId } from './misc/utils'
+import { ExtraChannelProps, wrapChannel } from './misc/channel-wrapper'
+import { AckFunction, Channels } from './misc/types'
+import { getTagOrThrowException } from './misc/utils'
 
 export default {
   pullRequest: {
     messages: {
-      text: async ({ ctx, conversation, payload, ack }) => {
+      text: wrapChannel<'pullRequest'>(async ({ conversation, payload, ack, owner, repo, octokit }) => {
         console.info(`Sending a text message on channel pull request with content ${payload.text}`)
-        const { owner, repo, token } = ctx.configuration
-        const octokit = new Octokit({ auth: token })
 
-        const prNumber = getConversationId(conversation)
-        const comment = await octokit.rest.issues.createComment({
+        await _createIssueComment({
+          issueNumber: +getTagOrThrowException(conversation.tags, 'pullRequestNumber'),
+          commentBody: payload.text,
+          ack,
           owner,
           repo,
-          issue_number: prNumber,
-          body: payload.text,
+          octokit,
         })
-        await ackMessage(comment.data.id, ack)
-      },
-    },
-  },
-  discussion: {
-    messages: {
-      text: async ({ ctx, conversation, payload, ack }) => {
-        console.info(`Sending a text message on channel discussion with content ${payload.text}`)
-        const { owner, repo, token } = ctx.configuration
-        const octokit = new Octokit({ auth: token })
-
-        const discussionNumber = getConversationId(conversation)
-
-        // Currently, there is no rest API to create a repo discussion comment
-        const {
-          repository: {
-            discussion: { id: discussionId },
-          },
-        } = await octokit.graphql<{ repository: { discussion: { id: string } } }>(
-          `query ($owner:String!,$repo:String!,$discussionNumber:Int!){
-            repository(owner:$owner,name:$repo) {
-              discussion(number:$discussionNumber) {
-                id
-              }
-            }
-          }`,
-          {
-            owner,
-            repo,
-            discussionNumber,
-          }
-        )
-        const {
-          addDiscussionComment: {
-            comment: { databaseId },
-          },
-        } = await octokit.graphql<{ addDiscussionComment: { comment: { databaseId: number } } }>(
-          `mutation ($discussionId: ID!, $body: String!) {
-            addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
-              comment {
-                databaseId
-              }
-            }
-          }`,
-          {
-            discussionId,
-            body: payload.text,
-          }
-        )
-
-        await ackMessage(databaseId, ack)
-      },
+      }),
     },
   },
   issue: {
     messages: {
-      text: async ({ ctx, conversation, payload, ack }) => {
+      text: wrapChannel<'issue'>(async ({ conversation, payload, ack, owner, repo, octokit }) => {
         console.info(`Sending a text message on channel issue with content ${payload.text}`)
-        const { owner, repo, token } = ctx.configuration
-        const octokit = new Octokit({ auth: token })
 
-        const issueNumber = getConversationId(conversation)
-        const comment = await octokit.rest.issues.createComment({
+        await _createIssueComment({
+          issueNumber: +getTagOrThrowException(conversation.tags, 'issueNumber'),
+          commentBody: payload.text,
+          ack,
           owner,
           repo,
-          issue_number: issueNumber,
+          octokit,
+        })
+      }),
+    },
+  },
+  discussion: {
+    messages: {
+      text: wrapChannel<'discussion'>(async ({ conversation, payload, ack, octokit }) => {
+        console.info(`Sending a text message on channel discussion with content ${payload.text}`)
+
+        const {
+          addDiscussionComment: { comment },
+        } = await octokit.executeGraphqlQuery('addDiscussionComment', {
+          discussionNodeId: getTagOrThrowException(conversation.tags, 'discussionNodeId'),
           body: payload.text,
         })
-        await ackMessage(comment.data.id, ack)
-      },
+
+        await ack({
+          tags: { commentId: comment.databaseId.toString(), commentNodeId: comment.id, commentUrl: comment.url },
+        })
+      }),
     },
   },
 } satisfies Channels
+
+const _createIssueComment = async ({
+  issueNumber,
+  commentBody,
+  ack,
+  owner,
+  repo,
+  octokit,
+}: { issueNumber: number; commentBody: string; ack: AckFunction } & ExtraChannelProps) => {
+  const { data } = await octokit.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    body: commentBody,
+  })
+
+  await ack({ tags: { commentNodeId: data.node_id, commentId: data.id.toString(), commentUrl: data.html_url } })
+}

--- a/integrations/github/src/channels.ts
+++ b/integrations/github/src/channels.ts
@@ -1,55 +1,56 @@
-import { ExtraChannelProps, wrapChannel } from './misc/channel-wrapper'
+import { ChannelInjections, wrapChannelAndInjectOctokit } from './misc/channel-wrapper'
 import { AckFunction, Channels } from './misc/types'
-import { getTagOrThrowException } from './misc/utils'
 
 export default {
   pullRequest: {
     messages: {
-      text: wrapChannel<'pullRequest'>(async ({ conversation, payload, ack, owner, repo, octokit }) => {
-        console.info(`Sending a text message on channel pull request with content ${payload.text}`)
-
-        await _createIssueComment({
-          issueNumber: +getTagOrThrowException(conversation.tags, 'pullRequestNumber'),
-          commentBody: payload.text,
-          ack,
-          owner,
-          repo,
-          octokit,
-        })
+      text: wrapChannelAndInjectOctokit('pullRequest', {
+        async channel({ conversation, payload, ack, owner, repo, octokit }) {
+          await _createIssueComment({
+            issueNumber: +_getTagOrThrowException(conversation.tags, 'pullRequestNumber'),
+            commentBody: payload.text,
+            ack,
+            owner,
+            repo,
+            octokit,
+          })
+        },
       }),
     },
   },
   issue: {
     messages: {
-      text: wrapChannel<'issue'>(async ({ conversation, payload, ack, owner, repo, octokit }) => {
-        console.info(`Sending a text message on channel issue with content ${payload.text}`)
+      text: wrapChannelAndInjectOctokit('issue', {
+        async channel({ conversation, payload, ack, owner, repo, octokit }) {
+          console.info(`Sending a text message on channel issue with content ${payload.text}`)
 
-        await _createIssueComment({
-          issueNumber: +getTagOrThrowException(conversation.tags, 'issueNumber'),
-          commentBody: payload.text,
-          ack,
-          owner,
-          repo,
-          octokit,
-        })
+          await _createIssueComment({
+            issueNumber: +_getTagOrThrowException(conversation.tags, 'issueNumber'),
+            commentBody: payload.text,
+            ack,
+            owner,
+            repo,
+            octokit,
+          })
+        },
       }),
     },
   },
   discussion: {
     messages: {
-      text: wrapChannel<'discussion'>(async ({ conversation, payload, ack, octokit }) => {
-        console.info(`Sending a text message on channel discussion with content ${payload.text}`)
+      text: wrapChannelAndInjectOctokit('discussion', {
+        async channel({ conversation, payload, ack, octokit }) {
+          const {
+            addDiscussionComment: { comment },
+          } = await octokit.executeGraphqlQuery('addDiscussionComment', {
+            discussionNodeId: _getTagOrThrowException(conversation.tags, 'discussionNodeId'),
+            body: payload.text,
+          })
 
-        const {
-          addDiscussionComment: { comment },
-        } = await octokit.executeGraphqlQuery('addDiscussionComment', {
-          discussionNodeId: getTagOrThrowException(conversation.tags, 'discussionNodeId'),
-          body: payload.text,
-        })
-
-        await ack({
-          tags: { commentId: comment.databaseId.toString(), commentNodeId: comment.id, commentUrl: comment.url },
-        })
+          await ack({
+            tags: { commentId: comment.databaseId.toString(), commentNodeId: comment.id, commentUrl: comment.url },
+          })
+        },
       }),
     },
   },
@@ -62,7 +63,7 @@ const _createIssueComment = async ({
   owner,
   repo,
   octokit,
-}: { issueNumber: number; commentBody: string; ack: AckFunction } & ExtraChannelProps) => {
+}: { issueNumber: number; commentBody: string; ack: AckFunction } & ChannelInjections) => {
   const { data } = await octokit.rest.issues.createComment({
     owner,
     repo,
@@ -71,4 +72,14 @@ const _createIssueComment = async ({
   })
 
   await ack({ tags: { commentNodeId: data.node_id, commentId: data.id.toString(), commentUrl: data.html_url } })
+}
+
+const _getTagOrThrowException = <R extends Record<string, string>>(tags: R, name: Extract<keyof R, string>) => {
+  const value = tags[name]
+
+  if (!value) {
+    throw new Error(`Missing tag ${name}`)
+  }
+
+  return value
 }

--- a/integrations/github/src/definitions/actions.ts
+++ b/integrations/github/src/definitions/actions.ts
@@ -1,6 +1,6 @@
 import { z, IntegrationDefinitionProps } from '@botpress/sdk'
 
-const Channels = ['pullRequest', 'discussion', 'issue'] as const
+const Channels = ['pullRequest', 'issue'] as const
 
 export type Target = {
   displayName: string
@@ -13,6 +13,7 @@ const findTarget = {
     schema: z.object({
       query: z.string(),
       channel: z.enum(Channels),
+      repo: z.string().title('Repository').describe('The repository name'),
     }),
   },
   output: {

--- a/integrations/github/src/definitions/channels.ts
+++ b/integrations/github/src/definitions/channels.ts
@@ -1,31 +1,114 @@
-import { IntegrationDefinitionProps, messages } from '@botpress/sdk'
+import { IntegrationDefinitionProps, messages, TagDefinition } from '@botpress/sdk'
 const { text } = messages.defaults
 
-export const channels = {
+const COMMON_TAGS = {
+  repository: {
+    repoId: {
+      title: 'Repository ID',
+      description: 'Unique identifier of the repository',
+    },
+    repoNodeId: {
+      title: 'Repository global node ID',
+      description: 'Node ID for GraphQL',
+    },
+    repoName: {
+      title: 'Repository Name',
+      description: 'Name of the repository',
+    },
+    repoUrl: {
+      title: 'Repository URL',
+      description: 'URL of the repository',
+    },
+    repoOwnerId: {
+      title: 'Repository Owner ID',
+      description: 'Unique identifier of the repository owner',
+    },
+    repoOwnerName: {
+      title: 'Repository Owner Name',
+      description: 'Name of the repository owner. Usually the organization name',
+    },
+    repoOwnerUrl: {
+      title: 'Repository Owner URL',
+      description: 'URL of the repository owner',
+    },
+  },
   pullRequest: {
-    message: {
-      tags: {
-        id: {},
-      },
+    pullRequestNumber: {
+      title: 'Pull Request Number',
+      description: 'The pull request number',
     },
-    conversation: {
-      tags: {
-        number: {},
-      },
+    pullRequestUrl: {
+      title: 'Pull Request URL',
+      description: 'URL of the pull request',
     },
-    messages: {
-      text,
+    pullRequestNodeId: {
+      title: 'Pull Request global node ID',
+      description: 'Node ID for GraphQL',
     },
   },
   discussion: {
-    message: {
-      tags: {
-        id: {},
-      },
+    discussionId: {
+      title: 'Discussion ID',
+      description: 'Unique identifier of the discussion',
     },
+    discussionNodeId: {
+      title: 'Discussion global node ID',
+      description: 'Node ID for GraphQL',
+    },
+    discussionUrl: {
+      title: 'Discussion URL',
+      description: 'URL of the discussion',
+    },
+    discussionNumber: {
+      title: 'Discussion Number',
+      description: 'The discussion number',
+    },
+    discussionCategoryId: {
+      title: 'Discussion Category ID',
+      description: 'Unique identifier of the discussion category',
+    },
+    discussionCategoryName: {
+      title: 'Discussion Category Name',
+      description: 'Name of the discussion category',
+    },
+    discussionCategoryNodeId: {
+      title: 'Discussion Category global node ID',
+      description: 'Node ID for GraphQL',
+    },
+  },
+  comment: {
+    commentId: {
+      title: 'Comment ID',
+      description: 'Unique identifier of the comment',
+    },
+    commentNodeId: {
+      title: 'Comment global node ID',
+      description: 'Node ID for GraphQL',
+    },
+    commentUrl: {
+      title: 'Comment URL',
+      description: 'URL of the comment',
+    },
+  },
+} as const satisfies Record<string, Record<string, TagDefinition>>
+
+export const channels = {
+  pullRequest: {
+    title: 'Pull Request',
+    description: 'A pull request in a GitHub repository',
     conversation: {
       tags: {
-        number: {},
+        ...COMMON_TAGS.repository,
+        ...COMMON_TAGS.pullRequest,
+        channel: {
+          title: 'Channel name',
+          description: 'Workaround for the SDK',
+        },
+      },
+    },
+    message: {
+      tags: {
+        ...COMMON_TAGS.comment,
       },
     },
     messages: {
@@ -33,18 +116,52 @@ export const channels = {
     },
   },
   issue: {
-    message: {
-      tags: {
-        id: {},
-      },
-    },
     conversation: {
       tags: {
-        number: {},
+        ...COMMON_TAGS.repository,
+        issueNumber: {
+          title: 'Issue Number',
+          description: 'The issue number',
+        },
+        issueUrl: {
+          title: 'Issue URL',
+          description: 'URL of the issue',
+        },
+        issueNodeId: {
+          title: 'Issue global node ID',
+          description: 'Node ID for GraphQL',
+        },
+      },
+    },
+    message: {
+      tags: {
+        ...COMMON_TAGS.comment,
       },
     },
     messages: {
       text,
     },
   },
-} satisfies IntegrationDefinitionProps['channels']
+  discussion: {
+    title: 'Discussion',
+    description: 'A discussion in a GitHub repository',
+    conversation: {
+      tags: {
+        ...COMMON_TAGS.repository,
+        ...COMMON_TAGS.discussion,
+        channel: {
+          title: 'Channel name',
+          description: 'Workaround for the SDK',
+        },
+      },
+    },
+    message: {
+      tags: {
+        ...COMMON_TAGS.comment,
+      },
+    },
+    messages: {
+      text,
+    },
+  },
+} as const satisfies IntegrationDefinitionProps['channels']

--- a/integrations/github/src/definitions/index.ts
+++ b/integrations/github/src/definitions/index.ts
@@ -1,20 +1,86 @@
-import { z, IntegrationDefinitionProps } from '@botpress/sdk'
+import { z, IntegrationDefinitionProps, ZodRawShape } from '@botpress/sdk'
 
 export { actions } from './actions'
 export { events } from './events'
 export { channels } from './channels'
 
 export const configuration = {
-  schema: z.object({
-    owner: z.string().min(1),
-    repo: z.string().min(1),
-    token: z.string().min(1),
-  }),
-} satisfies IntegrationDefinitionProps['configuration']
+  identifier: {
+    linkTemplateScript: 'linkTemplate.vrl',
+    required: true,
+  },
+  schema: z.object({}),
+} as const satisfies IntegrationDefinitionProps['configuration']
+
+const webhookSecret = {
+  githubWebhookSecret: z
+    .string()
+    .min(1)
+    .secret()
+    .title('GitHub Webhook Secret')
+    .describe(
+      'A high-entropy string that only you and Botpress know. Must be set to the same value as in the GitHub organization settings.'
+    ),
+} as const satisfies ZodRawShape
+
+export const configurations = {
+  manualApp: {
+    title: 'Manual configuration',
+    description: 'Configure manually with your own GitHub App',
+    schema: z.object({
+      githubAppId: z
+        .string()
+        .min(1)
+        .title('GitHub App ID')
+        .describe('Can be found in the GitHub App settings. OAuth apps are not supported.'),
+      githubAppPrivateKey: z
+        .string()
+        .min(1)
+        .secret()
+        .title('GitHub App Private Key')
+        .describe('The raw contents of the RSA private key. Can be downloaded from the GitHub App settings.')
+        .placeholder('-----BEGIN RSA PRIVATE KEY----- ...'),
+      githubAppInstallationId: z
+        .number()
+        .positive()
+        .title('GitHub App Installation ID')
+        .describe('Please refer to the integration documentation for details on how to obtain this.'),
+      ...webhookSecret,
+    }),
+  },
+  manualPAT: {
+    title: 'Manual configuration',
+    description: 'Configure manually with a Personal Access Token',
+    schema: z.object({
+      personalAccessToken: z
+        .string()
+        .min(1)
+        .secret()
+        .title('Personal Access Token')
+        .describe('An organization-level GitHub Personal Access Token with the necessary permissions.'),
+      ...webhookSecret,
+    }),
+  },
+} as const satisfies IntegrationDefinitionProps['configurations']
 
 export const user = {
   tags: {
-    id: {},
+    handle: {
+      title: 'GitHub Handle',
+      description: 'The GitHub handle of the user',
+    },
+    id: {
+      title: 'GitHub User ID',
+      description: 'The GitHub ID of the user',
+    },
+    nodeId: {
+      title: 'GitHub User Node ID',
+      description: 'The GraphQL Node ID of the user',
+    },
+    profileUrl: {
+      title: 'GitHub Profile URL',
+      description: "The URL of the user's profile",
+    },
   },
 } satisfies IntegrationDefinitionProps['user']
 
@@ -22,9 +88,29 @@ export const states = {
   configuration: {
     type: 'integration',
     schema: z.object({
-      webhookSecret: z.string().optional(),
-      webhookId: z.number().optional(),
-      botUserId: z.number().optional(),
+      githubInstallationId: z
+        .number()
+        .positive()
+        .optional()
+        .title('GitHub Installation ID')
+        .describe('The ID of the GitHub installation'),
+      organizationHandle: z
+        .string()
+        .optional()
+        .title('Organization Handle')
+        .describe('The handle of the organization that owns the repositories'),
     }),
   },
 } satisfies IntegrationDefinitionProps['states']
+
+export const secrets: IntegrationDefinitionProps['secrets'] = {
+  GITHUB_APP_ID: {
+    description: 'GitHub App ID for the Botpress GitHub App. This is not the client id',
+  },
+  GITHUB_PRIVATE_KEY: {
+    description: 'GitHub App RSA Private Key. Should be the full contents of the private key file',
+  },
+  GITHUB_WEBHOOK_SECRET: {
+    description: 'GitHub Webhook Secret. Should be a high-entropy string that only Botpress knows',
+  },
+}

--- a/integrations/github/src/events/pull-request-comment-created.ts
+++ b/integrations/github/src/events/pull-request-comment-created.ts
@@ -1,12 +1,12 @@
 import { IssueCommentCreatedEvent } from '@octokit/webhooks-types'
 import { getOrCreateBotpressConversationFromGithubPR, getOrCreateBotpressUserFromGithubUser } from '../misc/utils'
-import { HandlerProps } from '.botpress'
+import * as bp from '.botpress'
 
 export const firePullRequestCommentCreated = async ({
   githubEvent,
   client,
   ctx,
-}: HandlerProps & {
+}: bp.HandlerProps & {
   githubEvent: IssueCommentCreatedEvent
 }) => {
   const githubPullRequest = { ...githubEvent.issue, repository: githubEvent.repository }

--- a/integrations/github/src/events/pull-request-merged.ts
+++ b/integrations/github/src/events/pull-request-merged.ts
@@ -1,11 +1,11 @@
 import { PullRequestClosedEvent } from '@octokit/webhooks-types'
 import { getOrCreateBotpressConversationFromGithubPR, getOrCreateBotpressUserFromGithubUser } from '../misc/utils'
-import { HandlerProps } from '.botpress'
+import * as bp from '.botpress'
 
 export const firePullRequesMerged = async ({
   githubEvent,
   client,
-}: HandlerProps & {
+}: bp.HandlerProps & {
   githubEvent: PullRequestClosedEvent
 }) => {
   const githubPullRequest = { ...githubEvent.pull_request, repository: githubEvent.repository }

--- a/integrations/github/src/events/pull-request-opened.ts
+++ b/integrations/github/src/events/pull-request-opened.ts
@@ -1,12 +1,12 @@
 import { PullRequestOpenedEvent } from '@octokit/webhooks-types'
 
 import { getOrCreateBotpressConversationFromGithubPR, getOrCreateBotpressUserFromGithubUser } from '../misc/utils'
-import { HandlerProps } from '.botpress'
+import * as bp from '.botpress'
 
 export const firePullRequestOpened = async ({
   githubEvent,
   client,
-}: HandlerProps & {
+}: bp.HandlerProps & {
   githubEvent: PullRequestOpenedEvent
 }) => {
   const githubPullRequest = { ...githubEvent.pull_request, repository: githubEvent.repository }

--- a/integrations/github/src/misc/action-wrapper.ts
+++ b/integrations/github/src/misc/action-wrapper.ts
@@ -1,0 +1,55 @@
+import { RuntimeError } from '@botpress/sdk'
+import { GitHubClient } from './github-client'
+import { GithubSettings } from './github-settings'
+import { IntegrationProps } from '.botpress'
+
+type Actions = {
+  [K in keyof IntegrationProps['actions']]: IntegrationProps['actions'][K]
+}
+type ActionInjections = { octokit: GitHubClient; owner: string }
+type ActionWithInjections = {
+  [K in keyof Actions]: (
+    props: Parameters<Actions[K]>[0] & ActionInjections,
+    input: Parameters<Actions[K]>[0]['input']
+  ) => ReturnType<Actions[K]>
+}
+
+const tryCatch = async <T>(fn: () => Promise<T>, errorMessage: string): Promise<T> => {
+  try {
+    return await fn()
+  } catch (thrown: unknown) {
+    console.error(`Error: ${errorMessage}`, thrown)
+    throw new RuntimeError(errorMessage)
+  }
+}
+
+/**
+ * @example
+ * export const createIssue = wrapActionAndInjectOctokit('createIssue', {
+ *   async action({ octokit, owner, ctx, client }, { issueTitle }) {
+ *      // Your action logic here
+ *   },
+ *   errorMessage: 'Failed to create issue'
+ * })
+ */
+export const wrapActionAndInjectOctokit = <K extends keyof Actions>(
+  actionName: K,
+  {
+    action,
+    errorMessage,
+  }: {
+    action: ActionWithInjections[K]
+    errorMessage: string
+  }
+): Actions[K] =>
+  (async (props: Parameters<Actions[K]>[0]) => {
+    const octokit = await GitHubClient.create({ ctx: props.ctx, client: props.client })
+    const owner = await GithubSettings.getOrganizationHandle({ ctx: props.ctx, client: props.client })
+    const injections = { octokit, owner }
+
+    return tryCatch(() => {
+      props.logger.forBot().debug(`Running action "${actionName}" for owner "${owner}" [bot id: ${props.ctx.botId}]`)
+
+      return action({ ...props, ...injections }, props.input)
+    }, errorMessage)
+  }) as unknown as Actions[K]

--- a/integrations/github/src/misc/channel-wrapper.ts
+++ b/integrations/github/src/misc/channel-wrapper.ts
@@ -1,0 +1,27 @@
+import { GitHubClient } from './github-client'
+import { GithubSettings } from './github-settings'
+import * as bp from '.botpress'
+
+export type ExtraChannelProps = {
+  owner: string
+  repo: string
+  octokit: GitHubClient
+}
+type ChannelKey = keyof bp.MessageProps
+type MessageType<C extends ChannelKey> = keyof bp.MessageProps[C]
+type WrapChannelFunction = <C extends ChannelKey, T extends MessageType<C> = 'text'>(
+  fn: (props: bp.MessageProps[C][T] & ExtraChannelProps) => Promise<void>
+) => (props: bp.MessageProps[C][T]) => Promise<void>
+
+export const wrapChannel: WrapChannelFunction = (fn) => async (props) => {
+  const { ctx, client, conversation } = props
+  const octokit = await GitHubClient.create({ ctx, client })
+  const owner = await GithubSettings.getOrganizationHandle({ ctx, client })
+  const repo = conversation.tags.repoName
+
+  if (!repo) {
+    throw new Error('Missing repoName tag')
+  }
+
+  await fn({ ...props, owner, repo, octokit })
+}

--- a/integrations/github/src/misc/channel-wrapper.ts
+++ b/integrations/github/src/misc/channel-wrapper.ts
@@ -1,27 +1,50 @@
+import { RuntimeError } from '@botpress/sdk'
 import { GitHubClient } from './github-client'
 import { GithubSettings } from './github-settings'
 import * as bp from '.botpress'
 
-export type ExtraChannelProps = {
-  owner: string
-  repo: string
-  octokit: GitHubClient
+type Channels = {
+  [K in keyof bp.IntegrationProps['channels']]: bp.IntegrationProps['channels'][K]['messages']
 }
-type ChannelKey = keyof bp.MessageProps
-type MessageType<C extends ChannelKey> = keyof bp.MessageProps[C]
+export type ChannelInjections = { owner: string; repo: string; octokit: GitHubClient }
+type ChannelKey = keyof Channels
+type MessageType<C extends ChannelKey> = keyof Channels[C]
+type BaseChannelParams<C extends ChannelKey, T extends MessageType<C>> = Parameters<Channels[C][T]>[0]
+type ChannelParamsWithInjections<C extends ChannelKey, T extends MessageType<C>> = BaseChannelParams<C, T> &
+  ChannelInjections
 type WrapChannelFunction = <C extends ChannelKey, T extends MessageType<C> = 'text'>(
-  fn: (props: bp.MessageProps[C][T] & ExtraChannelProps) => Promise<void>
-) => (props: bp.MessageProps[C][T]) => Promise<void>
+  channelName: C,
+  impl: {
+    channel: (props: ChannelParamsWithInjections<C, T>) => Promise<void>
+  }
+) => (props: BaseChannelParams<C, T>) => any
 
-export const wrapChannel: WrapChannelFunction = (fn) => async (props) => {
-  const { ctx, client, conversation } = props
-  const octokit = await GitHubClient.create({ ctx, client })
-  const owner = await GithubSettings.getOrganizationHandle({ ctx, client })
-  const repo = conversation.tags.repoName
+export const wrapChannelAndInjectOctokit: WrapChannelFunction =
+  (channelName, { channel }) =>
+  async (props) => {
+    const { ctx, client, conversation } = props
+    const octokit = await GitHubClient.create({ ctx, client })
+    const owner = await GithubSettings.getOrganizationHandle({ ctx, client })
+    const repo = conversation.tags.repoName
 
-  if (!repo) {
-    throw new Error('Missing repoName tag')
+    if (!repo) {
+      throw new Error('Missing repoName tag')
+    }
+
+    return _tryCatch(() => {
+      props.logger
+        .forBot()
+        .debug(`Sending message in channel "${channelName}" for owner "${owner}" [bot id: ${props.ctx.botId}]`)
+
+      return channel({ ...props, owner, repo, octokit })
+    }, `Failed to send a message in channel "${channelName}"`)
   }
 
-  await fn({ ...props, owner, repo, octokit })
+const _tryCatch = async <T>(fn: () => Promise<T>, errorMessage: string): Promise<T> => {
+  try {
+    return await fn()
+  } catch (thrown: unknown) {
+    console.error(`Channel Error: ${errorMessage}`, thrown)
+    throw new RuntimeError(errorMessage)
+  }
 }

--- a/integrations/github/src/misc/github-client.ts
+++ b/integrations/github/src/misc/github-client.ts
@@ -1,0 +1,121 @@
+import { RuntimeError } from '@botpress/client'
+import { App as OctokitApp, Octokit } from 'octokit'
+import { GithubSettings } from './github-settings'
+import { GRAPHQL_QUERIES, QUERY_INPUT, QUERY_RESPONSE } from './graphql-queries'
+import * as types from './types'
+
+type AuthenticatedEntity = Readonly<{
+  id: string
+  nodeId: string
+  name: string
+  handle: string
+  avatarUrl: string
+  type: 'App' | 'PAT'
+  organizationHandle: string
+  url: string
+}>
+
+export class GitHubClient {
+  private _authenticatedEntity: AuthenticatedEntity | null = null
+
+  private constructor(private readonly _octokit: Octokit, private readonly _isApp: boolean) {}
+
+  public static async create({ ctx, client }: { ctx: types.Context; client: types.Client }) {
+    const octokit = await _getOctokit({ ctx, client })
+    const isApp = ctx.configurationType !== 'manualPAT'
+
+    return new GitHubClient(octokit, isApp)
+  }
+
+  public get rest() {
+    return this._octokit.rest
+  }
+
+  public async executeGraphqlQuery<K extends keyof GRAPHQL_QUERIES>(
+    queryName: K,
+    variables: GRAPHQL_QUERIES[K][QUERY_INPUT]
+  ): Promise<GRAPHQL_QUERIES[K][QUERY_RESPONSE]> {
+    return await this._octokit.graphql(GRAPHQL_QUERIES[queryName].query, variables)
+  }
+
+  public async getAuthenticatedEntity() {
+    if (!this._authenticatedEntity) {
+      this._authenticatedEntity = await this._getGithubAuthenticatedEntity()
+    }
+
+    return this._authenticatedEntity
+  }
+
+  private async _getGithubAuthenticatedEntity() {
+    return this._isApp ? await this._getGithubAuthenticatedApp() : await this._getGithubAuthenticatedUser()
+  }
+
+  private async _getGithubAuthenticatedApp() {
+    const app = await this._octokit.rest.apps.getAuthenticated()
+    const repos = await this._octokit.rest.apps.listReposAccessibleToInstallation({ per_page: 1 })
+    const firstRepo = repos.data.repositories[0]
+
+    if (!firstRepo) {
+      throw new RuntimeError('No repositories found for the authenticated app')
+    }
+
+    return {
+      id: app.data.id.toString(),
+      nodeId: app.data.node_id,
+      name: app.data.name,
+      handle: app.data.slug as string,
+      url: app.data.html_url,
+      avatarUrl: `https://avatars.githubusercontent.com/in/${app.data.id}`,
+      type: 'App',
+      organizationHandle: firstRepo.owner.login,
+    } as const satisfies AuthenticatedEntity
+  }
+
+  private async _getGithubAuthenticatedUser() {
+    const user = await this._octokit.rest.users.getAuthenticated()
+    const repos = await this._octokit.rest.repos.listForAuthenticatedUser({ per_page: 1 })
+    const firstRepo = repos.data[0]
+
+    if (!firstRepo) {
+      throw new RuntimeError('No repositories found for the authenticated user')
+    }
+
+    return {
+      id: user.data.id.toString(),
+      nodeId: user.data.node_id,
+      name: user.data.name ?? user.data.login,
+      handle: user.data.login,
+      url: user.data.html_url,
+      avatarUrl: user.data.avatar_url,
+      type: 'PAT',
+      organizationHandle: firstRepo.owner.login,
+    } as const satisfies AuthenticatedEntity
+  }
+}
+
+const _getOctokit = async ({ ctx, client }: { ctx: types.Context; client: types.Client }) => {
+  if (ctx.configurationType === 'manualPAT') {
+    return _getOctokitForPAT({ ctx })
+  }
+
+  return await _getOctokitForApp({ ctx, client })
+}
+
+const _getOctokitForApp = async ({ ctx, client }: { ctx: types.Context; client: types.Client }) => {
+  const { appId, privateKey, installationId } = GithubSettings.getAppSettings({ ctx, client })
+
+  try {
+    const octokitApp = new OctokitApp({ appId, privateKey })
+    return await octokitApp.getInstallationOctokit(await installationId)
+  } catch (_) {
+    throw new RuntimeError('Failed to authenticate with GitHub. Please check your credentials and try again.')
+  }
+}
+
+const _getOctokitForPAT = ({ ctx }: { ctx: types.Context }) => {
+  if (ctx.configurationType !== 'manualPAT') {
+    throw new RuntimeError('Invalid configuration type')
+  }
+
+  return new Octokit({ auth: ctx.configuration.personalAccessToken })
+}

--- a/integrations/github/src/misc/github-settings.ts
+++ b/integrations/github/src/misc/github-settings.ts
@@ -1,0 +1,74 @@
+import { RuntimeError } from '@botpress/client'
+
+import * as types from './types'
+import { secrets } from '.botpress'
+
+export class GithubSettings {
+  private constructor() {}
+
+  public static getWebhookSecret({ ctx }: { ctx: types.Context }) {
+    return ctx.configurationType === null ? secrets.GITHUB_WEBHOOK_SECRET : ctx.configuration.githubWebhookSecret
+  }
+
+  public static async getOrganizationHandle({ ctx, client }: { ctx: types.Context; client: types.Client }) {
+    const { state } = await client.getState({ type: 'integration', name: 'configuration', id: ctx.integrationId })
+
+    if (!state.payload.organizationHandle) {
+      throw new RuntimeError('Organization handle not found. Please complete the authorization flow and try again.')
+    }
+
+    return state.payload.organizationHandle
+  }
+
+  public static getAppSettings({ ctx, client }: { ctx: types.Context; client: types.Client }) {
+    const appId = this._getAppId({ ctx })
+    const privateKey = this._getAppPrivateKey({ ctx })
+    const installationId = this._getAppInstallationId({ ctx, client })
+
+    return {
+      appId,
+      privateKey,
+      installationId,
+    }
+  }
+
+  private static _getAppId({ ctx }: { ctx: types.Context }) {
+    return ctx.configurationType === 'manualApp' ? ctx.configuration.githubAppId : secrets.GITHUB_APP_ID
+  }
+  private static _getAppPrivateKey({ ctx }: { ctx: types.Context }) {
+    return ctx.configurationType === 'manualApp'
+      ? _fixRSAPrivateKey(ctx.configuration.githubAppPrivateKey)
+      : secrets.GITHUB_PRIVATE_KEY
+  }
+  private static async _getAppInstallationId({ ctx, client }: { ctx: types.Context; client: types.Client }) {
+    if (ctx.configurationType === 'manualApp') {
+      return ctx.configuration.githubAppInstallationId
+    }
+
+    const { state } = await client.getState({ type: 'integration', name: 'configuration', id: ctx.integrationId })
+
+    if (!state.payload.githubInstallationId) {
+      throw new RuntimeError('GitHub installation ID not found. Please complete the authorization flow and try again.')
+    }
+
+    return state.payload.githubInstallationId
+  }
+}
+
+/**
+ * A private key file is required in order to use GitHub Apps. However, it is
+ * currently only possible to paste single-line secrets in the Botpress Studio
+ * UI. This means that the RSA private key gets mangled when pasted in the UI.
+ * This function fixes the private key by adding newlines where necessary.
+ *
+ * FIXME: Remove this workaround once ZUI gets support for multi-line inputs.
+ */
+const _fixRSAPrivateKey = (key: string) => {
+  const parts = key.trim().split('-----')
+
+  const header = parts[1]?.trim()
+  const body = parts[2]?.trim()?.replace(/\s+/g, '\n')
+  const footer = parts[3]?.trim()
+
+  return `-----${header}-----\n${body}\n-----${footer}-----`
+}

--- a/integrations/github/src/misc/github-settings.ts
+++ b/integrations/github/src/misc/github-settings.ts
@@ -3,14 +3,12 @@ import { RuntimeError } from '@botpress/client'
 import * as types from './types'
 import { secrets } from '.botpress'
 
-export class GithubSettings {
-  private constructor() {}
-
-  public static getWebhookSecret({ ctx }: { ctx: types.Context }) {
+export namespace GithubSettings {
+  export function getWebhookSecret({ ctx }: { ctx: types.Context }) {
     return ctx.configurationType === null ? secrets.GITHUB_WEBHOOK_SECRET : ctx.configuration.githubWebhookSecret
   }
 
-  public static async getOrganizationHandle({ ctx, client }: { ctx: types.Context; client: types.Client }) {
+  export async function getOrganizationHandle({ ctx, client }: { ctx: types.Context; client: types.Client }) {
     const { state } = await client.getState({ type: 'integration', name: 'configuration', id: ctx.integrationId })
 
     if (!state.payload.organizationHandle) {
@@ -20,10 +18,10 @@ export class GithubSettings {
     return state.payload.organizationHandle
   }
 
-  public static getAppSettings({ ctx, client }: { ctx: types.Context; client: types.Client }) {
-    const appId = this._getAppId({ ctx })
-    const privateKey = this._getAppPrivateKey({ ctx })
-    const installationId = this._getAppInstallationId({ ctx, client })
+  export function getAppSettings({ ctx, client }: { ctx: types.Context; client: types.Client }) {
+    const appId = _getAppId({ ctx })
+    const privateKey = _getAppPrivateKey({ ctx })
+    const installationId = _getAppInstallationId({ ctx, client })
 
     return {
       appId,
@@ -32,15 +30,16 @@ export class GithubSettings {
     }
   }
 
-  private static _getAppId({ ctx }: { ctx: types.Context }) {
+  function _getAppId({ ctx }: { ctx: types.Context }) {
     return ctx.configurationType === 'manualApp' ? ctx.configuration.githubAppId : secrets.GITHUB_APP_ID
   }
-  private static _getAppPrivateKey({ ctx }: { ctx: types.Context }) {
+  function _getAppPrivateKey({ ctx }: { ctx: types.Context }) {
     return ctx.configurationType === 'manualApp'
       ? _fixRSAPrivateKey(ctx.configuration.githubAppPrivateKey)
       : secrets.GITHUB_PRIVATE_KEY
   }
-  private static async _getAppInstallationId({ ctx, client }: { ctx: types.Context; client: types.Client }) {
+
+  async function _getAppInstallationId({ ctx, client }: { ctx: types.Context; client: types.Client }) {
     if (ctx.configurationType === 'manualApp') {
       return ctx.configuration.githubAppInstallationId
     }

--- a/integrations/github/src/misc/graphql-queries.ts
+++ b/integrations/github/src/misc/graphql-queries.ts
@@ -1,0 +1,40 @@
+const QUERY_INPUT = Symbol('graphqlInputType')
+const QUERY_RESPONSE = Symbol('graphqlResponseType')
+
+type GraphQLQuery<TInput, TResponse> = {
+  query: string
+  [QUERY_INPUT]: TInput
+  [QUERY_RESPONSE]: TResponse
+}
+
+export const GRAPHQL_QUERIES = {
+  addDiscussionComment: {
+    query: `
+      mutation AddDiscussionComment($discussionNodeId: ID!, $body: String!) {
+        addDiscussionComment(input: {discussionId: $discussionNodeId, body: $body}) {
+          comment {
+            id
+            databaseId
+            url
+          }
+        }
+      }`,
+    [QUERY_INPUT]: {} as {
+      discussionNodeId: string
+      body: string
+    },
+    [QUERY_RESPONSE]: {} as {
+      addDiscussionComment: {
+        comment: {
+          id: string
+          databaseId: number
+          url: string
+        }
+      }
+    },
+  },
+} as const satisfies Record<string, GraphQLQuery<object, object>>
+
+export type GRAPHQL_QUERIES = typeof GRAPHQL_QUERIES
+export type QUERY_INPUT = typeof QUERY_INPUT
+export type QUERY_RESPONSE = typeof QUERY_RESPONSE

--- a/integrations/github/src/misc/guards.ts
+++ b/integrations/github/src/misc/guards.ts
@@ -1,6 +1,4 @@
 import type {
-  DiscussionCommentCreatedEvent,
-  DiscussionCreatedEvent,
   IssueCommentCreatedEvent,
   IssuesOpenedEvent,
   PingEvent,
@@ -11,6 +9,7 @@ import type {
 
 export const isPingEvent = (event: WebhookEvent): event is PingEvent => 'hook_id' in event && 'zen' in event
 
+/** Regular pull request comments */
 export const isPullRequestCommentCreatedEvent = (event: WebhookEvent): event is IssueCommentCreatedEvent =>
   'issue' in event && 'pull_request' in event.issue && 'comment' in event && event.action === 'created'
 
@@ -20,14 +19,5 @@ export const isPullRequestOpenedEvent = (event: WebhookEvent): event is PullRequ
 export const isPullRequestMergedEvent = (event: WebhookEvent): event is PullRequestClosedEvent =>
   'pull_request' in event && event.action === 'closed' && event.pull_request.merged
 
-export const isIssueCommentCreatedEvent = (event: WebhookEvent): event is IssueCommentCreatedEvent =>
-  'issue' in event && !('pull_request' in event.issue) && 'comment' in event && event.action === 'created'
-
 export const isIssueOpenedEvent = (event: WebhookEvent): event is IssuesOpenedEvent =>
   'issue' in event && event.action === 'opened'
-
-export const isDiscussionCreatedEvent = (event: WebhookEvent): event is DiscussionCreatedEvent =>
-  'discussion' in event && event.action === 'created'
-
-export const isDiscussionCommentCreatedEvent = (event: WebhookEvent): event is DiscussionCommentCreatedEvent =>
-  'discussion' in event && 'comment' in event && event.action === 'created'

--- a/integrations/github/src/misc/types.ts
+++ b/integrations/github/src/misc/types.ts
@@ -1,7 +1,9 @@
 import * as sdk from '@botpress/sdk'
 import * as bp from '.botpress'
 
+export type Context = bp.Context
 export type Client = bp.Client
+export type Request = sdk.Request
 export type User = bp.ClientResponses['getUser']['user']
 export type Message = bp.ClientResponses['createMessage']['message']
 export type Conversation = bp.ClientResponses['getConversation']['conversation']

--- a/integrations/github/src/misc/utils.ts
+++ b/integrations/github/src/misc/utils.ts
@@ -1,17 +1,4 @@
-import { RuntimeError } from '@botpress/client'
-import { GitHubClient } from './github-client'
-
 import * as types from './types'
-
-export const getTagOrThrowException = <R extends Record<string, string>>(tags: R, name: Extract<keyof R, string>) => {
-  const value = tags[name]
-
-  if (!value) {
-    throw new Error(`Missing tag ${name}`)
-  }
-
-  return value
-}
 
 type GitHubUser = {
   login: string
@@ -105,58 +92,4 @@ export const getOrCreateBotpressConversationFromGithubPR = async ({
   })
 
   return conversation
-}
-
-export const configureOrganizationHandle = async ({
-  ctx,
-  client,
-  gh,
-}: {
-  ctx: types.Context
-  client: types.Client
-  gh: GitHubClient
-}) => {
-  const { organizationHandle } = await gh.getAuthenticatedEntity()
-
-  await client.setState({
-    type: 'integration',
-    name: 'configuration',
-    id: ctx.integrationId,
-    payload: {
-      organizationHandle,
-    },
-  })
-}
-
-const _saveInstallationId = async ({
-  ctx,
-  client,
-  installationId,
-}: {
-  ctx: types.Context
-  client: types.Client
-  installationId: number
-}) => {
-  await client.setState({
-    type: 'integration',
-    name: 'configuration',
-    id: ctx.integrationId,
-    payload: {
-      githubInstallationId: installationId,
-    },
-  })
-}
-
-export const handleOauth = async (req: types.Request, client: types.Client, ctx: types.Context) => {
-  const parsedQueryString = new URLSearchParams(req.query)
-  const installationIdStr = parsedQueryString.get('installation_id')
-
-  if (!installationIdStr) {
-    throw new RuntimeError('Missing installation_id in query string')
-  }
-
-  const installationId = Number(installationIdStr)
-
-  await _saveInstallationId({ ctx, client, installationId })
-  await client.configureIntegration({ identifier: installationIdStr })
 }

--- a/integrations/github/src/setup.ts
+++ b/integrations/github/src/setup.ts
@@ -1,52 +1,11 @@
-import { Octokit } from 'octokit'
+import { GitHubClient } from './misc/github-client'
 import { RegisterFunction, UnregisterFunction } from './misc/types'
+import { configureOrganizationHandle } from './misc/utils'
 
-export const register: RegisterFunction = async ({ ctx, webhookUrl, client }) => {
-  const { owner, repo, token } = ctx.configuration
+export const register: RegisterFunction = async ({ ctx, client }) => {
+  const gh = await GitHubClient.create({ ctx, client })
 
-  const octokit = new Octokit({ auth: token })
-  const secret = `secret-${Math.random()}`
-
-  const alreadyRegistered = (await octokit.rest.repos.listWebhooks({ owner, repo })).data.find(
-    (w) => w.config.url === webhookUrl
-  )
-
-  if (alreadyRegistered) {
-    await octokit.rest.repos.deleteWebhook({ owner, repo, hook_id: alreadyRegistered.id })
-  }
-
-  const webhook = (
-    await octokit.rest.repos.createWebhook({
-      owner,
-      repo,
-      config: { url: webhookUrl, secret, content_type: 'json' },
-      events: ['pull_request', 'issue_comment', 'issues', 'discussion', 'discussion_comment'],
-    })
-  ).data
-
-  const botUserId = (await octokit.rest.users.getAuthenticated()).data.id
-  await client.setState({
-    type: 'integration',
-    name: 'configuration',
-    id: ctx.integrationId,
-    payload: { webhookSecret: secret, webhookId: webhook.id, botUserId },
-  })
+  await configureOrganizationHandle({ ctx, client, gh })
 }
 
-export const unregister: UnregisterFunction = async ({ ctx, client, logger }) => {
-  const { owner, repo, token } = ctx.configuration
-
-  const { state } = await client.getState({
-    type: 'integration',
-    name: 'configuration',
-    id: ctx.integrationId,
-  })
-
-  const octokit = new Octokit({ auth: token })
-  if (!state.payload.webhookId) {
-    logger.forBot().error('Unable to remove webhook from github: Webhook id not found')
-    return
-  }
-
-  await octokit.rest.repos.deleteWebhook({ owner, repo, hook_id: state.payload.webhookId })
-}
+export const unregister: UnregisterFunction = async (_) => {}

--- a/integrations/github/src/setup.ts
+++ b/integrations/github/src/setup.ts
@@ -1,11 +1,32 @@
 import { GitHubClient } from './misc/github-client'
 import { RegisterFunction, UnregisterFunction } from './misc/types'
-import { configureOrganizationHandle } from './misc/utils'
+import * as bp from '.botpress'
 
 export const register: RegisterFunction = async ({ ctx, client }) => {
   const gh = await GitHubClient.create({ ctx, client })
 
-  await configureOrganizationHandle({ ctx, client, gh })
+  await _configureOrganizationHandle({ ctx, client, gh })
 }
 
 export const unregister: UnregisterFunction = async (_) => {}
+
+const _configureOrganizationHandle = async ({
+  ctx,
+  client,
+  gh,
+}: {
+  ctx: bp.Context
+  client: bp.Client
+  gh: GitHubClient
+}) => {
+  const { organizationHandle } = await gh.getAuthenticatedEntity()
+
+  await client.setState({
+    type: 'integration',
+    name: 'configuration',
+    id: ctx.integrationId,
+    payload: {
+      organizationHandle,
+    },
+  })
+}


### PR DESCRIPTION
This is not actual OAuth: GitHub strongly discourages using OAuth Apps for new integrations and recommends using GitHub Apps instead. It turns out that the Botpress OAuth auth flow is still compatible though, so I was able to create a GitHub App for staging and production and authorizing these apps works just like all other BP integrations that use OAuth, even though it doesn't actually use OAuth for the handshake. Instead, octokit generates a temporary JWT and uses that to talk to GitHub's APIs.

---

BREAKING CHANGE: GitHub OAuth apps are no longer supported by the integration. Users upgrading to this version must either authorize Botpress's GitHub application or create their own GitHub App.

BREAKING CHANGE: the findTarget action now requires the repository and repository owner. This is required because the GitHub App can give access to several organizations or repos, so it is necessary to specify which one should be queried.

---

Since the integration now receives events at the organization level, as opposed to the repository level, it means one bot can interact with any and all repositories of an organization. Unfortunately, the events and channels needed to be modified to add the repository name so as to know where an event originates from, because there could be many PR `#18`  in an organization, for example.

---

Please merge the following PRs into this PR *before* merging this PR:

- [feat(integrations/github): implement more events and channels](https://github.com/botpress/botpress/pull/13322)
- [feat(integrations/github): properly set the bot's avatar and name](https://github.com/botpress/botpress/pull/13323)