### PR TITLE
feat(integrations/gmail): implement most message types

### DIFF
--- a/integrations/gmail/definitions/channels.ts
+++ b/integrations/gmail/definitions/channels.ts
@@ -4,7 +4,29 @@ export const channels = {
   channel: {
     title: 'Email thread',
     description: 'Messages in an email thread',
-    messages: sdk.messages.defaults,
+    messages: {
+      ...sdk.messages.defaults,
+      image: {
+        schema: sdk.messages.defaults.image.schema.extend({
+          title: sdk.z.string().title('Alt text').describe('Alt text for the image'),
+        }),
+      },
+      audio: {
+        schema: sdk.messages.defaults.audio.schema.extend({
+          title: sdk.z.string().title('Title').describe('Title for the audio file'),
+        }),
+      },
+      video: {
+        schema: sdk.messages.defaults.video.schema.extend({
+          title: sdk.z.string().title('Title').describe('Title for the video file'),
+        }),
+      },
+      file: {
+        schema: sdk.messages.defaults.file.schema.extend({
+          title: sdk.z.string().title('Title').describe('Title for the file'),
+        }),
+      },
+    },
     message: {
       tags: {
         id: { title: 'Gmail ID', description: 'The unique identifier of the message on Gmail' },

--- a/integrations/gmail/integration.definition.ts
+++ b/integrations/gmail/integration.definition.ts
@@ -3,7 +3,7 @@ import { configuration, identifier, channels, user, states, actions, events, sec
 
 export default new sdk.IntegrationDefinition({
   name: 'gmail',
-  version: '0.4.9',
+  version: '0.5.0',
   title: 'Gmail',
   description: 'This integration allows your bot to interact with Gmail.',
   icon: 'icon.svg',

--- a/integrations/gmail/package.json
+++ b/integrations/gmail/package.json
@@ -23,12 +23,17 @@
     "@botpress/common": "workspace:*",
     "@botpress/sdk": "workspace:*",
     "@botpress/sdk-addons": "workspace:*",
+    "@react-email/components": "0.0.25",
+    "@types/react": "^18.3.11",
+    "@types/react-dom": "^18.3.1",
     "gmail-api-parse-message": "^2.1.2",
     "googleapis": "^112.0.0",
     "js-base64": "^3.7.5",
     "node-html-parser": "^6",
     "nodemailer": "^6.7.2",
-    "query-string": "^6.14.1"
+    "query-string": "^6.14.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@sentry/cli": "^2.18.1",

--- a/integrations/gmail/src/channels/channel-wrapper.ts
+++ b/integrations/gmail/src/channels/channel-wrapper.ts
@@ -1,6 +1,7 @@
 import { createChannelWrapper } from '@botpress/common'
 import { GoogleClient, wrapWithTryCatch } from '../google-api'
 import * as bp from '.botpress'
+import * as sdk from '@botpress/sdk'
 
 export const wrapChannel: typeof _injectTools = (meta, channelImpl) =>
   _injectTools(meta, (props) =>
@@ -18,6 +19,20 @@ const _injectTools = createChannelWrapper<bp.IntegrationProps>()({
   toolFactories: {
     async googleClient({ client, ctx }) {
       return await GoogleClient.create({ client, ctx })
+    },
+
+    async inReplyTo({ client, conversation }) {
+      const { state } = await client.getState({
+        type: 'conversation',
+        name: 'thread',
+        id: conversation.id,
+      })
+
+      if (!state.payload.inReplyTo) {
+        throw new sdk.RuntimeError('Attempting to reply to a message, but no inReplyTo tag was found')
+      }
+
+      return state.payload.inReplyTo
     },
   },
 })

--- a/integrations/gmail/src/channels/channel-wrapper.ts
+++ b/integrations/gmail/src/channels/channel-wrapper.ts
@@ -1,7 +1,7 @@
 import { createChannelWrapper } from '@botpress/common'
+import * as sdk from '@botpress/sdk'
 import { GoogleClient, wrapWithTryCatch } from '../google-api'
 import * as bp from '.botpress'
-import * as sdk from '@botpress/sdk'
 
 export const wrapChannel: typeof _injectTools = (meta, channelImpl) =>
   _injectTools(meta, (props) =>

--- a/integrations/gmail/src/channels/channels.ts
+++ b/integrations/gmail/src/channels/channels.ts
@@ -5,6 +5,7 @@ import {
   generateAudioMessage,
   generateFileDownloadMessage,
   generateImageMessage,
+  generateMarkdownMessage,
   generateVideoMessage,
 } from '../utils/mail-composing'
 import { wrapChannel } from './channel-wrapper'
@@ -78,8 +79,16 @@ export const channels = {
           textContent: content,
         })
       }),
-      markdown: wrapChannel({ channelName: 'channel', messageType: 'markdown' }, () => {
-        throw new sdk.RuntimeError('This message type is not yet implemented')
+      markdown: wrapChannel({ channelName: 'channel', messageType: 'markdown' }, async (props) => {
+        const { markdown } = props.payload
+        const htmlContent = generateMarkdownMessage({ markdown })
+        const textContent = markdown
+
+        await _sendEmailReply({
+          ...props,
+          textContent,
+          htmlContent,
+        })
       }),
       location: wrapChannel({ channelName: 'channel', messageType: 'location' }, () => {
         throw new sdk.RuntimeError('This message type is not yet implemented')

--- a/integrations/gmail/src/channels/channels.ts
+++ b/integrations/gmail/src/channels/channels.ts
@@ -1,152 +1,126 @@
 import * as sdk from '@botpress/sdk'
 import { GoogleClient } from '../google-api'
-import { composeRawEmail } from '../utils/mail-composing'
+import {
+  composeRawEmail,
+  generateAudioMessage,
+  generateFileDownloadMessage,
+  generateImageMessage,
+  generateVideoMessage,
+} from '../utils/mail-composing'
 import { wrapChannel } from './channel-wrapper'
 import * as bp from '.botpress'
 
 export const channels = {
   channel: {
     messages: {
-      image: wrapChannel({ channelName: 'channel', messageType: 'image' }, ({ conversation, message, user }) => {
-        console.info('conversation', conversation)
-        console.info('message', message)
-        console.info('user', user)
-        throw new sdk.RuntimeError('Not implemented')
-      }),
-      markdown: wrapChannel({ channelName: 'channel', messageType: 'markdown' }, ({ conversation, message, user }) => {
-        console.info('conversation', conversation)
-        console.info('message', message)
-        console.info('user', user)
-        throw new sdk.RuntimeError('Not implemented')
-      }),
-      audio: wrapChannel({ channelName: 'channel', messageType: 'audio' }, ({ conversation, message, user }) => {
-        console.info('conversation', conversation)
-        console.info('message', message)
-        console.info('user', user)
-        throw new sdk.RuntimeError('Not implemented')
-      }),
-      video: wrapChannel({ channelName: 'channel', messageType: 'video' }, ({ conversation, message, user }) => {
-        console.info('conversation', conversation)
-        console.info('message', message)
-        console.info('user', user)
-        throw new sdk.RuntimeError('Not implemented')
-      }),
-      file: wrapChannel({ channelName: 'channel', messageType: 'file' }, ({ conversation, message, user }) => {
-        console.info('conversation', conversation)
-        console.info('message', message)
-        console.info('user', user)
-        throw new sdk.RuntimeError('Not implemented')
-      }),
-      location: wrapChannel({ channelName: 'channel', messageType: 'location' }, ({ conversation, message, user }) => {
-        console.info('conversation', conversation)
-        console.info('message', message)
-        console.info('user', user)
-        throw new sdk.RuntimeError('Not implemented')
-      }),
-      card: wrapChannel({ channelName: 'channel', messageType: 'card' }, ({ conversation, message, user }) => {
-        console.info('conversation', conversation)
-        console.info('message', message)
-        console.info('user', user)
-        throw new sdk.RuntimeError('Not implemented')
-      }),
-      carousel: wrapChannel({ channelName: 'channel', messageType: 'carousel' }, ({ conversation, message, user }) => {
-        console.info('conversation', conversation)
-        console.info('message', message)
-        console.info('user', user)
-        throw new sdk.RuntimeError('Not implemented')
-      }),
-      dropdown: wrapChannel({ channelName: 'channel', messageType: 'dropdown' }, ({ conversation, message, user }) => {
-        console.info('conversation', conversation)
-        console.info('message', message)
-        console.info('user', user)
-        throw new sdk.RuntimeError('Not implemented')
-      }),
-      bloc: wrapChannel({ channelName: 'channel', messageType: 'bloc' }, ({ conversation, message, user }) => {
-        console.info('conversation', conversation)
-        console.info('message', message)
-        console.info('user', user)
-        throw new sdk.RuntimeError('Not implemented')
-      }),
-      text: wrapChannel(
-        { channelName: 'channel', messageType: 'text' },
-        async ({ ctx, client, conversation, ack, payload }) => {
-          console.info('sending email')
+      image: wrapChannel({ channelName: 'channel', messageType: 'image' }, (props) => {
+        const { imageUrl, title: altText } = props.payload
+        const htmlContent = generateImageMessage({ imageUrl, altText })
+        const textContent = `Image:\n${imageUrl}`
 
-          const { state } = await client.getState({
-            type: 'conversation',
-            name: 'thread',
-            id: conversation.id,
-          })
+        return _sendEmailReply({
+          ...props,
+          textContent,
+          htmlContent,
+        })
+      }),
+      audio: wrapChannel({ channelName: 'channel', messageType: 'audio' }, (props) => {
+        const { audioUrl, title } = props.payload
+        const htmlContent = generateAudioMessage({ audioUrl, title })
+        const textContent = `Audio file:\n${audioUrl}`
 
-          if (!state.payload.inReplyTo) {
-            console.info('No inReplyTo tag found')
-            return
-          }
+        return _sendEmailReply({
+          ...props,
+          textContent,
+          htmlContent,
+        })
+      }),
+      video: wrapChannel({ channelName: 'channel', messageType: 'video' }, (props) => {
+        const { videoUrl, title } = props.payload
+        const htmlContent = generateVideoMessage({ videoUrl, title })
+        const textContent = `Video file:\n${videoUrl}`
 
-          await _sendEmailReply({
-            ctx,
-            content: payload.text,
-            conversation,
-            client,
-            ack,
-            inReplyTo: state.payload.inReplyTo,
-          })
+        return _sendEmailReply({
+          ...props,
+          textContent,
+          htmlContent,
+        })
+      }),
+      file: wrapChannel({ channelName: 'channel', messageType: 'file' }, (props) => {
+        const { fileUrl, title } = props.payload
+        const htmlContent = generateFileDownloadMessage({ fileUrl, title })
+        const textContent = `Linked file:\n${fileUrl}`
+
+        return _sendEmailReply({
+          ...props,
+          textContent,
+          htmlContent,
+        })
+      }),
+      text: wrapChannel({ channelName: 'channel', messageType: 'text' }, async (props) => {
+        const { text: textContent } = props.payload
+
+        await _sendEmailReply({
+          ...props,
+          textContent,
+        })
+      }),
+      choice: wrapChannel({ channelName: 'channel', messageType: 'choice' }, async (props) => {
+        const { text, options } = props.payload
+        let content = `${text}\n`
+
+        for (const option of options) {
+          content += `- ${option.label}\n`
         }
-      ),
-      choice: wrapChannel(
-        { channelName: 'channel', messageType: 'choice' },
-        async ({ client, conversation, ctx, payload, ack }) => {
-          console.info('sending email')
 
-          const { state } = await client.getState({
-            type: 'conversation',
-            name: 'thread',
-            id: conversation.id,
-          })
-
-          if (!state.payload.inReplyTo) {
-            console.info('No inReplyTo tag found')
-            return
-          }
-
-          let content = `${payload.text}\n`
-
-          for (const option of payload.options) {
-            content += `- ${option.label}\n`
-          }
-
-          await _sendEmailReply({
-            ctx,
-            content,
-            conversation,
-            client,
-            ack,
-            inReplyTo: state.payload.inReplyTo,
-          })
-        }
-      ),
+        await _sendEmailReply({
+          ...props,
+          textContent: content,
+        })
+      }),
+      markdown: wrapChannel({ channelName: 'channel', messageType: 'markdown' }, () => {
+        throw new sdk.RuntimeError('This message type is not yet implemented')
+      }),
+      location: wrapChannel({ channelName: 'channel', messageType: 'location' }, () => {
+        throw new sdk.RuntimeError('This message type is not yet implemented')
+      }),
+      card: wrapChannel({ channelName: 'channel', messageType: 'card' }, () => {
+        throw new sdk.RuntimeError('This message type is not yet implemented')
+      }),
+      carousel: wrapChannel({ channelName: 'channel', messageType: 'carousel' }, () => {
+        throw new sdk.RuntimeError('This message type is not yet implemented')
+      }),
+      dropdown: wrapChannel({ channelName: 'channel', messageType: 'dropdown' }, () => {
+        throw new sdk.RuntimeError('This message type is not yet implemented')
+      }),
+      bloc: wrapChannel({ channelName: 'channel', messageType: 'bloc' }, () => {
+        throw new sdk.RuntimeError('This message type is not yet implemented')
+      }),
     },
   },
 } as const satisfies bp.IntegrationProps['channels']
 
-type SendEmailProps = Pick<bp.AnyMessageProps, 'ctx' | 'conversation' | 'client' | 'ack'> & {
-  content: string
+const _sendEmailReply = async ({
+  conversation,
+  ack,
+  textContent,
+  htmlContent,
+  inReplyTo,
+  googleClient,
+}: bp.AnyMessageProps & {
+  textContent: string
+  htmlContent?: string
   inReplyTo: string
-}
-
-const _sendEmailReply = async ({ client, ctx, conversation, ack, content, inReplyTo }: SendEmailProps) => {
-  console.info('bulding the client')
-
-  const googleClient = await GoogleClient.create({ client, ctx })
-
+  googleClient: GoogleClient
+}) => {
   const { threadId, email, subject, references, cc } = _getConversationInfo(conversation)
 
   console.info('Creating mail')
   const raw = await composeRawEmail({
     to: email,
     subject,
-    text: content,
-    html: content,
+    text: textContent,
+    html: htmlContent ?? textContent,
     textEncoding: 'base64',
     inReplyTo,
     references: references ?? inReplyTo,
@@ -161,15 +135,12 @@ const _sendEmailReply = async ({ client, ctx, conversation, ack, content, inRepl
 }
 
 const _getConversationInfo = (conversation: bp.AnyMessageProps['conversation']) => {
-  const threadId = conversation.tags?.id
-  const subject = conversation.tags?.subject
-  const email = conversation.tags?.email
-  const references = conversation.tags?.references
-  const cc = conversation.tags?.cc
+  const { id, tags } = conversation
+  const { id: threadId, subject, email, references, cc } = tags
 
   if (!(threadId && subject && email)) {
-    console.info(`No valid information found for conversation ${conversation.id}`)
-    throw Error(`No valid information found for conversation ${conversation.id}`)
+    console.info(`No valid information found for conversation ${id}`)
+    throw new Error(`No valid information found for conversation ${id}`)
   }
 
   return { threadId, subject, email, references, cc }

--- a/integrations/gmail/src/channels/channels.ts
+++ b/integrations/gmail/src/channels/channels.ts
@@ -5,6 +5,7 @@ import {
   generateAudioMessage,
   generateFileDownloadMessage,
   generateImageMessage,
+  generateLocationMessage,
   generateMarkdownMessage,
   generateVideoMessage,
 } from '../utils/mail-composing'
@@ -90,8 +91,16 @@ export const channels = {
           htmlContent,
         })
       }),
-      location: wrapChannel({ channelName: 'channel', messageType: 'location' }, () => {
-        throw new sdk.RuntimeError('This message type is not yet implemented')
+      location: wrapChannel({ channelName: 'channel', messageType: 'location' }, async (props) => {
+        const { latitude, longitude, address, title } = props.payload
+        const htmlContent = generateLocationMessage({ latitude, longitude, address, title })
+        const textContent = `https://www.google.com/maps/search/?api=1&query=${latitude},${longitude}`
+
+        await _sendEmailReply({
+          ...props,
+          textContent,
+          htmlContent,
+        })
       }),
       card: wrapChannel({ channelName: 'channel', messageType: 'card' }, () => {
         throw new sdk.RuntimeError('This message type is not yet implemented')

--- a/integrations/gmail/src/utils/mail-composing.ts
+++ b/integrations/gmail/src/utils/mail-composing.ts
@@ -1,9 +1,0 @@
-import MailComposer from 'nodemailer/lib/mail-composer'
-import type Mail from 'nodemailer/lib/mailer'
-import { encodeBase64URL } from './string-utils'
-
-export const composeRawEmail = async (options: Mail.Options) => {
-  const mailComposer = new MailComposer(options)
-  const message = await mailComposer.compile().build()
-  return encodeBase64URL(message)
-}

--- a/integrations/gmail/src/utils/mail-composing.tsx
+++ b/integrations/gmail/src/utils/mail-composing.tsx
@@ -108,10 +108,10 @@ const _IconButton = ({ icon, text, href }: { icon: react.ReactNode; text: string
 )
 
 const _AudioMessage = ({ audioUrl, title: text }: { audioUrl: string; title: string }) =>
-  _IconButton({ icon: '➤', text, href: audioUrl })
+  _IconButton({ icon: <span style={{ fontSize: '1.3em', lineHeight: '100%' }}>⯈</span>, text, href: audioUrl })
 
 const _VideoMessage = ({ videoUrl, title: text }: { videoUrl: string; title: string }) =>
-  _IconButton({ icon: '➤', text, href: videoUrl })
+  _IconButton({ icon: <span style={{ fontSize: '1.3em', lineHeight: '100%' }}>⯈</span>, text, href: videoUrl })
 
 const _FileDownloadMessage = ({ fileUrl, title: text }: { fileUrl: string; title: string }) =>
   _IconButton({ icon: '🡳', text, href: fileUrl })

--- a/integrations/gmail/src/utils/mail-composing.tsx
+++ b/integrations/gmail/src/utils/mail-composing.tsx
@@ -1,9 +1,9 @@
+import { Body, Container, Head, Html, Img, Link, Button, Row, Column, Heading, Markdown } from '@react-email/components'
 import MailComposer from 'nodemailer/lib/mail-composer'
 import type Mail from 'nodemailer/lib/mailer'
-import { encodeBase64URL } from './string-utils'
-import { Body, Container, Head, Html, Img, Link, Button, Row, Column, Heading, Text } from '@react-email/components'
-import { renderToString } from 'react-dom/server'
 import * as react from 'react'
+import { renderToString } from 'react-dom/server'
+import { encodeBase64URL } from './string-utils'
 
 export const composeRawEmail = async (options: Mail.Options) => {
   const mailComposer = new MailComposer(options)
@@ -22,6 +22,9 @@ export const generateVideoMessage = ({ videoUrl, title }: { videoUrl: string; ti
 
 export const generateFileDownloadMessage = ({ fileUrl, title }: { fileUrl: string; title: string }) =>
   _renderMessage(<_fileDownloadMessage fileUrl={fileUrl} title={title} />)
+
+export const generateMarkdownMessage = ({ markdown }: { markdown: string }) =>
+  _renderMessage(<Markdown>{markdown}</Markdown>)
 
 const _renderMessage = (message: react.ReactNode) => renderToString(<_BaseMessage>{message}</_BaseMessage>)
 

--- a/integrations/gmail/src/utils/mail-composing.tsx
+++ b/integrations/gmail/src/utils/mail-composing.tsx
@@ -1,4 +1,17 @@
-import { Body, Container, Head, Html, Img, Link, Button, Row, Column, Heading, Markdown } from '@react-email/components'
+import {
+  Body,
+  Container,
+  Head,
+  Html,
+  Img,
+  Link,
+  Button,
+  Row,
+  Column,
+  Heading,
+  Markdown,
+  Text,
+} from '@react-email/components'
 import MailComposer from 'nodemailer/lib/mail-composer'
 import type Mail from 'nodemailer/lib/mailer'
 import * as react from 'react'
@@ -25,6 +38,18 @@ export const generateFileDownloadMessage = ({ fileUrl, title }: { fileUrl: strin
 
 export const generateMarkdownMessage = ({ markdown }: { markdown: string }) =>
   _renderMessage(<Markdown>{markdown}</Markdown>)
+
+export const generateLocationMessage = ({
+  latitude,
+  longitude,
+  address,
+  title,
+}: {
+  latitude: number
+  longitude: number
+  address?: string
+  title?: string
+}) => _renderMessage(<_LocationMessage latitude={latitude} longitude={longitude} address={address} title={title} />)
 
 const _renderMessage = (message: react.ReactNode) => renderToString(<_BaseMessage>{message}</_BaseMessage>)
 
@@ -58,18 +83,17 @@ const _primaryButtonStyle = {
   color: 'rgb(255,255,255)',
 } as const
 
+const _primaryHeadingStyle = {
+  fontSize: '24px',
+  lineHeight: '36px',
+  fontWeight: 600,
+  color: 'rgb(17,24,39)',
+  textAlign: 'center',
+} as const
+
 const _ImageMessage = ({ imageUrl, altText }: { imageUrl: string; altText: string }) => (
   <>
-    <Heading
-      as="h1"
-      style={{
-        fontSize: '24px',
-        lineHeight: '36px',
-        fontWeight: 600,
-        color: 'rgb(17,24,39)',
-        textAlign: 'center',
-      }}
-    >
+    <Heading as="h1" style={_primaryHeadingStyle}>
       {altText}
     </Heading>
     <Link href={imageUrl}>
@@ -97,3 +121,37 @@ const _VideoMessage = ({ videoUrl, title: text }: { videoUrl: string; title: str
 
 const _fileDownloadMessage = ({ fileUrl, title: text }: { fileUrl: string; title: string }) =>
   _IconButton({ icon: '🡳', text, href: fileUrl })
+
+const _LocationMessage = ({
+  latitude,
+  longitude,
+  address,
+  title,
+}: {
+  latitude: number
+  longitude: number
+  address?: string
+  title?: string
+}) => {
+  const previewUrl = `https://staticmap.maptoolkit.net/?size=350x250&zoom=16&marker=center:${latitude},${longitude}`
+  const googleMapsUrl = `https://www.google.com/maps/search/?api=1&query=${address ?? `${latitude},${longitude}`}`
+
+  return (
+    <>
+      {title && (
+        <Heading as="h1" style={_primaryHeadingStyle}>
+          {title}
+        </Heading>
+      )}
+      <Link href={googleMapsUrl}>
+        <Img alt={address} height={250} width={350} src={previewUrl} style={{ borderRadius: 12, margin: '0 auto' }} />
+      </Link>
+      {address && <Text style={{ textAlign: 'center' }}>{address}</Text>}
+      <Container style={{ marginTop: '1em', textAlign: 'center' }}>
+        <Button href={googleMapsUrl} style={_primaryButtonStyle}>
+          Open in Google Maps
+        </Button>
+      </Container>
+    </>
+  )
+}

--- a/integrations/gmail/src/utils/mail-composing.tsx
+++ b/integrations/gmail/src/utils/mail-composing.tsx
@@ -1,0 +1,96 @@
+import MailComposer from 'nodemailer/lib/mail-composer'
+import type Mail from 'nodemailer/lib/mailer'
+import { encodeBase64URL } from './string-utils'
+import { Body, Container, Head, Html, Img, Link, Button, Row, Column, Heading, Text } from '@react-email/components'
+import { renderToString } from 'react-dom/server'
+import * as react from 'react'
+
+export const composeRawEmail = async (options: Mail.Options) => {
+  const mailComposer = new MailComposer(options)
+  const message = await mailComposer.compile().build()
+  return encodeBase64URL(message)
+}
+
+export const generateImageMessage = ({ imageUrl, altText }: { imageUrl: string; altText: string }) =>
+  _renderMessage(<_ImageMessage imageUrl={imageUrl} altText={altText} />)
+
+export const generateAudioMessage = ({ audioUrl, title }: { audioUrl: string; title: string }) =>
+  _renderMessage(<_AudioMessage audioUrl={audioUrl} title={title} />)
+
+export const generateVideoMessage = ({ videoUrl, title }: { videoUrl: string; title: string }) =>
+  _renderMessage(<_VideoMessage videoUrl={videoUrl} title={title} />)
+
+export const generateFileDownloadMessage = ({ fileUrl, title }: { fileUrl: string; title: string }) =>
+  _renderMessage(<_fileDownloadMessage fileUrl={fileUrl} title={title} />)
+
+const _renderMessage = (message: react.ReactNode) => renderToString(<_BaseMessage>{message}</_BaseMessage>)
+
+const _BaseMessage = ({ children }: react.PropsWithChildren) => (
+  <Html>
+    <Head />
+    <Body style={_bodyStyle}>
+      <Container style={_innerContainerStyle}>{children}</Container>
+    </Body>
+  </Html>
+)
+
+const _bodyStyle = {
+  backgroundColor: '#ffffff',
+} as const
+
+const _innerContainerStyle = {
+  paddingLeft: '12px',
+  paddingRight: '12px',
+  margin: '0 auto',
+} as const
+
+const _primaryButtonStyle = {
+  backgroundColor: 'rgb(79,70,229)',
+  borderRadius: '8px',
+  paddingLeft: '40px',
+  paddingRight: '40px',
+  paddingTop: '12px',
+  paddingBottom: '12px',
+  fontWeight: '600',
+  color: 'rgb(255,255,255)',
+} as const
+
+const _ImageMessage = ({ imageUrl, altText }: { imageUrl: string; altText: string }) => (
+  <>
+    <Heading
+      as="h1"
+      style={{
+        fontSize: '24px',
+        lineHeight: '36px',
+        fontWeight: 600,
+        color: 'rgb(17,24,39)',
+        textAlign: 'center',
+      }}
+    >
+      {altText}
+    </Heading>
+    <Link href={imageUrl}>
+      <Img alt={altText} height={250} src={imageUrl} style={{ borderRadius: 12, margin: '0 auto' }} />
+    </Link>
+  </>
+)
+
+const _IconButton = ({ icon, text, href }: { icon: react.ReactNode; text: string; href: string }) => (
+  <Button href={href} style={_primaryButtonStyle}>
+    <Row>
+      <Column style={{ paddingRight: '.3em' }} role="presentation">
+        {icon}
+      </Column>
+      <Column>{text}</Column>
+    </Row>
+  </Button>
+)
+
+const _AudioMessage = ({ audioUrl, title: text }: { audioUrl: string; title: string }) =>
+  _IconButton({ icon: '➤', text, href: audioUrl })
+
+const _VideoMessage = ({ videoUrl, title: text }: { videoUrl: string; title: string }) =>
+  _IconButton({ icon: '➤', text, href: videoUrl })
+
+const _fileDownloadMessage = ({ fileUrl, title: text }: { fileUrl: string; title: string }) =>
+  _IconButton({ icon: '🡳', text, href: fileUrl })

--- a/integrations/gmail/src/utils/mail-composing.tsx
+++ b/integrations/gmail/src/utils/mail-composing.tsx
@@ -11,6 +11,7 @@ import {
   Heading,
   Markdown,
   Text,
+  Section,
 } from '@react-email/components'
 import MailComposer from 'nodemailer/lib/mail-composer'
 import type Mail from 'nodemailer/lib/mailer'
@@ -24,32 +25,25 @@ export const composeRawEmail = async (options: Mail.Options) => {
   return encodeBase64URL(message)
 }
 
-export const generateImageMessage = ({ imageUrl, altText }: { imageUrl: string; altText: string }) =>
-  _renderMessage(<_ImageMessage imageUrl={imageUrl} altText={altText} />)
+export const generateImageMessage = (props: Parameters<typeof _ImageMessage>[0]) => _renderMessage(_ImageMessage(props))
 
-export const generateAudioMessage = ({ audioUrl, title }: { audioUrl: string; title: string }) =>
-  _renderMessage(<_AudioMessage audioUrl={audioUrl} title={title} />)
+export const generateAudioMessage = (props: Parameters<typeof _AudioMessage>[0]) => _renderMessage(_AudioMessage(props))
 
-export const generateVideoMessage = ({ videoUrl, title }: { videoUrl: string; title: string }) =>
-  _renderMessage(<_VideoMessage videoUrl={videoUrl} title={title} />)
+export const generateVideoMessage = (props: Parameters<typeof _VideoMessage>[0]) => _renderMessage(_VideoMessage(props))
 
-export const generateFileDownloadMessage = ({ fileUrl, title }: { fileUrl: string; title: string }) =>
-  _renderMessage(<_fileDownloadMessage fileUrl={fileUrl} title={title} />)
+export const generateFileDownloadMessage = (props: Parameters<typeof _FileDownloadMessage>[0]) =>
+  _renderMessage(_FileDownloadMessage(props))
 
 export const generateMarkdownMessage = ({ markdown }: { markdown: string }) =>
   _renderMessage(<Markdown>{markdown}</Markdown>)
 
-export const generateLocationMessage = ({
-  latitude,
-  longitude,
-  address,
-  title,
-}: {
-  latitude: number
-  longitude: number
-  address?: string
-  title?: string
-}) => _renderMessage(<_LocationMessage latitude={latitude} longitude={longitude} address={address} title={title} />)
+export const generateCardMessage = (props: Parameters<typeof _CardMessage>[0]) => _renderMessage(_CardMessage(props))
+
+export const generateCarouselMessage = (props: Parameters<typeof _CarouselMessage>[0]) =>
+  _renderMessage(_CarouselMessage(props))
+
+export const generateLocationMessage = (props: Parameters<typeof _LocationMessage>[0]) =>
+  _renderMessage(_LocationMessage(props))
 
 const _renderMessage = (message: react.ReactNode) => renderToString(<_BaseMessage>{message}</_BaseMessage>)
 
@@ -119,7 +113,7 @@ const _AudioMessage = ({ audioUrl, title: text }: { audioUrl: string; title: str
 const _VideoMessage = ({ videoUrl, title: text }: { videoUrl: string; title: string }) =>
   _IconButton({ icon: '➤', text, href: videoUrl })
 
-const _fileDownloadMessage = ({ fileUrl, title: text }: { fileUrl: string; title: string }) =>
+const _FileDownloadMessage = ({ fileUrl, title: text }: { fileUrl: string; title: string }) =>
   _IconButton({ icon: '🡳', text, href: fileUrl })
 
 const _LocationMessage = ({
@@ -155,3 +149,113 @@ const _LocationMessage = ({
     </>
   )
 }
+
+const _CardMessage = ({
+  title,
+  subtitle,
+  imageUrl,
+  actions,
+}: {
+  title: string
+  subtitle: string
+  imageUrl: string
+  actions: {
+    action: 'postback' | 'url' | 'say'
+    label: string
+    value: string
+  }[]
+}) => (
+  <Container>
+    <Img
+      alt="banner image"
+      height="320"
+      src={imageUrl}
+      style={{
+        width: '100%',
+        borderRadius: 12,
+        objectFit: 'cover',
+      }}
+      role="presentation"
+    />
+    <Section
+      style={{
+        marginTop: 24,
+        textAlign: 'center',
+      }}
+    >
+      <Text
+        style={{
+          marginTop: 16,
+          marginBottom: 16,
+          fontSize: 18,
+          lineHeight: '28px',
+          fontWeight: 600,
+          color: 'rgb(79,70,229)',
+        }}
+      >
+        {subtitle}
+      </Text>
+      <Heading
+        as="h1"
+        style={{
+          margin: '0px',
+          marginTop: 8,
+          marginBottom: 16,
+          fontSize: 36,
+          lineHeight: '36px',
+          fontWeight: 600,
+          color: 'rgb(17,24,39)',
+        }}
+      >
+        {title}
+      </Heading>
+      <table
+        style={{
+          width: 'auto',
+          margin: '0 auto',
+        }}
+      >
+        {actions.map(({ label, value }) => (
+          <tr>
+            <td>
+              <Button
+                href={value}
+                style={{
+                  marginTop: 16,
+                  borderRadius: 8,
+                  backgroundColor: 'rgb(79,70,229)',
+                  paddingLeft: 40,
+                  paddingRight: 40,
+                  paddingTop: 12,
+                  paddingBottom: 12,
+                  fontWeight: 600,
+                  color: 'rgb(255,255,255)',
+                  display: 'block',
+                }}
+              >
+                {label}
+              </Button>
+            </td>
+          </tr>
+        ))}
+      </table>
+    </Section>
+  </Container>
+)
+
+const _CarouselMessage = ({
+  cards,
+}: {
+  cards: {
+    title: string
+    subtitle: string
+    imageUrl: string
+    actions: { action: 'postback' | 'url' | 'say'; label: string; value: string }[]
+  }[]
+}) => (
+  <>
+    {cards.map((cardProps) => (
+      <div style={{ marginBottom: '6em' }}>{_CardMessage(cardProps)}</div>
+    ))}
+  </>
+)

--- a/integrations/gmail/tsconfig.json
+++ b/integrations/gmail/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "lib": ["DOM"],
     "baseUrl": ".",
     "outDir": "dist"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,6 +448,15 @@ importers:
       '@botpress/sdk-addons':
         specifier: workspace:*
         version: link:../../packages/sdk-addons
+      '@react-email/components':
+        specifier: 0.0.25
+        version: 0.0.25(react-dom@18.3.1)(react@18.3.1)
+      '@types/react':
+        specifier: ^18.3.11
+        version: 18.3.11
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.1
       gmail-api-parse-message:
         specifier: ^2.1.2
         version: 2.1.2
@@ -466,6 +475,12 @@ importers:
       query-string:
         specifier: ^6.14.1
         version: 6.14.1
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@sentry/cli':
         specifier: ^2.18.1
@@ -3452,7 +3467,6 @@ packages:
       strip-ansi-cjs: /strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: /wrap-ansi@7.0.0
-    dev: true
 
   /@istanbuljs/load-nyc-config@1.1.0:
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -4082,6 +4096,10 @@ packages:
       aggregate-error: 3.1.0
     dev: false
 
+  /@one-ini/wasm@0.1.1:
+    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
+    dev: false
+
   /@parcel/watcher@2.1.0:
     resolution: {integrity: sha512-8s8yYjd19pDSsBpbkOHnT6Z2+UJSuLQx61pCFM0s5wSRvKCEMDjd/cHY3/GI1szHIWbpXpsJdg3V6ISGGx9xDw==}
     engines: {node: '>= 10.0.0'}
@@ -4097,8 +4115,223 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
     requiresBuild: true
-    dev: true
     optional: true
+
+  /@react-email/body@0.0.10(react@18.3.1):
+    resolution: {integrity: sha512-dMJyL9aU25ieatdPtVjCyQ/WHZYHwNc+Hy/XpF8Cc18gu21cUynVEeYQzFSeigDRMeBQ3PGAyjVDPIob7YlGwA==}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+    dev: false
+
+  /@react-email/button@0.0.17(react@18.3.1):
+    resolution: {integrity: sha512-ioHdsk+BpGS/PqjU6JS7tUrVy9yvbUx92Z+Cem2+MbYp55oEwQ9VHf7u4f5NoM0gdhfKSehBwRdYlHt/frEMcg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+    dev: false
+
+  /@react-email/code-block@0.0.9(react@18.3.1):
+    resolution: {integrity: sha512-Zrhc71VYrSC1fVXJuaViKoB/dBjxLw6nbE53Bm/eUuZPdnnZ1+ZUIh8jfaRKC5MzMjgnLGQTweGXVnfIrhyxtQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      prismjs: 1.29.0
+      react: 18.3.1
+    dev: false
+
+  /@react-email/code-inline@0.0.4(react@18.3.1):
+    resolution: {integrity: sha512-zj3oMQiiUCZbddSNt3k0zNfIBFK0ZNDIzzDyBaJKy6ZASTtWfB+1WFX0cpTX8q0gUiYK+A94rk5Qp68L6YXjXQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+    dev: false
+
+  /@react-email/column@0.0.12(react@18.3.1):
+    resolution: {integrity: sha512-Rsl7iSdDaeHZO938xb+0wR5ud0Z3MVfdtPbNKJNojZi2hApwLAQXmDrnn/AcPDM5Lpl331ZljJS8vHTWxxkvKw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+    dev: false
+
+  /@react-email/components@0.0.25(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-lnfVVrThEcET5NPoeaXvrz9UxtWpGRcut2a07dLbyKgNbP7vj/cXTI5TuHtanCvhCddFpMDnElNRghDOfPzwUg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      '@react-email/body': 0.0.10(react@18.3.1)
+      '@react-email/button': 0.0.17(react@18.3.1)
+      '@react-email/code-block': 0.0.9(react@18.3.1)
+      '@react-email/code-inline': 0.0.4(react@18.3.1)
+      '@react-email/column': 0.0.12(react@18.3.1)
+      '@react-email/container': 0.0.14(react@18.3.1)
+      '@react-email/font': 0.0.8(react@18.3.1)
+      '@react-email/head': 0.0.11(react@18.3.1)
+      '@react-email/heading': 0.0.14(react@18.3.1)
+      '@react-email/hr': 0.0.10(react@18.3.1)
+      '@react-email/html': 0.0.10(react@18.3.1)
+      '@react-email/img': 0.0.10(react@18.3.1)
+      '@react-email/link': 0.0.10(react@18.3.1)
+      '@react-email/markdown': 0.0.12(react@18.3.1)
+      '@react-email/preview': 0.0.11(react@18.3.1)
+      '@react-email/render': 1.0.1(react-dom@18.3.1)(react@18.3.1)
+      '@react-email/row': 0.0.10(react@18.3.1)
+      '@react-email/section': 0.0.14(react@18.3.1)
+      '@react-email/tailwind': 0.1.0(react@18.3.1)
+      '@react-email/text': 0.0.10(react@18.3.1)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - react-dom
+    dev: false
+
+  /@react-email/container@0.0.14(react@18.3.1):
+    resolution: {integrity: sha512-NgoaJJd9tTtsrveL86Ocr/AYLkGyN3prdXKd/zm5fQpfDhy/NXezyT3iF6VlwAOEUIu64ErHpAJd+P6ygR+vjg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+    dev: false
+
+  /@react-email/font@0.0.8(react@18.3.1):
+    resolution: {integrity: sha512-fSBEqYyVPAyyACBBHcs3wEYzNknpHMuwcSAAKE8fOoDfGqURr/vSxKPdh4tOa9z7G4hlcEfgGrCYEa2iPT22cw==}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+    dev: false
+
+  /@react-email/head@0.0.11(react@18.3.1):
+    resolution: {integrity: sha512-skw5FUgyamIMK+LN+fZQ5WIKQYf0dPiRAvsUAUR2eYoZp9oRsfkIpFHr0GWPkKAYjFEj+uJjaxQ/0VzQH7svVg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+    dev: false
+
+  /@react-email/heading@0.0.14(react@18.3.1):
+    resolution: {integrity: sha512-jZM7IVuZOXa0G110ES8OkxajPTypIKlzlO1K1RIe1auk76ukQRiCg1IRV4HZlWk1GGUbec5hNxsvZa2kU8cb9w==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+    dev: false
+
+  /@react-email/hr@0.0.10(react@18.3.1):
+    resolution: {integrity: sha512-3AA4Yjgl3zEid/KVx6uf6TuLJHVZvUc2cG9Wm9ZpWeAX4ODA+8g9HyuC0tfnjbRsVMhMcCGiECuWWXINi+60vA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+    dev: false
+
+  /@react-email/html@0.0.10(react@18.3.1):
+    resolution: {integrity: sha512-06uiuSKJBWQJfhCKv4MPupELei4Lepyz9Sth7Yq7Fq29CAeB1ejLgKkGqn1I+FZ72hQxPLdYF4iq4yloKv3JCg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+    dev: false
+
+  /@react-email/img@0.0.10(react@18.3.1):
+    resolution: {integrity: sha512-pJ8glJjDNaJ53qoM95pvX9SK05yh0bNQY/oyBKmxlBDdUII6ixuMc3SCwYXPMl+tgkQUyDgwEBpSTrLAnjL3hA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+    dev: false
+
+  /@react-email/link@0.0.10(react@18.3.1):
+    resolution: {integrity: sha512-tva3wvAWSR10lMJa9fVA09yRn7pbEki0ZZpHE6GD1jKbFhmzt38VgLO9B797/prqoDZdAr4rVK7LJFcdPx3GwA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+    dev: false
+
+  /@react-email/markdown@0.0.12(react@18.3.1):
+    resolution: {integrity: sha512-wsuvj1XAb6O63aizCLNEeqVgKR3oFjAwt9vjfg2y2oh4G1dZeo8zonZM2x1fmkEkBZhzwSHraNi70jSXhA3A9w==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      md-to-react-email: 5.0.2(react@18.3.1)
+      react: 18.3.1
+    dev: false
+
+  /@react-email/preview@0.0.11(react@18.3.1):
+    resolution: {integrity: sha512-7O/CT4b16YlSGrj18htTPx3Vbhu2suCGv/cSe5c+fuSrIM/nMiBSZ3Js16Vj0XJbAmmmlVmYFZw9L20wXJ+LjQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+    dev: false
+
+  /@react-email/render@1.0.1(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-W3gTrcmLOVYnG80QuUp22ReIT/xfLsVJ+n7ghSlG2BITB8evNABn1AO2rGQoXuK84zKtDAlxCdm3hRyIpZdGSA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      html-to-text: 9.0.5
+      js-beautify: 1.15.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-promise-suspense: 0.3.4
+    dev: false
+
+  /@react-email/row@0.0.10(react@18.3.1):
+    resolution: {integrity: sha512-jPyEhG3gsLX+Eb9U+A30fh0gK6hXJwF4ghJ+ZtFQtlKAKqHX+eCpWlqB3Xschd/ARJLod8WAswg0FB+JD9d0/A==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+    dev: false
+
+  /@react-email/section@0.0.14(react@18.3.1):
+    resolution: {integrity: sha512-+fYWLb4tPU1A/+GE5J1+SEMA7/wR3V30lQ+OR9t2kAJqNrARDbMx0bLnYnR1QL5TiFRz0pCF05SQUobk6gHEDQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+    dev: false
+
+  /@react-email/tailwind@0.1.0(react@18.3.1):
+    resolution: {integrity: sha512-qysVUEY+M3SKUvu35XDpzn7yokhqFOT3tPU6Mj/pgc62TL5tQFj6msEbBtwoKs2qO3WZvai0DIHdLhaOxBQSow==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+    dev: false
+
+  /@react-email/text@0.0.10(react@18.3.1):
+    resolution: {integrity: sha512-wNAnxeEAiFs6N+SxS0y6wTJWfewEzUETuyS2aZmT00xk50VijwyFRuhm4sYSjusMyshevomFwz5jNISCxRsGWw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    dependencies:
+      react: 18.3.1
+    dev: false
 
   /@readme/better-ajv-errors@1.6.0(ajv@8.17.1):
     resolution: {integrity: sha512-9gO9rld84Jgu13kcbKRU+WHseNhaVt76wYMeRDGsUGYxwJtI3RmEJ9LY9dZCYQGI8eUZLuxb5qDja0nqklpFjQ==}
@@ -4299,6 +4532,13 @@ packages:
       tslib: 2.6.2
     transitivePeerDependencies:
       - encoding
+    dev: false
+
+  /@selderee/plugin-htmlparser2@0.11.0:
+    resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+    dependencies:
+      domhandler: 5.0.3
+      selderee: 0.11.0
     dev: false
 
   /@sentry-internal/tracing@7.53.1:
@@ -4995,11 +5235,28 @@ packages:
       kleur: 3.0.3
     dev: true
 
+  /@types/prop-types@15.7.13:
+    resolution: {integrity: sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==}
+    dev: false
+
   /@types/qs@6.9.7:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
 
   /@types/range-parser@1.2.4:
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==}
+    dev: false
+
+  /@types/react-dom@18.3.1:
+    resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
+    dependencies:
+      '@types/react': 18.3.11
+    dev: false
+
+  /@types/react@18.3.11:
+    resolution: {integrity: sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==}
+    dependencies:
+      '@types/prop-types': 15.7.13
+      csstype: 3.1.3
     dev: false
 
   /@types/responselike@1.0.0:
@@ -5430,6 +5687,11 @@ packages:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
     dev: true
 
+  /abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dev: false
+
   /abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -5588,7 +5850,6 @@ packages:
   /ansi-regex@6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
-    dev: true
 
   /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -5609,7 +5870,6 @@ packages:
   /ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
-    dev: true
 
   /any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -6569,6 +6829,11 @@ packages:
     dependencies:
       delayed-stream: 1.0.0
 
+  /commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+    dev: false
+
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: true
@@ -6592,6 +6857,13 @@ packages:
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  /config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
+    dev: false
 
   /content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
@@ -6653,6 +6925,10 @@ packages:
   /css-what@6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
     engines: {node: '>= 6'}
+    dev: false
+
+  /csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
     dev: false
 
   /d@1.0.1:
@@ -6835,7 +7111,6 @@ packages:
   /deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /defer-to-connect@1.1.3:
     resolution: {integrity: sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==}
@@ -7016,7 +7291,6 @@ packages:
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-    dev: true
 
   /ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
@@ -7029,6 +7303,17 @@ packages:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
     dependencies:
       safe-buffer: 5.2.1
+
+  /editorconfig@1.0.4:
+    resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dependencies:
+      '@one-ini/wasm': 0.1.1
+      commander: 10.0.1
+      minimatch: 9.0.1
+      semver: 7.5.4
+    dev: false
 
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -7047,7 +7332,6 @@ packages:
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-    dev: true
 
   /enabled@2.0.0:
     resolution: {integrity: sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==}
@@ -8095,6 +8379,10 @@ packages:
     resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
     engines: {'0': node >=0.6.0}
 
+  /fast-deep-equal@2.0.1:
+    resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
+    dev: false
+
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -8299,7 +8587,6 @@ packages:
     dependencies:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
-    dev: true
 
   /forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
@@ -8589,7 +8876,6 @@ packages:
       minimatch: 9.0.3
       minipass: 6.0.2
       path-scurry: 1.10.2
-    dev: true
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -8898,6 +9184,17 @@ packages:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
 
+  /html-to-text@9.0.5:
+    resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@selderee/plugin-htmlparser2': 0.11.0
+      deepmerge: 4.3.1
+      dom-serializer: 2.0.0
+      htmlparser2: 8.0.2
+      selderee: 0.11.0
+    dev: false
+
   /htmlencode@0.0.4:
     resolution: {integrity: sha512-0uDvNVpzj/E2TfvLLyyXhKBRvF1y84aZsyRxRXFsQobnHaL4pcaXk+Y9cnFlvnxrBLeXDNq/VJBD+ngdBgQG1w==}
     dev: false
@@ -8909,6 +9206,15 @@ packages:
       domhandler: 4.3.1
       domutils: 2.8.0
       entities: 2.2.0
+    dev: false
+
+  /htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      entities: 4.5.0
     dev: false
 
   /http-cache-semantics@4.1.1:
@@ -9351,7 +9657,6 @@ packages:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-    dev: true
 
   /jest-changed-files@29.5.0:
     resolution: {integrity: sha512-IFG34IUMUaNBIxjQXF/iu7g6EcdMrGRRxaUSw92I/2g2YC6vCdTltl4nHvt7Ci5nSJwXIkCu8Ka1DKF+X7Z1Ag==}
@@ -9830,6 +10135,23 @@ packages:
     resolution: {integrity: sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA==}
     dev: false
 
+  /js-beautify@1.15.1:
+    resolution: {integrity: sha512-ESjNzSlt/sWE8sciZH8kBF8BPlwXPwhR6pWKAw8bw4Bwj+iZcnKW6ONWUutJ7eObuBZQpiIb8S7OYspWrKt7rA==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 1.0.4
+      glob: 10.3.10
+      js-cookie: 3.0.5
+      nopt: 7.2.1
+    dev: false
+
+  /js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
+    dev: false
+
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -10109,6 +10431,10 @@ packages:
       package-json: 6.5.0
     dev: false
 
+  /leac@0.6.0:
+    resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
+    dev: false
+
   /leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -10262,7 +10588,6 @@ packages:
   /lru-cache@10.2.0:
     resolution: {integrity: sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==}
     engines: {node: 14 || >=16.14}
-    dev: true
 
   /lru-cache@4.0.2:
     resolution: {integrity: sha512-uQw9OqphAGiZhkuPlpFGmdTU2tEuhxTourM/19qGJrxBPHAr/f8BT1a0i/lOclESnGatdJG/UCkP9kZB/Lh1iw==}
@@ -10349,6 +10674,21 @@ packages:
     resolution: {integrity: sha512-J6CPjP8pS5sgrRqxVRvkCIkZ6MFdRIjDkwUwgJ9nL2fbmM6qGQeB2C16hi8Cc9BOzj6xXzy0jyi0iPIfnMHYzA==}
     engines: {node: '>= 18'}
     hasBin: true
+    dev: false
+
+  /marked@7.0.4:
+    resolution: {integrity: sha512-t8eP0dXRJMtMvBojtkcsA7n48BkauktUKzfkPSCq85ZMTJ0v76Rke4DYz01omYpPTUh4p/f7HePgRo3ebG8+QQ==}
+    engines: {node: '>= 16'}
+    hasBin: true
+    dev: false
+
+  /md-to-react-email@5.0.2(react@18.3.1):
+    resolution: {integrity: sha512-x6kkpdzIzUhecda/yahltfEl53mH26QdWu4abUF9+S0Jgam8P//Ciro8cdhyMHnT5MQUJYrIbO6ORM2UxPiNNA==}
+    peerDependencies:
+      react: 18.x
+    dependencies:
+      marked: 7.0.4
+      react: 18.3.1
     dev: false
 
   /media-typer@0.3.0:
@@ -10474,12 +10814,18 @@ packages:
     dependencies:
       brace-expansion: 2.0.1
 
+  /minimatch@9.0.1:
+    resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
+
   /minimatch@9.0.3:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
-    dev: true
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -10682,6 +11028,14 @@ packages:
     dependencies:
       abbrev: 1.1.1
     dev: true
+
+  /nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+    dependencies:
+      abbrev: 2.0.0
+    dev: false
 
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -10998,6 +11352,13 @@ packages:
       lines-and-columns: 1.2.4
     dev: true
 
+  /parseley@0.12.1:
+    resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
+    dependencies:
+      leac: 0.6.0
+      peberminta: 0.9.0
+    dev: false
+
   /pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
     dependencies:
@@ -11040,7 +11401,6 @@ packages:
     dependencies:
       lru-cache: 10.2.0
       minipass: 6.0.2
-    dev: true
 
   /path-scurry@1.9.2:
     resolution: {integrity: sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==}
@@ -11058,6 +11418,10 @@ packages:
 
   /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+
+  /peberminta@0.9.0:
+    resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
+    dev: false
 
   /peek-readable@4.1.0:
     resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
@@ -11223,6 +11587,11 @@ packages:
       ansi-styles: 5.2.0
       react-is: 18.2.0
 
+  /prismjs@1.29.0:
+    resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
+    engines: {node: '>=6'}
+    dev: false
+
   /process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -11242,6 +11611,10 @@ packages:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+
+  /proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+    dev: false
 
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
@@ -11348,8 +11721,24 @@ packages:
       strip-json-comments: 2.0.1
     dev: false
 
+  /react-dom@18.3.1(react@18.3.1):
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+    dev: false
+
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+
+  /react-promise-suspense@0.3.4:
+    resolution: {integrity: sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==}
+    dependencies:
+      fast-deep-equal: 2.0.1
+    dev: false
 
   /react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -11646,6 +12035,12 @@ packages:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
     dev: false
 
+  /scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: false
+
   /scmp@2.1.0:
     resolution: {integrity: sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q==}
     dev: false
@@ -11656,6 +12051,12 @@ packages:
     dependencies:
       commander: 2.20.3
     dev: true
+
+  /selderee@0.11.0:
+    resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
+    dependencies:
+      parseley: 0.12.1
+    dev: false
 
   /semver@5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
@@ -11741,7 +12142,6 @@ packages:
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-    dev: true
 
   /simple-eval@1.0.0:
     resolution: {integrity: sha512-kpKJR+bqTscgC0xuAl2xHN6bB12lHjC2DCUfqjAx19bQyO3R2EVLOurm3H9AUltv/uFVcSCVNc6faegR+8NYLw==}
@@ -11910,7 +12310,6 @@ packages:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
-    dev: true
 
   /string.prototype.trim@1.2.9:
     resolution: {integrity: sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==}
@@ -11960,7 +12359,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.0.1
-    dev: true
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -13442,7 +13840,6 @@ packages:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
-    dev: true
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}


### PR DESCRIPTION
The integration previously only supported text messages. It now supports image, audio, video, file, markdown, location, card, and carousel messages.

This PR introduces a dependency on React, because I've used React Email and it isn't compatible with preact. We might want to revisit this in the future to use something more lightweight, but for now this works fine.