### PR TITLE
feat(integrations/slack): Implement typing indicator interface

### DIFF
--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -26,6 +26,7 @@ const sharedConfig = {
   typingIndicatorEmoji: z
     .boolean()
     .default(false)
+    .title('Typing Indicator Emoji')
     .describe('Temporarily add an emoji to received messages to indicate when bot is processing message'),
 }
 
@@ -132,14 +133,17 @@ export default new IntegrationDefinition({
       title: 'Reaction Removed',
       description: 'Triggered when a reaction is removed from a message',
       schema: z.object({
-        reaction: z.string(),
-        userId: z.string().optional(),
-        conversationId: z.string().optional(),
-        targets: z.object({
-          dm: z.record(z.string()).optional(),
-          channel: z.record(z.string()).optional(),
-          thread: z.record(z.string()).optional(),
-        }),
+        reaction: z.string().title('Reaction').describe('The reaction that was removed'),
+        userId: z.string().optional().title('User ID').describe('The ID of the user who removed the reaction'),
+        conversationId: z.string().optional().title('Conversation ID').describe('The ID of the conversation'),
+        targets: z
+          .object({
+            dm: z.record(z.string()).optional(),
+            channel: z.record(z.string()).optional(),
+            thread: z.record(z.string()).optional(),
+          })
+          .title('Targets')
+          .describe('The targets of the reaction'),
       }),
     },
     memberJoinedWorkspace: {
@@ -178,15 +182,21 @@ export default new IntegrationDefinition({
           .optional()
           .title('Botpress Inviter User ID')
           .describe('The Botpress ID of the user who invited the new member'),
-        targets: z.object({
-          slackUserId: z.string().title('Slack User ID').describe('The Slack ID of the user who joined the channel'),
-          slackChannelId: z.string().title('Slack Channel ID').describe('The Slack ID of the channel the user joined'),
-          slackInviterId: z
-            .string()
-            .optional()
-            .title('Slack Inviter ID')
-            .describe('The Slack ID of the user who invited the new member'),
-        }),
+        targets: z
+          .object({
+            slackUserId: z.string().title('Slack User ID').describe('The Slack ID of the user who joined the channel'),
+            slackChannelId: z
+              .string()
+              .title('Slack Channel ID')
+              .describe('The Slack ID of the channel the user joined'),
+            slackInviterId: z
+              .string()
+              .optional()
+              .title('Slack Inviter ID')
+              .describe('The Slack ID of the user who invited the new member'),
+          })
+          .title('Targets')
+          .describe('Slack IDs of the user, channel and inviter'),
       }),
     },
     memberLeftChannel: {
@@ -201,10 +211,13 @@ export default new IntegrationDefinition({
           .string()
           .title('Botpress Channel ID')
           .describe('The Botpress ID of the channel the user left'),
-        targets: z.object({
-          slackUserId: z.string().title('Slack User ID').describe('The Slack ID of the user who left the channel'),
-          slackChannelId: z.string().title('Slack Channel ID').describe('The Slack ID of the channel the user left'),
-        }),
+        targets: z
+          .object({
+            slackUserId: z.string().title('Slack User ID').describe('The Slack ID of the user who left the channel'),
+            slackChannelId: z.string().title('Slack Channel ID').describe('The Slack ID of the channel the user left'),
+          })
+          .title('Targets')
+          .describe('Slack IDs of the user and channel'),
       }),
     },
   },

--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -1,6 +1,6 @@
-/* bplint-disable */
 import { z, IntegrationDefinition } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
+import typingIndicator from 'bp_modules/typing-indicator'
 
 import {
   addReaction,
@@ -23,13 +23,17 @@ const sharedConfig = {
     .title('Bot avatar URL')
     .describe("URL for the image used as the Slack bot's avatar"),
   botName: z.string().optional().title('Bot name').describe('Name displayed as the sender in Slack conversations'),
+  typingIndicatorEmoji: z
+    .boolean()
+    .default(false)
+    .describe('Temporarily add an emoji to received messages to indicate when bot is processing message'),
 }
 
 export default new IntegrationDefinition({
   name: 'slack',
   title: 'Slack',
   description: 'Automate interactions with your team.',
-  version: '1.0.4',
+  version: '1.1.0',
   icon: 'icon.svg',
   readme: 'hub.md',
   configuration: {
@@ -223,4 +227,4 @@ export default new IntegrationDefinition({
     extractScript: 'extract.vrl',
     fallbackHandlerScript: 'fallbackHandler.vrl',
   },
-})
+}).extend(typingIndicator, () => ({}))

--- a/integrations/slack/package.json
+++ b/integrations/slack/package.json
@@ -28,5 +28,8 @@
     "@sentry/cli": "^2.39.1",
     "@types/lodash": "^4.14.191",
     "@types/verror": "^1.10.6"
+  },
+  "bpDependencies": {
+    "typing-indicator": "../../interfaces/typing-indicator"
   }
 }

--- a/integrations/slack/src/actions/index.ts
+++ b/integrations/slack/src/actions/index.ts
@@ -3,6 +3,7 @@ import { findTarget } from './find-target'
 import { syncMembers } from './list-users'
 import { retrieveMessage } from './retreive-message'
 import { startDmConversation } from './start-dm'
+import { startTypingIndicator, stopTypingIndicator } from './typing-indicator'
 import { updateChannelTopic } from './update-channel-topic'
 
 import * as bp from '.botpress'
@@ -14,4 +15,6 @@ export default {
   syncMembers,
   startDmConversation,
   updateChannelTopic,
+  startTypingIndicator,
+  stopTypingIndicator,
 } satisfies bp.IntegrationProps['actions']

--- a/integrations/slack/src/actions/typing-indicator.ts
+++ b/integrations/slack/src/actions/typing-indicator.ts
@@ -17,7 +17,6 @@ export const startTypingIndicator = wrapActionAndInjectSlackClient('startTypingI
       input,
     })
     await markAsSeen({ props, input })
-    // TODO: Send ... and update once real message is sent? Tag the attached message with the typing indicator Slack message ID
     return {}
   },
   errorMessage: 'Failed to start typing indicator',

--- a/integrations/slack/src/actions/typing-indicator.ts
+++ b/integrations/slack/src/actions/typing-indicator.ts
@@ -36,7 +36,7 @@ export const stopTypingIndicator = wrapActionAndInjectSlackClient('stopTypingInd
 })
 
 const markAsSeen = async ({
-  props: { client, logger, slackClient },
+  props: { client, ctx, logger, slackClient },
   input: { conversationId, messageId },
 }: {
   props: InjectedProps
@@ -58,6 +58,12 @@ const markAsSeen = async ({
     channel,
     ts,
   }
+  await SlackScopes.ensureHasAllScopes({
+    client,
+    ctx,
+    requiredScopes: ['channels:manage', 'groups:write', 'im:write', 'mpim:write'],
+    operation: 'conversations.mark',
+  })
   await slackClient.conversations.mark(markAsSeenArgs)
 }
 

--- a/integrations/slack/src/actions/typing-indicator.ts
+++ b/integrations/slack/src/actions/typing-indicator.ts
@@ -1,0 +1,101 @@
+import { RuntimeError } from '@botpress/client'
+import { wrapActionAndInjectSlackClient } from 'src/actions/action-wrapper'
+import { SlackScopes } from 'src/misc/slack-scopes'
+
+type WrapActionAction = Parameters<
+  typeof wrapActionAndInjectSlackClient<'startTypingIndicator' | 'stopTypingIndicator'>
+>[1]['action']
+type InjectedProps = Parameters<WrapActionAction>[0]
+type ActionInput = Parameters<WrapActionAction>[1]
+
+export const startTypingIndicator = wrapActionAndInjectSlackClient('startTypingIndicator', {
+  async action(props, input) {
+    await modifyReaction({
+      reactionName: 'eyes',
+      type: 'add',
+      props,
+      input,
+    })
+    await markAsSeen({ props, input })
+    // TODO: Send ... and update once real message is sent? Tag the attached message with the typing indicator Slack message ID
+    return {}
+  },
+  errorMessage: 'Failed to start typing indicator',
+})
+
+export const stopTypingIndicator = wrapActionAndInjectSlackClient('stopTypingIndicator', {
+  async action(props, input) {
+    await modifyReaction({
+      reactionName: 'eyes',
+      type: 'remove',
+      props,
+      input,
+    })
+    return {}
+  },
+  errorMessage: 'Failed to stop typing indicator',
+})
+
+const markAsSeen = async ({
+  props: { client, logger, slackClient },
+  input: { conversationId, messageId },
+}: {
+  props: InjectedProps
+  input: ActionInput
+}) => {
+  const { message } = await client.getMessage({ id: messageId })
+  const { conversation } = await client.getConversation({ id: conversationId })
+  logger.forBot().debug(`Marking message ${messageId} as seen in conversation ${conversationId} (typing indicator)`)
+
+  const channel = conversation.tags.id
+  const ts = message.tags.ts
+  if (!channel) {
+    throw new RuntimeError('Channel ID is missing in conversation tags')
+  }
+  if (!ts) {
+    throw new RuntimeError('Timestamp is missing in message tags')
+  }
+  const markAsSeenArgs = {
+    channel,
+    ts,
+  }
+  await slackClient.conversations.mark(markAsSeenArgs)
+}
+
+const modifyReaction = async ({
+  reactionName,
+  type,
+  input: { conversationId, messageId },
+  props: { client, slackClient, ctx, logger },
+}: {
+  reactionName: string
+  type: 'add' | 'remove'
+  input: ActionInput
+  props: InjectedProps
+}) => {
+  const { message } = await client.getMessage({ id: messageId })
+  const { conversation } = await client.getConversation({ id: conversationId })
+  const reactionArgs = {
+    name: reactionName,
+    channel: conversation.tags.id,
+    timestamp: message.tags.ts,
+  }
+
+  const operation = type === 'add' ? 'reactions.add' : 'reactions.remove'
+  await SlackScopes.ensureHasAllScopes({
+    client,
+    ctx,
+    requiredScopes: ['reactions:write'],
+    operation,
+  })
+  logger
+    .forBot()
+    .debug(
+      `Sending reaction to Slack message ${messageId} in conversation ${conversationId} (typing indicator): ${type} ${reactionName}`
+    )
+  if (type === 'add') {
+    await slackClient.reactions.add(reactionArgs)
+  } else {
+    await slackClient.reactions.remove(reactionArgs)
+  }
+}

--- a/integrations/slack/src/definitions/channels.ts
+++ b/integrations/slack/src/definitions/channels.ts
@@ -63,6 +63,12 @@ export const thread = {
   messages,
   message: { tags: messageTags },
   conversation: {
-    tags: { ...convoTags, thread: {} },
+    tags: {
+      ...convoTags,
+      thread: {
+        title: 'Thread ID',
+        description: 'The Slack ID of the thread',
+      },
+    },
   },
 } satisfies ChannelDef


### PR DESCRIPTION
This implements the typing indicator interface by adding a temporary emoji to the incoming message while it is processed by the bot. The incoming message is also marked as seen.
This also adds titles and descriptions to the integration definition fields to fix linting errors.