### PR TITLE
chore(sdk): make the workflow API as uniform as possible with other handlers

### DIFF
--- a/packages/sdk/src/bot/implementation.ts
+++ b/packages/sdk/src/bot/implementation.ts
@@ -88,7 +88,7 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
       {
         /** returns both the message handlers for the target type but global as well */
         get: (_, messageName: string) => {
-          const selfSpecificHandlers = this._messageHandlers[messageName as keyof MessageHandlersMap<TBot>] ?? []
+          const selfSpecificHandlers = this._messageHandlers[messageName] ?? []
           const selfGlobalHandlers = this._messageHandlers['*'] ?? []
           const selfHandlers = [...selfSpecificHandlers, ...selfGlobalHandlers]
           const pluginHandlers = Object.values(this._plugins).flatMap(

--- a/packages/sdk/src/bot/implementation.ts
+++ b/packages/sdk/src/bot/implementation.ts
@@ -302,7 +302,7 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
      * # EXPERIMENTAL
      * This API is experimental and may change in the future.
      */
-    workflowStarted: <T extends utils.types.StringKeys<WorkflowHandlersMap<TBot>['started']>>(
+    workflowStart: <T extends utils.types.StringKeys<WorkflowHandlersMap<TBot>['started']>>(
       type: T,
       handler: WorkflowHandlers<TBot>[T]
     ): void => {
@@ -316,7 +316,7 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
      * # EXPERIMENTAL
      * This API is experimental and may change in the future.
      */
-    workflowContinued: <T extends utils.types.StringKeys<WorkflowHandlersMap<TBot>['continued']>>(
+    workflowContinue: <T extends utils.types.StringKeys<WorkflowHandlersMap<TBot>['continued']>>(
       type: T,
       handler: WorkflowHandlers<TBot>[T]
     ): void => {
@@ -330,7 +330,7 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
      * # EXPERIMENTAL
      * This API is experimental and may change in the future.
      */
-    workflowTimedOut: <T extends utils.types.StringKeys<WorkflowHandlersMap<TBot>['timed_out']>>(
+    workflowTimeout: <T extends utils.types.StringKeys<WorkflowHandlersMap<TBot>['timed_out']>>(
       type: T,
       handler: WorkflowHandlers<TBot>[T]
     ): void => {

--- a/packages/sdk/src/bot/server/types.ts
+++ b/packages/sdk/src/bot/server/types.ts
@@ -18,7 +18,7 @@ export type BotContext = {
 }
 
 type _IncomingEvents<TBot extends common.BaseBot> = {
-  [K in keyof common.EnumerateEvents<TBot>]: utils.Merge<
+  [K in utils.StringKeys<common.EnumerateEvents<TBot>>]: utils.Merge<
     client.Event,
     { type: K; payload: common.EnumerateEvents<TBot>[K] }
   >
@@ -26,7 +26,7 @@ type _IncomingEvents<TBot extends common.BaseBot> = {
 
 type _IncomingMessages<TBot extends common.BaseBot> = {
   // TODO: use bot definiton message property to infer allowed tags
-  [K in keyof common.GetMessages<TBot>]: utils.Merge<
+  [K in utils.StringKeys<common.GetMessages<TBot>>]: utils.Merge<
     //
     client.Message,
     { type: K; payload: common.GetMessages<TBot>[K] }
@@ -34,21 +34,21 @@ type _IncomingMessages<TBot extends common.BaseBot> = {
 }
 
 type _IncomingStates<TBot extends common.BaseBot> = {
-  [K in keyof common.EnumerateStates<TBot>]: utils.Merge<
+  [K in utils.StringKeys<common.EnumerateStates<TBot>>]: utils.Merge<
     client.State,
     { name: K; payload: common.EnumerateStates<TBot>[K] }
   >
 }
 
 type _OutgoingMessageRequests<TBot extends common.BaseBot> = {
-  [K in keyof common.GetMessages<TBot>]: utils.Merge<
+  [K in utils.StringKeys<common.GetMessages<TBot>>]: utils.Merge<
     client.ClientInputs['createMessage'],
     { type: K; payload: common.GetMessages<TBot>[K] }
   >
 }
 
 type _OutgoingMessageResponses<TBot extends common.BaseBot> = {
-  [K in keyof common.GetMessages<TBot>]: utils.Merge<
+  [K in utils.StringKeys<common.GetMessages<TBot>>]: utils.Merge<
     client.ClientOutputs['createMessage'],
     {
       message: utils.Merge<client.Message, { type: K; payload: common.GetMessages<TBot>[K] }>
@@ -57,14 +57,14 @@ type _OutgoingMessageResponses<TBot extends common.BaseBot> = {
 }
 
 type _OutgoingCallActionRequests<TBot extends common.BaseBot> = {
-  [K in keyof common.EnumerateActionInputs<TBot>]: utils.Merge<
+  [K in utils.StringKeys<common.EnumerateActionInputs<TBot>>]: utils.Merge<
     client.ClientInputs['callAction'],
     { type: K; input: common.EnumerateActionInputs<TBot>[K] }
   >
 }
 
 type _OutgoingCallActionResponses<TBot extends common.BaseBot> = {
-  [K in keyof common.EnumerateActionOutputs<TBot>]: utils.Merge<
+  [K in utils.StringKeys<common.EnumerateActionOutputs<TBot>>]: utils.Merge<
     client.ClientOutputs['callAction'],
     { output: common.EnumerateActionOutputs<TBot>[K] }
   >
@@ -116,13 +116,13 @@ export type CommonHandlerProps<TBot extends common.BaseBot> = {
 }
 
 export type MessagePayloads<TBot extends common.BaseBot> = {
-  [K in keyof IncomingMessages<TBot>]: CommonHandlerProps<TBot> & {
-    message: IncomingMessages<TBot>[K]
+  [TMessageName in utils.StringKeys<IncomingMessages<TBot>>]: CommonHandlerProps<TBot> & {
+    message: IncomingMessages<TBot>[TMessageName]
     user: client.User
     conversation: client.Conversation
     event: client.Event
     states: {
-      [TState in keyof TBot['states']]: {
+      [TState in utils.StringKeys<TBot['states']>]: {
         type: 'user' | 'conversation' | 'bot'
         payload: TBot['states'][TState]
       }
@@ -131,31 +131,42 @@ export type MessagePayloads<TBot extends common.BaseBot> = {
 }
 
 export type MessageHandlers<TBot extends common.BaseBot> = {
-  [K in keyof IncomingMessages<TBot>]: (args: MessagePayloads<TBot>[K]) => Promise<void>
+  [TMessageName in utils.StringKeys<IncomingMessages<TBot>>]: (
+    args: MessagePayloads<TBot>[TMessageName]
+  ) => Promise<void>
 }
 
 export type EventPayloads<TBot extends common.BaseBot> = {
-  [K in keyof IncomingEvents<TBot>]: CommonHandlerProps<TBot> & { event: IncomingEvents<TBot>[K] }
+  [TEventName in utils.StringKeys<IncomingEvents<TBot>>]: CommonHandlerProps<TBot> & {
+    event: IncomingEvents<TBot>[TEventName]
+  }
 }
 
 export type EventHandlers<TBot extends common.BaseBot> = {
-  [K in keyof IncomingEvents<TBot>]: (args: EventPayloads<TBot>[K]) => Promise<void>
+  [TEventName in utils.StringKeys<IncomingEvents<TBot>>]: (args: EventPayloads<TBot>[TEventName]) => Promise<void>
 }
 
 export type StateExpiredPayloads<TBot extends common.BaseBot> = {
-  [K in keyof IncomingStates<TBot>]: CommonHandlerProps<TBot> & { state: IncomingStates<TBot>[K] }
+  [TSateName in utils.StringKeys<IncomingStates<TBot>>]: CommonHandlerProps<TBot> & {
+    state: IncomingStates<TBot>[TSateName]
+  }
 }
 
 export type StateExpiredHandlers<TBot extends common.BaseBot> = {
-  [K in keyof IncomingStates<TBot>]: (args: StateExpiredPayloads<TBot>[K]) => Promise<void>
+  [TSateName in utils.StringKeys<IncomingStates<TBot>>]: (args: StateExpiredPayloads<TBot>[TSateName]) => Promise<void>
 }
 
 export type ActionHandlerPayloads<TBot extends common.BaseBot> = {
-  [K in keyof TBot['actions']]: CommonHandlerProps<TBot> & { type?: K; input: TBot['actions'][K]['input'] }
+  [TActionName in utils.StringKeys<TBot['actions']>]: CommonHandlerProps<TBot> & {
+    type?: TActionName
+    input: TBot['actions'][TActionName]['input']
+  }
 }
 
 export type ActionHandlers<TBot extends common.BaseBot> = {
-  [K in keyof TBot['actions']]: (props: ActionHandlerPayloads<TBot>[K]) => Promise<TBot['actions'][K]['output']>
+  [TActionName in utils.StringKeys<TBot['actions']>]: (
+    props: ActionHandlerPayloads<TBot>[TActionName]
+  ) => Promise<TBot['actions'][TActionName]['output']>
 }
 
 export type BridgeWorkflowUpdateType =
@@ -180,7 +191,7 @@ export type WorkflowUpdateEvent = utils.Merge<
 >
 
 export type WorkflowPayloads<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
-  [WorkflowName in keyof TBot['workflows']]: CommonHandlerProps<TBot> & {
+  [TWorkflowName in utils.StringKeys<TBot['workflows']>]: CommonHandlerProps<TBot> & {
     conversation?: client.Conversation
     user?: client.User
 
@@ -188,12 +199,14 @@ export type WorkflowPayloads<TBot extends common.BaseBot, TExtraTools extends ob
      * # EXPERIMENTAL
      * This API is experimental and may change in the future.
      */
-    workflow: workflowProxy.WorkflowWithUtilities<TBot, WorkflowName>
+    workflow: workflowProxy.WorkflowWithUtilities<TBot, TWorkflowName>
   } & TExtraTools
 }
 
 export type WorkflowHandlers<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
-  [K in keyof TBot['workflows']]: (props: WorkflowPayloads<TBot, TExtraTools>[K]) => Promise<void>
+  [TWorkflowName in utils.StringKeys<TBot['workflows']>]: (
+    props: WorkflowPayloads<TBot, TExtraTools>[TWorkflowName]
+  ) => Promise<void>
 }
 
 type BaseHookDefinition = { stoppable?: boolean; data: any }
@@ -244,55 +257,59 @@ export type HookDefinitions<TBot extends common.BaseBot> = {
 }
 
 export type HookData<TBot extends common.BaseBot> = {
-  [H in keyof HookDefinitions<TBot>]: {
-    [T in keyof HookDefinitions<TBot>[H]['data']]: HookDefinitions<TBot>[H]['data'][T]
+  [THookType in utils.StringKeys<HookDefinitions<TBot>>]: {
+    [THookDataName in utils.StringKeys<
+      HookDefinitions<TBot>[THookType]['data']
+    >]: HookDefinitions<TBot>[THookType]['data'][THookDataName]
   }
 }
 
 export type HookInputs<TBot extends common.BaseBot> = {
-  [H in keyof HookData<TBot>]: {
-    [T in keyof HookData<TBot>[H]]: CommonHandlerProps<TBot> & {
-      data: HookData<TBot>[H][T]
+  [THookType in utils.StringKeys<HookData<TBot>>]: {
+    [THookDataName in utils.StringKeys<HookData<TBot>[THookType]>]: CommonHandlerProps<TBot> & {
+      data: HookData<TBot>[THookType][THookDataName]
     }
   }
 }
 
 export type HookOutputs<TBot extends common.BaseBot> = {
-  [H in keyof HookData<TBot>]: {
-    [T in keyof HookData<TBot>[H]]: {
-      data?: HookData<TBot>[H][T]
-    } & (HookDefinitions<TBot>[H]['stoppable'] extends true ? { stop?: boolean } : {})
+  [THookType in utils.StringKeys<HookData<TBot>>]: {
+    [THookDataName in utils.StringKeys<HookData<TBot>[THookType]>]: {
+      data?: HookData<TBot>[THookType][THookDataName]
+    } & (HookDefinitions<TBot>[THookType]['stoppable'] extends true ? { stop?: boolean } : {})
   }
 }
 
 export type HookHandlers<TBot extends common.BaseBot> = {
-  [H in keyof HookData<TBot>]: {
-    [T in keyof HookData<TBot>[H]]: (input: HookInputs<TBot>[H][T]) => Promise<HookOutputs<TBot>[H][T] | undefined>
+  [THookType in utils.StringKeys<HookData<TBot>>]: {
+    [THookDataName in utils.StringKeys<HookData<TBot>[THookType]>]: (
+      input: HookInputs<TBot>[THookType][THookDataName]
+    ) => Promise<HookOutputs<TBot>[THookType][THookDataName] | undefined>
   }
 }
 
 export type MessageHandlersMap<TBot extends common.BaseBot> = {
-  [T in keyof IncomingMessages<TBot>]?: MessageHandlers<TBot>[T][]
+  [TMessageName in utils.StringKeys<IncomingMessages<TBot>>]?: MessageHandlers<TBot>[TMessageName][]
 }
 
 export type EventHandlersMap<TBot extends common.BaseBot> = {
-  [T in keyof IncomingEvents<TBot>]?: EventHandlers<TBot>[T][]
+  [TEventName in utils.StringKeys<IncomingEvents<TBot>>]?: EventHandlers<TBot>[TEventName][]
 }
 
 export type StateExpiredHandlersMap<TBot extends common.BaseBot> = {
-  [T in keyof IncomingStates<TBot>]?: StateExpiredHandlers<TBot>[T][]
+  [TStateName in utils.StringKeys<IncomingStates<TBot>>]?: StateExpiredHandlers<TBot>[TStateName][]
 }
 
 export type HookHandlersMap<TBot extends common.BaseBot> = {
-  [H in keyof HookData<TBot>]: {
-    [T in keyof HookData<TBot>[H]]?: HookHandlers<TBot>[H][T][]
+  [THookType in utils.StringKeys<HookData<TBot>>]: {
+    [THookDataName in utils.StringKeys<HookData<TBot>[THookType]>]?: HookHandlers<TBot>[THookType][THookDataName][]
   }
 }
 
 export type WorkflowUpdateType = 'started' | 'continued' | 'timed_out'
 export type WorkflowHandlersMap<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
-  [U in WorkflowUpdateType]: {
-    [T in keyof TBot['workflows']]?: WorkflowHandlers<TBot, TExtraTools>[T][]
+  [TWorkflowUpdateType in WorkflowUpdateType]: {
+    [TWorkflowName in utils.StringKeys<TBot['workflows']>]?: WorkflowHandlers<TBot, TExtraTools>[TWorkflowName][]
   }
 }
 
@@ -321,29 +338,37 @@ type ImplementedActions<
   TPlugins extends Record<string, plugin.BasePlugin>,
 > = utils.UnionToIntersection<
   utils.ValueOf<{
-    [TPlugin in keyof TPlugins]: {
-      [TAction in keyof TPlugins[TPlugin]['actions'] as `${_GetPluginPrefix<utils.Cast<TPlugin, string>, TPlugins[TPlugin]>}${utils.Cast<TAction, string>}`]: TPlugins[TPlugin]['actions'][TAction]
+    [TPlugin in utils.StringKeys<TPlugins>]: {
+      [TAction in utils.StringKeys<
+        TPlugins[TPlugin]['actions']
+      > as `${_GetPluginPrefix<utils.Cast<TPlugin, string>, TPlugins[TPlugin]>}${utils.Cast<TAction, string>}`]: TPlugins[TPlugin]['actions'][TAction]
     }
   }>
 >
 
 type UnimplementedActions<TBot extends common.BaseBot, TPlugins extends Record<string, plugin.BasePlugin>> = Omit<
   TBot['actions'],
-  keyof ImplementedActions<TBot, TPlugins>
+  utils.StringKeys<ImplementedActions<TBot, TPlugins>>
 >
 
 export type ImplementedActionHandlers<
   TBot extends common.BaseBot,
   TPlugins extends Record<string, plugin.BasePlugin>,
 > = {
-  [K in keyof ImplementedActions<TBot, TPlugins>]: ActionHandlers<TBot>[utils.Cast<K, keyof ActionHandlers<TBot>>]
+  [K in utils.StringKeys<ImplementedActions<TBot, TPlugins>>]: ActionHandlers<TBot>[utils.Cast<
+    K,
+    keyof ActionHandlers<TBot>
+  >]
 }
 
 export type UnimplementedActionHandlers<
   TBot extends common.BaseBot,
   TPlugins extends Record<string, plugin.BasePlugin>,
 > = {
-  [K in keyof UnimplementedActions<TBot, TPlugins>]: ActionHandlers<TBot>[utils.Cast<K, keyof ActionHandlers<TBot>>]
+  [K in utils.StringKeys<UnimplementedActions<TBot, TPlugins>>]: ActionHandlers<TBot>[utils.Cast<
+    K,
+    keyof ActionHandlers<TBot>
+  >]
 }
 
 export type ServerProps = Omit<CommonHandlerProps<common.BaseBot>, 'workflows'> & {

--- a/packages/sdk/src/bot/server/types.ts
+++ b/packages/sdk/src/bot/server/types.ts
@@ -179,6 +179,23 @@ export type WorkflowUpdateEvent = utils.Merge<
   }
 >
 
+export type WorkflowPayloads<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
+  [WorkflowName in keyof TBot['workflows']]: CommonHandlerProps<TBot> & {
+    conversation?: client.Conversation
+    user?: client.User
+
+    /**
+     * # EXPERIMENTAL
+     * This API is experimental and may change in the future.
+     */
+    workflow: workflowProxy.WorkflowWithUtilities<TBot, WorkflowName>
+  } & TExtraTools
+}
+
+export type WorkflowHandlers<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
+  [K in keyof TBot['workflows']]: (props: WorkflowPayloads<TBot, TExtraTools>[K]) => Promise<void>
+}
+
 type BaseHookDefinition = { stoppable?: boolean; data: any }
 type HookDefinition<THookDef extends BaseHookDefinition = BaseHookDefinition> = THookDef
 
@@ -272,35 +289,10 @@ export type HookHandlersMap<TBot extends common.BaseBot> = {
   }
 }
 
-export type WorkflowPayloads<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
-  [WorkflowName in utils.StringKeys<TBot['workflows']>]: CommonHandlerProps<TBot> & {
-    conversation?: client.Conversation
-    user?: client.User
-
-    /**
-     * # EXPERIMENTAL
-     * This API is experimental and may change in the future.
-     */
-    workflow: workflowProxy.WorkflowWithUtilities<TBot, WorkflowName>
-  } & TExtraTools
-}
-
-export type WorkflowHandlers<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
-  [K in utils.StringKeys<TBot['workflows']>]: (props: WorkflowPayloads<TBot, TExtraTools>[K]) => Promise<void>
-}
-
-export type WorkflowUpdateTypeSnakeCase = 'started' | 'continued' | 'timed_out'
-export type WorkflowUpdateTypeCamelCase = 'started' | 'continued' | 'timedOut'
-
+export type WorkflowUpdateType = 'started' | 'continued' | 'timed_out'
 export type WorkflowHandlersMap<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
-  [UpdateType in WorkflowUpdateTypeSnakeCase]?: {
-    [WorkflowName in utils.StringKeys<TBot['workflows']>]?: WorkflowHandlers<TBot, TExtraTools>[WorkflowName][]
-  }
-}
-
-export type WorkflowHandlersFnMap<TBot extends common.BaseBot, TExtraTools extends object = {}> = {
-  [WorkflowName in utils.StringKeys<TBot['workflows']>]: {
-    [UType in WorkflowUpdateTypeCamelCase]: (handler: WorkflowHandlers<TBot, TExtraTools>[WorkflowName]) => void
+  [U in WorkflowUpdateType]: {
+    [T in keyof TBot['workflows']]?: WorkflowHandlers<TBot, TExtraTools>[T][]
   }
 }
 

--- a/packages/sdk/src/bot/server/workflows/update-type-conv.ts
+++ b/packages/sdk/src/bot/server/workflows/update-type-conv.ts
@@ -1,8 +1,6 @@
 import * as types from '../types'
 
-export const bridgeUpdateTypeToSnakeCase = (
-  updateType: types.BridgeWorkflowUpdateType
-): types.WorkflowUpdateTypeSnakeCase => {
+export const bridgeUpdateTypeToSnakeCase = (updateType: types.BridgeWorkflowUpdateType): types.WorkflowUpdateType => {
   switch (updateType) {
     case 'workflow_continued':
       return 'continued'
@@ -13,14 +11,4 @@ export const bridgeUpdateTypeToSnakeCase = (
     default:
       throw new Error(`Unsupported workflow update type: ${updateType}`)
   }
-}
-
-export const camelCaseUpdateTypeToSnakeCase = (
-  updateType: types.WorkflowUpdateTypeCamelCase
-): types.WorkflowUpdateTypeSnakeCase => {
-  if (updateType !== 'timedOut' && updateType !== 'continued' && updateType !== 'started') {
-    updateType satisfies never
-  }
-
-  return updateType === 'timedOut' ? 'timed_out' : updateType
 }

--- a/packages/sdk/src/bot/workflow-proxy/types.ts
+++ b/packages/sdk/src/bot/workflow-proxy/types.ts
@@ -44,7 +44,7 @@ type _ListInstances<TBot extends commonTypes.BaseBot, TWorkflowName extends type
 
 export type WorkflowWithUtilities<
   TBot extends commonTypes.BaseBot,
-  TWorkflowName extends keyof TBot['workflows'],
+  TWorkflowName extends typeUtils.StringKeys<TBot['workflows']>,
 > = Readonly<
   client.Workflow & {
     name: TWorkflowName

--- a/packages/sdk/src/bot/workflow-proxy/types.ts
+++ b/packages/sdk/src/bot/workflow-proxy/types.ts
@@ -44,7 +44,7 @@ type _ListInstances<TBot extends commonTypes.BaseBot, TWorkflowName extends type
 
 export type WorkflowWithUtilities<
   TBot extends commonTypes.BaseBot,
-  TWorkflowName extends typeUtils.StringKeys<TBot['workflows']>,
+  TWorkflowName extends keyof TBot['workflows'],
 > = Readonly<
   client.Workflow & {
     name: TWorkflowName

--- a/packages/sdk/src/plugin/implementation.ts
+++ b/packages/sdk/src/plugin/implementation.ts
@@ -380,7 +380,7 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
      * # EXPERIMENTAL
      * This API is experimental and may change in the future.
      */
-    workflowStarted: <T extends utils.types.StringKeys<WorkflowHandlersMap<TPlugin>['started']>>(
+    workflowStart: <T extends utils.types.StringKeys<WorkflowHandlersMap<TPlugin>['started']>>(
       type: T,
       handler: WorkflowHandlers<TPlugin>[T]
     ): void => {
@@ -394,7 +394,7 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
      * # EXPERIMENTAL
      * This API is experimental and may change in the future.
      */
-    workflowContinued: <T extends utils.types.StringKeys<WorkflowHandlersMap<TPlugin>['continued']>>(
+    workflowContinue: <T extends utils.types.StringKeys<WorkflowHandlersMap<TPlugin>['continued']>>(
       type: T,
       handler: WorkflowHandlers<TPlugin>[T]
     ): void => {
@@ -408,7 +408,7 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
      * # EXPERIMENTAL
      * This API is experimental and may change in the future.
      */
-    workflowTimedOut: <T extends utils.types.StringKeys<WorkflowHandlersMap<TPlugin>['timed_out']>>(
+    workflowTimeout: <T extends utils.types.StringKeys<WorkflowHandlersMap<TPlugin>['timed_out']>>(
       type: T,
       handler: WorkflowHandlers<TPlugin>[T]
     ): void => {

--- a/packages/sdk/src/plugin/implementation.ts
+++ b/packages/sdk/src/plugin/implementation.ts
@@ -3,19 +3,14 @@ import type {
   EventHandlersMap as BotEventHandlersMap,
   StateExpiredHandlersMap as BotStateExpiredHandlersMap,
   HookHandlersMap as BotHookHandlersMap,
+  WorkflowHandlersMap as BotWorkflowHandlersMap,
   ActionHandlers as BotActionHandlers,
   BotHandlers,
   BotSpecificClient,
-  WorkflowHandlersMap as BotWorkflowHandlersMap,
-  WorkflowHandlers as BotWorkflowHandlers,
-  WorkflowHandlersFnMap as BotWorkflowHandlersFnMap,
-  WorkflowUpdateTypeSnakeCase as BotWorkflowUpdateTypeSnakeCase,
-  WorkflowUpdateTypeCamelCase as BotWorkflowUpdateTypeCamelCase,
+  WorkflowUpdateType,
 } from '../bot'
-import { camelCaseUpdateTypeToSnakeCase } from '../bot/server/workflows/update-type-conv'
 import { WorkflowProxy, proxyWorkflows } from '../bot/workflow-proxy'
 import * as utils from '../utils'
-import type * as typeUtils from '../utils/type-utils'
 import { ActionProxy, proxyActions } from './action-proxy'
 import { BasePlugin, PluginInterfaceExtensions } from './common'
 import { formatEventRef, parseEventRef, resolveEvent } from './interface-resolution'
@@ -27,6 +22,7 @@ import {
   StateExpiredHandlersMap,
   StateExpiredHandlers,
   HookHandlersMap,
+  WorkflowHandlersMap,
   HookData,
   HookHandlers,
   ActionHandlers,
@@ -72,7 +68,11 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
     after_outgoing_message: {},
     after_outgoing_call_action: {},
   }
-  private _workflowHandlers: BotWorkflowHandlersMap<TPlugin> = {}
+  private _workflowHandlers: WorkflowHandlersMap<any> = {
+    started: {},
+    continued: {},
+    timed_out: {},
+  }
 
   public constructor(public readonly props: PluginImplementationProps<TPlugin>) {
     this._actionHandlers = props.actions
@@ -238,15 +238,19 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
     return new Proxy(
       {},
       {
-        get: (_, updateType: BotWorkflowUpdateTypeSnakeCase) => {
+        get: (_, updateType: WorkflowUpdateType) => {
+          const handlersOfType = this._workflowHandlers[updateType]
+          if (!handlersOfType) {
+            return undefined
+          }
+
           return new Proxy(
             {},
             {
-              get: (_, workflowName: typeUtils.StringKeys<TPlugin['workflows']>) => {
-                const handlersOfType = this._workflowHandlers[updateType]
-                const selfHandlers = handlersOfType?.[workflowName]
+              get: (_, workflowName: string) => {
+                const selfHandlers = handlersOfType[workflowName] ?? []
 
-                return (selfHandlers ?? []).map((handler) =>
+                return selfHandlers.map((handler) =>
                   utils.functions.setName(
                     (input: any) => handler({ ...input, ...this._getTools(input.client) }),
                     handler.name
@@ -257,7 +261,7 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
           )
         },
       }
-    )
+    ) as BotWorkflowHandlersMap<TPlugin>
   }
 
   public readonly on = {
@@ -267,39 +271,6 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
         handler as MessageHandlers<any>[string]
       )
     },
-
-    /**
-     * # EXPERIMENTAL
-     * This API is experimental and may change in the future.
-     */
-    workflows: new Proxy(
-      {},
-      {
-        get: <TWorkflowName extends typeUtils.StringKeys<TPlugin['workflows']>>(
-          _: unknown,
-          workflowName: TWorkflowName
-        ) =>
-          new Proxy(
-            {},
-            {
-              get: (_, updateType: BotWorkflowUpdateTypeCamelCase) => {
-                if (updateType !== 'started' && updateType !== 'continued' && updateType !== 'timedOut') {
-                  updateType satisfies never
-                }
-
-                return (handler: BotWorkflowHandlers<TPlugin>[TWorkflowName]): void => {
-                  const updateTypeSnakeCase = camelCaseUpdateTypeToSnakeCase(updateType)
-                  this._workflowHandlers[updateTypeSnakeCase] ??= {}
-                  this._workflowHandlers[updateTypeSnakeCase][workflowName] = utils.arrays.safePush(
-                    this._workflowHandlers[updateTypeSnakeCase][workflowName],
-                    handler
-                  )
-                }
-              },
-            }
-          ),
-      }
-    ) as BotWorkflowHandlersFnMap<TPlugin, Tools<TPlugin>>,
 
     event: <T extends keyof EventHandlersMap<TPlugin>>(type: T, handler: EventHandlers<TPlugin>[T]): void => {
       this._eventHandlers[type as string] = utils.arrays.safePush(

--- a/packages/sdk/src/plugin/implementation.ts
+++ b/packages/sdk/src/plugin/implementation.ts
@@ -31,6 +31,7 @@ import {
   StateExpiredPayloads,
   ActionHandlerPayloads,
   EventPayloads,
+  WorkflowHandlers,
 } from './server/types'
 
 export type PluginImplementationProps<TPlugin extends BasePlugin = BasePlugin> = {
@@ -366,6 +367,48 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
       this._hookHandlers.after_outgoing_call_action[type as string] = utils.arrays.safePush(
         this._hookHandlers.after_outgoing_call_action[type as string],
         handler as HookHandlers<any>['after_outgoing_call_action'][string]
+      )
+    },
+
+    /**
+     * # EXPERIMENTAL
+     * This API is experimental and may change in the future.
+     */
+    workflowStarted: <T extends keyof WorkflowHandlersMap<TPlugin>['started']>(
+      type: T,
+      handler: WorkflowHandlers<TPlugin>[T]
+    ): void => {
+      this._workflowHandlers.started[type as string] = utils.arrays.safePush(
+        this._workflowHandlers.started[type],
+        handler as WorkflowHandlers<any>[string]
+      )
+    },
+
+    /**
+     * # EXPERIMENTAL
+     * This API is experimental and may change in the future.
+     */
+    workflowContinued: <T extends keyof WorkflowHandlersMap<TPlugin>['continued']>(
+      type: T,
+      handler: WorkflowHandlers<TPlugin>[T]
+    ): void => {
+      this._workflowHandlers.continued[type as string] = utils.arrays.safePush(
+        this._workflowHandlers.continued[type],
+        handler as WorkflowHandlers<any>[string]
+      )
+    },
+
+    /**
+     * # EXPERIMENTAL
+     * This API is experimental and may change in the future.
+     */
+    workflowTimedOut: <T extends keyof WorkflowHandlersMap<TPlugin>['timed_out']>(
+      type: T,
+      handler: WorkflowHandlers<TPlugin>[T]
+    ): void => {
+      this._workflowHandlers.timed_out[type as string] = utils.arrays.safePush(
+        this._workflowHandlers.timed_out[type],
+        handler as WorkflowHandlers<any>[string]
       )
     },
   }

--- a/packages/sdk/src/plugin/server/types.ts
+++ b/packages/sdk/src/plugin/server/types.ts
@@ -157,6 +157,23 @@ export type ActionHandlers<TPlugin extends common.BasePlugin> = {
   ) => Promise<TPlugin['actions'][K]['output']>
 }
 
+export type WorkflowPayloads<TPlugin extends common.BasePlugin, TExtraTools extends object = {}> = {
+  [WorkflowName in keyof TPlugin['workflows']]: CommonHandlerProps<TPlugin> & {
+    conversation?: client.Conversation
+    user?: client.User
+
+    /**
+     * # EXPERIMENTAL
+     * This API is experimental and may change in the future.
+     */
+    workflow: workflowProxy.WorkflowWithUtilities<TPlugin, WorkflowName>
+  } & TExtraTools
+}
+
+export type WorkflowHandlers<TPlugin extends common.BasePlugin, TExtraTools extends object = {}> = {
+  [K in keyof TPlugin['workflows']]: (props: WorkflowPayloads<TPlugin, TExtraTools>[K]) => Promise<void>
+}
+
 type BaseHookDefinition = { stoppable?: boolean; data: any }
 type HookDefinition<THookDef extends BaseHookDefinition = BaseHookDefinition> = THookDef
 
@@ -252,6 +269,12 @@ export type StateExpiredHandlersMap<TPlugin extends common.BasePlugin> = {
 export type HookHandlersMap<TPlugin extends common.BasePlugin> = {
   [H in keyof HookData<TPlugin>]: {
     [T in keyof HookData<TPlugin>[H]]?: HookHandlers<TPlugin>[H][T][]
+  }
+}
+
+export type WorkflowHandlersMap<TPlugin extends common.BasePlugin, TExtraTools extends object = {}> = {
+  [U in bot.WorkflowUpdateType]: {
+    [T in keyof TPlugin['workflows']]?: WorkflowHandlers<TPlugin, TExtraTools>[T][]
   }
 }
 


### PR DESCRIPTION
The goal here is to make the workflow API as uniform as possible with other handlers. This means workflow handlers are registered exactly like hook handlers:

```ts
const bot = new bp.Bot({})

// register event handlers
bot.on.event('anEvent', async ({ event }) => {
  event
  return undefined
})
// register hook handlers
bot.on.beforeIncomingEvent('anEvent', async ({ data }) => {
  data
  return undefined
})
// register workflow handlers
bot.on.workflowContinue('job', async ({ workflow }) => {
  workflow
})

// invoke event handlers
bot.eventHandlers['anEvent']?.forEach(async (h) => {
  void h({})
})
// invoke hook handlers
bot.hookHandlers.before_incoming_event['anEvent']?.forEach(async (h) => {
  void h({})
})
// invoke workflow handlers
bot.workflowHandlers.continued['job']?.forEach((h) => {
  void h({})
})
```

Same goes for plugins:
```ts
const plugin = new bp.Plugin({})

// register event handlers
plugin.on.event('anEvent', async ({ event }) => {
  event
  return undefined
})
// register hook handlers
plugin.on.beforeIncomingEvent('anEvent', async ({ data }) => {
  data
  return undefined
})
// register workflow handlers
plugin.on.workflowContinue('job', async ({ workflow }) => {
  workflow
})

// invoke event handlers
plugin.eventHandlers['anEvent']?.forEach(async (h) => {
  void h({})
})
// invoke hook handlers
plugin.hookHandlers.before_incoming_event['anEvent']?.forEach(async (h) => {
  void h({})
})
// invoke workflow handlers
plugin.workflowHandlers.continued['job']?.forEach((h) => {
  void h({})
})
```

I also took the opportunity to standardize the naming and usage of `StringKeys` across bot and plugin implementation