### PR TITLE
chore: rm usage of integrations secrets in CI/CD

### DIFF
--- a/.github/actions/deploy-integrations/action.yml
+++ b/.github/actions/deploy-integrations/action.yml
@@ -33,60 +33,6 @@ input:
   cloud_ops_workspace_id:
     description: 'Cloud Ops workspace id'
     required: true
-  googledrive_secrets:
-    description: 'Google Drive secrets'
-    required: false
-  gmail_secrets:
-    description: 'Gmail secrets'
-    required: false
-  gsheets_secrets:
-    description: 'Google Sheets secrets'
-    required: false
-  googlecalendar_secrets:
-    description: 'Google Calendar secrets'
-    required: false
-  linear_secrets:
-    description: 'Linear secrets'
-    required: false
-  slack_secrets:
-    description: 'Slack secrets'
-    required: false
-  whatsapp_secrets:
-    description: 'Whatsapp secrets'
-    required: false
-  charts_secrets:
-    description: 'Charts secrets'
-    required: false
-  pdf_secrets:
-    description: 'PDF secrets'
-    required: false
-  browser_secrets:
-    description: 'Browser secrets'
-    required: false
-  openai_secrets:
-    description: 'OpenAI secrets'
-    required: false
-  groq_secrets:
-    description: 'Groq secrets'
-    required: false
-  todoist_secrets:
-    description: 'Todoist secrets'
-    required: false
-  cerebras_secrets:
-    description: 'Cerebras secrets'
-    required: false
-  messenger_secrets:
-    description: 'Messenger secrets'
-    required: false
-  github_secrets:
-    description: 'Github secrets'
-    required: false
-  intercom_secrets:
-    description: 'Intercom secrets'
-    required: false
-  instagram_secrets:
-    description: 'Instagram secrets'
-    required: false
 
 runs:
   using: 'composite'
@@ -137,53 +83,8 @@ runs:
             integration=$(basename $integration_path)
             exists=$(./.github/scripts/integration-exists.sh $integration)
 
-            base_command="bp deploy -v -y --noBuild --public $dryrun"
-            if [ $integration == "googledrive" ]; then
-                base_command="$base_command ${{ inputs.googledrive_secrets }}"
-            elif [ $integration == "gmail" ]; then
-                base_command="$base_command ${{ inputs.gmail_secrets }}"
-            elif [ $integration == "gsheets" ]; then
-                base_command="$base_command ${{ inputs.gsheets_secrets }}"
-            elif [ $integration == "googlecalendar" ]; then
-                base_command="$base_command ${{ inputs.googlecalendar_secrets }}"
-            elif [ $integration == "linear" ]; then
-                base_command="$base_command ${{ inputs.linear_secrets }}"
-            elif [ $integration == "slack" ]; then
-                base_command="$base_command ${{ inputs.slack_secrets }}"
-            elif [ $integration == "charts" ]; then
-                base_command="$base_command ${{ inputs.charts_secrets }}"
-            elif [ $integration == "whatsapp" ]; then
-                base_command="$base_command ${{ inputs.whatsapp_secrets }}"
-            elif [ $integration == "pdf-generator" ]; then
-                base_command="$base_command ${{ inputs.pdf_secrets }}"
-            elif [ $integration == "browser" ]; then
-                base_command="$base_command ${{ inputs.browser_secrets }}"
-            elif [ $integration == "openai" ]; then
-                base_command="$base_command ${{ inputs.openai_secrets }}"
-            elif [ $integration == "groq" ]; then
-                base_command="$base_command ${{ inputs.groq_secrets }}"
-            elif [ $integration == "anthropic" ]; then
-                base_command="$base_command ${{ inputs.anthropic_secrets }}"
-            elif [ $integration == "messenger" ]; then
-                base_command="$base_command ${{ inputs.messenger_secrets }}"
-            elif [ $integration == "fireworks-ai" ]; then
-                base_command="$base_command ${{ inputs.fireworks_ai_secrets }}"
-            elif [ $integration == "todoist" ]; then
-                base_command="$base_command ${{ inputs.todoist_secrets }}"
-            elif [ $integration == "cerebras" ]; then
-                base_command="$base_command ${{ inputs.cerebras_secrets }}"
-            elif [ $integration == "github" ]; then
-                base_command="$base_command ${{ inputs.github_secrets }}"
-            elif [ $integration == "google-ai" ]; then
-                base_command="$base_command ${{ inputs.google_ai_secrets }}"
-            elif [ $integration == "intercom" ]; then
-                base_command="$base_command ${{ inputs.intercom_secrets }} --allowDeprecated"
-            elif [ $integration == "line" ]; then
-                base_command="$base_command --allowDeprecated"
-            elif [ $integration == "instagram" ]; then
-                base_command="$base_command ${{ inputs.instagram_secrets }}"
-            fi
-
+            base_command="bp deploy -v -y --noBuild --public --allowDeprecated $dryrun"
+            
             if [ $exists -eq 0 ]; then
                 echo -e "\nDeploying integration: ### $integration ###\n"
                 pnpm retry -n 2 -- pnpm -F "@botpresshub/$integration" -c exec -- "$base_command"

--- a/.github/workflows/deploy-integrations-production.yml
+++ b/.github/workflows/deploy-integrations-production.yml
@@ -36,27 +36,6 @@ jobs:
           sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
           token_cloud_ops_account: ${{ secrets.PRODUCTION_TOKEN_CLOUD_OPS_ACCOUNT }}
           cloud_ops_workspace_id: ${{ secrets.PRODUCTION_CLOUD_OPS_WORKSPACE_ID }}
-          googledrive_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_GDRIVE_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_GDRIVE_CLIENT_SECRET }} --secrets WEBHOOK_SECRET=${{ secrets.PRODUCTION_GDRIVE_WEBHOOK_SECRET }}'
-          gmail_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_GMAIL_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_GMAIL_CLIENT_SECRET }} --secrets TOPIC_NAME=${{ secrets.PRODUCTION_GMAIL_TOPIC_NAME }} --secrets WEBHOOK_SHARED_SECRET=${{ secrets.PRODUCTION_GMAIL_WEBHOOK_SHARED_SECRET }} --secrets WEBHOOK_SERVICE_ACCOUNT=${{ secrets.PRODUCTION_GMAIL_WEBHOOK_SERVICE_ACCOUNT }}'
-          gsheets_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_GSHEETS_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_GSHEETS_CLIENT_SECRET }}'
-          googlecalendar_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_GOOGLECALENDAR_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_GOOGLECALENDAR_CLIENT_SECRET }}'
-          linear_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_LINEAR_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_LINEAR_CLIENT_SECRET }} --secrets WEBHOOK_SIGNING_SECRET=${{ secrets.PRODUCTION_LINEAR_WEBHOOK_SIGNING_SECRET }}'
-          slack_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_SLACK_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_SLACK_CLIENT_SECRET }} --secrets SIGNING_SECRET=${{ secrets.PRODUCTION_SLACK_SIGNING_SECRET }}'
-          charts_secrets: '--secrets QUICKCHARTS_API_KEY=${{ secrets.QUICKCHARTS_API_KEY }}'
-          pdf_secrets: '--secrets PDFSHIFT_API_KEY=${{ secrets.PDFSHIFT_API_KEY }}'
-          browser_secrets: '--secrets FIRECRAWL_API_KEY=${{ secrets.FIRECRAWL_API_KEY }} --secrets SCREENSHOT_API_KEY=${{ secrets.SCREENSHOT_API_KEY }}'
-          openai_secrets: '--secrets OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}'
-          groq_secrets: '--secrets GROQ_API_KEY=${{ secrets.GROQ_API_KEY }}'
-          whatsapp_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_WHATSAPP_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_WHATSAPP_CLIENT_SECRET }} --secrets ACCESS_TOKEN=${{ secrets.PRODUCTION_WHATSAPP_ACCESS_TOKEN }} --secrets NUMBER_PIN=${{ secrets.PRODUCTION_WHATSAPP_NUMBER_PIN }} --secrets SEGMENT_KEY=${{ secrets.PRODUCTION_WHATSAPP_SEGMENT_KEY }} --secrets VERIFY_TOKEN=${{ secrets.META_VERIFY_TOKEN }}'
-          anthropic_secrets: '--secrets ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}'
-          fireworks_ai_secrets: '--secrets FIREWORKS_AI_API_KEY=${{ secrets.FIREWORKS_AI_API_KEY }}'
-          todoist_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_TODOIST_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_TODOIST_CLIENT_SECRET }} --secrets WEBHOOK_SHARED_SECRET=${{ secrets.PRODUCTION_TODOIST_WEBHOOK_SHARED_SECRET }}'
-          cerebras_secrets: '--secrets CEREBRAS_API_KEY=${{ secrets.CEREBRAS_API_KEY }}'
-          messenger_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_MESSENGER_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_MESSENGER_CLIENT_SECRET  }} --secrets ACCESS_TOKEN=${{ secrets.PRODUCTION_MESSENGER_ACCESS_TOKEN  }} --secrets VERIFY_TOKEN=${{ secrets.META_VERIFY_TOKEN }}'
-          github_secrets: "--secrets GITHUB_APP_ID=${{ secrets.PRODUCTION_GITHUB_APP_ID }} --secrets 'GITHUB_PRIVATE_KEY=${{ secrets.PRODUCTION_GITHUB_PRIVATE_KEY }}' --secrets GITHUB_WEBHOOK_SECRET=${{ secrets.PRODUCTION_GITHUB_WEBHOOK_SECRET }}"
-          google_ai_secrets: '--secrets GOOGLE_AI_API_KEY=${{ secrets.GOOGLE_AI_API_KEY }}'
-          intercom_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_INTERCOM_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_INTERCOM_CLIENT_SECRET }}'
-          instagram_secrets: '--secrets CLIENT_ID=${{ secrets.PRODUCTION_INSTAGRAM_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.PRODUCTION_INSTAGRAM_CLIENT_SECRET }} --secrets VERIFY_TOKEN=${{ secrets.PRODUCTION_INSTAGRAM_VERIFY_TOKEN }}'
       - name: Deploy Plugins
         uses: ./.github/actions/deploy-plugins
         with:

--- a/.github/workflows/deploy-integrations-staging.yml
+++ b/.github/workflows/deploy-integrations-staging.yml
@@ -44,27 +44,6 @@ jobs:
           sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
           token_cloud_ops_account: ${{ secrets.STAGING_TOKEN_CLOUD_OPS_ACCOUNT }}
           cloud_ops_workspace_id: ${{ secrets.STAGING_CLOUD_OPS_WORKSPACE_ID }}
-          googledrive_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_GDRIVE_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_GDRIVE_CLIENT_SECRET }} --secrets WEBHOOK_SECRET=${{ secrets.STAGING_GDRIVE_WEBHOOK_SECRET }}'
-          gmail_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_GMAIL_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_GMAIL_CLIENT_SECRET }} --secrets TOPIC_NAME=${{ secrets.STAGING_GMAIL_TOPIC_NAME }} --secrets WEBHOOK_SHARED_SECRET=${{ secrets.STAGING_GMAIL_WEBHOOK_SHARED_SECRET }} --secrets WEBHOOK_SERVICE_ACCOUNT=${{ secrets.STAGING_GMAIL_WEBHOOK_SERVICE_ACCOUNT }}'
-          gsheets_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_GSHEETS_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_GSHEETS_CLIENT_SECRET }}'
-          googlecalendar_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_GOOGLECALENDAR_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_GOOGLECALENDAR_CLIENT_SECRET }}'
-          linear_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_LINEAR_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_LINEAR_CLIENT_SECRET }} --secrets WEBHOOK_SIGNING_SECRET=${{ secrets.STAGING_LINEAR_WEBHOOK_SIGNING_SECRET }}'
-          slack_secrets: --secrets CLIENT_ID=${{ secrets.STAGING_SLACK_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_SLACK_CLIENT_SECRET }} --secrets SIGNING_SECRET=${{ secrets.STAGING_SLACK_SIGNING_SECRET }}
-          charts_secrets: '--secrets QUICKCHARTS_API_KEY=${{ secrets.QUICKCHARTS_API_KEY }}'
-          whatsapp_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_WHATSAPP_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_WHATSAPP_CLIENT_SECRET }} --secrets ACCESS_TOKEN=${{ secrets.STAGING_WHATSAPP_ACCESS_TOKEN }} --secrets NUMBER_PIN=${{ secrets.STAGING_WHATSAPP_NUMBER_PIN }} --secrets SEGMENT_KEY=${{ secrets.STAGING_WHATSAPP_SEGMENT_KEY }} --secrets VERIFY_TOKEN=${{ secrets.META_VERIFY_TOKEN }}'
-          pdf_secrets: '--secrets PDFSHIFT_API_KEY=${{ secrets.PDFSHIFT_API_KEY }}'
-          browser_secrets: '--secrets FIRECRAWL_API_KEY=${{ secrets.FIRECRAWL_API_KEY }} --secrets SCREENSHOT_API_KEY=${{ secrets.SCREENSHOT_API_KEY }}'
-          openai_secrets: '--secrets OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}'
-          groq_secrets: '--secrets GROQ_API_KEY=${{ secrets.GROQ_API_KEY }}'
-          anthropic_secrets: '--secrets ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}'
-          fireworks_ai_secrets: '--secrets FIREWORKS_AI_API_KEY=${{ secrets.FIREWORKS_AI_API_KEY }}'
-          todoist_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_TODOIST_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_TODOIST_CLIENT_SECRET }} --secrets WEBHOOK_SHARED_SECRET=${{ secrets.STAGING_TODOIST_WEBHOOK_SHARED_SECRET }}'
-          cerebras_secrets: '--secrets CEREBRAS_API_KEY=${{ secrets.CEREBRAS_API_KEY }}'
-          messenger_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_MESSENGER_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_MESSENGER_CLIENT_SECRET  }} --secrets ACCESS_TOKEN=${{ secrets.STAGING_MESSENGER_ACCESS_TOKEN  }} --secrets VERIFY_TOKEN=${{ secrets.META_VERIFY_TOKEN }}'
-          github_secrets: "--secrets GITHUB_APP_ID=${{ secrets.STAGING_GITHUB_APP_ID }} --secrets 'GITHUB_PRIVATE_KEY=${{ secrets.STAGING_GITHUB_PRIVATE_KEY }}' --secrets GITHUB_WEBHOOK_SECRET=${{ secrets.STAGING_GITHUB_WEBHOOK_SECRET }}"
-          google_ai_secrets: '--secrets GOOGLE_AI_API_KEY=${{ secrets.GOOGLE_AI_API_KEY }}'
-          intercom_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_INTERCOM_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_INTERCOM_CLIENT_SECRET }}'
-          instagram_secrets: '--secrets CLIENT_ID=${{ secrets.STAGING_INSTAGRAM_CLIENT_ID }} --secrets CLIENT_SECRET=${{ secrets.STAGING_INSTAGRAM_CLIENT_SECRET }} --secrets VERIFY_TOKEN=${{ secrets.STAGING_INSTAGRAM_VERIFY_TOKEN }}'
       - name: Deploy Plugins
         uses: ./.github/actions/deploy-plugins
         if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
When deploying an integration, secrets are always copied from the previous version of the same major. This means we don't have to explicitly pass secrets at every deployment.

When a new integration or a new major is deployed, the first deployment needs to be manually done by the developer on his machine. Next deployments can then be done in the CI