### PR TITLE
chore(integrations/chat): fix alias to local sdk for windows

### DIFF
--- a/integrations/chat/package.json
+++ b/integrations/chat/package.json
@@ -17,7 +17,7 @@
     "lodash": "^4.17.21",
     "qs": "^6.11.0",
     "uuid": "^9.0.0",
-    "zod": "npm:@botpress/sdk@workspace:*"
+    "zod": "npm:@botpress/sdk"
   },
   "devDependencies": {
     "@botpress/chat-api": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,8 +444,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
       zod:
-        specifier: npm:@botpress/sdk@workspace:*
-        version: link:npm:@botpress/sdk@workspace:*
+        specifier: npm:@botpress/sdk
+        version: link:../../packages/sdk
     devDependencies:
       '@botpress/chat-api':
         specifier: workspace:*


### PR DESCRIPTION
thats the only thing that didnt work on my local windows machine