### PR TITLE
feat(hitl,zendesk)!: implement media messages

### DIFF
--- a/bots/hit-looper/bot.definition.ts
+++ b/bots/hit-looper/bot.definition.ts
@@ -37,7 +37,7 @@ export default new sdk.BotDefinition({
     },
   })
   .addPlugin(hitl, {
-    configuration: {},
+    configuration: { flowOnHitlStopped: false },
     interfaces: {
       hitl: {
         id: zendesk.id,

--- a/integrations/zendesk/integration.definition.ts
+++ b/integrations/zendesk/integration.definition.ts
@@ -7,7 +7,7 @@ import { actions, events, configuration, channels, states, user } from './src/de
 export default new IntegrationDefinition({
   name: 'zendesk',
   title: 'Zendesk',
-  version: '1.1.1',
+  version: '2.0.0',
   icon: 'icon.svg',
   description:
     'Optimize your support workflow. Trigger workflows from ticket updates as well as manage tickets, access conversations, and engage with customers.',

--- a/integrations/zendesk/src/actions/close-ticket.ts
+++ b/integrations/zendesk/src/actions/close-ticket.ts
@@ -5,7 +5,7 @@ import * as bp from '.botpress'
 export const closeTicket: bp.IntegrationProps['actions']['closeTicket'] = async ({ ctx, input }) => {
   const originalTicket = await getZendeskClient(ctx.configuration).getTicket(input.ticketId)
 
-  const ticket = await getZendeskClient(ctx.configuration).updateTicket(input.ticketId, {
+  const { ticket } = await getZendeskClient(ctx.configuration).updateTicket(input.ticketId, {
     comment: {
       body: input.comment,
       author_id: originalTicket.requester_id,

--- a/integrations/zendesk/src/actions/hitl.ts
+++ b/integrations/zendesk/src/actions/hitl.ts
@@ -90,12 +90,7 @@ export const stopHitl: bp.IntegrationProps['actions']['stopHitl'] = async ({ ctx
   const zendeskClient = getZendeskClient(ctx.configuration)
 
   try {
-    const originalTicket = await zendeskClient.getTicket(ticketId)
     await zendeskClient.updateTicket(ticketId, {
-      comment: {
-        body: input.reason,
-        author_id: originalTicket.requester_id,
-      },
       status: 'closed',
     })
     return {}

--- a/integrations/zendesk/src/channels.ts
+++ b/integrations/zendesk/src/channels.ts
@@ -1,3 +1,4 @@
+import * as bpCommon from '@botpress/common'
 import * as sdk from '@botpress/sdk'
 import { getZendeskClient } from './client'
 import * as bp from '.botpress'
@@ -29,22 +30,77 @@ class Tags<T extends Record<string, string>> {
   }
 }
 
+const wrapChannel = bpCommon.createChannelWrapper<bp.IntegrationProps>()({
+  toolFactories: {
+    ticketId: ({ conversation, logger }) => Tags.of(conversation, logger).get('id'),
+    zendeskAuthorId: async ({ client, logger, payload, user }) =>
+      Tags.of((await client.getUser({ id: payload.userId ?? user.id })).user, logger).get('id'),
+    zendeskClient: ({ ctx }) => getZendeskClient(ctx.configuration),
+  },
+})
+
 export default {
   hitl: {
     messages: {
-      text: async ({ client, ...props }) => {
-        const { text, userId } = props.payload
+      text: wrapChannel(
+        { channelName: 'hitl', messageType: 'text' },
+        async ({ ack, payload, ticketId, zendeskAuthorId, zendeskClient }) => {
+          const { zendeskCommentId } = await zendeskClient.createPlaintextComment(
+            ticketId,
+            zendeskAuthorId,
+            payload.text
+          )
+          await ack({ tags: { zendeskCommentId: String(zendeskCommentId) } })
+        }
+      ),
 
-        const conversationTags = Tags.of(props.conversation, props.logger)
-        const ticketId = conversationTags.get('id')
+      image: wrapChannel(
+        { channelName: 'hitl', messageType: 'image' },
+        async ({ ack, payload, ticketId, zendeskAuthorId, zendeskClient }) => {
+          const { zendeskCommentId } = await zendeskClient.createPlaintextComment(
+            ticketId,
+            zendeskAuthorId,
+            payload.imageUrl
+          )
+          await ack({ tags: { zendeskCommentId: String(zendeskCommentId) } })
+        }
+      ),
 
-        const bpUserId = userId ?? props.user.id
-        const { user } = await client.getUser({ id: bpUserId })
-        const userTags = Tags.of(user, props.logger)
-        const zendeskAuthorId = userTags.get('id')
+      audio: wrapChannel(
+        { channelName: 'hitl', messageType: 'audio' },
+        async ({ ack, payload, ticketId, zendeskAuthorId, zendeskClient }) => {
+          const { zendeskCommentId } = await zendeskClient.createPlaintextComment(
+            ticketId,
+            zendeskAuthorId,
+            payload.audioUrl
+          )
+          await ack({ tags: { zendeskCommentId: String(zendeskCommentId) } })
+        }
+      ),
 
-        return await getZendeskClient(props.ctx.configuration).createComment(ticketId, zendeskAuthorId, text)
-      },
+      video: wrapChannel(
+        { channelName: 'hitl', messageType: 'video' },
+        async ({ ack, payload, ticketId, zendeskAuthorId, zendeskClient }) => {
+          const { zendeskCommentId } = await zendeskClient.createPlaintextComment(
+            ticketId,
+            zendeskAuthorId,
+            payload.videoUrl
+          )
+          await ack({ tags: { zendeskCommentId: String(zendeskCommentId) } })
+        }
+      ),
+
+      file: wrapChannel(
+        { channelName: 'hitl', messageType: 'file' },
+        async ({ ack, payload, ticketId, zendeskAuthorId, zendeskClient }) => {
+          const { zendeskCommentId } = await zendeskClient.createPlaintextComment(
+            ticketId,
+            zendeskAuthorId,
+            payload.fileUrl
+          )
+          await ack({ tags: { zendeskCommentId: String(zendeskCommentId) } })
+        }
+      ),
     },
   },
 } satisfies bp.IntegrationProps['channels']

--- a/interfaces/hitl/interface.definition.ts
+++ b/interfaces/hitl/interface.definition.ts
@@ -1,109 +1,161 @@
-/* bplint-disable */
-import { z, AnyZodObject, messages, InterfaceDefinition } from '@botpress/sdk'
+import * as sdk from '@botpress/sdk'
 
-const withUserId = <S extends z.AnyZodObject>(s: { schema: S }) => ({
+type AnyMessageType = (typeof sdk.messages.defaults)[keyof typeof sdk.messages.defaults]
+const withUserId = (s: AnyMessageType) => ({
   ...s,
   schema: () =>
     s.schema.extend({
-      userId: z.string().optional().describe('Allows sending a message pretending to be a certain user'),
+      userId: sdk.z.string().optional().describe('Allows sending a message pretending to be a certain user'),
     }),
 })
 
-const messageSourceSchema = z.union([
-  z.object({ type: z.literal('user'), userId: z.string() }),
-  z.object({ type: z.literal('bot') }),
+const messageSourceSchema = sdk.z.union([
+  sdk.z.object({ type: sdk.z.literal('user'), userId: sdk.z.string() }),
+  sdk.z.object({ type: sdk.z.literal('bot') }),
 ])
 
 const allMessages = {
-  ...messages.defaults,
-  markdown: messages.markdown,
-} satisfies Record<string, { schema: AnyZodObject }>
+  ...sdk.messages.defaults,
+  markdown: sdk.messages.markdown,
+} satisfies Record<string, { schema: sdk.AnyZodObject }>
 
 type Tuple<T> = [T, T, ...T[]]
-const messagePayloadSchemas: AnyZodObject[] = Object.entries(allMessages).map(([k, v]) =>
-  z.object({
+const messagePayloadSchemas: sdk.AnyZodObject[] = Object.entries(allMessages).map(([k, v]) =>
+  sdk.z.object({
     source: messageSourceSchema,
-    type: z.literal(k),
+    type: sdk.z.literal(k),
     payload: v.schema,
   })
 )
 
-const messageSchema = z.union(messagePayloadSchemas as Tuple<AnyZodObject>)
+const messageSchema = sdk.z.union(messagePayloadSchemas as Tuple<sdk.AnyZodObject>)
 
-export default new InterfaceDefinition({
+export default new sdk.InterfaceDefinition({
   name: 'hitl',
-  version: '0.4.0',
+  version: '1.0.0',
   entities: {},
   events: {
     hitlAssigned: {
       schema: () =>
-        z.object({
-          conversationId: z.string(),
-          userId: z.string(),
+        sdk.z.object({
+          // Also known as downstreamConversationId:
+          conversationId: sdk.z
+            .string()
+            .title('HITL session ID')
+            .describe('ID of the Botpress conversation representing the HITL session'),
+
+          // Also known as humanAgentUserId:
+          userId: sdk.z
+            .string()
+            .title('Human agent user ID')
+            .describe('ID of the Botpress user representing the human agent assigned to the HITL session'),
         }),
     },
     hitlStopped: {
       schema: () =>
-        z.object({
-          conversationId: z.string(),
+        sdk.z.object({
+          // Also known as downstreamConversationId:
+          conversationId: sdk.z
+            .string()
+            .title('HITL session ID')
+            .describe('ID of the Botpress conversation representing the HITL session'),
         }),
     },
   },
   actions: {
     // TODO: allow for an interface to extend 'proactiveUser' and reuse its actions
     createUser: {
+      title: 'Create external user', // <= this is a downstream user
+      description: 'Create an end user in the external service and in Botpress',
       input: {
         schema: () =>
-          z.object({
-            name: z.string().optional(),
-            pictureUrl: z.string().optional(),
-            email: z.string().optional(),
+          sdk.z.object({
+            name: sdk.z.string().title('Display name').describe('Display name of the end user'),
+            pictureUrl: sdk.z.string().title('Picture URL').describe("URL of the end user's avatar").optional(),
+            email: sdk.z.string().title('Email address').describe('Email address of the end user').optional(),
           }),
       },
       output: {
         schema: () =>
-          z.object({
-            userId: z.string(),
+          sdk.z.object({
+            userId: sdk.z
+              .string()
+              .title('Botpress user ID')
+              .describe('ID of the Botpress user representing the end user'),
           }),
       },
     },
     startHitl: {
+      title: 'Start new HITL session', // <= this is a downstream conversation / ticket
+      description: 'Create a new HITL session in the external service and in Botpress',
       input: {
         schema: () =>
-          z.object({
-            userId: z.string(),
-            title: z.string(),
-            description: z.string().optional(),
-            messageHistory: z
+          sdk.z.object({
+            // Also known as downstreamUserId:
+            userId: sdk.z.string().title('User ID').describe('ID of the Botpress user representing the end user'),
+
+            // Ticket title:
+            title: sdk.z
+              .string()
+              .title('Title')
+              .describe('Title of the HITL session. This corresponds to a ticket title in systems that use tickets.')
+              .optional(),
+
+            // Ticket description:
+            description: sdk.z
+              .string()
+              .title('Description')
+              .describe(
+                'Description of the HITL session. This corresponds to a ticket description in systems that use tickets.'
+              )
+              .optional(),
+
+            // All messages sent prior to HITL session creation:
+            messageHistory: sdk.z
               .array(messageSchema)
-              .optional()
-              .describe('Message history to display in the HITL session'),
+              .title('Conversation history')
+              .describe(
+                'History of all messages in the conversation up to this point. Should be displayed to the human agent in the external service.'
+              ),
           }),
       },
       output: {
         schema: () =>
-          z.object({
-            conversationId: z.string(),
+          sdk.z.object({
+            // Also known as downstreamConversationId:
+            conversationId: sdk.z
+              .string()
+              .title('HITL session ID')
+              .describe('ID of the Botpress conversation representing the HITL session'),
           }),
       },
     },
     stopHitl: {
+      title: 'Stop HITL session',
+      description: 'Stop an existing HITL session in the external service',
       input: {
         schema: () =>
-          z.object({
-            conversationId: z.string(),
-            reason: z.enum(['timeout', 'cancel']).optional(),
+          sdk.z.object({
+            // Also known as downstreamConversationId:
+            conversationId: sdk.z
+              .string()
+              .title('HITL session ID')
+              .describe('ID of the Botpress conversation representing the HITL session'),
           }),
       },
       output: {
-        schema: () => z.object({}),
+        schema: () => sdk.z.object({}),
       },
     },
   },
   channels: {
     hitl: {
       messages: {
-        text: withUserId(messages.defaults.text),
+        text: withUserId(sdk.messages.defaults.text),
+        image: withUserId(sdk.messages.defaults.image),
+        audio: withUserId(sdk.messages.defaults.audio),
+        video: withUserId(sdk.messages.defaults.video),
+        file: withUserId(sdk.messages.defaults.file),
       },
     },
   },

--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -7,7 +7,7 @@ export const DEFAULT_HUMAN_AGENT_ASSIGNED_MESSAGE = 'A human agent has joined th
 export const DEFAULT_HITL_STOPPED_MESSAGE = 'The human agent closed the conversation. I will continue assisting you.'
 export const DEFAULT_USER_HITL_CANCELLED_MESSAGE = '( The user has ended the session. )'
 export const DEFAULT_INCOMPATIBLE_MSGTYPE_MESSAGE =
-  'Sorry, the user can only receive text messages. Please resend your message as a text message.'
+  'Sorry, the user can not receive this type of message. Please resend your message as a text message.'
 export const DEFAULT_USER_HITL_CLOSE_COMMAND = '/end'
 export const DEFAULT_USER_HITL_COMMAND_MESSAGE =
   'You have ended the session with the human agent. I will continue assisting you.'
@@ -16,7 +16,7 @@ export const DEFAULT_AGENT_ASSIGNED_TIMEOUT_MESSAGE =
 
 export default new sdk.PluginDefinition({
   name: 'hitl',
-  version: '0.5.0',
+  version: '0.7.0',
   title: 'Human In The Loop',
   description: 'Seamlessly transfer conversations to human agents',
   icon: 'icon.svg',
@@ -38,13 +38,13 @@ export default new sdk.PluginDefinition({
       onHitlStoppedMessage: sdk.z
         .string()
         .title('Escalation Terminated Message')
-        .describe('The message to send to the user when the hitl session stops and control is tranfered back to bot')
+        .describe('The message to send to the user when the HITL session stops and control is transferred back to bot')
         .optional()
         .placeholder(DEFAULT_HITL_STOPPED_MESSAGE),
       onUserHitlCancelledMessage: sdk.z
         .string()
         .title('Escalation Aborted Message')
-        .describe('The message to send to the human agent when the user abruptly ends the hitl session')
+        .describe('The message to send to the human agent when the user abruptly ends the HITL session')
         .optional()
         .placeholder(DEFAULT_USER_HITL_CANCELLED_MESSAGE),
       onIncompatibleMsgTypeMessage: sdk.z
@@ -59,14 +59,14 @@ export default new sdk.PluginDefinition({
         .string()
         .title('Termination Command')
         .describe(
-          'Users may send this command to end the hitl session at any time. It is case-insensitive, so it works regardless of letter casing.'
+          'Users may send this command to end the HITL session at any time. It is case-insensitive, so it works regardless of letter casing.'
         )
         .optional()
         .placeholder(DEFAULT_USER_HITL_CLOSE_COMMAND),
       onUserHitlCloseMessage: sdk.z
         .string()
         .title('Termination Command Message')
-        .describe('The message to send to the user when they end the hitl session using the termination command')
+        .describe('The message to send to the user when they end the HITL session using the termination command')
         .optional()
         .placeholder(DEFAULT_USER_HITL_COMMAND_MESSAGE),
       onAgentAssignedTimeoutMessage: sdk.z
@@ -87,8 +87,10 @@ export default new sdk.PluginDefinition({
       flowOnHitlStopped: sdk.z
         .boolean()
         .default(true)
-        .title('Flow on HITL Stopped')
-        .describe('Weither to wait for the user to respond to continue the flow after the hitl session'),
+        .title('Continue Flow on Session End?')
+        .describe(
+          'Enable this to continue the flow when the HITL session ends. Otherwise, the flow waits for user input.'
+        ),
     }),
   },
   actions: {
@@ -146,11 +148,11 @@ export default new sdk.PluginDefinition({
     tags: {
       downstream: {
         title: 'Downstream User ID',
-        description: 'ID of the downstream user binded to the upstream one',
+        description: 'ID of the downstream user bound to the upstream one',
       },
       upstream: {
         title: 'Upstream User ID',
-        description: 'ID of the upstream user binded to the downstream one',
+        description: 'ID of the upstream user bound to the downstream one',
       },
       integrationName: {
         title: 'HITL Integration Name',
@@ -162,11 +164,11 @@ export default new sdk.PluginDefinition({
     tags: {
       downstream: {
         title: 'Downstream Conversation ID',
-        description: 'ID of the downstream conversation binded to the upstream one',
+        description: 'ID of the downstream conversation bound to the upstream one',
       },
       upstream: {
         title: 'Upstream Conversation ID',
-        description: 'ID of the upstream conversation binded to the downstream one',
+        description: 'ID of the upstream conversation bound to the downstream one',
       },
       humanAgentId: {
         title: 'Human Agent ID',
@@ -204,7 +206,7 @@ export default new sdk.PluginDefinition({
     },
     continueWorkflow: {
       schema: sdk.z.object({
-        conversationId: sdk.z.string().title('Conversation ID').describe('ID of the conversation'),
+        conversationId: sdk.z.string().title('Upstream Conversation ID').describe('ID of the upstream conversation'),
       }),
     },
   },

--- a/plugins/hitl/src/actions/start-hitl.ts
+++ b/plugins/hitl/src/actions/start-hitl.ts
@@ -66,9 +66,7 @@ export const startHitl: bp.PluginProps['actions']['startHitl'] = async (props) =
 }
 
 const _sendHandoffMessage = (props: Props, upstreamCm: conv.ConversationManager): Promise<void> =>
-  upstreamCm.respond({
-    text: props.configuration.onHitlHandoffMessage ?? DEFAULT_HITL_HANDOFF_MESSAGE,
-  })
+  upstreamCm.respond({ type: 'text', text: props.configuration.onHitlHandoffMessage ?? DEFAULT_HITL_HANDOFF_MESSAGE })
 
 const _buildMessageHistory = async (
   props: Props,
@@ -103,7 +101,7 @@ const _buildMessageHistory = async (
 const _createDownstreamConversation = async (
   props: Props,
   downstreamUserId: string,
-  input: StartHitlInput,
+  input: Omit<StartHitlInput, 'messageHistory'>,
   messageHistory: MessageHistoryElement[]
 ): Promise<string> => {
   // Call startHitl in the hitl integration (zendesk, etc.):

--- a/plugins/hitl/src/actions/stop-hitl.ts
+++ b/plugins/hitl/src/actions/stop-hitl.ts
@@ -23,6 +23,7 @@ export const stopHitl: bp.PluginProps['actions']['stopHitl'] = async (props) => 
   const downstreamCm = conv.ConversationManager.from(props, downstreamConversationId)
 
   await downstreamCm.respond({
+    type: 'text',
     text: props.configuration.onUserHitlCancelledMessage ?? DEFAULT_USER_HITL_CANCELLED_MESSAGE,
   })
 

--- a/plugins/hitl/src/consts.ts
+++ b/plugins/hitl/src/consts.ts
@@ -1,0 +1,9 @@
+import * as sdk from '@botpress/sdk'
+
+export const SUPPORTED_MESSAGE_TYPES = [
+  'text',
+  'image',
+  'video',
+  'audio',
+  'file',
+] as const satisfies (keyof typeof sdk.messages.defaults)[]

--- a/plugins/hitl/src/conv-manager.ts
+++ b/plugins/hitl/src/conv-manager.ts
@@ -5,11 +5,6 @@ type HitlState = bp.states.hitl.Hitl['payload']
 
 const DEFAULT_STATE: HitlState = { hitlActive: false }
 
-export type RespondProps = {
-  text: string
-  userId?: string
-}
-
 export const HITL_END_REASON = {
   // PATIENT_LEFT: 'patient-left',
   PATIENT_USED_TERMINATION_COMMAND: 'patient-used-termination-command',
@@ -71,19 +66,19 @@ export class ConversationManager {
     })
   }
 
-  public async respond({ text, userId }: RespondProps): Promise<void> {
+  public async respond(messagePayload: types.MessagePayload): Promise<void> {
     await this._props.client.createMessage({
       userId: this._props.ctx.botId,
       conversationId: this._convId,
-      type: 'text',
-      payload: { text, userId },
+      type: messagePayload.type,
+      payload: { ...messagePayload },
       tags: {},
     })
   }
 
   public async abortHitlSession(errorMessage: string): Promise<void> {
     await this.setHitlInactive(HITL_END_REASON.INTERNAL_ERROR)
-    await this.respond({ text: errorMessage })
+    await this.respond({ type: 'text', text: errorMessage })
   }
 
   private async _getHitlState(): Promise<bp.states.hitl.Hitl['payload']> {

--- a/plugins/hitl/src/hooks/before-incoming-event/hitl-assigned.ts
+++ b/plugins/hitl/src/hooks/before-incoming-event/hitl-assigned.ts
@@ -28,6 +28,7 @@ export const handleEvent: bp.HookHandlers['before_incoming_event']['hitl:hitlAss
 
   await Promise.all([
     upstreamCm.respond({
+      type: 'text',
       text: props.configuration.onHumanAgentAssignedMessage ?? DEFAULT_HUMAN_AGENT_ASSIGNED_MESSAGE,
     }),
     downstreamCm.setHumanAgent(humanAgentUserId, humanAgentName),

--- a/plugins/hitl/src/hooks/before-incoming-event/hitl-stopped.ts
+++ b/plugins/hitl/src/hooks/before-incoming-event/hitl-stopped.ts
@@ -24,6 +24,7 @@ export const handleEvent: bp.HookHandlers['before_incoming_event']['hitl:hitlSto
 
   await Promise.allSettled([
     upstreamCm.respond({
+      type: 'text',
       text: props.configuration.onHitlStoppedMessage ?? DEFAULT_HITL_STOPPED_MESSAGE,
     }),
     downstreamCm.setHitlInactive(conv.HITL_END_REASON.AGENT_CLOSED_TICKET),

--- a/plugins/hitl/src/hooks/before-incoming-event/human-agent-assigned-timeout.ts
+++ b/plugins/hitl/src/hooks/before-incoming-event/human-agent-assigned-timeout.ts
@@ -69,6 +69,7 @@ const _handleTimeout = async (
 ) => {
   await downstreamCm.respond({
     // TODO: We might want to add a custom message for the human agent.
+    type: 'text',
     text: props.configuration.onUserHitlCancelledMessage ?? DEFAULT_USER_HITL_CANCELLED_MESSAGE,
   })
 
@@ -86,6 +87,7 @@ const _handleTimeout = async (
   await props.actions.hitl.stopHitl({ conversationId: downstreamCm.conversationId })
 
   await upstreamCm.respond({
+    type: 'text',
     text: props.configuration.onAgentAssignedTimeoutMessage ?? DEFAULT_AGENT_ASSIGNED_TIMEOUT_MESSAGE,
   })
 }

--- a/plugins/hitl/src/hooks/consts.ts
+++ b/plugins/hitl/src/hooks/consts.ts
@@ -1,2 +1,4 @@
+export * from '../consts'
+
 export const LET_BOT_HANDLE_EVENT = { stop: false } as const // let the event / message propagate to the bot
 export const STOP_EVENT_HANDLING = { stop: true } as const // prevent the event / message from propagating to the bot

--- a/plugins/hitl/src/types.ts
+++ b/plugins/hitl/src/types.ts
@@ -1,3 +1,5 @@
+import type * as sdk from '@botpress/sdk'
+import * as consts from './consts'
 import * as bp from '.botpress'
 
 export type AnyHandlerProps =
@@ -6,3 +8,15 @@ export type AnyHandlerProps =
   | bp.ActionHandlerProps
   | bp.HookHandlerProps['before_incoming_message']
   | bp.HookHandlerProps['before_incoming_event']
+
+export type ValueOf<T> = T[Extract<keyof T, string>]
+type ArrayToUnion<T> = T extends Array<infer U> ? U : never
+
+export type SupportedMessageTypes = ArrayToUnion<typeof consts.SUPPORTED_MESSAGE_TYPES>
+type BaseMessagePayloads = Pick<typeof sdk.messages.defaults, SupportedMessageTypes>
+export type MessagePayload = {
+  [TMsgType in keyof BaseMessagePayloads]: {
+    type: TMsgType
+    userId?: string
+  } & sdk.z.infer<BaseMessagePayloads[TMsgType]['schema']>
+}[keyof BaseMessagePayloads]


### PR DESCRIPTION
Resolves CLS-2817

Involves bumping a major for implementing integrations because I slightly refactored the HITL interface and `actions.startHitl.input.messageHistory` is no longer optional (the plugin _always_ provides the history array)

#### *Note:* this PR is quite large, so it's best to review commit by commit