### PR TITLE
feat(sdk): allow recurring events of plugins to be dynamic

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -22,7 +22,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.1",
     "@botpress/client": "0.48.0",
-    "@botpress/sdk": "3.5.1",
+    "@botpress/sdk": "3.6.0",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/src/code-generation/generators.test.ts
+++ b/packages/cli/src/code-generation/generators.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from 'vitest'
+import { getFunctionSource } from './generators'
+
+describe('getFunctionSource', () => {
+  describe('regular functions', () => {
+    it('converts named function declaration to arrow function', () => {
+      // Arrange
+      function namedFunctionDeclaration(a: number, b: number) {
+        return a + b
+      }
+
+      // Act
+      const result = getFunctionSource(namedFunctionDeclaration)
+
+      // Assert
+      expect(result).toContain('(a, b) =>')
+      expect(result).toContain('return a + b;')
+    })
+
+    it('converts anonymous function expression to arrow function', () => {
+      // Arrange
+      const anonymousFunctionExpression = function (a: number, b: number) {
+        return a + b
+      }
+
+      // Act
+      const result = getFunctionSource(anonymousFunctionExpression)
+
+      // Assert
+      expect(result).toContain('(a, b) =>')
+      expect(result).toContain('return a + b;')
+    })
+
+    it('converts named function expression to arrow function', () => {
+      // Arrange
+      const namedFunctionExpression = function add(a: number, b: number) {
+        return a + b
+      }
+
+      // Act
+      const result = getFunctionSource(namedFunctionExpression)
+
+      // Assert
+      expect(result).toContain('(a, b) =>')
+      expect(result).toContain('return a + b;')
+      expect(result).not.toContain('function add')
+    })
+  })
+
+  describe('arrow functions', () => {
+    it('preserves single-line arrow functions', () => {
+      // Arrange
+      const singleLineArrow = (a: number, b: number) => a + b
+
+      // Act
+      const result = getFunctionSource(singleLineArrow)
+
+      // Assert
+      expect(result).toBe('(a, b) => a + b')
+    })
+
+    it('preserves multi-line arrow functions with curly braces', () => {
+      // Arrange
+      const multiLineArrow = (a: number, b: number) => {
+        const sum = a + b
+        return sum
+      }
+
+      // Act
+      const result = getFunctionSource(multiLineArrow)
+
+      // Assert
+      expect(result).toContain('(a, b) => {')
+      expect(result).toContain('const sum = a + b;')
+      expect(result).toContain('return sum;')
+    })
+  })
+
+  describe('async functions', () => {
+    it('preserves async arrow functions', () => {
+      // Arrange
+      const asyncArrow = async (url: string) => {
+        const data = await Promise.resolve(url)
+        return data
+      }
+
+      // Act
+      const result = getFunctionSource(asyncArrow)
+
+      // Assert
+      expect(result).toContain('async (url) =>')
+      expect(result).toContain('await Promise.resolve(url)')
+    })
+
+    it('converts async function declarations to async arrow functions', () => {
+      // Arrange
+      async function asyncFunction(url: string) {
+        const data = await Promise.resolve(url)
+        return data
+      }
+
+      // Act
+      const result = getFunctionSource(asyncFunction)
+
+      // Assert
+      expect(result).toContain('(url) =>')
+      expect(result).toContain('await Promise.resolve(url)')
+    })
+  })
+
+  describe('class methods', () => {
+    it('converts instance methods to arrow functions', () => {
+      // Arrange
+      class TestClass {
+        multiply(a: number, b: number) {
+          return a * b
+        }
+      }
+      const instance = new TestClass()
+
+      // Act
+      const result = getFunctionSource(instance.multiply)
+
+      // Assert
+      expect(result).toContain('(a, b) =>')
+      expect(result).toContain('return a * b;')
+    })
+
+    it('converts static methods to arrow functions', () => {
+      // Arrange
+      class TestClass {
+        static subtract(a: number, b: number) {
+          return a - b
+        }
+      }
+
+      // Act
+      const result = getFunctionSource(TestClass.subtract)
+
+      // Assert
+      expect(result).toContain('(a, b) =>')
+      expect(result).toContain('return a - b;')
+    })
+
+    it('converts async class methods to async arrow functions', () => {
+      // Arrange
+      class TestClass {
+        async fetchData(url: string) {
+          const data = await Promise.resolve(url)
+          return data
+        }
+      }
+      const instance = new TestClass()
+
+      // Act
+      const result = getFunctionSource(instance.fetchData)
+
+      // Assert
+      expect(result).toContain('async (url) =>')
+      expect(result).toContain('await Promise.resolve(url)')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles functions with no parameters', () => {
+      // Arrange
+      const noParams = () => 'result'
+
+      // Act
+      const result = getFunctionSource(noParams)
+
+      // Assert
+      expect(result).toBe('() => "result"')
+    })
+
+    it('handles functions with default parameters', () => {
+      // Arrange
+      const defaultParams = (a: number, b: number = 1) => a + b
+
+      // Act
+      const result = getFunctionSource(defaultParams)
+
+      // Assert
+      expect(result).toContain('(a, b = 1) =>')
+    })
+
+    it('handles functions with destructured parameters', () => {
+      // Arrange
+      const destructuredParams = ({ a, b }: { a: number; b: number }) => a + b
+
+      // Act
+      const result = getFunctionSource(destructuredParams)
+
+      // Assert
+      expect(result).toContain('({ a, b }) =>')
+    })
+  })
+
+  describe('practical usage', () => {
+    it('produces valid exportable arrow function source', () => {
+      // Arrange
+      const sourceFunction = (a: number, b: number) => a * b
+
+      // Act
+      const source = getFunctionSource(sourceFunction)
+      const exportedSource = `const exportedFunc = ${source};`
+
+      // Assert
+      expect(() => {
+        // This would throw if the source was invalid JavaScript
+        new Function(exportedSource)
+      }).not.toThrow()
+    })
+  })
+})

--- a/packages/cli/src/code-generation/generators.ts
+++ b/packages/cli/src/code-generation/generators.ts
@@ -61,3 +61,17 @@ export function primitiveRecordToTypescriptValues(x: Record<string, Primitive>):
     .fromPairs()
     .value()
 }
+
+export const getFunctionSource = (fn: (...x: never[]) => unknown): string => {
+  const source = fn.toString().trim()
+  const isAsync = source.startsWith('async ')
+  const asyncPrefix = isAsync ? 'async ' : ''
+
+  const match = source.match(/^(?:async\s*)?(?:function\s*[^(]*|\w+)?\(([^)]*)\)\s*{([\s\S]*)}/)
+  if (match) {
+    const [, params, body] = match
+    return `${asyncPrefix}(${params}) => {${body}}`
+  }
+
+  return source
+}

--- a/packages/cli/src/code-generation/plugin-package/plugin-package-definition/index.ts
+++ b/packages/cli/src/code-generation/plugin-package/plugin-package-definition/index.ts
@@ -4,6 +4,7 @@ import { Module } from '../../module'
 import { ActionsModule } from './actions-module'
 import { DefaultConfigurationModule } from './configuration-module'
 import { EventsModule } from './events-module'
+import { RecurringEventsModule } from './recurring-events-module'
 import { InterfacesModule } from './interfaces-module'
 import { StatesModule } from './states-module'
 import * as types from './typings'
@@ -14,6 +15,7 @@ type PluginPackageModuleDependencies = {
   eventsModule: EventsModule
   statesModule: StatesModule
   interfacesModule: InterfacesModule
+  recurringEventsModule: RecurringEventsModule
 }
 
 export class PluginPackageDefinitionModule extends Module {
@@ -34,6 +36,9 @@ export class PluginPackageDefinitionModule extends Module {
     const eventsModule = new EventsModule(_plugin.events ?? {})
     eventsModule.unshift('events')
 
+    const recurringEventsModule = new RecurringEventsModule(_plugin.recurringEvents ?? {})
+    recurringEventsModule.unshift('recurringEvents')
+
     const statesModule = new StatesModule(_plugin.states ?? {})
     statesModule.unshift('states')
 
@@ -46,6 +51,7 @@ export class PluginPackageDefinitionModule extends Module {
       eventsModule,
       statesModule,
       interfacesModule,
+      recurringEventsModule,
     }
 
     for (const dep of Object.values(this._dependencies)) {
@@ -56,13 +62,15 @@ export class PluginPackageDefinitionModule extends Module {
   public async getContent() {
     let content = ''
 
-    const { defaultConfigModule, actionsModule, eventsModule, statesModule, interfacesModule } = this._dependencies
+    const { defaultConfigModule, actionsModule, eventsModule, recurringEventsModule, statesModule, interfacesModule } =
+      this._dependencies
 
     const defaultConfigImport = defaultConfigModule.import(this)
     const actionsImport = actionsModule.import(this)
     const eventsImport = eventsModule.import(this)
     const statesImport = statesModule.import(this)
     const interfacesImport = interfacesModule.import(this)
+    const recurringEventsImport = recurringEventsModule.import(this)
 
     const user = {
       tags: this._plugin.user?.tags ?? {},
@@ -81,11 +89,13 @@ export class PluginPackageDefinitionModule extends Module {
       `import * as ${eventsModule.name} from "./${eventsImport}"`,
       `import * as ${statesModule.name} from "./${statesImport}"`,
       `import * as ${interfacesModule.name} from "./${interfacesImport}"`,
+      `import * as ${recurringEventsModule.name} from "./${recurringEventsImport}"`,
       `export * as ${defaultConfigModule.name} from "./${defaultConfigImport}"`,
       `export * as ${actionsModule.name} from "./${actionsImport}"`,
       `export * as ${eventsModule.name} from "./${eventsImport}"`,
       `export * as ${statesModule.name} from "./${statesImport}"`,
       `export * as ${interfacesModule.name} from "./${interfacesImport}"`,
+      `export * as ${recurringEventsModule.name} from "./${recurringEventsImport}"`,
       '',
       'export default {',
       `  name: "${this._plugin.name}",`,
@@ -97,6 +107,7 @@ export class PluginPackageDefinitionModule extends Module {
       `  events: ${eventsModule.name}.${eventsModule.exportName},`,
       `  states: ${statesModule.name}.${statesModule.exportName},`,
       `  interfaces: ${interfacesModule.name}.${interfacesModule.exportName},`,
+      `  recurringEvents: ${recurringEventsModule.name}.${recurringEventsModule.exportName},`,
       '} satisfies sdk.PluginPackage["definition"]',
     ].join('\n')
 

--- a/packages/cli/src/code-generation/plugin-package/plugin-package-definition/recurring-events-module.ts
+++ b/packages/cli/src/code-generation/plugin-package/plugin-package-definition/recurring-events-module.ts
@@ -1,0 +1,33 @@
+import * as gen from '../../generators'
+import { Module, ReExportVariableModule } from '../../module'
+import * as strings from '../../strings'
+import * as commonTypes from '../../typings'
+
+class RecurringEventModule extends Module {
+  public constructor(
+    name: string,
+    private _event: commonTypes.DynamicRecurringEvents[string]
+  ) {
+    const eventName = name
+    const exportName = strings.varName(eventName)
+    super({ path: `${name}.ts`, exportName })
+  }
+
+  public async getContent(): Promise<string> {
+    if (typeof this._event === 'function') {
+      return '// @ts-ignore\n' + `export const ${this.exportName} = ${gen.getFunctionSource(this._event)}`
+    } else {
+      return `export const ${this.exportName} = ${JSON.stringify(this._event)}`
+    }
+  }
+}
+
+export class RecurringEventsModule extends ReExportVariableModule {
+  public constructor(recurringEvents: commonTypes.DynamicRecurringEvents) {
+    super({ exportName: strings.varName('recurringEvents') })
+    for (const [eventName, event] of Object.entries(recurringEvents)) {
+      const module = new RecurringEventModule(eventName, event)
+      this.pushDep(module)
+    }
+  }
+}

--- a/packages/cli/src/code-generation/typings.ts
+++ b/packages/cli/src/code-generation/typings.ts
@@ -94,12 +94,24 @@ export type InterfaceDefinition = PackageRef & {
   channels?: Record<string, TitleDescription & { messages: Record<string, TitleDescription & { schema: Schema }> }>
 }
 
+type RecurringEventDefinition = {
+  type: string
+  payload: Record<string, any>
+  schedule: { cron: string }
+}
+export type DynamicRecurringEvents = {
+  [x: string]:
+    | RecurringEventDefinition
+    | ((self: { configuration: Record<string, any> }) => RecurringEventDefinition | undefined)
+}
+
 export type PluginDefinition = PackageRef & {
   configuration?: TitleDescription & { schema?: Schema }
   user?: { tags: Record<string, {}> }
   conversation?: Tags
   states?: Record<string, TitleDescription & { type: client.State['type']; schema: Schema }>
   events?: Record<string, TitleDescription & { schema: Schema }>
+  recurringEvents?: DynamicRecurringEvents
   actions?: Record<string, TitleDescription & InputOutput>
   workflows?: Record<string, TitleDescription & Tags & InputOutput>
   dependencies?: {

--- a/packages/cli/src/command-implementations/add-command.ts
+++ b/packages/cli/src/command-implementations/add-command.ts
@@ -238,6 +238,7 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
                 )
               ),
             },
+            recurringEvents: projectDefinition.definition.recurringEvents,
           },
         },
       }

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.48.0",
-    "@botpress/sdk": "3.5.1"
+    "@botpress/sdk": "3.6.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.48.0",
-    "@botpress/sdk": "3.5.1"
+    "@botpress/sdk": "3.6.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "3.5.1"
+    "@botpress/sdk": "3.6.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.48.0",
-    "@botpress/sdk": "3.5.1"
+    "@botpress/sdk": "3.6.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.48.0",
-    "@botpress/sdk": "3.5.1",
+    "@botpress/sdk": "3.6.0",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/bot/definition.ts
+++ b/packages/sdk/src/bot/definition.ts
@@ -205,7 +205,20 @@ export class BotDefinition<
     self.user = this._mergeUser(self.user, pluginPkg.definition.user)
     self.conversation = this._mergeConversation(self.conversation, pluginPkg.definition.conversation)
     self.message = this._mergeMessage(self.message, pluginPkg.definition.message)
-    self.recurringEvents = this._mergeRecurringEvents(self.recurringEvents, pluginPkg.definition.recurringEvents)
+
+    // Allow recurring events to be dynamically generated based on the plugin's configuration:
+    self.recurringEvents = this._mergeRecurringEvents(
+      self.recurringEvents,
+      Object.fromEntries(
+        Object.entries(pluginPkg.definition.recurringEvents ?? {})
+          .map(([key, recurringEvent]) => [
+            key,
+            typeof recurringEvent === 'function' ? recurringEvent({ configuration: config }) : recurringEvent,
+          ])
+          .filter(([, recurringEvent]) => recurringEvent !== undefined) as [string, RecurringEventDefinition][]
+      )
+    )
+
     self.tables = this._mergeTables(self.tables, pluginPkg.definition.tables)
     self.workflows = this._mergeWorkflows(self.workflows, pluginPkg.definition.workflows)
 

--- a/packages/sdk/src/bot/definition.ts
+++ b/packages/sdk/src/bot/definition.ts
@@ -213,7 +213,9 @@ export class BotDefinition<
         Object.entries(pluginPkg.definition.recurringEvents ?? {})
           .map(([key, recurringEvent]) => [
             key,
-            typeof recurringEvent === 'function' ? recurringEvent({ configuration: config }) : recurringEvent,
+            typeof recurringEvent === 'function'
+              ? recurringEvent({ configuration: config.configuration })
+              : recurringEvent,
           ])
           .filter(([, recurringEvent]) => recurringEvent !== undefined) as [string, RecurringEventDefinition][]
       )

--- a/packages/sdk/src/package.ts
+++ b/packages/sdk/src/package.ts
@@ -43,7 +43,7 @@ type PluginPackageDefinition = NameVersion & {
   states?: Record<string, plugin.StateDefinition>
   configuration?: plugin.ConfigurationDefinition
   events?: Record<string, plugin.EventDefinition>
-  recurringEvents?: Record<string, plugin.RecurringEventDefinition>
+  recurringEvents?: plugin.DynamicRecurringEvents
   actions?: Record<string, plugin.ActionDefinition>
   tables?: Record<string, plugin.TableDefinition>
   workflows?: Record<string, plugin.WorkflowDefinition>

--- a/packages/sdk/src/plugin/definition.ts
+++ b/packages/sdk/src/plugin/definition.ts
@@ -11,7 +11,7 @@ import {
   WorkflowDefinition,
 } from '../bot/definition'
 import { IntegrationPackage, InterfacePackage } from '../package'
-import { ZuiObjectSchema } from '../zui'
+import type { ZuiObjectSchema, infer as ZodInfer } from '../zui'
 
 export {
   StateDefinition,
@@ -35,6 +35,12 @@ type BaseInterfaces = Record<string, any>
 type BaseIntegrations = Record<string, any>
 type BaseTables = Record<string, ZuiObjectSchema>
 type BaseWorkflows = Record<string, ZuiObjectSchema>
+
+export type DynamicRecurringEvents<TEvents extends BaseEvents = BaseEvents, TConfig extends BaseConfig = BaseConfig> = {
+  [x: string]:
+    | RecurringEventDefinition<TEvents>
+    | ((self: { configuration: ZodInfer<TConfig> }) => RecurringEventDefinition<TEvents> | undefined)
+}
 
 export type PluginDefinitionProps<
   TName extends string = string,
@@ -72,7 +78,7 @@ export type PluginDefinitionProps<
   events?: {
     [K in keyof TEvents]: EventDefinition<TEvents[K]>
   }
-  recurringEvents?: Record<string, RecurringEventDefinition<TEvents>>
+  recurringEvents?: DynamicRecurringEvents<TEvents, TConfig>
   actions?: {
     [K in keyof TActions]: ActionDefinition<TActions[K]>
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1861,7 +1861,7 @@ importers:
         specifier: 0.48.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 3.5.1
+        specifier: 3.6.0
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -1973,7 +1973,7 @@ importers:
         specifier: 0.48.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 3.5.1
+        specifier: 3.6.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -1989,7 +1989,7 @@ importers:
         specifier: 0.48.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 3.5.1
+        specifier: 3.6.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2002,7 +2002,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 3.5.1
+        specifier: 3.6.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2018,7 +2018,7 @@ importers:
         specifier: 0.48.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 3.5.1
+        specifier: 3.6.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2034,7 +2034,7 @@ importers:
         specifier: 0.48.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 3.5.1
+        specifier: 3.6.0
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
Allows plugins to provide a factory function for their recurring events. The factory has access to the plugin instance's config, and can use said config to determine which cron expression to use.

This is necessary to enable periodic synchronization in the file synchronizer plugin, since we allow bot owners to specify at which interval to perform periodic sync, which is currently impossible to accomplish without doing ugly hacks with the client.

Example usage:

```typescript
{
  recurringEvents: {
    periodicSync({ configuration }) {
      if (!configuration.enablePeriodicSync) {
        return
      }

      // Ensure the cron expression is offset by the current time to prevent
      // huge load spikes on the back-end:
      const currentTime = new Date()
      const currentHour = currentTime.getHours()
      const currentMinute = currentTime.getMinutes()

      return {
        type: 'periodicSync',
        payload: {},
        schedule: {
          cron:
            'everyNHours' in configuration.enablePeriodicSync
              ? `${currentMinute} */${configuration.enablePeriodicSync.everyNHours} * * *`
              : 'everyNDays' in configuration.enablePeriodicSync
                ? `${currentMinute} ${currentHour} */${configuration.enablePeriodicSync.everyNDays} * *`
                : configuration.enablePeriodicSync.cronExpression,
        },
      }
    },
  },
}
```

<sub> Resolves CLS-2830 </sub>