### PR TITLE
fix(integrations/github): use a multiline input for the RSA secret

### DIFF
--- a/integrations/github/integration.definition.ts
+++ b/integrations/github/integration.definition.ts
@@ -7,7 +7,7 @@ import { actions, events, configuration, configurations, channels, user, secrets
 export default new sdk.IntegrationDefinition({
   name: INTEGRATION_NAME,
   title: 'GitHub',
-  version: '1.1.3',
+  version: '1.1.4',
   icon: 'icon.svg',
   readme: 'hub.md',
   description: 'Github integration for Botpress',

--- a/integrations/github/src/definitions/index.ts
+++ b/integrations/github/src/definitions/index.ts
@@ -4,6 +4,7 @@ import * as sdk from '@botpress/sdk'
 export { actions } from './actions'
 export { events } from './events'
 export { channels } from './channels'
+import { multiLineString } from './zui'
 
 export const configuration = {
   identifier: {
@@ -34,13 +35,12 @@ export const configurations = {
         .min(1)
         .title('GitHub App ID')
         .describe('Can be found in the GitHub App settings. OAuth apps are not supported.'),
-      githubAppPrivateKey: z
-        .string()
+      githubAppPrivateKey: multiLineString
         .min(1)
         .secret()
         .title('GitHub App Private Key')
         .describe('The raw contents of the RSA private key. Can be downloaded from the GitHub App settings.')
-        .placeholder('-----BEGIN RSA PRIVATE KEY----- ...'),
+        .placeholder('-----BEGIN RSA PRIVATE KEY-----\n\n...\n\n-----END RSA PRIVATE KEY-----'),
       githubAppInstallationId: z
         .number()
         .positive()

--- a/integrations/github/src/definitions/zui.ts
+++ b/integrations/github/src/definitions/zui.ts
@@ -1,0 +1,11 @@
+import * as sdk from '@botpress/sdk'
+const { z } = sdk
+
+const StringComponent = {
+  string: { text: { id: 'text', params: z.object({ multiLine: z.boolean(), growVertically: z.boolean() }) } },
+} as const satisfies Pick<sdk.UIComponentDefinitions, 'string'>
+type StringComponent = Omit<sdk.UIComponentDefinitions, 'string'> & typeof StringComponent
+
+export const multiLineString = z
+  .string()
+  .displayAs<StringComponent>({ id: 'text', params: { multiLine: true, growVertically: true } })


### PR DESCRIPTION
uses the `text` component from inspector-kit to render the RSA secret field as a multiline input field:

![image](https://github.com/user-attachments/assets/169864b4-55b6-4d00-b676-380e21903782)
