### PR TITLE
fix(client): return size instead of null

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -124,6 +124,11 @@ export class Client extends gen.Client implements types.IClient {
       throw new errors.UploadFileError(`Failed to upload file: ${err.message}`, <AxiosError>err, file)
     }
 
-    return { file }
+    return {
+      file: {
+        ...file,
+        size,
+      },
+    }
   }
 }


### PR DESCRIPTION
when using the uploadFile method the size returned is null because the file is uploaded after it was created
![image](https://github.com/user-attachments/assets/115f7fa8-25f3-4ab8-a0a2-ed4363be25d4)