### PR TITLE
fix(packages/cli): fix reading multi-config integrations

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/command-implementations/deploy-command.ts
+++ b/packages/cli/src/command-implementations/deploy-command.ts
@@ -100,7 +100,7 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
       readme: readmeFileContent,
       configuration: await this.readIntegrationConfigDefinition(createBody.configuration),
       configurations: await utils.promises.awaitRecord(
-        utils.records.mapValues(createBody.configurations ?? {}, this.readIntegrationConfigDefinition)
+        utils.records.mapValues(createBody.configurations ?? {}, this.readIntegrationConfigDefinition.bind(this))
       ),
       identifier: {
         extractScript: identifierExtractScriptFileContent,

--- a/packages/cli/src/command-implementations/dev-command.ts
+++ b/packages/cli/src/command-implementations/dev-command.ts
@@ -253,7 +253,10 @@ export class DevCommand extends ProjectCommand<DevCommandDefinition> {
       url: externalUrl,
       configuration: await this.readIntegrationConfigDefinition(createIntegrationBody.configuration),
       configurations: await utils.promises.awaitRecord(
-        utils.records.mapValues(createIntegrationBody.configurations ?? {}, this.readIntegrationConfigDefinition)
+        utils.records.mapValues(
+          createIntegrationBody.configurations ?? {},
+          this.readIntegrationConfigDefinition.bind(this)
+        )
       ),
     }
 


### PR DESCRIPTION
`ProjectCommand.readIntegrationConfigDefinition` depends upon `ProjectCommand.readProjectFile`, but the `this` parameter wasn't bound properly, so it was undefined. This bug made it unable to deploy integrations that have an `identifier` VRL script in a multi-config block