### PR TITLE
fix(integrations/openai): don't send temperature param when using o1 models

### DIFF
--- a/integrations/openai/integration.definition.ts
+++ b/integrations/openai/integration.definition.ts
@@ -18,7 +18,7 @@ export default new IntegrationDefinition({
   title: 'OpenAI',
   description:
     'Gain access to OpenAI models for text generation, speech synthesis, audio transcription, and image generation.',
-  version: '10.0.0',
+  version: '10.0.1',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/openai/src/index.ts
+++ b/integrations/openai/src/index.ts
@@ -203,6 +203,13 @@ export default new bp.Integration({
           provider,
           models: languageModels,
           defaultModel: DEFAULT_LANGUAGE_MODEL_ID,
+          overrideRequest: (request) => {
+            if (input.model?.id.startsWith('o1-')) {
+              // The o1 models don't allow setting temperature
+              delete request.temperature
+            }
+            return request
+          },
         }
       )
       metadata.setCost(output.botpress.cost)

--- a/packages/common/src/llm/openai.ts
+++ b/packages/common/src/llm/openai.ts
@@ -40,6 +40,7 @@ export async function generateContent<M extends string>(
     provider: string
     models: Record<M, ModelDetails>
     defaultModel: M
+    overrideRequest?: (request: ChatCompletionCreateParamsNonStreaming) => ChatCompletionCreateParamsNonStreaming
   }
 ): Promise<GenerateContentOutput> {
   const modelId = (input.model?.id || props.defaultModel) as M
@@ -76,7 +77,7 @@ export async function generateContent<M extends string>(
 
   let response: OpenAI.Chat.Completions.ChatCompletion | undefined
 
-  const request: ChatCompletionCreateParamsNonStreaming = {
+  let request: ChatCompletionCreateParamsNonStreaming = {
     model: modelId,
     max_tokens: input.maxTokens || undefined, // note: ignore a zero value as the Studio doesn't support empty number inputs and is defaulting this to 0
     temperature: input.temperature,
@@ -88,6 +89,10 @@ export async function generateContent<M extends string>(
     messages,
     tool_choice: mapToOpenAIToolChoice(input.toolChoice),
     tools: mapToOpenAITools(input.tools),
+  }
+
+  if (props.overrideRequest) {
+    request = props.overrideRequest(request)
   }
 
   if (input.debug) {


### PR DESCRIPTION
This fixes the following error from OpenAI (it doesn't seem to be mentioned in their documentation):

> OpenAI error 400 (invalid_request_error:unsupported_parameter): Unsupported parameter: 'temperature' is not supported with this model