### PR TITLE
fix(sdk): make default types resilient to deep partial inputs

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -22,7 +22,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/client": "0.35.0",
-    "@botpress/sdk": "1.6.0",
+    "@botpress/sdk": "1.6.1",
     "@bpinternal/const": "^0.0.20",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.35.0",
-    "@botpress/sdk": "1.6.0"
+    "@botpress/sdk": "1.6.1"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.35.0",
-    "@botpress/sdk": "1.6.0"
+    "@botpress/sdk": "1.6.1"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.35.0",
-    "@botpress/sdk": "1.6.0"
+    "@botpress/sdk": "1.6.1"
   },
   "devDependencies": {
     "@types/node": "^18.11.17",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.35.0",
-    "@botpress/sdk": "1.6.0",
+    "@botpress/sdk": "1.6.1",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Botpress SDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/sdk/src/bot/types/generic.test.ts
+++ b/packages/sdk/src/bot/types/generic.test.ts
@@ -1,0 +1,50 @@
+import { test } from 'vitest'
+import * as utils from '../../utils/type-utils'
+import { BaseBot, DefaultBot } from './generic'
+
+test('DefaultBot with empty input should return a valid BaseBot', () => {
+  type Default = DefaultBot<{}>
+  type _assertion = utils.AssertExtends<Default, BaseBot>
+})
+
+test('DefaultBot with missing key should return a valid BaseBot', () => {
+  type Default = DefaultBot<{
+    states: {
+      foo: {
+        current: string
+      }
+    }
+  }>
+  type _assertion = utils.AssertExtends<Default, BaseBot>
+})
+
+test('DefaultBot with missing integration key should return a valid BaseBot', () => {
+  type Default = DefaultBot<{
+    integrations: {
+      foo: {
+        name: 'foo'
+        version: '1.0.0'
+        configuration: { token: string }
+      }
+    }
+  }>
+  type _assertion = utils.AssertExtends<Default, BaseBot>
+})
+
+test('DefaultBot with missing integration channel key should return a valid BaseBot', () => {
+  type Default = DefaultBot<{
+    integrations: {
+      foo: {
+        name: 'foo'
+        version: '1.0.0'
+        configuration: { token: string }
+        channels: {
+          bar: {
+            messages: { text: { text: string } }
+          }
+        }
+      }
+    }
+  }>
+  type _assertion = utils.AssertExtends<Default, BaseBot>
+})

--- a/packages/sdk/src/bot/types/generic.ts
+++ b/packages/sdk/src/bot/types/generic.ts
@@ -25,5 +25,3 @@ export type DefaultBot<B extends utils.DeepPartial<BaseBot>> = {
         [K in keyof B['integrations']]: DefaultIntegration<utils.Cast<B['integrations'][K], InputBaseIntegration>>
       }
 }
-
-type _MakeBot_creates_a_TBot = utils.AssertExtends<DefaultBot<{}>, BaseBot>

--- a/packages/sdk/src/bot/types/generic.ts
+++ b/packages/sdk/src/bot/types/generic.ts
@@ -1,20 +1,29 @@
-import { BaseIntegration } from '../../integration/types/generic'
+import { BaseIntegration, DefaultIntegration, InputBaseIntegration } from '../../integration/types/generic'
 import * as utils from '../../utils/type-utils'
 
 export * from '../../integration/types/generic'
+
+export type BaseAction = {
+  input: any
+  output: any
+}
 
 export type BaseBot = {
   integrations: Record<string, BaseIntegration>
   events: Record<string, any>
   states: Record<string, any>
-  actions: Record<string, Record<'input' | 'output', any>>
+  actions: Record<string, BaseAction>
 }
 
-export type DefaultBot<B extends Partial<BaseBot>> = {
-  integrations: utils.Default<B['integrations'], BaseBot['integrations']>
+export type DefaultBot<B extends utils.DeepPartial<BaseBot>> = {
   events: utils.Default<B['events'], BaseBot['events']>
   states: utils.Default<B['states'], BaseBot['states']>
   actions: utils.Default<B['actions'], BaseBot['actions']>
+  integrations: undefined extends B['integrations']
+    ? BaseBot['integrations']
+    : {
+        [K in keyof B['integrations']]: DefaultIntegration<utils.Cast<B['integrations'][K], InputBaseIntegration>>
+      }
 }
 
 type _MakeBot_creates_a_TBot = utils.AssertExtends<DefaultBot<{}>, BaseBot>

--- a/packages/sdk/src/fixtures.ts
+++ b/packages/sdk/src/fixtures.ts
@@ -1,7 +1,7 @@
 import { DefaultBot } from './bot/types/generic'
 import { DefaultChannel, DefaultIntegration } from './integration/types/generic'
 
-export type FooBarBazIntegration = DefaultIntegration<{
+type _FooBarBazIntegration = {
   actions: {
     doFoo: {
       input: {
@@ -62,11 +62,13 @@ export type FooBarBazIntegration = DefaultIntegration<{
       }
     }>
   }
-}>
+}
+
+export type FooBarBazIntegration = DefaultIntegration<_FooBarBazIntegration>
 
 export type FooBarBazBot = DefaultBot<{
   integrations: {
-    fooBarBaz: FooBarBazIntegration
+    fooBarBaz: _FooBarBazIntegration
   }
 }>
 

--- a/packages/sdk/src/integration/types/generic.test.ts
+++ b/packages/sdk/src/integration/types/generic.test.ts
@@ -1,0 +1,28 @@
+import { test } from 'vitest'
+import * as utils from '../../utils/type-utils'
+import { BaseIntegration, DefaultIntegration } from './generic'
+
+test('DefaultIntegration with empty input should return a valid BaseIntegration', () => {
+  type Default = DefaultIntegration<{}>
+  type _assertion = utils.AssertExtends<Default, BaseIntegration>
+})
+
+test('DefaultIntegration with missing key should return a valid BaseIntegration', () => {
+  type Default = DefaultIntegration<{
+    name: 'foo'
+    version: '1.0.0'
+    configuration: { foo: 'bar' }
+  }>
+  type _assertion = utils.AssertExtends<Default, BaseIntegration>
+})
+
+test('DefaultIntegration with missing channel key should return a valid BaseIntegration', () => {
+  type Default = DefaultIntegration<{
+    channels: {
+      foo: {
+        messages: { text: { text: string } }
+      }
+    }
+  }>
+  type _assertion = utils.AssertExtends<Default, BaseIntegration>
+})

--- a/packages/sdk/src/integration/types/generic.ts
+++ b/packages/sdk/src/integration/types/generic.ts
@@ -1,17 +1,26 @@
 import * as utils from '../../utils/type-utils'
 
+export type BaseMessage = {
+  tags: Record<string, any>
+}
+
+export type BaseConversation = {
+  tags: Record<string, any>
+}
+
 export type BaseChannel = {
   messages: Record<string, any>
-  message: {
-    tags: Record<string, any>
-  }
-  conversation: {
-    tags: Record<string, any>
-    creation: {
-      enabled: boolean
-      requiredTags: string[]
-    }
-  }
+  message: BaseMessage
+  conversation: BaseConversation
+}
+
+export type BaseUser = {
+  tags: Record<string, any>
+}
+
+export type BaseAction = {
+  input: any
+  output: any
 }
 
 export type BaseIntegration = {
@@ -19,38 +28,35 @@ export type BaseIntegration = {
   version: string
   configuration: any
   configurations: Record<string, any>
-  actions: Record<string, Record<'input' | 'output', any>>
+  actions: Record<string, BaseAction>
   channels: Record<string, BaseChannel>
   events: Record<string, any>
   states: Record<string, any>
-  user: {
-    tags: Record<string, any>
-    creation: {
-      enabled: boolean
-      requiredTags: string[]
-    }
-  }
+  user: BaseUser
   entities: Record<string, any>
 }
 
-export type DefaultChannel<C extends Partial<BaseIntegration['channels'][string]>> = {
-  messages: utils.Default<C['messages'], BaseIntegration['channels'][string]['messages']>
-  message: utils.Default<C['message'], BaseIntegration['channels'][string]['message']>
-  conversation: utils.Default<C['conversation'], BaseIntegration['channels'][string]['conversation']>
+export type InputBaseChannel = utils.DeepPartial<BaseChannel>
+export type DefaultChannel<C extends InputBaseChannel> = {
+  messages: utils.Default<C['messages'], BaseChannel['messages']>
+  message: utils.Default<C['message'], BaseChannel['message']>
+  conversation: utils.Default<C['conversation'], BaseChannel['conversation']>
 }
 
-export type DefaultIntegration<I extends Partial<BaseIntegration>> = {
+export type InputBaseIntegration = utils.DeepPartial<BaseIntegration>
+export type DefaultIntegration<I extends InputBaseIntegration> = {
   name: utils.Default<I['name'], BaseIntegration['name']>
   version: utils.Default<I['version'], BaseIntegration['version']>
   configuration: utils.Default<I['configuration'], BaseIntegration['configuration']>
   configurations: utils.Default<I['configurations'], BaseIntegration['configurations']>
   actions: utils.Default<I['actions'], BaseIntegration['actions']>
-  channels: utils.Default<I['channels'], BaseIntegration['channels']>
   events: utils.Default<I['events'], BaseIntegration['events']>
   states: utils.Default<I['states'], BaseIntegration['states']>
   user: utils.Default<I['user'], BaseIntegration['user']>
   entities: utils.Default<I['entities'], BaseIntegration['entities']>
+  channels: undefined extends I['channels']
+    ? BaseIntegration['channels']
+    : {
+        [K in keyof I['channels']]: DefaultChannel<utils.Cast<I['channels'][K], InputBaseChannel>>
+      }
 }
-
-type _MakeChannel_creates_a_TChannel = utils.AssertExtends<DefaultChannel<{}>, BaseChannel>
-type _MakeIntegration_creates_a_TIntegration = utils.AssertExtends<DefaultIntegration<{}>, BaseIntegration>

--- a/packages/sdk/src/utils/type-utils.test.ts
+++ b/packages/sdk/src/utils/type-utils.test.ts
@@ -134,3 +134,32 @@ test('default should return default value if undefined', () => {
     ]
   >
 })
+
+test('deep partial should make all properties optional', () => {
+  type Actual = utils.DeepPartial<{
+    name: string
+    age: number
+    address: readonly {
+      street: string
+      city: string
+    }[]
+    data: Promise<Buffer>
+  }>
+  type Expected = {
+    name?: string
+    age?: number
+    address?: readonly {
+      street?: string
+      city?: string
+    }[]
+    data?: Promise<Buffer>
+  }
+  type _assertion = utils.AssertAll<
+    [
+      //
+      utils.AssertExtends<Actual, Expected>,
+      utils.AssertExtends<Expected, Actual>,
+      utils.AssertTrue<utils.IsEqual<Actual, Expected>>
+    ]
+  >
+})

--- a/packages/sdk/src/utils/type-utils.ts
+++ b/packages/sdk/src/utils/type-utils.ts
@@ -33,14 +33,32 @@ export type ToSealedRecord<R extends Record<string, any>> = {
   [K in keyof R as string extends K ? never : K]: R[K]
 }
 
+type NormalizeObject<T extends object> = T extends infer O ? { [K in keyof O]: Normalize<O[K]> } : never
 export type Normalize<T> = T extends (...args: infer A) => infer R
   ? (...args: Normalize<A>) => Normalize<R>
+  : T extends Array<infer E>
+  ? Array<Normalize<E>>
+  : T extends ReadonlyArray<infer E>
+  ? ReadonlyArray<Normalize<E>>
   : T extends Promise<infer R>
   ? Promise<Normalize<R>>
   : T extends Buffer
   ? Buffer
   : T extends object
-  ? T extends infer O
-    ? { [K in keyof O]: Normalize<O[K]> }
-    : never
+  ? NormalizeObject<T>
+  : T
+
+type DeepPartialObject<T extends object> = T extends infer O ? { [K in keyof O]?: DeepPartial<O[K]> } : never
+export type DeepPartial<T> = T extends (...args: infer A) => infer R
+  ? (...args: DeepPartial<A>) => DeepPartial<R>
+  : T extends Array<infer E>
+  ? Array<DeepPartial<E>>
+  : T extends ReadonlyArray<infer E>
+  ? ReadonlyArray<DeepPartial<E>>
+  : T extends Promise<infer R>
+  ? Promise<DeepPartial<R>>
+  : T extends Buffer
+  ? Buffer
+  : T extends object
+  ? DeepPartialObject<T>
   : T

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "noErrorTruncation": true
   },
   "include": ["src/**/*"],
   "exclude": ["dist"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1746,7 +1746,7 @@ importers:
         specifier: 0.35.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 1.6.0
+        specifier: 1.6.1
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.0.20
@@ -1870,7 +1870,7 @@ importers:
         specifier: 0.35.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 1.6.0
+        specifier: 1.6.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1889,7 +1889,7 @@ importers:
         specifier: 0.35.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 1.6.0
+        specifier: 1.6.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1908,7 +1908,7 @@ importers:
         specifier: 0.35.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 1.6.0
+        specifier: 1.6.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1927,7 +1927,7 @@ importers:
         specifier: 0.35.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 1.6.0
+        specifier: 1.6.1
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
this PR is related to: https://github.com/botpress/botpress/pull/13445

The goal is still the same; to allow adding `BaseBot` and `BaseIntegration` props without breaking previously generated code.

This way, users that do not use latest CLI will still be able to use lastest SDK