### PR TITLE
feat: Google Calendar Event attendees, invitations, and google meet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,16 @@ node_modules
 bp_modules
 dist
 gen
+flake.nix
+flake.lock
 local/data
 .DS_Store
 *.tsbuildinfo
 __snapshots__
 .ignore.me.*
+.direnv/
 .env
+.envrc
 .botpress
 .botpresshome
 .botpresshome.*

--- a/integrations/googlecalendar/src/actions/create-event.ts
+++ b/integrations/googlecalendar/src/actions/create-event.ts
@@ -16,6 +16,9 @@ export const createEvent: bp.IntegrationProps['actions']['createEvent'] = async 
         location: input.location ?? undefined,
         startDateTime: input.startDateTime,
         endDateTime: input.endDateTime,
+        attendees: input.attendees,
+        sendUpdates: input.sendUpdates,
+        conferenceData: input.conferenceData,
       },
     },
   })

--- a/integrations/googlecalendar/src/actions/sync/event-create.ts
+++ b/integrations/googlecalendar/src/actions/sync/event-create.ts
@@ -37,6 +37,9 @@ export const eventCreate = (async (props: EventCreateProps) => {
           // The replaceAll is used to remove the extra quotes from the input created by the studio
           dateTime: item.endDateTime?.replaceAll('"', ''),
         },
+        attendees: input.attendees,
+        sendUpdates: input.sendUpdates,
+        conferenceData: input.conferenceData,
       },
     })
     return {

--- a/integrations/googlecalendar/src/misc/custom-schemas.ts
+++ b/integrations/googlecalendar/src/misc/custom-schemas.ts
@@ -9,9 +9,26 @@ const eventSchema = z.object({
   location: z.string().nullable().optional().describe('The event location.'),
   startDateTime: z.string().describe('The start date and time in RFC3339 format (e.g., "2023-12-31T10:00:00.000Z").'),
   endDateTime: z.string().describe('The end date and time in RFC3339 format (e.g., "2023-12-31T12:00:00.000Z").'),
+  attendees: z
+    .array(z.object({ email: z.string().email() }))
+    .optional()
+    .describe('Event attendees as an array of objects like { email: user@email.com }'),
+  conferenceData: z
+    .object({ createRequest: z.object({ requestId: z.string() }) })
+    .optional()
+    .describe(
+      "An Id to use to request a Google Meet conferencing link. Must be a nested object like {createRequest: { requestId: 'abc123'}}"
+    ),
 })
 
-export const createEventInputSchema = eventSchema
+export const createEventInputSchema = eventSchema.extend({
+  sendUpdates: z
+    .enum(['all', 'externalOnly', 'none'])
+    .default('none')
+    .describe(
+      "Options to send email invitations to attendees. Default is no invitations, other options include 'all' to send invites to all parties, or 'externalOnly' to send invites only to attendees outside your organization"
+    ),
+})
 
 export const createEventOutputSchema = z
   .object({


### PR DESCRIPTION
This PR adds three additional inputs for creating and updating Google Calendar events:
1. Attendees
2. Update emails
3. Google Meet video conferencing

Parameters follow the [v3 Google Calendar insert() API](https://developers.google.com/calendar/api/v3/reference/events/insert)

.gitignore also edited to include ignoring the dotfiles I use for local development.