### PR TITLE
feat(file-synchronizer): expose listFiles, allow to override rules

### DIFF
--- a/plugins/file-synchronizer/plugin.definition.ts
+++ b/plugins/file-synchronizer/plugin.definition.ts
@@ -1,9 +1,57 @@
 import * as sdk from '@botpress/sdk'
 import filesReadonly from './bp_modules/files-readonly'
 
+const FILE_FILTER_PROPS = {
+  includeFiles: sdk.z
+    .array(
+      sdk.z
+        .object({
+          pathGlobPattern: sdk.z
+            .string()
+            .describe(
+              'A glob pattern to match against the file path. Only files that match the pattern will be synchronized. Any pattern supported by picomatch is supported.'
+            ),
+          maxSizeInBytes: sdk.z
+            .number()
+            .optional()
+            .describe(
+              'Filter by maximum size (in bytes). Only files smaller than the specified size will be synchronized.'
+            ),
+          modifiedAfter: sdk.z
+            .string()
+            .datetime()
+            .optional()
+            .describe(
+              'Filter the items by modified date. Only files modified after the specified date will be synchronized.'
+            ),
+        })
+        .title('Include Criteria')
+        .describe('A file must match all criteria to be synchronized.')
+    )
+    .title('Include Rules')
+    .describe('A list of rules to include files. Only files that match one or more rules will be synchronized.'),
+  excludeFiles: sdk.z
+    .array(
+      sdk.z
+        .object({
+          pathGlobPattern: sdk.z
+            .string()
+            .describe(
+              'A glob pattern to match against the file path. Files that match the pattern will be ignored, even if they match the includeFiles configuration.'
+            ),
+        })
+        .title('Exclude Criteria')
+        .describe('A file must match all exclude criteria to be ignored.')
+    )
+    .title('Exclude Rules')
+    .describe(
+      'A list of rules to exclude files. Files that match one or more rules will be ignored. This takes precedence over Include Rules.'
+    ),
+} as const
+
 export default new sdk.PluginDefinition({
   name: 'file-synchronizer',
-  version: '0.3.0',
+  version: '0.4.0',
   title: 'File Synchronizer',
   description: 'Synchronize files from external services to Botpress',
   icon: 'icon.svg',
@@ -39,51 +87,34 @@ export default new sdk.PluginDefinition({
         .describe(
           'Enable real-time synchronization. Whever a file is created, updated, or deleted, synchronize it to Botpress immediately. This does not work with every integration.'
         ),
-      includeFiles: sdk.z
-        .array(
-          sdk.z.object({
-            pathGlobPattern: sdk.z
-              .string()
-              .describe(
-                'A glob pattern to match against the file path. Only files that match the pattern will be synchronized. Any pattern supported by picomatch is supported.'
-              ),
-            maxSizeInBytes: sdk.z
-              .number()
-              .optional()
-              .describe(
-                'Filter by maximum size (in bytes). Only files smaller than the specified size will be synchronized.'
-              ),
-            modifiedAfter: sdk.z
-              .string()
-              .datetime()
-              .optional()
-              .describe(
-                'Filter the items by modified date. Only files modified after the specified date will be synchronized.'
-              ),
-          })
-        )
-        .min(1),
-      excludeFiles: sdk.z.array(
-        sdk.z.object({
-          pathGlobPattern: sdk.z
-            .string()
-            .describe(
-              'A glob pattern to match against the file path. Files that match the pattern will be ignored, even if they match the includeFiles configuration.'
-            ),
-        })
-      ),
+      ...FILE_FILTER_PROPS,
     }),
   },
   actions: {
     syncFilesToBotpess: {
       title: 'Sync files to Botpress',
-      description: 'Start synchronization of all files from the external service to Botpress',
-      input: { schema: sdk.z.object({}) },
+      description: 'Start synchronization of files from the external service to Botpress',
+      input: {
+        schema: sdk.z.object({
+          includeFiles: FILE_FILTER_PROPS.includeFiles
+            .title('Include Rules Override')
+            .describe('If omitted, the global Include Rules will be used.')
+            .optional(),
+          excludeFiles: FILE_FILTER_PROPS.excludeFiles
+            .title('Exclude Rules Override')
+            .describe('If omitted, the global Exclude Rules will be used')
+            .optional(),
+        }),
+      },
       output: {
         schema: sdk.z.object({
           status: sdk.z.enum(['queued', 'already-running', 'error']),
         }),
       },
+    },
+    listItemsInFolder: {
+      // Re-export the action from the files-readonly interface:
+      ...filesReadonly.definition.actions.listItemsInFolder,
     },
   },
   events: {

--- a/plugins/file-synchronizer/src/index.ts
+++ b/plugins/file-synchronizer/src/index.ts
@@ -8,6 +8,10 @@ const plugin = new bp.Plugin({
       props.logger.info('Called action syncFilesToBotpess')
       return await actions.syncFilesToBotpess.callAction(props)
     },
+    async listItemsInFolder(props) {
+      props.logger.info('Called action listItemsInFolder. Redirecting to integration...')
+      return await props.actions['files-readonly'].listItemsInFolder(props.input)
+    },
   },
 })
 


### PR DESCRIPTION
- Exposes the `listItemsInFolder` action of the underlying integration that implements the `files-readonly` interface. This allows enumerating files without calling the integration directly.
- Allows to override the include/exclude rules in the `syncFilesToBotpress` action. This allows to choose which files to synchronize. When include/exclude rules are specified for the action, they override the global include/exclude rules defined in the plugin's config.