### PR TITLE
fix(cli): if single line log is interrupted it behaves like normal logger

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/logger/base-logger.ts
+++ b/packages/cli/src/logger/base-logger.ts
@@ -6,11 +6,18 @@ import * as utils from '../utils'
 
 export type LoggerOptions = {
   verbose: boolean
-  json?: boolean // prevents loggin anything else than json
+  json: boolean // prevents loggin anything else than json
+  outStream: NodeJS.WriteStream
+  errStream: NodeJS.WriteStream
 }
 
 const STDOUT_CHUNK_SIZE = 100
-const DEFAULT_OPTIONS: LoggerOptions = { verbose: false }
+const DEFAULT_OPTIONS: LoggerOptions = {
+  verbose: false,
+  json: false,
+  outStream: process.stdout,
+  errStream: process.stderr,
+}
 
 type ChalkColor = (str: string) => string
 const NO_COLOR: ChalkColor = (str: string) => str
@@ -88,6 +95,8 @@ const BOX_OPTIONS: boxen.Options = {
   borderStyle: 'round',
   borderColor: 'yellow',
 }
+
+export type StreamType = 'out' | 'err'
 
 export abstract class BaseLogger {
   protected opts: LoggerOptions
@@ -175,8 +184,9 @@ export abstract class BaseLogger {
     }
   }
 
-  protected render(message: string, stream: NodeJS.WriteStream = process.stdout): void {
+  protected render(message: string, streamType: StreamType = 'out'): void {
     // chunking the message ensures that the process won't exit before the message is fully written
+    const stream = streamType === 'err' ? this.opts.errStream : this.opts.outStream
     for (const chunk of utils.string.chunkString(message, STDOUT_CHUNK_SIZE)) {
       stream.write(chunk)
     }

--- a/packages/cli/src/logger/index.ts
+++ b/packages/cli/src/logger/index.ts
@@ -44,15 +44,12 @@ class _SingleLineLogger extends BaseLogger {
   }
 
   protected print(message: string, props: Partial<{ prefix: string }> = {}): void {
-    let suffix: string
-    if (!this._commited) {
+    if (!this._commited && process.stdout.isTTY) {
       this.opts.outStream.clearLine(0)
       this.opts.outStream.cursorTo(0)
-      suffix = ''
-    } else {
-      suffix = '\n'
     }
 
+    const suffix = this._commited ? '\n' : ''
     const { prefix } = props
     if (prefix) {
       this.render(`${prefix} ${message}${suffix}`)

--- a/packages/cli/src/logger/index.ts
+++ b/packages/cli/src/logger/index.ts
@@ -44,12 +44,15 @@ class _SingleLineLogger extends BaseLogger {
   }
 
   protected print(message: string, props: Partial<{ prefix: string }> = {}): void {
+    let suffix: string
     if (!this._commited) {
       this.opts.outStream.clearLine(0)
       this.opts.outStream.cursorTo(0)
+      suffix = ''
+    } else {
+      suffix = '\n'
     }
 
-    const suffix = this._commited ? '\n' : ''
     const { prefix } = props
     if (prefix) {
       this.render(`${prefix} ${message}${suffix}`)

--- a/packages/cli/src/logger/index.ts
+++ b/packages/cli/src/logger/index.ts
@@ -46,7 +46,7 @@ class _SingleLineLogger extends BaseLogger {
 
   protected print(message: string, props: Partial<{ prefix: string }> = {}): void {
     let suffix: string
-    if (!this._commited && process.stdout.isTTY) {
+    if (!this._commited && this.opts.outStream.isTTY) {
       this.opts.outStream.clearLine(0)
       this.opts.outStream.cursorTo(0)
       suffix = ''

--- a/packages/cli/src/logger/index.ts
+++ b/packages/cli/src/logger/index.ts
@@ -29,6 +29,9 @@ export class Logger extends BaseLogger {
   }
 }
 
+/**
+ * Prints to a single line unless it is committed. When committed, it will print normally using new lines.
+ */
 class _SingleLineLogger extends BaseLogger {
   private _commited = false
 
@@ -37,22 +40,21 @@ class _SingleLineLogger extends BaseLogger {
       return
     }
     this._commited = true
-    this.render('\n')
+    this.print('')
   }
 
   protected print(message: string, props: Partial<{ prefix: string }> = {}): void {
-    if (this._commited) {
-      return
+    if (!this._commited) {
+      this.opts.outStream.clearLine(0)
+      this.opts.outStream.cursorTo(0)
     }
 
-    this.opts.outStream.clearLine(0)
+    const suffix = this._commited ? '\n' : ''
     const { prefix } = props
-    this.opts.outStream.cursorTo(0)
-
     if (prefix) {
-      this.render(`${prefix} ${message}`)
+      this.render(`${prefix} ${message}${suffix}`)
       return
     }
-    this.render(message)
+    this.render(message + suffix)
   }
 }

--- a/packages/cli/src/logger/index.ts
+++ b/packages/cli/src/logger/index.ts
@@ -30,7 +30,8 @@ export class Logger extends BaseLogger {
 }
 
 /**
- * Prints to a single line unless it is committed. When committed, it will print normally using new lines.
+ * Prints to a single line unless it is committed.
+ * When committed or if the stream is not TTY, it prints normally using new lines.
  */
 class _SingleLineLogger extends BaseLogger {
   private _commited = false
@@ -44,12 +45,15 @@ class _SingleLineLogger extends BaseLogger {
   }
 
   protected print(message: string, props: Partial<{ prefix: string }> = {}): void {
+    let suffix: string
     if (!this._commited && process.stdout.isTTY) {
       this.opts.outStream.clearLine(0)
       this.opts.outStream.cursorTo(0)
+      suffix = ''
+    } else {
+      suffix = '\n'
     }
 
-    const suffix = this._commited ? '\n' : ''
     const { prefix } = props
     if (prefix) {
       this.render(`${prefix} ${message}${suffix}`)

--- a/packages/cli/src/logger/logger.test.ts
+++ b/packages/cli/src/logger/logger.test.ts
@@ -1,0 +1,114 @@
+import { Logger } from '.'
+import { test, expect } from 'vitest'
+
+type _IFakeStream = Partial<NodeJS.WriteStream> & {
+  data: string
+}
+class _FakeStream implements _IFakeStream {
+  private _lines: string[] = []
+  private _y = 0
+  private _x = 0
+
+  public static create(): _IFakeStream {
+    return new _FakeStream()
+  }
+
+  private get _currentLine(): string {
+    return this._lines[this._y] || ''
+  }
+
+  private set _currentLine(line: string) {
+    this._lines[this._y] = line
+  }
+
+  public write(str: Uint8Array | string): boolean {
+    const tokens: string[] = str.toString().split(/(\n)/).filter(Boolean)
+
+    for (const token of tokens) {
+      if (token === '\n') {
+        this._y++
+        this._currentLine = ''
+        continue
+      }
+      this._currentLine = this._currentLine + token
+    }
+
+    return true
+  }
+
+  public clearLine(dir: -1 | 0 | 1) {
+    if (dir === 0) {
+      this._currentLine = ''
+    } else if (dir === -1) {
+      const right = this._currentLine.slice(this._x)
+      this._currentLine = right
+    } else {
+      const left = this._currentLine.slice(0, this._x)
+      this._currentLine = left
+    }
+    return true
+  }
+
+  public cursorTo(x: number, y?: number | Function): boolean {
+    this._x = x
+    this._y = typeof y === 'number' ? y : this._y
+    return true
+  }
+
+  public get data(): string {
+    return this._lines.join('\n')
+  }
+}
+
+test('logging with a prefix should write the prefix', () => {
+  const stream = _FakeStream.create()
+  const logger = new Logger({ outStream: stream as NodeJS.WriteStream, errStream: stream as NodeJS.WriteStream })
+
+  logger.log('lol1', { prefix: '###' })
+  expect(stream.data).toEqual('### lol1\n')
+})
+
+test('logging a certain sequence of messages should write message in order', () => {
+  const stream = _FakeStream.create()
+  const logger = new Logger({ outStream: stream as NodeJS.WriteStream, errStream: stream as NodeJS.WriteStream })
+
+  logger.log('lol1')
+  logger.log('lol2')
+  logger.log('lol3')
+  logger.log('lol4')
+
+  expect(stream.data).toEqual(`lol1
+lol2
+lol3
+lol4
+`)
+})
+
+test('logging on a single line should write message on a single line', () => {
+  const stream = _FakeStream.create()
+  const logger = new Logger({ outStream: stream as NodeJS.WriteStream, errStream: stream as NodeJS.WriteStream }).line()
+  logger.log('lol1')
+  logger.log('lol2')
+  logger.log('lol3')
+  logger.log('lol4')
+
+  expect(stream.data).toEqual('lol4')
+})
+
+test('logging on a single line, then logging on multiple line should commit the single line', () => {
+  const stream = _FakeStream.create()
+
+  const logger = new Logger({ outStream: stream as NodeJS.WriteStream, errStream: stream as NodeJS.WriteStream })
+  logger.log('lol1')
+
+  const line = logger.line()
+  line.log('lol2')
+  line.log('lol3')
+  logger.log('lol4')
+  line.log('lol5')
+
+  expect(stream.data).toEqual(`lol1
+lol3
+lol4
+`)
+})

--- a/packages/cli/src/logger/logger.test.ts
+++ b/packages/cli/src/logger/logger.test.ts
@@ -21,6 +21,10 @@ class _FakeStream implements _IFakeStream {
     this._lines[this._y] = line
   }
 
+  public get isTTY() {
+    return true
+  }
+
   public write(str: Uint8Array | string): boolean {
     const tokens: string[] = str.toString().split(/(\n)/).filter(Boolean)
 

--- a/packages/cli/src/logger/logger.test.ts
+++ b/packages/cli/src/logger/logger.test.ts
@@ -95,7 +95,7 @@ test('logging on a single line should write message on a single line', () => {
   expect(stream.data).toEqual('lol4')
 })
 
-test('logging on a single line, then logging on multiple line should commit the single line', () => {
+test('logging on a single line, then logging on multiple line should keep logging on next line', () => {
   const stream = _FakeStream.create()
 
   const logger = new Logger({ outStream: stream as NodeJS.WriteStream, errStream: stream as NodeJS.WriteStream })
@@ -110,5 +110,6 @@ test('logging on a single line, then logging on multiple line should commit the 
   expect(stream.data).toEqual(`lol1
 lol3
 lol4
+lol5
 `)
 })


### PR DESCRIPTION
different approach for https://github.com/botpress/botpress/pull/13727

![image](https://github.com/user-attachments/assets/e9647b19-2413-4487-855e-ec29ed983331)
