### PR TITLE
feat(hitl): allow to automatically flow after hitl session ends

### DIFF
--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -16,7 +16,7 @@ export const DEFAULT_AGENT_ASSIGNED_TIMEOUT_MESSAGE =
 
 export default new sdk.PluginDefinition({
   name: 'hitl',
-  version: '0.4.6',
+  version: '0.5.0',
   title: 'Human In The Loop',
   description: 'Seamlessly transfer conversations to human agents',
   icon: 'icon.svg',
@@ -84,6 +84,11 @@ export default new sdk.PluginDefinition({
         .nonnegative()
         .optional()
         .placeholder('0'),
+      flowOnHitlStopped: sdk.z
+        .boolean()
+        .default(true)
+        .title('Flow on HITL Stopped')
+        .describe('Weither to wait for the user to respond to continue the flow after the hitl session'),
     }),
   },
   actions: {
@@ -195,6 +200,11 @@ export default new sdk.PluginDefinition({
           .string()
           .title('Downstream Conversation ID')
           .describe('ID of the downstream conversation'),
+      }),
+    },
+    continueWorkflow: {
+      schema: sdk.z.object({
+        conversationId: sdk.z.string().title('Conversation ID').describe('ID of the conversation'),
       }),
     },
   },

--- a/plugins/hitl/src/actions/stop-hitl.ts
+++ b/plugins/hitl/src/actions/stop-hitl.ts
@@ -34,10 +34,7 @@ export const stopHitl: bp.PluginProps['actions']['stopHitl'] = async (props) => 
   // Call stopHitl in the hitl integration (zendesk, etc.):
   await props.actions.hitl.stopHitl({ conversationId: downstreamConversationId })
 
-  if (props.configuration.flowOnHitlStopped) {
-    // the bot will continue the conversation without the patient having to send another message
-    await upstreamCm.continueWorkflow()
-  }
+  // TODO: possibly send the workflowContinue event here
 
   return {}
 }

--- a/plugins/hitl/src/actions/stop-hitl.ts
+++ b/plugins/hitl/src/actions/stop-hitl.ts
@@ -34,5 +34,10 @@ export const stopHitl: bp.PluginProps['actions']['stopHitl'] = async (props) => 
   // Call stopHitl in the hitl integration (zendesk, etc.):
   await props.actions.hitl.stopHitl({ conversationId: downstreamConversationId })
 
+  if (props.configuration.flowOnHitlStopped) {
+    // the bot will continue the conversation without the patient having to send another message
+    await upstreamCm.continueWorkflow()
+  }
+
   return {}
 }

--- a/plugins/hitl/src/conv-manager.ts
+++ b/plugins/hitl/src/conv-manager.ts
@@ -61,6 +61,16 @@ export class ConversationManager {
     ])
   }
 
+  public async continueWorkflow(): Promise<void> {
+    await this._props.client.createEvent({
+      type: 'continueWorkflow',
+      conversationId: this._convId,
+      payload: {
+        conversationId: this._convId,
+      } satisfies bp.events.continueWorkflow.ContinueWorkflow,
+    })
+  }
+
   public async respond({ text, userId }: RespondProps): Promise<void> {
     await this._props.client.createMessage({
       userId: this._props.ctx.botId,

--- a/plugins/hitl/src/hooks/before-incoming-event/hitl-stopped.ts
+++ b/plugins/hitl/src/hooks/before-incoming-event/hitl-stopped.ts
@@ -29,5 +29,11 @@ export const handleEvent: bp.HookHandlers['before_incoming_event']['hitl:hitlSto
     downstreamCm.setHitlInactive(conv.HITL_END_REASON.AGENT_CLOSED_TICKET),
     upstreamCm.setHitlInactive(conv.HITL_END_REASON.AGENT_CLOSED_TICKET),
   ])
+
+  if (props.configuration.flowOnHitlStopped) {
+    // the bot will continue the conversation without the patient having to send another message
+    await upstreamCm.continueWorkflow()
+  }
+
   return consts.STOP_EVENT_HANDLING
 }

--- a/plugins/hitl/src/hooks/before-incoming-event/hitl-stopped.ts
+++ b/plugins/hitl/src/hooks/before-incoming-event/hitl-stopped.ts
@@ -30,10 +30,7 @@ export const handleEvent: bp.HookHandlers['before_incoming_event']['hitl:hitlSto
     upstreamCm.setHitlInactive(conv.HITL_END_REASON.AGENT_CLOSED_TICKET),
   ])
 
-  if (props.configuration.flowOnHitlStopped) {
-    // the bot will continue the conversation without the patient having to send another message
-    await upstreamCm.continueWorkflow()
-  }
+  // TODO: possibly send the workflowContinue event here
 
   return consts.STOP_EVENT_HANDLING
 }

--- a/plugins/hitl/src/hooks/before-incoming-event/hitl-stopped.ts
+++ b/plugins/hitl/src/hooks/before-incoming-event/hitl-stopped.ts
@@ -30,7 +30,10 @@ export const handleEvent: bp.HookHandlers['before_incoming_event']['hitl:hitlSto
     upstreamCm.setHitlInactive(conv.HITL_END_REASON.AGENT_CLOSED_TICKET),
   ])
 
-  // TODO: possibly send the workflowContinue event here
+  if (props.configuration.flowOnHitlStopped) {
+    // the bot will continue the conversation without the patient having to send another message
+    await upstreamCm.continueWorkflow()
+  }
 
   return consts.STOP_EVENT_HANDLING
 }

--- a/plugins/hitl/src/hooks/before-incoming-event/human-agent-assigned-timeout.ts
+++ b/plugins/hitl/src/hooks/before-incoming-event/human-agent-assigned-timeout.ts
@@ -36,6 +36,12 @@ export const handleEvent: bp.HookHandlers['before_incoming_event']['humanAgentAs
   }
 
   await _handleTimeout(props, upstreamCm, downstreamCm)
+
+  if (props.configuration.flowOnHitlStopped) {
+    // the bot will continue the conversation without the patient having to send another message
+    await upstreamCm.continueWorkflow()
+  }
+
   return consts.STOP_EVENT_HANDLING
 }
 

--- a/plugins/hitl/src/hooks/before-incoming-message/all.ts
+++ b/plugins/hitl/src/hooks/before-incoming-message/all.ts
@@ -99,6 +99,12 @@ const _handleUpstreamMessage = async (
 
   if (_isHitlCloseCommand(props)) {
     await _handleHitlCloseCommand(props, { downstreamCm, upstreamCm })
+
+    if (props.configuration.flowOnHitlStopped) {
+      // the bot will continue the conversation without the patient having to send another message
+      await upstreamCm.continueWorkflow()
+    }
+
     return consts.STOP_EVENT_HANDLING
   }
 


### PR DESCRIPTION
Multiple clients requested this feature. Without it, once the HITL session ends, the user needs to send a new message for the upstream flow to keep executing. This feature allows the bot to keep flowing without the need for the user to send a new message.