### PR TITLE
fix(integrations/gmail): ensure incoming webhooks are routed properly

### DIFF
--- a/integrations/gmail/integration.definition.ts
+++ b/integrations/gmail/integration.definition.ts
@@ -3,7 +3,7 @@ import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 
 export default new IntegrationDefinition({
   name: 'gmail',
-  version: '0.4.3',
+  version: '0.4.4',
   title: 'Gmail',
   description: 'This integration allows your bot to interact with Gmail.',
   icon: 'icon.svg',

--- a/integrations/gmail/integration.definition.ts
+++ b/integrations/gmail/integration.definition.ts
@@ -55,6 +55,9 @@ export default new IntegrationDefinition({
       }),
     },
   },
+  identifier: {
+    extractScript: 'extract.vrl',
+  },
   secrets: {
     ...sentryHelpers.COMMON_SECRET_NAMES,
     CLIENT_ID: { description: 'Gmail Client ID' },

--- a/integrations/gmail/linkTemplate.vrl
+++ b/integrations/gmail/linkTemplate.vrl
@@ -2,7 +2,7 @@ webhookId = to_string!(.webhookId)
 webhookUrl = to_string!(.webhookUrl)
 env = to_string!(.env)
 
-clientId = "293378330844-okgoo9h35i54bbfsdn7ugp1gslemgdcv.apps.googleusercontent.com"
+clientId = "498444171125-5r2u44kldnvq5ui8skrvjq7a4u0dccnd.apps.googleusercontent.com"
 
 if env == "production" {
   clientId = "348984595962-u6at0g0ej8d4ke7ojmepr7osa55jf8qm.apps.googleusercontent.com"


### PR DESCRIPTION
This is a fix for CLS-2404.

Three problems causes webhook events to not be delivered to the Gmail integration:
- There were no pub/sub subscriptions on the topics in GCP (have they somehow expired?)
  - I've recreated the subscriptions for the production and staging environment
- The client id for the staging environment was wrong
  - I've updated `linkTemplate.vrl` accordingly
  - The GitHub repo secret `STAGING_GMAIL_CLIENT_ID` is also updated
- The `extract.vrl` script for the `/integration/global/gmail` endpoint was valid and working (tested using VRL Playground), but somehow it was not being referenced in the integration definition
  - I've added the missing `identifier` key in the integration definition

With these fixes, the integration is now receiving webhook events again