### PR TITLE
feat(integrations/todoist): add new actions

### DIFF
--- a/integrations/todoist/definitions/actions.ts
+++ b/integrations/todoist/definitions/actions.ts
@@ -1,5 +1,5 @@
 import sdk, { z } from '@botpress/sdk'
-import { Task, Project } from './entities'
+import { Task, Project, Section, SharedLabel } from './entities'
 
 export const actions = {
   changeTaskPriority: {
@@ -42,6 +42,105 @@ export const actions = {
     output: {
       schema: z.object({
         projectId: Project.schema.shape.id.nullable(),
+      }),
+    },
+  },
+  getAllProjects: {
+    title: 'Get All Projects',
+    description: 'Get all projects',
+    input: {
+      schema: z.object({}),
+    },
+    output: {
+      schema: z.object({
+        projects: z.array(Project.schema).title('Projects').describe('All projects that are available to the user'),
+      }),
+    },
+  },
+  getAllSections: {
+    title: 'Get All Sections',
+    description: 'Get all sections in a project',
+    input: {
+      schema: z.object({
+        projectId: Project.schema.shape.id
+          .optional()
+          .title('Project ID (optional)')
+          .describe('The ID of the project. If omitted, the sections of all projects will be returned.'),
+      }),
+    },
+    output: {
+      schema: z.object({
+        sections: z
+          .array(Section.schema)
+          .title('Sections')
+          .describe('All sections in the project, or all sections in all projects if projectId is omitted'),
+      }),
+    },
+  },
+  getAllTasks: {
+    title: 'Get All Tasks',
+    description: 'Find tasks using optional filters',
+    input: {
+      schema: z.object({
+        projectId: Project.schema.shape.id
+          .optional()
+          .title('Filter by Project ID (optional)')
+          .describe('The ID of the project. If omitted, tasks from all projects will be included in the results.'),
+        sectionId: Section.schema.shape.id
+          .optional()
+          .title('Filter by Section ID (optional)')
+          .describe('The ID of the section. If omitted, tasks from all sections will be included in the results.'),
+        labelName: SharedLabel.schema.shape.name
+          .optional()
+          .title('Filter by Label Name (optional)')
+          .describe('The name of the label. If omitted, tasks with any label will be included in the results.'),
+      }),
+    },
+    output: {
+      schema: z.object({
+        tasks: z.array(Task.schema).title('Tasks').describe('All matching tasks'),
+      }),
+    },
+  },
+  createNewTask: {
+    title: 'Create New Task',
+    description: 'Create a new task',
+    input: {
+      schema: z.object({
+        content: Task.schema.shape.content,
+        description: Task.schema.shape.description.optional(),
+        projectId: Project.schema.shape.id
+          .optional()
+          .title('Project ID (optional)')
+          .describe("The ID of the project. If omitted, the task will be added to the user's Inbox."),
+        sectionId: Section.schema.shape.id
+          .optional()
+          .title('Section ID (optional)')
+          .describe('The ID of section to put task into.'),
+        labelNames: z
+          .array(SharedLabel.schema.shape.name)
+          .optional()
+          .title('Label Names (optional)')
+          .describe('The names of the labels to add to the task. If omitted, no label will be added.'),
+        parentTaskId: Task.schema.shape.id
+          .optional()
+          .title('Parent Task ID (optional)')
+          .describe('The ID of the parent task. If omitted, the task will have no parent task.'),
+        priority: Task.schema.shape.priority
+          .optional()
+          .title('Priority (optional)')
+          .describe('The priority level of the task, from 1 (normal) to 4 (urgent).'),
+        dueDate: Task.schema.shape.dueDate
+          .optional()
+          .title('Due Date')
+          .describe(
+            'The due date of the task. Must be in RFC3339 format in UTC. If omitted, the task will have no due date.'
+          ),
+      }),
+    },
+    output: {
+      schema: z.object({
+        taskId: Task.schema.shape.id,
       }),
     },
   },

--- a/integrations/todoist/definitions/entities/personal-label.ts
+++ b/integrations/todoist/definitions/entities/personal-label.ts
@@ -11,7 +11,7 @@ export namespace PersonalLabel {
     orderWithinList: z
       .number()
       .title('Order Within List')
-      .positive()
+      .nonnegative()
       .describe("Numerical index indicating label's order within the user's label list."),
     isFavorite: z.boolean().title('Is Favorite?').describe('Whether the label is marked as favorite or not.'),
   } as const

--- a/integrations/todoist/definitions/entities/project.ts
+++ b/integrations/todoist/definitions/entities/project.ts
@@ -22,7 +22,7 @@ export namespace Project {
     numberOfComments: z
       .number()
       .title('Number of Comments')
-      .positive()
+      .nonnegative()
       .describe('The number of comments on the project.'),
     isShared: z.boolean().title('Is Shared?').describe('Whether the project is shared or not.'),
     isFavorite: z.boolean().title('Is Favorite?').describe('Whether the project is marked as favorite or not.'),

--- a/integrations/todoist/definitions/entities/task.ts
+++ b/integrations/todoist/definitions/entities/task.ts
@@ -69,7 +69,7 @@ export namespace Task {
     numberOfComments: z
       .number()
       .title('Number of Comments')
-      .positive()
+      .nonnegative()
       .describe('The number of comments associated with the task (read-only).'),
     createdAt: z.string().title('Created At').describe('The date when the task was created (read-only).'),
     createdBy: z.string().title('Created By ID').describe('The ID of the user who created the task (read-only).'),

--- a/integrations/todoist/hub.md
+++ b/integrations/todoist/hub.md
@@ -1,23 +1,22 @@
-# Description
-
 Integrate your chatbot with Todoist to create and modify tasks, post comments, and more.
 
-# Installation and configuration
+## Migrating from version `0.x` to `1.x`
 
-Follow these instructions to set up Todoist integration for your Botpress bot.
+If you are migrating from version `0.x` to `1.x`, please note the following breaking changes:
 
-If you are authenticating your Botpress bot with OAuth, follow these steps:
+> The "Task Create" action has been replaced with the "Create New Task" action.
 
-1. Botpress Todoist App installation.
-   - Install the Botpress Todoist integration in [Todoist](https://app.todoist.com/app/settings/integrations/browse).
-2. Todoist Botpress integration configuration
-   - Install the Todoist integration in your Botpress bot.
-   - Click on the authorization button.
-   - When redirected, agree with the permissions given to the bot by Todoist and either:
-     - Log in with your user account if you want the bot actions and comments to appear as yours;
-     - Log in with a user account you created for your bot specifically. You will have to invite the bot's user to a shared project for it to be able to post comment, do actions, etc.
+## Configuration
 
-If you wish to connect your bot with your personnal API token, follow these steps
+### Automatic configuration with OAuth
+
+To set up the Todoist integration using OAuth, click the authorization button and follow the on-screen instructions to connect your Botpress chatbot to Todoist.
+
+When configuring your bot with OAuth, you can either log in with your user account or with a user account you created specifically for your bot.
+Please keep in mind that if you log in with your user account, the bot actions and comments will appear as yours.
+For most use cases, it is recommended to create a user account specifically for your bot. You will have to invite the bot's user to a shared project for it to be able to post comment, do actions, etc.
+
+### Manual configuration using a personal API token
 
 1. Todoist App creation
    - Create an app in the [App Management page](https://developer.todoist.com/appconsole.html).
@@ -37,3 +36,9 @@ If you wish to connect your bot with your personnal API token, follow these step
      - _item:completed_;
      - _note:added_.
    - Save the Webhook configuration.
+
+## Limitations
+
+Standard Todoist API limitations apply to the Todoist integration in Botpress. These limitations include rate limits, payload size restrictions, and other constraints imposed by Todoist. Ensure that your chatbot adheres to these limitations to maintain optimal performance and reliability.
+
+More details are available in the [Todoist Developer Documentation](https://developer.todoist.com/rest/v2/#request-limits).

--- a/integrations/todoist/integration.definition.ts
+++ b/integrations/todoist/integration.definition.ts
@@ -1,5 +1,4 @@
 import * as sdk from '@botpress/sdk'
-import creatable from './bp_modules/creatable'
 import {
   actions,
   channels,
@@ -30,4 +29,4 @@ export default new sdk.IntegrationDefinition({
   secrets,
   states,
   user,
-}).extend(creatable, ({ task }) => ({ item: task }))
+})

--- a/integrations/todoist/package.json
+++ b/integrations/todoist/package.json
@@ -18,7 +18,5 @@
     "@botpress/common": "workspace:*",
     "@botpresshub/creatable": "workspace:*"
   },
-  "bpDependencies": {
-    "creatable": "../../interfaces/creatable"
-  }
+  "bpDependencies": {}
 }

--- a/integrations/todoist/src/actions/implementations/create-new-task.ts
+++ b/integrations/todoist/src/actions/implementations/create-new-task.ts
@@ -1,0 +1,10 @@
+import { wrapAction } from '../action-wrapper'
+
+export const createNewTask = wrapAction(
+  { actionName: 'createNewTask', errorMessageWhenFailed: 'Failed to create task' },
+  async ({ todoistClient }, task) => {
+    const newTask = await todoistClient.createNewTask({ task })
+
+    return { taskId: newTask.id }
+  }
+)

--- a/integrations/todoist/src/actions/implementations/get-all-projects.ts
+++ b/integrations/todoist/src/actions/implementations/get-all-projects.ts
@@ -1,0 +1,6 @@
+import { wrapAction } from '../action-wrapper'
+
+export const getAllProjects = wrapAction(
+  { actionName: 'getAllProjects', errorMessageWhenFailed: 'Failed to retrieve projects' },
+  async ({ todoistClient }) => ({ projects: await todoistClient.getAllProjects() })
+)

--- a/integrations/todoist/src/actions/implementations/get-all-sections.ts
+++ b/integrations/todoist/src/actions/implementations/get-all-sections.ts
@@ -1,0 +1,6 @@
+import { wrapAction } from '../action-wrapper'
+
+export const getAllSections = wrapAction(
+  { actionName: 'getAllSections', errorMessageWhenFailed: 'Failed to retrieve sections' },
+  async ({ todoistClient }, { projectId }) => ({ sections: await todoistClient.getAllSections({ projectId }) })
+)

--- a/integrations/todoist/src/actions/implementations/get-all-tasks.ts
+++ b/integrations/todoist/src/actions/implementations/get-all-tasks.ts
@@ -1,0 +1,8 @@
+import { wrapAction } from '../action-wrapper'
+
+export const getAllTasks = wrapAction(
+  { actionName: 'getAllTasks', errorMessageWhenFailed: 'Failed to retrieve tasks' },
+  async ({ todoistClient }, { projectId, labelName, sectionId }) => ({
+    tasks: await todoistClient.getAllTasks({ projectId, labelName, sectionId }),
+  })
+)

--- a/integrations/todoist/src/actions/implementations/interfaces/task-create.ts
+++ b/integrations/todoist/src/actions/implementations/interfaces/task-create.ts
@@ -1,6 +1,0 @@
-import { wrapAction } from '../../action-wrapper'
-
-export const taskCreate = wrapAction(
-  { actionName: 'taskCreate', errorMessageWhenFailed: 'Failed to create task' },
-  async ({ todoistClient }, { item }) => ({ item: await todoistClient.createNewTask({ task: item }) })
-)

--- a/integrations/todoist/src/actions/index.ts
+++ b/integrations/todoist/src/actions/index.ts
@@ -1,8 +1,10 @@
 import { changeTaskPriority } from './implementations/change-task-priority'
+import { createNewTask } from './implementations/create-new-task'
+import { getAllProjects } from './implementations/get-all-projects'
+import { getAllSections } from './implementations/get-all-sections'
+import { getAllTasks } from './implementations/get-all-tasks'
 import { getProjectId } from './implementations/get-project-id'
 import { getTaskId } from './implementations/get-task-id'
-
-import { taskCreate } from './implementations/interfaces/task-create'
 
 import * as bp from '.botpress'
 
@@ -10,6 +12,8 @@ export const actions = {
   changeTaskPriority,
   getProjectId,
   getTaskId,
-
-  taskCreate,
+  createNewTask,
+  getAllProjects,
+  getAllSections,
+  getAllTasks,
 } as const satisfies bp.IntegrationProps['actions']

--- a/integrations/todoist/src/todoist-api/mapping/response-mapping.ts
+++ b/integrations/todoist/src/todoist-api/mapping/response-mapping.ts
@@ -2,9 +2,10 @@ import {
   Task as TodoistTask,
   Project as TodoistProject,
   Comment as TodoistComment,
+  Section as TodoistSection,
 } from '@doist/todoist-api-typescript'
 import * as entities from 'definitions/entities'
-import { Task, Project, Comment, PickRequired } from '../types'
+import { Task, Project, Comment, PickRequired, Section } from '../types'
 import { reverseScale } from './common/math-utils'
 
 export namespace ResponseMapping {
@@ -45,6 +46,13 @@ export namespace ResponseMapping {
     isTeamInbox: todoistProject.isTeamInbox,
     numberOfComments: todoistProject.commentCount,
     webUrl: todoistProject.url,
+  })
+
+  export const mapSection = (todoistSection: TodoistSection): Section => ({
+    id: todoistSection.id,
+    name: todoistSection.name,
+    projectId: todoistSection.projectId,
+    positionWithinParent: todoistSection.order,
   })
 
   export const mapTaskComment = (todoistComment: TodoistComment): Comment & PickRequired<Comment, 'taskId'> => ({

--- a/integrations/todoist/src/todoist-api/todoist-client.ts
+++ b/integrations/todoist/src/todoist-api/todoist-client.ts
@@ -3,7 +3,7 @@ import { handleErrorsDecorator as handleErrors } from './error-handling'
 import { RequestMapping, ResponseMapping } from './mapping'
 import { exchangeAuthCodeAndSaveRefreshToken, getAccessToken } from './oauth-client'
 import { TodoistSyncClient } from './sync-client'
-import { CreateTaskRequest, Project, Task, UpdateTaskRequest } from './types'
+import { CreateTaskRequest, Project, Task, UpdateTaskRequest, Section, GetAllTasksRequest } from './types'
 import * as bp from '.botpress'
 
 export class TodoistClient {
@@ -63,6 +63,27 @@ export class TodoistClient {
     const matchingProject = projects.find((project) => project.name === name)
 
     return matchingProject ? ResponseMapping.mapProject(matchingProject) : null
+  }
+
+  @handleErrors('Failed to get all projects')
+  public async getAllProjects(): Promise<Project[]> {
+    const projects = await this._todoistRestClient.getProjects()
+
+    return projects.map(ResponseMapping.mapProject)
+  }
+
+  @handleErrors('Failed to get all sections')
+  public async getAllSections({ projectId }: { projectId?: string }): Promise<Section[]> {
+    const sections = await this._todoistRestClient.getSections(projectId)
+
+    return sections.map(ResponseMapping.mapSection)
+  }
+
+  @handleErrors('Failed to get all tasks')
+  public async getAllTasks({ projectId, sectionId, labelName }: GetAllTasksRequest): Promise<Task[]> {
+    const tasks = await this._todoistRestClient.getTasks({ projectId, sectionId, label: labelName })
+
+    return tasks.map(ResponseMapping.mapTask)
   }
 
   @handleErrors('Failed to find project by ID')

--- a/integrations/todoist/src/todoist-api/types.d.ts
+++ b/integrations/todoist/src/todoist-api/types.d.ts
@@ -1,4 +1,9 @@
-import { Task as TaskEntity, Project as ProjectEntity, Comment as CommentEntity } from 'definitions'
+import {
+  Task as TaskEntity,
+  Project as ProjectEntity,
+  Comment as CommentEntity,
+  Section as SectionEntity,
+} from 'definitions'
 
 // Entities:
 type Task = TaskEntity.InferredType
@@ -6,6 +11,9 @@ type BareMinimumTask = PartialExcept<Task, 'content'>
 
 type Project = ProjectEntity.InferredType
 type BareMinimumProject = PartialExcept<Project, 'name'>
+
+type Section = SectionEntity.InferredType
+type BareMinimumSection = PartialExcept<Section, 'name'>
 
 type Comment = CommentEntity.InferredType
 type BareMinimumComment = PartialExcept<Comment, 'content'>
@@ -29,6 +37,11 @@ type UpdateTaskRequest = Omit<
   | 'createdBy'
   | 'assigner'
 >
+type GetAllTasksRequest = {
+  projectId?: string
+  sectionId?: string
+  labelName?: string
+}
 
 // Type utilities:
 

--- a/integrations/todoist/src/webhook-events/handler-dispatcher.ts
+++ b/integrations/todoist/src/webhook-events/handler-dispatcher.ts
@@ -1,6 +1,6 @@
-import { TodoistClient } from '../todoist-api'
 import sdk from '@botpress/sdk'
 import * as crypto from 'crypto'
+import { TodoistClient } from '../todoist-api'
 import { handleCommentAddedEvent, isCommentAddedEvent } from './handlers/comment-added'
 import { oauthCallbackHandler } from './handlers/oauth-callback'
 import { handlePriorityChangedEvent, isPriorityChangedEvent } from './handlers/priority-changed'


### PR DESCRIPTION
- removes implementation of the `creatable` interface, as suggested by @franklevasseur 
  - replaces the action with an equivalent "create new task" action
- adds more querying actions to help users find tasks, projects and sections