### PR TITLE
feat(ci/github-actions) speed up run-checks

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -1,0 +1,22 @@
+name: Setup
+description: install dependencies and build
+
+inputs:
+  filter:
+    description: 'packages to build'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup
+      uses: ./.github/actions/setup
+    - name: Build
+      shell: bash
+      run: |
+        filter="${{ inputs.filter }}"
+        if [ -z "$filter" ]; then
+          pnpm build
+        else
+          pnpm build --filter $filter
+        fi

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,11 +1,5 @@
 name: Setup
-description: install dependencies and build
-
-inputs:
-  filter:
-    type: string
-    description: 'packages to build'
-    required: false
+description: checkout and install dependencies
 
 runs:
   using: 'composite'
@@ -13,7 +7,7 @@ runs:
     - uses: pnpm/action-setup@v4
       with:
         version: 8.6.2
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '18.x'
         check-latest: true
@@ -21,12 +15,3 @@ runs:
     - name: Install dependencies
       shell: bash
       run: pnpm i --frozen-lockfile
-    - name: Build
-      shell: bash
-      run: |
-        filter="${{ inputs.filter }}"
-        if [ -z "$filter" ]; then
-          pnpm build
-        else
-          pnpm build --filter $filter
-        fi

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,6 +17,7 @@ runs:
       with:
         node-version: '18.x'
         check-latest: true
+        cache: 'pnpm'
     - name: Install dependencies
       shell: bash
       run: pnpm i --frozen-lockfile

--- a/.github/workflows/check-integration-versions.yml
+++ b/.github/workflows/check-integration-versions.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
-        uses: ./.github/actions/setup
+        uses: ./.github/actions/setup-and-build
       - name: Login to Botpress
         run: pnpm bp login -y --token ${{ secrets.PRODUCTION_TOKEN_CLOUD_OPS_ACCOUNT }} --workspace-id ${{ secrets.PRODUCTION_CLOUD_OPS_WORKSPACE_ID }}
       - name: Get changed files

--- a/.github/workflows/deploy-bots.yml
+++ b/.github/workflows/deploy-bots.yml
@@ -10,14 +10,14 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
         env:
           BUGBUSTER_GITHUB_TOKEN: ${{ secrets.BUGBUSTER_GITHUB_TOKEN }}
           BUGBUSTER_GITHUB_WEBHOOK_SECRET: ${{ secrets.BUGBUSTER_GITHUB_WEBHOOK_SECRET }}
           BUGBUSTER_SLACK_BOT_TOKEN: ${{ secrets.BUGBUSTER_SLACK_BOT_TOKEN }}
           BUGBUSTER_SLACK_SIGNING_SECRET: ${{ secrets.BUGBUSTER_SLACK_SIGNING_SECRET }}
-        uses: ./.github/actions/setup
+        uses: ./.github/actions/setup-and-build
       - name: Deploy Bots
         run: |
           api_url="https://api.botpress.cloud"

--- a/.github/workflows/deploy-integrations-production.yml
+++ b/.github/workflows/deploy-integrations-production.yml
@@ -17,9 +17,9 @@ jobs:
   deploy-production:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
-        uses: ./.github/actions/setup
+        uses: ./.github/actions/setup-and-build
       - name: Deploy Interfaces
         uses: ./.github/actions/deploy-interfaces
         with:

--- a/.github/workflows/deploy-integrations-staging.yml
+++ b/.github/workflows/deploy-integrations-staging.yml
@@ -21,9 +21,9 @@ jobs:
   deploy-staging:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
-        uses: ./.github/actions/setup
+        uses: ./.github/actions/setup-and-build
       - name: Deploy Interfaces
         uses: ./.github/actions/deploy-interfaces
         with:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -17,9 +17,9 @@ jobs:
     env:
       NODE_OPTIONS: '--max_old_space_size=8192'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
-        uses: ./.github/actions/setup
+        uses: ./.github/actions/setup-and-build
         with:
           filter: '@botpress/*'
       - name: Publish Client

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -2,22 +2,90 @@ name: Run Checks
 
 on: pull_request
 
+env:
+  NODE_OPTIONS: '--max_old_space_size=8192'
+
 permissions:
   id-token: write
   contents: read
 
 jobs:
-  run-checks:
+  setup:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    env:
-      NODE_OPTIONS: '--max_old_space_size=8192'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/setup
-      - run: pnpm run check:format
-      - run: pnpm run check:lint
-      - run: pnpm run check:type
-      - run: pnpm run check:dep
+      - name: Cache entire workspace
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            **/dist
+            **/.botpress
+            **/bp_modules
+            **/gen
+          key: ${{ github.sha }}-workspace-${{ github.run_number }}
+
+  checks:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        check: [format, lint, type, dep]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.6.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+          check-latest: true
+          cache: 'pnpm'
+      - name: Install dependencies
+        shell: bash
+        run: pnpm i --frozen-lockfile
+      - name: Restore workspace
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            **/dist
+            **/.botpress
+            **/bp_modules
+            **/gen
+          key: ${{ github.sha }}-workspace-${{ github.run_number }}
+      - run: pnpm run check:${{ matrix.check }}
+
+  run-tests:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.6.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+          check-latest: true
+          cache: 'pnpm'
+      - name: Install dependencies
+        shell: bash
+        run: pnpm i --frozen-lockfile
+      - name: Restore workspace
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            **/dist
+            **/.botpress
+            **/bp_modules
+            **/gen
+          key: ${{ github.sha }}-workspace-${{ github.run_number }}
       - run: pnpm run test
+
+  all-checks:
+    needs: [checks, run-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All checks completed successfully"

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup
-        uses: ./.github/actions/setup
+        uses: ./.github/actions/setup-and-build
       - name: Cache entire workspace
         uses: actions/cache/save@v4
         with:
@@ -35,17 +35,6 @@ jobs:
         check: [format, lint, type, dep]
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 8.6.2
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '18.x'
-          check-latest: true
-          cache: 'pnpm'
-      - name: Install dependencies
-        shell: bash
-        run: pnpm i --frozen-lockfile
       - name: Restore workspace
         uses: actions/cache/restore@v4
         with:
@@ -55,6 +44,8 @@ jobs:
             **/bp_modules
             **/gen
           key: ${{ github.sha }}-workspace-${{ github.run_number }}
+      - name: Setup
+        uses: ./.github/actions/setup
       - run: pnpm run check:${{ matrix.check }}
 
   run-tests:
@@ -62,17 +53,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 8.6.2
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '18.x'
-          check-latest: true
-          cache: 'pnpm'
-      - name: Install dependencies
-        shell: bash
-        run: pnpm i --frozen-lockfile
       - name: Restore workspace
         uses: actions/cache/restore@v4
         with:
@@ -82,6 +62,8 @@ jobs:
             **/bp_modules
             **/gen
           key: ${{ github.sha }}-workspace-${{ github.run_number }}
+      - name: Setup
+        uses: ./.github/actions/setup
       - run: pnpm run test
 
   all-checks:

--- a/.github/workflows/run-cli-tests.yml
+++ b/.github/workflows/run-cli-tests.yml
@@ -15,9 +15,9 @@ jobs:
     env:
       NODE_OPTIONS: '--max_old_space_size=8192'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
-        uses: ./.github/actions/setup
+        uses: ./.github/actions/setup-and-build
         with:
           filter: '@botpress/cli'
       - run: |

--- a/.github/workflows/run-client-tests.yml
+++ b/.github/workflows/run-client-tests.yml
@@ -13,9 +13,9 @@ jobs:
     env:
       NODE_OPTIONS: '--max_old_space_size=8192'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup
-        uses: ./.github/actions/setup
+        uses: ./.github/actions/setup-and-build
         with:
           filter: '@botpress/client'
       - run: |


### PR DESCRIPTION
Splits the `run-checks` job to run all checks in parallel:

![image](https://github.com/user-attachments/assets/00ff84cc-159e-4da0-80cd-90972221ba2e)

Please note: because of a nodejs 20 bug, [caching is slow](https://github.com/actions/cache/issues/1442), but this should be resolved soon in [actions/cache/save@v4](https://github.com/actions/cache). Once this is fixed, we'll shave off 2+ minutes off the `setup` job