### PR TITLE
feat(integrations/github): properly set the bot's avatar and name

### DIFF
--- a/integrations/github/integration.definition.ts
+++ b/integrations/github/integration.definition.ts
@@ -7,7 +7,7 @@ import { actions, events, configuration, configurations, channels, user, secrets
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   title: 'GitHub',
-  version: '1.0.1',
+  version: '1.0.2',
   icon: 'icon.svg',
   readme: 'hub.md',
   description: 'Github integration for Botpress',

--- a/integrations/github/src/setup.ts
+++ b/integrations/github/src/setup.ts
@@ -5,10 +5,30 @@ import * as bp from '.botpress'
 export const register: RegisterFunction = async ({ ctx, client }) => {
   const gh = await GitHubClient.create({ ctx, client })
 
+  await _configureBotpressNameAndAvatar({ ctx, client, gh })
   await _configureOrganizationHandle({ ctx, client, gh })
 }
 
 export const unregister: UnregisterFunction = async (_) => {}
+
+const _configureBotpressNameAndAvatar = async ({
+  ctx,
+  client,
+  gh,
+}: {
+  ctx: bp.Context
+  client: bp.Client
+  gh: GitHubClient
+}) => {
+  const { id, name, avatarUrl, nodeId, handle, url } = await gh.getAuthenticatedEntity()
+
+  await client.updateUser({
+    id: ctx.botUserId,
+    tags: { id, handle, nodeId, profileUrl: url },
+    name,
+    pictureUrl: avatarUrl,
+  })
+}
 
 const _configureOrganizationHandle = async ({
   ctx,


### PR DESCRIPTION
This PR updates the github integration to set the bot's avatar and name.