### PR TITLE
fix(cli): make `bp lint` work properly for complex schemas

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,7 @@
   },
   "main": "dist/index.js",
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/client": "0.31.0",
     "@botpress/sdk": "0.11.6",
     "@bpinternal/const": "^0.0.20",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/api/bot-body.ts
+++ b/packages/cli/src/api/bot-body.ts
@@ -5,24 +5,24 @@ import * as utils from '../utils'
 export type CreateBotBody = Parameters<client.Client['createBot']>[0]
 export type UpdateBotBody = Parameters<client.Client['updateBot']>[0]
 
-export const prepareCreateBotBody = (bot: sdk.Bot): CreateBotBody => ({
+export const prepareCreateBotBody = async (bot: sdk.Bot): Promise<CreateBotBody> => ({
   ...bot.props,
   configuration: bot.props.configuration
     ? {
         ...bot.props.configuration,
-        schema: utils.schema.mapZodToJsonSchema(bot.props.configuration),
+        schema: await utils.schema.mapZodToJsonSchema(bot.props.configuration),
       }
     : undefined,
   events: bot.props.events
-    ? utils.records.mapValues(bot.props.events, (event) => ({
+    ? await utils.records.mapValuesAsync(bot.props.events, async (event) => ({
         ...event,
-        schema: utils.schema.mapZodToJsonSchema(event),
+        schema: await utils.schema.mapZodToJsonSchema(event),
       }))
     : undefined,
   states: bot.props.states
-    ? utils.records.mapValues(bot.props.states, (state) => ({
+    ? await utils.records.mapValuesAsync(bot.props.states, async (state) => ({
         ...state,
-        schema: utils.schema.mapZodToJsonSchema(state),
+        schema: await utils.schema.mapZodToJsonSchema(state),
       }))
     : undefined,
 })

--- a/packages/cli/src/api/integration-body.ts
+++ b/packages/cli/src/api/integration-body.ts
@@ -1,5 +1,6 @@
 import type { Client, Integration } from '@botpress/client'
 import type * as sdk from '@botpress/sdk'
+import { ZodToJsonOptions } from 'src/utils/schema-utils'
 import * as utils from '../utils'
 
 export type CreateIntegrationBody = Parameters<Client['createIntegration']>[0]
@@ -11,7 +12,10 @@ type UpdateIntegrationChannelBody = UpdateIntegrationChannelsBody[string]
 type Channels = Integration['channels']
 type Channel = Integration['channels'][string]
 
-export const prepareCreateIntegrationBody = (integration: sdk.IntegrationDefinition): CreateIntegrationBody => ({
+export const prepareCreateIntegrationBody = async (
+  integration: sdk.IntegrationDefinition,
+  options: ZodToJsonOptions = {}
+): Promise<CreateIntegrationBody> => ({
   name: integration.name,
   version: integration.version,
   title: integration.title,
@@ -25,53 +29,53 @@ export const prepareCreateIntegrationBody = (integration: sdk.IntegrationDefinit
   configuration: integration.configuration
     ? {
         ...integration.configuration,
-        schema: utils.schema.mapZodToJsonSchema(integration.configuration),
+        schema: await utils.schema.mapZodToJsonSchema(integration.configuration, options),
       }
     : undefined,
   configurations: integration.configurations
-    ? utils.records.mapValues(integration.configurations, (configuration) => ({
+    ? await utils.records.mapValuesAsync(integration.configurations, async (configuration) => ({
         ...configuration,
-        schema: utils.schema.mapZodToJsonSchema(configuration),
+        schema: await utils.schema.mapZodToJsonSchema(configuration, options),
       }))
     : undefined,
   events: integration.events
-    ? utils.records.mapValues(integration.events, (event) => ({
+    ? await utils.records.mapValuesAsync(integration.events, async (event) => ({
         ...event,
-        schema: utils.schema.mapZodToJsonSchema(event),
+        schema: await utils.schema.mapZodToJsonSchema(event, options),
       }))
     : undefined,
   actions: integration.actions
-    ? utils.records.mapValues(integration.actions, (action) => ({
+    ? await utils.records.mapValuesAsync(integration.actions, async (action) => ({
         ...action,
         input: {
           ...action.input,
-          schema: utils.schema.mapZodToJsonSchema(action.input),
+          schema: await utils.schema.mapZodToJsonSchema(action.input, options),
         },
         output: {
           ...action.output,
-          schema: utils.schema.mapZodToJsonSchema(action.output),
+          schema: await utils.schema.mapZodToJsonSchema(action.output, options),
         },
       }))
     : undefined,
   channels: integration.channels
-    ? utils.records.mapValues(integration.channels, (channel) => ({
+    ? await utils.records.mapValuesAsync(integration.channels, async (channel) => ({
         ...channel,
-        messages: utils.records.mapValues(channel.messages, (message) => ({
+        messages: await utils.records.mapValuesAsync(channel.messages, async (message) => ({
           ...message,
-          schema: utils.schema.mapZodToJsonSchema(message),
+          schema: await utils.schema.mapZodToJsonSchema(message, options),
         })),
       }))
     : undefined,
   states: integration.states
-    ? utils.records.mapValues(integration.states, (state) => ({
+    ? await utils.records.mapValuesAsync(integration.states, async (state) => ({
         ...state,
-        schema: utils.schema.mapZodToJsonSchema(state),
+        schema: await utils.schema.mapZodToJsonSchema(state, options),
       }))
     : undefined,
   entities: integration.entities
-    ? utils.records.mapValues(integration.entities, (entity) => ({
+    ? await utils.records.mapValuesAsync(integration.entities, async (entity) => ({
         ...entity,
-        schema: utils.schema.mapZodToJsonSchema(entity),
+        schema: await utils.schema.mapZodToJsonSchema(entity, options),
       }))
     : undefined,
 })

--- a/packages/cli/src/api/interface-body.ts
+++ b/packages/cli/src/api/interface-body.ts
@@ -6,31 +6,31 @@ import * as utils from '../utils'
 export type CreateInterfaceBody = Parameters<Client['createInterface']>[0]
 export type UpdateInterfaceBody = Parameters<Client['updateInterface']>[0]
 
-export const prepareCreateInterfaceBody = (intrface: sdk.InterfaceDeclaration): CreateInterfaceBody => ({
+export const prepareCreateInterfaceBody = async (intrface: sdk.InterfaceDeclaration): Promise<CreateInterfaceBody> => ({
   name: intrface.name,
   version: intrface.version,
   entities: intrface.entities
-    ? utils.records.mapValues(intrface.entities, (entity) => ({
+    ? await utils.records.mapValuesAsync(intrface.entities, async (entity) => ({
         ...entity,
-        schema: utils.schema.mapZodToJsonSchema(entity),
+        schema: await utils.schema.mapZodToJsonSchema(entity),
       }))
     : {},
   events: intrface.events
-    ? utils.records.mapValues(intrface.events, (event) => ({
+    ? await utils.records.mapValuesAsync(intrface.events, async (event) => ({
         ...event,
-        schema: utils.schema.mapZodToJsonSchema(_dereference(intrface, event)),
+        schema: await utils.schema.mapZodToJsonSchema(_dereference(intrface, event)),
       }))
     : {},
   actions: intrface.actions
-    ? utils.records.mapValues(intrface.actions, (action) => ({
+    ? await utils.records.mapValuesAsync(intrface.actions, async (action) => ({
         ...action,
         input: {
           ...action.input,
-          schema: utils.schema.mapZodToJsonSchema(_dereference(intrface, action.input)),
+          schema: await utils.schema.mapZodToJsonSchema(_dereference(intrface, action.input)),
         },
         output: {
           ...action.output,
-          schema: utils.schema.mapZodToJsonSchema(_dereference(intrface, action.output)),
+          schema: await utils.schema.mapZodToJsonSchema(_dereference(intrface, action.output)),
         },
       }))
     : {},

--- a/packages/cli/src/code-generation/index.ts
+++ b/packages/cli/src/code-generation/index.ts
@@ -17,7 +17,7 @@ export const generateIntegrationImplementationTypings = async (
   sdkIntegration: sdk.IntegrationDefinition,
   implementationTypingsPath: string
 ): Promise<types.File[]> => {
-  const integration = mapIntegration.from.sdk(sdkIntegration)
+  const integration = await mapIntegration.from.sdk(sdkIntegration)
   const indexModule = await IntegrationImplementationIndexModule.create(integration)
   indexModule.unshift(implementationTypingsPath)
   return indexModule.flatten()
@@ -59,7 +59,7 @@ export const generateIntegrationInstance = async (
   if ('id' in anyIntegration) {
     integration = mapIntegration.from.client(anyIntegration)
   } else {
-    integration = mapIntegration.from.sdk(anyIntegration)
+    integration = await mapIntegration.from.sdk(anyIntegration)
   }
 
   const indexModule = await IntegrationInstanceIndexModule.create(integration)

--- a/packages/cli/src/command-implementations/deploy-command.ts
+++ b/packages/cli/src/command-implementations/deploy-command.ts
@@ -85,7 +85,7 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
       return
     }
 
-    let createBody: CreateIntegrationBody = prepareCreateIntegrationBody(integrationDef)
+    let createBody: CreateIntegrationBody = await prepareCreateIntegrationBody(integrationDef)
     createBody = {
       ...createBody,
       interfaces: await this._formatInterfacesImplStatements(api, integrationDef),
@@ -167,7 +167,7 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
       return
     }
 
-    const createBody: CreateInterfaceBody = prepareCreateInterfaceBody(interfaceDeclaration)
+    const createBody: CreateInterfaceBody = await prepareCreateInterfaceBody(interfaceDeclaration)
 
     const startedMessage = `Deploying interface ${chalk.bold(name)} v${version}...`
     const successMessage = 'Interface deployed'
@@ -293,7 +293,7 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
     const integrationInstances = await this.fetchBotIntegrationInstances(botImpl, api)
     const updateBotBody = prepareUpdateBotBody(
       {
-        ...prepareCreateBotBody(botImpl),
+        ...(await prepareCreateBotBody(botImpl)),
         id: bot.id,
         code,
         integrations: integrationInstances,

--- a/packages/cli/src/command-implementations/dev-command.ts
+++ b/packages/cli/src/command-implementations/dev-command.ts
@@ -243,7 +243,7 @@ export class DevCommand extends ProjectCommand<DevCommandDefinition> {
     const line = this.logger.line()
     line.started(`Deploying dev integration ${chalk.bold(integrationDef.name)}...`)
 
-    let createIntegrationBody: CreateIntegrationBody = prepareCreateIntegrationBody(integrationDef)
+    let createIntegrationBody: CreateIntegrationBody = await prepareCreateIntegrationBody(integrationDef)
     createIntegrationBody = {
       ...createIntegrationBody,
       url: externalUrl,
@@ -322,7 +322,7 @@ export class DevCommand extends ProjectCommand<DevCommandDefinition> {
     const integrationInstances = await this.fetchBotIntegrationInstances(botImpl, api)
     const updateBotBody = prepareUpdateBotBody(
       {
-        ...prepareCreateBotBody(botImpl),
+        ...(await prepareCreateBotBody(botImpl)),
         id: bot.id,
         url: externalUrl,
         integrations: integrationInstances,

--- a/packages/cli/src/command-implementations/lint-command.ts
+++ b/packages/cli/src/command-implementations/lint-command.ts
@@ -23,7 +23,7 @@ export class LintCommand extends ProjectCommand<LintCommandDefinition> {
   }
 
   private async _runLintForIntegration(definition: IntegrationDefinition): Promise<void> {
-    const parsedIntegrationDefinition = prepareCreateIntegrationBody(definition)
+    const parsedIntegrationDefinition = await prepareCreateIntegrationBody(definition, { dereference: true })
     const linter = new IntegrationLinter(parsedIntegrationDefinition)
 
     await linter.lint()

--- a/packages/cli/src/command-implementations/read-command.ts
+++ b/packages/cli/src/command-implementations/read-command.ts
@@ -10,7 +10,7 @@ export class ReadCommand extends ProjectCommand<ReadCommandDefinition> {
   public async run(): Promise<void> {
     const projectDef = await this.readProjectDefinitionFromFS()
     if (projectDef.type === 'integration') {
-      const parsed = prepareCreateIntegrationBody(projectDef.definition)
+      const parsed = await prepareCreateIntegrationBody(projectDef.definition)
       parsed.interfaces = utils.records.mapValues(projectDef.definition.interfaces, (iface) => ({
         id: '...', // need to be logged in to get this id
         ...iface,
@@ -19,7 +19,7 @@ export class ReadCommand extends ProjectCommand<ReadCommandDefinition> {
       return
     }
     if (projectDef.type === 'interface') {
-      const parsed = prepareCreateInterfaceBody(projectDef.definition)
+      const parsed = await prepareCreateInterfaceBody(projectDef.definition)
       this.logger.json(parsed)
       return
     }

--- a/packages/cli/src/linter/integration-linter.test.ts
+++ b/packages/cli/src/linter/integration-linter.test.ts
@@ -138,7 +138,7 @@ const mockLogger = {
 
 const lintDefinition = async (definition: IntegrationDefinitionProps) => {
   const integrationDefinition = new IntegrationDefinition(definition)
-  const linter = new IntegrationLinter(prepareCreateIntegrationBody(integrationDefinition))
+  const linter = new IntegrationLinter(await prepareCreateIntegrationBody(integrationDefinition))
   await linter.lint()
   return linter
 }

--- a/packages/cli/src/utils/record-utils.ts
+++ b/packages/cli/src/utils/record-utils.ts
@@ -41,6 +41,19 @@ export const mapValues = <A, B>(record: Record<string, A>, fn: (value: A, key: s
   return newRecord
 }
 
+export const mapValuesAsync = async <A, B>(
+  record: Record<string, A>,
+  fn: (value: A, key: string) => Promise<B>
+): Promise<Record<string, B>> => {
+  const newRecord: Record<string, B> = {}
+
+  for (const [key, value] of Object.entries(record)) {
+    newRecord[key] = await fn(value, key)
+  }
+
+  return newRecord
+}
+
 export const mapKeys = <A>(record: Record<string, A>, fn: (value: A, key: string) => string): Record<string, A> => {
   const newRecord: Record<string, A> = {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1651,6 +1651,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@apidevtools/json-schema-ref-parser':
+        specifier: ^11.7.0
+        version: 11.7.0
       '@botpress/client':
         specifier: 0.31.0
         version: link:../client
@@ -1987,6 +1990,15 @@ packages:
       web-streams-polyfill: 3.3.3
     transitivePeerDependencies:
       - encoding
+    dev: false
+
+  /@apidevtools/json-schema-ref-parser@11.7.0:
+    resolution: {integrity: sha512-pRrmXMCwnmrkS3MLgAIW5dXRzeTv6GLjkjb4HmxNnvAKXN1Nfzp4KmGADBQvlVUcqi+a5D+hfGDLLnd5NnYxog==}
+    engines: {node: '>= 16'}
+    dependencies:
+      '@jsdevtools/ono': 7.1.3
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.1.0
     dev: false
 
   /@apidevtools/swagger-methods@3.0.2:


### PR DESCRIPTION
In the github integration I'm working on, some events have schemas that share properties, which results in JSON schemas with references:

```jsonc
{
  "type": "object",
  "properties": {
    "pullRequest": {
      "type": "object",
      "properties": {
        "target": {
          // ... target properties
        },
        "source": {
          "type": "object",
          "properties": {
            "ref": {
              "$ref": "#/properties/pullRequest/properties/target/properties/ref"
            },
            "label": {
              "$ref": "#/properties/pullRequest/properties/target/properties/label"
            },
            "repository": {
              "$ref": "#/properties/pullRequest/properties/target/properties/repository"
            }
          }
        }
      }
    }
  },
  "$schema": "http://json-schema.org/draft-07/schema#"
}
```

Normally, Spectral would be able to handle those references just fine, but since they are deeply nested in a non-schema json object, it's unable to do so; Spectral expects `#` to match the root of the `Document`, but it actually matches the root of the nearest `$schema`. As such, it's completely unable to handle references.