### PR TITLE
chore(zai): fix broken CI

### DIFF
--- a/integrations/anthropic/src/index.ts
+++ b/integrations/anthropic/src/index.ts
@@ -1,9 +1,9 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { llm } from '@botpress/common'
+import { GenerateContentInput } from '@botpress/common/src/llm'
 import { generateContent } from './actions/generate-content'
 import { ModelId } from './schemas'
 import * as bp from '.botpress'
-import { GenerateContentInput } from '@botpress/common/src/llm'
 
 const anthropic = new Anthropic({
   apiKey: bp.secrets.ANTHROPIC_API_KEY,

--- a/integrations/anthropic/src/index.ts
+++ b/integrations/anthropic/src/index.ts
@@ -1,9 +1,9 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { llm } from '@botpress/common'
-import { GenerateContentInput } from '@botpress/common/src/llm'
 import { generateContent } from './actions/generate-content'
 import { ModelId } from './schemas'
 import * as bp from '.botpress'
+import { GenerateContentInput } from '@botpress/common/src/llm'
 
 const anthropic = new Anthropic({
   apiKey: bp.secrets.ANTHROPIC_API_KEY,

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@botpress/cli": "workspace:*",
     "@botpress/client": "workspace:*",
     "@botpress/sdk": "workspace:*",
-    "@bpinternal/depsynky": "^0.1.0",
+    "@bpinternal/depsynky": "0.2.0",
     "@bpinternal/readiness": "^0.0.16",
     "@stylistic/eslint-plugin": "^2.12.1",
     "@types/node": "^18.19.67",

--- a/packages/cognitive/src/client.ts
+++ b/packages/cognitive/src/client.ts
@@ -130,7 +130,7 @@ export class Cognitive {
     const { integration, model: modelName } = await this._selectModel(model)
     const def = this._models.find((m) => m.integration === integration && (m.name === modelName || m.id === modelName))
     if (!def) {
-      console.log('Models:', this._models)
+      console.info('Models:', this._models)
       throw new Error(`Model ${modelName} not found`)
     }
 

--- a/packages/cognitive/src/models.ts
+++ b/packages/cognitive/src/models.ts
@@ -112,7 +112,7 @@ export class RemoteModelProvider extends ModelProvider {
 
   public async fetchInstalledModels() {
     const { bot } = await this._client.getBot({ id: this._client.botId })
-    const models: any[] = []
+    const models: Model[] = []
 
     const registered = Object.values(bot.integrations).filter((x) => x.status === 'registered')
 
@@ -138,7 +138,7 @@ export class RemoteModelProvider extends ModelProvider {
               input: model.input,
               output: model.output,
               tags: model.tags,
-            } satisfies Model)
+            })
           }
         }
       })

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -26,7 +26,7 @@
     "json5": "^2.2.3",
     "jsonrepair": "^3.10.0",
     "lodash-es": "^4.17.21",
-    "@botpress/cognitive": "^0.1.5"
+    "@botpress/cognitive": "^0.1.6"
   },
   "devDependencies": {
     "@botpress/client": "workspace:^",

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -23,10 +23,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@botpress/cognitive": "^0.1.6",
     "json5": "^2.2.3",
     "jsonrepair": "^3.10.0",
-    "lodash-es": "^4.17.21",
-    "@botpress/cognitive": "^0.1.6"
+    "lodash-es": "^4.17.21"
   },
   "devDependencies": {
     "@botpress/client": "workspace:^",

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "json5": "^2.2.3",
     "jsonrepair": "^3.10.0",
-    "lodash-es": "^4.17.21"
+    "lodash-es": "^4.17.21",
+    "@botpress/cognitive": "^0.1.5"
   },
   "devDependencies": {
     "@botpress/client": "workspace:^",
@@ -39,7 +40,6 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "@botpress/cognitive": "^0.1.5",
     "@bpinternal/thicktoken": "^1.0.0",
     "@bpinternal/zui": "^0.17.1"
   },

--- a/packages/zai/src/zai.ts
+++ b/packages/zai/src/zai.ts
@@ -117,7 +117,7 @@ export class Zai {
     return Zai.tokenizer
   }
 
-  protected async fetchModelDetails() {
+  protected async fetchModelDetails(): Promise<void> {
     if (!this.ModelDetails) {
       this.ModelDetails = await this.client.getModelDetails(this.Model)
     }

--- a/packages/zai/vitest.setup.ts
+++ b/packages/zai/vitest.setup.ts
@@ -5,13 +5,31 @@ import { getClient } from './e2e/utils'
 globalThis.STUDIO = false
 
 beforeAll(async () => {
-  if (!process.env.CLOUD_PAT) {
+  const token = process.env.CLOUD_PAT
+  if (!token) {
     throw new Error('Missing CLOUD_PAT')
   }
 
-  if (!process.env.CLOUD_BOT_ID) {
+  const botId = process.env.CLOUD_BOT_ID
+  if (!botId) {
     throw new Error('Missing CLOUD_BOT_ID')
   }
 
-  setupClient(getClient())
+  const client = getClient()
+
+  const { integration: openai } = await client.getPublicIntegration({
+    name: 'openai',
+    version: 'latest',
+  })
+
+  await client.updateBot({
+    id: botId,
+    integrations: {
+      [openai.id]: {
+        enabled: true,
+      },
+    },
+  })
+
+  setupClient(client)
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: workspace:*
         version: link:packages/sdk
       '@bpinternal/depsynky':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: 0.2.0
+        version: 0.2.0
       '@bpinternal/readiness':
         specifier: ^0.0.16
         version: 0.0.16
@@ -4092,8 +4092,8 @@ packages:
       - webdriverio
     dev: false
 
-  /@bpinternal/depsynky@0.1.0:
-    resolution: {integrity: sha512-NamRzF53WWICuxhwamQkw3esWjBPjEYlVqJES+4WdUlRjDqN5luOJsJ5KRvYsp3CWsBPvS6pbQz60qE/Z6kv7w==}
+  /@bpinternal/depsynky@0.2.0:
+    resolution: {integrity: sha512-RS9IdcgTLoYhyscACrE2BgqbKAy6Yx3y1ziVR1JMQVy09EXVnsXCbf3Fz35mmp/4W4V5vrk/1oQziADWTNgDqQ==}
     engines: {node: '>=16.0.0', pnpm: 8.6.2}
     hasBin: true
     dependencies:
@@ -10234,14 +10234,9 @@ packages:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
-  /escalade@3.1.1:
-    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
-    engines: {node: '>=6'}
-
   /escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
-    dev: false
 
   /escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -16032,7 +16027,7 @@ packages:
       browserslist: '>= 4.21.0'
     dependencies:
       browserslist: 4.21.7
-      escalade: 3.1.1
+      escalade: 3.2.0
       picocolors: 1.1.1
     dev: true
 
@@ -16752,7 +16747,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       cliui: 8.0.1
-      escalade: 3.1.1
+      escalade: 3.2.0
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2185,7 +2185,7 @@ importers:
   packages/zai:
     dependencies:
       '@botpress/cognitive':
-        specifier: ^0.1.5
+        specifier: ^0.1.6
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^1.0.0


### PR DESCRIPTION
changes
- Vitest setup file installs openai in the used bot; this is required for tests to run in the CI
- Cognitive is an actual dependency of zai instead of a peer dependency, but it is still tagged with a caret range anchor to allow flexibility.