### PR TITLE
chore: deploy file synchronizer in production

### DIFF
--- a/.github/workflows/deploy-integrations-production.yml
+++ b/.github/workflows/deploy-integrations-production.yml
@@ -40,7 +40,7 @@ jobs:
         uses: ./.github/actions/deploy-plugins
         with:
           environment: 'production'
-          extra_filter: "-F '!analytics' -F '!file-synchronizer' -F '!logger' -F '!personality' -F '!synchronizer' -F '!knowledge'"
+          extra_filter: "-F '!analytics' -F '!logger' -F '!personality' -F '!synchronizer' -F '!knowledge'"
           force: ${{ github.event.inputs.force == 'true' }}
           token_cloud_ops_account: ${{ secrets.PRODUCTION_TOKEN_CLOUD_OPS_ACCOUNT }}
           cloud_ops_workspace_id: ${{ secrets.PRODUCTION_CLOUD_OPS_WORKSPACE_ID }}


### PR DESCRIPTION
The file-synchronizer plugin is feature-flagged in the hub frontend, so this is not an official release. We'll first give certain users early access to test it out.