### PR TITLE
feat(hitl): add custom args

### DIFF
--- a/interfaces/hitl/interface.definition.ts
+++ b/interfaces/hitl/interface.definition.ts
@@ -32,7 +32,7 @@ const messageSchema = z.union(messagePayloadSchemas as Tuple<AnyZodObject>)
 
 export default new InterfaceDefinition({
   name: 'hitl',
-  version: '0.4.0',
+  version: '0.4.1',
   entities: {},
   events: {
     hitlAssigned: {
@@ -78,6 +78,8 @@ export default new InterfaceDefinition({
               .array(messageSchema)
               .optional()
               .describe('Message history to display in the HITL session'),
+            // Or string since type record doesn't work for frontend input schema
+            customArgs: z.record(z.unknown()).or(z.string()).optional().describe('Custom integration arguments'),
           }),
       },
       output: {

--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -16,7 +16,7 @@ export const DEFAULT_AGENT_ASSIGNED_TIMEOUT_MESSAGE =
 
 export default new sdk.PluginDefinition({
   name: 'hitl',
-  version: '0.4.5',
+  version: '0.4.6',
   title: 'Human In The Loop',
   description: 'Seamlessly transfer conversations to human agents',
   icon: 'icon.svg',
@@ -111,6 +111,18 @@ export default new sdk.PluginDefinition({
             .title('Conversation ID') // this is the upstream conversation
             .describe('ID of the conversation on which to start the HITL mode')
             .placeholder('{{ event.conversationId }}'),
+          customArgs: sdk.z
+            .string()
+            .title('Custom Arguments')
+            .displayAs<any>({
+              id: 'json',
+              params: {
+                allowDynamicVariable: true,
+                showPreview: true,
+              },
+            })
+            .optional()
+            .describe('Custom integration arguments, check your HITL Integration docs for details'),
         }),
       },
       output: { schema: sdk.z.object({}) },

--- a/plugins/hitl/src/actions/start-hitl.ts
+++ b/plugins/hitl/src/actions/start-hitl.ts
@@ -106,12 +106,26 @@ const _createDownstreamConversation = async (
   input: StartHitlInput,
   messageHistory: MessageHistoryElement[]
 ): Promise<string> => {
+  let customArgs = input.customArgs
+
+  // We could be receiving a JSON object as string, so we need to parse it.
+  // This behavior is not optimal but type record or object is not supported
+  // on frontend components yet
+  if (typeof input.customArgs == 'string') {
+    try {
+      customArgs = JSON.parse(input.customArgs as string)
+    } catch (err: any) {
+      customArgs = { err }
+    }
+  }
+
   // Call startHitl in the hitl integration (zendesk, etc.):
   const { conversationId: downstreamConversationId } = await props.actions.hitl.startHitl({
     title: input.title,
     description: input.description,
     userId: downstreamUserId,
     messageHistory,
+    customArgs,
   })
 
   return downstreamConversationId


### PR DESCRIPTION
This is my proposal to address PD-49, so each HITL Integration can allow custom arguments; for instance, Salesforce allows custom routing parameters properties to be added, it could be anything. The responsibility of documenting these custom arguments will be on the Integration, that will receive the object on the startHitl action

![image](https://github.com/user-attachments/assets/bdca4a58-eaad-4b66-8c19-ad31f88504f6)
