### PR TITLE
chore(integrations/slack): fix eslint warnings

### DIFF
--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -28,7 +28,7 @@ export default new IntegrationDefinition({
   name: 'slack',
   title: 'Slack',
   description: 'This integration allows your bot to interact with Slack.',
-  version: '1.0.0',
+  version: '1.0.1',
   icon: 'icon.svg',
   readme: 'hub.md',
   configuration: {

--- a/integrations/slack/src/misc/utils.ts
+++ b/integrations/slack/src/misc/utils.ts
@@ -362,50 +362,50 @@ export const getSigningSecret = async (client: Client, ctx: IntegrationCtx) => {
 
 export class SlackEventSignatureValidator {
   public constructor(
-    private readonly signingSecret: string,
-    private readonly request: Request,
-    private readonly logger: IntegrationLogger
+    private readonly _signingSecret: string,
+    private readonly _request: Request,
+    private readonly _logger: IntegrationLogger
   ) {}
 
   public isEventProperlyAuthenticated(): boolean {
-    return this.validateHeadersArePresent() && this.validateTimestamp() && this.validateSignature()
+    return this._validateHeadersArePresent() && this._validateTimestamp() && this._validateSignature()
   }
 
-  private validateHeadersArePresent(): boolean {
-    const timestamp = this.request.headers['x-slack-request-timestamp']
-    const slackSignature = this.request.headers['x-slack-signature']
+  private _validateHeadersArePresent(): boolean {
+    const timestamp = this._request.headers['x-slack-request-timestamp']
+    const slackSignature = this._request.headers['x-slack-signature']
 
     if (!timestamp || !slackSignature) {
-      this.logger.forBot().error('Request signature verification failed: missing timestamp or signature')
+      this._logger.forBot().error('Request signature verification failed: missing timestamp or signature')
       return false
     }
 
     return true
   }
 
-  private validateTimestamp(): boolean {
+  private _validateTimestamp(): boolean {
     const fiveMinutesAgo = Math.floor(Date.now() / 1000) - 60 * 5
-    const timestamp = this.request.headers['x-slack-request-timestamp'] as string
+    const timestamp = this._request.headers['x-slack-request-timestamp'] as string
 
     if (parseInt(timestamp) < fiveMinutesAgo) {
-      this.logger.forBot().error('Request signature verification failed: timestamp is too old')
+      this._logger.forBot().error('Request signature verification failed: timestamp is too old')
       return false
     }
 
     return true
   }
 
-  private validateSignature(): boolean {
-    const sigBasestring = `v0:${this.request.headers['x-slack-request-timestamp']}:${this.request.body}`
-    const mySignature = 'v0=' + crypto.createHmac('sha256', this.signingSecret).update(sigBasestring).digest('hex')
+  private _validateSignature(): boolean {
+    const sigBasestring = `v0:${this._request.headers['x-slack-request-timestamp']}:${this._request.body}`
+    const mySignature = 'v0=' + crypto.createHmac('sha256', this._signingSecret).update(sigBasestring).digest('hex')
 
     try {
       return crypto.timingSafeEqual(
         Buffer.from(mySignature, 'utf8'),
-        Buffer.from(this.request.headers['x-slack-signature'] as string, 'utf8')
+        Buffer.from(this._request.headers['x-slack-signature'] as string, 'utf8')
       )
     } catch (error) {
-      this.logger.forBot().error('An error occurred while verifying the request signature')
+      this._logger.forBot().error('An error occurred while verifying the request signature')
       return false
     }
   }


### PR DESCRIPTION
this fixes eslint warnings for slack following enforcement of the eslint rule (0f972304a6561d76eb93e1e068aada567b532810) that says that private members must begin with an underscore