### PR TITLE
fix(cli): fix dev bot deploy message

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/command-implementations/dev-command.ts
+++ b/packages/cli/src/command-implementations/dev-command.ts
@@ -309,8 +309,7 @@ export class DevCommand extends ProjectCommand<DevCommandDefinition> {
       await this.projectCache.set('devId', bot.id)
     }
 
-    const updateLine = this.logger.line()
-    updateLine.started('Deploying dev bot...')
+    this.logger.started('Deploying dev bot...')
 
     const updateBotBody = apiUtils.prepareUpdateBotBody(
       {
@@ -325,8 +324,7 @@ export class DevCommand extends ProjectCommand<DevCommandDefinition> {
     const { bot: updatedBot } = await api.client.updateBot(updateBotBody).catch((thrown) => {
       throw errors.BotpressCLIError.wrap(thrown, 'Could not deploy dev bot')
     })
-    updateLine.success(`Dev Bot deployed with id "${updatedBot.id}" at "${externalUrl}"`)
-    updateLine.commit()
+    this.logger.success(`Dev Bot deployed with id "${updatedBot.id}" at "${externalUrl}"`)
 
     const tablesPublisher = new tables.TablesPublisher({ api, logger: this.logger, prompt: this.prompt })
     await tablesPublisher.deployTables({ botId: updatedBot.id, botDefinition: botDef })


### PR DESCRIPTION
commit 2e57baa4228c2598fe7780607d0344f7a6cdc155 broke logging for the dev command when the bot has dependencies, because it now asks the client to fetch the dependencies and the client prints log lines when it finds them, so it breaks the `updateLine` single-line logger and the message never gets printed.