### PR TITLE
feat(integrations/instagram): Implement proactive user and conversation creation interfaces

### DIFF
--- a/integrations/instagram/integration.definition.ts
+++ b/integrations/instagram/integration.definition.ts
@@ -12,11 +12,15 @@ export default new IntegrationDefinition({
   readme: 'hub.md',
   configuration: {
     schema: z.object({
-      appId: z.string().min(1),
-      appSecret: z.string().min(1),
-      verifyToken: z.string().min(1),
-      pageId: z.string().min(1),
-      accessToken: z.string().min(1),
+      appId: z.string().min(1).title('App ID').describe('The Meta App ID'),
+      appSecret: z.string().min(1).title('App Secret').describe('The Meta App Secret'),
+      verifyToken: z.string().min(1).title('Verify Token').describe('The verify token used to verify webhook requests'),
+      pageId: z.string().min(1).title('Page ID').describe('The Facebook page ID linked to the Instagram account'),
+      accessToken: z
+        .string()
+        .min(1)
+        .title('Access Token')
+        .describe('The access token of the Facebook page to your Meta App'),
       instagramBusinessAccountId: z
         .string()
         .min(1)
@@ -29,10 +33,32 @@ export default new IntegrationDefinition({
   },
   channels: {
     channel: {
+      title: 'Direct Message',
+      description: 'Direct message conversation between an Instagram user and the bot',
       messages: { ...messages.defaults, markdown: messages.markdown },
-      message: { tags: { id: {}, messageId: {}, senderId: {}, recipientId: {} } },
+      message: {
+        tags: {
+          id: {
+            title: 'Message ID',
+            description: 'The Instagram message ID',
+          },
+          senderId: {
+            title: 'Sender ID',
+            description: 'The Instagram user ID of the message sender',
+          },
+          recipientId: {
+            title: 'Recipient ID',
+            description: 'The Instagram user ID of the message recipient',
+          },
+        },
+      },
       conversation: {
-        tags: { id: {} },
+        tags: {
+          id: {
+            title: 'Conversation ID',
+            description: 'The Instagram user ID of the user taking part in the conversation',
+          },
+        },
       },
     },
   },
@@ -40,7 +66,12 @@ export default new IntegrationDefinition({
   events: {},
   secrets: sentryHelpers.COMMON_SECRET_NAMES,
   user: {
-    tags: { id: {} },
+    tags: {
+      id: {
+        title: 'User ID',
+        description: 'The Instagram user ID',
+      },
+    },
   },
   entities: {
     user: {

--- a/integrations/instagram/integration.definition.ts
+++ b/integrations/instagram/integration.definition.ts
@@ -14,7 +14,7 @@ export default new IntegrationDefinition({
     schema: z.object({
       appId: z.string().min(1).title('App ID').describe('The Meta App ID'),
       appSecret: z.string().min(1).title('App Secret').describe('The Meta App Secret'),
-      verifyToken: z.string().min(1).title('Verify Token').describe('The verify token used to verify webhook requests'),
+      verifyToken: z.string().min(1).title('Verify Token').describe('The token used to verify webhook requests'),
       pageId: z.string().min(1).title('Page ID').describe('The Facebook page ID linked to the Instagram account'),
       accessToken: z
         .string()

--- a/integrations/instagram/integration.definition.ts
+++ b/integrations/instagram/integration.definition.ts
@@ -1,10 +1,11 @@
-/* bplint-disable */
 import { z, IntegrationDefinition, messages } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
+import proactiveConversation from 'bp_modules/proactive-conversation'
+import proactiveUser from 'bp_modules/proactive-user'
 
 export default new IntegrationDefinition({
   name: 'instagram',
-  version: '0.4.6',
+  version: '1.0.0',
   title: 'Instagram',
   description: 'Automate interactions, manage comments, and send/receive messages all in real-time.',
   icon: 'icon.svg',
@@ -16,6 +17,14 @@ export default new IntegrationDefinition({
       verifyToken: z.string().min(1),
       pageId: z.string().min(1),
       accessToken: z.string().min(1),
+      instagramBusinessAccountId: z
+        .string()
+        .min(1)
+        .optional()
+        .title('Instagram Business Account ID')
+        .describe(
+          'The Instagram Business Account ID of the Instagram profile connected to the Facebook page. Set this value if it is different from the Facebook page ID.'
+        ),
     }),
   },
   channels: {
@@ -23,8 +32,7 @@ export default new IntegrationDefinition({
       messages: { ...messages.defaults, markdown: messages.markdown },
       message: { tags: { id: {}, messageId: {}, senderId: {}, recipientId: {} } },
       conversation: {
-        tags: { id: {}, recipientId: {}, senderId: {} },
-        creation: { enabled: true, requiredTags: ['id'] },
+        tags: { id: {} },
       },
     },
   },
@@ -33,6 +41,37 @@ export default new IntegrationDefinition({
   secrets: sentryHelpers.COMMON_SECRET_NAMES,
   user: {
     tags: { id: {} },
-    creation: { enabled: true, requiredTags: ['id'] },
+  },
+  entities: {
+    user: {
+      title: 'User',
+      description: 'An Instagram user',
+      schema: z
+        .object({
+          id: z.string().title('ID').describe('The Instagram user ID'),
+        })
+        .title('User')
+        .describe('The user object fields'),
+    },
+    dm: {
+      title: 'Direct Message',
+      description: 'An Instagram direct message conversation',
+      schema: z
+        .object({
+          id: z.string().title('User ID').describe('The Instagram user ID of the user taking part in the conversation'),
+        })
+        .title('Conversation')
+        .describe('The conversation object fields'),
+    },
   },
 })
+  .extend(proactiveUser, ({ user }) => {
+    return {
+      user,
+    }
+  })
+  .extend(proactiveConversation, ({ dm }) => {
+    return {
+      conversation: dm,
+    }
+  })

--- a/integrations/instagram/integration.definition.ts
+++ b/integrations/instagram/integration.definition.ts
@@ -27,7 +27,7 @@ export default new IntegrationDefinition({
         .optional()
         .title('Instagram Business Account ID')
         .describe(
-          'The Instagram Business Account ID of the Instagram profile connected to the Facebook page. Set this value if it is different from the Facebook page ID.'
+          'The Instagram Business Account ID of the Instagram profile connected to the Facebook page. Set this if it differs from the Facebook page ID.'
         ),
     }),
   },
@@ -56,7 +56,7 @@ export default new IntegrationDefinition({
         tags: {
           id: {
             title: 'Conversation ID',
-            description: 'The Instagram user ID of the user taking part in the conversation',
+            description: 'The Instagram user ID of the user in the conversation',
           },
         },
       },
@@ -89,20 +89,16 @@ export default new IntegrationDefinition({
       description: 'An Instagram direct message conversation',
       schema: z
         .object({
-          id: z.string().title('User ID').describe('The Instagram user ID of the user taking part in the conversation'),
+          id: z.string().title('User ID').describe('The Instagram user ID of the user in the conversation'),
         })
         .title('Conversation')
         .describe('The conversation object fields'),
     },
   },
 })
-  .extend(proactiveUser, ({ user }) => {
-    return {
-      user,
-    }
-  })
-  .extend(proactiveConversation, ({ dm }) => {
-    return {
-      conversation: dm,
-    }
-  })
+  .extend(proactiveUser, ({ user }) => ({
+    user,
+  }))
+  .extend(proactiveConversation, ({ dm }) => ({
+    conversation: dm,
+  }))

--- a/integrations/instagram/package.json
+++ b/integrations/instagram/package.json
@@ -19,5 +19,9 @@
     "@botpress/cli": "workspace:*",
     "@botpress/common": "workspace:*",
     "@sentry/cli": "^2.39.1"
+  },
+  "bpDependencies": {
+    "proactiveUser": "../../interfaces/proactive-user",
+    "proactiveConversation": "../../interfaces/proactive-conversation"
   }
 }

--- a/integrations/instagram/src/misc/incoming-message.ts
+++ b/integrations/instagram/src/misc/incoming-message.ts
@@ -1,5 +1,5 @@
 import { InstagramMessage, IntegrationLogger } from './types'
-import { getUserProfile } from './utils'
+import { getBotInstagramUserId, getUserProfile } from './utils'
 import * as bp from '.botpress'
 
 export async function handleMessage(
@@ -8,12 +8,15 @@ export async function handleMessage(
 ) {
   if (message?.message?.text) {
     logger.forBot().debug('Received text message from Instagram:', message.message.text)
+    const botInstagramUserId = getBotInstagramUserId(ctx)
+    if (message.sender.id === botInstagramUserId) {
+      logger.forBot().debug('Ignoring message from bot')
+      return
+    }
     const { conversation } = await client.getOrCreateConversation({
       channel: 'channel',
       tags: {
         id: message.sender.id,
-        senderId: message.sender.id,
-        recipientId: message.recipient.id,
       },
     })
 
@@ -41,7 +44,7 @@ export async function handleMessage(
       }
     }
 
-    await client.createMessage({
+    await client.getOrCreateMessage({
       type: 'text',
       tags: {
         id: message.message.mid,

--- a/integrations/instagram/src/misc/outgoing-message.ts
+++ b/integrations/instagram/src/misc/outgoing-message.ts
@@ -1,5 +1,5 @@
 import { MessengerClient } from 'messaging-api-messenger'
-import { getMessengerClient } from './utils'
+import { getBotInstagramUserId, getMessengerClient } from './utils'
 import * as bp from '.botpress'
 
 type Channels = bp.Integration['channels']
@@ -19,6 +19,8 @@ export async function sendMessage(
   await ack({
     tags: {
       id: message.messageId,
+      senderId: getBotInstagramUserId(ctx),
+      recipientId,
     },
   })
 }

--- a/integrations/instagram/src/misc/utils.ts
+++ b/integrations/instagram/src/misc/utils.ts
@@ -111,3 +111,8 @@ export const getUserProfile = async (
     })) as InstagramUserProfile
   }
 }
+
+export const getBotInstagramUserId = (ctx: bp.Context) => {
+  const { instagramBusinessAccountId, pageId } = ctx.configuration
+  return instagramBusinessAccountId ?? pageId
+}


### PR DESCRIPTION
This PR replaces the deprecated `createUser` and `createConversation` functions by the integration specific implementations of the `proactiveUser` and `proactiveConversation` interfaces. 

Some fixes were also done while at it:
- Reactivate linting and fix linting errors
- Ensure bot user/messages and conversations are not duplicated