### PR TITLE
feat(sdk): bots can define actions

### DIFF
--- a/bots/bugbuster/src/bot.ts
+++ b/bots/bugbuster/src/bot.ts
@@ -1,2 +1,2 @@
 import * as bp from '.botpress'
-export const bot = new bp.Bot({})
+export const bot = new bp.Bot({ actions: {} })

--- a/bots/hello-world/bot.definition.ts
+++ b/bots/hello-world/bot.definition.ts
@@ -1,6 +1,7 @@
 import * as sdk from '@botpress/sdk'
+import * as env from './.genenv'
+import telegram from './bp_modules/telegram'
 import webhook from './bp_modules/webhook'
-import whatsapp from './bp_modules/whatsapp'
 
 export default new sdk.BotDefinition({
   actions: {
@@ -16,9 +17,11 @@ export default new sdk.BotDefinition({
     },
   },
 })
-  .add(whatsapp, {
+  .add(telegram, {
     enabled: true,
-    configuration: {},
+    configuration: {
+      botToken: env.HELLO_WORLD_TELEGRAM_BOT_TOKEN,
+    },
   })
   .add(webhook, {
     enabled: true,

--- a/bots/hello-world/bot.definition.ts
+++ b/bots/hello-world/bot.definition.ts
@@ -2,7 +2,20 @@ import * as sdk from '@botpress/sdk'
 import webhook from './bp_modules/webhook'
 import whatsapp from './bp_modules/whatsapp'
 
-export default new sdk.BotDefinition({})
+export default new sdk.BotDefinition({
+  actions: {
+    sayHello: {
+      title: 'Say Hello',
+      description: 'Says hello to the caller',
+      input: {
+        schema: sdk.z.object({ name: sdk.z.string().optional() }),
+      },
+      output: {
+        schema: sdk.z.object({ message: sdk.z.string() }),
+      },
+    },
+  },
+})
   .add(whatsapp, {
     enabled: true,
     configuration: {},

--- a/bots/hello-world/integrations.ts
+++ b/bots/hello-world/integrations.ts
@@ -2,7 +2,7 @@ import * as common from '@botpress/common'
 import * as path from 'path'
 
 const { runCommand } = common.cmd
-const integrationNames: string[] = ['whatsapp', 'webhook']
+const integrationNames: string[] = ['telegram', 'webhook']
 for (const integrationName of integrationNames) {
   const integrationPath = path.resolve(path.join('..', '..', 'integrations', integrationName))
   runCommand(`pnpm exec bp add ${integrationPath} -y`, { workDir: __dirname })

--- a/bots/hello-world/package.json
+++ b/bots/hello-world/package.json
@@ -3,6 +3,7 @@
   "description": "Hello-world bot",
   "private": true,
   "scripts": {
+    "postinstall": "genenv -o ./.genenv/index.ts -e HELLO_WORLD_TELEGRAM_BOT_TOKEN",
     "check:type": "tsc --noEmit",
     "check:bplint": "pnpm exec bp lint",
     "build": "bp build",
@@ -16,6 +17,7 @@
   },
   "devDependencies": {
     "@botpress/common": "workspace:*",
+    "@bpinternal/genenv": "0.0.1",
     "@types/json-schema": "^7.0.11",
     "@types/node": "^18.11.17",
     "@types/qs": "^6.9.7",

--- a/bots/hello-world/src/index.ts
+++ b/bots/hello-world/src/index.ts
@@ -7,7 +7,7 @@ const truncate = (str: string, maxLength: number = 500): string =>
 const bot = new bp.Bot({
   actions: {
     sayHello: async ({ input }) => {
-      const name = input?.name || 'world'
+      const name = input?.name || 'World'
       return { message: `Hello, ${name}!` }
     },
   },
@@ -22,14 +22,17 @@ bot.hook.after_incoming_message('*', async (x) => console.info('after_incoming_m
 bot.hook.after_outgoing_message('*', async (x) => console.info('after_outgoing_message', x.data))
 bot.hook.after_call_action('*', async (x) => console.info('after_call_action', x.data))
 
-bot.message(async ({ message, client, ctx }) => {
+bot.message(async (props) => {
+  const { message, client, ctx, self } = props
+
+  const { message: response } = await self.actionHandlers.sayHello({ ...props, input: {} })
   await client.createMessage({
     conversationId: message.conversationId,
     userId: ctx.botId,
     tags: {},
     type: 'text',
     payload: {
-      text: 'Hello world!',
+      text: response,
     },
   })
 })

--- a/bots/hello-world/src/index.ts
+++ b/bots/hello-world/src/index.ts
@@ -4,7 +4,14 @@ import * as bp from '.botpress'
 const truncate = (str: string, maxLength: number = 500): string =>
   str.length > maxLength ? `${str.slice(0, maxLength)}...` : str
 
-const bot = new bp.Bot({})
+const bot = new bp.Bot({
+  actions: {
+    sayHello: async ({ input }) => {
+      const name = input?.name || 'world'
+      return { message: `Hello, ${name}!` }
+    },
+  },
+})
 
 bot.hook.before_incoming_event('*', async (x) => console.info('before_incoming_event', x.data))
 bot.hook.before_incoming_message('*', async (x) => console.info('before_incoming_message', x.data))

--- a/bots/hit-looper/src/bot.ts
+++ b/bots/hit-looper/src/bot.ts
@@ -1,2 +1,2 @@
 import * as bp from '.botpress'
-export const bot = new bp.Bot({})
+export const bot = new bp.Bot({ actions: {} })

--- a/bots/sheetzy/src/bot.ts
+++ b/bots/sheetzy/src/bot.ts
@@ -1,2 +1,2 @@
 import * as bp from '.botpress'
-export const bot = new bp.Bot({})
+export const bot = new bp.Bot({ actions: {} })

--- a/bots/sinlin/src/bot.ts
+++ b/bots/sinlin/src/bot.ts
@@ -2,4 +2,4 @@ import * as bp from '.botpress'
 export * from '.botpress'
 
 export type IssueState = bp.states.issue.Issue
-export const bot = new bp.Bot({})
+export const bot = new bp.Bot({ actions: {} })

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "1.4.10",
+  "version": "1.5.0",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -22,7 +22,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/client": "0.35.0",
-    "@botpress/sdk": "1.4.0",
+    "@botpress/sdk": "1.5.0",
     "@bpinternal/const": "^0.0.20",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/src/code-generation/bot-implementation/bot-typings/actions-module.ts
+++ b/packages/cli/src/code-generation/bot-implementation/bot-typings/actions-module.ts
@@ -1,0 +1,54 @@
+import * as sdk from '@botpress/sdk'
+import { zuiSchemaToTypeScriptType } from '../../generators'
+import { Module, ReExportTypeModule } from '../../module'
+import * as strings from '../../strings'
+
+type ActionInput = sdk.BotActionDefinition['input']
+type ActionOutput = sdk.BotActionDefinition['output']
+
+export class ActionInputModule extends Module {
+  public constructor(private _input: ActionInput) {
+    const name = 'input'
+    const exportName = strings.typeName(name)
+    super({ path: `${name}.ts`, exportName })
+  }
+
+  public async getContent() {
+    return zuiSchemaToTypeScriptType(this._input.schema, this.exportName)
+  }
+}
+
+export class ActionOutputModule extends Module {
+  public constructor(private _output: ActionOutput) {
+    const name = 'output'
+    const exportName = strings.typeName(name)
+    super({ path: `${name}.ts`, exportName })
+  }
+
+  public async getContent() {
+    return zuiSchemaToTypeScriptType(this._output.schema, this.exportName)
+  }
+}
+
+export class ActionModule extends ReExportTypeModule {
+  public constructor(actionName: string, action: sdk.BotActionDefinition) {
+    super({ exportName: strings.typeName(actionName) })
+
+    const inputModule = new ActionInputModule(action.input)
+    const outputModule = new ActionOutputModule(action.output)
+
+    this.pushDep(inputModule)
+    this.pushDep(outputModule)
+  }
+}
+
+export class ActionsModule extends ReExportTypeModule {
+  public constructor(actions: Record<string, sdk.BotActionDefinition>) {
+    super({ exportName: strings.typeName('actions') })
+    for (const [actionName, action] of Object.entries(actions)) {
+      const module = new ActionModule(actionName, action)
+      module.unshift(actionName)
+      this.pushDep(module)
+    }
+  }
+}

--- a/packages/cli/src/code-generation/bot-implementation/bot-typings/index.ts
+++ b/packages/cli/src/code-generation/bot-implementation/bot-typings/index.ts
@@ -2,6 +2,7 @@ import * as sdk from '@botpress/sdk'
 import * as consts from '../../consts'
 import { IntegrationTypingsModule } from '../../integration-implementation/integration-typings'
 import { Module, ReExportTypeModule } from '../../module'
+import { ActionsModule } from './actions-module'
 import { EventsModule } from './events-module'
 import { StatesModule } from './states-module'
 
@@ -23,6 +24,7 @@ type BotTypingsIndexDependencies = {
   integrationsModule: BotIntegrationsModule
   eventsModule: EventsModule
   statesModule: StatesModule
+  actionsModule: ActionsModule
 }
 
 export class BotTypingsModule extends Module {
@@ -46,33 +48,43 @@ export class BotTypingsModule extends Module {
     statesModule.unshift('states')
     this.pushDep(statesModule)
 
+    const actionsModule = new ActionsModule(bot.actions ?? {})
+    actionsModule.unshift('actions')
+    this.pushDep(actionsModule)
+
     this._dependencies = {
       integrationsModule,
       eventsModule,
       statesModule,
+      actionsModule,
     }
   }
 
   public async getContent() {
-    const { integrationsModule, eventsModule, statesModule } = this._dependencies
+    const { integrationsModule, eventsModule, statesModule, actionsModule } = this._dependencies
 
     const integrationsImport = integrationsModule.import(this)
     const eventsImport = eventsModule.import(this)
     const statesImport = statesModule.import(this)
+    const actionsImport = actionsModule
+
     return [
       consts.GENERATED_HEADER,
       `import * as ${integrationsModule.name} from './${integrationsImport}'`,
       `import * as ${eventsModule.name} from './${eventsModule.name}'`,
       `import * as ${statesModule.name} from './${statesModule.name}'`,
+      `import * as ${actionsModule.name} from './${actionsImport.name}'`,
       '',
       `export * as ${integrationsModule.name} from './${integrationsImport}'`,
       `export * as ${eventsModule.name} from './${eventsImport}'`,
       `export * as ${statesModule.name} from './${statesImport}'`,
+      `export * as ${actionsModule.name} from './${actionsImport.name}'`,
       '',
       'export type TBot = {',
       `  integrations: ${integrationsModule.name}.${integrationsModule.exportName}`,
       `  events: ${eventsModule.name}.${eventsModule.exportName}`,
       `  states: ${statesModule.name}.${statesModule.exportName}`,
+      `  actions: ${actionsModule.name}.${actionsModule.exportName}`,
       '}',
     ].join('\n')
   }

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.35.0",
-    "@botpress/sdk": "1.4.0"
+    "@botpress/sdk": "1.5.0"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/empty-bot/src/index.ts
+++ b/packages/cli/templates/empty-bot/src/index.ts
@@ -1,5 +1,7 @@
 import * as bp from '.botpress'
 
-const bot = new bp.Bot({})
+const bot = new bp.Bot({
+  actions: {},
+})
 
 export default bot

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.35.0",
-    "@botpress/sdk": "1.4.0"
+    "@botpress/sdk": "1.5.0"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.35.0",
-    "@botpress/sdk": "1.4.0"
+    "@botpress/sdk": "1.5.0"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.35.0",
-    "@botpress/sdk": "1.4.0",
+    "@botpress/sdk": "1.5.0",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Botpress SDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/sdk/src/bot/definition.ts
+++ b/packages/sdk/src/bot/definition.ts
@@ -5,6 +5,7 @@ import z, { AnyZodObject } from '../zui'
 
 type BaseStates = Record<string, AnyZodObject>
 type BaseEvents = Record<string, AnyZodObject>
+type BaseActions = Record<string, AnyZodObject>
 
 export type TagDefinition = {
   title?: string
@@ -42,6 +43,13 @@ export type MessageDefinition = {
   tags?: Record<string, TagDefinition>
 }
 
+export type ActionDefinition<TAction extends BaseActions[string] = BaseActions[string]> = {
+  title?: string
+  description?: string
+  input: SchemaDefinition<TAction>
+  output: SchemaDefinition<AnyZodObject> // cannot infer both input and output types (typescript limitation)
+}
+
 export type IntegrationConfigInstance<I extends IntegrationPackage = IntegrationPackage> = {
   enabled: boolean
 } & (
@@ -59,7 +67,11 @@ export type IntegrationConfigInstance<I extends IntegrationPackage = Integration
 
 export type IntegrationInstance = IntegrationPackage & IntegrationConfigInstance
 
-export type BotDefinitionProps<TStates extends BaseStates = BaseStates, TEvents extends BaseEvents = BaseEvents> = {
+export type BotDefinitionProps<
+  TStates extends BaseStates = BaseStates,
+  TEvents extends BaseEvents = BaseEvents,
+  TActions extends BaseActions = BaseActions
+> = {
   integrations?: {
     [K: string]: IntegrationInstance
   }
@@ -74,9 +86,16 @@ export type BotDefinitionProps<TStates extends BaseStates = BaseStates, TEvents 
     [K in keyof TEvents]: EventDefinition<TEvents[K]>
   }
   recurringEvents?: Record<string, RecurringEventDefinition<TEvents>>
+  actions?: {
+    [K in keyof TActions]: ActionDefinition<TActions[K]>
+  }
 }
 
-export class BotDefinition<TStates extends BaseStates = BaseStates, TEvents extends BaseEvents = BaseEvents> {
+export class BotDefinition<
+  TStates extends BaseStates = BaseStates,
+  TEvents extends BaseEvents = BaseEvents,
+  TActions extends BaseActions = BaseActions
+> {
   public readonly integrations: this['props']['integrations']
   public readonly user: this['props']['user']
   public readonly conversation: this['props']['conversation']
@@ -85,7 +104,8 @@ export class BotDefinition<TStates extends BaseStates = BaseStates, TEvents exte
   public readonly configuration: this['props']['configuration']
   public readonly events: this['props']['events']
   public readonly recurringEvents: this['props']['recurringEvents']
-  public constructor(public readonly props: BotDefinitionProps<TStates, TEvents>) {
+  public readonly actions: this['props']['actions']
+  public constructor(public readonly props: BotDefinitionProps<TStates, TEvents, TActions>) {
     this.integrations = props.integrations
     this.user = props.user
     this.conversation = props.conversation
@@ -94,6 +114,7 @@ export class BotDefinition<TStates extends BaseStates = BaseStates, TEvents exte
     this.configuration = props.configuration
     this.events = props.events
     this.recurringEvents = props.recurringEvents
+    this.actions = props.actions
   }
 
   public add<I extends IntegrationPackage>(integrationPkg: I, config: IntegrationConfigInstance<I>): this {

--- a/packages/sdk/src/bot/server/types.ts
+++ b/packages/sdk/src/bot/server/types.ts
@@ -41,14 +41,14 @@ type OutgoingMessageResponses<TBot extends types.BaseBot> = {
   >
 }
 
-type CallActionRequests<TBot extends types.BaseBot> = {
+type OutgoingCallActionRequests<TBot extends types.BaseBot> = {
   [K in keyof types.EnumerateActionInputs<TBot>]: utils.Merge<
     client.ClientInputs['callAction'],
     { type: K; input: types.EnumerateActionInputs<TBot>[K] }
   >
 }
 
-type CallActionResponses<TBot extends types.BaseBot> = {
+type OutgoingCallActionResponses<TBot extends types.BaseBot> = {
   [K in keyof types.EnumerateActionOutputs<TBot>]: utils.Merge<
     client.ClientOutputs['callAction'],
     { output: types.EnumerateActionOutputs<TBot>[K] }
@@ -59,8 +59,8 @@ export type IncomingEvent<TBot extends types.BaseBot> = utils.ValueOf<IncomingEv
 export type IncomingMessage<TBot extends types.BaseBot> = utils.ValueOf<IncomingMessages<TBot>>
 export type OutgoingMessageRequest<TBot extends types.BaseBot> = utils.ValueOf<OutgoingMessageRequests<TBot>>
 export type OutgoingMessageResponse<TBot extends types.BaseBot> = utils.ValueOf<OutgoingMessageResponses<TBot>>
-export type CallActionRequest<TBot extends types.BaseBot> = utils.ValueOf<CallActionRequests<TBot>>
-export type CallActionResponse<TBot extends types.BaseBot> = utils.ValueOf<CallActionResponses<TBot>>
+export type OutgoingCallActionRequest<TBot extends types.BaseBot> = utils.ValueOf<OutgoingCallActionRequests<TBot>>
+export type OutgoingCallActionResponse<TBot extends types.BaseBot> = utils.ValueOf<OutgoingCallActionResponses<TBot>>
 
 export type CommonHandlerProps<TBot extends types.BaseBot> = {
   ctx: BotContext
@@ -90,6 +90,16 @@ export type StateExpiredPayload<_TBot extends types.BaseBot> = { state: client.S
 export type StateExpiredHandlerProps<TBot extends types.BaseBot> = CommonHandlerProps<TBot> & StateExpiredPayload<TBot>
 export type StateExpiredHandler<TBot extends types.BaseBot> = (args: StateExpiredHandlerProps<TBot>) => Promise<void>
 
+export type ActionHandlerPayloads<TBot extends types.BaseBot> = {
+  [K in keyof TBot['actions']]: { type: K; input: TBot['actions'][K]['input'] }
+}
+export type ActionHandlerProps<TBot extends types.BaseBot> = {
+  [K in keyof TBot['actions']]: CommonHandlerProps<TBot> & ActionHandlerPayloads<TBot>[K]
+}
+export type ActionHandlers<TBot extends types.BaseBot> = {
+  [K in keyof TBot['actions']]: (props: ActionHandlerProps<TBot>[K]) => Promise<TBot['actions'][K]['output']>
+}
+
 /**
  * TODO:
  * - add concept of stoppable / un-stoppable hooks (e.g. before_incoming_message  Vs before_outgoing_message)
@@ -99,11 +109,11 @@ export type HookDefinitions<TBot extends types.BaseBot> = {
   before_incoming_event: IncomingEvents<TBot> & { '*': IncomingEvent<TBot> }
   before_incoming_message: IncomingMessages<TBot> & { '*': IncomingMessage<TBot> }
   before_outgoing_message: OutgoingMessageRequests<TBot> & { '*': OutgoingMessageRequest<TBot> }
-  before_call_action: CallActionRequests<TBot> & { '*': CallActionRequest<TBot> }
+  before_call_action: OutgoingCallActionRequests<TBot> & { '*': OutgoingCallActionRequest<TBot> }
   after_incoming_event: IncomingEvents<TBot> & { '*': IncomingEvent<TBot> }
   after_incoming_message: IncomingMessages<TBot> & { '*': IncomingMessage<TBot> }
   after_outgoing_message: OutgoingMessageResponses<TBot> & { '*': OutgoingMessageResponse<TBot> }
-  after_call_action: CallActionResponses<TBot> & { '*': CallActionResponse<TBot> }
+  after_call_action: OutgoingCallActionResponses<TBot> & { '*': OutgoingCallActionResponse<TBot> }
 }
 
 export type HookInputs<TBot extends types.BaseBot> = {
@@ -139,6 +149,7 @@ export type HookImplementationsMap<TBot extends types.BaseBot> = {
 }
 
 export type BotHandlers<TBot extends types.BaseBot> = {
+  actionHandlers: ActionHandlers<TBot>
   messageHandlers: MessageHandler<TBot>[]
   eventHandlers: EventHandler<TBot>[]
   stateExpiredHandlers: StateExpiredHandler<TBot>[]

--- a/packages/sdk/src/bot/server/types.ts
+++ b/packages/sdk/src/bot/server/types.ts
@@ -65,6 +65,7 @@ export type OutgoingCallActionResponse<TBot extends types.BaseBot> = utils.Value
 export type CommonHandlerProps<TBot extends types.BaseBot> = {
   ctx: BotContext
   client: BotSpecificClient<TBot>
+  self: BotHandlers<TBot>
 }
 
 export type MessagePayload<TBot extends types.BaseBot> = {
@@ -91,7 +92,7 @@ export type StateExpiredHandlerProps<TBot extends types.BaseBot> = CommonHandler
 export type StateExpiredHandler<TBot extends types.BaseBot> = (args: StateExpiredHandlerProps<TBot>) => Promise<void>
 
 export type ActionHandlerPayloads<TBot extends types.BaseBot> = {
-  [K in keyof TBot['actions']]: { type: K; input: TBot['actions'][K]['input'] }
+  [K in keyof TBot['actions']]: { type?: K; input: TBot['actions'][K]['input'] }
 }
 export type ActionHandlerProps<TBot extends types.BaseBot> = {
   [K in keyof TBot['actions']]: CommonHandlerProps<TBot> & ActionHandlerPayloads<TBot>[K]

--- a/packages/sdk/src/bot/types/generic.ts
+++ b/packages/sdk/src/bot/types/generic.ts
@@ -7,6 +7,7 @@ export type BaseBot = {
   integrations: Record<string, BaseIntegration>
   events: Record<string, any>
   states: Record<string, any>
+  actions: Record<string, Record<'input' | 'output', any>>
 }
 
 /**
@@ -16,6 +17,7 @@ export type MakeBot<B extends Partial<BaseBot>> = {
   integrations: utils.Default<B['integrations'], BaseBot['integrations']>
   events: utils.Default<B['events'], BaseBot['events']>
   states: utils.Default<B['states'], BaseBot['states']>
+  actions: utils.Default<B['actions'], BaseBot['actions']>
 }
 
 type _MakeBot_creates_a_TBot = utils.AssertExtends<MakeBot<{}>, BaseBot>

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -51,6 +51,7 @@ export {
   UserDefinition as BotUserDefinition,
   ConversationDefinition as BotConversationDefinition,
   MessageDefinition as BotMessageDefinition,
+  ActionDefinition as BotActionDefinition,
 } from './bot'
 
 export {

--- a/packages/sdk/src/integration/implementation.ts
+++ b/packages/sdk/src/integration/implementation.ts
@@ -47,6 +47,6 @@ export class IntegrationImplementation<TIntegration extends BaseIntegration = Ba
     this.webhook = props.handler
   }
 
-  public readonly handler = integrationHandler(this as any as IntegrationImplementation<BaseIntegration>)
+  public readonly handler = integrationHandler(this as IntegrationImplementation<any>)
   public readonly start = (port?: number): Promise<Server> => serve(this.handler, port)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1746,7 +1746,7 @@ importers:
         specifier: 0.35.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 1.4.0
+        specifier: 1.5.0
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.0.20
@@ -1870,7 +1870,7 @@ importers:
         specifier: 0.35.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 1.4.0
+        specifier: 1.5.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1889,7 +1889,7 @@ importers:
         specifier: 0.35.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 1.4.0
+        specifier: 1.5.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1908,7 +1908,7 @@ importers:
         specifier: 0.35.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 1.4.0
+        specifier: 1.5.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1927,7 +1927,7 @@ importers:
         specifier: 0.35.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 1.4.0
+        specifier: 1.5.0
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       '@botpress/common':
         specifier: workspace:*
         version: link:../../packages/common
+      '@bpinternal/genenv':
+        specifier: 0.0.1
+        version: 0.0.1
       '@types/json-schema':
         specifier: ^7.0.11
         version: 7.0.12

--- a/turbo.json
+++ b/turbo.json
@@ -586,7 +586,7 @@
     },
     "@bp-bots/hello-world#add:integrations": {
       "cache": false,
-      "dependsOn": ["@botpress/cli#build", "@botpresshub/telegram#build"]
+      "dependsOn": ["@botpress/cli#build", "@botpresshub/telegram#build", "@botpresshub/webhook#build"]
     },
     "@bp-bots/hello-world#build": {
       "cache": false,


### PR DESCRIPTION
3 commits:

1. feat(sdk): bots can define actions

As expected, bots can define and implement actions. These actions are called by the bridge operation `callAction` of the API is called.

2. feat(sdk): bots can call their own actions in-memory without a network call

This is simply about adding a `self` parameter to all bot handlers which is the actual bot. This way the bot developer can call his own bot actions using `self.actionHandlers.sayHello({ ...props, input: {} })`

4. chore: bump sdk version

This should technically be a major bump since the previously generated code for bots will no longer pass the type-checking. Still, since very few users actually develop bots as code, we'll bump a minor and expect users to sync their SDK and CLI versions