### PR TITLE
chore(integrations/fireworks-api): update DeepSeek R1 models

### DIFF
--- a/integrations/fireworks-ai/integration.definition.ts
+++ b/integrations/fireworks-ai/integration.definition.ts
@@ -9,7 +9,7 @@ export default new IntegrationDefinition({
   title: 'Fireworks AI',
   description:
     'Choose from curated Fireworks AI models for content generation, chat completions, and audio transcription.',
-  version: '6.0.1',
+  version: '7.0.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/fireworks-ai/src/index.ts
+++ b/integrations/fireworks-ai/src/index.ts
@@ -15,16 +15,30 @@ const DEFAULT_LANGUAGE_MODEL_ID: LanguageModelId = 'accounts/fireworks/models/ll
 //  https://fireworks.ai/pricing
 const languageModels: Record<LanguageModelId, llm.ModelDetails> = {
   'accounts/fireworks/models/deepseek-r1': {
-    name: 'DeepSeek R1',
+    name: 'DeepSeek R1 (Fast)',
     description:
-      'DeepSeek-R1 is a state-of-the-art large language model optimized with reinforcement learning and cold-start data for exceptional reasoning, math, and code performance. **Note**: This model will always use a temperature of 0.6 as recommended by DeepSeek.',
+      'This version of the R1 model has a perfect balance between speed and cost-efficiency for real-time interactive experiences, with speeds up to 90 tokens per second.\n\nDeepSeek-R1 is a state-of-the-art large language model optimized with reinforcement learning and cold-start data for exceptional reasoning, math, and code performance. **Note**: This model will always use a temperature of 0.6 as recommended by DeepSeek.',
     tags: ['recommended', 'reasoning', 'general-purpose', 'coding'],
     input: {
-      costPer1MTokens: 8,
+      costPer1MTokens: 3,
       maxTokens: 128_000,
     },
     output: {
       costPer1MTokens: 8,
+      maxTokens: 32_768,
+    },
+  },
+  'accounts/fireworks/models/deepseek-r1-basic': {
+    name: 'DeepSeek R1 (Basic)',
+    description:
+      'This version of the R1 model is optimized for throughput and cost-effectiveness and has a lower cost but slightly higher latency than the "Fast" version of the model.\n\nDeepSeek-R1 is a state-of-the-art large language model optimized with reinforcement learning and cold-start data for exceptional reasoning, math, and code performance. **Note**: This model will always use a temperature of 0.6 as recommended by DeepSeek.',
+    tags: ['recommended', 'reasoning', 'general-purpose', 'coding'],
+    input: {
+      costPer1MTokens: 0.55,
+      maxTokens: 128_000,
+    },
+    output: {
+      costPer1MTokens: 2.19,
       maxTokens: 32_768,
     },
   },

--- a/integrations/fireworks-ai/src/schemas.ts
+++ b/integrations/fireworks-ai/src/schemas.ts
@@ -3,6 +3,7 @@ import { z } from '@botpress/sdk'
 export const languageModelId = z
   .enum([
     'accounts/fireworks/models/deepseek-r1',
+    'accounts/fireworks/models/deepseek-r1-basic',
     'accounts/fireworks/models/deepseek-v3',
     'accounts/fireworks/models/llama-v3p1-405b-instruct',
     'accounts/fireworks/models/llama-v3p1-70b-instruct',


### PR DESCRIPTION
Fireworks AI has lowered the input token pricing for the DeepSeek R1 model, and has also released a "Basic" version of the model which matches the same lower pricing offered by DeepSeek in China, but in this case with the model being hosted on US datacenters. See: https://fireworks.ai/blog/fireworks-ai-developer-cloud