### PR TITLE
feat(browser): add `waitFor` configuration

### DIFF
--- a/integrations/browser/integration.definition.ts
+++ b/integrations/browser/integration.definition.ts
@@ -13,13 +13,14 @@ export default new IntegrationDefinition({
   actions: actionDefinitions,
   configuration: {
     schema: z.object({
-      waitFor: z
+       renderWaitTime: z
         .number()
         .min(0)
         .max(10_000)
         .optional()
         .default(0)
-        .describe('Wait x amount of milliseconds for the page to load to fetch content'),
+        .title('Render Wait Time')
+        .describe('Defines the wait time in milliseconds for the page to render before fetching content. Adjust for pages with heavy or dynamic elements.'),
     }),
   },
   secrets: {

--- a/integrations/browser/integration.definition.ts
+++ b/integrations/browser/integration.definition.ts
@@ -1,16 +1,27 @@
 /* bplint-disable */
-import { IntegrationDefinition } from '@botpress/sdk'
+import { IntegrationDefinition, z } from '@botpress/sdk'
 import { actionDefinitions } from 'src/definitions/actions'
 
 export default new IntegrationDefinition({
   name: 'browser',
   title: 'Browser',
-  version: '0.2.2',
+  version: '0.3.0',
   description:
     'Capture screenshots and retrieve web page content with metadata for automated browsing and data extraction.',
   readme: 'hub.md',
   icon: 'icon.svg',
   actions: actionDefinitions,
+  configuration: {
+    schema: z.object({
+      waitFor: z
+        .number()
+        .min(0)
+        .max(10_000)
+        .optional()
+        .default(0)
+        .describe('Wait x amount of milliseconds for the page to load to fetch content'),
+    }),
+  },
   secrets: {
     SCREENSHOT_API_KEY: {},
     FIRECRAWL_API_KEY: {},

--- a/integrations/browser/src/actions/browse-pages.ts
+++ b/integrations/browser/src/actions/browse-pages.ts
@@ -28,6 +28,7 @@ const getPageContent = async ({
     'https://api.firecrawl.dev/v0/scrape',
     {
       url,
+      // https://docs.firecrawl.dev/v0/api-reference/endpoint/scrape
       pageOptions: {
         onlyMainContent: true,
         waitFor,

--- a/integrations/browser/src/actions/browse-pages.ts
+++ b/integrations/browser/src/actions/browse-pages.ts
@@ -51,7 +51,7 @@ export const browsePages: bp.IntegrationProps['actions']['browsePages'] = async 
 
   try {
     const pageContentPromises = await Promise.allSettled(
-      input.urls.map((url) => getPageContent({ url, logger, waitFor: ctx.configuration.waitFor }))
+      input.urls.map((url) => getPageContent({ url, logger, waitFor: ctx.configuration.renderWaitTime }))
     )
 
     return {


### PR DESCRIPTION
To correctly crawl some client-side rendered content we might need to wait

https://docs.firecrawl.dev/v0/api-reference/endpoint/scrape