### PR TITLE
fix(browser): add wait for param for dynamic pages

### DIFF
--- a/integrations/browser/integration.definition.ts
+++ b/integrations/browser/integration.definition.ts
@@ -5,7 +5,7 @@ import { actionDefinitions } from 'src/definitions/actions'
 export default new IntegrationDefinition({
   name: 'browser',
   title: 'Browser',
-  version: '0.2.2',
+  version: '0.3.0',
   description:
     'Capture screenshots and retrieve web page content with metadata for automated browsing and data extraction.',
   readme: 'hub.md',

--- a/integrations/browser/src/definitions/actions.ts
+++ b/integrations/browser/src/definitions/actions.ts
@@ -27,6 +27,13 @@ const browsePages = {
   input: {
     schema: z.object({
       urls: z.array(z.string()),
+      waitFor: z
+        .number()
+        .optional()
+        .default(350)
+        .describe(
+          'Time to wait before extracting the content (in milliseconds). Set this value higher for dynamic pages.'
+        ),
     }),
   },
   output: {


### PR DESCRIPTION
Its the difference between
<img width="604" alt="image" src="https://github.com/user-attachments/assets/c2cbd1e2-9bb9-480f-8553-a6deab4b5009" />
and
<img width="736" alt="image" src="https://github.com/user-attachments/assets/c2e1322f-fcee-407d-af90-470158153498" />
