### PR TITLE
fix(integrations/linear)!: require a webhook secret for manual configuration

### DIFF
--- a/integrations/linear/integration.definition.ts
+++ b/integrations/linear/integration.definition.ts
@@ -4,7 +4,7 @@ import { actions, channels, events, configuration, configurations, user, states,
 
 export default new IntegrationDefinition({
   name: 'linear',
-  version: '0.5.1',
+  version: '1.0.0',
   title: 'Linear',
   description:
     'Elevate project management with Linear. Update, create, and track issues effortlessly. Improve collaboration with workflow actions like marking duplicates, managing teams and connect your chatbot directly in discussions',

--- a/integrations/linear/src/definitions/index.ts
+++ b/integrations/linear/src/definitions/index.ts
@@ -22,6 +22,11 @@ export const configurations = {
     description: 'Configure Linear with an API Key.',
     schema: z.object({
       apiKey: z.string().describe('The API key for Linear'),
+      webhookSigningSecret: z
+        .string()
+        .secret()
+        .title('Webhook Signing Secret')
+        .describe('The secret key for verifying incoming Linear webhook events'),
     }),
   },
 } satisfies IntegrationDefinitionProps['configurations']


### PR DESCRIPTION
Currently, it is impossible to receive incoming webhook events when using manual configuration for Linear. This is because the integration _always_ uses the Botpress webhook secret to validate webhooks, while it should be using the secret that is unique to the user's webhook.

---

BREAKING CHANGE: the signing secret must now be provided and this field is _not_ optional.