### PR TITLE
fix(hitl): ensure downstream stays closed

### DIFF
--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -11,7 +11,7 @@ export const DEFAULT_INCOMPATIBLE_MSGTYPE_MESSAGE =
 
 export default new sdk.PluginDefinition({
   name: 'hitl',
-  version: '0.1.0',
+  version: '0.1.1',
   configuration: {
     schema: sdk.z.object({
       onHitlHandoffMessage: sdk.z

--- a/plugins/hitl/src/hooks/before-incoming-message.ts
+++ b/plugins/hitl/src/hooks/before-incoming-message.ts
@@ -98,6 +98,12 @@ const _handleUpstreamMessage = async (
   }
 
   const downstreamCm = conv.ConversationManager.from(props, downstreamConversationId)
+  const isDownstreamHitlActive = await downstreamCm.isHitlActive()
+
+  if (!isDownstreamHitlActive) {
+    await upstreamCm.setHitlInactive()
+    return LET_BOT_HANDLE_MESSAGE
+  }
 
   props.logger.withConversationId(upstreamConversation.id).info('Sending message to downstream')
   await downstreamCm.respond({

--- a/plugins/hitl/src/user-linker.ts
+++ b/plugins/hitl/src/user-linker.ts
@@ -36,11 +36,7 @@ export class UserLinker {
     const { userId: downstreamUserId } = await this._props.actions.hitl.createUser({
       name: upstreamUserOverrides?.name ?? upstreamUser.tags['name'] ?? upstreamUser.name ?? 'Unknown User',
       pictureUrl: upstreamUserOverrides?.pictureUrl ?? upstreamUser.tags['pictureUrl'] ?? upstreamUser.pictureUrl,
-      email:
-        upstreamUserOverrides?.email ??
-        upstreamUser.tags['email'] ??
-        upstreamUser.tags.email ??
-        'anonymous@noemail.com',
+      email: upstreamUserOverrides?.email ?? upstreamUser.tags['email'] ?? 'anonymous@noemail.com',
     })
 
     const [{ user: updatedUpstreamUser }, { user: updatedDownstreamUser }] = await Promise.all([


### PR DESCRIPTION
Addresses CLS-2686.
This should prevent the hitl plugin from ever sending messages downstream when the session is inactive.