### PR TITLE
chore(integrations/linear): explain why registration fails

### DIFF
--- a/integrations/linear/integration.definition.ts
+++ b/integrations/linear/integration.definition.ts
@@ -4,7 +4,7 @@ import { actions, channels, events, configuration, configurations, user, states,
 
 export default new IntegrationDefinition({
   name: 'linear',
-  version: '1.0.0',
+  version: '1.0.1',
   title: 'Linear',
   description:
     'Elevate project management with Linear. Update, create, and track issues effortlessly. Improve collaboration with workflow actions like marking duplicates, managing teams and connect your chatbot directly in discussions',

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -1,4 +1,4 @@
-import { z, Request } from '@botpress/sdk'
+import { z, Request, RuntimeError } from '@botpress/sdk'
 import { LinearClient } from '@linear/sdk'
 import axios from 'axios'
 import queryString from 'query-string'
@@ -165,5 +165,14 @@ export const handleOauth = async (req: Request, client: bp.Client, ctx: bp.Conte
 
   const linearClient = new LinearClient({ accessToken })
   const organization = await linearClient.organization
-  await client.configureIntegration({ identifier: organization.id })
+
+  try {
+    await client.configureIntegration({ identifier: organization.id })
+  } catch (_: unknown) {
+    throw new RuntimeError(
+      'Unable to configure the integration because the Linear workspace is already registered to another Botpress bot. ' +
+        'The conflicting bot may be part of another Botpress workspace. ' +
+        "Please reach out to our support team if you're unable to find the conflicting bot."
+    )
+  }
 }


### PR DESCRIPTION
This is an attempt at addressing CLS-2369.

The PR makes it explicit that only a single bot, no matter in which Botpress workspace, can be linked to a Linear workspace. This probably should also be added to all other integrations that support OAuth.

Since `RuntimeError` is the only error that gets surfaced in the OAuth registration flow, we're using that error to convey the information to the bot owner