### PR TITLE
chore: speedup ci using depot

### DIFF
--- a/.github/workflows/check-windows-build.yml
+++ b/.github/workflows/check-windows-build.yml
@@ -1,4 +1,4 @@
-name: Run Checks
+name: Check Windows Build
 
 on: pull_request
 
@@ -7,8 +7,8 @@ permissions:
   contents: read
 
 jobs:
-  run-checks:
-    runs-on: depot-ubuntu-22.04-8
+  check-windows-build:
+    runs-on: windows-latest
     timeout-minutes: 10
     env:
       NODE_OPTIONS: '--max_old_space_size=8192'
@@ -19,11 +19,3 @@ jobs:
         with:
           turbo_team: ${{ secrets.TURBO_TEAM }}
           turbo_token: ${{ secrets.TURBO_TOKEN }}
-      - run: pnpm run check:dep
-      - run: pnpm run check:sherif
-      - run: pnpm run check:oxlint
-      - run: pnpm run check:format
-      - run: pnpm run check:eslint
-      - run: pnpm run check:bplint
-      - run: pnpm run check:type
-      - run: pnpm run test


### PR DESCRIPTION
the CI was to slow, I did 3 changes:
1. Run only the build (setup) step on windows. There's no need to run all checks.
2. Run checks on a powerful depot machine (see [depot](https://depot.dev/docs/github-actions/runner-types))
3. Enable back turbo cache