### PR TITLE
feat(sdk): allow plugins to listen on interface channels

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -22,7 +22,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.1",
     "@botpress/client": "0.48.3",
-    "@botpress/sdk": "4.0.0",
+    "@botpress/sdk": "4.1.0",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.48.3",
-    "@botpress/sdk": "4.0.0"
+    "@botpress/sdk": "4.1.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.48.3",
-    "@botpress/sdk": "4.0.0"
+    "@botpress/sdk": "4.1.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "4.0.0"
+    "@botpress/sdk": "4.1.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.48.3",
-    "@botpress/sdk": "4.0.0"
+    "@botpress/sdk": "4.1.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "0.48.3",
-    "@botpress/sdk": "4.0.0",
+    "@botpress/sdk": "4.1.0",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/plugin/common/types.ts
+++ b/packages/sdk/src/plugin/common/types.ts
@@ -19,6 +19,23 @@ export type EnumerateInterfaceEvents<TPlugin extends BasePlugin> = UnionToInters
   }[keyof TPlugin['interfaces']]
 >
 
+type ChannelKey<TIntegrationName extends string, TMessageName extends string> = string extends TIntegrationName
+  ? string
+  : string extends TMessageName
+    ? string
+    : Join<[TIntegrationName, ':', TMessageName]>
+
+export type EnumerateInterfaceChannels<TPlugin extends BasePlugin> = UnionToIntersection<
+  {
+    [TInterfaceName in keyof TPlugin['interfaces']]: {
+      [TChannelName in keyof TPlugin['interfaces'][TInterfaceName]['channels'] as ChannelKey<
+        Cast<TInterfaceName, string>,
+        Cast<TChannelName, string>
+      >]: TPlugin['interfaces'][TInterfaceName]['channels'][TChannelName]
+    }
+  }[keyof TPlugin['interfaces']]
+>
+
 /**
  * Used by a bot to tell the plugin what integration should be used to implement an interface.
  */

--- a/packages/sdk/src/plugin/server/types.ts
+++ b/packages/sdk/src/plugin/server/types.ts
@@ -16,12 +16,15 @@ type _IncomingEvents<TPlugin extends common.BasePlugin> = {
   >
 }
 
+type EnumeratePluginMessages<TPlugin extends common.BasePlugin> = bot.GetMessages<TPlugin> &
+  common.EnumerateInterfaceChannels<TPlugin>
+
 type _IncomingMessages<TPlugin extends common.BasePlugin> = {
   // TODO: use bot definiton message property to infer allowed tags
-  [K in utils.StringKeys<bot.GetMessages<TPlugin>>]: utils.Merge<
+  [K in utils.StringKeys<EnumeratePluginMessages<TPlugin>>]: utils.Merge<
     //
     client.Message,
-    { type: K; payload: bot.GetMessages<TPlugin>[K] }
+    { type: K; payload: EnumeratePluginMessages<TPlugin>[K] }
   >
 }
 
@@ -33,17 +36,17 @@ type _IncomingStates<TPlugin extends common.BasePlugin> = {
 }
 
 type _OutgoingMessageRequests<TPlugin extends common.BasePlugin> = {
-  [K in utils.StringKeys<bot.GetMessages<TPlugin>>]: utils.Merge<
+  [K in utils.StringKeys<EnumeratePluginMessages<TPlugin>>]: utils.Merge<
     client.ClientInputs['createMessage'],
-    { type: K; payload: bot.GetMessages<TPlugin>[K] }
+    { type: K; payload: EnumeratePluginMessages<TPlugin>[K] }
   >
 }
 
 type _OutgoingMessageResponses<TPlugin extends common.BasePlugin> = {
-  [K in utils.StringKeys<bot.GetMessages<TPlugin>>]: utils.Merge<
+  [K in utils.StringKeys<EnumeratePluginMessages<TPlugin>>]: utils.Merge<
     client.ClientOutputs['createMessage'],
     {
-      message: utils.Merge<client.Message, { type: K; payload: bot.GetMessages<TPlugin>[K] }>
+      message: utils.Merge<client.Message, { type: K; payload: EnumeratePluginMessages<TPlugin>[K] }>
     }
   >
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1880,7 +1880,7 @@ importers:
         specifier: 0.48.3
         version: link:../client
       '@botpress/sdk':
-        specifier: 4.0.0
+        specifier: 4.1.0
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -1992,7 +1992,7 @@ importers:
         specifier: 0.48.3
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.0.0
+        specifier: 4.1.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2008,7 +2008,7 @@ importers:
         specifier: 0.48.3
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.0.0
+        specifier: 4.1.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2021,7 +2021,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 4.0.0
+        specifier: 4.1.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2037,7 +2037,7 @@ importers:
         specifier: 0.48.3
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.0.0
+        specifier: 4.1.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2053,7 +2053,7 @@ importers:
         specifier: 0.48.3
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.0.0
+        specifier: 4.1.0
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
this enables listening to interface channels from a plugin: `plugin.on.beforeIncomingMessage('hitl:hitl', ...)`