### PR TITLE
feat(sdk, cli): add support for bot workflows

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -22,7 +22,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.1",
     "@botpress/client": "0.48.0",
-    "@botpress/sdk": "3.4.0",
+    "@botpress/sdk": "3.5.0",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/src/code-generation/bot-implementation/bot-typings/index.ts
+++ b/packages/cli/src/code-generation/bot-implementation/bot-typings/index.ts
@@ -6,6 +6,7 @@ import { ActionsModule } from './actions-module'
 import { EventsModule } from './events-module'
 import { StatesModule } from './states-module'
 import { TablesModule } from './tables-module'
+import { WorkflowsModule } from './workflows-module'
 
 class BotIntegrationsModule extends ReExportTypeModule {
   public constructor(bot: sdk.BotDefinition) {
@@ -27,6 +28,7 @@ type BotTypingsIndexDependencies = {
   statesModule: StatesModule
   actionsModule: ActionsModule
   tablesModule: TablesModule
+  workflowsModule: WorkflowsModule
 }
 
 export class BotTypingsModule extends Module {
@@ -58,23 +60,30 @@ export class BotTypingsModule extends Module {
     actionsModule.unshift('actions')
     this.pushDep(actionsModule)
 
+    const workflowsModule = new WorkflowsModule(bot.workflows ?? {})
+    workflowsModule.unshift('workflows')
+    this.pushDep(workflowsModule)
+
     this._dependencies = {
       integrationsModule,
       eventsModule,
       statesModule,
       actionsModule,
       tablesModule,
+      workflowsModule,
     }
   }
 
   public async getContent() {
-    const { integrationsModule, eventsModule, statesModule, actionsModule, tablesModule } = this._dependencies
+    const { integrationsModule, eventsModule, statesModule, actionsModule, tablesModule, workflowsModule } =
+      this._dependencies
 
     const integrationsImport = integrationsModule.import(this)
     const eventsImport = eventsModule.import(this)
     const statesImport = statesModule.import(this)
     const actionsImport = actionsModule
     const tablesImport = tablesModule.import(this)
+    const workflowsImport = workflowsModule
 
     return [
       consts.GENERATED_HEADER,
@@ -83,12 +92,14 @@ export class BotTypingsModule extends Module {
       `import * as ${statesModule.name} from './${statesModule.name}'`,
       `import * as ${actionsModule.name} from './${actionsImport.name}'`,
       `import * as ${tablesModule.name} from './${tablesImport}'`,
+      `import * as ${workflowsModule.name} from './${workflowsImport.name}'`,
       '',
       `export * as ${integrationsModule.name} from './${integrationsImport}'`,
       `export * as ${eventsModule.name} from './${eventsImport}'`,
       `export * as ${statesModule.name} from './${statesImport}'`,
       `export * as ${actionsModule.name} from './${actionsImport.name}'`,
       `export * as ${tablesModule.name} from './${tablesImport}'`,
+      `export * as ${workflowsModule.name} from './${workflowsImport.name}'`,
       '',
       'export type TBot = {',
       `  integrations: ${integrationsModule.name}.${integrationsModule.exportName}`,
@@ -96,6 +107,7 @@ export class BotTypingsModule extends Module {
       `  states: ${statesModule.name}.${statesModule.exportName}`,
       `  actions: ${actionsModule.name}.${actionsModule.exportName}`,
       `  tables: ${tablesModule.name}.${tablesModule.exportName}`,
+      `  workflows: ${workflowsModule.name}.${workflowsModule.exportName}`,
       '}',
     ].join('\n')
   }

--- a/packages/cli/src/code-generation/bot-implementation/bot-typings/workflows-module.ts
+++ b/packages/cli/src/code-generation/bot-implementation/bot-typings/workflows-module.ts
@@ -1,0 +1,73 @@
+import * as sdk from '@botpress/sdk'
+import { primitiveToTypescriptValue, zuiSchemaToTypeScriptType } from '../../generators'
+import { Module, ReExportTypeModule } from '../../module'
+import * as strings from '../../strings'
+
+type WorkflowInput = sdk.BotWorkflowDefinition['input']
+type WorkflowOutput = sdk.BotWorkflowDefinition['output']
+type WorkflowTags = sdk.BotWorkflowDefinition['tags']
+
+export class WorkflowInputModule extends Module {
+  public constructor(private _input: WorkflowInput) {
+    const name = 'input'
+    const exportName = strings.typeName(name)
+    super({ path: `${name}.ts`, exportName })
+  }
+
+  public async getContent() {
+    return zuiSchemaToTypeScriptType(this._input.schema, this.exportName)
+  }
+}
+
+export class WorkflowOutputModule extends Module {
+  public constructor(private _output: WorkflowOutput) {
+    const name = 'output'
+    const exportName = strings.typeName(name)
+    super({ path: `${name}.ts`, exportName })
+  }
+
+  public async getContent() {
+    return zuiSchemaToTypeScriptType(this._output.schema, this.exportName)
+  }
+}
+
+export class WorkflowTagsModule extends Module {
+  public constructor(private _tags: WorkflowTags) {
+    const name = 'tags'
+    const exportName = strings.typeName(name)
+    super({ path: `${name}.ts`, exportName })
+  }
+
+  public async getContent() {
+    const tags = Object.keys(this._tags ?? {})
+      .map((tagName) => `${primitiveToTypescriptValue(tagName)}: string`)
+      .join(', ')
+
+    return `export type ${this.exportName} = { ${tags} }`
+  }
+}
+
+export class WorkflowModule extends ReExportTypeModule {
+  public constructor(workflowName: string, workflow: sdk.BotWorkflowDefinition) {
+    super({ exportName: strings.typeName(workflowName) })
+
+    const inputModule = new WorkflowInputModule(workflow.input)
+    const outputModule = new WorkflowOutputModule(workflow.output)
+    const tagsModule = new WorkflowTagsModule(workflow.tags)
+
+    this.pushDep(inputModule)
+    this.pushDep(outputModule)
+    this.pushDep(tagsModule)
+  }
+}
+
+export class WorkflowsModule extends ReExportTypeModule {
+  public constructor(workflows: Record<string, sdk.BotWorkflowDefinition>) {
+    super({ exportName: strings.typeName('workflows') })
+    for (const [workflowName, workflow] of Object.entries(workflows)) {
+      const module = new WorkflowModule(workflowName, workflow)
+      module.unshift(workflowName)
+      this.pushDep(module)
+    }
+  }
+}

--- a/packages/cli/src/code-generation/plugin-implementation/plugin-typings/index.ts
+++ b/packages/cli/src/code-generation/plugin-implementation/plugin-typings/index.ts
@@ -9,6 +9,7 @@ import { DefaultConfigurationModule } from './configuration-module'
 import { EventsModule } from './events-module'
 import { StatesModule } from './states-module'
 import { TablesModule } from './tables-module'
+import { WorkflowsModule } from './workflows-module'
 
 class PluginIntegrationsModule extends ReExportTypeModule {
   public constructor(plugin: sdk.PluginDefinition) {
@@ -46,6 +47,7 @@ type PluginTypingsIndexDependencies = {
   statesModule: StatesModule
   actionsModule: ActionsModule
   tablesModule: TablesModule
+  workflowsModule: WorkflowsModule
 }
 
 type _assertPropsInPluginDefinition = utils.types.AssertKeyOf<'props', sdk.PluginDefinition>
@@ -104,6 +106,10 @@ export class PluginTypingsModule extends Module {
     tablesModule.unshift('tables')
     this.pushDep(tablesModule)
 
+    const workflowsModule = new WorkflowsModule(plugin.workflows ?? {})
+    workflowsModule.unshift('workflows')
+    this.pushDep(workflowsModule)
+
     this._dependencies = {
       integrationsModule,
       interfacesModule,
@@ -112,6 +118,7 @@ export class PluginTypingsModule extends Module {
       statesModule,
       actionsModule,
       tablesModule,
+      workflowsModule,
     }
   }
 
@@ -124,6 +131,7 @@ export class PluginTypingsModule extends Module {
       statesModule,
       actionsModule,
       tablesModule,
+      workflowsModule,
     } = this._dependencies
 
     const integrationsImport = integrationsModule.import(this)
@@ -133,6 +141,7 @@ export class PluginTypingsModule extends Module {
     const statesImport = statesModule.import(this)
     const actionsImport = actionsModule
     const tablesImport = tablesModule.import(this)
+    const workflowsImport = workflowsModule
 
     return [
       consts.GENERATED_HEADER,
@@ -143,6 +152,7 @@ export class PluginTypingsModule extends Module {
       `import * as ${statesModule.name} from './${statesModule.name}'`,
       `import * as ${actionsModule.name} from './${actionsImport.name}'`,
       `import * as ${tablesModule.name} from './${tablesImport}'`,
+      `import * as ${workflowsModule.name} from './${workflowsImport.name}'`,
       '',
       `export * as ${integrationsModule.name} from './${integrationsImport}'`,
       `export * as ${interfacesModule.name} from './${interfacesImport}'`,
@@ -151,6 +161,7 @@ export class PluginTypingsModule extends Module {
       `export * as ${statesModule.name} from './${statesImport}'`,
       `export * as ${actionsModule.name} from './${actionsImport.name}'`,
       `export * as ${tablesModule.name} from './${tablesImport}'`,
+      `export * as ${workflowsModule.name} from './${workflowsImport.name}'`,
       '',
       'export type TPlugin = {',
       `  name: "${this._plugin.name}"`,
@@ -162,6 +173,7 @@ export class PluginTypingsModule extends Module {
       `  states: ${statesModule.name}.${statesModule.exportName}`,
       `  actions: ${actionsModule.name}.${actionsModule.exportName}`,
       `  tables: ${tablesModule.name}.${tablesModule.exportName}`,
+      `  workflows: ${workflowsModule.name}.${workflowsModule.exportName}`,
       '}',
     ].join('\n')
   }

--- a/packages/cli/src/code-generation/plugin-implementation/plugin-typings/index.ts
+++ b/packages/cli/src/code-generation/plugin-implementation/plugin-typings/index.ts
@@ -106,7 +106,7 @@ export class PluginTypingsModule extends Module {
     tablesModule.unshift('tables')
     this.pushDep(tablesModule)
 
-    const workflowsModule = new WorkflowsModule(plugin.workflows ?? {})
+    const workflowsModule = new WorkflowsModule(_plugin.workflows ?? {})
     workflowsModule.unshift('workflows')
     this.pushDep(workflowsModule)
 

--- a/packages/cli/src/code-generation/plugin-implementation/plugin-typings/workflows-module.ts
+++ b/packages/cli/src/code-generation/plugin-implementation/plugin-typings/workflows-module.ts
@@ -1,0 +1,73 @@
+import * as sdk from '@botpress/sdk'
+import { primitiveToTypescriptValue, zuiSchemaToTypeScriptType } from '../../generators'
+import { Module, ReExportTypeModule } from '../../module'
+import * as strings from '../../strings'
+
+type WorkflowInput = sdk.BotWorkflowDefinition['input']
+type WorkflowOutput = sdk.BotWorkflowDefinition['output']
+type WorkflowTags = sdk.BotWorkflowDefinition['tags']
+
+export class WorkflowInputModule extends Module {
+  public constructor(private _input: WorkflowInput) {
+    const name = 'input'
+    const exportName = strings.typeName(name)
+    super({ path: `${name}.ts`, exportName })
+  }
+
+  public async getContent() {
+    return zuiSchemaToTypeScriptType(this._input.schema, this.exportName)
+  }
+}
+
+export class WorkflowOutputModule extends Module {
+  public constructor(private _output: WorkflowOutput) {
+    const name = 'output'
+    const exportName = strings.typeName(name)
+    super({ path: `${name}.ts`, exportName })
+  }
+
+  public async getContent() {
+    return zuiSchemaToTypeScriptType(this._output.schema, this.exportName)
+  }
+}
+
+export class WorkflowTagsModule extends Module {
+  public constructor(private _tags: WorkflowTags) {
+    const name = 'tags'
+    const exportName = strings.typeName(name)
+    super({ path: `${name}.ts`, exportName })
+  }
+
+  public async getContent() {
+    const tags = Object.keys(this._tags ?? {})
+      .map((tagName) => `${primitiveToTypescriptValue(tagName)}: string`)
+      .join(', ')
+
+    return `export type ${this.exportName} = { ${tags} }`
+  }
+}
+
+export class WorkflowModule extends ReExportTypeModule {
+  public constructor(workflowName: string, workflow: sdk.BotWorkflowDefinition) {
+    super({ exportName: strings.typeName(workflowName) })
+
+    const inputModule = new WorkflowInputModule(workflow.input)
+    const outputModule = new WorkflowOutputModule(workflow.output)
+    const tagsModule = new WorkflowTagsModule(workflow.tags)
+
+    this.pushDep(inputModule)
+    this.pushDep(outputModule)
+    this.pushDep(tagsModule)
+  }
+}
+
+export class WorkflowsModule extends ReExportTypeModule {
+  public constructor(workflows: Record<string, sdk.BotWorkflowDefinition>) {
+    super({ exportName: strings.typeName('workflows') })
+    for (const [workflowName, workflow] of Object.entries(workflows)) {
+      const module = new WorkflowModule(workflowName, workflow)
+      module.unshift(workflowName)
+      this.pushDep(module)
+    }
+  }
+}

--- a/packages/cli/src/code-generation/typings.ts
+++ b/packages/cli/src/code-generation/typings.ts
@@ -7,6 +7,8 @@ type Schema = Record<string, any>
 type Aliases = Record<string, { name: string }>
 
 type TitleDescription = { title?: string; description?: string }
+type Tags = { tags: Record<string, {}> }
+type InputOutput = { input: { schema: Schema }; output: { schema: Schema } }
 
 export type File = { path: string; content: string }
 
@@ -95,10 +97,11 @@ export type InterfaceDefinition = PackageRef & {
 export type PluginDefinition = PackageRef & {
   configuration?: TitleDescription & { schema?: Schema }
   user?: { tags: Record<string, {}> }
-  conversation?: { tags: Record<string, {}> }
+  conversation?: Tags
   states?: Record<string, TitleDescription & { type: client.State['type']; schema: Schema }>
   events?: Record<string, TitleDescription & { schema: Schema }>
-  actions?: Record<string, TitleDescription & { input: { schema: Schema }; output: { schema: Schema } }>
+  actions?: Record<string, TitleDescription & InputOutput>
+  workflows?: Record<string, TitleDescription & Tags & InputOutput>
   dependencies?: {
     interfaces?: Record<string, PackageRef>
     integrations?: Record<string, PackageRef>

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.48.0",
-    "@botpress/sdk": "3.4.0"
+    "@botpress/sdk": "3.5.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.48.0",
-    "@botpress/sdk": "3.4.0"
+    "@botpress/sdk": "3.5.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "3.4.0"
+    "@botpress/sdk": "3.5.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.48.0",
-    "@botpress/sdk": "3.4.0"
+    "@botpress/sdk": "3.5.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.48.0",
-    "@botpress/sdk": "3.4.0",
+    "@botpress/sdk": "3.5.0",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/bot/client/index.ts
+++ b/packages/sdk/src/bot/client/index.ts
@@ -68,6 +68,14 @@ export class BotSpecificClient<TBot extends common.BaseBot> implements types.Cli
     this._run('updateTableRows', x)) as types.UpdateTableRows<TBot>
   public upsertTableRows: types.UpsertTableRows<TBot> = ((x) =>
     this._run('upsertTableRows', x)) as types.UpsertTableRows<TBot>
+  public createWorkflow: types.CreateWorkflow<TBot> = ((x) =>
+    this._run('createWorkflow', x)) as types.CreateWorkflow<TBot>
+  public getWorkflow: types.GetWorkflow<TBot> = ((x) => this._run('getWorkflow', x)) as types.GetWorkflow<TBot>
+  public updateWorkflow: types.UpdateWorkflow<TBot> = ((x) =>
+    this._run('updateWorkflow', x)) as types.UpdateWorkflow<TBot>
+  public deleteWorkflow: types.DeleteWorkflow<TBot> = ((x) =>
+    this._run('deleteWorkflow', x)) as types.DeleteWorkflow<TBot>
+  public listWorkflows: types.ListWorkflows<TBot> = ((x) => this._run('listWorkflows', x)) as types.ListWorkflows<TBot>
 
   /**
    * @deprecated Use `callAction` to delegate the conversation creation to an integration.

--- a/packages/sdk/src/bot/client/types.ts
+++ b/packages/sdk/src/bot/client/types.ts
@@ -179,7 +179,9 @@ export type GetFile<_TBot extends common.BaseBot> = client.Client['getFile']
 export type UpdateFileMetadata<_TBot extends common.BaseBot> = client.Client['updateFileMetadata']
 export type SearchFiles<_TBot extends common.BaseBot> = client.Client['searchFiles']
 
-export type CreateWorkflow<TBot extends common.BaseBot> = <WorkflowName extends keyof common.EnumerateWorkflows<TBot>>(
+export type CreateWorkflow<TBot extends common.BaseBot> = <
+  WorkflowName extends Extract<keyof common.EnumerateWorkflows<TBot>, string>,
+>(
   x: utils.Merge<
     Arg<client.Client['createWorkflow']>,
     {
@@ -211,7 +213,9 @@ export type UpdateWorkflow<_TBot extends common.BaseBot> = client.Client['update
 // FIXME: there's no way to infer types for deleteWorkflow, since all we have is its id
 export type DeleteWorkflow<_TBot extends common.BaseBot> = client.Client['deleteWorkflow']
 
-export type ListWorkflows<TBot extends common.BaseBot> = <WorkflowName extends keyof common.EnumerateWorkflows<TBot>>(
+export type ListWorkflows<TBot extends common.BaseBot> = <
+  WorkflowName extends Extract<keyof common.EnumerateWorkflows<TBot>, string>,
+>(
   x: utils.Merge<
     Arg<client.Client['listWorkflows']>,
     {

--- a/packages/sdk/src/bot/client/types.ts
+++ b/packages/sdk/src/bot/client/types.ts
@@ -179,6 +179,48 @@ export type GetFile<_TBot extends common.BaseBot> = client.Client['getFile']
 export type UpdateFileMetadata<_TBot extends common.BaseBot> = client.Client['updateFileMetadata']
 export type SearchFiles<_TBot extends common.BaseBot> = client.Client['searchFiles']
 
+export type CreateWorkflow<TBot extends common.BaseBot> = <WorkflowName extends keyof common.EnumerateWorkflows<TBot>>(
+  x: utils.Merge<
+    Arg<client.Client['createWorkflow']>,
+    {
+      name: utils.Cast<WorkflowName, string>
+      input: utils.Cast<
+        common.EnumerateWorkflows<TBot>[WorkflowName],
+        common.IntegrationInstanceActionDefinition
+      >['input']
+      tags?: utils.AtLeastOneProperty<common.EnumerateWorkflows<TBot>[WorkflowName]['tags']>
+    }
+  >
+) => Promise<
+  Readonly<{
+    workflow: utils.Merge<
+      Awaited<Res<client.Client['createWorkflow']>>['workflow'],
+      {
+        name: NoInfer<WorkflowName>
+      }
+    >
+  }>
+>
+
+// FIXME: there's no way to infer types for getWorkflow, since all we have is its id
+export type GetWorkflow<_TBot extends common.BaseBot> = client.Client['getWorkflow']
+
+// FIXME: there's no way to infer types for updateWorkflow, since all we have is its id
+export type UpdateWorkflow<_TBot extends common.BaseBot> = client.Client['updateWorkflow']
+
+// FIXME: there's no way to infer types for deleteWorkflow, since all we have is its id
+export type DeleteWorkflow<_TBot extends common.BaseBot> = client.Client['deleteWorkflow']
+
+export type ListWorkflows<TBot extends common.BaseBot> = <WorkflowName extends keyof common.EnumerateWorkflows<TBot>>(
+  x: utils.Merge<
+    Arg<client.Client['listWorkflows']>,
+    {
+      name?: utils.Cast<WorkflowName, string>
+      tags?: utils.AtLeastOneProperty<common.EnumerateWorkflows<TBot>[WorkflowName]['tags']>
+    }
+  >
+) => Promise<Readonly<Awaited<Res<client.Client['listWorkflows']>>>>
+
 export type GetTableRow<TBot extends common.BaseBot> = <
   TableName extends keyof common.EnumerateTables<TBot>,
   Columns = utils.Cast<common.EnumerateTables<TBot>[TableName], Record<string, any>>,

--- a/packages/sdk/src/bot/client/types.ts
+++ b/packages/sdk/src/bot/client/types.ts
@@ -179,18 +179,13 @@ export type GetFile<_TBot extends common.BaseBot> = client.Client['getFile']
 export type UpdateFileMetadata<_TBot extends common.BaseBot> = client.Client['updateFileMetadata']
 export type SearchFiles<_TBot extends common.BaseBot> = client.Client['searchFiles']
 
-export type CreateWorkflow<TBot extends common.BaseBot> = <
-  WorkflowName extends Extract<keyof common.EnumerateWorkflows<TBot>, string>,
->(
+export type CreateWorkflow<TBot extends common.BaseBot> = <TWorkflowName extends utils.StringKeys<TBot['workflows']>>(
   x: utils.Merge<
     Arg<client.Client['createWorkflow']>,
     {
-      name: utils.Cast<WorkflowName, string>
-      input: utils.Cast<
-        common.EnumerateWorkflows<TBot>[WorkflowName],
-        common.IntegrationInstanceActionDefinition
-      >['input']
-      tags?: utils.AtLeastOneProperty<common.EnumerateWorkflows<TBot>[WorkflowName]['tags']>
+      name: utils.Cast<TWorkflowName, string>
+      input: utils.Cast<TBot['workflows'][TWorkflowName], common.IntegrationInstanceActionDefinition>['input']
+      tags?: utils.AtLeastOneProperty<TBot['workflows'][TWorkflowName]['tags']>
     }
   >
 ) => Promise<
@@ -198,7 +193,7 @@ export type CreateWorkflow<TBot extends common.BaseBot> = <
     workflow: utils.Merge<
       Awaited<Res<client.Client['createWorkflow']>>['workflow'],
       {
-        name: NoInfer<WorkflowName>
+        name: NoInfer<TWorkflowName>
       }
     >
   }>
@@ -213,14 +208,12 @@ export type UpdateWorkflow<_TBot extends common.BaseBot> = client.Client['update
 // FIXME: there's no way to infer types for deleteWorkflow, since all we have is its id
 export type DeleteWorkflow<_TBot extends common.BaseBot> = client.Client['deleteWorkflow']
 
-export type ListWorkflows<TBot extends common.BaseBot> = <
-  WorkflowName extends Extract<keyof common.EnumerateWorkflows<TBot>, string>,
->(
+export type ListWorkflows<TBot extends common.BaseBot> = <TWorkflowName extends utils.StringKeys<TBot['workflows']>>(
   x: utils.Merge<
     Arg<client.Client['listWorkflows']>,
     {
-      name?: utils.Cast<WorkflowName, string>
-      tags?: utils.AtLeastOneProperty<common.EnumerateWorkflows<TBot>[WorkflowName]['tags']>
+      name?: utils.Cast<TWorkflowName, string>
+      tags?: utils.AtLeastOneProperty<TBot['workflows'][TWorkflowName]['tags']>
     }
   >
 ) => Promise<Readonly<Awaited<Res<client.Client['listWorkflows']>>>>

--- a/packages/sdk/src/bot/common/generic.ts
+++ b/packages/sdk/src/bot/common/generic.ts
@@ -16,7 +16,7 @@ export type BaseWorkflow = {
   input: any
   output: any
   tags?: {
-    [k: string]: any
+    [k: string]: string
   }
 }
 

--- a/packages/sdk/src/bot/common/generic.ts
+++ b/packages/sdk/src/bot/common/generic.ts
@@ -12,12 +12,21 @@ export type BaseTable = {
   [k: string]: any
 }
 
+export type BaseWorkflow = {
+  input: any
+  output: any
+  tags?: {
+    [k: string]: any
+  }
+}
+
 export type BaseBot = {
   integrations: Record<string, BaseIntegration>
   events: Record<string, any>
   states: Record<string, any>
   actions: Record<string, BaseAction>
   tables: Record<string, BaseTable>
+  workflows: Record<string, BaseWorkflow>
 }
 
 export type InputBaseBot = utils.DeepPartial<BaseBot>
@@ -31,4 +40,5 @@ export type DefaultBot<B extends InputBaseBot> = {
         [K in keyof B['integrations']]: DefaultIntegration<utils.Cast<B['integrations'][K], InputBaseIntegration>>
       }
   tables: utils.Default<B['tables'], BaseBot['tables']>
+  workflows: utils.Default<B['workflows'], BaseBot['workflows']>
 }

--- a/packages/sdk/src/bot/common/types.ts
+++ b/packages/sdk/src/bot/common/types.ts
@@ -108,7 +108,3 @@ export type EnumerateStates<TBot extends BaseBot> = {
 export type EnumerateTables<TBot extends BaseBot> = {
   [K in keyof TBot['tables']]: TBot['tables'][K]
 }
-
-export type EnumerateWorkflows<TBot extends BaseBot> = {
-  [K in keyof TBot['workflows']]: TBot['workflows'][K]
-}

--- a/packages/sdk/src/bot/common/types.ts
+++ b/packages/sdk/src/bot/common/types.ts
@@ -108,3 +108,7 @@ export type EnumerateStates<TBot extends BaseBot> = {
 export type EnumerateTables<TBot extends BaseBot> = {
   [K in keyof TBot['tables']]: TBot['tables'][K]
 }
+
+export type EnumerateWorkflows<TBot extends BaseBot> = {
+  [K in keyof TBot['workflows']]: TBot['workflows'][K]
+}

--- a/packages/sdk/src/bot/definition.ts
+++ b/packages/sdk/src/bot/definition.ts
@@ -129,6 +129,11 @@ export type BotDefinitionProps<
   tables?: {
     [K in keyof TTables]: TableDefinition<TTables[K]>
   }
+
+  /**
+   * # EXPERIMENTAL
+   * This API is experimental and may change in the future.
+   */
   workflows?: {
     [K in keyof TWorkflows]: WorkflowDefinition<TWorkflows[K]>
   }

--- a/packages/sdk/src/bot/definition.ts
+++ b/packages/sdk/src/bot/definition.ts
@@ -13,6 +13,7 @@ type BaseStates = Record<string, ZuiObjectSchema>
 type BaseEvents = Record<string, ZuiObjectSchema>
 type BaseActions = Record<string, ZuiObjectSchema>
 type BaseTables = Record<string, ZuiObjectSchema>
+type BaseWorkflows = Record<string, ZuiObjectSchema>
 
 export type TagDefinition = {
   title?: string
@@ -57,6 +58,14 @@ export type ActionDefinition<TAction extends BaseActions[string] = BaseActions[s
   output: SchemaDefinition<ZuiObjectSchema> // cannot infer both input and output types (typescript limitation)
 }
 
+export type WorkflowDefinition<TWorkflow extends BaseWorkflows[string] = BaseWorkflows[string]> = {
+  title?: string
+  description?: string
+  input: SchemaDefinition<TWorkflow>
+  output: SchemaDefinition<ZuiObjectSchema> // cannot infer both input and output types (typescript limitation)
+  tags?: Record<string, TagDefinition>
+}
+
 export type TableDefinition<TTable extends BaseTables[string] = BaseTables[string]> = Merge<
   Omit<Table, 'id' | 'createdAt' | 'updatedAt' | 'name'>,
   {
@@ -95,6 +104,7 @@ export type BotDefinitionProps<
   TEvents extends BaseEvents = BaseEvents,
   TActions extends BaseActions = BaseActions,
   TTables extends BaseTables = BaseTables,
+  TWorkflows extends BaseWorkflows = BaseWorkflows,
 > = {
   integrations?: {
     [K: string]: IntegrationInstance
@@ -119,6 +129,9 @@ export type BotDefinitionProps<
   tables?: {
     [K in keyof TTables]: TableDefinition<TTables[K]>
   }
+  workflows?: {
+    [K in keyof TWorkflows]: WorkflowDefinition<TWorkflows[K]>
+  }
 }
 
 export class BotDefinition<
@@ -126,6 +139,7 @@ export class BotDefinition<
   TEvents extends BaseEvents = BaseEvents,
   TActions extends BaseActions = BaseActions,
   TTables extends BaseTables = BaseTables,
+  TWorkflows extends BaseWorkflows = BaseWorkflows,
 > {
   public readonly integrations: this['props']['integrations']
   public readonly plugins: this['props']['plugins']
@@ -138,7 +152,8 @@ export class BotDefinition<
   public readonly recurringEvents: this['props']['recurringEvents']
   public readonly actions: this['props']['actions']
   public readonly tables: this['props']['tables']
-  public constructor(public readonly props: BotDefinitionProps<TStates, TEvents, TActions, TTables>) {
+  public readonly workflows: this['props']['workflows']
+  public constructor(public readonly props: BotDefinitionProps<TStates, TEvents, TActions, TTables, TWorkflows>) {
     this.integrations = props.integrations
     this.plugins = props.plugins
     this.user = props.user
@@ -150,6 +165,7 @@ export class BotDefinition<
     this.recurringEvents = props.recurringEvents
     this.actions = props.actions
     this.tables = props.tables
+    this.workflows = props.workflows
   }
 
   public addIntegration<I extends IntegrationPackage>(integrationPkg: I, config: IntegrationConfigInstance<I>): this {
@@ -186,6 +202,7 @@ export class BotDefinition<
     self.message = this._mergeMessage(self.message, pluginPkg.definition.message)
     self.recurringEvents = this._mergeRecurringEvents(self.recurringEvents, pluginPkg.definition.recurringEvents)
     self.tables = this._mergeTables(self.tables, pluginPkg.definition.tables)
+    self.workflows = this._mergeWorkflows(self.workflows, pluginPkg.definition.workflows)
 
     self.states = this._mergeStates(self.states, this._prefixKeys(pluginPkg.definition.states, config.alias))
     self.events = this._mergeEvents(self.events, this._prefixKeys(pluginPkg.definition.events, config.alias))
@@ -277,6 +294,16 @@ export class BotDefinition<
     return {
       ...tables1,
       ...tables2,
+    }
+  }
+
+  private _mergeWorkflows = (
+    workflows1: BotDefinitionProps['workflows'],
+    workflows2: BotDefinitionProps['workflows']
+  ): BotDefinitionProps['workflows'] => {
+    return {
+      ...workflows1,
+      ...workflows2,
     }
   }
 

--- a/packages/sdk/src/bot/implementation.ts
+++ b/packages/sdk/src/bot/implementation.ts
@@ -22,6 +22,7 @@ import {
   type WorkflowHandlersFnMap,
   type WorkflowUpdateTypeCamelCase,
 } from './server'
+import type * as typeUtils from '../utils/type-utils'
 
 export type BotImplementationProps<TBot extends BaseBot = BaseBot, TPlugins extends Record<string, BasePlugin> = {}> = {
   actions: UnimplementedActionHandlers<TBot, TPlugins>
@@ -166,7 +167,7 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
           return new Proxy(
             {},
             {
-              get: (_, workflowName: Extract<keyof TBot['workflows'], string>) => {
+              get: (_, workflowName: typeUtils.StringKeys<TBot['workflows']>) => {
                 const handlersOfType = this._workflowHandlers[updateType]
                 const selfHandlers = handlersOfType?.[workflowName]
 
@@ -194,7 +195,7 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
     workflows: new Proxy(
       {},
       {
-        get: (_, workflowName: Extract<keyof TBot['workflows'], string>) =>
+        get: <TWorkflowName extends typeUtils.StringKeys<TBot['workflows']>>(_: unknown, workflowName: TWorkflowName) =>
           new Proxy(
             {},
             {
@@ -203,11 +204,11 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
                   updateType satisfies never
                 }
 
-                return (handler: WorkflowHandlers<TBot>[string]): void => {
+                return (handler: WorkflowHandlers<TBot>[TWorkflowName]): void => {
                   this._workflowHandlers[updateType] ??= {}
                   this._workflowHandlers[updateType][workflowName] = utils.arrays.safePush(
                     this._workflowHandlers[updateType][workflowName],
-                    handler as WorkflowHandlers<TBot>[string]
+                    handler as WorkflowHandlers<TBot>[TWorkflowName]
                   )
                 }
               },

--- a/packages/sdk/src/bot/implementation.ts
+++ b/packages/sdk/src/bot/implementation.ts
@@ -2,6 +2,7 @@ import type { Server } from 'node:http'
 import { BasePlugin, PluginImplementation } from '../plugin'
 import { serve } from '../serve'
 import * as utils from '../utils'
+import type * as typeUtils from '../utils/type-utils'
 import { BaseBot } from './common'
 import {
   botHandler,
@@ -20,9 +21,10 @@ import {
   type WorkflowHandlersMap,
   type WorkflowHandlers,
   type WorkflowHandlersFnMap,
-  type WorkflowUpdateTypeCamelCase,
+  type WorkflowUpdateTypeSnakeCase,
+  WorkflowUpdateTypeCamelCase,
 } from './server'
-import type * as typeUtils from '../utils/type-utils'
+import { camelCaseUpdateTypeToSnakeCase } from './server/workflows/update-type-conv'
 
 export type BotImplementationProps<TBot extends BaseBot = BaseBot, TPlugins extends Record<string, BasePlugin> = {}> = {
   actions: UnimplementedActionHandlers<TBot, TPlugins>
@@ -163,7 +165,7 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
     return new Proxy(
       {},
       {
-        get: (_, updateType: WorkflowUpdateTypeCamelCase) => {
+        get: (_, updateType: WorkflowUpdateTypeSnakeCase) => {
           return new Proxy(
             {},
             {
@@ -209,9 +211,10 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
                 }
 
                 return (handler: WorkflowHandlers<TBot>[TWorkflowName]): void => {
-                  this._workflowHandlers[updateType] ??= {}
-                  this._workflowHandlers[updateType][workflowName] = utils.arrays.safePush(
-                    this._workflowHandlers[updateType][workflowName],
+                  const updateTypeSnakeCase = camelCaseUpdateTypeToSnakeCase(updateType)
+                  this._workflowHandlers[updateTypeSnakeCase] ??= {}
+                  this._workflowHandlers[updateTypeSnakeCase][workflowName] = utils.arrays.safePush(
+                    this._workflowHandlers[updateTypeSnakeCase][workflowName],
                     handler as WorkflowHandlers<TBot>[TWorkflowName]
                   )
                 }

--- a/packages/sdk/src/bot/implementation.ts
+++ b/packages/sdk/src/bot/implementation.ts
@@ -192,6 +192,10 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
       )
     },
 
+    /**
+     * # EXPERIMENTAL
+     * This API is experimental and may change in the future.
+     */
     workflows: new Proxy(
       {},
       {

--- a/packages/sdk/src/bot/server/responses.ts
+++ b/packages/sdk/src/bot/server/responses.ts
@@ -1,0 +1,1 @@
+export const SUCCESS_RESPONSE = { status: 200 } as const

--- a/packages/sdk/src/bot/server/types.ts
+++ b/packages/sdk/src/bot/server/types.ts
@@ -107,6 +107,11 @@ export type CommonHandlerProps<TBot extends common.BaseBot> = {
   ctx: BotContext
   logger: BotLogger
   client: BotClient<TBot>
+
+  /**
+   * # EXPERIMENTAL
+   * This API is experimental and may change in the future.
+   */
   workflows: workflowProxy.WorkflowProxy<TBot>
 }
 
@@ -271,6 +276,11 @@ export type WorkflowPayloads<TBot extends common.BaseBot, TExtraTools extends ob
   [WorkflowName in utils.StringKeys<TBot['workflows']>]: CommonHandlerProps<TBot> & {
     conversation?: client.Conversation
     user?: client.User
+
+    /**
+     * # EXPERIMENTAL
+     * This API is experimental and may change in the future.
+     */
     workflow: workflowProxy.WorkflowWithUtilities<TBot, WorkflowName>
   } & TExtraTools
 }

--- a/packages/sdk/src/bot/server/types.ts
+++ b/packages/sdk/src/bot/server/types.ts
@@ -158,14 +158,14 @@ export type ActionHandlers<TBot extends common.BaseBot> = {
   [K in keyof TBot['actions']]: (props: ActionHandlerPayloads<TBot>[K]) => Promise<TBot['actions'][K]['output']>
 }
 
-export type WorkflowUpdateType =
+export type BridgeWorkflowUpdateType =
   | 'child_workflow_deleted'
   | 'child_workflow_finished'
   | 'workflow_timedout'
   | 'workflow_started'
   | 'workflow_continued'
 export type WorkflowUpdateEventPayload = {
-  type: WorkflowUpdateType
+  type: BridgeWorkflowUpdateType
   childWorkflow?: client.Workflow
   workflow: client.Workflow
   conversation?: client.Conversation
@@ -289,10 +289,11 @@ export type WorkflowHandlers<TBot extends common.BaseBot, TExtraTools extends ob
   [K in utils.StringKeys<TBot['workflows']>]: (props: WorkflowPayloads<TBot, TExtraTools>[K]) => Promise<void>
 }
 
+export type WorkflowUpdateTypeSnakeCase = 'started' | 'continued' | 'timed_out'
 export type WorkflowUpdateTypeCamelCase = 'started' | 'continued' | 'timedOut'
 
 export type WorkflowHandlersMap<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
-  [UpdateType in WorkflowUpdateTypeCamelCase]?: {
+  [UpdateType in WorkflowUpdateTypeSnakeCase]?: {
     [WorkflowName in utils.StringKeys<TBot['workflows']>]?: WorkflowHandlers<TBot, TExtraTools>[WorkflowName][]
   }
 }

--- a/packages/sdk/src/bot/server/types.ts
+++ b/packages/sdk/src/bot/server/types.ts
@@ -268,7 +268,7 @@ export type HookHandlersMap<TBot extends common.BaseBot> = {
 }
 
 export type WorkflowPayloads<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
-  [WorkflowName in keyof common.EnumerateWorkflows<TBot>]: CommonHandlerProps<TBot> & {
+  [WorkflowName in utils.StringKeys<TBot['workflows']>]: CommonHandlerProps<TBot> & {
     conversation?: client.Conversation
     user?: client.User
     workflow: workflowProxy.WorkflowWithUtilities<TBot, WorkflowName>
@@ -276,19 +276,19 @@ export type WorkflowPayloads<TBot extends common.BaseBot, TExtraTools extends ob
 }
 
 export type WorkflowHandlers<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
-  [K in keyof common.EnumerateWorkflows<TBot>]: (props: WorkflowPayloads<TBot, TExtraTools>[K]) => Promise<void>
+  [K in utils.StringKeys<TBot['workflows']>]: (props: WorkflowPayloads<TBot, TExtraTools>[K]) => Promise<void>
 }
 
 export type WorkflowUpdateTypeCamelCase = 'started' | 'continued' | 'timedOut'
 
 export type WorkflowHandlersMap<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
   [UpdateType in WorkflowUpdateTypeCamelCase]?: {
-    [WorkflowName in keyof common.EnumerateWorkflows<TBot>]?: WorkflowHandlers<TBot, TExtraTools>[WorkflowName][]
+    [WorkflowName in utils.StringKeys<TBot['workflows']>]?: WorkflowHandlers<TBot, TExtraTools>[WorkflowName][]
   }
 }
 
 export type WorkflowHandlersFnMap<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
-  [WorkflowName in Extract<keyof TBot['workflows'], string>]: {
+  [WorkflowName in utils.StringKeys<TBot['workflows']>]: {
     [UType in WorkflowUpdateTypeCamelCase]: (handler: WorkflowHandlers<TBot, TExtraTools>[WorkflowName]) => void
   }
 }

--- a/packages/sdk/src/bot/server/types.ts
+++ b/packages/sdk/src/bot/server/types.ts
@@ -1,9 +1,11 @@
 import * as client from '@botpress/client'
 import * as plugin from '../../plugin'
+import type { Request } from '../../serve'
 import * as utils from '../../utils/type-utils'
 import { type BotLogger } from '../bot-logger'
 import { BotSpecificClient } from '../client'
 import * as common from '../common'
+import type * as workflowProxy from '../workflow-proxy/types'
 
 export type BotOperation = 'event_received' | 'register' | 'unregister' | 'ping' | 'action_triggered'
 export type BotContext = {
@@ -105,6 +107,7 @@ export type CommonHandlerProps<TBot extends common.BaseBot> = {
   ctx: BotContext
   logger: BotLogger
   client: BotClient<TBot>
+  workflows: workflowProxy.WorkflowProxy<TBot>
 }
 
 export type MessagePayloads<TBot extends common.BaseBot> = {
@@ -149,6 +152,27 @@ export type ActionHandlerPayloads<TBot extends common.BaseBot> = {
 export type ActionHandlers<TBot extends common.BaseBot> = {
   [K in keyof TBot['actions']]: (props: ActionHandlerPayloads<TBot>[K]) => Promise<TBot['actions'][K]['output']>
 }
+
+export type WorkflowUpdateType =
+  | 'child_workflow_deleted'
+  | 'child_workflow_finished'
+  | 'workflow_timedout'
+  | 'workflow_started'
+  | 'workflow_continued'
+export type WorkflowUpdateEventPayload = {
+  type: WorkflowUpdateType
+  childWorkflow?: client.Workflow
+  workflow: client.Workflow
+  conversation?: client.Conversation
+  user?: client.User
+}
+export type WorkflowUpdateEvent = utils.Merge<
+  client.Event,
+  {
+    type: 'workflow_update'
+    payload: WorkflowUpdateEventPayload
+  }
+>
 
 type BaseHookDefinition = { stoppable?: boolean; data: any }
 type HookDefinition<THookDef extends BaseHookDefinition = BaseHookDefinition> = THookDef
@@ -243,6 +267,32 @@ export type HookHandlersMap<TBot extends common.BaseBot> = {
   }
 }
 
+export type WorkflowPayloads<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
+  [WorkflowName in keyof common.EnumerateWorkflows<TBot>]: CommonHandlerProps<TBot> & {
+    conversation?: client.Conversation
+    user?: client.User
+    workflow: workflowProxy.WorkflowWithUtilities<TBot, WorkflowName>
+  } & TExtraTools
+}
+
+export type WorkflowHandlers<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
+  [K in keyof common.EnumerateWorkflows<TBot>]: (props: WorkflowPayloads<TBot, TExtraTools>[K]) => Promise<void>
+}
+
+export type WorkflowUpdateTypeCamelCase = 'started' | 'continued' | 'timedOut'
+
+export type WorkflowHandlersMap<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
+  [UpdateType in WorkflowUpdateTypeCamelCase]?: {
+    [WorkflowName in keyof common.EnumerateWorkflows<TBot>]?: WorkflowHandlers<TBot, TExtraTools>[WorkflowName][]
+  }
+}
+
+export type WorkflowHandlersFnMap<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
+  [WorkflowName in Extract<keyof TBot['workflows'], string>]: {
+    [UType in WorkflowUpdateTypeCamelCase]: (handler: WorkflowHandlers<TBot, TExtraTools>[WorkflowName]) => void
+  }
+}
+
 /**
  * TODO:
  * the consumer of this type shouldnt be able to access "*" directly;
@@ -254,6 +304,7 @@ export type BotHandlers<TBot extends common.BaseBot> = {
   eventHandlers: EventHandlersMap<TBot>
   stateExpiredHandlers: StateExpiredHandlersMap<TBot>
   hookHandlers: HookHandlersMap<TBot>
+  workflowHandlers: WorkflowHandlersMap<TBot>
 }
 
 // plugins
@@ -290,4 +341,9 @@ export type UnimplementedActionHandlers<
   TPlugins extends Record<string, plugin.BasePlugin>,
 > = {
   [K in keyof UnimplementedActions<TBot, TPlugins>]: ActionHandlers<TBot>[utils.Cast<K, keyof ActionHandlers<TBot>>]
+}
+
+export type ServerProps = Omit<CommonHandlerProps<common.BaseBot>, 'workflows'> & {
+  req: Request
+  self: BotHandlers<common.BaseBot>
 }

--- a/packages/sdk/src/bot/server/workflows/update-handler.ts
+++ b/packages/sdk/src/bot/server/workflows/update-handler.ts
@@ -1,0 +1,102 @@
+import { Response } from '../../../serve'
+import { proxyWorkflows, wrapWorkflowInstance } from '../../workflow-proxy'
+import { SUCCESS_RESPONSE } from '../responses'
+import * as types from '../types'
+
+const WORKFLOW_UPDATE_TYPES = [
+  'child_workflow_deleted',
+  'child_workflow_finished',
+  'workflow_timedout',
+  'workflow_started',
+  'workflow_continued',
+] as const
+
+export const handleWorkflowUpdateEvent = async (
+  props: types.ServerProps,
+  event: types.WorkflowUpdateEvent
+): Promise<Response> => {
+  if (props.ctx.type !== 'workflow_update' || !WORKFLOW_UPDATE_TYPES.includes(event.payload.type)) {
+    throw new Error('Unexpected event type')
+  }
+
+  if (!event.payload.workflow.name) {
+    props.logger
+      .withWorkflowId(event.payload.workflow.id)
+      .warn(
+        'Received workflow update event without a workflow name. Assuming this workflow was not defined by the bot.',
+        event.payload.workflow
+      )
+    return SUCCESS_RESPONSE
+  }
+
+  switch (event.payload.type) {
+    case 'child_workflow_deleted':
+    case 'child_workflow_finished':
+      props.logger
+        .withWorkflowId(event.payload.workflow.id)
+        .info(`Received child workflow event "${event.payload.type}", but child workflows are not yet supported`)
+      break
+    case 'workflow_timedout':
+    case 'workflow_started':
+    case 'workflow_continued':
+      return await _handleWorkflowUpdate(props, event)
+    default:
+      event.payload.type satisfies never
+  }
+
+  return SUCCESS_RESPONSE
+}
+
+const _handleWorkflowUpdate = async (props: types.ServerProps, event: types.WorkflowUpdateEvent): Promise<Response> => {
+  const updateType = _updateTypeToCamelCase(event.payload.type)
+  const handlers = props.self.workflowHandlers[updateType]?.[event.payload.workflow.name]
+
+  if (!handlers || handlers.length === 0) {
+    props.logger
+      .withWorkflowId(event.payload.workflow.id)
+      .warn(`No ${updateType} handler found for workflow "${event.payload.workflow.name}"`)
+    return SUCCESS_RESPONSE
+  }
+
+  await _acknowledgeWorkflowStart(props, event)
+  await _dispatchToHandlers(props, event)
+
+  return SUCCESS_RESPONSE
+}
+
+const _updateTypeToCamelCase = (updateType: types.WorkflowUpdateType): types.WorkflowUpdateTypeCamelCase => {
+  switch (updateType) {
+    case 'workflow_continued':
+      return 'continued'
+    case 'workflow_started':
+      return 'started'
+    case 'workflow_timedout':
+      return 'timedOut'
+    default:
+      throw new Error(`Unsupported workflow update type: ${updateType}`)
+  }
+}
+
+const _acknowledgeWorkflowStart = async (props: types.ServerProps, event: types.WorkflowUpdateEvent): Promise<void> => {
+  if (event.payload.workflow.status !== 'pending') {
+    return
+  }
+
+  // Acknowledge start of workflow processing:
+  await props.client.updateWorkflow({ id: event.payload.workflow.id, status: 'in_progress', eventId: event.id })
+}
+
+const _dispatchToHandlers = async (props: types.ServerProps, event: types.WorkflowUpdateEvent): Promise<void> => {
+  const updateType = _updateTypeToCamelCase(event.payload.type)
+  const handlers = props.self.workflowHandlers[updateType]?.[event.payload.workflow.name]
+
+  for (const handler of handlers!) {
+    await handler({
+      ...props,
+      conversation: event.payload.conversation,
+      user: event.payload.user,
+      workflow: wrapWorkflowInstance({ ...props, workflow: event.payload.workflow }),
+      workflows: proxyWorkflows(props.client),
+    })
+  }
+}

--- a/packages/sdk/src/bot/server/workflows/update-handler.ts
+++ b/packages/sdk/src/bot/server/workflows/update-handler.ts
@@ -2,6 +2,7 @@ import { Response } from '../../../serve'
 import { proxyWorkflows, wrapWorkflowInstance } from '../../workflow-proxy'
 import { SUCCESS_RESPONSE } from '../responses'
 import * as types from '../types'
+import { bridgeUpdateTypeToSnakeCase } from './update-type-conv'
 
 const WORKFLOW_UPDATE_TYPES = [
   'child_workflow_deleted',
@@ -48,7 +49,7 @@ export const handleWorkflowUpdateEvent = async (
 }
 
 const _handleWorkflowUpdate = async (props: types.ServerProps, event: types.WorkflowUpdateEvent): Promise<Response> => {
-  const updateType = _updateTypeToCamelCase(event.payload.type)
+  const updateType = bridgeUpdateTypeToSnakeCase(event.payload.type)
   const handlers = props.self.workflowHandlers[updateType]?.[event.payload.workflow.name]
 
   if (!handlers || handlers.length === 0) {
@@ -64,19 +65,6 @@ const _handleWorkflowUpdate = async (props: types.ServerProps, event: types.Work
   return SUCCESS_RESPONSE
 }
 
-const _updateTypeToCamelCase = (updateType: types.WorkflowUpdateType): types.WorkflowUpdateTypeCamelCase => {
-  switch (updateType) {
-    case 'workflow_continued':
-      return 'continued'
-    case 'workflow_started':
-      return 'started'
-    case 'workflow_timedout':
-      return 'timedOut'
-    default:
-      throw new Error(`Unsupported workflow update type: ${updateType}`)
-  }
-}
-
 const _acknowledgeWorkflowStart = async (props: types.ServerProps, event: types.WorkflowUpdateEvent): Promise<void> => {
   if (event.payload.workflow.status !== 'pending') {
     return
@@ -87,7 +75,7 @@ const _acknowledgeWorkflowStart = async (props: types.ServerProps, event: types.
 }
 
 const _dispatchToHandlers = async (props: types.ServerProps, event: types.WorkflowUpdateEvent): Promise<void> => {
-  const updateType = _updateTypeToCamelCase(event.payload.type)
+  const updateType = bridgeUpdateTypeToSnakeCase(event.payload.type)
   const handlers = props.self.workflowHandlers[updateType]?.[event.payload.workflow.name]
 
   for (const handler of handlers!) {

--- a/packages/sdk/src/bot/server/workflows/update-type-conv.ts
+++ b/packages/sdk/src/bot/server/workflows/update-type-conv.ts
@@ -1,0 +1,26 @@
+import * as types from '../types'
+
+export const bridgeUpdateTypeToSnakeCase = (
+  updateType: types.BridgeWorkflowUpdateType
+): types.WorkflowUpdateTypeSnakeCase => {
+  switch (updateType) {
+    case 'workflow_continued':
+      return 'continued'
+    case 'workflow_started':
+      return 'started'
+    case 'workflow_timedout':
+      return 'timed_out'
+    default:
+      throw new Error(`Unsupported workflow update type: ${updateType}`)
+  }
+}
+
+export const camelCaseUpdateTypeToSnakeCase = (
+  updateType: types.WorkflowUpdateTypeCamelCase
+): types.WorkflowUpdateTypeSnakeCase => {
+  if (updateType !== 'timedOut' && updateType !== 'continued' && updateType !== 'started') {
+    updateType satisfies never
+  }
+
+  return updateType === 'timedOut' ? 'timed_out' : updateType
+}

--- a/packages/sdk/src/bot/workflow-proxy/index.ts
+++ b/packages/sdk/src/bot/workflow-proxy/index.ts
@@ -1,0 +1,2 @@
+export * from './proxy'
+export * from './types'

--- a/packages/sdk/src/bot/workflow-proxy/proxy.ts
+++ b/packages/sdk/src/bot/workflow-proxy/proxy.ts
@@ -1,7 +1,6 @@
 import type * as client from '@botpress/client'
 import type { BotSpecificClient } from '../../bot'
 import type * as typeUtils from '../../utils/type-utils'
-import type * as botClient from '../client/types'
 import type { BaseBot } from '../common'
 import type { WorkflowProxy, WorkflowWithUtilities } from './types'
 

--- a/packages/sdk/src/bot/workflow-proxy/proxy.ts
+++ b/packages/sdk/src/bot/workflow-proxy/proxy.ts
@@ -3,14 +3,13 @@ import type { BotSpecificClient } from '../../bot'
 import type * as typeUtils from '../../utils/type-utils'
 import type * as botClient from '../client/types'
 import type { BaseBot } from '../common'
-import type * as commonTypes from '../common'
 import type { WorkflowProxy, WorkflowWithUtilities } from './types'
 
 export const proxyWorkflows = <TBot extends BaseBot>(
   client: BotSpecificClient<TBot> | client.Client
 ): WorkflowProxy<TBot> =>
   new Proxy({} as WorkflowProxy<TBot>, {
-    get: <TWorkflowName extends Extract<keyof TBot['workflows'], string>>(_: unknown, workflowName: TWorkflowName) =>
+    get: <TWorkflowName extends typeUtils.StringKeys<TBot['workflows']>>(_: unknown, workflowName: TWorkflowName) =>
       ({
         listInstances: {
           all: (input) => _listWorkflows({ workflowName, client, input }),
@@ -40,7 +39,10 @@ export const proxyWorkflows = <TBot extends BaseBot>(
       }) satisfies WorkflowProxy<TBot>[TWorkflowName],
   })
 
-const _listWorkflows = async <TBot extends BaseBot, TWorkflowName extends string>(props: {
+const _listWorkflows = async <
+  TBot extends BaseBot,
+  TWorkflowName extends typeUtils.StringKeys<TBot['workflows']>,
+>(props: {
   workflowName: TWorkflowName
   client: BotSpecificClient<TBot> | client.Client
   statuses?: client.ClientInputs['listWorkflows']['statuses']
@@ -61,7 +63,10 @@ const _listWorkflows = async <TBot extends BaseBot, TWorkflowName extends string
   }
 }
 
-const _startNewWorkflowInstance = async <TBot extends BaseBot, TWorkflowName extends string>(props: {
+const _startNewWorkflowInstance = async <
+  TBot extends BaseBot,
+  TWorkflowName extends typeUtils.StringKeys<TBot['workflows']>,
+>(props: {
   client: BotSpecificClient<TBot> | client.Client
   input: Parameters<botClient.CreateWorkflow<TBot>>[0]
 }) => {
@@ -71,7 +76,7 @@ const _startNewWorkflowInstance = async <TBot extends BaseBot, TWorkflowName ext
 
 export const wrapWorkflowInstance = <
   TBot extends BaseBot,
-  TWorkflowName extends keyof commonTypes.EnumerateWorkflows<TBot>,
+  TWorkflowName extends typeUtils.StringKeys<TBot['workflows']>,
 >(props: {
   client: BotSpecificClient<TBot> | client.Client
   workflow: client.Workflow

--- a/packages/sdk/src/bot/workflow-proxy/proxy.ts
+++ b/packages/sdk/src/bot/workflow-proxy/proxy.ts
@@ -1,0 +1,104 @@
+import type * as client from '@botpress/client'
+import type { BotSpecificClient } from '../../bot'
+import type * as typeUtils from '../../utils/type-utils'
+import type * as botClient from '../client/types'
+import type { BaseBot } from '../common'
+import type * as commonTypes from '../common'
+import type { WorkflowProxy, WorkflowWithUtilities } from './types'
+
+export const proxyWorkflows = <TBot extends BaseBot>(
+  client: BotSpecificClient<TBot> | client.Client
+): WorkflowProxy<TBot> =>
+  new Proxy({} as WorkflowProxy<TBot>, {
+    get: <TWorkflowName extends Extract<keyof TBot['workflows'], string>>(_: unknown, workflowName: TWorkflowName) =>
+      ({
+        listInstances: {
+          all: (input) => _listWorkflows({ workflowName, client, input }),
+          running: (input) => _listWorkflows({ workflowName, client, input, statuses: ['in_progress'] }),
+          scheduled: (input) => _listWorkflows({ workflowName, client, input, statuses: ['pending', 'listening'] }),
+          allFinished: (input) =>
+            _listWorkflows({
+              workflowName,
+              client,
+              input,
+              statuses: ['completed', 'cancelled', 'failed', 'timedout'],
+            }),
+          cancelled: (input) => _listWorkflows({ workflowName, client, input, statuses: ['cancelled'] }),
+          failed: (input) => _listWorkflows({ workflowName, client, input, statuses: ['failed'] }),
+          succeeded: (input) => _listWorkflows({ workflowName, client, input, statuses: ['completed'] }),
+          timedOut: (input) => _listWorkflows({ workflowName, client, input, statuses: ['timedout'] }),
+        },
+        startNewInstance: (input) =>
+          _startNewWorkflowInstance({
+            client,
+            input: {
+              name: workflowName as typeUtils.Cast<TWorkflowName, string>,
+              status: 'pending',
+              ...input,
+            },
+          }),
+      }) satisfies WorkflowProxy<TBot>[TWorkflowName],
+  })
+
+const _listWorkflows = async <TBot extends BaseBot, TWorkflowName extends string>(props: {
+  workflowName: TWorkflowName
+  client: BotSpecificClient<TBot> | client.Client
+  statuses?: client.ClientInputs['listWorkflows']['statuses']
+  input?: Pick<client.ClientInputs['listWorkflows'], 'nextToken' | 'conversationId' | 'userId'> & {
+    tags?: typeUtils.AtLeastOneProperty<TBot['workflows'][TWorkflowName]['tags']>
+  }
+}) => {
+  const ret = await props.client.listWorkflows({
+    name: props.workflowName as any,
+    statuses: props.statuses,
+    ...props.input,
+  })
+  return {
+    ...ret,
+    workflows: ret.workflows.map((workflow) =>
+      wrapWorkflowInstance<TBot, TWorkflowName>({ client: props.client, workflow })
+    ),
+  }
+}
+
+const _startNewWorkflowInstance = async <TBot extends BaseBot, TWorkflowName extends string>(props: {
+  client: BotSpecificClient<TBot> | client.Client
+  input: Parameters<botClient.CreateWorkflow<TBot>>[0]
+}) => {
+  const { workflow } = await props.client.createWorkflow(props.input)
+  return { workflow: wrapWorkflowInstance<TBot, TWorkflowName>({ client: props.client, workflow }) }
+}
+
+export const wrapWorkflowInstance = <
+  TBot extends BaseBot,
+  TWorkflowName extends keyof commonTypes.EnumerateWorkflows<TBot>,
+>(props: {
+  client: BotSpecificClient<TBot> | client.Client
+  workflow: client.Workflow
+}): WorkflowWithUtilities<TBot, TWorkflowName> => ({
+  ...(props.workflow as WorkflowWithUtilities<TBot, TWorkflowName>),
+
+  async update(x) {
+    const { workflow } = await props.client.updateWorkflow({ id: props.workflow.id, ...x })
+    return { workflow: wrapWorkflowInstance<TBot, TWorkflowName>({ client: props.client, workflow }) }
+  },
+
+  async setFailed({ failureReason }) {
+    const { workflow } = await props.client.updateWorkflow({
+      id: props.workflow.id,
+      status: 'failed',
+      failureReason,
+    })
+    return { workflow: wrapWorkflowInstance<TBot, TWorkflowName>({ client: props.client, workflow }) }
+  },
+
+  async setCompleted({ output } = {}) {
+    const { workflow } = await props.client.updateWorkflow({ id: props.workflow.id, status: 'completed', output })
+    return { workflow: wrapWorkflowInstance<TBot, TWorkflowName>({ client: props.client, workflow }) }
+  },
+
+  async cancel() {
+    const { workflow } = await props.client.updateWorkflow({ id: props.workflow.id, status: 'cancelled' })
+    return { workflow: wrapWorkflowInstance<TBot, TWorkflowName>({ client: props.client, workflow }) }
+  },
+})

--- a/packages/sdk/src/bot/workflow-proxy/types.test.ts
+++ b/packages/sdk/src/bot/workflow-proxy/types.test.ts
@@ -1,0 +1,74 @@
+import { test } from 'vitest'
+import type { EmptyBot, FooBarBazBot } from '../../fixtures'
+import type { WorkflowProxy } from './types'
+import type * as typeUtils from '../../utils/type-utils'
+import type { BaseBot } from '../common'
+
+test('WorkflowProxy of FooBarBazBot should reflect workflows of bot', async () => {
+  type Actual = WorkflowProxy<FooBarBazBot>
+  type Expected = Readonly<{
+    fooWorkflow: {
+      startNewInstance: (x: any) => any
+      listInstances: {
+        all: (x: any) => any
+        running: (x: any) => any
+        scheduled: (x: any) => any
+        allFinished: (x: any) => any
+        succeeded: (x: any) => any
+        cancelled: (x: any) => any
+        timedOut: (x: any) => any
+        failed: (x: any) => any
+      }
+    }
+  }>
+
+  type _assertion = typeUtils.AssertAll<
+    [
+      //
+      typeUtils.IsExtend<Actual, Expected>,
+      typeUtils.IsExtend<Expected, Actual>,
+      typeUtils.IsEquivalent<Actual, Expected>,
+    ]
+  >
+})
+
+test('WorkflowProxy of EmptyBot should be almost empty', async () => {
+  type Actual = WorkflowProxy<EmptyBot>
+  type Expected = {}
+
+  type _assertion = typeUtils.AssertAll<
+    [
+      //
+      typeUtils.IsExtend<Actual, Expected>,
+      typeUtils.IsExtend<Expected, Actual>,
+      typeUtils.IsEquivalent<Actual, Expected>,
+    ]
+  >
+})
+
+test('WorkflowProxy of BaseBot should be a record', async () => {
+  type Actual = WorkflowProxy<BaseBot>
+  type Expected = {
+    [x: string]: {
+      startNewInstance: (x: any) => any
+      listInstances: {
+        all: (x: any) => any
+        running: (x: any) => any
+        scheduled: (x: any) => any
+        allFinished: (x: any) => any
+        succeeded: (x: any) => any
+        cancelled: (x: any) => any
+        timedOut: (x: any) => any
+        failed: (x: any) => any
+      }
+    }
+  }
+  type _assertion = typeUtils.AssertAll<
+    [
+      //
+      typeUtils.IsExtend<Actual, Expected>,
+      typeUtils.IsExtend<Expected, Actual>,
+      typeUtils.IsEquivalent<Actual, Expected>,
+    ]
+  >
+})

--- a/packages/sdk/src/bot/workflow-proxy/types.ts
+++ b/packages/sdk/src/bot/workflow-proxy/types.ts
@@ -1,0 +1,100 @@
+import type * as client from '@botpress/client'
+import type * as typeUtils from '../../utils/type-utils'
+import type * as commonTypes from '../common'
+
+export type WorkflowProxy<TBot extends commonTypes.BaseBot = commonTypes.BaseBot> = Readonly<{
+  [TWorkflowName in keyof TBot['workflows']]: Readonly<{
+    startNewInstance: (
+      x: Pick<client.ClientInputs['createWorkflow'], 'conversationId' | 'userId' | 'timeoutAt'> & {
+        tags?: typeUtils.AtLeastOneProperty<TBot['workflows'][TWorkflowName]['tags']>
+        input: TBot['workflows'][TWorkflowName]['input']
+      }
+    ) => Promise<
+      Readonly<
+        Omit<client.ClientOutputs['createWorkflow'], 'workflow'> & {
+          workflow: WorkflowWithUtilities<TBot, TWorkflowName>
+        }
+      >
+    >
+
+    listInstances: Readonly<{
+      all: _ListInstances<TBot, TWorkflowName>
+      running: _ListInstances<TBot, TWorkflowName>
+      scheduled: _ListInstances<TBot, TWorkflowName>
+      allFinished: _ListInstances<TBot, TWorkflowName>
+      succeeded: _ListInstances<TBot, TWorkflowName>
+      cancelled: _ListInstances<TBot, TWorkflowName>
+      timedOut: _ListInstances<TBot, TWorkflowName>
+      failed: _ListInstances<TBot, TWorkflowName>
+    }>
+  }>
+}>
+
+type _ListInstances<TBot extends commonTypes.BaseBot, TWorkflowName extends keyof TBot['workflows']> = (
+  x?: Pick<client.ClientInputs['listWorkflows'], 'nextToken' | 'conversationId' | 'userId'> & {
+    tags?: typeUtils.AtLeastOneProperty<TBot['workflows'][TWorkflowName]['tags']>
+  }
+) => Promise<
+  Readonly<
+    Omit<client.ClientOutputs['listWorkflows'], 'workflows'> & {
+      workflows: WorkflowWithUtilities<TBot, TWorkflowName>[]
+    }
+  >
+>
+
+export type WorkflowWithUtilities<
+  TBot extends commonTypes.BaseBot,
+  TWorkflowName extends keyof commonTypes.EnumerateWorkflows<TBot>,
+> = Readonly<
+  client.Workflow & {
+    name: TWorkflowName
+    input: typeUtils.Cast<
+      commonTypes.EnumerateWorkflows<TBot>[TWorkflowName],
+      commonTypes.IntegrationInstanceActionDefinition
+    >['input']
+    output: Partial<
+      typeUtils.Cast<
+        commonTypes.EnumerateWorkflows<TBot>[TWorkflowName],
+        commonTypes.IntegrationInstanceActionDefinition
+      >['output']
+    >
+    tags: Partial<commonTypes.EnumerateWorkflows<TBot>[TWorkflowName]['tags']>
+
+    /**
+     * Updates the current workflow instance
+     */
+    update(
+      x: typeUtils.AtLeastOneProperty<
+        Pick<client.ClientInputs['updateWorkflow'], 'userId' | 'timeoutAt'> & {
+          tags?: typeUtils.AtLeastOneProperty<commonTypes.EnumerateWorkflows<TBot>[TWorkflowName]['tags']>
+          output?: typeUtils.Cast<
+            commonTypes.EnumerateWorkflows<TBot>[TWorkflowName],
+            commonTypes.IntegrationInstanceActionDefinition
+          >['output']
+        }
+      >
+    ): Promise<{ workflow: WorkflowWithUtilities<TBot, TWorkflowName> }>
+
+    /**
+     * Marks the current workflow instance as failed and stops execution
+     */
+    setFailed(
+      x: Required<Pick<client.ClientInputs['updateWorkflow'], 'failureReason'>>
+    ): Promise<{ workflow: WorkflowWithUtilities<TBot, TWorkflowName> }>
+
+    /**
+     * Marks the current workflow instance as completed and stops execution
+     */
+    setCompleted(x?: {
+      output?: typeUtils.Cast<
+        commonTypes.EnumerateWorkflows<TBot>[TWorkflowName],
+        commonTypes.IntegrationInstanceActionDefinition
+      >['output']
+    }): Promise<{ workflow: WorkflowWithUtilities<TBot, TWorkflowName> }>
+
+    /**
+     * Discards all output data and cancels the current workflow instance
+     */
+    cancel(): Promise<{ workflow: WorkflowWithUtilities<TBot, TWorkflowName> }>
+  }
+>

--- a/packages/sdk/src/bot/workflow-proxy/types.ts
+++ b/packages/sdk/src/bot/workflow-proxy/types.ts
@@ -3,7 +3,7 @@ import type * as typeUtils from '../../utils/type-utils'
 import type * as commonTypes from '../common'
 
 export type WorkflowProxy<TBot extends commonTypes.BaseBot = commonTypes.BaseBot> = Readonly<{
-  [TWorkflowName in keyof TBot['workflows']]: Readonly<{
+  [TWorkflowName in typeUtils.StringKeys<TBot['workflows']>]: Readonly<{
     startNewInstance: (
       x: Pick<client.ClientInputs['createWorkflow'], 'conversationId' | 'userId' | 'timeoutAt'> & {
         tags?: typeUtils.AtLeastOneProperty<TBot['workflows'][TWorkflowName]['tags']>
@@ -30,7 +30,7 @@ export type WorkflowProxy<TBot extends commonTypes.BaseBot = commonTypes.BaseBot
   }>
 }>
 
-type _ListInstances<TBot extends commonTypes.BaseBot, TWorkflowName extends keyof TBot['workflows']> = (
+type _ListInstances<TBot extends commonTypes.BaseBot, TWorkflowName extends typeUtils.StringKeys<TBot['workflows']>> = (
   x?: Pick<client.ClientInputs['listWorkflows'], 'nextToken' | 'conversationId' | 'userId'> & {
     tags?: typeUtils.AtLeastOneProperty<TBot['workflows'][TWorkflowName]['tags']>
   }
@@ -44,21 +44,15 @@ type _ListInstances<TBot extends commonTypes.BaseBot, TWorkflowName extends keyo
 
 export type WorkflowWithUtilities<
   TBot extends commonTypes.BaseBot,
-  TWorkflowName extends keyof commonTypes.EnumerateWorkflows<TBot>,
+  TWorkflowName extends typeUtils.StringKeys<TBot['workflows']>,
 > = Readonly<
   client.Workflow & {
     name: TWorkflowName
-    input: typeUtils.Cast<
-      commonTypes.EnumerateWorkflows<TBot>[TWorkflowName],
-      commonTypes.IntegrationInstanceActionDefinition
-    >['input']
+    input: typeUtils.Cast<TBot['workflows'][TWorkflowName], commonTypes.IntegrationInstanceActionDefinition>['input']
     output: Partial<
-      typeUtils.Cast<
-        commonTypes.EnumerateWorkflows<TBot>[TWorkflowName],
-        commonTypes.IntegrationInstanceActionDefinition
-      >['output']
+      typeUtils.Cast<TBot['workflows'][TWorkflowName], commonTypes.IntegrationInstanceActionDefinition>['output']
     >
-    tags: Partial<commonTypes.EnumerateWorkflows<TBot>[TWorkflowName]['tags']>
+    tags: Partial<TBot['workflows'][TWorkflowName]['tags']>
 
     /**
      * Updates the current workflow instance
@@ -66,9 +60,9 @@ export type WorkflowWithUtilities<
     update(
       x: typeUtils.AtLeastOneProperty<
         Pick<client.ClientInputs['updateWorkflow'], 'userId' | 'timeoutAt'> & {
-          tags?: typeUtils.AtLeastOneProperty<commonTypes.EnumerateWorkflows<TBot>[TWorkflowName]['tags']>
+          tags?: typeUtils.AtLeastOneProperty<TBot['workflows'][TWorkflowName]['tags']>
           output?: typeUtils.Cast<
-            commonTypes.EnumerateWorkflows<TBot>[TWorkflowName],
+            TBot['workflows'][TWorkflowName],
             commonTypes.IntegrationInstanceActionDefinition
           >['output']
         }
@@ -87,7 +81,7 @@ export type WorkflowWithUtilities<
      */
     setCompleted(x?: {
       output?: typeUtils.Cast<
-        commonTypes.EnumerateWorkflows<TBot>[TWorkflowName],
+        TBot['workflows'][TWorkflowName],
         commonTypes.IntegrationInstanceActionDefinition
       >['output']
     }): Promise<{ workflow: WorkflowWithUtilities<TBot, TWorkflowName> }>

--- a/packages/sdk/src/fixtures.ts
+++ b/packages/sdk/src/fixtures.ts
@@ -175,6 +175,13 @@ export type FooBarBazBot = DefaultBot<{
   states: {
     currentUser: { name: string; age: number }
   }
+  workflows: {
+    fooWorkflow: {
+      tags: { foo: string }
+      input: { string: string; optionalNumber?: number }
+      output: { optionalString?: string; number: number }
+    }
+  }
 }>
 
 export type FooBarBazPlugin = DefaultPlugin<{
@@ -192,6 +199,13 @@ export type FooBarBazPlugin = DefaultPlugin<{
       output: {
         result: unknown
       }
+    }
+  }
+  workflows: {
+    fooWorkflow: {
+      tags: { foo: string }
+      input: { string: string; optionalNumber?: number }
+      output: { optionalString?: string; number: number }
     }
   }
 }>

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -56,6 +56,7 @@ export {
   MessageDefinition as BotMessageDefinition,
   ActionDefinition as BotActionDefinition,
   TableDefinition as BotTableDefinition,
+  WorkflowDefinition as BotWorkflowDefinition,
   BotLogger,
 } from './bot'
 

--- a/packages/sdk/src/package.ts
+++ b/packages/sdk/src/package.ts
@@ -46,6 +46,7 @@ type PluginPackageDefinition = NameVersion & {
   recurringEvents?: Record<string, plugin.RecurringEventDefinition>
   actions?: Record<string, plugin.ActionDefinition>
   tables?: Record<string, plugin.TableDefinition>
+  workflows?: Record<string, plugin.WorkflowDefinition>
 }
 
 export type IntegrationPackage = PackageReference & {

--- a/packages/sdk/src/plugin/common/generic.ts
+++ b/packages/sdk/src/plugin/common/generic.ts
@@ -15,7 +15,7 @@ export type BaseWorkflow = {
   input: any
   output: any
   tags?: {
-    [k: string]: any
+    [k: string]: string
   }
 }
 

--- a/packages/sdk/src/plugin/common/generic.ts
+++ b/packages/sdk/src/plugin/common/generic.ts
@@ -8,114 +8,15 @@ export type BaseAction = {
 }
 
 export type BaseTable = {
-  // This type is equivalent to Exclude<Client.Table, 'id' | 'createdAt' | 'updatedAt'>
+  [k: string]: any
+}
 
-  /**
-   * Required. This name is used to identify your table.
-   */
-  name: string
-  /**
-   * The 'factor' multiplies the row's data storage limit by 4KB and its quota count, but can only be set at table creation and not modified later. For instance, a factor of 2 increases storage to 8KB but counts as 2 rows in your quota. The default factor is 1.
-   */
-  factor?: number
-  /**
-   * A table designated as "frozen" is immutable in terms of its name and schema structure; modifications to its schema or a renaming operation are not permitted. The only action that can be taken on such a table is deletion. The schema established at the time of creation is locked in as the final structure. To implement any changes, the table must be duplicated with the desired alterations.
-   */
-  frozen?: boolean
-  schema: {
-    $schema?: string
-    /**
-     * List of keys/columns in the table.
-     */
-    properties: {
-      [k: string]: {
-        type: 'string' | 'number' | 'boolean' | 'object' | 'array' | 'null'
-        format?: 'date-time'
-        description?: string
-        /**
-         * String properties must match this pattern
-         */
-        pattern?: string
-        /**
-         * String properties must be one of these values
-         */
-        enum?: string[]
-        /**
-         * Defines the shape of items in an array
-         */
-        items?: {
-          type: 'string' | 'number' | 'boolean' | 'object' | 'array' | 'null'
-          [k: string]: any
-        }
-        nullable?: boolean
-        properties?: {
-          [k: string]: {
-            type: 'string' | 'number' | 'boolean' | 'object' | 'array' | 'null'
-            [k: string]: any
-          }
-        }
-        'x-zui': {
-          index: number
-          /**
-           * Indicates if the column is vectorized and searchable.
-           */
-          searchable?: boolean
-          /**
-           * Indicates if the field is hidden in the UI
-           */
-          hidden?: boolean
-          /**
-           * Order of the column in the UI
-           */
-          order?: number
-          /**
-           * Width of the column in the UI
-           */
-          width?: number
-          computed?: {
-            action: 'ai' | 'code' | 'workflow'
-            dependencies?: string[]
-            /**
-             * Prompt when action is "ai"
-             */
-            prompt?: string
-            /**
-             * Code to execute when action is "code"
-             */
-            code?: string
-            /**
-             * Model to use when action is "ai"
-             */
-            model?: string
-            /**
-             * ID of Workflow to execute when action is "workflow"
-             */
-            workflowId?: string
-            enabled?: boolean
-          }
-        }
-      }
-    }
-    /**
-     * Additional properties can be provided, but they will be ignored if no column matches.
-     */
-    additionalProperties: true
-    /**
-     * Array of required properties.
-     */
-    required?: string[]
-    type: 'object'
-  }
-  /**
-   * Optional tags to help organize your tables. These should be passed here as an object representing key/value pairs.
-   */
+export type BaseWorkflow = {
+  input: any
+  output: any
   tags?: {
-    [k: string]: string
+    [k: string]: any
   }
-  /**
-   * Indicates if the table is enabled for computation.
-   */
-  isComputeEnabled?: boolean
 }
 
 export type BasePlugin = {
@@ -128,6 +29,7 @@ export type BasePlugin = {
   states: Record<string, any>
   actions: Record<string, BaseAction>
   tables: Record<string, BaseTable>
+  workflows: Record<string, BaseWorkflow>
 }
 
 export type InputBasePlugin = utils.DeepPartial<BasePlugin>
@@ -139,6 +41,7 @@ export type DefaultPlugin<B extends utils.DeepPartial<BasePlugin>> = {
   states: utils.Default<B['states'], BasePlugin['states']>
   actions: utils.Default<B['actions'], BasePlugin['actions']>
   tables: utils.Default<B['tables'], BasePlugin['tables']>
+  workflows: utils.Default<B['workflows'], BasePlugin['workflows']>
   integrations: undefined extends B['integrations']
     ? BasePlugin['integrations']
     : {

--- a/packages/sdk/src/plugin/definition.ts
+++ b/packages/sdk/src/plugin/definition.ts
@@ -79,6 +79,11 @@ export type PluginDefinitionProps<
   tables?: {
     [K in keyof TTables]: TableDefinition<TTables[K]>
   }
+
+  /**
+   * # EXPERIMENTAL
+   * This API is experimental and may change in the future.
+   */
   workflows?: {
     [K in keyof TWorkflows]: WorkflowDefinition<TWorkflows[K]>
   }

--- a/packages/sdk/src/plugin/definition.ts
+++ b/packages/sdk/src/plugin/definition.ts
@@ -8,6 +8,7 @@ import {
   MessageDefinition,
   ActionDefinition,
   TableDefinition,
+  WorkflowDefinition,
 } from '../bot/definition'
 import { IntegrationPackage, InterfacePackage } from '../package'
 import { ZuiObjectSchema } from '../zui'
@@ -23,6 +24,7 @@ export {
   ActionDefinition,
   TableDefinition,
   IntegrationConfigInstance,
+  WorkflowDefinition,
 } from '../bot/definition'
 
 type BaseConfig = ZuiObjectSchema
@@ -32,6 +34,7 @@ type BaseActions = Record<string, ZuiObjectSchema>
 type BaseInterfaces = Record<string, any>
 type BaseIntegrations = Record<string, any>
 type BaseTables = Record<string, ZuiObjectSchema>
+type BaseWorkflows = Record<string, ZuiObjectSchema>
 
 export type PluginDefinitionProps<
   TName extends string = string,
@@ -43,6 +46,7 @@ export type PluginDefinitionProps<
   TInterfaces extends BaseInterfaces = BaseInterfaces,
   TIntegrations extends BaseIntegrations = BaseIntegrations,
   TTables extends BaseTables = BaseTables,
+  TWorkflows extends BaseWorkflows = BaseWorkflows,
 > = {
   name: TName
   version: TVersion
@@ -75,6 +79,9 @@ export type PluginDefinitionProps<
   tables?: {
     [K in keyof TTables]: TableDefinition<TTables[K]>
   }
+  workflows?: {
+    [K in keyof TWorkflows]: WorkflowDefinition<TWorkflows[K]>
+  }
 }
 
 export class PluginDefinition<
@@ -87,6 +94,7 @@ export class PluginDefinition<
   TInterfaces extends BaseInterfaces = BaseInterfaces,
   TIntegrations extends BaseIntegrations = BaseIntegrations,
   TTables extends BaseTables = BaseTables,
+  TWorkflows extends BaseWorkflows = BaseWorkflows,
 > {
   public readonly name: this['props']['name']
   public readonly version: this['props']['version']
@@ -108,6 +116,7 @@ export class PluginDefinition<
   public readonly recurringEvents: this['props']['recurringEvents']
   public readonly actions: this['props']['actions']
   public readonly tables: this['props']['tables']
+  public readonly workflows: this['props']['workflows']
 
   public constructor(
     public readonly props: PluginDefinitionProps<
@@ -119,7 +128,8 @@ export class PluginDefinition<
       TActions,
       TInterfaces,
       TIntegrations,
-      TTables
+      TTables,
+      TWorkflows
     >
   ) {
     this.name = props.name
@@ -139,5 +149,6 @@ export class PluginDefinition<
     this.recurringEvents = props.recurringEvents
     this.actions = props.actions
     this.tables = props.tables
+    this.workflows = props.workflows
   }
 }

--- a/packages/sdk/src/plugin/implementation.ts
+++ b/packages/sdk/src/plugin/implementation.ts
@@ -72,7 +72,7 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
     after_outgoing_message: {},
     after_outgoing_call_action: {},
   }
-  private _workflowHandlers: BotWorkflowHandlersMap<TPlugin, Tools<TPlugin>> = {}
+  private _workflowHandlers: BotWorkflowHandlersMap<TPlugin> = {}
 
   public constructor(public readonly props: PluginImplementationProps<TPlugin>) {
     this._actionHandlers = props.actions

--- a/packages/sdk/src/plugin/implementation.ts
+++ b/packages/sdk/src/plugin/implementation.ts
@@ -266,6 +266,10 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
       )
     },
 
+    /**
+     * # EXPERIMENTAL
+     * This API is experimental and may change in the future.
+     */
     workflows: new Proxy(
       {},
       {

--- a/packages/sdk/src/plugin/implementation.ts
+++ b/packages/sdk/src/plugin/implementation.ts
@@ -9,8 +9,10 @@ import type {
   WorkflowHandlersMap as BotWorkflowHandlersMap,
   WorkflowHandlers as BotWorkflowHandlers,
   WorkflowHandlersFnMap as BotWorkflowHandlersFnMap,
+  WorkflowUpdateTypeSnakeCase as BotWorkflowUpdateTypeSnakeCase,
   WorkflowUpdateTypeCamelCase as BotWorkflowUpdateTypeCamelCase,
 } from '../bot'
+import { camelCaseUpdateTypeToSnakeCase } from '../bot/server/workflows/update-type-conv'
 import { WorkflowProxy, proxyWorkflows } from '../bot/workflow-proxy'
 import * as utils from '../utils'
 import type * as typeUtils from '../utils/type-utils'
@@ -236,7 +238,7 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
     return new Proxy(
       {},
       {
-        get: (_, updateType: BotWorkflowUpdateTypeCamelCase) => {
+        get: (_, updateType: BotWorkflowUpdateTypeSnakeCase) => {
           return new Proxy(
             {},
             {
@@ -286,10 +288,11 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
                 }
 
                 return (handler: BotWorkflowHandlers<TPlugin>[TWorkflowName]): void => {
-                  this._workflowHandlers[updateType] ??= {}
-                  this._workflowHandlers[updateType][workflowName] = utils.arrays.safePush(
-                    this._workflowHandlers[updateType][workflowName],
-                    handler as BotWorkflowHandlers<TPlugin>[TWorkflowName]
+                  const updateTypeSnakeCase = camelCaseUpdateTypeToSnakeCase(updateType)
+                  this._workflowHandlers[updateTypeSnakeCase] ??= {}
+                  this._workflowHandlers[updateTypeSnakeCase][workflowName] = utils.arrays.safePush(
+                    this._workflowHandlers[updateTypeSnakeCase][workflowName],
+                    handler
                   )
                 }
               },

--- a/packages/sdk/src/plugin/server/types.ts
+++ b/packages/sdk/src/plugin/server/types.ts
@@ -1,7 +1,8 @@
 import * as client from '@botpress/client'
 import * as bot from '../../bot'
+import * as workflowProxy from '../../bot/workflow-proxy'
 import * as utils from '../../utils/type-utils'
-import * as proxy from '../action-proxy'
+import * as actionProxy from '../action-proxy'
 import * as common from '../common'
 
 type EnumeratePluginEvents<TPlugin extends common.BasePlugin> = bot.EnumerateEvents<TPlugin> &
@@ -100,7 +101,8 @@ export type CommonHandlerProps<TPlugin extends common.BasePlugin> = {
   client: PluginClient<TPlugin>
   configuration: PluginConfiguration<TPlugin>
   interfaces: common.PluginInterfaceExtensions<TPlugin>
-  actions: proxy.ActionProxy<TPlugin>
+  actions: actionProxy.ActionProxy<TPlugin>
+  workflows: workflowProxy.WorkflowProxy<TPlugin>
   // states: proxy.StateProxy<TPlugin> // TODO: add state proxy to automatically append plugin alias
   alias: string
 }

--- a/packages/sdk/src/plugin/server/types.ts
+++ b/packages/sdk/src/plugin/server/types.ts
@@ -102,6 +102,11 @@ export type CommonHandlerProps<TPlugin extends common.BasePlugin> = {
   configuration: PluginConfiguration<TPlugin>
   interfaces: common.PluginInterfaceExtensions<TPlugin>
   actions: actionProxy.ActionProxy<TPlugin>
+
+  /**
+   * # EXPERIMENTAL
+   * This API is experimental and may change in the future.
+   */
   workflows: workflowProxy.WorkflowProxy<TPlugin>
   // states: proxy.StateProxy<TPlugin> // TODO: add state proxy to automatically append plugin alias
   alias: string

--- a/packages/sdk/src/utils/type-utils.test.ts
+++ b/packages/sdk/src/utils/type-utils.test.ts
@@ -83,6 +83,20 @@ describe('AtLeastOneProperty<T>', () => {
       ]
     >
   })
+
+  test('when T is undefined, should not allow any properties', () => {
+    type A = utils.AtLeastOneProperty<undefined>
+    type B = {}
+    type C = { foo: 1 }
+    type _assertion = utils.AssertAll<
+      [
+        //
+        utils.AssertExtends<B, A>,
+        utils.AssertExtends<A, B>,
+        utils.AssertNotExtends<A, C>,
+      ]
+    >
+  })
 })
 
 describe('ExactlyOneProperty<T>', () => {

--- a/packages/sdk/src/utils/type-utils.ts
+++ b/packages/sdk/src/utils/type-utils.ts
@@ -6,14 +6,18 @@ export type Writable<T> = { -readonly [K in keyof T]: T[K] }
 export type Default<T, U> = undefined extends T ? U : T
 
 export type AtLeastOne<T> = [T, ...T[]]
-export type AtLeastOneProperty<T> = {
-  [K in keyof T]?: T[K]
-} & {
-  [K in keyof T]: Pick<T, K>
-}[keyof T]
-export type ExactlyOneProperty<T> = {
-  [K in keyof T]: { [P in K]: T[P] } & { [P in Exclude<keyof T, K>]?: never }
-}[keyof T]
+export type AtLeastOneProperty<T> = T extends undefined
+  ? {}
+  : {
+      [K in keyof T]?: T[K]
+    } & {
+      [K in keyof T]: Pick<T, K>
+    }[keyof T]
+export type ExactlyOneProperty<T> = T extends undefined
+  ? {}
+  : {
+      [K in keyof T]: { [P in K]: T[P] } & { [P in Exclude<keyof T, K>]?: never }
+    }[keyof T]
 
 export type IsExtend<X, Y> = X extends Y ? true : false
 export type IsEquivalent<X, Y> = IsExtend<X, Y> extends true ? IsExtend<Y, X> : false

--- a/packages/sdk/src/utils/type-utils.ts
+++ b/packages/sdk/src/utils/type-utils.ts
@@ -79,3 +79,5 @@ export type DeepPartial<T> = T extends (...args: infer A) => infer R
             : T
 
 export type SafeOmit<T, K extends keyof T> = Omit<T, K>
+
+export type StringKeys<T> = Extract<keyof T, string>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1807,7 +1807,7 @@ importers:
         specifier: 0.48.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 3.4.0
+        specifier: 3.5.0
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -1919,7 +1919,7 @@ importers:
         specifier: 0.48.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 3.4.0
+        specifier: 3.5.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1935,7 +1935,7 @@ importers:
         specifier: 0.48.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 3.4.0
+        specifier: 3.5.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1948,7 +1948,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 3.4.0
+        specifier: 3.5.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1964,7 +1964,7 @@ importers:
         specifier: 0.48.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 3.4.0
+        specifier: 3.5.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1980,7 +1980,7 @@ importers:
         specifier: 0.48.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 3.4.0
+        specifier: 3.5.0
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
The concept of robust bot workflows [was drafted all the way back in September of 2024](https://github.com/botpress/engineering-handbook/blob/master/projects/robustness-of-execution.md), but whilst the back-end fully supports it, it was never implemented in the SDK.

> [!NOTE]
> To find out more about robust workflows, please read the design doc: [robustness-of-execution.md](https://github.com/botpress/engineering-handbook/blob/master/projects/robustness-of-execution.md).

This PR adds support for robust workflows to both bots and plugins. To make the DX friendlier and easier to grasp, the SDK offers a high level of abstraction by handling workflow dispatching and provides utilities to bot/plugin developers.

To make use of these workflows, one must first define it within the bot or plugin definition:

```typescript
export default new sdk.BotDefinition({
  workflows: {
    foobar: {
      title: 'Foo Bar',
      description: 'Foo workflow',
      input: {
        schema: sdk.z.object({
          str: sdk.z.string(),
          optionalStr: sdk.z.string().optional(),
          num: sdk.z.number(),
        }),
      },
      output: {
        schema: sdk.z.object({
          str: sdk.z.string(),
          optionalStr: sdk.z.string().optional(),
          num: sdk.z.number(),
        }),
      },
      tags: {
        fooTag: {
          title: 'Foo Tag',
          description: 'Foo tag',
        },
        barTag: {
          title: 'Bar Tag',
          description: 'Bar tag',
        },
      },
    },
  },
})
```

> [!IMPORTANT]
> The backend does not (yet) have a concept of _workflow definition_: all workflows are always dynamic, which means one can pass anything as input/output. However, in order to provide strong typings, this PR forces bot and plugin developers to define their entire workflow as a zod schema. This has the added benefit that if we decide to later add support for workflow definitions on the backend and start to strictly enforce it, we can do so without breaking any bot or plugin.

Once a workflow is defined, one can add hooks by using `bot.on.workflows.<name>` or `plugin.workflows.<name>`:

```typescript
bot.on.workflows.foobar.started(async (props) => {
  console.info('>> foobar workflow started')
  await props.workflow.update({ output: { str: 'bar', num: 0 } })
})

bot.on.workflows.bar.continued(async (props) => {
  console.info('>> foobar workflow continued')
  await props.workflow.update({ output: { str: 'bar', num: (props.workflow.output?.num ?? 0) + 1 } })

  if (props.workflow.output?.num === 10) {
    console.info('>> foobar workflow completed')
    await props.workflow.setCompleted()
  }
})
````

The above snippet would be executed for the `foobar` workflow until the `num` output property (which we defined in the workflow definition) equals `10`, at which point it would set the workflow as completed using the `workflow` contextual utility.

> [!NOTE]
> The following hooks are available for workflows:
> - `bot.on.workflows.<name>.started` - executed only once when the workflow instance is created
> - `bot.on.workflows.<name>.continued` - executed on all subsequent runs
> - `bot.on.workflows.<name>.timedOut` - executed only once, if the workflow times out

> [!TIP]
> Workflow hook handlers have access to a special utility named `workflow` that is context-aware and allows to perform operations on the current workflow instance:
> - `workflow.setFailed({ failureReason: 'some reason' })`
> - `workflow.setCompleted({ output })`
> - `workflow.update({ output, tags, timeoutAt  })`
>
> They also have access to `conversation` and `user` read-only objects if the workflow is associated with a conversation or user.

To start a new workflow instance, all handlers everywhere (channel message, register, events, plugin hooks) get injected with a `workflows` proxy object that allows them to start specific workflows:

```typescript
bot.on.message('text', async (props) => {
  const text: string = props.message.payload.text

  if (text.startsWith('/start')) {
    await props.workflows.foobar.startNewInstance({
      input: { str: 'bar', num: 42 },
      tags: { barTag: 'abc' },
    })
  }
})
```

Handlers are also able to list workflows and act upon them:

```typescript
bot.on.message('text', async (props) => {
  const text: string = props.message.payload.text

  if (text.startsWith('/endAll')) {
    const { workflows } = await props.workflows.fooBar.listInstances.running({ tags: { barTag: 'abc' } })

    for (const workflow of workflows) {
      await workflow.cancel()
    }
  }
})
```

> [!NOTE]
> The following operations are available to all handlers:
> - `workflows.<name>.startNewInstance({ input, tags, timeoutAt, conversationId, userId })`
> - `workflows.<name>.listInstances.all({ tags, conversationId, userId, nextToken })`
> - `workflows.<name>.listInstances.running({ tags, conversationId, userId, nextToken })`
> - `workflows.<name>.listInstances.scheduled({ tags, conversationId, userId, nextToken })`
> - `workflows.<name>.listInstances.allFinished({ tags, conversationId, userId, nextToken })`
> - `workflows.<name>.listInstances.succeeded({ tags, conversationId, userId, nextToken })`
> - `workflows.<name>.listInstances.cancelled({ tags, conversationId, userId, nextToken })`
> - `workflows.<name>.listInstances.timedOut({ tags, conversationId, userId, nextToken })`
> - `workflows.<name>.listInstances.failed({ tags, conversationId, userId, nextToken })`