### PR TITLE
fix(integrations/gmail): fix message replies without a body

### DIFF
--- a/integrations/gmail/integration.definition.ts
+++ b/integrations/gmail/integration.definition.ts
@@ -3,7 +3,7 @@ import { configuration, identifier, channels, user, states, actions, events, sec
 
 export default new sdk.IntegrationDefinition({
   name: 'gmail',
-  version: '0.4.7',
+  version: '0.4.8',
   title: 'Gmail',
   description: 'This integration allows your bot to interact with Gmail.',
   icon: 'icon.svg',

--- a/integrations/gmail/src/webhook-events/new-mail.ts
+++ b/integrations/gmail/src/webhook-events/new-mail.ts
@@ -155,13 +155,15 @@ const _processMessage = async (
   if (message.textHtml) {
     try {
       // Extract the body from the message:
-      const bodyNode = parseHtml(message.textHtml).querySelector('body')
+      const rootNode = parseHtml(message.textHtml)
+      const bodyNode = rootNode.querySelector('body')
+      const messageRoot = bodyNode ?? rootNode
 
       // Remove previous quoted messages in the thread:
-      bodyNode?.querySelectorAll('.gmail_quote')?.forEach((m) => m.remove())
+      messageRoot.querySelectorAll('.gmail_quote')?.forEach((m) => m.remove())
 
-      // Extract the text content from the body, if any:
-      content = bodyNode?.structuredText ?? content
+      // Extract the text content:
+      content = messageRoot.structuredText
     } catch (thrown) {
       console.error('Error while parsing html content', thrown)
     }


### PR DESCRIPTION
Email replies on gmail do not always include a `<body>` tag, so `.gmail_quote` blocks weren't always being removed