### PR TITLE
chore(ci): temporarily disable zendesk deployment

### DIFF
--- a/.github/actions/deploy-integrations/action.yml
+++ b/.github/actions/deploy-integrations/action.yml
@@ -114,7 +114,7 @@ runs:
         # deploy
 
         redeploy=${{ inputs.force == 'true' && 1 || 0 }}
-        all_filters="-F '{integrations/*}' -F '!asana' ${{ inputs.extra_filter }}"
+        all_filters="-F '{integrations/*}' -F '!asana' -F '!zendesk' ${{ inputs.extra_filter }}"
         list_integrations_cmd="pnpm list $all_filters --json"
         integration_paths=$(eval $list_integrations_cmd | jq -r "map(".path") | .[]")
 


### PR DESCRIPTION
deployment for the zendesk integration is currently broken because a breaking change was introduced but the major was not bumped