### PR TITLE
feat(integrations/googlecalendar): event attendees, invitations, and google meet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,16 @@ node_modules
 bp_modules
 dist
 gen
+flake.nix
+flake.lock
 local/data
 .DS_Store
 *.tsbuildinfo
 __snapshots__
 .ignore.me.*
+.direnv/
 .env
+.envrc
 .botpress
 .botpresshome
 .botpresshome.*

--- a/integrations/googlecalendar/integration.definition.ts
+++ b/integrations/googlecalendar/integration.definition.ts
@@ -56,6 +56,16 @@ export default new IntegrationDefinition({
           .string()
           .optional()
           .describe('The end date and time in RFC3339 format (e.g., "2023-12-31T12:00:00.000Z").'),
+        attendees: z
+          .array(z.object({ email: z.string().optional() }))
+          .optional()
+          .describe('Event attendees as an array of objects like { email: user@email.com }'),
+        conferenceData: z
+          .object({ createRequest: z.object({ requestId: z.string().optional() }).optional() })
+          .optional()
+          .describe(
+            "An Id to use to request a Google Meet conferencing link. Must be a nested object like {createRequest: { requestId: 'abc123'}}"
+          ),
       }),
       ui: {},
     },

--- a/integrations/googlecalendar/integration.definition.ts
+++ b/integrations/googlecalendar/integration.definition.ts
@@ -19,7 +19,7 @@ import { updateEventUi, deleteEventUi, createEventUi } from './src/misc/custom-u
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '0.4.3',
+  version: '0.5.0',
   description:
     "Elevate your chatbot's capabilities with the Botpress integration for Google Calendar. Seamlessly sync your chatbot with Google Calendar to effortlessly manage events, appointments, and schedules",
   title: 'Google Calendar',

--- a/integrations/googlecalendar/integration.definition.ts
+++ b/integrations/googlecalendar/integration.definition.ts
@@ -19,7 +19,7 @@ import { updateEventUi, deleteEventUi, createEventUi } from './src/misc/custom-u
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '0.5.0',
+  version: '1.0.0',
   description:
     "Elevate your chatbot's capabilities with the Botpress integration for Google Calendar. Seamlessly sync your chatbot with Google Calendar to effortlessly manage events, appointments, and schedules",
   title: 'Google Calendar',

--- a/integrations/googlecalendar/src/actions/create-event.ts
+++ b/integrations/googlecalendar/src/actions/create-event.ts
@@ -17,9 +17,9 @@ export const createEvent: bp.IntegrationProps['actions']['createEvent'] = async 
         startDateTime: input.startDateTime,
         endDateTime: input.endDateTime,
         attendees: input.attendees,
-        sendUpdates: input.sendUpdates,
         conferenceData: input.conferenceData,
       },
+      sendUpdates: input.sendUpdates,
     },
   })
   return {

--- a/integrations/googlecalendar/src/actions/create-event.ts
+++ b/integrations/googlecalendar/src/actions/create-event.ts
@@ -16,6 +16,9 @@ export const createEvent: bp.IntegrationProps['actions']['createEvent'] = async 
         location: input.location ?? undefined,
         startDateTime: input.startDateTime,
         endDateTime: input.endDateTime,
+        attendees: input.attendees,
+        sendUpdates: input.sendUpdates,
+        conferenceData: input.conferenceData,
       },
     },
   })

--- a/integrations/googlecalendar/src/actions/sync/event-create.ts
+++ b/integrations/googlecalendar/src/actions/sync/event-create.ts
@@ -37,6 +37,9 @@ export const eventCreate = (async (props: EventCreateProps) => {
           // The replaceAll is used to remove the extra quotes from the input created by the studio
           dateTime: item.endDateTime?.replaceAll('"', ''),
         },
+        attendees: input.attendees,
+        sendUpdates: input.sendUpdates,
+        conferenceData: input.conferenceData,
       },
     })
     return {

--- a/integrations/googlecalendar/src/actions/sync/event-create.ts
+++ b/integrations/googlecalendar/src/actions/sync/event-create.ts
@@ -13,6 +13,7 @@ type EventCreateProps = Merge<
       EventCreateInput,
       {
         item: Omit<EventCreateInput['item'], 'id'>
+        sendUpdates?: bp.actions.createEvent.input.Input['sendUpdates']
       }
     >
   }
@@ -37,10 +38,10 @@ export const eventCreate = (async (props: EventCreateProps) => {
           // The replaceAll is used to remove the extra quotes from the input created by the studio
           dateTime: item.endDateTime?.replaceAll('"', ''),
         },
-        attendees: input.attendees,
-        sendUpdates: input.sendUpdates,
-        conferenceData: input.conferenceData,
+        attendees: input.item.attendees,
+        conferenceData: input.item.conferenceData,
       },
+      sendUpdates: input.sendUpdates,
     })
     return {
       item: mapEvent(response.data),

--- a/integrations/googlecalendar/src/misc/custom-schemas.ts
+++ b/integrations/googlecalendar/src/misc/custom-schemas.ts
@@ -9,9 +9,26 @@ const eventSchema = z.object({
   location: z.string().nullable().optional().describe('The event location.'),
   startDateTime: z.string().describe('The start date and time in RFC3339 format (e.g., "2023-12-31T10:00:00.000Z").'),
   endDateTime: z.string().describe('The end date and time in RFC3339 format (e.g., "2023-12-31T12:00:00.000Z").'),
+  attendees: z
+    .array(z.object({ email: z.string().email() }))
+    .optional()
+    .describe('Event attendees as an array of objects like { email: user@email.com }'),
+  conferenceData: z
+    .object({ createRequest: z.object({ requestId: z.string() }) })
+    .optional()
+    .describe(
+      "An Id to use to request a Google Meet conferencing link. Must be a nested object like {createRequest: { requestId: 'abc123'}}"
+    ),
 })
 
-export const createEventInputSchema = eventSchema
+export const createEventInputSchema = eventSchema.extend({
+  sendUpdates: z
+    .enum(['all', 'externalOnly', 'none'])
+    .default('none')
+    .describe(
+      "Options to send email invitations to attendees. Default is no invitations, other options include 'all' to send invites to all parties, or 'externalOnly' to send invites only to attendees outside your organization"
+    ),
+})
 
 export const createEventOutputSchema = z
   .object({

--- a/integrations/googlecalendar/src/misc/custom-schemas.ts
+++ b/integrations/googlecalendar/src/misc/custom-schemas.ts
@@ -5,8 +5,8 @@ export type Schema = ActionDefinitions[string]['input']['schema']
 
 const eventSchema = z.object({
   summary: z.string().describe('The event title/summary.'),
-  description: z.string().nullable().optional().describe('The event description.'),
-  location: z.string().nullable().optional().describe('The event location.'),
+  description: z.string().optional().describe('The event description.'),
+  location: z.string().optional().describe('The event location.'),
   startDateTime: z.string().describe('The start date and time in RFC3339 format (e.g., "2023-12-31T10:00:00.000Z").'),
   endDateTime: z.string().describe('The end date and time in RFC3339 format (e.g., "2023-12-31T12:00:00.000Z").'),
   attendees: z
@@ -77,7 +77,13 @@ export const listEventsOutputSchema = z.object({
       z
         .object({
           eventId: z.string().nullable().describe('The ID of the calendar event.'),
-          event: eventSchema.describe('The calendar event data.'),
+          event: z
+            .object({
+              ...eventSchema.shape,
+              description: z.string().nullable().optional().describe('The event description.'),
+              location: z.string().nullable().optional().describe('The event location.'),
+            })
+            .describe('The calendar event data.'),
         })
         .partial()
     )

--- a/integrations/googlecalendar/src/misc/custom-uis.ts
+++ b/integrations/googlecalendar/src/misc/custom-uis.ts
@@ -35,6 +35,10 @@ export const createEventUi = {
     title: 'Location',
     examples: ['Meeting Room'],
   },
+  sendUpdates: {
+    title: 'Send Updates',
+    examples: ['all', 'externalOnly', 'none'],
+  },
 } satisfies UiOf<typeof schemas.createEventInputSchema>
 
 export const updateEventUi = {

--- a/integrations/googlecalendar/src/misc/map-event.ts
+++ b/integrations/googlecalendar/src/misc/map-event.ts
@@ -15,5 +15,23 @@ export const mapEvent = (event: calendar_v3.Schema$Event): bp.entities.event.Eve
     description: event.description ?? undefined,
     endDateTime: event.end?.dateTime ?? undefined,
     startDateTime: event.start?.dateTime ?? undefined,
+    attendees: event.attendees?.map((x) => ({ email: x.email ?? undefined })) ?? undefined,
+    conferenceData: _mapConferenceData(event.conferenceData),
+  }
+}
+
+const _mapConferenceData = (
+  conferenceData: calendar_v3.Schema$ConferenceData | undefined
+): bp.entities.event.Event['conferenceData'] => {
+  if (!conferenceData) {
+    return conferenceData
+  }
+  if (!conferenceData.createRequest) {
+    return {}
+  }
+  return {
+    createRequest: {
+      requestId: conferenceData.createRequest.requestId ?? undefined,
+    },
   }
 }


### PR DESCRIPTION
This PR adds three additional inputs for creating and updating Google Calendar events:
1. Attendees
2. Update emails
3. Google Meet video conferencing

Parameters follow the [v3 Google Calendar insert() API](https://developers.google.com/calendar/api/v3/reference/events/insert)

.gitignore also edited to include ignoring the dotfiles I use for local development.