### PR TITLE
feat(zendesk): implement hitl message history

### DIFF
--- a/integrations/zendesk/integration.definition.ts
+++ b/integrations/zendesk/integration.definition.ts
@@ -7,7 +7,7 @@ import { actions, events, configuration, channels, states, user } from './src/de
 export default new IntegrationDefinition({
   name: 'zendesk',
   title: 'Zendesk',
-  version: '1.0.9',
+  version: '1.1.0',
   icon: 'icon.svg',
   description:
     'Optimize your support workflow. Trigger workflows from ticket updates as well as manage tickets, access conversations, and engage with customers.',

--- a/integrations/zendesk/src/actions/hitl.ts
+++ b/integrations/zendesk/src/actions/hitl.ts
@@ -2,7 +2,8 @@ import * as sdk from '@botpress/sdk'
 import { getZendeskClient } from '../client'
 import * as bp from '.botpress'
 
-export const startHitl: bp.IntegrationProps['actions']['startHitl'] = async ({ ctx, input, client }) => {
+export const startHitl: bp.IntegrationProps['actions']['startHitl'] = async (props) => {
+  const { ctx, input, client } = props
   const zendeskClient = getZendeskClient(ctx.configuration)
 
   const { user } = await client.getUser({
@@ -13,11 +14,9 @@ export const startHitl: bp.IntegrationProps['actions']['startHitl'] = async ({ c
     throw new sdk.RuntimeError(`User ${user.id} not linked in Zendesk`)
   }
 
-  const ticket = await zendeskClient.createTicket(
-    input.title ?? 'Untitled Ticket',
-    input.description ?? 'Someone opened a ticket using your Botpress chatbot',
-    { id: zendeskAuthorId }
-  )
+  const ticket = await zendeskClient.createTicket(input.title ?? 'Untitled Ticket', await _buildTicketBody(props), {
+    id: zendeskAuthorId,
+  })
 
   const zendeskTicketId = `${ticket.id}`
   const { conversation } = await client.getOrCreateConversation({
@@ -31,11 +30,51 @@ export const startHitl: bp.IntegrationProps['actions']['startHitl'] = async ({ c
     external_id: conversation.id,
   })
 
-  // TODO: possibly display the message history
-
   return {
     conversationId: conversation.id,
   }
+}
+
+const _buildTicketBody = async ({ input, client, ctx }: bp.ActionProps['startHitl']) => {
+  const description = input.description?.trim() || 'Someone opened a ticket using your Botpress chatbot.'
+
+  const messageHistory = (
+    await Promise.all(
+      input.messageHistory
+        // NOTE: currently, the hitl plugin only supports text messages
+        ?.filter((message) => message.type === 'text')
+        .map(async (message) => {
+          const { payload, source } = message
+          const user = await _getBotpressUser({
+            userId: source.type === 'user' ? source.userId : ctx.botUserId,
+            client,
+          })
+          const userTags = user.tags as Record<string, string>
+          const author = userTags['name'] ?? user.name ?? (source.type === 'bot' ? 'Botpress' : 'Unknown User')
+          const authorIcon = source.type === 'bot' ? '🤖' : '👤'
+
+          return `${authorIcon} ${author}:\n> ${payload.text}`
+        }) ?? []
+    )
+  ).join('\n\n---\n\n')
+
+  return description + (messageHistory.length ? `\n\n---\n\n${messageHistory}` : '')
+}
+
+type User = bp.ClientResponses['getUser']['user']
+const _USERS_CACHE = new Map<string, User>()
+
+const _getBotpressUser = async ({ userId, client }: { userId: string; client: bp.Client }): Promise<User> => {
+  const cachedUser = _USERS_CACHE.get(userId)
+
+  if (cachedUser) {
+    return cachedUser
+  }
+
+  const { user } = await client.getUser({ id: userId })
+  _USERS_CACHE.set(userId, user)
+
+  return user
 }
 
 export const stopHitl: bp.IntegrationProps['actions']['stopHitl'] = async ({ ctx, input, client }) => {


### PR DESCRIPTION
Addresses CLS-2760.

The agent on Zendesk now receives the full conversation:

![image](https://github.com/user-attachments/assets/ce6daa6a-588d-4748-a474-9d3ae17176ff)
