### PR TITLE
feat(integrations/todoist): fetch user's avatar/name

### DIFF
--- a/integrations/todoist/definitions/states.ts
+++ b/integrations/todoist/definitions/states.ts
@@ -10,6 +10,8 @@ export const states = {
         .describe('The access token used to communicate with the Todoist API'),
     }),
   },
+
+  // TODO: This state is unused. Delete it in the next major version.
   configuration: {
     type: 'integration',
     schema: z.object({

--- a/integrations/todoist/definitions/user-tags.ts
+++ b/integrations/todoist/definitions/user-tags.ts
@@ -3,8 +3,8 @@ import sdk from '@botpress/sdk'
 export const user = {
   tags: {
     id: {
-      title: 'User ID',
-      description: 'The ID of a user',
+      title: 'Todoist User ID',
+      description: 'The unique ID of the user on Todoist',
     },
   },
 } as const satisfies sdk.IntegrationDefinitionProps['user']

--- a/integrations/todoist/integration.definition.ts
+++ b/integrations/todoist/integration.definition.ts
@@ -17,7 +17,7 @@ export default new sdk.IntegrationDefinition({
   name: 'todoist',
   title: 'Todoist',
   description: 'Create and modify tasks, post comments and more.',
-  version: '0.0.5',
+  version: '0.1.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   actions,

--- a/integrations/todoist/src/setup.ts
+++ b/integrations/todoist/src/setup.ts
@@ -5,15 +5,13 @@ export const register: bp.IntegrationProps['register'] = async ({ logger, client
   logger.forBot().info('Registering Todoist integration')
 
   const todoistClient = await TodoistClient.create({ client, ctx })
-  const userId = await todoistClient.getAuthenticatedUserId()
+  const userIdentity = await todoistClient.getAuthenticatedUserIdentity()
 
-  await client.setState({
-    id: ctx.integrationId,
-    type: 'integration',
-    name: 'configuration',
-    payload: {
-      botUserId: userId,
-    },
+  await client.updateUser({
+    id: ctx.botUserId,
+    name: userIdentity.name,
+    pictureUrl: userIdentity.pictureUrl,
+    tags: { id: userIdentity.id },
   })
 }
 

--- a/integrations/todoist/src/todoist-api/todoist-client.ts
+++ b/integrations/todoist/src/todoist-api/todoist-client.ts
@@ -34,8 +34,12 @@ export class TodoistClient {
   }
 
   @handleErrors('Failed to retrieve authenticated user')
-  public getAuthenticatedUserId() {
-    return this._todoistSyncClient.getAuthenticatedUserId()
+  public getAuthenticatedUserIdentity() {
+    return this._todoistSyncClient.getAuthenticatedUserIdentity()
+  }
+
+  public static getUserAvatarUrl({ imageId }: { imageId: string }) {
+    return `https://dcff1xvirvpfp.cloudfront.net/${imageId}_medium.jpg`
   }
 
   @handleErrors('Failed to find task by name')

--- a/integrations/todoist/src/webhook-events/handlers/comment-added.ts
+++ b/integrations/todoist/src/webhook-events/handlers/comment-added.ts
@@ -1,19 +1,18 @@
-import { NoteEvent, Event } from '../schemas'
-import * as bp from '.botpress'
+import type { WebhookEventHandler } from '../handler-dispatcher'
+import type { NoteAddedEvent, Event } from '../schemas'
 
-export const isCommentAddedEvent = (event: Event): event is NoteEvent => event.event_name === 'note:added'
+export const isCommentAddedEvent = (event: Event): event is NoteAddedEvent => event.event_name === 'note:added'
 
-export const handleCommentAddedEvent = async (event: NoteEvent, { client }: bp.HandlerProps) => {
+export const handleCommentAddedEvent: WebhookEventHandler<NoteAddedEvent> = async ({
+  client,
+  event,
+  initiatorUserId,
+}) => {
   const conversationId = event.event_data.item_id
-  const userId = event.event_data.posted_uid
   const commentId = event.event_data.id
   const { conversation } = await client.getOrCreateConversation({
     channel: 'comments',
     tags: { id: conversationId },
-  })
-
-  const { user } = await client.getOrCreateUser({
-    tags: { id: userId },
   })
 
   await client.getOrCreateMessage({
@@ -21,7 +20,7 @@ export const handleCommentAddedEvent = async (event: NoteEvent, { client }: bp.H
       id: commentId,
     },
     type: 'text',
-    userId: user.id,
+    userId: initiatorUserId,
     conversationId: conversation.id,
     payload: {
       text: event.event_data.content,

--- a/integrations/todoist/src/webhook-events/handlers/oauth-callback.ts
+++ b/integrations/todoist/src/webhook-events/handlers/oauth-callback.ts
@@ -17,24 +17,18 @@ export const oauthCallbackHandler = async ({ client, ctx, req, logger }: bp.Hand
 
   const todoistClient = await TodoistClient.create({ client, ctx })
 
-  const userId = await todoistClient.getAuthenticatedUserId()
+  const userIdentity = await todoistClient.getAuthenticatedUserIdentity()
+
   client.configureIntegration({
-    identifier: userId,
+    identifier: userIdentity.id,
   })
 
   await client.updateUser({
     id: ctx.botUserId,
+    name: userIdentity.name,
+    pictureUrl: userIdentity.pictureUrl,
     tags: {
-      id: userId,
-    },
-  })
-
-  await client.setState({
-    type: 'integration',
-    name: 'configuration',
-    id: ctx.integrationId,
-    payload: {
-      botUserId: userId,
+      id: userIdentity.id,
     },
   })
 

--- a/integrations/todoist/src/webhook-events/handlers/priority-changed.ts
+++ b/integrations/todoist/src/webhook-events/handlers/priority-changed.ts
@@ -1,13 +1,17 @@
 import { ResponseMapping } from 'src/todoist-api/mapping'
-import { ItemUpdatedEvent, Event } from '../schemas'
-import * as bp from '.botpress'
+import type { WebhookEventHandler } from '../handler-dispatcher'
+import type { ItemUpdatedEvent, Event } from '../schemas'
 
 export const isPriorityChangedEvent = (event: Event): event is ItemUpdatedEvent =>
   event.event_name === 'item:updated' &&
   event.event_data_extra?.update_intent === 'item_updated' &&
   event.event_data_extra?.old_item?.priority !== event.event_data.priority
 
-export const handlePriorityChangedEvent = async (event: ItemUpdatedEvent, { client }: bp.HandlerProps) => {
+export const handlePriorityChangedEvent: WebhookEventHandler<ItemUpdatedEvent> = async ({
+  event,
+  client,
+  initiatorUserId,
+}) => {
   const newPriority = event.event_data.priority
   const oldPriority = event.event_data_extra?.old_item.priority
 
@@ -25,6 +29,7 @@ export const handlePriorityChangedEvent = async (event: ItemUpdatedEvent, { clie
         oldPriority: oldPriority ? ResponseMapping.mapPriority(oldPriority) : undefined,
       },
       conversationId: conversation.id,
+      userId: initiatorUserId,
     })
   }
 }

--- a/integrations/todoist/src/webhook-events/handlers/task-completed.ts
+++ b/integrations/todoist/src/webhook-events/handlers/task-completed.ts
@@ -1,9 +1,14 @@
-import { ItemCompletedEvent, Event } from '../schemas'
-import * as bp from '.botpress'
+import { ResponseMapping } from 'src/todoist-api/mapping'
+import type { WebhookEventHandler } from '../handler-dispatcher'
+import type { ItemCompletedEvent, Event } from '../schemas'
 
 export const isTaskCompletedEvent = (event: Event): event is ItemCompletedEvent => event.event_name === 'item:completed'
 
-export const handleTaskCompletedEvent = async (event: ItemCompletedEvent, { client }: bp.HandlerProps) => {
+export const handleTaskCompletedEvent: WebhookEventHandler<ItemCompletedEvent> = async ({
+  event,
+  client,
+  initiatorUserId,
+}) => {
   const { conversation } = await client.getOrCreateConversation({
     channel: 'comments',
     tags: { id: event.event_data.id },
@@ -16,8 +21,9 @@ export const handleTaskCompletedEvent = async (event: ItemCompletedEvent, { clie
       user_id: event.event_data.user_id,
       content: event.event_data.content,
       description: event.event_data.description,
-      priority: event.event_data.priority,
+      priority: ResponseMapping.mapPriority(event.event_data.priority),
     },
     conversationId: conversation.id,
+    userId: initiatorUserId,
   })
 }

--- a/integrations/todoist/src/webhook-events/handlers/task-created.ts
+++ b/integrations/todoist/src/webhook-events/handlers/task-created.ts
@@ -1,9 +1,14 @@
-import { ItemAddedEvent, Event } from '../schemas'
-import * as bp from '.botpress'
+import { ResponseMapping } from 'src/todoist-api/mapping'
+import type { WebhookEventHandler } from '../handler-dispatcher'
+import type { ItemAddedEvent, Event } from '../schemas'
 
 export const isTaskCreatedEvent = (event: Event): event is ItemAddedEvent => event.event_name === 'item:added'
 
-export const handleTaskCreatedEvent = async (event: ItemAddedEvent, { client }: bp.HandlerProps) => {
+export const handleTaskCreatedEvent: WebhookEventHandler<ItemAddedEvent> = async ({
+  event,
+  client,
+  initiatorUserId,
+}) => {
   const { conversation } = await client.getOrCreateConversation({
     channel: 'comments',
     tags: { id: event.event_data.id },
@@ -15,8 +20,9 @@ export const handleTaskCreatedEvent = async (event: ItemAddedEvent, { client }: 
       id: event.event_data.id,
       content: event.event_data.content,
       description: event.event_data.description,
-      priority: event.event_data.priority,
+      priority: ResponseMapping.mapPriority(event.event_data.priority),
     },
     conversationId: conversation.id,
+    userId: initiatorUserId,
   })
 }


### PR DESCRIPTION
## #13440 should be merged first
> once #13440 is merged, the *base* of this PR should be changed from `pb/todoist-refac` to `master` before merging

---

This PR ensures we always fetch users' avatars and names when available