### PR TITLE
fix(todoist): fix sync client `/user` http method

### DIFF
--- a/integrations/todoist/integration.definition.ts
+++ b/integrations/todoist/integration.definition.ts
@@ -16,7 +16,7 @@ export default new sdk.IntegrationDefinition({
   name: 'todoist',
   title: 'Todoist',
   description: 'Create and modify tasks, post comments and more.',
-  version: '1.0.0',
+  version: '1.0.1',
   readme: 'hub.md',
   icon: 'icon.svg',
   actions,

--- a/integrations/todoist/src/setup.ts
+++ b/integrations/todoist/src/setup.ts
@@ -1,8 +1,17 @@
+import * as sdk from '@botpress/sdk'
 import { TodoistClient } from './todoist-api'
 import * as bp from '.botpress'
 
 export const register: bp.IntegrationProps['register'] = async ({ logger, client, ctx }) => {
   logger.forBot().info('Registering Todoist integration')
+
+  if (ctx.configurationType === null) {
+    try {
+      await client.getState({ type: 'integration', name: 'credentials', id: ctx.integrationId })
+    } catch {
+      throw new sdk.RuntimeError('Please authenticate with Todoist before enabling the integration')
+    }
+  }
 
   const todoistClient = await TodoistClient.create({ client, ctx })
   const userIdentity = await todoistClient.getAuthenticatedUserIdentity()

--- a/integrations/todoist/src/todoist-api/sync-client.ts
+++ b/integrations/todoist/src/todoist-api/sync-client.ts
@@ -12,7 +12,7 @@ export class TodoistSyncClient {
   }
 
   public async getAuthenticatedUserIdentity() {
-    const identity = await this._post({
+    const identity = await this._get({
       endpoint: 'user',
       responseSchema: {
         id: z.string(),
@@ -43,6 +43,22 @@ export class TodoistSyncClient {
         method: 'POST',
         body: JSON.stringify(params),
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      },
+      responseSchema,
+    })
+  }
+
+  private async _get<T extends ZodRawShape>({
+    endpoint,
+    responseSchema,
+  }: {
+    endpoint: string
+    responseSchema: T
+  }): Promise<z.infer<ZodObject<T, 'strip'>>> {
+    return this._sendRequest({
+      endpoint,
+      init: {
+        method: 'GET',
       },
       responseSchema,
     })


### PR DESCRIPTION
For some reason, the `https://api.todoist.com/sync/v9/user` endpoint now expects a GET, while it previously expected a POST