### PR TITLE
chore(integrations): handle LLM provider errors as UpstreamProviderError

### DIFF
--- a/integrations/anthropic/integration.definition.ts
+++ b/integrations/anthropic/integration.definition.ts
@@ -7,7 +7,7 @@ export default new IntegrationDefinition({
   name: 'anthropic',
   title: 'Anthropic',
   description: 'Access a curated list of Claude models to set as your chosen LLM.',
-  version: '5.1.0',
+  version: '5.2.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/anthropic/src/actions/generate-content.ts
+++ b/integrations/anthropic/src/actions/generate-content.ts
@@ -1,6 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { MessageCreateParams, MessageCreateParamsNonStreaming } from '@anthropic-ai/sdk/resources/messages'
-import { InvalidPayloadError, RuntimeError } from '@botpress/client'
+import { InvalidPayloadError, UpstreamProviderError } from '@botpress/client'
 import { llm } from '@botpress/common'
 import { z, IntegrationLogger } from '@botpress/sdk'
 import assert from 'assert'
@@ -86,13 +86,14 @@ export async function generateContent<M extends string>(
     if (err instanceof Anthropic.APIError) {
       const parsedInnerError = AnthropicInnerErrorSchema.safeParse(err.error)
       if (parsedInnerError.success) {
-        throw new RuntimeError(
-          `Anthropic error ${err.status} (${parsedInnerError.data.error.type}) - ${parsedInnerError.data.error.message}`
+        throw new UpstreamProviderError(
+          `Anthropic error ${err.status} (${parsedInnerError.data.error.type}) - ${parsedInnerError.data.error.message}`,
+          err
         )
       }
     }
 
-    throw new RuntimeError(err.message)
+    throw new UpstreamProviderError(err.message, err)
   } finally {
     if (input.debug && response) {
       logger.forBot().info('Response received from Anthropic: ' + JSON.stringify(response, null, 2))

--- a/integrations/cerebras/integration.definition.ts
+++ b/integrations/cerebras/integration.definition.ts
@@ -8,7 +8,7 @@ export default new IntegrationDefinition({
   title: 'Cerebras',
   description:
     'Get access to a curated list of Cerebras models for content generation and chat completions within your bot.',
-  version: '2.1.0',
+  version: '2.2.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/fireworks-ai/integration.definition.ts
+++ b/integrations/fireworks-ai/integration.definition.ts
@@ -9,7 +9,7 @@ export default new IntegrationDefinition({
   title: 'Fireworks AI',
   description:
     'Choose from curated Fireworks AI models for content generation, chat completions, and audio transcription.',
-  version: '3.1.0',
+  version: '3.2.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/google-ai/integration.definition.ts
+++ b/integrations/google-ai/integration.definition.ts
@@ -7,7 +7,7 @@ export default new IntegrationDefinition({
   name: 'google-ai',
   title: 'Google AI',
   description: 'Gain access to Gemini models for content generation, chat responses, and advanced language tasks.',
-  version: '1.0.0',
+  version: '1.1.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/google-ai/src/actions/generate-content.ts
+++ b/integrations/google-ai/src/actions/generate-content.ts
@@ -1,4 +1,4 @@
-import { InvalidPayloadError, RuntimeError } from '@botpress/client'
+import { InvalidPayloadError, UpstreamProviderError } from '@botpress/client'
 import { llm } from '@botpress/common'
 import { IntegrationLogger } from '@botpress/sdk'
 import {
@@ -43,7 +43,7 @@ export async function generateContent<M extends string>(
   try {
     ;({ response } = await googleAIModel.generateContent(request))
   } catch (err: any) {
-    throw new RuntimeError(`Google AI error: ${err.message}`)
+    throw new UpstreamProviderError(`Google AI error: ${err.message}`, err)
   } finally {
     if (input.debug && response) {
       logger.forBot().info('Response received from Google AI: ' + JSON.stringify(response, null, 2))

--- a/integrations/groq/integration.definition.ts
+++ b/integrations/groq/integration.definition.ts
@@ -8,7 +8,7 @@ export default new IntegrationDefinition({
   name: 'groq',
   title: 'Groq',
   description: 'Gain access to Groq models for content generation, chat responses, and audio transcription.',
-  version: '9.0.0',
+  version: '9.1.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/openai/integration.definition.ts
+++ b/integrations/openai/integration.definition.ts
@@ -18,7 +18,7 @@ export default new IntegrationDefinition({
   title: 'OpenAI',
   description:
     'Gain access to OpenAI models for text generation, speech synthesis, audio transcription, and image generation.',
-  version: '9.0.0',
+  version: '9.1.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/openai/src/index.ts
+++ b/integrations/openai/src/index.ts
@@ -1,4 +1,4 @@
-import { InvalidPayloadError } from '@botpress/client'
+import { InvalidPayloadError, UpstreamProviderError } from '@botpress/client'
 import { llm, speechToText, textToImage } from '@botpress/common'
 import crypto from 'crypto'
 import { TextToSpeechPricePer1MCharacters } from 'integration.definition'
@@ -269,7 +269,13 @@ export default new bp.Integration({
         speed: input.speed ?? 1,
       }
 
-      const response = await openAIClient.audio.speech.create(params)
+      let response: Response
+
+      try {
+        response = await openAIClient.audio.speech.create(params)
+      } catch (err: any) {
+        throw new UpstreamProviderError(err.message, err)
+      }
 
       const key = generateFileKey('openai-generateSpeech-', input, `.${params.response_format}`)
 

--- a/packages/chat-api/package.json
+++ b/packages/chat-api/package.json
@@ -13,7 +13,7 @@
     "esbuild": "^0.16.12"
   },
   "dependencies": {
-    "@botpress/api": "0.56.0",
+    "@botpress/api": "0.57.0",
     "@bpinternal/opapi": "0.10.30",
     "lodash": "^4.17.21",
     "zod": "^3.20.6",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -21,8 +21,8 @@
   "main": "dist/index.js",
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
-    "@botpress/client": "0.37.1",
-    "@botpress/sdk": "2.0.3",
+    "@botpress/client": "0.38.0",
+    "@botpress/sdk": "2.0.4",
     "@bpinternal/const": "^0.0.20",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -5,8 +5,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.37.1",
-    "@botpress/sdk": "2.0.3"
+    "@botpress/client": "0.38.0",
+    "@botpress/sdk": "2.0.4"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.37.1",
-    "@botpress/sdk": "2.0.3"
+    "@botpress/client": "0.38.0",
+    "@botpress/sdk": "2.0.4"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "2.0.3"
+    "@botpress/sdk": "2.0.4"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.37.1",
-    "@botpress/sdk": "2.0.3"
+    "@botpress/client": "0.38.0",
+    "@botpress/sdk": "2.0.4"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.37.1",
-    "@botpress/sdk": "2.0.3",
+    "@botpress/client": "0.38.0",
+    "@botpress/sdk": "2.0.4",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -31,7 +31,7 @@
     "type-fest": "^3.4.0"
   },
   "devDependencies": {
-    "@botpress/api": "0.56.0",
+    "@botpress/api": "0.57.0",
     "@types/qs": "^6.9.7",
     "esbuild": "^0.16.12",
     "lodash": "^4.17.21",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "0.37.1",
+  "version": "0.38.0",
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/common/src/llm/openai.ts
+++ b/packages/common/src/llm/openai.ts
@@ -1,4 +1,4 @@
-import { InvalidPayloadError, RuntimeError } from '@botpress/client'
+import { InvalidPayloadError, UpstreamProviderError } from '@botpress/client'
 import { z, IntegrationLogger } from '@botpress/sdk'
 import assert from 'assert'
 import OpenAI from 'openai'
@@ -108,12 +108,11 @@ export async function generateContent<M extends string>(
           parsedError.data.error?.message ?? err.message
         }`
 
-        throw new RuntimeError(message)
+        throw new UpstreamProviderError(message, err)
       }
     }
 
-    // Fallback
-    throw new RuntimeError(err.message)
+    throw new UpstreamProviderError(`${props.provider} error: ${err.message}`, err)
   } finally {
     if (input.debug && response) {
       logger.forBot().info(`Response received from ${props.provider}: ` + JSON.stringify(response, null, 2))

--- a/packages/common/src/speech-to-text/openai.ts
+++ b/packages/common/src/speech-to-text/openai.ts
@@ -1,4 +1,4 @@
-import { InvalidPayloadError } from '@botpress/client'
+import { InvalidPayloadError, UpstreamProviderError } from '@botpress/client'
 import { IntegrationLogger } from '@botpress/sdk'
 import OpenAI from 'openai'
 import * as stt from '.'
@@ -40,12 +40,11 @@ export async function transcribeAudio<M extends string>(
   } catch (err: any) {
     if (err instanceof OpenAI.APIError) {
       logger.forBot().error(`${props.provider} error: ${err.message}`)
-      throw err
+    } else {
+      logger.forBot().error(err.message)
     }
 
-    // Fallback
-    logger.forBot().error(err.message)
-    throw err
+    throw new UpstreamProviderError(`${props.provider} error: ${err.message}`, err)
   }
 
   // Note: OpenAI client doesn't have typings for the verbose JSON response format

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Botpress SDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -14,7 +14,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "0.37.1",
+    "@botpress/client": "0.38.0",
     "@bpinternal/zui": "0.12.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1990,8 +1990,8 @@ importers:
         version: 3.11.1
     devDependencies:
       '@botpress/api':
-        specifier: 0.56.0
-        version: 0.56.0(openapi-types@12.1.3)
+        specifier: 0.57.0
+        version: 0.57.0(openapi-types@12.1.3)
       '@types/qs':
         specifier: ^6.9.7
         version: 6.9.7
@@ -3668,6 +3668,17 @@ packages:
       - debug
       - openapi-types
       - supports-color
+    dev: false
+
+  /@botpress/api@0.57.0(openapi-types@12.1.3):
+    resolution: {integrity: sha512-P2qDhGT2AAARNF15goczLWoKTSGK+xzpo2mItfFlV0ZYtWsbZ+bjaCDWqkf8QrcNBO9wId9VudHIjGLdfuV5xQ==}
+    dependencies:
+      '@bpinternal/opapi': 0.10.22(openapi-types@12.1.3)
+    transitivePeerDependencies:
+      - debug
+      - openapi-types
+      - supports-color
+    dev: true
 
   /@botpress/client@0.14.2:
     resolution: {integrity: sha512-hHtwGbqg4mTN2V5fQjSCZtp80JJt7W541wFs9bFphAbFuWmLHk40Y502oHsb3JLlJHgFdFaJloE5ZmEhHckKLg==}
@@ -7798,6 +7809,7 @@ packages:
     engines: {node: '>=6.5'}
     dependencies:
       event-target-shim: 5.0.1
+    dev: false
 
   /abortcontroller-polyfill@1.7.5:
     resolution: {integrity: sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==}
@@ -8697,6 +8709,7 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    dev: false
 
   /bundle-require@4.0.2(esbuild@0.19.12):
     resolution: {integrity: sha512-jwzPOChofl67PSTW2SGubV9HBQAhhR2i6nskiOThauo9dzwDUgOWQScFVaJkjEfYX+UXiD+LEx8EblQMc2wIag==}
@@ -10136,6 +10149,7 @@ packages:
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
+    dev: false
 
   /eventemitter3@3.1.2:
     resolution: {integrity: sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==}
@@ -10148,6 +10162,7 @@ packages:
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+    dev: false
 
   /eventsource@2.0.2:
     resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
@@ -12431,17 +12446,6 @@ packages:
       triple-beam: 1.3.0
     dev: false
 
-  /logform@2.6.1:
-    resolution: {integrity: sha512-CdaO738xRapbKIMVn2m4F6KTj4j7ooJ8POVnebSgKo3KBz5axNXRAL7ZdRjIV6NOr2Uf4vjtRkxrFETOioCqSA==}
-    engines: {node: '>= 12.0.0'}
-    dependencies:
-      '@colors/colors': 1.6.0
-      '@types/triple-beam': 1.3.2
-      fecha: 4.2.3
-      ms: 2.1.3
-      safe-stable-stringify: 2.4.3
-      triple-beam: 1.3.0
-
   /logform@2.7.0:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
     engines: {node: '>= 12.0.0'}
@@ -13525,10 +13529,6 @@ packages:
   /process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
-  /process@0.11.10:
-    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
-    engines: {node: '>= 0.6.0'}
-
   /progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
@@ -13726,16 +13726,6 @@ packages:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-
-  /readable-stream@4.5.2:
-    resolution: {integrity: sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      abort-controller: 3.0.0
-      buffer: 6.0.3
-      events: 3.3.0
-      process: 0.11.10
-      string_decoder: 1.3.0
 
   /readable-web-to-node-stream@3.0.2:
     resolution: {integrity: sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==}
@@ -15713,14 +15703,6 @@ packages:
       triple-beam: 1.3.0
     dev: false
 
-  /winston-transport@4.8.0:
-    resolution: {integrity: sha512-qxSTKswC6llEMZKgCQdaWgDuMJQnhuvF5f2Nk3SNXc4byfQ+voo2mX1Px9dkNOuR8p0KAjfPG29PuYUSIb+vSA==}
-    engines: {node: '>= 12.0.0'}
-    dependencies:
-      logform: 2.7.0
-      readable-stream: 4.5.2
-      triple-beam: 1.3.0
-
   /winston-transport@4.9.0:
     resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
     engines: {node: '>= 12.0.0'}
@@ -15728,7 +15710,6 @@ packages:
       logform: 2.7.0
       readable-stream: 3.6.2
       triple-beam: 1.3.0
-    dev: false
 
   /winston@3.13.0:
     resolution: {integrity: sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==}
@@ -15738,13 +15719,13 @@ packages:
       '@dabh/diagnostics': 2.0.3
       async: 3.2.4
       is-stream: 2.0.1
-      logform: 2.6.1
+      logform: 2.7.0
       one-time: 1.0.0
       readable-stream: 3.6.2
       safe-stable-stringify: 2.4.3
       stack-trace: 0.0.10
       triple-beam: 1.3.0
-      winston-transport: 4.8.0
+      winston-transport: 4.9.0
 
   /winston@3.17.0:
     resolution: {integrity: sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1659,8 +1659,8 @@ importers:
   packages/chat-api:
     dependencies:
       '@botpress/api':
-        specifier: 0.56.0
-        version: 0.56.0(openapi-types@12.1.3)
+        specifier: 0.57.0
+        version: 0.57.0(openapi-types@12.1.3)
       '@bpinternal/opapi':
         specifier: 0.10.30
         version: 0.10.30(openapi-types@12.1.3)
@@ -3660,16 +3660,6 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@botpress/api@0.56.0(openapi-types@12.1.3):
-    resolution: {integrity: sha512-k3uvethP5KXIvth7zBX70LadQuA3gmMdplrD/Yid9u0cqWdNypFEVp+0rWZh/BMRawcQImvsLhpEw6GMq806HA==}
-    dependencies:
-      '@bpinternal/opapi': 0.10.22(openapi-types@12.1.3)
-    transitivePeerDependencies:
-      - debug
-      - openapi-types
-      - supports-color
-    dev: false
-
   /@botpress/api@0.57.0(openapi-types@12.1.3):
     resolution: {integrity: sha512-P2qDhGT2AAARNF15goczLWoKTSGK+xzpo2mItfFlV0ZYtWsbZ+bjaCDWqkf8QrcNBO9wId9VudHIjGLdfuV5xQ==}
     dependencies:
@@ -3678,7 +3668,6 @@ packages:
       - debug
       - openapi-types
       - supports-color
-    dev: true
 
   /@botpress/client@0.14.2:
     resolution: {integrity: sha512-hHtwGbqg4mTN2V5fQjSCZtp80JJt7W541wFs9bFphAbFuWmLHk40Y502oHsb3JLlJHgFdFaJloE5ZmEhHckKLg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1773,10 +1773,10 @@ importers:
         specifier: ^11.7.0
         version: 11.7.0
       '@botpress/client':
-        specifier: 0.37.1
+        specifier: 0.38.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 2.0.3
+        specifier: 2.0.4
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.0.20
@@ -1894,10 +1894,10 @@ importers:
   packages/cli/templates/empty-bot:
     dependencies:
       '@botpress/client':
-        specifier: 0.37.1
+        specifier: 0.38.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 2.0.3
+        specifier: 2.0.4
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1910,10 +1910,10 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 0.37.1
+        specifier: 0.38.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 2.0.3
+        specifier: 2.0.4
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1926,7 +1926,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 2.0.3
+        specifier: 2.0.4
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1939,10 +1939,10 @@ importers:
   packages/cli/templates/hello-world:
     dependencies:
       '@botpress/client':
-        specifier: 0.37.1
+        specifier: 0.38.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 2.0.3
+        specifier: 2.0.4
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1955,10 +1955,10 @@ importers:
   packages/cli/templates/webhook-message:
     dependencies:
       '@botpress/client':
-        specifier: 0.37.1
+        specifier: 0.38.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 2.0.3
+        specifier: 2.0.4
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8
@@ -2020,7 +2020,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 0.37.1
+        specifier: 0.38.0
         version: link:../client
       '@bpinternal/zui':
         specifier: 0.12.0


### PR DESCRIPTION
This will allow the DM to detect when the upstream LLM provider (e.g. OpenAI) is failing and use a different LLM integration as fallback.