### PR TITLE
fix(integrations/github): fix deployments by reconstituting the RSA secret

### DIFF
--- a/.github/actions/deploy-integrations/action.yml
+++ b/.github/actions/deploy-integrations/action.yml
@@ -108,7 +108,7 @@ runs:
         # deploy
 
         redeploy=${{ inputs.force == 'true' && 1 || 0 }}
-        all_filters="-F '{integrations/*}' -F '!asana' -F '!trello' -F '!webchat' -F '!github' ${{ inputs.extra_filter }}"
+        all_filters="-F '{integrations/*}' -F '!asana' -F '!trello' -F '!webchat' ${{ inputs.extra_filter }}"
         list_integrations_cmd="pnpm list $all_filters --json"
         integration_paths=$(eval $list_integrations_cmd | jq -r "map(".path") | .[]")
 

--- a/.github/workflows/deploy-integrations-production.yml
+++ b/.github/workflows/deploy-integrations-production.yml
@@ -49,4 +49,4 @@ jobs:
           todoist_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_TODOIST_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_TODOIST_CLIENT_SECRET }}'
           cerebras_secrets: '--secrets CEREBRAS_API_KEY=${{ secrets.CEREBRAS_API_KEY }}'
           messenger_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_MESSENGER_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_MESSENGER_CLIENT_SECRET  }} --secrets ACCESS_TOKEN=${{ secrets.PRODUCTION_MESSENGER_ACCESS_TOKEN  }}'
-          github_secrets: '--secrets GITHUB_APP_ID=${{ secrets.PRODUCTION_GITHUB_APP_ID }} --secrets GITHUB_PRIVATE_KEY=${{ secrets.PRODUCTION_GITHUB_PRIVATE_KEY }} --secrets GITHUB_WEBHOOK_SECRET=${{ secrets.PRODUCTION_GITHUB_WEBHOOK_SECRET }}'
+          github_secrets: "--secrets GITHUB_APP_ID=${{ secrets.PRODUCTION_GITHUB_APP_ID }} --secrets 'GITHUB_PRIVATE_KEY=${{ secrets.PRODUCTION_GITHUB_PRIVATE_KEY }}' --secrets GITHUB_WEBHOOK_SECRET=${{ secrets.PRODUCTION_GITHUB_WEBHOOK_SECRET }}"

--- a/.github/workflows/deploy-integrations-staging.yml
+++ b/.github/workflows/deploy-integrations-staging.yml
@@ -53,4 +53,4 @@ jobs:
           todoist_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_TODOIST_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_TODOIST_CLIENT_SECRET }}'
           cerebras_secrets: '--secrets CEREBRAS_API_KEY=${{ secrets.CEREBRAS_API_KEY }}'
           messenger_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_MESSENGER_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_MESSENGER_CLIENT_SECRET  }} --secrets ACCESS_TOKEN=${{ secrets.STAGING_MESSENGER_ACCESS_TOKEN  }}'
-          github_secrets: '--secrets GITHUB_APP_ID=${{ secrets.STAGING_GITHUB_APP_ID }} --secrets GITHUB_PRIVATE_KEY=${{ secrets.STAGING_GITHUB_PRIVATE_KEY }} --secrets GITHUB_WEBHOOK_SECRET=${{ secrets.STAGING_GITHUB_WEBHOOK_SECRET }}'
+          github_secrets: "--secrets GITHUB_APP_ID=${{ secrets.STAGING_GITHUB_APP_ID }} --secrets 'GITHUB_PRIVATE_KEY=${{ secrets.STAGING_GITHUB_PRIVATE_KEY }}' --secrets GITHUB_WEBHOOK_SECRET=${{ secrets.STAGING_GITHUB_WEBHOOK_SECRET }}"

--- a/integrations/github/integration.definition.ts
+++ b/integrations/github/integration.definition.ts
@@ -7,7 +7,7 @@ import { actions, events, configuration, configurations, channels, user, secrets
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   title: 'GitHub',
-  version: '1.0.0',
+  version: '1.0.1',
   icon: 'icon.svg',
   readme: 'hub.md',
   description: 'Github integration for Botpress',


### PR DESCRIPTION
The GitHub integration requires an RSA private key as a secret. However, this secret spans multiple lines, which breaks the bash script in our GitHub Actions pipeline. This PR does not fix the underlying problem, but rather extends a preexisting workaround to support Botpress-provided secrets.

The secrets for `PRODUCTION_GITHUB_PRIVATE_KEY` and `STAGING_GITHUB_PRIVATE_KEY` have already been updated: every line break is replaced by a space, and the `_fixRSAPrivateKey` function will turn it back into a standard RSA key.