### PR TITLE
fix: replace empty integrations config by any for backward compatibility

### DIFF
--- a/integrations/anthropic/integration.definition.ts
+++ b/integrations/anthropic/integration.definition.ts
@@ -8,6 +8,9 @@ export default new IntegrationDefinition({
   version: '3.3.3',
   readme: 'hub.md',
   icon: 'icon.svg',
+  configuration: {
+    schema: z.any() as unknown as z.AnyZodObject, // TODO: remove this and bump a major
+  },
   entities: {
     modelRef: {
       schema: z.object({

--- a/integrations/cerebras/integration.definition.ts
+++ b/integrations/cerebras/integration.definition.ts
@@ -8,6 +8,9 @@ export default new IntegrationDefinition({
   version: '0.2.2',
   readme: 'hub.md',
   icon: 'icon.svg',
+  configuration: {
+    schema: z.any() as unknown as z.AnyZodObject, // TODO: remove this and bump
+  },
   entities: {
     modelRef: {
       schema: z.object({

--- a/integrations/fireworks-ai/integration.definition.ts
+++ b/integrations/fireworks-ai/integration.definition.ts
@@ -9,6 +9,9 @@ export default new IntegrationDefinition({
   version: '0.4.2',
   readme: 'hub.md',
   icon: 'icon.svg',
+  configuration: {
+    schema: z.any() as unknown as z.AnyZodObject, // TODO: remove this and bump a major
+  },
   entities: {
     modelRef: {
       schema: z.object({

--- a/integrations/groq/integration.definition.ts
+++ b/integrations/groq/integration.definition.ts
@@ -9,6 +9,9 @@ export default new IntegrationDefinition({
   version: '6.3.2',
   readme: 'hub.md',
   icon: 'icon.svg',
+  configuration: {
+    schema: z.any() as unknown as z.AnyZodObject, // TODO: remove this and bump a major
+  },
   entities: {
     modelRef: {
       schema: z.object({


### PR DESCRIPTION
Here's the issue:

- previously, the default config in the backend was `unknown`
- now the default config in the backend was `object`
- this creates a breaking change for integrations without config because `unknown` does not extend `object`

To fix this, we explicitly set the config to `any`. This is a temporary workaround as eventually, we'll enforce config schemas to be objects.