### PR TITLE
feat(client) Bump client and API versions to 0.46.0 and 0.76.0 respectively

### DIFF
--- a/packages/chat-api/package.json
+++ b/packages/chat-api/package.json
@@ -13,7 +13,7 @@
     "esbuild": "^0.16.12"
   },
   "dependencies": {
-    "@botpress/api": "0.75.0",
+    "@botpress/api": "0.76.0",
     "@bpinternal/opapi": "0.12.1",
     "lodash": "^4.17.21",
     "zod": "^3.20.6",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.1",
-    "@botpress/client": "0.45.0",
+    "@botpress/client": "0.46.0",
     "@botpress/sdk": "3.2.0",
     "@bpinternal/const": "^0.0.20",
     "@bpinternal/tunnel": "^0.1.1",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -5,7 +5,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.45.0",
+    "@botpress/client": "0.46.0",
     "@botpress/sdk": "3.2.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.45.0",
+    "@botpress/client": "0.46.0",
     "@botpress/sdk": "3.2.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.45.0",
+    "@botpress/client": "0.46.0",
     "@botpress/sdk": "3.2.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.45.0",
+    "@botpress/client": "0.46.0",
     "@botpress/sdk": "3.2.0",
     "axios": "^1.6.8"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,7 +29,7 @@
     "type-fest": "^3.4.0"
   },
   "devDependencies": {
-    "@botpress/api": "0.75.0",
+    "@botpress/api": "0.76.0",
     "@types/qs": "^6.9.7",
     "esbuild": "^0.16.12",
     "lodash": "^4.17.21",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "0.45.0",
+    "@botpress/client": "0.46.0",
     "browser-or-node": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -36,7 +36,7 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "@botpress/client": "0.45.0",
+    "@botpress/client": "0.46.0",
     "@bpinternal/thicktoken": "^1.0.1",
     "@bpinternal/zui": "^0.13.4",
     "lodash": "^4.17.21",

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -38,7 +38,7 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "@botpress/client": "0.45.0",
+    "@botpress/client": "0.46.0",
     "@bpinternal/thicktoken": "^1.0.0",
     "@bpinternal/zui": "^0.13.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2038,8 +2038,8 @@ importers:
         version: 3.11.1
     devDependencies:
       '@botpress/api':
-        specifier: 0.75.0
-        version: 0.75.0(openapi-types@12.1.3)
+        specifier: 0.76.0
+        version: 0.76.0(openapi-types@12.1.3)
       '@types/qs':
         specifier: ^6.9.7
         version: 6.9.7
@@ -3913,6 +3913,17 @@ packages:
       - debug
       - openapi-types
       - supports-color
+    dev: false
+
+  /@botpress/api@0.76.0(openapi-types@12.1.3):
+    resolution: {integrity: sha512-Qc4ujgRPDotVOFvpOqtmOx7GvwZRDGhoGJ8rTty2CNHKx2wlFqFq06bgOqRBy/4dmDIuc7HHcLIUTp7k/Hbz1w==}
+    dependencies:
+      '@bpinternal/opapi': 0.12.1(openapi-types@12.1.3)
+    transitivePeerDependencies:
+      - debug
+      - openapi-types
+      - supports-color
+    dev: true
 
   /@bpinternal/const@0.0.20:
     resolution: {integrity: sha512-AVeQy25M9eXMvjnLZVbFmr++qkONYrwW7qLXD9q9ccD4WLEgMmJZ6e+BSUnwPEBQ8LiqWQXf/YJ1MJxoVkcyNw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1821,7 +1821,7 @@ importers:
         specifier: 0.5.1
         version: link:../chat-client
       '@botpress/client':
-        specifier: 0.45.0
+        specifier: 0.46.0
         version: link:../client
       '@botpress/sdk':
         specifier: 3.2.0
@@ -1942,7 +1942,7 @@ importers:
   packages/cli/templates/empty-bot:
     dependencies:
       '@botpress/client':
-        specifier: 0.45.0
+        specifier: 0.46.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 3.2.0
@@ -1958,7 +1958,7 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 0.45.0
+        specifier: 0.46.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 3.2.0
@@ -1987,7 +1987,7 @@ importers:
   packages/cli/templates/hello-world:
     dependencies:
       '@botpress/client':
-        specifier: 0.45.0
+        specifier: 0.46.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 3.2.0
@@ -2003,7 +2003,7 @@ importers:
   packages/cli/templates/webhook-message:
     dependencies:
       '@botpress/client':
-        specifier: 0.45.0
+        specifier: 0.46.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 3.2.0
@@ -2111,7 +2111,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 0.45.0
+        specifier: 0.46.0
         version: link:../client
       '@bpinternal/zui':
         specifier: ^0.13.5
@@ -2142,7 +2142,7 @@ importers:
   packages/vai:
     dependencies:
       '@botpress/client':
-        specifier: 0.45.0
+        specifier: 0.46.0
         version: link:../client
       '@bpinternal/thicktoken':
         specifier: ^1.0.1
@@ -2185,7 +2185,7 @@ importers:
   packages/zai:
     dependencies:
       '@botpress/client':
-        specifier: 0.45.0
+        specifier: 0.46.0
         version: link:../client
       '@bpinternal/thicktoken':
         specifier: ^1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1711,8 +1711,8 @@ importers:
   packages/chat-api:
     dependencies:
       '@botpress/api':
-        specifier: 0.75.0
-        version: 0.75.0(openapi-types@12.1.3)
+        specifier: 0.76.0
+        version: 0.76.0(openapi-types@12.1.3)
       '@bpinternal/opapi':
         specifier: 0.12.1
         version: 0.12.1(openapi-types@12.1.3)
@@ -3905,16 +3905,6 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@botpress/api@0.75.0(openapi-types@12.1.3):
-    resolution: {integrity: sha512-QGwMOb3+ou9go7OKwL/NY9Ai+QrwhTxcRe87cCHj7uIuRbxND1av/HEW2HWn/E8E9+bGt9E8zte47cV35rjElw==}
-    dependencies:
-      '@bpinternal/opapi': 0.12.1(openapi-types@12.1.3)
-    transitivePeerDependencies:
-      - debug
-      - openapi-types
-      - supports-color
-    dev: false
-
   /@botpress/api@0.76.0(openapi-types@12.1.3):
     resolution: {integrity: sha512-Qc4ujgRPDotVOFvpOqtmOx7GvwZRDGhoGJ8rTty2CNHKx2wlFqFq06bgOqRBy/4dmDIuc7HHcLIUTp7k/Hbz1w==}
     dependencies:
@@ -3923,7 +3913,6 @@ packages:
       - debug
       - openapi-types
       - supports-color
-    dev: true
 
   /@bpinternal/const@0.0.20:
     resolution: {integrity: sha512-AVeQy25M9eXMvjnLZVbFmr++qkONYrwW7qLXD9q9ccD4WLEgMmJZ6e+BSUnwPEBQ8LiqWQXf/YJ1MJxoVkcyNw==}


### PR DESCRIPTION
Part of [CLS-2640](https://linear.app/botpress/issue/CLS-2640/add-upcoming-invoice-items-in-dashboard) Update the Botpress client version to 0.46.0 and the API version to 0.76.0 across all relevant files.