### PR TITLE
feat(integrations/todoist): validate signature of incoming webhooks

### DIFF
--- a/.github/workflows/deploy-integrations-production.yml
+++ b/.github/workflows/deploy-integrations-production.yml
@@ -53,7 +53,7 @@ jobs:
           whatsapp_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_WHATSAPP_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_WHATSAPP_CLIENT_SECRET }} --secrets ACCESS_TOKEN=${{ secrets.PRODUCTION_WHATSAPP_ACCESS_TOKEN }} --secrets NUMBER_PIN=${{ secrets.PRODUCTION_WHATSAPP_NUMBER_PIN }} --secrets SEGMENT_KEY=${{ secrets.PRODUCTION_WHATSAPP_SEGMENT_KEY }}'
           anthropic_secrets: '--secrets ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}'
           fireworks_ai_secrets: '--secrets FIREWORKS_AI_API_KEY=${{ secrets.FIREWORKS_AI_API_KEY }}'
-          todoist_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_TODOIST_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_TODOIST_CLIENT_SECRET }}'
+          todoist_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_TODOIST_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_TODOIST_CLIENT_SECRET }} --secrets WEBHOOK_SHARED_SECRET=${{ secrets.PRODUCTION_TODOIST_WEBHOOK_SHARED_SECRET }}'
           cerebras_secrets: '--secrets CEREBRAS_API_KEY=${{ secrets.CEREBRAS_API_KEY }}'
           messenger_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_MESSENGER_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_MESSENGER_CLIENT_SECRET  }} --secrets ACCESS_TOKEN=${{ secrets.PRODUCTION_MESSENGER_ACCESS_TOKEN  }}'
           github_secrets: "--secrets GITHUB_APP_ID=${{ secrets.PRODUCTION_GITHUB_APP_ID }} --secrets 'GITHUB_PRIVATE_KEY=${{ secrets.PRODUCTION_GITHUB_PRIVATE_KEY }}' --secrets GITHUB_WEBHOOK_SECRET=${{ secrets.PRODUCTION_GITHUB_WEBHOOK_SECRET }}"

--- a/.github/workflows/deploy-integrations-staging.yml
+++ b/.github/workflows/deploy-integrations-staging.yml
@@ -56,7 +56,7 @@ jobs:
           groq_secrets: '--secrets GROQ_API_KEY=${{ secrets.GROQ_API_KEY }}'
           anthropic_secrets: '--secrets ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}'
           fireworks_ai_secrets: '--secrets FIREWORKS_AI_API_KEY=${{ secrets.FIREWORKS_AI_API_KEY }}'
-          todoist_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_TODOIST_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_TODOIST_CLIENT_SECRET }}'
+          todoist_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_TODOIST_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_TODOIST_CLIENT_SECRET }} --secrets WEBHOOK_SHARED_SECRET=${{ secrets.STAGING_TODOIST_WEBHOOK_SHARED_SECRET }}'
           cerebras_secrets: '--secrets CEREBRAS_API_KEY=${{ secrets.CEREBRAS_API_KEY }}'
           messenger_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_MESSENGER_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_MESSENGER_CLIENT_SECRET  }} --secrets ACCESS_TOKEN=${{ secrets.STAGING_MESSENGER_ACCESS_TOKEN  }}'
           github_secrets: "--secrets GITHUB_APP_ID=${{ secrets.STAGING_GITHUB_APP_ID }} --secrets 'GITHUB_PRIVATE_KEY=${{ secrets.STAGING_GITHUB_PRIVATE_KEY }}' --secrets GITHUB_WEBHOOK_SECRET=${{ secrets.STAGING_GITHUB_WEBHOOK_SECRET }}"

--- a/integrations/todoist/definitions/secrets.ts
+++ b/integrations/todoist/definitions/secrets.ts
@@ -9,4 +9,8 @@ export const secrets = {
     optional: false,
     description: 'Client Secret in the App Management page of your Todoist app',
   },
+  WEBHOOK_SHARED_SECRET: {
+    optional: false,
+    description: 'Webhook shared secret',
+  },
 } as const satisfies sdk.IntegrationDefinitionProps['secrets']

--- a/integrations/todoist/integration.definition.ts
+++ b/integrations/todoist/integration.definition.ts
@@ -17,7 +17,7 @@ export default new sdk.IntegrationDefinition({
   name: 'todoist',
   title: 'Todoist',
   description: 'Create and modify tasks, post comments and more.',
-  version: '0.0.5',
+  version: '0.0.6',
   readme: 'hub.md',
   icon: 'icon.svg',
   actions,

--- a/integrations/todoist/src/webhook-events/handler-dispatcher.ts
+++ b/integrations/todoist/src/webhook-events/handler-dispatcher.ts
@@ -1,3 +1,5 @@
+import sdk from '@botpress/sdk'
+import * as crypto from 'crypto'
 import { handleCommentAddedEvent, isCommentAddedEvent } from './handlers/comment-added'
 import { oauthCallbackHandler } from './handlers/oauth-callback'
 import { handlePriorityChangedEvent, isPriorityChangedEvent } from './handlers/priority-changed'
@@ -19,7 +21,7 @@ const EVENT_HANDLERS: Readonly<WebhookEventHandlerEntry<any>[]> = [
 export const handler: bp.IntegrationProps['handler'] = async (props: bp.HandlerProps) => {
   const { logger, req } = props
 
-  if (req.path === '/oauth') {
+  if (props.req.path.startsWith('/oauth')) {
     logger.forBot().info('Handling Todoist OAuth callback')
     return await oauthCallbackHandler(props)
   }
@@ -30,8 +32,40 @@ export const handler: bp.IntegrationProps['handler'] = async (props: bp.HandlerP
 
   console.debug(req)
 
+  await _ensureWebhookIsAuthenticated(props)
   await _dispatchEvent(props)
 }
+
+const _ensureWebhookIsAuthenticated = async ({ req }: bp.HandlerProps) => {
+  // Calculating the checksum is computationally expensive, so we first check
+  // whether a specific string (the "shared secret") is present in the query
+  // parameters to short-circuit the validation process.
+
+  if (!_isSharedSecretValid(req) || !_isChecksumValid(req)) {
+    throw new sdk.RuntimeError('Webhook request is not properly authenticated')
+  }
+}
+
+const _isSharedSecretValid = (req: sdk.Request) => {
+  const searchParams = new URLSearchParams(req.query)
+  const sharedSecret = searchParams.get('shared_secret')
+
+  return sharedSecret === bp.secrets.WEBHOOK_SHARED_SECRET
+}
+
+const _isChecksumValid = (req: sdk.Request) => {
+  const http_headers = new Headers(req.headers as Record<string, string>)
+  const todoist_checksum = http_headers.get('X-Todoist-Hmac-SHA256')
+  const actual_checksum = _computeRequestChecksum(req)
+
+  return todoist_checksum === actual_checksum
+}
+
+const _computeRequestChecksum = (req: sdk.Request) =>
+  crypto
+    .createHmac('sha256', bp.secrets.CLIENT_SECRET)
+    .update(req.body ?? '')
+    .digest('base64')
 
 const _dispatchEvent = async (props: bp.HandlerProps) => {
   const event = _getEventData(props)


### PR DESCRIPTION
## #13440 should be merged first
> once #13440 is merged, the *base* of this PR should be changed from `pb/todoist-refac` to `master` before merging

---

The secrets have already been added to the repo. Tested in staging and it works as expected.