### PR TITLE
chore(client) bump @botpress/client version to 1.2.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -22,7 +22,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.1",
     "@botpress/client": "1.2.0",
-    "@botpress/sdk": "4.0.2",
+    "@botpress/sdk": "4.0.3",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.1",
-    "@botpress/client": "1.1.0",
+    "@botpress/client": "1.2.0",
     "@botpress/sdk": "4.0.2",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -5,7 +5,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.1.0",
+    "@botpress/client": "1.2.0",
     "@botpress/sdk": "4.0.2"
   },
   "devDependencies": {

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.2.0",
-    "@botpress/sdk": "4.0.2"
+    "@botpress/sdk": "4.0.3"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.1.0",
+    "@botpress/client": "1.2.0",
     "@botpress/sdk": "4.0.2"
   },
   "devDependencies": {

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.2.0",
-    "@botpress/sdk": "4.0.2"
+    "@botpress/sdk": "4.0.3"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "4.0.2"
+    "@botpress/sdk": "4.0.3"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.1.0",
+    "@botpress/client": "1.2.0",
     "@botpress/sdk": "4.0.2"
   },
   "devDependencies": {

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.2.0",
-    "@botpress/sdk": "4.0.2"
+    "@botpress/sdk": "4.0.3"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.1.0",
+    "@botpress/client": "1.2.0",
     "@botpress/sdk": "4.0.2",
     "axios": "^1.6.8"
   },

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.2.0",
-    "@botpress/sdk": "4.0.2",
+    "@botpress/sdk": "4.0.3",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/cognitive/package.json
+++ b/packages/cognitive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cognitive",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Wrapper around the Botpress Client to call LLMs",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "1.1.0",
+    "@botpress/client": "1.2.0",
     "browser-or-node": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -36,7 +36,7 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "@botpress/client": "1.1.0",
+    "@botpress/client": "1.2.0",
     "@bpinternal/thicktoken": "^1.0.1",
     "@bpinternal/zui": "^0.13.4",
     "lodash": "^4.17.21",

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -23,7 +23,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@botpress/cognitive": "0.1.12",
+    "@botpress/cognitive": "0.1.13",
     "json5": "^2.2.3",
     "jsonrepair": "^3.10.0",
     "lodash-es": "^4.17.21"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1877,7 +1877,7 @@ importers:
         specifier: 0.5.1
         version: link:../chat-client
       '@botpress/client':
-        specifier: 1.1.0
+        specifier: 1.2.0
         version: link:../client
       '@botpress/sdk':
         specifier: 4.0.2
@@ -1989,7 +1989,7 @@ importers:
   packages/cli/templates/empty-bot:
     dependencies:
       '@botpress/client':
-        specifier: 1.1.0
+        specifier: 1.2.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 4.0.2
@@ -2005,7 +2005,7 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 1.1.0
+        specifier: 1.2.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 4.0.2
@@ -2034,7 +2034,7 @@ importers:
   packages/cli/templates/hello-world:
     dependencies:
       '@botpress/client':
-        specifier: 1.1.0
+        specifier: 1.2.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 4.0.2
@@ -2050,7 +2050,7 @@ importers:
   packages/cli/templates/webhook-message:
     dependencies:
       '@botpress/client':
-        specifier: 1.1.0
+        specifier: 1.2.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 4.0.2
@@ -2152,7 +2152,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 1.1.0
+        specifier: 1.2.0
         version: link:../client
       '@bpinternal/zui':
         specifier: ^0.13.5
@@ -2183,7 +2183,7 @@ importers:
   packages/vai:
     dependencies:
       '@botpress/client':
-        specifier: 1.1.0
+        specifier: 1.2.0
         version: link:../client
       '@bpinternal/thicktoken':
         specifier: ^1.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1880,7 +1880,7 @@ importers:
         specifier: 1.2.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 4.0.2
+        specifier: 4.0.3
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -1992,7 +1992,7 @@ importers:
         specifier: 1.2.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.0.2
+        specifier: 4.0.3
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2008,7 +2008,7 @@ importers:
         specifier: 1.2.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.0.2
+        specifier: 4.0.3
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2021,7 +2021,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 4.0.2
+        specifier: 4.0.3
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2037,7 +2037,7 @@ importers:
         specifier: 1.2.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.0.2
+        specifier: 4.0.3
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2053,7 +2053,7 @@ importers:
         specifier: 1.2.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.0.2
+        specifier: 4.0.3
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8
@@ -2226,7 +2226,7 @@ importers:
   packages/zai:
     dependencies:
       '@botpress/cognitive':
-        specifier: 0.1.12
+        specifier: 0.1.13
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^1.0.0


### PR DESCRIPTION
Update the version of the @botpress/client dependency across multiple files to 1.2.0. It adds the ability to search through public integrations 