### PR TITLE
fix(integrations/gmail): fix deployment

### DIFF
--- a/integrations/gmail/definitions/channels.ts
+++ b/integrations/gmail/definitions/channels.ts
@@ -8,22 +8,22 @@ export const channels = {
       ...sdk.messages.defaults,
       image: {
         schema: sdk.messages.defaults.image.schema.extend({
-          title: sdk.z.string().title('Alt text').describe('Alt text for the image'),
+          title: sdk.z.string().optional().title('Alt text').describe('Alt text for the image'),
         }),
       },
       audio: {
         schema: sdk.messages.defaults.audio.schema.extend({
-          title: sdk.z.string().title('Title').describe('Title for the audio file'),
+          title: sdk.z.string().optional().title('Title').describe('Title for the audio file'),
         }),
       },
       video: {
         schema: sdk.messages.defaults.video.schema.extend({
-          title: sdk.z.string().title('Title').describe('Title for the video file'),
+          title: sdk.z.string().optional().title('Title').describe('Title for the video file'),
         }),
       },
       file: {
         schema: sdk.messages.defaults.file.schema.extend({
-          title: sdk.z.string().title('Title').describe('Title for the file'),
+          title: sdk.z.string().optional().title('Title').describe('Title for the file'),
         }),
       },
     },

--- a/integrations/gmail/integration.definition.ts
+++ b/integrations/gmail/integration.definition.ts
@@ -3,7 +3,7 @@ import { configuration, identifier, channels, user, states, actions, events, sec
 
 export default new sdk.IntegrationDefinition({
   name: 'gmail',
-  version: '0.5.0',
+  version: '0.5.1',
   title: 'Gmail',
   description: 'This integration allows your bot to interact with Gmail.',
   icon: 'icon.svg',

--- a/integrations/gmail/src/channels/channels.ts
+++ b/integrations/gmail/src/channels/channels.ts
@@ -19,7 +19,7 @@ export const channels = {
     messages: {
       image: wrapChannel({ channelName: 'channel', messageType: 'image' }, (props) => {
         const { imageUrl, title: altText } = props.payload
-        const htmlContent = generateImageMessage({ imageUrl, altText })
+        const htmlContent = generateImageMessage({ imageUrl, altText: altText ?? 'image' })
         const textContent = `Image:\n${imageUrl}`
 
         return _sendEmailReply({
@@ -30,7 +30,7 @@ export const channels = {
       }),
       audio: wrapChannel({ channelName: 'channel', messageType: 'audio' }, (props) => {
         const { audioUrl, title } = props.payload
-        const htmlContent = generateAudioMessage({ audioUrl, title })
+        const htmlContent = generateAudioMessage({ audioUrl, title: title ?? 'Play audio file' })
         const textContent = `Audio file:\n${audioUrl}`
 
         return _sendEmailReply({
@@ -41,7 +41,7 @@ export const channels = {
       }),
       video: wrapChannel({ channelName: 'channel', messageType: 'video' }, (props) => {
         const { videoUrl, title } = props.payload
-        const htmlContent = generateVideoMessage({ videoUrl, title })
+        const htmlContent = generateVideoMessage({ videoUrl, title: title ?? 'Play video file' })
         const textContent = `Video file:\n${videoUrl}`
 
         return _sendEmailReply({
@@ -52,7 +52,7 @@ export const channels = {
       }),
       file: wrapChannel({ channelName: 'channel', messageType: 'file' }, (props) => {
         const { fileUrl, title } = props.payload
-        const htmlContent = generateFileDownloadMessage({ fileUrl, title })
+        const htmlContent = generateFileDownloadMessage({ fileUrl, title: title ?? 'Download file' })
         const textContent = `Linked file:\n${fileUrl}`
 
         return _sendEmailReply({

--- a/integrations/gmail/tsconfig.json
+++ b/integrations/gmail/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "jsxImportSource": "react",
-    "lib": ["DOM"],
+    "lib": ["es2022", "DOM"],
     "baseUrl": ".",
     "outDir": "dist"
   },


### PR DESCRIPTION
The update to this integration was deemed "breaking" because I added the missing `title` input parameter to some message types of the main channel, which broke the assertion `#.title: undefined ⊈ string`.
By making the field optional, it will allow it to be deployed without bumping the major version.

Edit: I just ran `deploy-staging` on this branch and it worked fine