### PR TITLE
chore(openai): bump integration version

### DIFF
--- a/integrations/openai/integration.definition.ts
+++ b/integrations/openai/integration.definition.ts
@@ -15,7 +15,7 @@ export const TextToSpeechPricePer1MCharacters: Record<TextToSpeechModel, number>
 export default new IntegrationDefinition({
   name: 'openai',
   title: 'OpenAI',
-  version: '6.6.2',
+  version: '7.0.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {


### PR DESCRIPTION
To fix a [backwards incompatible change](https://github.com/botpress/botpress/actions/runs/11483395791/job/31958721741) in the output schema of the `listLanguageModels` action that may have been introduced by the recent SDK update.