### PR TITLE
fix(cli): ensure all action properties get installed

### DIFF
--- a/packages/cli/src/code-generation/generators.ts
+++ b/packages/cli/src/code-generation/generators.ts
@@ -1,8 +1,11 @@
 import * as sdk from '@botpress/sdk'
 import { JSONSchema7 } from 'json-schema'
+import _ from 'lodash'
 import * as prettier from 'prettier'
 import * as utils from '../utils'
 import * as consts from './consts'
+
+export type Primitive = string | number | boolean | null | undefined
 
 export const zuiSchemaToTypeScriptType = async (zuiSchema: sdk.z.Schema, name: string): Promise<string> => {
   let code = zuiSchema.toTypescript()
@@ -22,12 +25,17 @@ export const jsonSchemaToTypescriptZuiSchema = async (
 ): Promise<string> => {
   schema = await utils.schema.dereferenceSchema(schema)
   const zuiSchema = sdk.z.fromJsonSchema(schema)
+
+  const allProps = {
+    ...extraProps,
+    schema: zuiSchema.toTypescriptSchema(),
+  }
+
   let code = [
     consts.GENERATED_HEADER,
     'import { z } from "@botpress/sdk"',
     `export const ${name} = {`,
-    ...Object.entries(extraProps).map(([key, value]) => `  ${key}: ${value},`),
-    `  schema: ${zuiSchema.toTypescriptSchema()}`,
+    ...Object.entries(allProps).map(([key, value]) => `  ${key}: ${value},`),
     '}',
   ].join('\n')
   code = await prettier.format(code, { parser: 'typescript' })
@@ -38,9 +46,18 @@ export const stringifySingleLine = (x: object): string => {
   return JSON.stringify(x, null, 1).replace(/\n */g, ' ')
 }
 
-export function primitiveToTypescriptValue(x: string | number | boolean | null | undefined): string {
+export function primitiveToTypescriptValue(x: Primitive): string {
   if (typeof x === 'undefined') {
     return 'undefined'
   }
   return JSON.stringify(x)
+}
+
+export function primitiveRecordToTypescriptValues(x: Record<string, Primitive>): Record<string, string> {
+  return _(x)
+    .toPairs()
+    .filter(([_key, value]) => value !== undefined)
+    .map(([key, value]) => [key, primitiveToTypescriptValue(value)])
+    .fromPairs()
+    .value()
 }

--- a/packages/cli/src/code-generation/integration-package/integration-package-definition/actions-module.ts
+++ b/packages/cli/src/code-generation/integration-package/integration-package-definition/actions-module.ts
@@ -32,7 +32,15 @@ export class ActionOutputModule extends Module {
 
 export class ActionModule extends ReExportVariableModule {
   public constructor(actionName: string, action: types.ActionDefinition) {
-    super({ exportName: strings.varName(actionName) })
+    super({
+      exportName: strings.varName(actionName),
+      extraProps: {
+        billable: JSON.stringify(action.billable),
+        cacheable: JSON.stringify(action.cacheable),
+        title: JSON.stringify(action.title),
+        description: JSON.stringify(action.description),
+      },
+    })
 
     const inputModule = new ActionInputModule(action.input)
     const outputModule = new ActionOutputModule(action.output)

--- a/packages/cli/src/code-generation/integration-package/integration-package-definition/actions-module.ts
+++ b/packages/cli/src/code-generation/integration-package/integration-package-definition/actions-module.ts
@@ -1,4 +1,5 @@
 import { jsonSchemaToTypescriptZuiSchema } from '../../generators'
+import * as gen from '../../generators'
 import { Module, ReExportVariableModule } from '../../module'
 import * as strings from '../../strings'
 import * as types from './typings'
@@ -35,10 +36,10 @@ export class ActionModule extends ReExportVariableModule {
     super({
       exportName: strings.varName(actionName),
       extraProps: {
-        billable: JSON.stringify(action.billable),
-        cacheable: JSON.stringify(action.cacheable),
-        title: JSON.stringify(action.title),
-        description: JSON.stringify(action.description),
+        title: gen.primitiveToTypescriptValue(action.title),
+        description: gen.primitiveToTypescriptValue(action.description),
+        billable: gen.primitiveToTypescriptValue(action.billable),
+        cacheable: gen.primitiveToTypescriptValue(action.cacheable),
       },
     })
 

--- a/packages/cli/src/code-generation/integration-package/integration-package-definition/actions-module.ts
+++ b/packages/cli/src/code-generation/integration-package/integration-package-definition/actions-module.ts
@@ -35,12 +35,12 @@ export class ActionModule extends ReExportVariableModule {
   public constructor(actionName: string, action: types.ActionDefinition) {
     super({
       exportName: strings.varName(actionName),
-      extraProps: {
-        title: gen.primitiveToTypescriptValue(action.title),
-        description: gen.primitiveToTypescriptValue(action.description),
-        billable: gen.primitiveToTypescriptValue(action.billable),
-        cacheable: gen.primitiveToTypescriptValue(action.cacheable),
-      },
+      extraProps: gen.primitiveRecordToTypescriptValues({
+        title: action.title,
+        description: action.description,
+        billable: action.billable,
+        cacheable: action.cacheable,
+      }),
     })
 
     const inputModule = new ActionInputModule(action.input)

--- a/packages/cli/src/code-generation/integration-package/integration-package-definition/channels-module.ts
+++ b/packages/cli/src/code-generation/integration-package/integration-package-definition/channels-module.ts
@@ -1,5 +1,6 @@
 import { GENERATED_HEADER, INDEX_FILE } from '../../consts'
 import { jsonSchemaToTypescriptZuiSchema, stringifySingleLine } from '../../generators'
+import * as gen from '../../generators'
 import { Module, ReExportVariableModule } from '../../module'
 import * as strings from '../../strings'
 import * as types from './typings'
@@ -16,7 +17,10 @@ class MessageModule extends Module {
   }
 
   public async getContent() {
-    return jsonSchemaToTypescriptZuiSchema(this._message.schema, this.exportName)
+    return jsonSchemaToTypescriptZuiSchema(this._message.schema, this.exportName, {
+      title: gen.primitiveToTypescriptValue(this._message.title),
+      description: gen.primitiveToTypescriptValue(this._message.description),
+    })
   }
 }
 
@@ -65,6 +69,8 @@ class ChannelModule extends Module {
       `export * from './${messageImport}'`,
       '',
       `export const ${this.exportName} = {`,
+      `  title: ${gen.primitiveToTypescriptValue(this._channel.title)},`,
+      `  description: ${gen.primitiveToTypescriptValue(this._channel.description)},`,
       `  messages: ${this._messagesModule.exportName},`,
       `  message: ${stringifySingleLine(message)},`,
       `  conversation: ${stringifySingleLine(conversation)},`,

--- a/packages/cli/src/code-generation/integration-package/integration-package-definition/channels-module.ts
+++ b/packages/cli/src/code-generation/integration-package/integration-package-definition/channels-module.ts
@@ -17,10 +17,14 @@ class MessageModule extends Module {
   }
 
   public async getContent() {
-    return jsonSchemaToTypescriptZuiSchema(this._message.schema, this.exportName, {
-      title: gen.primitiveToTypescriptValue(this._message.title),
-      description: gen.primitiveToTypescriptValue(this._message.description),
-    })
+    return jsonSchemaToTypescriptZuiSchema(
+      this._message.schema,
+      this.exportName,
+      gen.primitiveRecordToTypescriptValues({
+        title: this._message.title,
+        description: this._message.description,
+      })
+    )
   }
 }
 

--- a/packages/cli/src/code-generation/integration-package/integration-package-definition/configuration-module.ts
+++ b/packages/cli/src/code-generation/integration-package/integration-package-definition/configuration-module.ts
@@ -1,6 +1,7 @@
 import { JSONSchema7 } from 'json-schema'
 import { INDEX_FILE } from '../../consts'
 import { jsonSchemaToTypescriptZuiSchema } from '../../generators'
+import * as gen from '../../generators'
 import { Module } from '../../module'
 import * as strings from '../../strings'
 import * as types from './typings'
@@ -17,6 +18,9 @@ export class DefaultConfigurationModule extends Module {
 
   public async getContent() {
     const schema: JSONSchema7 = this._configuration.schema ?? { type: 'object', properties: {} }
-    return jsonSchemaToTypescriptZuiSchema(schema, this.exportName)
+    return jsonSchemaToTypescriptZuiSchema(schema, this.exportName, {
+      title: gen.primitiveToTypescriptValue(this._configuration.title),
+      description: gen.primitiveToTypescriptValue(this._configuration.description),
+    })
   }
 }

--- a/packages/cli/src/code-generation/integration-package/integration-package-definition/configuration-module.ts
+++ b/packages/cli/src/code-generation/integration-package/integration-package-definition/configuration-module.ts
@@ -18,9 +18,13 @@ export class DefaultConfigurationModule extends Module {
 
   public async getContent() {
     const schema: JSONSchema7 = this._configuration.schema ?? { type: 'object', properties: {} }
-    return jsonSchemaToTypescriptZuiSchema(schema, this.exportName, {
-      title: gen.primitiveToTypescriptValue(this._configuration.title),
-      description: gen.primitiveToTypescriptValue(this._configuration.description),
-    })
+    return jsonSchemaToTypescriptZuiSchema(
+      schema,
+      this.exportName,
+      gen.primitiveRecordToTypescriptValues({
+        title: this._configuration.title,
+        description: this._configuration.description,
+      })
+    )
   }
 }

--- a/packages/cli/src/code-generation/integration-package/integration-package-definition/configurations-module.ts
+++ b/packages/cli/src/code-generation/integration-package/integration-package-definition/configurations-module.ts
@@ -20,10 +20,14 @@ export class ConfigurationModule extends Module {
 
   public async getContent() {
     const schema: JSONSchema7 = this._configuration.schema ?? { type: 'object', properties: {} }
-    return jsonSchemaToTypescriptZuiSchema(schema, this.exportName, {
-      title: gen.primitiveToTypescriptValue(this._configuration.title),
-      description: gen.primitiveToTypescriptValue(this._configuration.description),
-    })
+    return jsonSchemaToTypescriptZuiSchema(
+      schema,
+      this.exportName,
+      gen.primitiveRecordToTypescriptValues({
+        title: this._configuration.title,
+        description: this._configuration.description,
+      })
+    )
   }
 }
 

--- a/packages/cli/src/code-generation/integration-package/integration-package-definition/configurations-module.ts
+++ b/packages/cli/src/code-generation/integration-package/integration-package-definition/configurations-module.ts
@@ -1,4 +1,6 @@
+import { JSONSchema7 } from 'json-schema'
 import { jsonSchemaToTypescriptZuiSchema } from '../../generators'
+import * as gen from '../../generators'
 import { Module, ReExportVariableModule } from '../../module'
 import * as strings from '../../strings'
 import * as types from './typings'
@@ -17,11 +19,11 @@ export class ConfigurationModule extends Module {
   }
 
   public async getContent() {
-    const { schema } = this._configuration
-    if (!schema) {
-      return `export const ${this.exportName} = z.object({});`
-    }
-    return jsonSchemaToTypescriptZuiSchema(schema, this.exportName)
+    const schema: JSONSchema7 = this._configuration.schema ?? { type: 'object', properties: {} }
+    return jsonSchemaToTypescriptZuiSchema(schema, this.exportName, {
+      title: gen.primitiveToTypescriptValue(this._configuration.title),
+      description: gen.primitiveToTypescriptValue(this._configuration.description),
+    })
   }
 }
 

--- a/packages/cli/src/code-generation/integration-package/integration-package-definition/entities-module.ts
+++ b/packages/cli/src/code-generation/integration-package/integration-package-definition/entities-module.ts
@@ -1,4 +1,5 @@
 import { jsonSchemaToTypescriptZuiSchema } from '../../generators'
+import * as gen from '../../generators'
 import { Module, ReExportVariableModule } from '../../module'
 import * as strings from '../../strings'
 import * as types from './typings'
@@ -14,7 +15,10 @@ export class EntityModule extends Module {
   }
 
   public async getContent() {
-    return jsonSchemaToTypescriptZuiSchema(this._entity.schema, this.exportName)
+    return jsonSchemaToTypescriptZuiSchema(this._entity.schema, this.exportName, {
+      title: gen.primitiveToTypescriptValue(this._entity.title),
+      description: gen.primitiveToTypescriptValue(this._entity.description),
+    })
   }
 }
 

--- a/packages/cli/src/code-generation/integration-package/integration-package-definition/entities-module.ts
+++ b/packages/cli/src/code-generation/integration-package/integration-package-definition/entities-module.ts
@@ -15,10 +15,14 @@ export class EntityModule extends Module {
   }
 
   public async getContent() {
-    return jsonSchemaToTypescriptZuiSchema(this._entity.schema, this.exportName, {
-      title: gen.primitiveToTypescriptValue(this._entity.title),
-      description: gen.primitiveToTypescriptValue(this._entity.description),
-    })
+    return jsonSchemaToTypescriptZuiSchema(
+      this._entity.schema,
+      this.exportName,
+      gen.primitiveRecordToTypescriptValues({
+        title: this._entity.title,
+        description: this._entity.description,
+      })
+    )
   }
 }
 

--- a/packages/cli/src/code-generation/integration-package/integration-package-definition/events-module.ts
+++ b/packages/cli/src/code-generation/integration-package/integration-package-definition/events-module.ts
@@ -15,10 +15,14 @@ export class EventModule extends Module {
   }
 
   public async getContent() {
-    return jsonSchemaToTypescriptZuiSchema(this._event.schema, this.exportName, {
-      title: gen.primitiveToTypescriptValue(this._event.title),
-      description: gen.primitiveToTypescriptValue(this._event.description),
-    })
+    return jsonSchemaToTypescriptZuiSchema(
+      this._event.schema,
+      this.exportName,
+      gen.primitiveRecordToTypescriptValues({
+        title: this._event.title,
+        description: this._event.description,
+      })
+    )
   }
 }
 

--- a/packages/cli/src/code-generation/integration-package/integration-package-definition/events-module.ts
+++ b/packages/cli/src/code-generation/integration-package/integration-package-definition/events-module.ts
@@ -1,4 +1,5 @@
 import { jsonSchemaToTypescriptZuiSchema } from '../../generators'
+import * as gen from '../../generators'
 import { Module, ReExportVariableModule } from '../../module'
 import * as strings from '../../strings'
 import * as types from './typings'
@@ -14,10 +15,10 @@ export class EventModule extends Module {
   }
 
   public async getContent() {
-    if (!this._event.schema) {
-      return `export const ${this.exportName} = z.object({});`
-    }
-    return jsonSchemaToTypescriptZuiSchema(this._event.schema, this.exportName)
+    return jsonSchemaToTypescriptZuiSchema(this._event.schema, this.exportName, {
+      title: gen.primitiveToTypescriptValue(this._event.title),
+      description: gen.primitiveToTypescriptValue(this._event.description),
+    })
   }
 }
 

--- a/packages/cli/src/code-generation/integration-package/integration-package-definition/states-module.ts
+++ b/packages/cli/src/code-generation/integration-package/integration-package-definition/states-module.ts
@@ -1,4 +1,5 @@
 import { jsonSchemaToTypescriptZuiSchema } from '../../generators'
+import * as gen from '../../generators'
 import { Module, ReExportVariableModule } from '../../module'
 import * as strings from '../../strings'
 import * as types from './typings'
@@ -17,6 +18,8 @@ export class StateModule extends Module {
   public async getContent() {
     return jsonSchemaToTypescriptZuiSchema(this._state.schema, this.exportName, {
       type: `"${this._state.type}" as const`,
+      title: gen.primitiveToTypescriptValue(this._state.title),
+      description: gen.primitiveToTypescriptValue(this._state.description),
     })
   }
 }

--- a/packages/cli/src/code-generation/integration-package/integration-package-definition/states-module.ts
+++ b/packages/cli/src/code-generation/integration-package/integration-package-definition/states-module.ts
@@ -18,8 +18,10 @@ export class StateModule extends Module {
   public async getContent() {
     return jsonSchemaToTypescriptZuiSchema(this._state.schema, this.exportName, {
       type: `"${this._state.type}" as const`,
-      title: gen.primitiveToTypescriptValue(this._state.title),
-      description: gen.primitiveToTypescriptValue(this._state.description),
+      ...gen.primitiveRecordToTypescriptValues({
+        title: this._state.title,
+        description: this._state.description,
+      }),
     })
   }
 }

--- a/packages/cli/src/code-generation/interface-package/interface-package-definition/actions-module.ts
+++ b/packages/cli/src/code-generation/interface-package/interface-package-definition/actions-module.ts
@@ -32,7 +32,15 @@ export class ActionOutputModule extends Module {
 
 export class ActionModule extends ReExportVariableModule {
   public constructor(actionName: string, action: types.ActionDefinition) {
-    super({ exportName: strings.varName(actionName) })
+    super({
+      exportName: strings.varName(actionName),
+      extraProps: {
+        billable: JSON.stringify(action.billable),
+        cacheable: JSON.stringify(action.cacheable),
+        title: JSON.stringify(action.title),
+        description: JSON.stringify(action.description),
+      },
+    })
 
     const inputModule = new ActionInputModule(action.input)
     const outputModule = new ActionOutputModule(action.output)

--- a/packages/cli/src/code-generation/interface-package/interface-package-definition/actions-module.ts
+++ b/packages/cli/src/code-generation/interface-package/interface-package-definition/actions-module.ts
@@ -1,4 +1,5 @@
 import { jsonSchemaToTypescriptZuiSchema } from '../../generators'
+import * as gen from '../../generators'
 import { Module, ReExportVariableModule } from '../../module'
 import * as strings from '../../strings'
 import * as types from './typings'
@@ -35,10 +36,10 @@ export class ActionModule extends ReExportVariableModule {
     super({
       exportName: strings.varName(actionName),
       extraProps: {
-        billable: JSON.stringify(action.billable),
-        cacheable: JSON.stringify(action.cacheable),
-        title: JSON.stringify(action.title),
-        description: JSON.stringify(action.description),
+        title: gen.primitiveToTypescriptValue(action.title),
+        description: gen.primitiveToTypescriptValue(action.description),
+        billable: gen.primitiveToTypescriptValue(action.billable),
+        cacheable: gen.primitiveToTypescriptValue(action.cacheable),
       },
     })
 

--- a/packages/cli/src/code-generation/interface-package/interface-package-definition/actions-module.ts
+++ b/packages/cli/src/code-generation/interface-package/interface-package-definition/actions-module.ts
@@ -35,12 +35,12 @@ export class ActionModule extends ReExportVariableModule {
   public constructor(actionName: string, action: types.ActionDefinition) {
     super({
       exportName: strings.varName(actionName),
-      extraProps: {
-        title: gen.primitiveToTypescriptValue(action.title),
-        description: gen.primitiveToTypescriptValue(action.description),
-        billable: gen.primitiveToTypescriptValue(action.billable),
-        cacheable: gen.primitiveToTypescriptValue(action.cacheable),
-      },
+      extraProps: gen.primitiveRecordToTypescriptValues({
+        title: action.title,
+        description: action.description,
+        billable: action.billable,
+        cacheable: action.cacheable,
+      }),
     })
 
     const inputModule = new ActionInputModule(action.input)

--- a/packages/cli/src/code-generation/interface-package/interface-package-definition/channels-module.ts
+++ b/packages/cli/src/code-generation/interface-package/interface-package-definition/channels-module.ts
@@ -1,5 +1,6 @@
 import { GENERATED_HEADER, INDEX_FILE } from '../../consts'
 import { jsonSchemaToTypescriptZuiSchema } from '../../generators'
+import * as gen from '../../generators'
 import { Module, ReExportVariableModule } from '../../module'
 import * as strings from '../../strings'
 import * as types from './typings'
@@ -16,7 +17,10 @@ class MessageModule extends Module {
   }
 
   public async getContent() {
-    return jsonSchemaToTypescriptZuiSchema(this._message.schema, this.exportName)
+    return jsonSchemaToTypescriptZuiSchema(this._message.schema, this.exportName, {
+      title: gen.primitiveToTypescriptValue(this._message.title),
+      description: gen.primitiveToTypescriptValue(this._message.description),
+    })
   }
 }
 

--- a/packages/cli/src/code-generation/interface-package/interface-package-definition/channels-module.ts
+++ b/packages/cli/src/code-generation/interface-package/interface-package-definition/channels-module.ts
@@ -17,10 +17,14 @@ class MessageModule extends Module {
   }
 
   public async getContent() {
-    return jsonSchemaToTypescriptZuiSchema(this._message.schema, this.exportName, {
-      title: gen.primitiveToTypescriptValue(this._message.title),
-      description: gen.primitiveToTypescriptValue(this._message.description),
-    })
+    return jsonSchemaToTypescriptZuiSchema(
+      this._message.schema,
+      this.exportName,
+      gen.primitiveRecordToTypescriptValues({
+        title: this._message.title,
+        description: this._message.description,
+      })
+    )
   }
 }
 

--- a/packages/cli/src/code-generation/interface-package/interface-package-definition/entities-module.ts
+++ b/packages/cli/src/code-generation/interface-package/interface-package-definition/entities-module.ts
@@ -1,4 +1,5 @@
 import { jsonSchemaToTypescriptZuiSchema } from '../../generators'
+import * as gen from '../../generators'
 import { Module, ReExportVariableModule } from '../../module'
 import * as strings from '../../strings'
 import * as types from './typings'
@@ -14,7 +15,10 @@ export class EntityModule extends Module {
   }
 
   public async getContent() {
-    return jsonSchemaToTypescriptZuiSchema(this._entity.schema, this.exportName)
+    return jsonSchemaToTypescriptZuiSchema(this._entity.schema, this.exportName, {
+      title: gen.primitiveToTypescriptValue(this._entity.title),
+      description: gen.primitiveToTypescriptValue(this._entity.description),
+    })
   }
 }
 

--- a/packages/cli/src/code-generation/interface-package/interface-package-definition/entities-module.ts
+++ b/packages/cli/src/code-generation/interface-package/interface-package-definition/entities-module.ts
@@ -15,10 +15,14 @@ export class EntityModule extends Module {
   }
 
   public async getContent() {
-    return jsonSchemaToTypescriptZuiSchema(this._entity.schema, this.exportName, {
-      title: gen.primitiveToTypescriptValue(this._entity.title),
-      description: gen.primitiveToTypescriptValue(this._entity.description),
-    })
+    return jsonSchemaToTypescriptZuiSchema(
+      this._entity.schema,
+      this.exportName,
+      gen.primitiveRecordToTypescriptValues({
+        title: this._entity.title,
+        description: this._entity.description,
+      })
+    )
   }
 }
 

--- a/packages/cli/src/code-generation/interface-package/interface-package-definition/events-module.ts
+++ b/packages/cli/src/code-generation/interface-package/interface-package-definition/events-module.ts
@@ -18,10 +18,14 @@ export class EventModule extends Module {
     if (!this._event.schema) {
       return `export const ${this.exportName} = z.object({});`
     }
-    return jsonSchemaToTypescriptZuiSchema(this._event.schema, this.exportName, {
-      title: gen.primitiveToTypescriptValue(this._event.title),
-      description: gen.primitiveToTypescriptValue(this._event.description),
-    })
+    return jsonSchemaToTypescriptZuiSchema(
+      this._event.schema,
+      this.exportName,
+      gen.primitiveRecordToTypescriptValues({
+        title: this._event.title,
+        description: this._event.description,
+      })
+    )
   }
 }
 

--- a/packages/cli/src/code-generation/interface-package/interface-package-definition/events-module.ts
+++ b/packages/cli/src/code-generation/interface-package/interface-package-definition/events-module.ts
@@ -1,4 +1,5 @@
 import { jsonSchemaToTypescriptZuiSchema } from '../../generators'
+import * as gen from '../../generators'
 import { Module, ReExportVariableModule } from '../../module'
 import * as strings from '../../strings'
 import * as types from './typings'
@@ -17,7 +18,10 @@ export class EventModule extends Module {
     if (!this._event.schema) {
       return `export const ${this.exportName} = z.object({});`
     }
-    return jsonSchemaToTypescriptZuiSchema(this._event.schema, this.exportName)
+    return jsonSchemaToTypescriptZuiSchema(this._event.schema, this.exportName, {
+      title: gen.primitiveToTypescriptValue(this._event.title),
+      description: gen.primitiveToTypescriptValue(this._event.description),
+    })
   }
 }
 

--- a/packages/cli/src/code-generation/module.ts
+++ b/packages/cli/src/code-generation/module.ts
@@ -143,13 +143,14 @@ export class ReExportVariableModule extends Module {
 
     content += '\n'
 
-    const allProps: { key: string; value: string }[] = [
-      ...this.deps.map(({ name, exportName }) => ({ key: name, value: `${strings.importAlias(name)}.${exportName}` })),
-      ...Object.entries(this._extraProps).map(([key, value]) => ({ key, value })),
-    ]
+    const depProps: Record<string, string> = Object.fromEntries(
+      this.deps.map(({ name, exportName }) => [name, `${strings.importAlias(name)}.${exportName}`])
+    )
+
+    const allProps = { ...depProps, ...this._extraProps }
 
     content += `export const ${this.exportName} = {\n`
-    for (const { key, value } of allProps) {
+    for (const [key, value] of Object.entries(allProps)) {
       content += `  "${key}": ${value},\n`
     }
     content += '}'

--- a/packages/cli/src/code-generation/plugin-package/plugin-package-definition/actions-module.ts
+++ b/packages/cli/src/code-generation/plugin-package/plugin-package-definition/actions-module.ts
@@ -1,4 +1,5 @@
 import { jsonSchemaToTypescriptZuiSchema } from '../../generators'
+import * as gen from '../../generators'
 import { Module, ReExportVariableModule } from '../../module'
 import * as strings from '../../strings'
 import * as types from './typings'
@@ -32,7 +33,13 @@ export class ActionOutputModule extends Module {
 
 export class ActionModule extends ReExportVariableModule {
   public constructor(actionName: string, action: types.ActionDefinition) {
-    super({ exportName: strings.varName(actionName) })
+    super({
+      exportName: strings.varName(actionName),
+      extraProps: {
+        title: gen.primitiveToTypescriptValue(action.title),
+        description: gen.primitiveToTypescriptValue(action.description),
+      },
+    })
 
     const inputModule = new ActionInputModule(action.input)
     const outputModule = new ActionOutputModule(action.output)

--- a/packages/cli/src/code-generation/plugin-package/plugin-package-definition/actions-module.ts
+++ b/packages/cli/src/code-generation/plugin-package/plugin-package-definition/actions-module.ts
@@ -35,10 +35,10 @@ export class ActionModule extends ReExportVariableModule {
   public constructor(actionName: string, action: types.ActionDefinition) {
     super({
       exportName: strings.varName(actionName),
-      extraProps: {
-        title: gen.primitiveToTypescriptValue(action.title),
-        description: gen.primitiveToTypescriptValue(action.description),
-      },
+      extraProps: gen.primitiveRecordToTypescriptValues({
+        title: action.title,
+        description: action.description,
+      }),
     })
 
     const inputModule = new ActionInputModule(action.input)

--- a/packages/cli/src/code-generation/plugin-package/plugin-package-definition/configuration-module.ts
+++ b/packages/cli/src/code-generation/plugin-package/plugin-package-definition/configuration-module.ts
@@ -1,6 +1,7 @@
 import { JSONSchema7 } from 'json-schema'
 import { INDEX_FILE } from '../../consts'
 import { jsonSchemaToTypescriptZuiSchema } from '../../generators'
+import * as gen from '../../generators'
 import { Module } from '../../module'
 import * as strings from '../../strings'
 import * as types from './typings'
@@ -17,6 +18,9 @@ export class DefaultConfigurationModule extends Module {
 
   public async getContent() {
     const schema: JSONSchema7 = this._configuration.schema ?? { type: 'object', properties: {} }
-    return jsonSchemaToTypescriptZuiSchema(schema, this.exportName)
+    return jsonSchemaToTypescriptZuiSchema(schema, this.exportName, {
+      title: gen.primitiveToTypescriptValue(this._configuration.title),
+      description: gen.primitiveToTypescriptValue(this._configuration.description),
+    })
   }
 }

--- a/packages/cli/src/code-generation/plugin-package/plugin-package-definition/configuration-module.ts
+++ b/packages/cli/src/code-generation/plugin-package/plugin-package-definition/configuration-module.ts
@@ -18,9 +18,13 @@ export class DefaultConfigurationModule extends Module {
 
   public async getContent() {
     const schema: JSONSchema7 = this._configuration.schema ?? { type: 'object', properties: {} }
-    return jsonSchemaToTypescriptZuiSchema(schema, this.exportName, {
-      title: gen.primitiveToTypescriptValue(this._configuration.title),
-      description: gen.primitiveToTypescriptValue(this._configuration.description),
-    })
+    return jsonSchemaToTypescriptZuiSchema(
+      schema,
+      this.exportName,
+      gen.primitiveRecordToTypescriptValues({
+        title: this._configuration.title,
+        description: this._configuration.description,
+      })
+    )
   }
 }

--- a/packages/cli/src/code-generation/plugin-package/plugin-package-definition/events-module.ts
+++ b/packages/cli/src/code-generation/plugin-package/plugin-package-definition/events-module.ts
@@ -15,13 +15,14 @@ export class EventModule extends Module {
   }
 
   public async getContent() {
-    if (!this._event.schema) {
-      return `export const ${this.exportName} = z.object({});`
-    }
-    return jsonSchemaToTypescriptZuiSchema(this._event.schema, this.exportName, {
-      title: gen.primitiveToTypescriptValue(this._event.title),
-      description: gen.primitiveToTypescriptValue(this._event.description),
-    })
+    return jsonSchemaToTypescriptZuiSchema(
+      this._event.schema,
+      this.exportName,
+      gen.primitiveRecordToTypescriptValues({
+        title: this._event.title,
+        description: this._event.description,
+      })
+    )
   }
 }
 

--- a/packages/cli/src/code-generation/plugin-package/plugin-package-definition/events-module.ts
+++ b/packages/cli/src/code-generation/plugin-package/plugin-package-definition/events-module.ts
@@ -1,4 +1,5 @@
 import { jsonSchemaToTypescriptZuiSchema } from '../../generators'
+import * as gen from '../../generators'
 import { Module, ReExportVariableModule } from '../../module'
 import * as strings from '../../strings'
 import * as types from './typings'
@@ -17,7 +18,10 @@ export class EventModule extends Module {
     if (!this._event.schema) {
       return `export const ${this.exportName} = z.object({});`
     }
-    return jsonSchemaToTypescriptZuiSchema(this._event.schema, this.exportName)
+    return jsonSchemaToTypescriptZuiSchema(this._event.schema, this.exportName, {
+      title: gen.primitiveToTypescriptValue(this._event.title),
+      description: gen.primitiveToTypescriptValue(this._event.description),
+    })
   }
 }
 

--- a/packages/cli/src/code-generation/plugin-package/plugin-package-definition/states-module.ts
+++ b/packages/cli/src/code-generation/plugin-package/plugin-package-definition/states-module.ts
@@ -1,4 +1,5 @@
 import { jsonSchemaToTypescriptZuiSchema } from '../../generators'
+import * as gen from '../../generators'
 import { Module, ReExportVariableModule } from '../../module'
 import * as strings from '../../strings'
 import * as types from './typings'
@@ -17,6 +18,8 @@ export class StateModule extends Module {
   public async getContent() {
     return jsonSchemaToTypescriptZuiSchema(this._state.schema, this.exportName, {
       type: `"${this._state.type}" as const`,
+      title: gen.primitiveToTypescriptValue(this._state.title),
+      description: gen.primitiveToTypescriptValue(this._state.description),
     })
   }
 }

--- a/packages/cli/src/code-generation/plugin-package/plugin-package-definition/states-module.ts
+++ b/packages/cli/src/code-generation/plugin-package/plugin-package-definition/states-module.ts
@@ -18,8 +18,10 @@ export class StateModule extends Module {
   public async getContent() {
     return jsonSchemaToTypescriptZuiSchema(this._state.schema, this.exportName, {
       type: `"${this._state.type}" as const`,
-      title: gen.primitiveToTypescriptValue(this._state.title),
-      description: gen.primitiveToTypescriptValue(this._state.description),
+      ...gen.primitiveRecordToTypescriptValues({
+        title: this._state.title,
+        description: this._state.description,
+      }),
     })
   }
 }

--- a/packages/cli/src/code-generation/typings.ts
+++ b/packages/cli/src/code-generation/typings.ts
@@ -6,6 +6,8 @@ type PackageRef = { id?: string; name: string; version: string }
 type Schema = Record<string, any>
 type Aliases = Record<string, { name: string }>
 
+type TitleDescription = { title?: string; description?: string }
+
 export type File = { path: string; content: string }
 
 export type IntegrationDefinition = PackageRef & {
@@ -19,19 +21,19 @@ export type IntegrationDefinition = PackageRef & {
       channels?: Aliases
     }
   >
-  configuration?: {
+  configuration?: TitleDescription & {
     schema?: Schema
   }
   configurations?: Record<
     string,
-    {
+    TitleDescription & {
       schema?: Schema
     }
   >
   channels?: Record<
     string,
-    {
-      messages: Record<string, { schema: Schema }>
+    TitleDescription & {
+      messages: Record<string, TitleDescription & { schema: Schema }>
       conversation?: {
         tags?: Record<string, {}>
         creation?: {
@@ -46,17 +48,15 @@ export type IntegrationDefinition = PackageRef & {
   >
   states?: Record<
     string,
-    {
+    TitleDescription & {
       type: client.State['type']
       schema: Schema
     }
   >
-  events?: Record<string, { schema: Schema }>
+  events?: Record<string, TitleDescription & { schema: Schema }>
   actions?: Record<
     string,
-    {
-      title?: string
-      description?: string
+    TitleDescription & {
       billable?: boolean
       cacheable?: boolean
       input: {
@@ -67,7 +67,7 @@ export type IntegrationDefinition = PackageRef & {
       }
     }
   >
-  entities?: Record<string, { schema: Schema }>
+  entities?: Record<string, TitleDescription & { schema: Schema }>
   user?: {
     tags?: Record<string, {}>
     creation?: {
@@ -78,31 +78,27 @@ export type IntegrationDefinition = PackageRef & {
 }
 
 export type InterfaceDefinition = PackageRef & {
-  entities?: Record<string, { schema: Schema }>
-  events?: Record<string, { schema: Schema }>
+  entities?: Record<string, TitleDescription & { schema: Schema }>
+  events?: Record<string, TitleDescription & { schema: Schema }>
   actions?: Record<
     string,
-    {
-      title?: string
-      description?: string
+    TitleDescription & {
       billable?: boolean
       cacheable?: boolean
       input: { schema: Schema }
-      output: {
-        schema: Schema
-      }
+      output: { schema: Schema }
     }
   >
-  channels?: Record<string, { messages: Record<string, { schema: Schema }> }>
+  channels?: Record<string, TitleDescription & { messages: Record<string, TitleDescription & { schema: Schema }> }>
 }
 
 export type PluginDefinition = PackageRef & {
-  configuration?: { schema?: Schema }
+  configuration?: TitleDescription & { schema?: Schema }
   user?: { tags: Record<string, {}> }
   conversation?: { tags: Record<string, {}> }
-  states?: Record<string, { type: client.State['type']; schema: Schema }>
-  events?: Record<string, { schema: Schema }>
-  actions?: Record<string, { input: { schema: Schema }; output: { schema: Schema } }>
+  states?: Record<string, TitleDescription & { type: client.State['type']; schema: Schema }>
+  events?: Record<string, TitleDescription & { schema: Schema }>
+  actions?: Record<string, TitleDescription & { input: { schema: Schema }; output: { schema: Schema } }>
   dependencies?: {
     interfaces?: Record<string, PackageRef>
     integrations?: Record<string, PackageRef>

--- a/packages/cli/src/code-generation/typings.ts
+++ b/packages/cli/src/code-generation/typings.ts
@@ -55,6 +55,10 @@ export type IntegrationDefinition = PackageRef & {
   actions?: Record<
     string,
     {
+      title?: string
+      description?: string
+      billable?: boolean
+      cacheable?: boolean
       input: {
         schema: Schema
       }
@@ -79,6 +83,10 @@ export type InterfaceDefinition = PackageRef & {
   actions?: Record<
     string,
     {
+      title?: string
+      description?: string
+      billable?: boolean
+      cacheable?: boolean
       input: { schema: Schema }
       output: {
         schema: Schema

--- a/packages/sdk/src/zui.ts
+++ b/packages/sdk/src/zui.ts
@@ -10,11 +10,16 @@ export type GenericZuiSchema<
 export type ZuiObjectSchema = z.ZodObject | z.ZodRecord
 
 export const mergeObjectSchemas = (a: ZuiObjectSchema, b: ZuiObjectSchema): ZuiObjectSchema => {
-  if (a instanceof z.ZodObject && b instanceof z.ZodObject) {
-    return a.merge(b)
+  const aDef = a._def
+  const bDef = b._def
+
+  if (aDef.typeName === z.ZodFirstPartyTypeKind.ZodObject && bDef.typeName === z.ZodFirstPartyTypeKind.ZodObject) {
+    const aShape = aDef.shape()
+    const bShape = bDef.shape()
+    return z.object({ ...aShape, ...bShape })
   }
-  if (a instanceof z.ZodRecord && b instanceof z.ZodRecord) {
-    return z.record(z.intersection(a.valueSchema, b.valueSchema))
+  if (aDef.typeName === z.ZodFirstPartyTypeKind.ZodRecord && bDef.typeName === z.ZodFirstPartyTypeKind.ZodRecord) {
+    return z.record(z.intersection(aDef.valueType, bDef.valueType))
   }
   // TODO: adress this case
   throw new Error('Cannot merge object schemas with record schemas')


### PR DESCRIPTION
This PR does 2 things:
1. repair the merge logic when an action is defined both in an interface and an integration
2. ensure non-schema properties like `billeable`, `cacheable`, `title` and `description` a generated as well