### PR TITLE
fix(integrations/github): do not break back-compat for issueOpened

### DIFF
--- a/integrations/github/integration.definition.ts
+++ b/integrations/github/integration.definition.ts
@@ -7,7 +7,7 @@ import { actions, events, configuration, configurations, channels, user, secrets
 export default new sdk.IntegrationDefinition({
   name: INTEGRATION_NAME,
   title: 'GitHub',
-  version: '1.1.1',
+  version: '1.1.2',
   icon: 'icon.svg',
   readme: 'hub.md',
   description: 'Github integration for Botpress',

--- a/integrations/github/src/definitions/events.ts
+++ b/integrations/github/src/definitions/events.ts
@@ -14,6 +14,27 @@ const pullRequestOpened = {
   schema: z.object({
     pullRequest: PullRequest.title('Pull Request').describe('The pull request that was opened'),
     ...COMMON_EVENT_FIELDS.sender,
+
+    // The following fields have been kept for backwards compatibility.
+    // TODO: Remove these fields in the next major version :
+    type: z.literal('github:pullRequestOpened').optional().title('DEPRECATED: type'),
+    id: z.number().title('DEPRECATED: id').describe('use pullRequest.id instead'),
+    title: z.string().title('DEPRECATED: title').describe('use pullRequest.name instead'),
+    content: z.string().title('DEPRECATED: content').describe('use pullRequest.body instead'),
+    baseBranch: z.string().optional().title('DEPRECATED: baseBranch').describe('use pullRequest.source.ref instead'),
+    userId: z.string().optional().title('DEPRECATED: userId').describe('use pullRequest.author.id instead'),
+    conversationId: z
+      .string()
+      .optional()
+      .title('DEPRECATED: conversationId')
+      .describe('use the conversation id associated with the event instead'),
+    targets: z
+      .object({
+        pullRequest: z.string().optional().title('DEPRECATED: pullRequest').describe('use pullRequest.number instead'),
+        issue: z.string().optional().title('DEPRECATED: issue'),
+        discussion: z.string().optional().title('DEPRECATED: discussion'),
+      })
+      .title('DEPRECATED: targets'),
   }),
 } as const satisfies sdk.EventDefinition
 
@@ -23,6 +44,27 @@ export const pullRequestMerged = {
   schema: z.object({
     pullRequest: PullRequest.title('Pull Request').describe('The pull request that was merged'),
     ...COMMON_EVENT_FIELDS.sender,
+
+    // The following fields have been kept for backwards compatibility.
+    // TODO: Remove these fields in the next major version :
+    type: z.literal('github:pullRequestMerged').optional().title('DEPRECATED: type'),
+    id: z.number().title('DEPRECATED: id').describe('use pullRequest.id instead'),
+    title: z.string().title('DEPRECATED: title').describe('use pullRequest.name instead'),
+    content: z.string().title('DEPRECATED: content').describe('use pullRequest.body instead'),
+    baseBranch: z.string().optional().title('DEPRECATED: baseBranch').describe('use pullRequest.source.ref instead'),
+    userId: z.string().optional().title('DEPRECATED: userId').describe('use pullRequest.author.id instead'),
+    conversationId: z
+      .string()
+      .optional()
+      .title('DEPRECATED: conversationId')
+      .describe('use the conversation id associated with the event instead'),
+    targets: z
+      .object({
+        pullRequest: z.string().optional().title('DEPRECATED: pullRequest').describe('use pullRequest.number instead'),
+        issue: z.string().optional().title('DEPRECATED: issue'),
+        discussion: z.string().optional().title('DEPRECATED: discussion'),
+      })
+      .title('DEPRECATED: targets'),
   }),
 } as const satisfies sdk.EventDefinition
 

--- a/integrations/github/src/definitions/events.ts
+++ b/integrations/github/src/definitions/events.ts
@@ -32,6 +32,20 @@ export const issueOpened = {
   schema: z.object({
     issue: Issue.title('Issue').describe('The issue that was opened'),
     ...COMMON_EVENT_FIELDS.sender,
+
+    // The following fields have been kept for backwards compatibility.
+    // TODO: Remove these fields in the next major version :
+    id: z.number().title('DEPRECATED: id').describe('use issue.id instead'),
+    issueUrl: z.string().title('DEPRECATED: issueUrl').describe('use issue.url instead'),
+    repoUrl: z.string().title('DEPRECATED: repoUrl').describe('use issue.repository.url instead'),
+    number: z.number().title('DEPRECATED: number').describe('use issue.number instead'),
+    title: z.string().title('DEPRECATED: title').describe('use issue.name instead'),
+    content: z.string().nullable().title('DEPRECATED: content').describe('use issue.body instead'),
+    repositoryName: z.string().title('DEPRECATED: repositoryName').describe('use issue.repository.name instead'),
+    repositoryOwner: z
+      .string()
+      .title('DEPRECATED: repositoryOwner')
+      .describe('use issue.repository.owner.handle instead'),
   }),
 } as const satisfies sdk.EventDefinition
 

--- a/integrations/github/src/events/issue/issue-opened.ts
+++ b/integrations/github/src/events/issue/issue-opened.ts
@@ -11,6 +11,17 @@ export const fireIssueOpened = wrapEvent<IssuesOpenedEvent>({
       payload: {
         issue: await mapping.mapIssue(githubEvent.issue, githubEvent.repository),
         eventSender,
+
+        // The following fields have been kept for backwards compatibility.
+        // TODO: Remove these fields in the next major version
+        content: githubEvent.issue.body,
+        id: githubEvent.issue.id,
+        issueUrl: githubEvent.issue.html_url,
+        number: githubEvent.issue.number,
+        repositoryName: githubEvent.repository.name,
+        repositoryOwner: githubEvent.repository.owner.login,
+        repoUrl: githubEvent.repository.html_url,
+        title: githubEvent.issue.title,
       },
       userId: eventSender.botpressUser,
       conversationId: conversation.id,

--- a/integrations/github/src/events/pull-request/pull-request-merged.ts
+++ b/integrations/github/src/events/pull-request/pull-request-merged.ts
@@ -11,6 +11,17 @@ export const firePullRequesMerged = wrapEvent<PullRequestClosedEvent>({
       payload: {
         pullRequest: await mapping.mapPullRequest(githubEvent.pull_request, githubEvent.repository),
         eventSender,
+
+        // The following fields have been kept for backwards compatibility.
+        // TODO: Remove these fields in the next major version
+        type: 'github:pullRequestMerged',
+        baseBranch: githubEvent.pull_request.base.ref,
+        content: githubEvent.pull_request.body?.toString() ?? '',
+        conversationId: conversation.id,
+        id: githubEvent.pull_request.id,
+        targets: { pullRequest: githubEvent.pull_request.number.toString() },
+        title: githubEvent.pull_request.title,
+        userId: githubEvent.pull_request.user.login,
       },
       conversationId: conversation.id,
       userId: eventSender.botpressUser,

--- a/integrations/github/src/events/pull-request/pull-request-opened.ts
+++ b/integrations/github/src/events/pull-request/pull-request-opened.ts
@@ -12,6 +12,17 @@ export const firePullRequestOpened = wrapEvent<PullRequestOpenedEvent>({
       payload: {
         pullRequest: await mapping.mapPullRequest(githubEvent.pull_request, githubEvent.repository),
         eventSender,
+
+        // The following fields have been kept for backwards compatibility.
+        // TODO: Remove these fields in the next major version
+        type: 'github:pullRequestOpened',
+        baseBranch: githubEvent.pull_request.base.ref,
+        content: githubEvent.pull_request.body?.toString() ?? '',
+        conversationId: conversation.id,
+        id: githubEvent.pull_request.id,
+        targets: { pullRequest: githubEvent.pull_request.number.toString() },
+        title: githubEvent.pull_request.title,
+        userId: githubEvent.pull_request.user.login,
       },
       conversationId: conversation.id,
       userId: eventSender.botpressUser,


### PR DESCRIPTION
PR #13322 introduced entities to the GitHub integration and newly implemented events now return entities. However, the PR also broke backward-compatibility for the existing `issueOpened` event by failing to provide all the fields it was previously providing.

This PR re-adds the missing fields to avoid having to bump the major version