### PR TITLE
feat(slack): allow passing legacy bot tokens

### DIFF
--- a/integrations/slack/definitions/configuration.ts
+++ b/integrations/slack/definitions/configuration.ts
@@ -35,9 +35,8 @@ export const configurations = {
       refreshToken: sdk.z
         .string()
         .secret()
-        .regex(/^xoxe[-]1/)
-        .title('Slack Bot Refresh Token')
-        .describe('Available in the app admin panel under OAuth & Permissions. Always starts with xoxe-1'),
+        .title('Slack Refresh Token or Bot Token')
+        .describe('Available in the app admin panel under OAuth & Permissions'),
       signingSecret: sdk.z
         .string()
         .secret()

--- a/integrations/slack/hub.md
+++ b/integrations/slack/hub.md
@@ -9,7 +9,7 @@ If you configured the integration using manual configuration, you will need to u
 1. Go to the Slack API portal and navigate to your app.
 2. In the "OAuth & Permissions" section, scroll down to the "Advanced token security via token rotation" section.
 3. Click "Opt In" to enable token rotation. Confirm you wish to opt in.
-4. Copy the Refresh Token and paste it into the integration settings in Botpress. You may need to refresh the page in the Slack API portal to see the new token.
+4. Copy the Refresh Token (starts with `xoxe-1-`) or legacy Bot Token (starts with `xoxb-`) and paste it into the integration settings in Botpress. You may need to refresh the page in the Slack API portal to see the new token.
 
 ## Configuration
 
@@ -51,10 +51,11 @@ If you prefer to manually configure the integration, you can provide a bot token
    - `team:read`: needed to obtain metadata on your team in order to operate on the right instance of your bot.
    - `users.profile:read`: needed to retrieve profile information for channel and DM members.
    - `users:read`: needed to obtain a list of all members of the workspace and to receive notifications when new members join the workspace.
-6. Scroll up to the "Advanced token security via token rotation " section and click "Opt In" to enable token rotation. Confirm you wish to opt in.
-7. Copy the Refresh Token. You will need it to set up the integration on Botpress. You may need to refresh the page in the Slack API portal to see the refresh token.
-8. Navigate to the "Basic Information" section of your Slack app.
-9. Copy the "Client ID", "Client Secret", and "Signing Secret". You will need them to set up the integration on Botpress.
+6. **IMPORTANT:** install your Slack app to your workspace. This is a crucial step to ensure that the bot can send and receive messages. To do this, scroll up to the "OAuth Tokens for Your Workspace" section and click "Install App to Workspace". Follow the on-screen instructions to authorize the app.
+7. Scroll up to the "Advanced token security via token rotation " section and click "Opt In" to enable token rotation. Confirm you wish to opt in.
+8. Copy the Refresh Token (starts with `xoxe-1-`) or legacy Bot Token (starts with `xoxb-`). You will need it to set up the integration on Botpress. You may need to refresh the page in the Slack API portal to see the token.
+9. Navigate to the "Basic Information" section of your Slack app.
+10. Copy the "Client ID", "Client Secret", and "Signing Secret". You will need them to set up the integration on Botpress.
 
 #### Step 2 - Setting up the integration in Botpress
 

--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -17,7 +17,7 @@ export default new IntegrationDefinition({
   name: 'slack',
   title: 'Slack',
   description: 'Automate interactions with your team.',
-  version: '2.0.1',
+  version: '2.1.0',
   icon: 'icon.svg',
   readme: 'hub.md',
   configuration,

--- a/integrations/slack/src/slack-api/slack-client.ts
+++ b/integrations/slack/src/slack-api/slack-client.ts
@@ -75,6 +75,23 @@ export class SlackClient {
     return await SlackClient._createNewInstance({ logger, oAuthClient })
   }
 
+  public static async createFromLegacyBotToken({
+    ctx,
+    client,
+    logger,
+    legacyBotToken,
+  }: {
+    client: bp.Client
+    ctx: bp.Context
+    logger: bp.Logger
+    legacyBotToken: string
+  }) {
+    const oAuthClient = new SlackOAuthClient({ ctx, client, logger })
+    await oAuthClient.requestShortLivedCredentials.fromLegacyBotToken(legacyBotToken)
+
+    return await SlackClient._createNewInstance({ logger, oAuthClient })
+  }
+
   private static async _createNewInstance({
     logger,
     oAuthClient,


### PR DESCRIPTION
Resolves DEV-2820.

- Allows using legacy bot tokens (`xoxb-`) to set up the integration. The integration then automatically exchanges the long-lived legacy token for a rotating refresh token.
- Removes the validation regex from the zod schema of the token and performs runtime checks instead to provide better error messages.
- Adds error handling to the oauth client.