### PR TITLE
feat(browser): use v1, add favicon, title, desc

### DIFF
--- a/integrations/browser/integration.definition.ts
+++ b/integrations/browser/integration.definition.ts
@@ -5,7 +5,7 @@ import { actionDefinitions } from 'src/definitions/actions'
 export default new IntegrationDefinition({
   name: 'browser',
   title: 'Browser',
-  version: '0.3.0',
+  version: '0.4.0',
   description:
     'Capture screenshots and retrieve web page content with metadata for automated browsing and data extraction.',
   readme: 'hub.md',

--- a/integrations/browser/src/definitions/actions.ts
+++ b/integrations/browser/src/definitions/actions.ts
@@ -20,7 +20,12 @@ const captureScreenshot = {
 const fullPage = z.object({
   url: z.string(),
   content: z.string(),
+  favicon: z.string().optional(),
+  title: z.string().optional(),
+  description: z.string().optional(),
 })
+
+export type FullPage = z.infer<typeof fullPage>
 
 const browsePages = {
   title: 'Browse Pages',


### PR DESCRIPTION
The output is the same but now it also include the page title, description and favicon.
Migrated to v1 since v0 is deprecated.