### PR TITLE
fix(cognitive): fix fallback detection, clean old downtimes

### DIFF
--- a/packages/cognitive/e2e/client.test.ts
+++ b/packages/cognitive/e2e/client.test.ts
@@ -86,8 +86,8 @@ describe('client', () => {
         isApiError: true,
         code: 400,
         id: '123',
-        type: 'UPSTREAM_PROVIDER_FAILED',
-        subtype: 'UPSTREAM_PROVIDER_FAILED',
+        type: 'Runtime',
+        metadata: { subtype: 'UPSTREAM_PROVIDER_FAILED' },
       })
 
       provider.fetchModelPreferences.mockResolvedValue({

--- a/packages/cognitive/src/errors.ts
+++ b/packages/cognitive/src/errors.ts
@@ -29,7 +29,8 @@ export const getActionFromError = (error: any): Action => {
     return 'abort'
   }
 
-  if (error.type === 'Internal' || error.subtype === 'UPSTREAM_PROVIDER_FAILED') {
+  const subtype = (error.metadata as any)?.subtype
+  if (error.type === 'Internal' || subtype === 'UPSTREAM_PROVIDER_FAILED') {
     // The model is degraded, so we want to try another model
     return 'fallback'
   }

--- a/packages/cognitive/src/index.ts
+++ b/packages/cognitive/src/index.ts
@@ -1,3 +1,4 @@
 export { Events, BotpressClientLike } from './types'
 export * from './client'
-export { ModelPreferences, ModelProvider, RemoteModelProvider } from './models'
+export { ModelPreferences, ModelProvider, RemoteModelProvider, Model } from './models'
+export { type GenerateContentInput, type GenerateContentOutput } from './gen'

--- a/packages/cognitive/src/models.ts
+++ b/packages/cognitive/src/models.ts
@@ -3,6 +3,7 @@ import { ExtendedClient, getExtendedClient } from './bp-client'
 import { Model as RawModel } from './gen'
 import { BotpressClientLike } from './types'
 
+export const DOWNTIME_THRESHOLD_MINUTES = 5
 const PREFERENCES_FILE_SUFFIX = 'models.config.json'
 
 // Biases for vendors and models
@@ -75,7 +76,7 @@ export const getFastModels = (models: Model[], boosts: Record<ModelRef, number> 
 export const pickModel = (models: ModelRef[], downtimes: ModelPreferences['downtimes'] = []) => {
   const copy = [...models]
   const elasped = (date: string) => new Date().getTime() - new Date(date).getTime()
-  const DOWNTIME_THRESHOLD = 1000 * 60 * 5 // 5 minutes
+  const DOWNTIME_THRESHOLD = 1000 * 60 * DOWNTIME_THRESHOLD_MINUTES
 
   if (!copy.length) {
     throw new Error('At least one model is required')
@@ -149,18 +150,9 @@ export class RemoteModelProvider extends ModelProvider {
   public async fetchModelPreferences(): Promise<ModelPreferences | null> {
     try {
       const { file } = await this._client.getFile({ id: this._preferenceFileKey })
-      const { data } = await this._client.axios.get(file.url, {
-        // we piggy-back axios to avoid adding a new dependency
-        // unset all headers to avoid S3 pre-signed signature mismatch
-        headers: Object.keys(this._client.config.headers).reduce(
-          (acc, key) => {
-            acc[key] = undefined
-            return acc
-          },
-          {} as Record<string, undefined>
-        ),
-      })
-      return data as ModelPreferences
+
+      const response = await fetch(file.url)
+      return (await response.json()) as ModelPreferences
     } catch (err) {
       if (err instanceof ResourceNotFoundError) {
         return null


### PR DESCRIPTION
1. Fixes the error which uses `metadata.subtype` instead of just `subtype`
<img width="352" alt="image" src="https://github.com/user-attachments/assets/8db59f31-591f-4560-807f-5b28550192da" />

2. Cleaning up old downtimes when saving a more recent one (so we can see when the last downtime happened, without letting the array get too big)

3. Exporting useful types
4. Using fetch instead of axios to get the presigned url, otherwise it doesn't work in the browser