### PR TITLE
chore: rm turbo cache in CI/CD

### DIFF
--- a/.github/workflows/check-integration-versions.yml
+++ b/.github/workflows/check-integration-versions.yml
@@ -14,9 +14,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup
         uses: ./.github/actions/setup
-        with:
-          turbo_team: ${{ secrets.TURBO_TEAM }}
-          turbo_token: ${{ secrets.TURBO_TOKEN }}
       - name: Login to Botpress
         run: pnpm bp login -y --token ${{ secrets.PRODUCTION_TOKEN_CLOUD_OPS_ACCOUNT }} --workspace-id ${{ secrets.PRODUCTION_CLOUD_OPS_WORKSPACE_ID }}
       - name: Get changed files

--- a/.github/workflows/deploy-bots.yml
+++ b/.github/workflows/deploy-bots.yml
@@ -18,9 +18,6 @@ jobs:
           BUGBUSTER_SLACK_BOT_TOKEN: ${{ secrets.BUGBUSTER_SLACK_BOT_TOKEN }}
           BUGBUSTER_SLACK_SIGNING_SECRET: ${{ secrets.BUGBUSTER_SLACK_SIGNING_SECRET }}
         uses: ./.github/actions/setup
-        with:
-          turbo_team: ${{ secrets.TURBO_TEAM }}
-          turbo_token: ${{ secrets.TURBO_TOKEN }}
       - name: Deploy Bots
         run: |
           api_url="https://api.botpress.cloud"

--- a/.github/workflows/deploy-integrations-production.yml
+++ b/.github/workflows/deploy-integrations-production.yml
@@ -20,9 +20,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup
         uses: ./.github/actions/setup
-        with:
-          turbo_team: ${{ secrets.TURBO_TEAM }}
-          turbo_token: ${{ secrets.TURBO_TOKEN }}
       - name: Deploy Interfaces
         uses: ./.github/actions/deploy-interfaces
         with:

--- a/.github/workflows/deploy-integrations-staging.yml
+++ b/.github/workflows/deploy-integrations-staging.yml
@@ -24,9 +24,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup
         uses: ./.github/actions/setup
-        with:
-          turbo_team: ${{ secrets.TURBO_TEAM }}
-          turbo_token: ${{ secrets.TURBO_TOKEN }}
       - name: Deploy Interfaces
         uses: ./.github/actions/deploy-interfaces
         with:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -22,8 +22,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           extra_filters: "-F '@botpress/*'"
-          turbo_team: ${{ secrets.TURBO_TEAM }}
-          turbo_token: ${{ secrets.TURBO_TOKEN }}
+
       - name: Publish Client
         uses: botpress/gh-actions/publish-if-not-exists@master
         with:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          extra_filters: "-F '@botpress/*'"
+          extra_filters: '-F @botpress/*'
 
       - name: Publish Client
         uses: botpress/gh-actions/publish-if-not-exists@master

--- a/.github/workflows/run-chat-tests.yml
+++ b/.github/workflows/run-chat-tests.yml
@@ -18,8 +18,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           extra_filters: '-F @botpresshub/chat -F @bp-bots/echo -F @botpress/chat'
-          turbo_team: ${{ secrets.TURBO_TEAM }}
-          turbo_token: ${{ secrets.TURBO_TOKEN }}
       - name: Install tilt
         run: curl -k -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
       - name: Run Tilt

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -12,15 +12,11 @@ jobs:
     timeout-minutes: 15
     env:
       NODE_OPTIONS: '--max_old_space_size=8192'
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+
     steps:
       - uses: actions/checkout@v2
       - name: Setup
         uses: ./.github/actions/setup
-        with:
-          turbo_team: ${{ secrets.TURBO_TEAM }}
-          turbo_token: ${{ secrets.TURBO_TOKEN }}
       - run: pnpm run check:dep
       - run: pnpm run check:sherif
       - run: pnpm run check:format

--- a/.github/workflows/run-cli-tests.yml
+++ b/.github/workflows/run-cli-tests.yml
@@ -20,8 +20,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           extra_filters: '-F @botpress/cli'
-          turbo_team: ${{ secrets.TURBO_TEAM }}
-          turbo_token: ${{ secrets.TURBO_TOKEN }}
       - run: |
           pnpm run -F cli test:e2e -v \
             --api-url https://api.botpress.dev \

--- a/.github/workflows/run-client-tests.yml
+++ b/.github/workflows/run-client-tests.yml
@@ -18,8 +18,6 @@ jobs:
         uses: ./.github/actions/setup
         with:
           extra_filters: '-F @botpress/client'
-          turbo_team: ${{ secrets.TURBO_TEAM }}
-          turbo_token: ${{ secrets.TURBO_TOKEN }}
       - run: |
           # pnpm -F client exec puppeteer browsers install chrome
           pnpm -F client run test:e2e

--- a/packages/chat-client/package.json
+++ b/packages/chat-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/chat",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Botpress Chat API Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/cli/.npmignore
+++ b/packages/cli/.npmignore
@@ -3,6 +3,7 @@ node_modules
 tsconfig.tsbuildinfo
 
 /src
+/e2e
 /tsconfig.json
 
 /templates/*/dist

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -21,7 +21,7 @@
   "main": "dist/index.js",
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
-    "@botpress/chat": "0.4.4",
+    "@botpress/chat": "0.4.5",
     "@botpress/client": "0.38.1",
     "@botpress/sdk": "2.0.5",
     "@bpinternal/const": "^0.0.20",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -22,8 +22,8 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.4.4",
-    "@botpress/client": "0.38.0",
-    "@botpress/sdk": "2.0.4",
+    "@botpress/client": "0.38.1",
+    "@botpress/sdk": "2.0.5",
     "@bpinternal/const": "^0.0.20",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -5,8 +5,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.38.0",
-    "@botpress/sdk": "2.0.4"
+    "@botpress/client": "0.38.1",
+    "@botpress/sdk": "2.0.5"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.38.0",
-    "@botpress/sdk": "2.0.4"
+    "@botpress/client": "0.38.1",
+    "@botpress/sdk": "2.0.5"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "2.0.4"
+    "@botpress/sdk": "2.0.5"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.38.0",
-    "@botpress/sdk": "2.0.4"
+    "@botpress/client": "0.38.1",
+    "@botpress/sdk": "2.0.5"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.38.0",
-    "@botpress/sdk": "2.0.4",
+    "@botpress/client": "0.38.1",
+    "@botpress/sdk": "2.0.5",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Botpress SDK",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -14,7 +14,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "0.38.0",
+    "@botpress/client": "0.38.1",
     "@bpinternal/zui": "0.12.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1776,10 +1776,10 @@ importers:
         specifier: 0.4.4
         version: link:../chat-client
       '@botpress/client':
-        specifier: 0.38.0
+        specifier: 0.38.1
         version: link:../client
       '@botpress/sdk':
-        specifier: 2.0.4
+        specifier: 2.0.5
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.0.20
@@ -1897,10 +1897,10 @@ importers:
   packages/cli/templates/empty-bot:
     dependencies:
       '@botpress/client':
-        specifier: 0.38.0
+        specifier: 0.38.1
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 2.0.4
+        specifier: 2.0.5
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1913,10 +1913,10 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 0.38.0
+        specifier: 0.38.1
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 2.0.4
+        specifier: 2.0.5
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1929,7 +1929,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 2.0.4
+        specifier: 2.0.5
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1942,10 +1942,10 @@ importers:
   packages/cli/templates/hello-world:
     dependencies:
       '@botpress/client':
-        specifier: 0.38.0
+        specifier: 0.38.1
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 2.0.4
+        specifier: 2.0.5
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1958,10 +1958,10 @@ importers:
   packages/cli/templates/webhook-message:
     dependencies:
       '@botpress/client':
-        specifier: 0.38.0
+        specifier: 0.38.1
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 2.0.4
+        specifier: 2.0.5
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8
@@ -2023,7 +2023,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 0.38.0
+        specifier: 0.38.1
         version: link:../client
       '@bpinternal/zui':
         specifier: 0.12.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1773,7 +1773,7 @@ importers:
         specifier: ^11.7.0
         version: 11.7.0
       '@botpress/chat':
-        specifier: 0.4.4
+        specifier: 0.4.5
         version: link:../chat-client
       '@botpress/client':
         specifier: 0.38.1


### PR DESCRIPTION
The latest version of the CLI fails with `Error: Cannot find module './dist/index.js'` and I believe it might be a turbo caching problem.