### PR TITLE
fix(cli): fix bp lint for properties named `properties`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/linter/ruleset-tests/bot.ruleset.test.ts
+++ b/packages/cli/src/linter/ruleset-tests/bot.ruleset.test.ts
@@ -10,16 +10,18 @@ const EMPTY_STRING = ''
 const TRUTHY_STRING = 'truthy'
 const EVENT_NAME = 'eventName'
 const PARAM_NAME = 'paramName'
+const PROPERTIES_PARAM = 'properties'
+const PARAM_NAMES = [PARAM_NAME, PROPERTIES_PARAM] as const
 const TAG_NAME = 'tagName'
 const STATE_NAME = 'stateName'
 const ZUI = 'x-zui'
 const LEGACY_ZUI = 'ui'
 
 describeRule('event-outputparams-should-have-title', (lint) => {
-  test('missing title should trigger', async () => {
+  test.each(PARAM_NAMES)('missing title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      events: { [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: {} } } } } },
+      events: { [EVENT_NAME]: { schema: { properties: { [paramName]: { [ZUI]: {} } } } } },
     } as const satisfies PartialDefinition
 
     // act
@@ -27,15 +29,15 @@ describeRule('event-outputparams-should-have-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', PARAM_NAME, ZUI])
+    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', paramName, ZUI])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('empty title should trigger', async () => {
+  test.each(PARAM_NAMES)('empty title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       events: {
-        [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: EMPTY_STRING } } } } },
+        [EVENT_NAME]: { schema: { properties: { [paramName]: { [ZUI]: { title: EMPTY_STRING } } } } },
       },
     } as const satisfies PartialDefinition
 
@@ -44,15 +46,15 @@ describeRule('event-outputparams-should-have-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', PARAM_NAME, ZUI, 'title'])
+    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', paramName, ZUI, 'title'])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('valid title should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid title should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       events: {
-        [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: TRUTHY_STRING } } } } },
+        [EVENT_NAME]: { schema: { properties: { [paramName]: { [ZUI]: { title: TRUTHY_STRING } } } } },
       },
     } as const satisfies PartialDefinition
 
@@ -65,10 +67,10 @@ describeRule('event-outputparams-should-have-title', (lint) => {
 })
 
 describeRule('event-outputparams-must-have-description', (lint) => {
-  test('missing description should trigger', async () => {
+  test.each(PARAM_NAMES)('missing description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      events: { [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: {} } } } },
+      events: { [EVENT_NAME]: { schema: { properties: { [paramName]: {} } } } },
     } as const satisfies PartialDefinition
 
     // act
@@ -76,15 +78,15 @@ describeRule('event-outputparams-must-have-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', PARAM_NAME])
+    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', paramName])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('empty description should trigger', async () => {
+  test.each(PARAM_NAMES)('empty description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       events: {
-        [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: { description: EMPTY_STRING } } } },
+        [EVENT_NAME]: { schema: { properties: { [paramName]: { description: EMPTY_STRING } } } },
       },
     } as const satisfies PartialDefinition
 
@@ -93,15 +95,15 @@ describeRule('event-outputparams-must-have-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', PARAM_NAME, 'description'])
+    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', paramName, 'description'])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('valid description should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid description should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       events: {
-        [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: { description: TRUTHY_STRING } } } },
+        [EVENT_NAME]: { schema: { properties: { [paramName]: { description: TRUTHY_STRING } } } },
       },
     } as const satisfies PartialDefinition
 
@@ -114,10 +116,10 @@ describeRule('event-outputparams-must-have-description', (lint) => {
 })
 
 describeRule('configuration-fields-must-have-a-title', (lint) => {
-  test('missing title should trigger', async () => {
+  test.each(PARAM_NAMES)('missing title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      configuration: { schema: { properties: { [PARAM_NAME]: { [ZUI]: {} } } } },
+      configuration: { schema: { properties: { [paramName]: { [ZUI]: {} } } } },
     } as const satisfies PartialDefinition
 
     // act
@@ -125,14 +127,14 @@ describeRule('configuration-fields-must-have-a-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['configuration', 'schema', 'properties', PARAM_NAME, ZUI])
+    expect(results[0]?.path).toEqual(['configuration', 'schema', 'properties', paramName, ZUI])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('empty title should trigger', async () => {
+  test.each(PARAM_NAMES)('empty title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      configuration: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: EMPTY_STRING } } } } },
+      configuration: { schema: { properties: { [paramName]: { [ZUI]: { title: EMPTY_STRING } } } } },
     } as const satisfies PartialDefinition
 
     // act
@@ -140,14 +142,14 @@ describeRule('configuration-fields-must-have-a-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['configuration', 'schema', 'properties', PARAM_NAME, ZUI, 'title'])
+    expect(results[0]?.path).toEqual(['configuration', 'schema', 'properties', paramName, ZUI, 'title'])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('valid title should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid title should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      configuration: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: TRUTHY_STRING } } } } },
+      configuration: { schema: { properties: { [paramName]: { [ZUI]: { title: TRUTHY_STRING } } } } },
     } as const satisfies PartialDefinition
 
     // act
@@ -159,10 +161,10 @@ describeRule('configuration-fields-must-have-a-title', (lint) => {
 })
 
 describeRule('configuration-fields-must-have-a-description', (lint) => {
-  test('missing description should trigger', async () => {
+  test.each(PARAM_NAMES)('missing description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      configuration: { schema: { properties: { [PARAM_NAME]: {} } } },
+      configuration: { schema: { properties: { [paramName]: {} } } },
     } as const satisfies PartialDefinition
 
     // act
@@ -170,14 +172,14 @@ describeRule('configuration-fields-must-have-a-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['configuration', 'schema', 'properties', PARAM_NAME])
+    expect(results[0]?.path).toEqual(['configuration', 'schema', 'properties', paramName])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('empty description should trigger', async () => {
+  test.each(PARAM_NAMES)('empty description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      configuration: { schema: { properties: { [PARAM_NAME]: { description: EMPTY_STRING } } } },
+      configuration: { schema: { properties: { [paramName]: { description: EMPTY_STRING } } } },
     } as const satisfies PartialDefinition
 
     // act
@@ -185,14 +187,14 @@ describeRule('configuration-fields-must-have-a-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['configuration', 'schema', 'properties', PARAM_NAME, 'description'])
+    expect(results[0]?.path).toEqual(['configuration', 'schema', 'properties', paramName, 'description'])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('valid description should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid description should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      configuration: { schema: { properties: { [PARAM_NAME]: { description: TRUTHY_STRING } } } },
+      configuration: { schema: { properties: { [paramName]: { description: TRUTHY_STRING } } } },
     } as const satisfies PartialDefinition
 
     // act
@@ -458,15 +460,15 @@ describeRule('message-tags-must-have-a-description', (lint) => {
 })
 
 describeRule('legacy-zui-title-should-be-removed', (lint) => {
-  test('legacy zui title should trigger', async () => {
+  test.each(PARAM_NAMES)('legacy zui title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       configuration: {
-        [LEGACY_ZUI]: { [PARAM_NAME]: { title: TRUTHY_STRING } },
+        [LEGACY_ZUI]: { [paramName]: { title: TRUTHY_STRING } },
         schema: {},
       },
-      events: { [EVENT_NAME]: { [LEGACY_ZUI]: { [PARAM_NAME]: { title: TRUTHY_STRING } }, schema: {} } },
-      states: { [STATE_NAME]: { [LEGACY_ZUI]: { [PARAM_NAME]: { title: TRUTHY_STRING } }, schema: {} } },
+      events: { [EVENT_NAME]: { [LEGACY_ZUI]: { [paramName]: { title: TRUTHY_STRING } }, schema: {} } },
+      states: { [STATE_NAME]: { [LEGACY_ZUI]: { [paramName]: { title: TRUTHY_STRING } }, schema: {} } },
     } as const satisfies PartialDefinition
 
     // act
@@ -479,15 +481,15 @@ describeRule('legacy-zui-title-should-be-removed', (lint) => {
 })
 
 describeRule('legacy-zui-examples-should-be-removed', (lint) => {
-  test('legacy zui examples should trigger', async () => {
+  test.each(PARAM_NAMES)('legacy zui examples should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       configuration: {
-        [LEGACY_ZUI]: { [PARAM_NAME]: { examples: [TRUTHY_STRING] } },
+        [LEGACY_ZUI]: { [paramName]: { examples: [TRUTHY_STRING] } },
         schema: {},
       },
-      events: { [EVENT_NAME]: { [LEGACY_ZUI]: { [PARAM_NAME]: { examples: [TRUTHY_STRING] } }, schema: {} } },
-      states: { [STATE_NAME]: { [LEGACY_ZUI]: { [PARAM_NAME]: { examples: [TRUTHY_STRING] } }, schema: {} } },
+      events: { [EVENT_NAME]: { [LEGACY_ZUI]: { [paramName]: { examples: [TRUTHY_STRING] } }, schema: {} } },
+      states: { [STATE_NAME]: { [LEGACY_ZUI]: { [paramName]: { examples: [TRUTHY_STRING] } }, schema: {} } },
     } as const satisfies PartialDefinition
 
     // act
@@ -500,10 +502,10 @@ describeRule('legacy-zui-examples-should-be-removed', (lint) => {
 })
 
 describeRule('state-fields-should-have-title', (lint) => {
-  test('missing title should trigger', async () => {
+  test.each(PARAM_NAMES)('missing title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      states: { [STATE_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: {} } } } } },
+      states: { [STATE_NAME]: { schema: { properties: { [paramName]: { [ZUI]: {} } } } } },
     } as const satisfies PartialDefinition
 
     // act
@@ -511,13 +513,13 @@ describeRule('state-fields-should-have-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['states', STATE_NAME, 'schema', 'properties', PARAM_NAME, ZUI])
+    expect(results[0]?.path).toEqual(['states', STATE_NAME, 'schema', 'properties', paramName, ZUI])
   })
 
-  test('empty title should trigger', async () => {
+  test.each(PARAM_NAMES)('empty title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      states: { [STATE_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: EMPTY_STRING } } } } } },
+      states: { [STATE_NAME]: { schema: { properties: { [paramName]: { [ZUI]: { title: EMPTY_STRING } } } } } },
     } as const satisfies PartialDefinition
 
     // act
@@ -525,13 +527,13 @@ describeRule('state-fields-should-have-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['states', STATE_NAME, 'schema', 'properties', PARAM_NAME, ZUI, 'title'])
+    expect(results[0]?.path).toEqual(['states', STATE_NAME, 'schema', 'properties', paramName, ZUI, 'title'])
   })
 
-  test('valid title should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid title should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      states: { [STATE_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: TRUTHY_STRING } } } } } },
+      states: { [STATE_NAME]: { schema: { properties: { [paramName]: { [ZUI]: { title: TRUTHY_STRING } } } } } },
     } as const satisfies PartialDefinition
 
     // act
@@ -543,10 +545,10 @@ describeRule('state-fields-should-have-title', (lint) => {
 })
 
 describeRule('state-fields-must-have-description', (lint) => {
-  test('missing description should trigger', async () => {
+  test.each(PARAM_NAMES)('missing description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      states: { [STATE_NAME]: { schema: { properties: { [PARAM_NAME]: {} } } } },
+      states: { [STATE_NAME]: { schema: { properties: { [paramName]: {} } } } },
     } as const satisfies PartialDefinition
 
     // act
@@ -554,13 +556,13 @@ describeRule('state-fields-must-have-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['states', STATE_NAME, 'schema', 'properties', PARAM_NAME])
+    expect(results[0]?.path).toEqual(['states', STATE_NAME, 'schema', 'properties', paramName])
   })
 
-  test('empty description should trigger', async () => {
+  test.each(PARAM_NAMES)('empty description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      states: { [STATE_NAME]: { schema: { properties: { [PARAM_NAME]: { description: EMPTY_STRING } } } } },
+      states: { [STATE_NAME]: { schema: { properties: { [paramName]: { description: EMPTY_STRING } } } } },
     } as const satisfies PartialDefinition
 
     // act
@@ -568,13 +570,13 @@ describeRule('state-fields-must-have-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['states', STATE_NAME, 'schema', 'properties', PARAM_NAME, 'description'])
+    expect(results[0]?.path).toEqual(['states', STATE_NAME, 'schema', 'properties', paramName, 'description'])
   })
 
-  test('valid description should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid description should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      states: { [STATE_NAME]: { schema: { properties: { [PARAM_NAME]: { description: TRUTHY_STRING } } } } },
+      states: { [STATE_NAME]: { schema: { properties: { [paramName]: { description: TRUTHY_STRING } } } } },
     } as const satisfies PartialDefinition
 
     // act

--- a/packages/cli/src/linter/ruleset-tests/integration.ruleset.test.ts
+++ b/packages/cli/src/linter/ruleset-tests/integration.ruleset.test.ts
@@ -12,6 +12,8 @@ const ACTION_NAME = 'actionName'
 const EVENT_NAME = 'eventName'
 const CONFIG_NAME = 'configName'
 const PARAM_NAME = 'paramName'
+const PROPERTIES_PARAM = 'properties'
+const PARAM_NAMES = [PARAM_NAME, PROPERTIES_PARAM] as const
 const TAG_NAME = 'tagName'
 const CHANNEL_NAME = 'channelName'
 const STATE_NAME = 'stateName'
@@ -251,10 +253,10 @@ describeRule('actions-must-have-a-description', (lint) => {
 })
 
 describeRule('action-inputparams-should-have-a-title', (lint) => {
-  test('missing title should trigger', async () => {
+  test.each(PARAM_NAMES)('missing title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      actions: { [ACTION_NAME]: { input: { schema: { properties: { [PARAM_NAME]: { [ZUI]: {} } } } } } },
+      actions: { [ACTION_NAME]: { input: { schema: { properties: { [paramName]: { [ZUI]: {} } } } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -262,15 +264,15 @@ describeRule('action-inputparams-should-have-a-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'input', 'schema', 'properties', PARAM_NAME, ZUI])
+    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'input', 'schema', 'properties', paramName, ZUI])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('empty title should trigger', async () => {
+  test.each(PARAM_NAMES)('empty title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { input: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: EMPTY_STRING } } } } } },
+        [ACTION_NAME]: { input: { schema: { properties: { [paramName]: { [ZUI]: { title: EMPTY_STRING } } } } } },
       },
     } as const satisfies PartialIntegration
 
@@ -279,24 +281,15 @@ describeRule('action-inputparams-should-have-a-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual([
-      'actions',
-      ACTION_NAME,
-      'input',
-      'schema',
-      'properties',
-      PARAM_NAME,
-      ZUI,
-      'title',
-    ])
+    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'input', 'schema', 'properties', paramName, ZUI, 'title'])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('valid title should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid title should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { input: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: TRUTHY_STRING } } } } } },
+        [ACTION_NAME]: { input: { schema: { properties: { [paramName]: { [ZUI]: { title: TRUTHY_STRING } } } } } },
       },
     } as const satisfies PartialIntegration
 
@@ -309,10 +302,10 @@ describeRule('action-inputparams-should-have-a-title', (lint) => {
 })
 
 describeRule('action-inputparams-must-have-a-description', (lint) => {
-  test('missing description should trigger', async () => {
+  test.each(PARAM_NAMES)('missing description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      actions: { [ACTION_NAME]: { input: { schema: { properties: { [PARAM_NAME]: {} } } } } },
+      actions: { [ACTION_NAME]: { input: { schema: { properties: { [paramName]: {} } } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -320,15 +313,15 @@ describeRule('action-inputparams-must-have-a-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'input', 'schema', 'properties', PARAM_NAME])
+    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'input', 'schema', 'properties', paramName])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('empty description should trigger', async () => {
+  test.each(PARAM_NAMES)('empty description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { input: { schema: { properties: { [PARAM_NAME]: { description: EMPTY_STRING } } } } },
+        [ACTION_NAME]: { input: { schema: { properties: { [paramName]: { description: EMPTY_STRING } } } } },
       },
     } as const satisfies PartialIntegration
 
@@ -343,17 +336,17 @@ describeRule('action-inputparams-must-have-a-description', (lint) => {
       'input',
       'schema',
       'properties',
-      PARAM_NAME,
+      paramName,
       'description',
     ])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('valid description should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid description should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { input: { schema: { properties: { [PARAM_NAME]: { description: TRUTHY_STRING } } } } },
+        [ACTION_NAME]: { input: { schema: { properties: { [paramName]: { description: TRUTHY_STRING } } } } },
       },
     } as const satisfies PartialIntegration
 
@@ -366,10 +359,10 @@ describeRule('action-inputparams-must-have-a-description', (lint) => {
 })
 
 describeRule('action-outputparams-should-have-a-title', (lint) => {
-  test('missing title should trigger', async () => {
+  test.each(PARAM_NAMES)('missing title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      actions: { [ACTION_NAME]: { output: { schema: { properties: { [PARAM_NAME]: { [ZUI]: {} } } } } } },
+      actions: { [ACTION_NAME]: { output: { schema: { properties: { [paramName]: { [ZUI]: {} } } } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -377,15 +370,15 @@ describeRule('action-outputparams-should-have-a-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'output', 'schema', 'properties', PARAM_NAME, ZUI])
+    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'output', 'schema', 'properties', paramName, ZUI])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('empty title should trigger', async () => {
+  test.each(PARAM_NAMES)('empty title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { output: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: EMPTY_STRING } } } } } },
+        [ACTION_NAME]: { output: { schema: { properties: { [paramName]: { [ZUI]: { title: EMPTY_STRING } } } } } },
       },
     } as const satisfies PartialIntegration
 
@@ -400,18 +393,18 @@ describeRule('action-outputparams-should-have-a-title', (lint) => {
       'output',
       'schema',
       'properties',
-      PARAM_NAME,
+      paramName,
       ZUI,
       'title',
     ])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('valid title should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid title should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { output: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: TRUTHY_STRING } } } } } },
+        [ACTION_NAME]: { output: { schema: { properties: { [paramName]: { [ZUI]: { title: TRUTHY_STRING } } } } } },
       },
     } as const satisfies PartialIntegration
 
@@ -424,10 +417,10 @@ describeRule('action-outputparams-should-have-a-title', (lint) => {
 })
 
 describeRule('action-outputparams-must-have-a-description', (lint) => {
-  test('missing description should trigger', async () => {
+  test.each(PARAM_NAMES)('missing description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      actions: { [ACTION_NAME]: { output: { schema: { properties: { [PARAM_NAME]: {} } } } } },
+      actions: { [ACTION_NAME]: { output: { schema: { properties: { [paramName]: {} } } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -435,15 +428,15 @@ describeRule('action-outputparams-must-have-a-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'output', 'schema', 'properties', PARAM_NAME])
+    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'output', 'schema', 'properties', paramName])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('empty description should trigger', async () => {
+  test.each(PARAM_NAMES)('empty description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { output: { schema: { properties: { [PARAM_NAME]: { description: EMPTY_STRING } } } } },
+        [ACTION_NAME]: { output: { schema: { properties: { [paramName]: { description: EMPTY_STRING } } } } },
       },
     } as const satisfies PartialIntegration
 
@@ -458,17 +451,17 @@ describeRule('action-outputparams-must-have-a-description', (lint) => {
       'output',
       'schema',
       'properties',
-      PARAM_NAME,
+      paramName,
       'description',
     ])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('valid description should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid description should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { output: { schema: { properties: { [PARAM_NAME]: { description: TRUTHY_STRING } } } } },
+        [ACTION_NAME]: { output: { schema: { properties: { [paramName]: { description: TRUTHY_STRING } } } } },
       },
     } as const satisfies PartialIntegration
 
@@ -481,10 +474,10 @@ describeRule('action-outputparams-must-have-a-description', (lint) => {
 })
 
 describeRule('event-outputparams-should-have-title', (lint) => {
-  test('missing title should trigger', async () => {
+  test.each(PARAM_NAMES)('missing title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      events: { [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: {} } } } } },
+      events: { [EVENT_NAME]: { schema: { properties: { [paramName]: { [ZUI]: {} } } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -492,15 +485,15 @@ describeRule('event-outputparams-should-have-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', PARAM_NAME, ZUI])
+    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', paramName, ZUI])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('empty title should trigger', async () => {
+  test.each(PARAM_NAMES)('empty title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       events: {
-        [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: EMPTY_STRING } } } } },
+        [EVENT_NAME]: { schema: { properties: { [paramName]: { [ZUI]: { title: EMPTY_STRING } } } } },
       },
     } as const satisfies PartialIntegration
 
@@ -509,15 +502,15 @@ describeRule('event-outputparams-should-have-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', PARAM_NAME, ZUI, 'title'])
+    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', paramName, ZUI, 'title'])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('valid title should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid title should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       events: {
-        [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: TRUTHY_STRING } } } } },
+        [EVENT_NAME]: { schema: { properties: { [paramName]: { [ZUI]: { title: TRUTHY_STRING } } } } },
       },
     } as const satisfies PartialIntegration
 
@@ -530,10 +523,10 @@ describeRule('event-outputparams-should-have-title', (lint) => {
 })
 
 describeRule('event-outputparams-must-have-description', (lint) => {
-  test('missing description should trigger', async () => {
+  test.each(PARAM_NAMES)('missing description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      events: { [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: {} } } } },
+      events: { [EVENT_NAME]: { schema: { properties: { [paramName]: {} } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -541,15 +534,15 @@ describeRule('event-outputparams-must-have-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', PARAM_NAME])
+    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', paramName])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('empty description should trigger', async () => {
+  test.each(PARAM_NAMES)('empty description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       events: {
-        [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: { description: EMPTY_STRING } } } },
+        [EVENT_NAME]: { schema: { properties: { [paramName]: { description: EMPTY_STRING } } } },
       },
     } as const satisfies PartialIntegration
 
@@ -558,15 +551,15 @@ describeRule('event-outputparams-must-have-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', PARAM_NAME, 'description'])
+    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', paramName, 'description'])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('valid description should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid description should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       events: {
-        [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: { description: TRUTHY_STRING } } } },
+        [EVENT_NAME]: { schema: { properties: { [paramName]: { description: TRUTHY_STRING } } } },
       },
     } as const satisfies PartialIntegration
 
@@ -659,10 +652,10 @@ describeRule('events-must-have-a-description', (lint) => {
 })
 
 describeRule('configuration-fields-must-have-a-title', (lint) => {
-  test('missing title should trigger', async () => {
+  test.each(PARAM_NAMES)('missing title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      configuration: { schema: { properties: { [PARAM_NAME]: { [ZUI]: {} } } } },
+      configuration: { schema: { properties: { [paramName]: { [ZUI]: {} } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -670,14 +663,14 @@ describeRule('configuration-fields-must-have-a-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['configuration', 'schema', 'properties', PARAM_NAME, ZUI])
+    expect(results[0]?.path).toEqual(['configuration', 'schema', 'properties', paramName, ZUI])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('empty title should trigger', async () => {
+  test.each(PARAM_NAMES)('empty title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      configuration: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: EMPTY_STRING } } } } },
+      configuration: { schema: { properties: { [paramName]: { [ZUI]: { title: EMPTY_STRING } } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -685,14 +678,14 @@ describeRule('configuration-fields-must-have-a-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['configuration', 'schema', 'properties', PARAM_NAME, ZUI, 'title'])
+    expect(results[0]?.path).toEqual(['configuration', 'schema', 'properties', paramName, ZUI, 'title'])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('valid title should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid title should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      configuration: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: TRUTHY_STRING } } } } },
+      configuration: { schema: { properties: { [paramName]: { [ZUI]: { title: TRUTHY_STRING } } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -704,10 +697,10 @@ describeRule('configuration-fields-must-have-a-title', (lint) => {
 })
 
 describeRule('configuration-fields-must-have-a-description', (lint) => {
-  test('missing description should trigger', async () => {
+  test.each(PARAM_NAMES)('missing description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      configuration: { schema: { properties: { [PARAM_NAME]: {} } } },
+      configuration: { schema: { properties: { [paramName]: {} } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -715,14 +708,14 @@ describeRule('configuration-fields-must-have-a-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['configuration', 'schema', 'properties', PARAM_NAME])
+    expect(results[0]?.path).toEqual(['configuration', 'schema', 'properties', paramName])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('empty description should trigger', async () => {
+  test.each(PARAM_NAMES)('empty description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      configuration: { schema: { properties: { [PARAM_NAME]: { description: EMPTY_STRING } } } },
+      configuration: { schema: { properties: { [paramName]: { description: EMPTY_STRING } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -730,14 +723,14 @@ describeRule('configuration-fields-must-have-a-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['configuration', 'schema', 'properties', PARAM_NAME, 'description'])
+    expect(results[0]?.path).toEqual(['configuration', 'schema', 'properties', paramName, 'description'])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('valid description should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid description should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      configuration: { schema: { properties: { [PARAM_NAME]: { description: TRUTHY_STRING } } } },
+      configuration: { schema: { properties: { [paramName]: { description: TRUTHY_STRING } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -839,10 +832,10 @@ describeRule('multiple-configurations-must-have-a-description', (lint) => {
 })
 
 describeRule('multipes-configurations-fields-must-have-a-title', (lint) => {
-  test('missing title should trigger', async () => {
+  test.each(PARAM_NAMES)('missing title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      configurations: { [CONFIG_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: {} } } } } },
+      configurations: { [CONFIG_NAME]: { schema: { properties: { [paramName]: { [ZUI]: {} } } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -850,15 +843,15 @@ describeRule('multipes-configurations-fields-must-have-a-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['configurations', CONFIG_NAME, 'schema', 'properties', PARAM_NAME, ZUI])
+    expect(results[0]?.path).toEqual(['configurations', CONFIG_NAME, 'schema', 'properties', paramName, ZUI])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('empty title should trigger', async () => {
+  test.each(PARAM_NAMES)('empty title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       configurations: {
-        [CONFIG_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: EMPTY_STRING } } } } },
+        [CONFIG_NAME]: { schema: { properties: { [paramName]: { [ZUI]: { title: EMPTY_STRING } } } } },
       },
     } as const satisfies PartialIntegration
 
@@ -867,15 +860,15 @@ describeRule('multipes-configurations-fields-must-have-a-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['configurations', CONFIG_NAME, 'schema', 'properties', PARAM_NAME, ZUI, 'title'])
+    expect(results[0]?.path).toEqual(['configurations', CONFIG_NAME, 'schema', 'properties', paramName, ZUI, 'title'])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('valid title should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid title should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       configurations: {
-        [CONFIG_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: TRUTHY_STRING } } } } },
+        [CONFIG_NAME]: { schema: { properties: { [paramName]: { [ZUI]: { title: TRUTHY_STRING } } } } },
       },
     } as const satisfies PartialIntegration
 
@@ -888,10 +881,10 @@ describeRule('multipes-configurations-fields-must-have-a-title', (lint) => {
 })
 
 describeRule('multipes-configurations-fields-must-have-a-description', (lint) => {
-  test('missing description should trigger', async () => {
+  test.each(PARAM_NAMES)('missing description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      configurations: { [CONFIG_NAME]: { schema: { properties: { [PARAM_NAME]: {} } } } },
+      configurations: { [CONFIG_NAME]: { schema: { properties: { [paramName]: {} } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -899,15 +892,15 @@ describeRule('multipes-configurations-fields-must-have-a-description', (lint) =>
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['configurations', CONFIG_NAME, 'schema', 'properties', PARAM_NAME])
+    expect(results[0]?.path).toEqual(['configurations', CONFIG_NAME, 'schema', 'properties', paramName])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('empty description should trigger', async () => {
+  test.each(PARAM_NAMES)('empty description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       configurations: {
-        [CONFIG_NAME]: { schema: { properties: { [PARAM_NAME]: { description: EMPTY_STRING } } } },
+        [CONFIG_NAME]: { schema: { properties: { [paramName]: { description: EMPTY_STRING } } } },
       },
     } as const satisfies PartialIntegration
 
@@ -916,15 +909,15 @@ describeRule('multipes-configurations-fields-must-have-a-description', (lint) =>
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['configurations', CONFIG_NAME, 'schema', 'properties', PARAM_NAME, 'description'])
+    expect(results[0]?.path).toEqual(['configurations', CONFIG_NAME, 'schema', 'properties', paramName, 'description'])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('valid description should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid description should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       configurations: {
-        [CONFIG_NAME]: { schema: { properties: { [PARAM_NAME]: { description: TRUTHY_STRING } } } },
+        [CONFIG_NAME]: { schema: { properties: { [paramName]: { description: TRUTHY_STRING } } } },
       },
     } as const satisfies PartialIntegration
 
@@ -1283,23 +1276,23 @@ describeRule('channels-message-tags-must-have-a-description', (lint) => {
 })
 
 describeRule('legacy-zui-title-should-be-removed', (lint) => {
-  test('legacy zui title should trigger', async () => {
+  test.each(PARAM_NAMES)('legacy zui title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { input: { [LEGACY_ZUI]: { [PARAM_NAME]: { title: TRUTHY_STRING } }, schema: {} } },
+        [ACTION_NAME]: { input: { [LEGACY_ZUI]: { [paramName]: { title: TRUTHY_STRING } }, schema: {} } },
       },
       configuration: {
-        [LEGACY_ZUI]: { [PARAM_NAME]: { title: TRUTHY_STRING } },
+        [LEGACY_ZUI]: { [paramName]: { title: TRUTHY_STRING } },
         schema: {},
       },
-      events: { [EVENT_NAME]: { [LEGACY_ZUI]: { [PARAM_NAME]: { title: TRUTHY_STRING } }, schema: {} } },
+      events: { [EVENT_NAME]: { [LEGACY_ZUI]: { [paramName]: { title: TRUTHY_STRING } }, schema: {} } },
       channels: {
         [CHANNEL_NAME]: {
-          messages: { [MESSAGE_TYPE]: { [LEGACY_ZUI]: { [PARAM_NAME]: { title: TRUTHY_STRING } }, schema: {} } },
+          messages: { [MESSAGE_TYPE]: { [LEGACY_ZUI]: { [paramName]: { title: TRUTHY_STRING } }, schema: {} } },
         },
       },
-      states: { [STATE_NAME]: { [LEGACY_ZUI]: { [PARAM_NAME]: { title: TRUTHY_STRING } }, schema: {} } },
+      states: { [STATE_NAME]: { [LEGACY_ZUI]: { [paramName]: { title: TRUTHY_STRING } }, schema: {} } },
     } as const satisfies PartialIntegration
 
     // act
@@ -1312,23 +1305,23 @@ describeRule('legacy-zui-title-should-be-removed', (lint) => {
 })
 
 describeRule('legacy-zui-examples-should-be-removed', (lint) => {
-  test('legacy zui examples should trigger', async () => {
+  test.each(PARAM_NAMES)('legacy zui examples should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { input: { [LEGACY_ZUI]: { [PARAM_NAME]: { examples: [TRUTHY_STRING] } }, schema: {} } },
+        [ACTION_NAME]: { input: { [LEGACY_ZUI]: { [paramName]: { examples: [TRUTHY_STRING] } }, schema: {} } },
       },
       configuration: {
-        [LEGACY_ZUI]: { [PARAM_NAME]: { examples: [TRUTHY_STRING] } },
+        [LEGACY_ZUI]: { [paramName]: { examples: [TRUTHY_STRING] } },
         schema: {},
       },
-      events: { [EVENT_NAME]: { [LEGACY_ZUI]: { [PARAM_NAME]: { examples: [TRUTHY_STRING] } }, schema: {} } },
+      events: { [EVENT_NAME]: { [LEGACY_ZUI]: { [paramName]: { examples: [TRUTHY_STRING] } }, schema: {} } },
       channels: {
         [CHANNEL_NAME]: {
-          messages: { [MESSAGE_TYPE]: { [LEGACY_ZUI]: { [PARAM_NAME]: { examples: [TRUTHY_STRING] } }, schema: {} } },
+          messages: { [MESSAGE_TYPE]: { [LEGACY_ZUI]: { [paramName]: { examples: [TRUTHY_STRING] } }, schema: {} } },
         },
       },
-      states: { [STATE_NAME]: { [LEGACY_ZUI]: { [PARAM_NAME]: { examples: [TRUTHY_STRING] } }, schema: {} } },
+      states: { [STATE_NAME]: { [LEGACY_ZUI]: { [paramName]: { examples: [TRUTHY_STRING] } }, schema: {} } },
     } as const satisfies PartialIntegration
 
     // act
@@ -1341,10 +1334,10 @@ describeRule('legacy-zui-examples-should-be-removed', (lint) => {
 })
 
 describeRule('state-fields-should-have-title', (lint) => {
-  test('missing title should trigger', async () => {
+  test.each(PARAM_NAMES)('missing title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      states: { [STATE_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: {} } } } } },
+      states: { [STATE_NAME]: { schema: { properties: { [paramName]: { [ZUI]: {} } } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -1352,13 +1345,13 @@ describeRule('state-fields-should-have-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['states', STATE_NAME, 'schema', 'properties', PARAM_NAME, ZUI])
+    expect(results[0]?.path).toEqual(['states', STATE_NAME, 'schema', 'properties', paramName, ZUI])
   })
 
-  test('empty title should trigger', async () => {
+  test.each(PARAM_NAMES)('empty title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      states: { [STATE_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: EMPTY_STRING } } } } } },
+      states: { [STATE_NAME]: { schema: { properties: { [paramName]: { [ZUI]: { title: EMPTY_STRING } } } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -1366,13 +1359,13 @@ describeRule('state-fields-should-have-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['states', STATE_NAME, 'schema', 'properties', PARAM_NAME, ZUI, 'title'])
+    expect(results[0]?.path).toEqual(['states', STATE_NAME, 'schema', 'properties', paramName, ZUI, 'title'])
   })
 
-  test('valid title should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid title should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      states: { [STATE_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: TRUTHY_STRING } } } } } },
+      states: { [STATE_NAME]: { schema: { properties: { [paramName]: { [ZUI]: { title: TRUTHY_STRING } } } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -1384,10 +1377,10 @@ describeRule('state-fields-should-have-title', (lint) => {
 })
 
 describeRule('state-fields-must-have-description', (lint) => {
-  test('missing description should trigger', async () => {
+  test.each(PARAM_NAMES)('missing description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      states: { [STATE_NAME]: { schema: { properties: { [PARAM_NAME]: {} } } } },
+      states: { [STATE_NAME]: { schema: { properties: { [paramName]: {} } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -1395,13 +1388,13 @@ describeRule('state-fields-must-have-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['states', STATE_NAME, 'schema', 'properties', PARAM_NAME])
+    expect(results[0]?.path).toEqual(['states', STATE_NAME, 'schema', 'properties', paramName])
   })
 
-  test('empty description should trigger', async () => {
+  test.each(PARAM_NAMES)('empty description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      states: { [STATE_NAME]: { schema: { properties: { [PARAM_NAME]: { description: EMPTY_STRING } } } } },
+      states: { [STATE_NAME]: { schema: { properties: { [paramName]: { description: EMPTY_STRING } } } } },
     } as const satisfies PartialIntegration
 
     // act
@@ -1409,13 +1402,13 @@ describeRule('state-fields-must-have-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['states', STATE_NAME, 'schema', 'properties', PARAM_NAME, 'description'])
+    expect(results[0]?.path).toEqual(['states', STATE_NAME, 'schema', 'properties', paramName, 'description'])
   })
 
-  test('valid description should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid description should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      states: { [STATE_NAME]: { schema: { properties: { [PARAM_NAME]: { description: TRUTHY_STRING } } } } },
+      states: { [STATE_NAME]: { schema: { properties: { [paramName]: { description: TRUTHY_STRING } } } } },
     } as const satisfies PartialIntegration
 
     // act

--- a/packages/cli/src/linter/ruleset-tests/interface.ruleset.test.ts
+++ b/packages/cli/src/linter/ruleset-tests/interface.ruleset.test.ts
@@ -11,18 +11,19 @@ const TRUTHY_STRING = 'truthy'
 const ACTION_NAME = 'actionName'
 const EVENT_NAME = 'eventName'
 const PARAM_NAME = 'paramName'
+const PROPERTIES_PARAM = 'properties'
+const PARAM_NAMES = [PARAM_NAME, PROPERTIES_PARAM] as const
 const CHANNEL_NAME = 'channelName'
-const STATE_NAME = 'stateName'
 const ENTITY_NAME = 'entityName'
 const MESSAGE_TYPE = 'text'
 const ZUI = 'x-zui'
 const LEGACY_ZUI = 'ui'
 
 describeRule('action-inputparams-should-have-a-title', (lint) => {
-  test('missing title should trigger', async () => {
+  test.each(PARAM_NAMES)('missing title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      actions: { [ACTION_NAME]: { input: { schema: { properties: { [PARAM_NAME]: { [ZUI]: {} } } } } } },
+      actions: { [ACTION_NAME]: { input: { schema: { properties: { [paramName]: { [ZUI]: {} } } } } } },
     } as const satisfies PartialInterface
 
     // act
@@ -30,15 +31,15 @@ describeRule('action-inputparams-should-have-a-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'input', 'schema', 'properties', PARAM_NAME, ZUI])
+    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'input', 'schema', 'properties', paramName, ZUI])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('empty title should trigger', async () => {
+  test.each(PARAM_NAMES)('empty title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { input: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: EMPTY_STRING } } } } } },
+        [ACTION_NAME]: { input: { schema: { properties: { [paramName]: { [ZUI]: { title: EMPTY_STRING } } } } } },
       },
     } as const satisfies PartialInterface
 
@@ -47,24 +48,15 @@ describeRule('action-inputparams-should-have-a-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual([
-      'actions',
-      ACTION_NAME,
-      'input',
-      'schema',
-      'properties',
-      PARAM_NAME,
-      ZUI,
-      'title',
-    ])
+    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'input', 'schema', 'properties', paramName, ZUI, 'title'])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('valid title should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid title should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { input: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: TRUTHY_STRING } } } } } },
+        [ACTION_NAME]: { input: { schema: { properties: { [paramName]: { [ZUI]: { title: TRUTHY_STRING } } } } } },
       },
     } as const satisfies PartialInterface
 
@@ -77,10 +69,10 @@ describeRule('action-inputparams-should-have-a-title', (lint) => {
 })
 
 describeRule('action-inputparams-must-have-a-description', (lint) => {
-  test('missing description should trigger', async () => {
+  test.each(PARAM_NAMES)('missing description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      actions: { [ACTION_NAME]: { input: { schema: { properties: { [PARAM_NAME]: {} } } } } },
+      actions: { [ACTION_NAME]: { input: { schema: { properties: { [paramName]: {} } } } } },
     } as const satisfies PartialInterface
 
     // act
@@ -88,15 +80,15 @@ describeRule('action-inputparams-must-have-a-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'input', 'schema', 'properties', PARAM_NAME])
+    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'input', 'schema', 'properties', paramName])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('empty description should trigger', async () => {
+  test.each(PARAM_NAMES)('empty description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { input: { schema: { properties: { [PARAM_NAME]: { description: EMPTY_STRING } } } } },
+        [ACTION_NAME]: { input: { schema: { properties: { [paramName]: { description: EMPTY_STRING } } } } },
       },
     } as const satisfies PartialInterface
 
@@ -111,17 +103,17 @@ describeRule('action-inputparams-must-have-a-description', (lint) => {
       'input',
       'schema',
       'properties',
-      PARAM_NAME,
+      paramName,
       'description',
     ])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('valid description should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid description should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { input: { schema: { properties: { [PARAM_NAME]: { description: TRUTHY_STRING } } } } },
+        [ACTION_NAME]: { input: { schema: { properties: { [paramName]: { description: TRUTHY_STRING } } } } },
       },
     } as const satisfies PartialInterface
 
@@ -134,10 +126,10 @@ describeRule('action-inputparams-must-have-a-description', (lint) => {
 })
 
 describeRule('action-outputparams-should-have-a-title', (lint) => {
-  test('missing title should trigger', async () => {
+  test.each(PARAM_NAMES)('missing title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      actions: { [ACTION_NAME]: { output: { schema: { properties: { [PARAM_NAME]: { [ZUI]: {} } } } } } },
+      actions: { [ACTION_NAME]: { output: { schema: { properties: { [paramName]: { [ZUI]: {} } } } } } },
     } as const satisfies PartialInterface
 
     // act
@@ -145,15 +137,15 @@ describeRule('action-outputparams-should-have-a-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'output', 'schema', 'properties', PARAM_NAME, ZUI])
+    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'output', 'schema', 'properties', paramName, ZUI])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('empty title should trigger', async () => {
+  test.each(PARAM_NAMES)('empty title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { output: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: EMPTY_STRING } } } } } },
+        [ACTION_NAME]: { output: { schema: { properties: { [paramName]: { [ZUI]: { title: EMPTY_STRING } } } } } },
       },
     } as const satisfies PartialInterface
 
@@ -168,18 +160,18 @@ describeRule('action-outputparams-should-have-a-title', (lint) => {
       'output',
       'schema',
       'properties',
-      PARAM_NAME,
+      paramName,
       ZUI,
       'title',
     ])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('valid title should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid title should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { output: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: TRUTHY_STRING } } } } } },
+        [ACTION_NAME]: { output: { schema: { properties: { [paramName]: { [ZUI]: { title: TRUTHY_STRING } } } } } },
       },
     } as const satisfies PartialInterface
 
@@ -192,10 +184,10 @@ describeRule('action-outputparams-should-have-a-title', (lint) => {
 })
 
 describeRule('action-outputparams-must-have-a-description', (lint) => {
-  test('missing description should trigger', async () => {
+  test.each(PARAM_NAMES)('missing description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      actions: { [ACTION_NAME]: { output: { schema: { properties: { [PARAM_NAME]: {} } } } } },
+      actions: { [ACTION_NAME]: { output: { schema: { properties: { [paramName]: {} } } } } },
     } as const satisfies PartialInterface
 
     // act
@@ -203,15 +195,15 @@ describeRule('action-outputparams-must-have-a-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'output', 'schema', 'properties', PARAM_NAME])
+    expect(results[0]?.path).toEqual(['actions', ACTION_NAME, 'output', 'schema', 'properties', paramName])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('empty description should trigger', async () => {
+  test.each(PARAM_NAMES)('empty description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { output: { schema: { properties: { [PARAM_NAME]: { description: EMPTY_STRING } } } } },
+        [ACTION_NAME]: { output: { schema: { properties: { [paramName]: { description: EMPTY_STRING } } } } },
       },
     } as const satisfies PartialInterface
 
@@ -226,17 +218,17 @@ describeRule('action-outputparams-must-have-a-description', (lint) => {
       'output',
       'schema',
       'properties',
-      PARAM_NAME,
+      paramName,
       'description',
     ])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('valid description should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid description should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { output: { schema: { properties: { [PARAM_NAME]: { description: TRUTHY_STRING } } } } },
+        [ACTION_NAME]: { output: { schema: { properties: { [paramName]: { description: TRUTHY_STRING } } } } },
       },
     } as const satisfies PartialInterface
 
@@ -249,10 +241,10 @@ describeRule('action-outputparams-must-have-a-description', (lint) => {
 })
 
 describeRule('event-outputparams-should-have-title', (lint) => {
-  test('missing title should trigger', async () => {
+  test.each(PARAM_NAMES)('missing title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      events: { [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: {} } } } } },
+      events: { [EVENT_NAME]: { schema: { properties: { [paramName]: { [ZUI]: {} } } } } },
     } as const satisfies PartialInterface
 
     // act
@@ -260,15 +252,15 @@ describeRule('event-outputparams-should-have-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', PARAM_NAME, ZUI])
+    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', paramName, ZUI])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('empty title should trigger', async () => {
+  test.each(PARAM_NAMES)('empty title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       events: {
-        [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: EMPTY_STRING } } } } },
+        [EVENT_NAME]: { schema: { properties: { [paramName]: { [ZUI]: { title: EMPTY_STRING } } } } },
       },
     } as const satisfies PartialInterface
 
@@ -277,15 +269,15 @@ describeRule('event-outputparams-should-have-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', PARAM_NAME, ZUI, 'title'])
+    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', paramName, ZUI, 'title'])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('valid title should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid title should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       events: {
-        [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: TRUTHY_STRING } } } } },
+        [EVENT_NAME]: { schema: { properties: { [paramName]: { [ZUI]: { title: TRUTHY_STRING } } } } },
       },
     } as const satisfies PartialInterface
 
@@ -298,10 +290,10 @@ describeRule('event-outputparams-should-have-title', (lint) => {
 })
 
 describeRule('event-outputparams-must-have-description', (lint) => {
-  test('missing description should trigger', async () => {
+  test.each(PARAM_NAMES)('missing description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      events: { [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: {} } } } },
+      events: { [EVENT_NAME]: { schema: { properties: { [paramName]: {} } } } },
     } as const satisfies PartialInterface
 
     // act
@@ -309,15 +301,15 @@ describeRule('event-outputparams-must-have-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', PARAM_NAME])
+    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', paramName])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('empty description should trigger', async () => {
+  test.each(PARAM_NAMES)('empty description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       events: {
-        [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: { description: EMPTY_STRING } } } },
+        [EVENT_NAME]: { schema: { properties: { [paramName]: { description: EMPTY_STRING } } } },
       },
     } as const satisfies PartialInterface
 
@@ -326,15 +318,15 @@ describeRule('event-outputparams-must-have-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', PARAM_NAME, 'description'])
+    expect(results[0]?.path).toEqual(['events', EVENT_NAME, 'schema', 'properties', paramName, 'description'])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('valid description should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid description should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       events: {
-        [EVENT_NAME]: { schema: { properties: { [PARAM_NAME]: { description: TRUTHY_STRING } } } },
+        [EVENT_NAME]: { schema: { properties: { [paramName]: { description: TRUTHY_STRING } } } },
       },
     } as const satisfies PartialInterface
 
@@ -347,19 +339,19 @@ describeRule('event-outputparams-must-have-description', (lint) => {
 })
 
 describeRule('legacy-zui-title-should-be-removed', (lint) => {
-  test('legacy zui title should trigger', async () => {
+  test.each(PARAM_NAMES)('legacy zui title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { input: { [LEGACY_ZUI]: { [PARAM_NAME]: { title: TRUTHY_STRING } }, schema: {} } },
+        [ACTION_NAME]: { input: { [LEGACY_ZUI]: { [paramName]: { title: TRUTHY_STRING } }, schema: {} } },
       },
-      events: { [EVENT_NAME]: { [LEGACY_ZUI]: { [PARAM_NAME]: { title: TRUTHY_STRING } }, schema: {} } },
+      events: { [EVENT_NAME]: { [LEGACY_ZUI]: { [paramName]: { title: TRUTHY_STRING } }, schema: {} } },
       channels: {
         [CHANNEL_NAME]: {
-          messages: { [MESSAGE_TYPE]: { [LEGACY_ZUI]: { [PARAM_NAME]: { title: TRUTHY_STRING } }, schema: {} } },
+          messages: { [MESSAGE_TYPE]: { [LEGACY_ZUI]: { [paramName]: { title: TRUTHY_STRING } }, schema: {} } },
         },
       },
-      entities: { [ENTITY_NAME]: { [LEGACY_ZUI]: { [PARAM_NAME]: { title: TRUTHY_STRING } }, schema: {} } },
+      entities: { [ENTITY_NAME]: { [LEGACY_ZUI]: { [paramName]: { title: TRUTHY_STRING } }, schema: {} } },
     } as const satisfies PartialInterface
 
     // act
@@ -372,19 +364,19 @@ describeRule('legacy-zui-title-should-be-removed', (lint) => {
 })
 
 describeRule('legacy-zui-examples-should-be-removed', (lint) => {
-  test('legacy zui examples should trigger', async () => {
+  test.each(PARAM_NAMES)('legacy zui examples should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       actions: {
-        [ACTION_NAME]: { input: { [LEGACY_ZUI]: { [PARAM_NAME]: { examples: [TRUTHY_STRING] } }, schema: {} } },
+        [ACTION_NAME]: { input: { [LEGACY_ZUI]: { [paramName]: { examples: [TRUTHY_STRING] } }, schema: {} } },
       },
-      events: { [EVENT_NAME]: { [LEGACY_ZUI]: { [PARAM_NAME]: { examples: [TRUTHY_STRING] } }, schema: {} } },
+      events: { [EVENT_NAME]: { [LEGACY_ZUI]: { [paramName]: { examples: [TRUTHY_STRING] } }, schema: {} } },
       channels: {
         [CHANNEL_NAME]: {
-          messages: { [MESSAGE_TYPE]: { [LEGACY_ZUI]: { [PARAM_NAME]: { examples: [TRUTHY_STRING] } }, schema: {} } },
+          messages: { [MESSAGE_TYPE]: { [LEGACY_ZUI]: { [paramName]: { examples: [TRUTHY_STRING] } }, schema: {} } },
         },
       },
-      entities: { [ENTITY_NAME]: { [LEGACY_ZUI]: { [PARAM_NAME]: { examples: [TRUTHY_STRING] } }, schema: {} } },
+      entities: { [ENTITY_NAME]: { [LEGACY_ZUI]: { [paramName]: { examples: [TRUTHY_STRING] } }, schema: {} } },
     } as const satisfies PartialInterface
 
     // act
@@ -487,10 +479,10 @@ describeRule('entities-must-have-a-description', (lint) => {
 })
 
 describeRule('entity-fields-should-have-a-title', (lint) => {
-  test('missing title should trigger', async () => {
+  test.each(PARAM_NAMES)('missing title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      entities: { [ENTITY_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: {} } } } } },
+      entities: { [ENTITY_NAME]: { schema: { properties: { [paramName]: { [ZUI]: {} } } } } },
     } as const satisfies PartialInterface
 
     // act
@@ -498,15 +490,15 @@ describeRule('entity-fields-should-have-a-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['entities', ENTITY_NAME, 'schema', 'properties', PARAM_NAME, ZUI])
+    expect(results[0]?.path).toEqual(['entities', ENTITY_NAME, 'schema', 'properties', paramName, ZUI])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('empty title should trigger', async () => {
+  test.each(PARAM_NAMES)('empty title should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       entities: {
-        [ENTITY_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: EMPTY_STRING } } } } },
+        [ENTITY_NAME]: { schema: { properties: { [paramName]: { [ZUI]: { title: EMPTY_STRING } } } } },
       },
     } as const satisfies PartialInterface
 
@@ -515,15 +507,15 @@ describeRule('entity-fields-should-have-a-title', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['entities', ENTITY_NAME, 'schema', 'properties', PARAM_NAME, ZUI, 'title'])
+    expect(results[0]?.path).toEqual(['entities', ENTITY_NAME, 'schema', 'properties', paramName, ZUI, 'title'])
     expect(results[0]?.message).toContain('title')
   })
 
-  test('valid title should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid title should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       entities: {
-        [ENTITY_NAME]: { schema: { properties: { [PARAM_NAME]: { [ZUI]: { title: TRUTHY_STRING } } } } },
+        [ENTITY_NAME]: { schema: { properties: { [paramName]: { [ZUI]: { title: TRUTHY_STRING } } } } },
       },
     } as const satisfies PartialInterface
 
@@ -536,10 +528,10 @@ describeRule('entity-fields-should-have-a-title', (lint) => {
 })
 
 describeRule('entity-fields-must-have-a-description', (lint) => {
-  test('missing description should trigger', async () => {
+  test.each(PARAM_NAMES)('missing description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
-      entities: { [ENTITY_NAME]: { schema: { properties: { [PARAM_NAME]: {} } } } },
+      entities: { [ENTITY_NAME]: { schema: { properties: { [paramName]: {} } } } },
     } as const satisfies PartialInterface
 
     // act
@@ -547,15 +539,15 @@ describeRule('entity-fields-must-have-a-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['entities', ENTITY_NAME, 'schema', 'properties', PARAM_NAME])
+    expect(results[0]?.path).toEqual(['entities', ENTITY_NAME, 'schema', 'properties', paramName])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('empty description should trigger', async () => {
+  test.each(PARAM_NAMES)('empty description should trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       entities: {
-        [ENTITY_NAME]: { schema: { properties: { [PARAM_NAME]: { description: EMPTY_STRING } } } },
+        [ENTITY_NAME]: { schema: { properties: { [paramName]: { description: EMPTY_STRING } } } },
       },
     } as const satisfies PartialInterface
 
@@ -564,15 +556,15 @@ describeRule('entity-fields-must-have-a-description', (lint) => {
 
     // assert
     expect(results).toHaveLength(1)
-    expect(results[0]?.path).toEqual(['entities', ENTITY_NAME, 'schema', 'properties', PARAM_NAME, 'description'])
+    expect(results[0]?.path).toEqual(['entities', ENTITY_NAME, 'schema', 'properties', paramName, 'description'])
     expect(results[0]?.message).toContain('description')
   })
 
-  test('valid description should not trigger', async () => {
+  test.each(PARAM_NAMES)('valid description should not trigger (%s)', async (paramName) => {
     // arrange
     const definition = {
       entities: {
-        [ENTITY_NAME]: { schema: { properties: { [PARAM_NAME]: { description: TRUTHY_STRING } } } },
+        [ENTITY_NAME]: { schema: { properties: { [paramName]: { description: TRUTHY_STRING } } } },
       },
     } as const satisfies PartialInterface
 

--- a/packages/cli/src/linter/rulesets/bot.ruleset.ts
+++ b/packages/cli/src/linter/rulesets/bot.ruleset.ts
@@ -9,7 +9,7 @@ export const BOT_RULESET = {
       description: 'All event output parameters SHOULD have a title',
       message: '{{description}}: {{error}} SHOULD provide a non-empty title by using .title() in its Zod schema',
       severity: 'warn',
-      given: '$.events[*].schema..properties[*]',
+      given: '$.events[*]..schema.properties[*]',
       then: [
         {
           field: 'x-zui.title',
@@ -22,7 +22,7 @@ export const BOT_RULESET = {
       message:
         '{{description}}: {{error}} SHOULD provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
-      given: '$.events[*].schema..properties[*]',
+      given: '$.events[*]..schema.properties[*]',
       then: [
         {
           field: 'description',
@@ -32,9 +32,9 @@ export const BOT_RULESET = {
     },
     'configuration-fields-must-have-a-title': {
       description: 'All configuration fields MUST have a title',
-      message: '{{description}}: {{property}} MUST provide a non-empty title by using .title() in its Zod schema',
+      message: '{{description}}: {{error}} MUST provide a non-empty title by using .title() in its Zod schema',
       severity: 'error',
-      given: '$.configuration.schema..properties[*].x-zui',
+      given: '$.configuration..schema.properties[*].x-zui',
       then: [
         {
           field: 'title',
@@ -44,10 +44,9 @@ export const BOT_RULESET = {
     },
     'configuration-fields-must-have-a-description': {
       description: 'All configuration fields MUST have a description',
-      message:
-        '{{description}}: {{property}} MUST provide a non-empty description by using .describe() in its Zod schema',
+      message: '{{description}}: {{error}} MUST provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
-      given: '$.configuration.schema..properties[*]',
+      given: '$.configuration..schema.properties[*]',
       then: [
         {
           field: 'description',
@@ -144,7 +143,7 @@ export const BOT_RULESET = {
       description: 'All state fields SHOULD have a title',
       message: '{{description}}: {{error}} SHOULD provide a non-empty title by using .title() in its Zod schema',
       severity: 'warn',
-      given: '$.states[*].schema..properties[*]',
+      given: '$.states[*]..schema.properties[*]',
       then: [
         {
           field: 'x-zui.title',
@@ -157,7 +156,7 @@ export const BOT_RULESET = {
       message:
         '{{description}}: {{error}} SHOULD provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
-      given: '$.states[*].schema..properties[*]',
+      given: '$.states[*]..schema.properties[*]',
       then: [
         {
           field: 'description',

--- a/packages/cli/src/linter/rulesets/integration.ruleset.ts
+++ b/packages/cli/src/linter/rulesets/integration.ruleset.ts
@@ -47,7 +47,7 @@ export const INTEGRATION_RULESET = {
       description: 'All action input parameters SHOULD have a title',
       message: '{{description}}: {{error}} SHOULD provide a non-empty title by using .title() in its Zod schema',
       severity: 'warn',
-      given: '$.actions[*].input.schema..properties[*].x-zui',
+      given: '$.actions[*].input..schema.properties[*].x-zui',
       then: [
         {
           field: 'title',
@@ -59,7 +59,7 @@ export const INTEGRATION_RULESET = {
       description: 'All action input parameters MUST have a description',
       message: '{{description}}: {{error}} MUST provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
-      given: '$.actions[*].input.schema..properties[*]',
+      given: '$.actions[*].input..schema.properties[*]',
       then: [
         {
           field: 'description',
@@ -71,7 +71,7 @@ export const INTEGRATION_RULESET = {
       description: 'All action output parameters SHOULD have a title',
       message: '{{description}}: {{error}} SHOULD provide a non-empty title by using .title() in its Zod schema',
       severity: 'warn',
-      given: '$.actions[*].output.schema..properties[*].x-zui',
+      given: '$.actions[*].output..schema.properties[*].x-zui',
       then: [
         {
           field: 'title',
@@ -83,7 +83,7 @@ export const INTEGRATION_RULESET = {
       description: 'All action output parameters MUST have a description',
       message: '{{description}}: {{error}} MUST provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
-      given: '$.actions[*].output.schema..properties[*]',
+      given: '$.actions[*].output..schema.properties[*]',
       then: [
         {
           field: 'description',
@@ -95,7 +95,7 @@ export const INTEGRATION_RULESET = {
       description: 'All event output parameters SHOULD have a title',
       message: '{{description}}: {{error}} SHOULD provide a non-empty title by using .title() in its Zod schema',
       severity: 'warn',
-      given: '$.events[*].schema..properties[*]',
+      given: '$.events[*]..schema.properties[*]',
       then: [
         {
           field: 'x-zui.title',
@@ -108,7 +108,7 @@ export const INTEGRATION_RULESET = {
       message:
         '{{description}}: {{error}} SHOULD provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
-      given: '$.events[*].schema..properties[*]',
+      given: '$.events[*]..schema.properties[*]',
       then: [
         {
           field: 'description',
@@ -142,9 +142,9 @@ export const INTEGRATION_RULESET = {
     },
     'configuration-fields-must-have-a-title': {
       description: 'All configuration fields MUST have a title',
-      message: '{{description}}: {{property}} MUST provide a non-empty title by using .title() in its Zod schema',
+      message: '{{description}}: {{error}} MUST provide a non-empty title by using .title() in its Zod schema',
       severity: 'error',
-      given: '$.configuration.schema..properties[*].x-zui',
+      given: '$.configuration..schema.properties[*].x-zui',
       then: [
         {
           field: 'title',
@@ -154,10 +154,9 @@ export const INTEGRATION_RULESET = {
     },
     'configuration-fields-must-have-a-description': {
       description: 'All configuration fields MUST have a description',
-      message:
-        '{{description}}: {{property}} MUST provide a non-empty description by using .describe() in its Zod schema',
+      message: '{{description}}: {{error}} MUST provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
-      given: '$.configuration.schema..properties[*]',
+      given: '$.configuration..schema.properties[*]',
       then: [
         {
           field: 'description',
@@ -183,7 +182,7 @@ export const INTEGRATION_RULESET = {
       description: 'All configuration fields in multiple configurations MUST have a title',
       message: '{{description}}: {{error}} MUST provide a non-empty title by using .title() in its Zod schema',
       severity: 'error',
-      given: '$.configurations[*].schema..properties[*].x-zui',
+      given: '$.configurations[*]..schema.properties[*].x-zui',
       then: [
         {
           field: 'title',
@@ -197,7 +196,7 @@ export const INTEGRATION_RULESET = {
       description: 'All configuration fields in multiple configurations MUST have a description',
       message: '{{description}}: {{error}} MUST provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
-      given: '$.configurations[*].schema..properties[*]',
+      given: '$.configurations[*]..schema.properties[*]',
       then: [
         {
           field: 'description',
@@ -320,7 +319,7 @@ export const INTEGRATION_RULESET = {
       description: 'All state fields SHOULD have a title',
       message: '{{description}}: {{error}} SHOULD provide a non-empty title by using .title() in its Zod schema',
       severity: 'warn',
-      given: '$.states[*].schema..properties[*]',
+      given: '$.states[*]..schema.properties[*]',
       then: [
         {
           field: 'x-zui.title',
@@ -333,7 +332,7 @@ export const INTEGRATION_RULESET = {
       message:
         '{{description}}: {{error}} SHOULD provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
-      given: '$.states[*].schema..properties[*]',
+      given: '$.states[*]..schema.properties[*]',
       then: [
         {
           field: 'description',

--- a/packages/cli/src/linter/rulesets/interface.ruleset.ts
+++ b/packages/cli/src/linter/rulesets/interface.ruleset.ts
@@ -9,7 +9,7 @@ export const INTERFACE_RULESET = {
       description: 'All action input parameters SHOULD have a title',
       message: '{{description}}: {{error}} SHOULD provide a non-empty title by using .title() in its Zod schema',
       severity: 'warn',
-      given: '$.actions[*].input.schema..properties[*].x-zui',
+      given: '$.actions[*].input..schema.properties[*].x-zui',
       then: [
         {
           field: 'title',
@@ -21,7 +21,7 @@ export const INTERFACE_RULESET = {
       description: 'All action input parameters MUST have a description',
       message: '{{description}}: {{error}} MUST provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
-      given: '$.actions[*].input.schema..properties[*]',
+      given: '$.actions[*].input..schema.properties[*]',
       then: [
         {
           field: 'description',
@@ -33,7 +33,7 @@ export const INTERFACE_RULESET = {
       description: 'All action output parameters SHOULD have a title',
       message: '{{description}}: {{error}} SHOULD provide a non-empty title by using .title() in its Zod schema',
       severity: 'warn',
-      given: '$.actions[*].output.schema..properties[*].x-zui',
+      given: '$.actions[*].output..schema.properties[*].x-zui',
       then: [
         {
           field: 'title',
@@ -45,7 +45,7 @@ export const INTERFACE_RULESET = {
       description: 'All action output parameters MUST have a description',
       message: '{{description}}: {{error}} MUST provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
-      given: '$.actions[*].output.schema..properties[*]',
+      given: '$.actions[*].output..schema.properties[*]',
       then: [
         {
           field: 'description',
@@ -57,7 +57,7 @@ export const INTERFACE_RULESET = {
       description: 'All event output parameters SHOULD have a title',
       message: '{{description}}: {{error}} SHOULD provide a non-empty title by using .title() in its Zod schema',
       severity: 'warn',
-      given: '$.events[*].schema..properties[*]',
+      given: '$.events[*]..schema.properties[*]',
       then: [
         {
           field: 'x-zui.title',
@@ -70,7 +70,7 @@ export const INTERFACE_RULESET = {
       message:
         '{{description}}: {{error}} SHOULD provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
-      given: '$.events[*].schema..properties[*]',
+      given: '$.events[*]..schema.properties[*]',
       then: [
         {
           field: 'description',
@@ -109,7 +109,7 @@ export const INTERFACE_RULESET = {
       description: 'All entity fields SHOULD have a title',
       message: '{{description}}: {{error}} SHOULD provide a non-empty title by using .title() in its Zod schema',
       severity: 'warn',
-      given: '$.entities[*].schema..properties[*]',
+      given: '$.entities[*]..schema.properties[*]',
       then: [
         {
           field: 'x-zui.title',
@@ -121,7 +121,7 @@ export const INTERFACE_RULESET = {
       description: 'All entity fields MUST have a description',
       message: '{{description}}: {{error}} MUST provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
-      given: '$.entities[*].schema..properties[*]',
+      given: '$.entities[*]..schema.properties[*]',
       then: [
         {
           field: 'description',


### PR DESCRIPTION
The google sheets integration defines an output parameter named `properties` in action `getInfoSpreadsheet`. This causes the linter to break because of rules with json paths such as `$.actions[*].output.schema..properties[*].x-zui`.
The `..` in the path matches recursively, no matter how deep. This was used so that an a schema like `z.object({ foo: z.object({ bar: z.string() }) })` would need to give titles and descriptions for nested properties, not just for the top-level properties.
This, however, breaks down when the linter encounters a property named `properties`, because it expects it to have a descendant (`[*]`) before the zui metadata (`x-zui`).

After much head-scratching, I've found a satisfactory solution: move the recursion to `schema` rather than `properties`:  `$.actions[*].output..schema.properties[*].x-zui`. This way, it only matches `properties` if it is a direct descendant of `schema`.
I've thus corrected the rulesets and I've added new tests to prevent regressions.