### PR TITLE
chore(freshchat): update hitl

### DIFF
--- a/integrations/freshchat/integration.definition.ts
+++ b/integrations/freshchat/integration.definition.ts
@@ -6,7 +6,7 @@ import { events, configuration, channels, states, user } from './src/definitions
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   title: 'Freshchat (Beta)',
-  version: '0.0.3',
+  version: '1.0.0',
   icon: 'icon.svg',
   description: 'This integration allows your bot to use Freshchat as a HITL Provider',
   readme: 'hub.md',
@@ -24,6 +24,14 @@ export default new IntegrationDefinition({
       conversation: {
         tags: {
           id: { title: 'Freshchat Conversation Id', description: 'Freshchat Conversation Id' },
+        },
+      },
+      message: {
+        tags: {
+          id: {
+            title: 'Freshchat Message ID',
+            description: 'The ID of the message in Freshchat',
+          },
         },
       },
     },

--- a/integrations/freshchat/package.json
+++ b/integrations/freshchat/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@botpress/client": "workspace:*",
+    "@botpress/common": "workspace:*",
     "@botpress/sdk": "workspace:*",
     "@botpress/sdk-addons": "workspace:*",
     "axios": "^1.4.0"

--- a/integrations/freshchat/src/channels.ts
+++ b/integrations/freshchat/src/channels.ts
@@ -1,30 +1,109 @@
-import * as bp from '../.botpress'
+import * as bpCommon from '@botpress/common'
+import * as sdk from '@botpress/sdk'
 import { getFreshchatClient } from './client'
+import * as bp from '.botpress'
+
+const wrapChannel = bpCommon.createChannelWrapper<bp.IntegrationProps>()({
+  toolFactories: {
+    freshchatClient({ ctx, logger }) {
+      return getFreshchatClient({ ...ctx.configuration }, logger)
+    },
+
+    async freshchatUserId({ client, payload, user: attachedUser }) {
+      const user = payload.userId ? (await client.getUser({ id: payload.userId })).user : attachedUser
+      const freshchatUserId = user.tags.id
+
+      if (!freshchatUserId) {
+        throw new sdk.RuntimeError('Freshchat user id not found')
+      }
+
+      return freshchatUserId
+    },
+
+    async freshchatConversationId({ conversation }) {
+      const freshchatConversationId = conversation.tags.id
+
+      if (!freshchatConversationId) {
+        throw new sdk.RuntimeError('Freshchat conversation id not found')
+      }
+
+      return freshchatConversationId
+    },
+  },
+})
 
 export const channels = {
   hitl: {
     messages: {
-      text: async ({ client, ctx, conversation, logger, ...props }: bp.AnyMessageProps) => {
-        const freshchatClient = getFreshchatClient({ ...ctx.configuration }, logger)
-
-        const { text: userMessage, userId } = props.payload
-
-        const { user } = await client.getUser({ id: userId as string })
-
-        const freshchatUserId = user.tags.id
-        const freshchatConversationId = conversation.tags.id
-
-        if (!freshchatConversationId?.length) {
-          logger.forBot().error('No Freshchat Conversation Id')
-          return
+      text: wrapChannel(
+        { channelName: 'hitl', messageType: 'text' },
+        async ({ ack, payload, freshchatClient, freshchatUserId, freshchatConversationId }) => {
+          const freshchatMessageId = await freshchatClient.sendMessage(
+            freshchatUserId,
+            freshchatConversationId,
+            payload.text
+          )
+          await ack({
+            tags: { id: freshchatMessageId },
+          })
         }
+      ),
 
-        return await freshchatClient.sendMessage(
-          freshchatUserId as string,
-          freshchatConversationId as string,
-          userMessage
-        )
-      },
+      image: wrapChannel(
+        { channelName: 'hitl', messageType: 'image' },
+        async ({ ack, payload, freshchatClient, freshchatUserId, freshchatConversationId }) => {
+          const freshchatMessageId = await freshchatClient.sendMessage(
+            freshchatUserId,
+            freshchatConversationId,
+            payload.imageUrl
+          )
+          await ack({
+            tags: { id: freshchatMessageId },
+          })
+        }
+      ),
+
+      audio: wrapChannel(
+        { channelName: 'hitl', messageType: 'audio' },
+        async ({ ack, payload, freshchatClient, freshchatUserId, freshchatConversationId }) => {
+          const freshchatMessageId = await freshchatClient.sendMessage(
+            freshchatUserId,
+            freshchatConversationId,
+            payload.audioUrl
+          )
+          await ack({
+            tags: { id: freshchatMessageId },
+          })
+        }
+      ),
+
+      video: wrapChannel(
+        { channelName: 'hitl', messageType: 'video' },
+        async ({ ack, payload, freshchatClient, freshchatUserId, freshchatConversationId }) => {
+          const freshchatMessageId = await freshchatClient.sendMessage(
+            freshchatUserId,
+            freshchatConversationId,
+            payload.videoUrl
+          )
+          await ack({
+            tags: { id: freshchatMessageId },
+          })
+        }
+      ),
+
+      file: wrapChannel(
+        { channelName: 'hitl', messageType: 'file' },
+        async ({ ack, payload, freshchatClient, freshchatUserId, freshchatConversationId }) => {
+          const freshchatMessageId = await freshchatClient.sendMessage(
+            freshchatUserId,
+            freshchatConversationId,
+            payload.fileUrl
+          )
+          await ack({
+            tags: { id: freshchatMessageId },
+          })
+        }
+      ),
     },
   },
 } satisfies bp.IntegrationProps['channels']

--- a/integrations/freshchat/src/definitions/index.ts
+++ b/integrations/freshchat/src/definitions/index.ts
@@ -21,5 +21,6 @@ export const states = {
 export const user = {
   tags: {
     id: { description: 'Freshchat User Id', title: 'Freshchat User Id' },
+    email: { description: 'Freshchat User Email', title: 'Freshchat User Email' },
   },
 } satisfies IntegrationDefinitionProps['user']

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -637,6 +637,9 @@ importers:
       '@botpress/client':
         specifier: workspace:*
         version: link:../../packages/client
+      '@botpress/common':
+        specifier: workspace:*
+        version: link:../../packages/common
       '@botpress/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
@@ -650,9 +653,6 @@ importers:
       '@botpress/cli':
         specifier: workspace:*
         version: link:../../packages/cli
-      '@botpress/common':
-        specifier: workspace:*
-        version: link:../../packages/common
       '@botpresshub/hitl':
         specifier: workspace:*
         version: link:../../interfaces/hitl


### PR DESCRIPTION
- Rebases the integration to use the latest version of the hitl interface
  - now supports media messages 
- Very slight refactor:
  - mark conversations as resolved on stopHitl
  - allow users without email (same as zendesk)

Resolves CLS-2865