### PR TITLE
fix(cli): workspace handle empty string is equivalent to undefined

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/command-implementations/init-command.ts
+++ b/packages/cli/src/command-implementations/init-command.ts
@@ -245,7 +245,7 @@ class WorkspaceResolver {
     }
 
     const workspace = await this._promptUserToSelectWorkspace()
-    return workspace.handle ?? (await this._assignHandleToWorkspace(workspace))
+    return workspace.handle || (await this._assignHandleToWorkspace(workspace))
   }
 
   private async _fetchWorkspaces(): Promise<void> {


### PR DESCRIPTION
Don't ask me why, I don't know... see: https://github.com/botpress/skynet/pull/2898