### PR TITLE
fix(integrations/googledrive): Fix file channels cache inconsistency when syncing

### DIFF
--- a/integrations/googledrive/src/handler.ts
+++ b/integrations/googledrive/src/handler.ts
@@ -22,12 +22,17 @@ export const handler: bp.IntegrationProps['handler'] = async (props) => {
     }
   }
 
+  const notification = notifParseResult.data
+  if (!NotificationHandler.isSupported(notification)) {
+    return
+  }
+
   const driveClient = await Client.create({ client, ctx, logger })
   const filesCache = await FilesCache.load({ client, ctx })
   const fileChannelsCache = await FileChannelsCache.load({ client, ctx })
   const fileEventHandler = new FileEventHandler(client, driveClient, filesCache, fileChannelsCache)
   const notificationHandler = new NotificationHandler(driveClient, filesCache, fileEventHandler)
-  await notificationHandler.handle(notifParseResult.data)
+  await notificationHandler.handle(notification)
   await filesCache.save()
   await fileChannelsCache.save()
 }

--- a/integrations/googledrive/src/notification-handler.ts
+++ b/integrations/googledrive/src/notification-handler.ts
@@ -12,6 +12,11 @@ export class NotificationHandler {
     private _fileEventHandler: FileEventHandler
   ) {}
 
+  public static isSupported(notification: Notification): boolean {
+    const type = notification.headers['x-goog-resource-state']
+    return type === 'update' || type === 'remove'
+  }
+
   public async handle(notification: Notification): Promise<void> {
     const type = notification.headers['x-goog-resource-state']
     const changes = notification.headers['x-goog-changed']


### PR DESCRIPTION
Fixes problem where cache was overwritten when receiving first 'sync' notifications' while still executing sync action