### PR TITLE
feat: allow passing custom esbuild options in integration definition

### DIFF
--- a/packages/cli/src/command-implementations/bundle-command.ts
+++ b/packages/cli/src/command-implementations/bundle-command.ts
@@ -50,7 +50,7 @@ export class BundleCommand extends ProjectCommand<BundleCommandDefinition> {
 
     await utils.esbuild.buildCode({
       code,
-      cwd: abs.workDir,
+      absWorkingDir: abs.workDir,
       outfile,
       logLevel,
       write: true,

--- a/packages/cli/src/command-implementations/bundle-command.ts
+++ b/packages/cli/src/command-implementations/bundle-command.ts
@@ -18,9 +18,9 @@ export class BundleCommand extends ProjectCommand<BundleCommandDefinition> {
     const line = this.logger.line()
 
     if (projectDef.type === 'integration') {
-      const { name } = projectDef.definition
+      const { name, __advanced } = projectDef.definition
       line.started(`Bundling integration ${chalk.bold(name)}...`)
-      return await this._bundle(line)
+      return await this._bundle(line, __advanced?.esbuild ?? {})
     }
 
     if (projectDef.type === 'bot') {
@@ -36,7 +36,7 @@ export class BundleCommand extends ProjectCommand<BundleCommandDefinition> {
     throw new errors.UnsupportedProjectType()
   }
 
-  private async _bundle(line: SingleLineLogger, props: Partial<utils.esbuild.BuildCodeProps> = {}) {
+  private async _bundle(line: SingleLineLogger, props: Partial<utils.esbuild.BuildOptions> = {}) {
     const logLevel = this.argv.verbose ? 'info' : 'silent'
     const abs = this.projectPaths.abs
     const rel = this.projectPaths.rel('workDir')
@@ -49,6 +49,7 @@ export class BundleCommand extends ProjectCommand<BundleCommandDefinition> {
     line.debug(`Writing bundle to ${outfile}`)
 
     await utils.esbuild.buildCode({
+      ...props,
       code,
       absWorkingDir: abs.workDir,
       outfile,
@@ -56,7 +57,6 @@ export class BundleCommand extends ProjectCommand<BundleCommandDefinition> {
       write: true,
       sourcemap: this.argv.sourceMap,
       minify: this.argv.minify,
-      ...props,
     })
 
     line.success(`Bundle available at ${chalk.grey(rel.outDir)}`)

--- a/packages/cli/src/command-implementations/bundle-command.ts
+++ b/packages/cli/src/command-implementations/bundle-command.ts
@@ -37,7 +37,6 @@ export class BundleCommand extends ProjectCommand<BundleCommandDefinition> {
   }
 
   private async _bundle(line: SingleLineLogger, props: Partial<utils.esbuild.BuildOptions> = {}) {
-    const logLevel = this.argv.verbose ? 'info' : 'silent'
     const abs = this.projectPaths.abs
     const rel = this.projectPaths.rel('workDir')
 
@@ -45,18 +44,21 @@ export class BundleCommand extends ProjectCommand<BundleCommandDefinition> {
     const importFrom = utils.path.rmExtension(unixPath)
     const code = `import x from './${importFrom}'; export default x; export const handler = x.handler;`
 
-    const outfile = abs.outFile // TODO: ensure dir exists
-    line.debug(`Writing bundle to ${outfile}`)
+    line.debug(`Writing bundle to ${abs.outFile}`)
 
-    await utils.esbuild.buildCode({
-      ...props,
-      code,
-      absWorkingDir: abs.workDir,
-      outfile,
-      logLevel,
-      write: true,
+    const buildOptions: Partial<utils.esbuild.BuildOptions> = {
+      logLevel: this.argv.verbose ? 'info' : 'silent',
       sourcemap: this.argv.sourceMap,
       minify: this.argv.minify,
+      ...props,
+    }
+
+    await utils.esbuild.buildCode({
+      ...buildOptions,
+      absWorkingDir: abs.workDir,
+      outfile: abs.outFile,
+      write: true,
+      code,
     })
 
     line.success(`Bundle available at ${chalk.grey(rel.outDir)}`)

--- a/packages/cli/src/command-implementations/project-command.ts
+++ b/packages/cli/src/command-implementations/project-command.ts
@@ -149,7 +149,7 @@ export abstract class ProjectCommand<C extends ProjectCommandDefinition> extends
     const bpLintDisabled = await this._isBpLintDisabled(abs.integrationDefinition)
 
     const { outputFiles } = await utils.esbuild.buildEntrypoint({
-      cwd: abs.workDir,
+      absWorkingDir: abs.workDir,
       outfile: '',
       entrypoint: rel.integrationDefinition,
       write: false,
@@ -180,7 +180,7 @@ export abstract class ProjectCommand<C extends ProjectCommandDefinition> extends
     const bpLintDisabled = await this._isBpLintDisabled(abs.interfaceDefinition)
 
     const { outputFiles } = await utils.esbuild.buildEntrypoint({
-      cwd: abs.workDir,
+      absWorkingDir: abs.workDir,
       outfile: '',
       entrypoint: rel.interfaceDefinition,
       write: false,
@@ -210,7 +210,7 @@ export abstract class ProjectCommand<C extends ProjectCommandDefinition> extends
     const bpLintDisabled = await this._isBpLintDisabled(abs.botDefinition)
 
     const { outputFiles } = await utils.esbuild.buildEntrypoint({
-      cwd: abs.workDir,
+      absWorkingDir: abs.workDir,
       outfile: '',
       entrypoint: rel.botDefinition,
       write: false,
@@ -241,7 +241,7 @@ export abstract class ProjectCommand<C extends ProjectCommandDefinition> extends
     const bpLintDisabled = await this._isBpLintDisabled(abs.pluginDefinition)
 
     const { outputFiles } = await utils.esbuild.buildEntrypoint({
-      cwd: abs.workDir,
+      absWorkingDir: abs.workDir,
       outfile: '',
       entrypoint: rel.pluginDefinition,
       write: false,

--- a/packages/cli/src/command-implementations/project-command.ts
+++ b/packages/cli/src/command-implementations/project-command.ts
@@ -150,7 +150,6 @@ export abstract class ProjectCommand<C extends ProjectCommandDefinition> extends
 
     const { outputFiles } = await utils.esbuild.buildEntrypoint({
       absWorkingDir: abs.workDir,
-      outfile: '',
       entrypoint: rel.integrationDefinition,
       write: false,
       minify: false,
@@ -181,7 +180,6 @@ export abstract class ProjectCommand<C extends ProjectCommandDefinition> extends
 
     const { outputFiles } = await utils.esbuild.buildEntrypoint({
       absWorkingDir: abs.workDir,
-      outfile: '',
       entrypoint: rel.interfaceDefinition,
       write: false,
       minify: false,
@@ -211,7 +209,6 @@ export abstract class ProjectCommand<C extends ProjectCommandDefinition> extends
 
     const { outputFiles } = await utils.esbuild.buildEntrypoint({
       absWorkingDir: abs.workDir,
-      outfile: '',
       entrypoint: rel.botDefinition,
       write: false,
       minify: false,
@@ -242,7 +239,6 @@ export abstract class ProjectCommand<C extends ProjectCommandDefinition> extends
 
     const { outputFiles } = await utils.esbuild.buildEntrypoint({
       absWorkingDir: abs.workDir,
-      outfile: '',
       entrypoint: rel.pluginDefinition,
       write: false,
       minify: false,

--- a/packages/cli/src/utils/esbuild-utils.ts
+++ b/packages/cli/src/utils/esbuild-utils.ts
@@ -2,22 +2,22 @@ import * as esb from 'esbuild'
 
 export * from 'esbuild'
 
-type BaseProps<W extends boolean> = esb.BuildOptions & {
+type BaseProps = esb.BuildOptions & {
   absWorkingDir: string
-  outfile: string
-  write: W
 }
 
-export type BuildCodeProps<W extends boolean> = BaseProps<W> & {
+export type BuildCodeProps = BaseProps & {
   code: string
+  write: true
+  outfile: string
 }
 
-export type BuildEntrypointProps<W extends boolean> = BaseProps<W> & {
+export type BuildEntrypointProps = BaseProps & {
   entrypoint: string
+  write: false
 }
 
 const DEFAULT_OPTIONS: esb.BuildOptions = {
-  minify: true,
   bundle: true,
   sourcemap: false,
   logLevel: 'silent',
@@ -28,9 +28,10 @@ const DEFAULT_OPTIONS: esb.BuildOptions = {
   keepNames: true, // important : https://github.com/node-fetch/node-fetch/issues/784#issuecomment-1014768204
 }
 
-export function buildCode(p: BuildCodeProps<true>): Promise<esb.BuildResult>
-export function buildCode(p: BuildCodeProps<false>): Promise<esb.BuildResult & { outputFiles: esb.OutputFile[] }>
-export function buildCode<W extends boolean>(p: BuildCodeProps<W>) {
+/**
+ * Bundles a string of typescript code and writes the output to a file
+ */
+export function buildCode(p: BuildCodeProps): Promise<esb.BuildResult> {
   const { code, ...props } = p
   return esb.build({
     ...DEFAULT_OPTIONS,
@@ -43,15 +44,15 @@ export function buildCode<W extends boolean>(p: BuildCodeProps<W>) {
   })
 }
 
-export function buildEntrypoint(p: BuildEntrypointProps<true>): Promise<esb.BuildResult>
-export function buildEntrypoint(
-  p: BuildEntrypointProps<false>
-): Promise<esb.BuildResult & { outputFiles: esb.OutputFile[] }>
-export function buildEntrypoint<W extends boolean>(p: BuildEntrypointProps<W>) {
+/**
+ * Bundles a typescript file and returns the output as a string
+ */
+export function buildEntrypoint(p: BuildEntrypointProps): Promise<esb.BuildResult & { outputFiles: esb.OutputFile[] }> {
   const { entrypoint, ...props } = p
   return esb.build({
     ...DEFAULT_OPTIONS,
     ...props,
+    outfile: undefined,
     entryPoints: [entrypoint],
   })
 }

--- a/packages/cli/src/utils/esbuild-utils.ts
+++ b/packages/cli/src/utils/esbuild-utils.ts
@@ -1,16 +1,18 @@
 import * as esb from 'esbuild'
 
+export * from 'esbuild'
+
 type BaseProps<W extends boolean> = esb.BuildOptions & {
   absWorkingDir: string
   outfile: string
   write: W
 }
 
-export type BuildCodeProps<W extends boolean = true> = BaseProps<W> & {
+export type BuildCodeProps<W extends boolean> = BaseProps<W> & {
   code: string
 }
 
-export type BuildEntrypointProps<W extends boolean = true> = BaseProps<W> & {
+export type BuildEntrypointProps<W extends boolean> = BaseProps<W> & {
   entrypoint: string
 }
 
@@ -29,25 +31,27 @@ const DEFAULT_OPTIONS: esb.BuildOptions = {
 export function buildCode(p: BuildCodeProps<true>): Promise<esb.BuildResult>
 export function buildCode(p: BuildCodeProps<false>): Promise<esb.BuildResult & { outputFiles: esb.OutputFile[] }>
 export function buildCode<W extends boolean>(p: BuildCodeProps<W>) {
-  const { code, absWorkingDir } = p
+  const { code, ...props } = p
   return esb.build({
     ...DEFAULT_OPTIONS,
-    ...p,
+    ...props,
     stdin: {
       contents: code,
-      resolveDir: absWorkingDir,
+      resolveDir: props.absWorkingDir,
       loader: 'ts',
     },
   })
 }
 
 export function buildEntrypoint(p: BuildEntrypointProps<true>): Promise<esb.BuildResult>
-export function buildEntrypoint(p: BuildEntrypointProps<false>): Promise<esb.BuildResult & { outputFiles: esb.OutputFile[] }>
+export function buildEntrypoint(
+  p: BuildEntrypointProps<false>
+): Promise<esb.BuildResult & { outputFiles: esb.OutputFile[] }>
 export function buildEntrypoint<W extends boolean>(p: BuildEntrypointProps<W>) {
-  const { entrypoint } = p
+  const { entrypoint, ...props } = p
   return esb.build({
     ...DEFAULT_OPTIONS,
-    ...p,
+    ...props,
     entryPoints: [entrypoint],
   })
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -20,5 +20,13 @@
   "devDependencies": {
     "esbuild": "^0.16.12",
     "tsup": "^8.0.2"
+  },
+  "peerDependencies": {
+    "esbuild": "^0.16.12"
+  },
+  "peerDependenciesMeta": {
+    "esbuild": {
+      "optional": true
+    }
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,14 +16,12 @@
   "dependencies": {
     "@botpress/client": "0.41.0"
   },
-  "peerDependencies": {
-    "@bpinternal/zui": "^0.13.5"
-  },
   "devDependencies": {
     "esbuild": "^0.16.12",
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
+    "@bpinternal/zui": "^0.13.5",
     "esbuild": "^0.16.12"
   },
   "peerDependenciesMeta": {

--- a/packages/sdk/src/integration/definition/index.ts
+++ b/packages/sdk/src/integration/definition/index.ts
@@ -1,6 +1,6 @@
+import type * as esbuild from 'esbuild'
 import { InterfacePackage } from '../../package'
 import * as utils from '../../utils'
-import type * as esbuild from 'esbuild'
 import { z } from '../../zui'
 import { SchemaStore, BrandedSchema, createStore, isBranded, getName } from './branded-schema'
 import { BaseConfig, BaseEvents, BaseActions, BaseChannels, BaseStates, BaseEntities, BaseConfigs } from './generic'

--- a/packages/sdk/src/integration/definition/index.ts
+++ b/packages/sdk/src/integration/definition/index.ts
@@ -1,6 +1,6 @@
 import { InterfacePackage } from '../../package'
 import * as utils from '../../utils'
-import * as esbuild from 'esbuild'
+import type * as esbuild from 'esbuild'
 import { z } from '../../zui'
 import { SchemaStore, BrandedSchema, createStore, isBranded, getName } from './branded-schema'
 import { BaseConfig, BaseEvents, BaseActions, BaseChannels, BaseStates, BaseEntities, BaseConfigs } from './generic'

--- a/packages/sdk/src/integration/definition/index.ts
+++ b/packages/sdk/src/integration/definition/index.ts
@@ -1,5 +1,6 @@
 import { InterfacePackage } from '../../package'
 import * as utils from '../../utils'
+import * as esbuild from 'esbuild'
 import { z } from '../../zui'
 import { SchemaStore, BrandedSchema, createStore, isBranded, getName } from './branded-schema'
 import { BaseConfig, BaseEvents, BaseActions, BaseChannels, BaseStates, BaseEntities, BaseConfigs } from './generic'
@@ -79,6 +80,10 @@ export type IntegrationDefinitionProps<
   }
 
   interfaces?: Record<string, InterfaceExtension>
+
+  __advanced?: {
+    esbuild?: Partial<esbuild.BuildOptions>
+  }
 }
 
 type EntitiesOfPackage<TPackage extends InterfacePackage> = {
@@ -123,6 +128,7 @@ export class IntegrationDefinition<
   public readonly identifier: this['props']['identifier']
   public readonly entities: this['props']['entities']
   public readonly interfaces: this['props']['interfaces']
+  public readonly __advanced: this['props']['__advanced']
   public constructor(
     public readonly props: IntegrationDefinitionProps<
       TName,
@@ -153,6 +159,7 @@ export class IntegrationDefinition<
     this.secrets = props.secrets
     this.entities = props.entities
     this.interfaces = props.interfaces
+    this.__advanced = props.__advanced
   }
 
   public extend<P extends InterfacePackage>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2082,9 +2082,6 @@ importers:
       '@botpress/client':
         specifier: 0.41.0
         version: link:../client
-      '@bpinternal/zui':
-        specifier: ^0.13.5
-        version: 0.13.5
     devDependencies:
       esbuild:
         specifier: ^0.16.12
@@ -3893,6 +3890,7 @@ packages:
     peerDependenciesMeta:
       react:
         optional: true
+    dev: true
 
   /@colors/colors@1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2082,6 +2082,9 @@ importers:
       '@botpress/client':
         specifier: 0.41.0
         version: link:../client
+      '@bpinternal/zui':
+        specifier: ^0.13.5
+        version: 0.13.5
     devDependencies:
       esbuild:
         specifier: ^0.16.12
@@ -3890,7 +3893,6 @@ packages:
     peerDependenciesMeta:
       react:
         optional: true
-    dev: true
 
   /@colors/colors@1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}


### PR DESCRIPTION
Since esbuild is a peer dependency of sdk, I'm not sure of how the typings will behave if the dependency is not installed, but let's try it

closes CLS-2592