### PR TITLE
fix(cli): Skip secrets copy between integration versions when explicitely deleted

### DIFF
--- a/packages/chat-api/package.json
+++ b/packages/chat-api/package.json
@@ -13,7 +13,7 @@
     "esbuild": "^0.16.12"
   },
   "dependencies": {
-    "@botpress/api": "0.78.0",
+    "@botpress/api": "0.79.0",
     "@bpinternal/opapi": "0.12.1",
     "lodash": "^4.17.21",
     "zod": "^3.20.6"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.1",
-    "@botpress/client": "0.47.0",
+    "@botpress/client": "0.48.0",
     "@botpress/sdk": "3.4.0",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",

--- a/packages/cli/src/command-implementations/deploy-command.ts
+++ b/packages/cli/src/command-implementations/deploy-command.ts
@@ -136,9 +136,7 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
 
       const knownSecrets = previousVersion?.secrets
 
-      const createSecrets = await this.promptSecrets(integrationDef, this.argv, { knownSecrets })
-      createBody.secrets = utils.records.filterValues(createSecrets, utils.guards.is.notNull)
-
+      createBody.secrets = await this.promptSecrets(integrationDef, this.argv, { knownSecrets })
       this._detectDeprecatedFeatures(integrationDef, {
         allowDeprecated: this._allowDeprecatedFeatures(integrationDef, previousVersion),
       })

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -5,7 +5,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.47.0",
+    "@botpress/client": "0.48.0",
     "@botpress/sdk": "3.4.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.47.0",
+    "@botpress/client": "0.48.0",
     "@botpress/sdk": "3.4.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.47.0",
+    "@botpress/client": "0.48.0",
     "@botpress/sdk": "3.4.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "0.47.0",
+    "@botpress/client": "0.48.0",
     "@botpress/sdk": "3.4.0",
     "axios": "^1.6.8"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -28,7 +28,7 @@
     "qs": "^6.11.0"
   },
   "devDependencies": {
-    "@botpress/api": "0.78.0",
+    "@botpress/api": "0.79.0",
     "@types/qs": "^6.9.7",
     "esbuild": "^0.16.12",
     "lodash": "^4.17.21",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "0.47.0",
+    "@botpress/client": "0.48.0",
     "browser-or-node": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -36,7 +36,7 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "@botpress/client": "0.47.0",
+    "@botpress/client": "0.48.0",
     "@bpinternal/thicktoken": "^1.0.1",
     "@bpinternal/zui": "^0.13.4",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1697,8 +1697,8 @@ importers:
   packages/chat-api:
     dependencies:
       '@botpress/api':
-        specifier: 0.78.0
-        version: 0.78.0(openapi-types@12.1.3)
+        specifier: 0.79.0
+        version: 0.79.0(openapi-types@12.1.3)
       '@bpinternal/opapi':
         specifier: 0.12.1
         version: 0.12.1(openapi-types@12.1.3)
@@ -1804,7 +1804,7 @@ importers:
         specifier: 0.5.1
         version: link:../chat-client
       '@botpress/client':
-        specifier: 0.47.0
+        specifier: 0.48.0
         version: link:../client
       '@botpress/sdk':
         specifier: 3.4.0
@@ -1916,7 +1916,7 @@ importers:
   packages/cli/templates/empty-bot:
     dependencies:
       '@botpress/client':
-        specifier: 0.47.0
+        specifier: 0.48.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 3.4.0
@@ -1932,7 +1932,7 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 0.47.0
+        specifier: 0.48.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 3.4.0
@@ -1961,7 +1961,7 @@ importers:
   packages/cli/templates/hello-world:
     dependencies:
       '@botpress/client':
-        specifier: 0.47.0
+        specifier: 0.48.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 3.4.0
@@ -1977,7 +1977,7 @@ importers:
   packages/cli/templates/webhook-message:
     dependencies:
       '@botpress/client':
-        specifier: 0.47.0
+        specifier: 0.48.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 3.4.0
@@ -2009,8 +2009,8 @@ importers:
         version: 6.11.0
     devDependencies:
       '@botpress/api':
-        specifier: 0.78.0
-        version: 0.78.0(openapi-types@12.1.3)
+        specifier: 0.79.0
+        version: 0.79.0(openapi-types@12.1.3)
       '@types/qs':
         specifier: ^6.9.7
         version: 6.9.7
@@ -2082,7 +2082,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 0.47.0
+        specifier: 0.48.0
         version: link:../client
       '@bpinternal/zui':
         specifier: ^0.13.5
@@ -2113,7 +2113,7 @@ importers:
   packages/vai:
     dependencies:
       '@botpress/client':
-        specifier: 0.47.0
+        specifier: 0.48.0
         version: link:../client
       '@bpinternal/thicktoken':
         specifier: ^1.0.1
@@ -4022,8 +4022,8 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@botpress/api@0.78.0(openapi-types@12.1.3):
-    resolution: {integrity: sha512-tqDUDsKPy6e6/dLRou+L376kUNtbVtoYpzpbtQnNuhmq+hTm2GEMXhV2dobv78Va/56yHYg2NADMWYkN8RKzIw==}
+  /@botpress/api@0.79.0(openapi-types@12.1.3):
+    resolution: {integrity: sha512-YkOOPlXD1OldKMX8/xJmKBcEvJKNEyV9RFrFiAmYVxgy0mJarDH+L66fMiiTY/Kl23gXUWR/pVjqplc96iBR7g==}
     dependencies:
       '@bpinternal/opapi': 0.12.1(openapi-types@12.1.3)
     transitivePeerDependencies:
@@ -6328,7 +6328,7 @@ packages:
       '@slack/logger': 3.0.0
       '@slack/types': 2.8.0
       '@types/is-stream': 1.1.0
-      '@types/node': 18.19.67
+      '@types/node': 18.19.76
       axios: 0.27.2
       eventemitter3: 3.1.2
       form-data: 2.5.1
@@ -7570,7 +7570,7 @@ packages:
   /@types/nodemailer@6.4.8:
     resolution: {integrity: sha512-oVsJSCkqViCn8/pEu2hfjwVO+Gb3e+eTWjg3PcjeFKRItfKpKwHphQqbYmPQrlMk+op7pNNWPbsJIEthpFN/OQ==}
     dependencies:
-      '@types/node': 18.19.67
+      '@types/node': 18.19.76
     dev: true
 
   /@types/prettier@2.7.3:
@@ -8817,12 +8817,6 @@ packages:
     dependencies:
       balanced-match: 1.0.2
 
-  /braces@3.0.2:
-    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
-    engines: {node: '>=8'}
-    dependencies:
-      fill-range: 7.1.1
-
   /braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -9067,7 +9061,7 @@ packages:
     engines: {node: '>= 8.10.0'}
     dependencies:
       anymatch: 3.1.3
-      braces: 3.0.2
+      braces: 3.0.3
       glob-parent: 5.1.2
       is-binary-path: 2.1.0
       is-glob: 4.0.3
@@ -9083,7 +9077,7 @@ packages:
     requiresBuild: true
     dependencies:
       anymatch: 3.1.3
-      braces: 3.0.2
+      braces: 3.0.3
       glob-parent: 5.1.2
       is-binary-path: 2.1.0
       is-glob: 4.0.3
@@ -15221,7 +15215,7 @@ packages:
     resolution: {integrity: sha512-yPxVJxUzP1QHhHeFnYjJl48QwDS1+5befcL7ju7+t+i88D5r0rbsL+GkCCS6zgcU+TiV5bF9eMGcKyJfLf8BZQ==}
     engines: {node: '>=12.*'}
     dependencies:
-      '@types/node': 18.19.67
+      '@types/node': 18.19.76
       qs: 6.13.0
     dev: false
 


### PR DESCRIPTION
Explicitely specifying secrets to skip when copying from a previous integration version was made available in the API in PR #2796

Fixes CLS-2614