### PR TITLE
fix(integrations/whatsapp): blank templateLanguage causes errors

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -22,7 +22,7 @@ const TagsForCreatingConversation = {
   templateLanguage: {
     title: 'Message Template language (optional)',
     description:
-      'Language of the Whatsapp Message Template to start the conversation with. Defaults to "en_US" (U.S. English).',
+      'Language of the Whatsapp Message Template to start the conversation with. Defaults to "en" (English).',
   },
   templateVariables: {
     title: 'Message Template variables (optional)',

--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -41,7 +41,7 @@ const commonConfigSchema = z.object({
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '3.0.0',
+  version: '3.0.1',
   title: 'WhatsApp',
   description: 'Send and receive messages through WhatsApp.',
   icon: 'icon.svg',

--- a/integrations/whatsapp/src/conversation.ts
+++ b/integrations/whatsapp/src/conversation.ts
@@ -28,7 +28,7 @@ export async function startConversation(
   }
 ): Promise<Pick<Conversation, 'id'>> {
   const { channel, phoneNumberId, userPhone, templateName, templateVariablesJson } = params
-  const templateLanguage = params.templateLanguage || 'en_US'
+  const templateLanguage = params.templateLanguage || 'en'
 
   const { client, ctx, logger } = dependencies
 


### PR DESCRIPTION
Bug found by @adkah while updating docs. I don't steal credit.

The template language is an optional field. On WhatsApp, the default template language is (English). On Botpress, our integration sets it to English-US by default. This causes errors for our users who left the template language as is. This update makes it default to _normal(?)_ English --> thus removing the error.