### PR TITLE
feat(cli): configurable outdir and entrypoint both become constant

### DIFF
--- a/packages/cli/e2e/defaults.ts
+++ b/packages/cli/e2e/defaults.ts
@@ -1,13 +1,9 @@
-import * as consts from '../src/consts'
-
 const noBuild = false
 const secrets = [] satisfies string[]
 const sourceMap = false
 const verbose = false
 const confirm = true
 const json = false
-const entryPoint = consts.defaultEntrypoint
-const outDir = consts.defaultOutputFolder
 const allowDeprecated = false
 const isPublic = false
 const minify = true
@@ -19,8 +15,6 @@ export default {
   verbose,
   confirm,
   json,
-  entryPoint,
-  outDir,
   allowDeprecated,
   public: isPublic,
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/command-definitions.ts
+++ b/packages/cli/src/command-definitions.ts
@@ -36,7 +36,7 @@ export default {
   read: { description: 'Read and parse an integration definition', schema: config.schemas.read },
   serve: { description: 'Serve your project locally', schema: config.schemas.serve },
   deploy: { description: 'Deploy your project to the cloud', schema: config.schemas.deploy },
-  add: { description: 'Install an integration in your bot', schema: config.schemas.add },
+  add: { description: 'Install a package; could be an integration or an interface', schema: config.schemas.add },
   dev: { description: 'Run your project in dev mode', schema: config.schemas.dev },
   lint: { description: 'EXPERIMENTAL: Lint an integration definition', schema: config.schemas.lint },
 } satisfies DefinitionTree

--- a/packages/cli/src/command-implementations/add-command.ts
+++ b/packages/cli/src/command-implementations/add-command.ts
@@ -141,8 +141,6 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
 
     const cmd = new AnyProjectCommand(ApiClient, this.prompt, this.logger, {
       ...this.argv,
-      entryPoint: consts.defaultEntrypoint,
-      outDir: consts.defaultOutputFolder,
       workDir,
     })
 

--- a/packages/cli/src/command-implementations/project-command.ts
+++ b/packages/cli/src/command-implementations/project-command.ts
@@ -20,8 +20,8 @@ import { GlobalCommand } from './global-command'
 export type ProjectCommandDefinition = CommandDefinition<typeof config.schemas.project>
 export type ProjectCache = { botId: string; devId: string }
 
-type ConfigurableProjectPaths = { entryPoint: string; outDir: string; workDir: string }
-type ConstantProjectPaths = typeof consts.fromOutDir & typeof consts.fromWorkDir
+type ConfigurableProjectPaths = { workDir: string }
+type ConstantProjectPaths = typeof consts.fromWorkDir
 type AllProjectPaths = ConfigurableProjectPaths & ConstantProjectPaths
 
 type IntegrationInstance = NonNullable<sdk.BotDefinition['integrations']>[string]
@@ -38,13 +38,8 @@ export type ProjectDefinition =
 class ProjectPaths extends utils.path.PathStore<keyof AllProjectPaths> {
   public constructor(argv: CommandArgv<ProjectCommandDefinition>) {
     const absWorkDir = utils.path.absoluteFrom(utils.path.cwd(), argv.workDir)
-    const absEntrypoint = utils.path.absoluteFrom(absWorkDir, argv.entryPoint)
-    const absOutDir = utils.path.absoluteFrom(absWorkDir, argv.outDir)
     super({
       workDir: absWorkDir,
-      entryPoint: absEntrypoint,
-      outDir: absOutDir,
-      ..._.mapValues(consts.fromOutDir, (p) => utils.path.absoluteFrom(absOutDir, p)),
       ..._.mapValues(consts.fromWorkDir, (p) => utils.path.absoluteFrom(absWorkDir, p)),
     })
   }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -121,8 +121,6 @@ const globalSchema = {
 
 const projectSchema = {
   ...globalSchema,
-  entryPoint: { type: 'string', description: 'The entry point of the project', default: consts.defaultEntrypoint },
-  outDir: { type: 'string', description: 'The output directory', default: consts.defaultOutputFolder },
   workDir,
 } satisfies CommandSchema
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -200,7 +200,7 @@ const addSchema = {
   packageType,
   installPath: {
     type: 'string',
-    description: 'The path where to install the integration',
+    description: 'The path where to install the package',
     default: consts.defaultInstallPath,
   },
 } satisfies CommandSchema

--- a/packages/cli/src/consts.ts
+++ b/packages/cli/src/consts.ts
@@ -14,7 +14,6 @@ export const defaultTunnelUrl = 'https://tunnel.botpress.cloud'
 // not configurable
 
 export const cliRootDir = CLI_ROOT_DIR
-
 export const emptyBotDirName = 'empty-bot'
 export const emptyIntegrationDirName = 'empty-integration'
 export const helloWorldIntegrationDirName = 'hello-world'

--- a/packages/cli/src/consts.ts
+++ b/packages/cli/src/consts.ts
@@ -5,11 +5,8 @@ import { CLI_ROOT_DIR } from './root'
 // configurable
 
 export const defaultBotpressHome = pathlib.join(os.homedir(), '.botpress')
-
-export const defaultOutputFolder = '.botpress'
 export const defaultWorkDir = process.cwd()
 export const defaultInstallPath = process.cwd()
-export const defaultEntrypoint = pathlib.join('src', 'index.ts')
 export const defaultBotpressApiUrl = 'https://api.botpress.cloud'
 export const defaultBotpressAppUrl = 'https://app.botpress.cloud'
 export const defaultTunnelUrl = 'https://tunnel.botpress.cloud'
@@ -23,6 +20,8 @@ export const emptyIntegrationDirName = 'empty-integration'
 export const helloWorldIntegrationDirName = 'hello-world'
 export const webhookMessageIntegrationDirName = 'webhook-message'
 export const installDirName = 'bp_modules'
+export const outDirName = '.botpress'
+export const distDirName = 'dist'
 
 export const fromCliRootDir = {
   emptyBotTemplate: pathlib.join('templates', emptyBotDirName),
@@ -35,16 +34,23 @@ export const fromHomeDir = {
   globalCacheFile: 'global.cache.json',
 }
 
+export const fromOutDir = {
+  distDir: distDirName,
+  outFile: pathlib.join(distDirName, 'index.js'),
+  implementationDir: 'implementation',
+  secretsDir: 'secrets',
+  projectCacheFile: 'project.cache.json',
+}
+
 export const fromWorkDir = {
   integrationDefinition: 'integration.definition.ts',
   interfaceDefinition: 'interface.definition.ts',
   botDefinition: 'bot.definition.ts',
-}
-
-export const fromOutDir = {
-  distDir: 'dist',
-  outFile: pathlib.join('dist', 'index.js'),
-  implementationDir: 'implementation',
-  secretsDir: 'secrets',
-  projectCacheFile: 'project.cache.json',
+  entryPoint: pathlib.join('src', 'index.ts'),
+  outDir: outDirName,
+  distDir: pathlib.join(outDirName, fromOutDir.distDir),
+  outFile: pathlib.join(outDirName, fromOutDir.outFile),
+  implementationDir: pathlib.join(outDirName, fromOutDir.implementationDir),
+  secretsDir: pathlib.join(outDirName, fromOutDir.secretsDir),
+  projectCacheFile: pathlib.join(outDirName, fromOutDir.projectCacheFile),
 }


### PR DESCRIPTION
This is technically a breaking change, but I assume that very few users actually use `--entry-point` and `--out-dir` arguments. If so, the fix is really easy.

If we ever want to bring back configurable entrypoint and outdir, it should be from the definition file. This way, reading the definition file, tells us exactly where to find anything related to the project.