### PR TITLE
feat(sdk): plugin and bot handlers are returned in register ordered

### DIFF
--- a/packages/sdk/src/bot/implementation.ts
+++ b/packages/sdk/src/bot/implementation.ts
@@ -5,21 +5,25 @@ import * as utils from '../utils'
 import { BaseBot } from './common'
 import {
   botHandler,
-  type MessageHandlersMap,
-  type MessageHandlers,
-  type EventHandlersMap,
-  type EventHandlers,
-  type StateExpiredHandlersMap,
-  type StateExpiredHandlers,
-  type HookHandlersMap,
-  type HookData,
-  type HookHandlers,
-  type ActionHandlers,
-  type BotHandlers,
-  type UnimplementedActionHandlers,
-  type WorkflowHandlersMap,
-  type WorkflowUpdateType,
-  type WorkflowHandlers,
+  ActionHandlers,
+  MessageHandlers,
+  EventHandlers,
+  StateExpiredHandlers,
+  HookHandlers,
+  WorkflowHandlers,
+  MessageHandlersMap,
+  EventHandlersMap,
+  StateExpiredHandlersMap,
+  HookHandlersMap,
+  WorkflowHandlersMap,
+  OrderedMessageHandlersMap,
+  OrderedEventHandlersMap,
+  OrderedStateExpiredHandlersMap,
+  OrderedHookHandlersMap,
+  OrderedWorkflowHandlersMap,
+  BotHandlers,
+  UnimplementedActionHandlers,
+  WorkflowUpdateType,
 } from './server'
 
 export type BotImplementationProps<TBot extends BaseBot = BaseBot, TPlugins extends Record<string, BasePlugin> = {}> = {
@@ -33,10 +37,10 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
   implements BotHandlers<TBot>
 {
   private _actionHandlers: ActionHandlers<any>
-  private _messageHandlers: MessageHandlersMap<any> = {}
-  private _eventHandlers: EventHandlersMap<any> = {}
-  private _stateExpiredHandlers: StateExpiredHandlersMap<any> = {}
-  private _hookHandlers: HookHandlersMap<any> = {
+  private _messageHandlers: OrderedMessageHandlersMap<any> = {}
+  private _eventHandlers: OrderedEventHandlersMap<any> = {}
+  private _stateExpiredHandlers: OrderedStateExpiredHandlersMap<any> = {}
+  private _hookHandlers: OrderedHookHandlersMap<any> = {
     before_incoming_event: {},
     before_incoming_message: {},
     before_outgoing_message: {},
@@ -46,13 +50,15 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
     after_outgoing_message: {},
     after_outgoing_call_action: {},
   }
-  private _workflowHandlers: WorkflowHandlersMap<any> = {
+  private _workflowHandlers: OrderedWorkflowHandlersMap<any> = {
     started: {},
     continued: {},
     timed_out: {},
   }
 
   private _plugins: Record<string, PluginImplementation<any>> = {}
+
+  private _registerOrder: number = 0
 
   public constructor(public readonly props: BotImplementationProps<TBot, TPlugins>) {
     this._actionHandlers = props.actions as ActionHandlers<TBot>
@@ -88,13 +94,15 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
       {
         /** returns both the message handlers for the target type but global as well */
         get: (_, messageName: string) => {
-          const selfSpecificHandlers = this._messageHandlers[messageName] ?? []
-          const selfGlobalHandlers = this._messageHandlers['*'] ?? []
-          const selfHandlers = [...selfSpecificHandlers, ...selfGlobalHandlers]
           const pluginHandlers = Object.values(this._plugins).flatMap(
             (plugin) => plugin.messageHandlers[messageName] ?? []
           )
-          return utils.arrays.unique([...selfHandlers, ...pluginHandlers])
+          const selfSpecificHandlers = this._messageHandlers[messageName] ?? []
+          const selfGlobalHandlers = this._messageHandlers['*'] ?? []
+          const selfHandlers = [...selfSpecificHandlers, ...selfGlobalHandlers]
+            .sort((a, b) => a.order - b.order)
+            .map(({ handler }) => handler)
+          return utils.arrays.unique([...pluginHandlers, ...selfHandlers])
         },
       }
     ) as MessageHandlersMap<TBot>
@@ -106,11 +114,13 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
       {
         /** returns both the event handlers for the target type but global as well */
         get: (_, eventName: string) => {
+          const pluginHandlers = Object.values(this._plugins).flatMap((plugin) => plugin.eventHandlers[eventName] ?? [])
           const selfSpecificHandlers = this._eventHandlers[eventName as keyof EventHandlersMap<TBot>] ?? []
           const selfGlobalHandlers = this._eventHandlers['*'] ?? []
           const selfHandlers = [...selfSpecificHandlers, ...selfGlobalHandlers]
-          const pluginHandlers = Object.values(this._plugins).flatMap((plugin) => plugin.eventHandlers[eventName] ?? [])
-          return utils.arrays.unique([...selfHandlers, ...pluginHandlers])
+            .sort((a, b) => a.order - b.order)
+            .map(({ handler }) => handler)
+          return utils.arrays.unique([...pluginHandlers, ...selfHandlers])
         },
       }
     ) as EventHandlersMap<TBot>
@@ -122,14 +132,16 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
       {
         /** returns both the state expired handlers for the target type but global as well */
         get: (_, stateName: string) => {
+          const pluginHandlers = Object.values(this._plugins).flatMap(
+            (plugin) => plugin.stateExpiredHandlers[stateName] ?? []
+          )
           const selfSpecificHandlers =
             this._stateExpiredHandlers[stateName as keyof StateExpiredHandlersMap<TBot>] ?? []
           const selfGlobalHandlers = this._stateExpiredHandlers['*'] ?? []
           const selfHandlers = [...selfSpecificHandlers, ...selfGlobalHandlers]
-          const pluginHandlers = Object.values(this._plugins).flatMap(
-            (plugin) => plugin.stateExpiredHandlers[stateName] ?? []
-          )
-          return utils.arrays.unique([...selfHandlers, ...pluginHandlers])
+            .sort((a, b) => a.order - b.order)
+            .map(({ handler }) => handler)
+          return utils.arrays.unique([...pluginHandlers, ...selfHandlers])
         },
       }
     ) as StateExpiredHandlersMap<TBot>
@@ -149,16 +161,18 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
             {},
             {
               get: (_, hookDataName: string) => {
+                const pluginHandlers = Object.values(this._plugins).flatMap(
+                  (plugin) => plugin.hookHandlers[hookType]?.[hookDataName] ?? ([] as Function[]) // FIXME: fix typings here
+                )
+
                 const selfHooks = this._hookHandlers[hookType] ?? {}
                 const selfSpecificHandlers = selfHooks[hookDataName] ?? []
                 const selfGlobalHandlers = selfHooks['*'] ?? []
                 const selfHandlers = [...selfSpecificHandlers, ...selfGlobalHandlers]
+                  .sort((a, b) => a.order - b.order)
+                  .map(({ handler }) => handler)
 
-                const pluginHandlers = Object.values(this._plugins).flatMap(
-                  (plugin) => (plugin.hookHandlers[hookType]?.[hookDataName] ?? []) as typeof selfHandlers
-                )
-
-                return utils.arrays.unique([...selfHandlers, ...pluginHandlers])
+                return utils.arrays.unique([...pluginHandlers, ...selfHandlers])
               },
             }
           )
@@ -181,7 +195,8 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
             {},
             {
               get: (_, workflowName: string) => {
-                const selfHandlers = handlersOfType[workflowName] ?? []
+                const selfHandlers =
+                  handlersOfType[workflowName]?.sort((a, b) => a.order - b.order).map(({ handler }) => handler) ?? []
 
                 const pluginHandlers = Object.values(this._plugins).flatMap(
                   (plugin) => plugin.workflowHandlers[updateType]?.[workflowName] ?? []
@@ -201,100 +216,100 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
       type: T,
       handler: MessageHandlers<TBot>[T]
     ): void => {
-      this._messageHandlers[type] = utils.arrays.safePush(
-        this._messageHandlers[type],
-        handler as MessageHandlers<any>[string]
-      )
+      this._messageHandlers[type] = utils.arrays.safePush(this._messageHandlers[type], {
+        handler: handler as MessageHandlers<any>[string],
+        order: this._registerOrder++,
+      })
     },
 
     event: <T extends utils.types.StringKeys<EventHandlersMap<TBot>>>(
       type: T,
       handler: EventHandlers<TBot>[T]
     ): void => {
-      this._eventHandlers[type] = utils.arrays.safePush(
-        this._eventHandlers[type],
-        handler as EventHandlers<any>[string]
-      )
+      this._eventHandlers[type] = utils.arrays.safePush(this._eventHandlers[type], {
+        handler: handler as EventHandlers<any>[string],
+        order: this._registerOrder++,
+      })
     },
     stateExpired: <T extends utils.types.StringKeys<StateExpiredHandlersMap<TBot>>>(
       type: T,
       handler: StateExpiredHandlers<TBot>[T]
     ): void => {
-      this._stateExpiredHandlers[type] = utils.arrays.safePush(
-        this._stateExpiredHandlers[type],
-        handler as StateExpiredHandlers<any>[string]
-      )
+      this._stateExpiredHandlers[type] = utils.arrays.safePush(this._stateExpiredHandlers[type], {
+        handler: handler as StateExpiredHandlers<any>[string],
+        order: this._registerOrder++,
+      })
     },
-    beforeIncomingEvent: <T extends utils.types.StringKeys<HookData<TBot>['before_incoming_event']>>(
+    beforeIncomingEvent: <T extends utils.types.StringKeys<HookHandlersMap<TBot>['before_incoming_event']>>(
       type: T,
       handler: HookHandlers<TBot>['before_incoming_event'][T]
     ) => {
       this._hookHandlers.before_incoming_event[type] = utils.arrays.safePush(
         this._hookHandlers.before_incoming_event[type],
-        handler as HookHandlers<any>['before_incoming_event'][string]
+        { handler: handler as HookHandlers<any>['before_incoming_event'][string], order: this._registerOrder++ }
       )
     },
-    beforeIncomingMessage: <T extends utils.types.StringKeys<HookData<TBot>['before_incoming_message']>>(
+    beforeIncomingMessage: <T extends utils.types.StringKeys<HookHandlersMap<TBot>['before_incoming_message']>>(
       type: T,
       handler: HookHandlers<TBot>['before_incoming_message'][T]
     ) => {
       this._hookHandlers.before_incoming_message[type] = utils.arrays.safePush(
         this._hookHandlers.before_incoming_message[type],
-        handler as HookHandlers<any>['before_incoming_message'][string]
+        { handler: handler as HookHandlers<any>['before_incoming_message'][string], order: this._registerOrder++ }
       )
     },
-    beforeOutgoingMessage: <T extends utils.types.StringKeys<HookData<TBot>['before_outgoing_message']>>(
+    beforeOutgoingMessage: <T extends utils.types.StringKeys<HookHandlersMap<TBot>['before_outgoing_message']>>(
       type: T,
       handler: HookHandlers<TBot>['before_outgoing_message'][T]
     ) => {
       this._hookHandlers.before_outgoing_message[type] = utils.arrays.safePush(
         this._hookHandlers.before_outgoing_message[type],
-        handler as HookHandlers<any>['before_outgoing_message'][string]
+        { handler: handler as HookHandlers<any>['before_outgoing_message'][string], order: this._registerOrder++ }
       )
     },
-    beforeOutgoingCallAction: <T extends utils.types.StringKeys<HookData<TBot>['before_outgoing_call_action']>>(
+    beforeOutgoingCallAction: <T extends utils.types.StringKeys<HookHandlersMap<TBot>['before_outgoing_call_action']>>(
       type: T,
       handler: HookHandlers<TBot>['before_outgoing_call_action'][T]
     ) => {
       this._hookHandlers.before_outgoing_call_action[type] = utils.arrays.safePush(
         this._hookHandlers.before_outgoing_call_action[type],
-        handler as HookHandlers<any>['before_outgoing_call_action'][string]
+        { handler: handler as HookHandlers<any>['before_outgoing_call_action'][string], order: this._registerOrder++ }
       )
     },
-    afterIncomingEvent: <T extends utils.types.StringKeys<HookData<TBot>['after_incoming_event']>>(
+    afterIncomingEvent: <T extends utils.types.StringKeys<HookHandlersMap<TBot>['after_incoming_event']>>(
       type: T,
       handler: HookHandlers<TBot>['after_incoming_event'][T]
     ) => {
       this._hookHandlers.after_incoming_event[type] = utils.arrays.safePush(
         this._hookHandlers.after_incoming_event[type],
-        handler as HookHandlers<any>['after_incoming_event'][string]
+        { handler: handler as HookHandlers<any>['after_incoming_event'][string], order: this._registerOrder++ }
       )
     },
-    afterIncomingMessage: <T extends utils.types.StringKeys<HookData<TBot>['after_incoming_message']>>(
+    afterIncomingMessage: <T extends utils.types.StringKeys<HookHandlersMap<TBot>['after_incoming_message']>>(
       type: T,
       handler: HookHandlers<TBot>['after_incoming_message'][T]
     ) => {
       this._hookHandlers.after_incoming_message[type] = utils.arrays.safePush(
         this._hookHandlers.after_incoming_message[type],
-        handler as HookHandlers<any>['after_incoming_message'][string]
+        { handler: handler as HookHandlers<any>['after_incoming_message'][string], order: this._registerOrder++ }
       )
     },
-    afterOutgoingMessage: <T extends utils.types.StringKeys<HookData<TBot>['after_outgoing_message']>>(
+    afterOutgoingMessage: <T extends utils.types.StringKeys<HookHandlersMap<TBot>['after_outgoing_message']>>(
       type: T,
       handler: HookHandlers<TBot>['after_outgoing_message'][T]
     ) => {
       this._hookHandlers.after_outgoing_message[type] = utils.arrays.safePush(
         this._hookHandlers.after_outgoing_message[type],
-        handler as HookHandlers<any>['after_outgoing_message'][string]
+        { handler: handler as HookHandlers<any>['after_outgoing_message'][string], order: this._registerOrder++ }
       )
     },
-    afterOutgoingCallAction: <T extends utils.types.StringKeys<HookData<TBot>['after_outgoing_call_action']>>(
+    afterOutgoingCallAction: <T extends utils.types.StringKeys<HookHandlersMap<TBot>['after_outgoing_call_action']>>(
       type: T,
       handler: HookHandlers<TBot>['after_outgoing_call_action'][T]
     ) => {
       this._hookHandlers.after_outgoing_call_action[type] = utils.arrays.safePush(
         this._hookHandlers.after_outgoing_call_action[type],
-        handler as HookHandlers<any>['after_outgoing_call_action'][string]
+        { handler: handler as HookHandlers<any>['after_outgoing_call_action'][string], order: this._registerOrder++ }
       )
     },
 
@@ -306,10 +321,10 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
       type: T,
       handler: WorkflowHandlers<TBot>[T]
     ): void => {
-      this._workflowHandlers.started[type] = utils.arrays.safePush(
-        this._workflowHandlers.started[type],
-        handler as WorkflowHandlers<any>[string]
-      )
+      this._workflowHandlers.started[type] = utils.arrays.safePush(this._workflowHandlers.started[type], {
+        handler: handler as WorkflowHandlers<any>[string],
+        order: this._registerOrder++,
+      })
     },
 
     /**
@@ -320,10 +335,10 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
       type: T,
       handler: WorkflowHandlers<TBot>[T]
     ): void => {
-      this._workflowHandlers.continued[type] = utils.arrays.safePush(
-        this._workflowHandlers.continued[type],
-        handler as WorkflowHandlers<any>[string]
-      )
+      this._workflowHandlers.continued[type] = utils.arrays.safePush(this._workflowHandlers.continued[type], {
+        handler: handler as WorkflowHandlers<any>[string],
+        order: this._registerOrder++,
+      })
     },
 
     /**
@@ -334,10 +349,10 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
       type: T,
       handler: WorkflowHandlers<TBot>[T]
     ): void => {
-      this._workflowHandlers.timed_out[type] = utils.arrays.safePush(
-        this._workflowHandlers.timed_out[type],
-        handler as WorkflowHandlers<any>[string]
-      )
+      this._workflowHandlers.timed_out[type] = utils.arrays.safePush(this._workflowHandlers.timed_out[type], {
+        handler: handler as WorkflowHandlers<any>[string],
+        order: this._registerOrder++,
+      })
     },
   }
 

--- a/packages/sdk/src/bot/server/types.ts
+++ b/packages/sdk/src/bot/server/types.ts
@@ -313,6 +313,42 @@ export type WorkflowHandlersMap<TBot extends common.BaseBot, TExtraTools extends
   }
 }
 
+export type OrderedMessageHandlersMap<TBot extends common.BaseBot> = {
+  [TMessageName in utils.StringKeys<IncomingMessages<TBot>>]?: {
+    handler: MessageHandlers<TBot>[TMessageName]
+    order: number
+  }[]
+}
+
+export type OrderedEventHandlersMap<TBot extends common.BaseBot> = {
+  [TEventName in utils.StringKeys<IncomingEvents<TBot>>]?: { handler: EventHandlers<TBot>[TEventName]; order: number }[]
+}
+
+export type OrderedStateExpiredHandlersMap<TBot extends common.BaseBot> = {
+  [TStateName in utils.StringKeys<IncomingStates<TBot>>]?: {
+    handler: StateExpiredHandlers<TBot>[TStateName]
+    order: number
+  }[]
+}
+
+export type OrderedHookHandlersMap<TBot extends common.BaseBot> = {
+  [THookType in utils.StringKeys<HookData<TBot>>]: {
+    [THookDataName in utils.StringKeys<HookData<TBot>[THookType]>]?: {
+      handler: HookHandlers<TBot>[THookType][THookDataName]
+      order: number
+    }[]
+  }
+}
+
+export type OrderedWorkflowHandlersMap<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
+  [TWorkflowUpdateType in WorkflowUpdateType]: {
+    [TWorkflowName in utils.StringKeys<TBot['workflows']>]?: {
+      handler: WorkflowHandlers<TBot, TExtraTools>[TWorkflowName]
+      order: number
+    }[]
+  }
+}
+
 /**
  * TODO:
  * the consumer of this type shouldnt be able to access "*" directly;

--- a/packages/sdk/src/plugin/implementation.test.ts
+++ b/packages/sdk/src/plugin/implementation.test.ts
@@ -194,3 +194,59 @@ test('getting creatable:itemCreated after_incoming_event hook handlers also retu
   const itemCreatedHandlers = plugin.hookHandlers.after_incoming_event['creatable:itemCreated']
   expect(itemCreatedHandlers?.map((handler) => handler.name)).toEqual(['handler2'])
 })
+
+test('getting message handlers respects register order', () => {
+  const plugin = createPlugin()
+
+  plugin.on.message('*', async function handler1() {
+    return undefined
+  })
+  plugin.on.message('text', async function handler2() {
+    return undefined
+  })
+
+  const handlers = plugin.messageHandlers['text']
+  expect(handlers?.map((handler) => handler.name)).toEqual(['handler1', 'handler2'])
+})
+
+test('getting event handlers respects register order', () => {
+  const plugin = createPlugin()
+
+  plugin.on.event('*', async function handler1() {})
+  plugin.on.event('creatable:itemCreated', async function handler2() {})
+  plugin.on.event('github:prOpened', async function handler3() {})
+
+  const handlers = plugin.eventHandlers['github:prOpened']
+  expect(handlers?.map((handler) => handler.name)).toEqual(['handler1', 'handler2', 'handler3'])
+})
+
+test('getting state handlers respects register order', () => {
+  const plugin = createPlugin()
+
+  plugin.on.stateExpired('*', async function handler1() {
+    return undefined
+  })
+  plugin.on.stateExpired('myState', async function handler2() {
+    return undefined
+  })
+
+  const handlers = plugin.stateExpiredHandlers['myState']
+  expect(handlers?.map((handler) => handler.name)).toEqual(['handler1', 'handler2'])
+})
+
+test('getting hook handlers respects register order', () => {
+  const plugin = createPlugin()
+
+  plugin.on.beforeIncomingEvent('*', async function handler1() {
+    return undefined
+  })
+  plugin.on.beforeIncomingEvent('creatable:itemCreated', async function handler2() {
+    return undefined
+  })
+  plugin.on.beforeIncomingEvent('github:prOpened', async function handler3() {
+    return undefined
+  })
+
+  const handlers = plugin.hookHandlers.before_incoming_event['github:prOpened']
+  expect(handlers?.map((handler) => handler.name)).toEqual(['handler1', 'handler2', 'handler3'])
+})

--- a/packages/sdk/src/plugin/server/types.ts
+++ b/packages/sdk/src/plugin/server/types.ts
@@ -289,7 +289,49 @@ export type HookHandlersMap<TPlugin extends common.BasePlugin> = {
 
 export type WorkflowHandlersMap<TPlugin extends common.BasePlugin, TExtraTools extends object = {}> = {
   [TWorkflowUpdateType in bot.WorkflowUpdateType]: {
-    [TWorkflowName in utils.StringKeys<TPlugin['workflows']>]?: WorkflowHandlers<TPlugin, TExtraTools>[TWorkflowName][]
+    [TWorkflowName in utils.StringKeys<TPlugin['workflows']>]?: {
+      handler: WorkflowHandlers<TPlugin, TExtraTools>[TWorkflowName]
+      order: number
+    }[]
+  }
+}
+
+export type OrderedMessageHandlersMap<TPlugin extends common.BasePlugin> = {
+  [TMessageName in utils.StringKeys<IncomingMessages<TPlugin>>]?: {
+    handler: MessageHandlers<TPlugin>[TMessageName]
+    order: number
+  }[]
+}
+
+export type OrderedEventHandlersMap<TPlugin extends common.BasePlugin> = {
+  [TEventName in utils.StringKeys<IncomingEvents<TPlugin>>]?: {
+    handler: EventHandlers<TPlugin>[TEventName]
+    order: number
+  }[]
+}
+
+export type OrderedStateExpiredHandlersMap<TPlugin extends common.BasePlugin> = {
+  [TStateName in utils.StringKeys<IncomingStates<TPlugin>>]?: {
+    handler: StateExpiredHandlers<TPlugin>[TStateName]
+    order: number
+  }[]
+}
+
+export type OrderedHookHandlersMap<TPlugin extends common.BasePlugin> = {
+  [THookType in utils.StringKeys<HookData<TPlugin>>]: {
+    [THookDataName in utils.StringKeys<HookData<TPlugin>[THookType]>]?: {
+      handler: HookHandlers<TPlugin>[THookType][THookDataName]
+      order: number
+    }[]
+  }
+}
+
+export type OrderedWorkflowHandlersMap<TPlugin extends common.BasePlugin, TExtraTools extends object = {}> = {
+  [TWorkflowUpdateType in bot.WorkflowUpdateType]: {
+    [TWorkflowName in utils.StringKeys<TPlugin['workflows']>]?: {
+      handler: WorkflowHandlers<TPlugin, TExtraTools>[TWorkflowName]
+      order: number
+    }[]
   }
 }
 


### PR DESCRIPTION
This PR ensures that:

- plugin handlers are always returned in register order, including global and interface handlers
- bot handlers are also returned in register order; we consider plugins to be registered before all other handlers