### PR TITLE
feat(integrations/gmail): validate signature of incoming webhooks

### DIFF
--- a/.github/workflows/deploy-integrations-production.yml
+++ b/.github/workflows/deploy-integrations-production.yml
@@ -35,7 +35,7 @@ jobs:
           sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
           token_cloud_ops_account: ${{ secrets.PRODUCTION_TOKEN_CLOUD_OPS_ACCOUNT }}
           cloud_ops_workspace_id: ${{ secrets.PRODUCTION_CLOUD_OPS_WORKSPACE_ID }}
-          gmail_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_GMAIL_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_GMAIL_CLIENT_SECRET }} --secrets TOPIC_NAME=${{ secrets.PRODUCTION_GMAIL_TOPIC_NAME }}'
+          gmail_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_GMAIL_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_GMAIL_CLIENT_SECRET }} --secrets TOPIC_NAME=${{ secrets.PRODUCTION_GMAIL_TOPIC_NAME }} --secrets WEBHOOK_SHARED_SECRET=${{ secrets.PRODUCTION_GMAIL_WEBHOOK_SHARED_SECRET }} --secrets WEBHOOK_SERVICE_ACCOUNT=${{ PRODUCTION_GMAIL_WEBHOOK_SERVICE_ACCOUNT }}'
           linear_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_LINEAR_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_LINEAR_CLIENT_SECRET }} --secrets WEBHOOK_SIGNING_SECRET=${{ secrets.PRODUCTION_LINEAR_WEBHOOK_SIGNING_SECRET }}'
           slack_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_SLACK_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_SLACK_CLIENT_SECRET }} --secrets SIGNING_SECRET=${{ secrets.PRODUCTION_SLACK_SIGNING_SECRET }}'
           charts_secrets: '--secrets QUICKCHARTS_API_KEY=${{ secrets.QUICKCHARTS_API_KEY }}'

--- a/.github/workflows/deploy-integrations-staging.yml
+++ b/.github/workflows/deploy-integrations-staging.yml
@@ -39,7 +39,7 @@ jobs:
           sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
           token_cloud_ops_account: ${{ secrets.STAGING_TOKEN_CLOUD_OPS_ACCOUNT }}
           cloud_ops_workspace_id: ${{ secrets.STAGING_CLOUD_OPS_WORKSPACE_ID }}
-          gmail_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_GMAIL_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_GMAIL_CLIENT_SECRET }} --secrets TOPIC_NAME=${{ secrets.STAGING_GMAIL_TOPIC_NAME }}'
+          gmail_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_GMAIL_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_GMAIL_CLIENT_SECRET }} --secrets TOPIC_NAME=${{ secrets.STAGING_GMAIL_TOPIC_NAME }} --secrets WEBHOOK_SHARED_SECRET=${{ secrets.STAGING_GMAIL_WEBHOOK_SHARED_SECRET }} --secrets WEBHOOK_SERVICE_ACCOUNT=${{ STAGING_GMAIL_WEBHOOK_SERVICE_ACCOUNT }}'
           linear_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_LINEAR_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_LINEAR_CLIENT_SECRET }} --secrets WEBHOOK_SIGNING_SECRET=${{ secrets.STAGING_LINEAR_WEBHOOK_SIGNING_SECRET }}'
           slack_secrets: --secrets CLIENT_ID=${{ secrets.STAGING_SLACK_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_SLACK_CLIENT_SECRET }} --secrets SIGNING_SECRET=${{ secrets.STAGING_SLACK_SIGNING_SECRET }}
           charts_secrets: '--secrets QUICKCHARTS_API_KEY=${{ secrets.QUICKCHARTS_API_KEY }}'

--- a/integrations/gmail/definitions/secrets.ts
+++ b/integrations/gmail/definitions/secrets.ts
@@ -6,4 +6,5 @@ export const secrets = {
   CLIENT_ID: { description: 'Gmail Client ID' },
   CLIENT_SECRET: { description: 'Gmail Client Secret' },
   TOPIC_NAME: { description: 'Google Cloud Pub/Sub topic name for Gmail messages' },
+  WEBHOOK_SHARED_SECRET: {},
 } as const satisfies sdk.IntegrationDefinitionProps['secrets']

--- a/integrations/gmail/definitions/secrets.ts
+++ b/integrations/gmail/definitions/secrets.ts
@@ -6,5 +6,6 @@ export const secrets = {
   CLIENT_ID: { description: 'Gmail Client ID' },
   CLIENT_SECRET: { description: 'Gmail Client Secret' },
   TOPIC_NAME: { description: 'Google Cloud Pub/Sub topic name for Gmail messages' },
-  WEBHOOK_SHARED_SECRET: {},
+  WEBHOOK_SHARED_SECRET: { description: 'Pub/Sub webhook shared secret' },
+  WEBHOOK_SERVICE_ACCOUNT: { description: 'Pub/Sub JWT service account' },
 } as const satisfies sdk.IntegrationDefinitionProps['secrets']

--- a/integrations/gmail/definitions/states.ts
+++ b/integrations/gmail/definitions/states.ts
@@ -26,4 +26,13 @@ export const states = {
         .describe('The last history ID processed by the integration'),
     }),
   },
+  googlePublicCertCache: {
+    type: 'integration',
+    schema: z.object({
+      certificates: z
+        .string()
+        .title('Certificates JSON')
+        .describe('The certs used by Google for federated sign-on, stringified as JSON'),
+    }),
+  },
 } as const satisfies sdk.IntegrationDefinitionProps['states']

--- a/integrations/gmail/integration.definition.ts
+++ b/integrations/gmail/integration.definition.ts
@@ -3,7 +3,7 @@ import { configuration, identifier, channels, user, states, actions, events, sec
 
 export default new sdk.IntegrationDefinition({
   name: 'gmail',
-  version: '0.4.8',
+  version: '0.4.9',
   title: 'Gmail',
   description: 'This integration allows your bot to interact with Gmail.',
   icon: 'icon.svg',

--- a/integrations/gmail/src/google-api/google-client.ts
+++ b/integrations/gmail/src/google-api/google-client.ts
@@ -1,13 +1,12 @@
 import * as sdk from '@botpress/sdk'
 import { google } from 'googleapis'
+import { GmailClient, GoogleOAuth2Client } from './types'
 import * as bp from '.botpress'
-
-type Gmail = ReturnType<typeof google.gmail>
 
 const GLOBAL_OAUTH_ENDPOINT = `${process.env.BP_WEBHOOK_URL}/oauth` as const
 
 export class GoogleClient {
-  private constructor(private readonly _gmail: Gmail) {}
+  private constructor(private readonly _gmail: GmailClient) {}
 
   public static async create({
     client,
@@ -111,7 +110,7 @@ export class GoogleClient {
   private static async _exchangeAuthorizationCodeForRefreshToken(authorizationCode: string) {
     const oauth2Client = this._getOAuthClient()
     const { tokens } = await oauth2Client.getToken({
-      code: authorizationCode.toString(),
+      code: authorizationCode,
     })
 
     if (!tokens.refresh_token) {
@@ -121,7 +120,7 @@ export class GoogleClient {
     return tokens.refresh_token
   }
 
-  private static _getOAuthClient() {
+  private static _getOAuthClient(): GoogleOAuth2Client {
     return new google.auth.OAuth2(bp.secrets.CLIENT_ID, bp.secrets.CLIENT_SECRET, GLOBAL_OAUTH_ENDPOINT)
   }
 }

--- a/integrations/gmail/src/google-api/index.ts
+++ b/integrations/gmail/src/google-api/index.ts
@@ -1,2 +1,3 @@
 export * from './error-handling'
 export * from './google-client'
+export * from './jwt-validation'

--- a/integrations/gmail/src/google-api/jwt-validation.ts
+++ b/integrations/gmail/src/google-api/jwt-validation.ts
@@ -1,0 +1,89 @@
+import { google } from 'googleapis'
+import { MS_IN_12_HOURS } from 'src/utils/datetime-utils'
+import { GoogleOAuth2Client, GoogleCerts, LoginTicketPayload } from './types'
+import * as bp from '.botpress'
+
+const CERT_CACHE_STATE_NAME = 'googlePublicCertCache'
+const ALLOWED_ISSUERS = ['https://accounts.google.com']
+const REQUIRED_AUDIENCE = bp.secrets.WEBHOOK_SHARED_SECRET
+const REQUIRED_RECIPIENT = bp.secrets.WEBHOOK_SERVICE_ACCOUNT
+
+export class JWTVerifier {
+  private readonly _oauth2Client: GoogleOAuth2Client
+  private readonly _client: bp.Client
+  private readonly _ctx: bp.Context
+
+  public constructor({ ctx, client }: { ctx: bp.Context; client: bp.Client }) {
+    this._oauth2Client = new google.auth.OAuth2()
+    this._client = client
+    this._ctx = ctx
+  }
+
+  public async isJWTProperlySigned(token: string): Promise<boolean> {
+    try {
+      return await this._verifyJWTSignature(token)
+    } catch (thrown: unknown) {
+      console.error("Couldn't verify JWT signature", thrown)
+      return false
+    }
+  }
+
+  private async _verifyJWTSignature(token: string): Promise<boolean> {
+    const certificates = await this._getCertificates()
+    const loginTicketPayload = await this._getLoginTicketPayload(certificates, token)
+
+    return this._validatePayload(loginTicketPayload)
+  }
+
+  private async _getCertificates(): Promise<GoogleCerts> {
+    const cachedCerts = await this._getCachedCertificates()
+
+    return cachedCerts ?? (await this._fetchAndCacheCertificates())
+  }
+
+  private async _getLoginTicketPayload(certificates: GoogleCerts, token: string): Promise<LoginTicketPayload> {
+    const loginTicket = await this._oauth2Client.verifySignedJwtWithCertsAsync(
+      token,
+      certificates,
+      REQUIRED_AUDIENCE,
+      ALLOWED_ISSUERS
+    )
+
+    return loginTicket.getPayload()
+  }
+
+  private _validatePayload(payload: LoginTicketPayload): boolean {
+    if (!payload?.email_verified || payload.email !== REQUIRED_RECIPIENT) {
+      console.error('Invalid or unverified email in JWT payload')
+      return false
+    }
+
+    return true
+  }
+  private async _getCachedCertificates(): Promise<GoogleCerts | null> {
+    try {
+      const { state } = await this._client.getState({
+        type: 'integration',
+        name: CERT_CACHE_STATE_NAME,
+        id: this._ctx.integrationId,
+      })
+      return JSON.parse(state.payload.certificates)
+    } catch {
+      return null
+    }
+  }
+
+  private async _fetchAndCacheCertificates(): Promise<GoogleCerts> {
+    const { certs } = await this._oauth2Client.getFederatedSignonCertsAsync()
+
+    await this._client.setState({
+      name: CERT_CACHE_STATE_NAME,
+      type: 'integration',
+      expiry: MS_IN_12_HOURS,
+      id: this._ctx.integrationId,
+      payload: { certificates: JSON.stringify(certs) },
+    })
+
+    return certs
+  }
+}

--- a/integrations/gmail/src/google-api/types.d.ts
+++ b/integrations/gmail/src/google-api/types.d.ts
@@ -1,0 +1,8 @@
+import { google } from 'googleapis'
+
+export type GmailClient = ReturnType<typeof google.gmail>
+export type GoogleOAuth2Client = InstanceType<(typeof google.auth)['OAuth2']>
+export type GoogleCerts = Awaited<ReturnType<GoogleOAuth2Client['getFederatedSignonCertsAsync']>>['certs']
+export type LoginTicketPayload = ReturnType<
+  Awaited<ReturnType<GoogleOAuth2Client['verifySignedJwtWithCertsAsync']>>['getPayload']
+>

--- a/integrations/gmail/src/utils/datetime-utils.ts
+++ b/integrations/gmail/src/utils/datetime-utils.ts
@@ -1,0 +1,1 @@
+export const MS_IN_12_HOURS = 43_200_000 as const

--- a/integrations/gmail/src/webhook-events/handler.ts
+++ b/integrations/gmail/src/webhook-events/handler.ts
@@ -17,6 +17,16 @@ export const handler = async (props: bp.HandlerProps) => {
   await handleIncomingEmail(props)
 }
 
+/*
+  NOTE: the JWT validation process can be somewhat expensive, because we have to
+        fetch Google's public certs and cache them. This means we'd rather not
+        perform this validation for bogus request, so we short-circuit the
+        validation process by first checking whether a specific string is
+        present in the query parameters, as suggested by Google. On subsequent
+        non-bogus webhook events, validation is quicker though because we use
+        the cert cache rather than poking Google every time for its certs.
+*/
+
 const _isWebhookEventProperlyAuthenticated = async (props: bp.HandlerProps) =>
   _isSharedSecretValid(props) && (await _isJWTValid(props))
 

--- a/integrations/gmail/src/webhook-events/handler.ts
+++ b/integrations/gmail/src/webhook-events/handler.ts
@@ -1,3 +1,4 @@
+import { JWTVerifier } from 'src/google-api'
 import { handleIncomingEmail } from './new-mail'
 import { handleOAuthCallback } from './oauth-callback'
 import * as bp from '.botpress'
@@ -10,17 +11,31 @@ export const handler = async (props: bp.HandlerProps) => {
   }
 
   if (!(await _isWebhookEventProperlyAuthenticated(props))) {
-    throw new Error('Incoming webhook event is not properly authenticated')
+    throw new Error('Incoming webhook event is not properly authenticated', { cause: props.req })
   }
 
   await handleIncomingEmail(props)
 }
 
-const _isWebhookEventProperlyAuthenticated = async (props: bp.HandlerProps) => _isSharedSecretValid(props)
+const _isWebhookEventProperlyAuthenticated = async (props: bp.HandlerProps) =>
+  _isSharedSecretValid(props) && (await _isJWTValid(props))
 
 const _isSharedSecretValid = ({ req }: bp.HandlerProps) => {
   const searchParams = new URLSearchParams(req.query)
   const sharedSecret = searchParams.get('shared_secret')
 
   return sharedSecret === bp.secrets.WEBHOOK_SHARED_SECRET
+}
+
+const _isJWTValid = async ({ req, client, ctx }: bp.HandlerProps) => {
+  const authorizationHeader = req.headers.authorization
+
+  if (!authorizationHeader?.startsWith('Bearer ')) {
+    return false
+  }
+
+  const bearerToken = authorizationHeader.slice(7)
+  const jwtVerifier = new JWTVerifier({ client, ctx })
+
+  return await jwtVerifier.isJWTProperlySigned(bearerToken)
 }

--- a/integrations/gmail/src/webhook-events/handler.ts
+++ b/integrations/gmail/src/webhook-events/handler.ts
@@ -9,5 +9,18 @@ export const handler = async (props: bp.HandlerProps) => {
     return handleOAuthCallback(props)
   }
 
+  if (!(await _isWebhookEventProperlyAuthenticated(props))) {
+    throw new Error('Incoming webhook event is not properly authenticated')
+  }
+
   await handleIncomingEmail(props)
+}
+
+const _isWebhookEventProperlyAuthenticated = async (props: bp.HandlerProps) => _isSharedSecretValid(props)
+
+const _isSharedSecretValid = ({ req }: bp.HandlerProps) => {
+  const searchParams = new URLSearchParams(req.query)
+  const sharedSecret = searchParams.get('shared_secret')
+
+  return sharedSecret === bp.secrets.WEBHOOK_SHARED_SECRET
 }


### PR DESCRIPTION
Implements webhook push event authentication following [Google's guidelines](https://cloud.google.com/pubsub/docs/authenticate-push-subscriptions#node.js).

Google's public certificates are cached for 12 hours in an integration *state* to reduce network overhead