### PR TITLE
fix(cli): add support for public/private plugins and interfaces

### DIFF
--- a/packages/cli/e2e/tests/install-plugins.ts
+++ b/packages/cli/e2e/tests/install-plugins.ts
@@ -1,0 +1,37 @@
+import pathlib from 'path'
+import impl from '../../src/command-implementations'
+import defaults from '../defaults'
+import { Test } from '../typings'
+import * as utils from '../utils'
+
+export const installAllPlugins: Test = {
+  name: 'cli should allow installing public plugins',
+  handler: async ({ tmpDir, logger, ...creds }) => {
+    const botpressHomeDir = pathlib.join(tmpDir, '.botpresshome')
+    const baseDir = pathlib.join(tmpDir, 'plugins')
+
+    const argv = {
+      ...defaults,
+      botpressHome: botpressHomeDir,
+      confirm: true,
+      ...creds,
+    }
+
+    await impl.login({ ...argv }).then(utils.handleExitCode)
+
+    const plugins: string[] = ['hitl', 'file-synchronizer']
+
+    for (const iface of plugins) {
+      logger.info(`Installing plugin: ${iface}`)
+      await impl
+        .add({
+          ...argv,
+          packageRef: iface,
+          packageType: 'plugin',
+          installPath: baseDir,
+          useDev: false,
+        })
+        .then(utils.handleExitCode)
+    }
+  },
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/api/client.ts
+++ b/packages/cli/src/api/client.ts
@@ -1,8 +1,7 @@
 import * as client from '@botpress/client'
-import semver from 'semver'
 import yn from 'yn'
 import type { Logger } from '../logger'
-import { formatPackageRef, ApiPackageRef, NamePackageRef, isLatest } from '../package-ref'
+import { formatPackageRef, ApiPackageRef, NamePackageRef } from '../package-ref'
 import * as utils from '../utils'
 import { findPreviousIntegrationVersion } from './find-previous-version'
 import * as paging from './paging'
@@ -11,9 +10,13 @@ import {
   ApiClientProps,
   PublicIntegration,
   PrivateIntegration,
-  Integration,
-  Interface,
-  Plugin,
+  PublicOrPrivateIntegration,
+  PublicInterface,
+  PrivateInterface,
+  PublicOrPrivateInterface,
+  PrivatePlugin,
+  PublicPlugin,
+  PublicOrPrivatePlugin,
   BotSummary,
 } from './types'
 
@@ -82,15 +85,15 @@ export class ApiClient {
     return this.client.updateWorkspace({ id: this.workspaceId, ...props })
   }
 
-  public async getIntegration(ref: ApiPackageRef): Promise<Integration> {
-    const integration = await this.findIntegration(ref)
+  public async getPublicOrPrivateIntegration(ref: ApiPackageRef): Promise<PublicOrPrivateIntegration> {
+    const integration = await this.findPublicOrPrivateIntegration(ref)
     if (!integration) {
       throw new Error(`Integration "${formatPackageRef(ref)}" not found`)
     }
     return integration
   }
 
-  public async findIntegration(ref: ApiPackageRef): Promise<Integration | undefined> {
+  public async findPublicOrPrivateIntegration(ref: ApiPackageRef): Promise<PublicOrPrivateIntegration | undefined> {
     const formatted = formatPackageRef(ref)
 
     const privateIntegration = await this.findPrivateIntegration(ref)
@@ -126,16 +129,48 @@ export class ApiClient {
     if (ref.type === 'id') {
       return this.client
         .getPublicIntegrationById(ref)
-        .then((r) => r.integration)
+        .then((r) => ({ ...r.integration, public: true }) as const)
         .catch(this._returnUndefinedOnError('ResourceNotFound'))
     }
     return this.client
       .getPublicIntegration(ref)
-      .then((r) => r.integration)
+      .then((r) => ({ ...r.integration, public: true }) as const)
       .catch(this._returnUndefinedOnError('ResourceNotFound'))
   }
 
-  public async getPublicInterface(ref: ApiPackageRef): Promise<Interface> {
+  public async findPublicOrPrivateInterface(ref: ApiPackageRef): Promise<PublicOrPrivateInterface | undefined> {
+    const formatted = formatPackageRef(ref)
+
+    const privateInterface = await this.findPrivateInterface(ref)
+    if (privateInterface) {
+      this._logger.debug(`Found interface "${formatted}" in workspace`)
+      return privateInterface
+    }
+
+    const publicInterface = await this.findPublicInterface(ref)
+    if (publicInterface) {
+      this._logger.debug(`Found interface "${formatted}" in hub`)
+      return publicInterface
+    }
+
+    return
+  }
+
+  public async findPrivateInterface(ref: ApiPackageRef): Promise<PrivateInterface | undefined> {
+    const { workspaceId } = this
+    if (ref.type === 'id') {
+      return this.client
+        .getInterface(ref)
+        .then((r) => ({ ...r.interface, workspaceId }))
+        .catch(this._returnUndefinedOnError('ResourceNotFound'))
+    }
+    return this.client
+      .getInterfaceByName(ref)
+      .then((r) => ({ ...r.interface, workspaceId }))
+      .catch(this._returnUndefinedOnError('ResourceNotFound'))
+  }
+
+  public async getPublicInterface(ref: ApiPackageRef): Promise<PublicInterface> {
     const intrface = await this.findPublicInterface(ref)
     if (!intrface) {
       throw new Error(`Interface "${formatPackageRef(ref)}" not found`)
@@ -143,62 +178,64 @@ export class ApiClient {
     return intrface
   }
 
-  public async findPublicInterface(ref: ApiPackageRef): Promise<Interface | undefined> {
+  public async findPublicInterface(ref: ApiPackageRef): Promise<PublicInterface | undefined> {
     if (ref.type === 'id') {
       return this.client
-        .getInterface(ref)
-        .then((r) => r.interface)
+        .getPublicInterfaceById(ref)
+        .then((r) => ({ ...r.interface, public: true }) as const)
         .catch(this._returnUndefinedOnError('ResourceNotFound'))
     }
 
-    if (isLatest(ref)) {
-      // TODO: handle latest keyword in backend
-      return this._findLatestInterfaceVersion(ref)
-    }
-
     return this.client
-      .getInterfaceByName(ref)
-      .then((r) => r.interface)
+      .getPublicInterface(ref)
+      .then((r) => ({ ...r.interface, public: true }) as const)
       .catch(this._returnUndefinedOnError('ResourceNotFound'))
   }
 
-  public async findPublicPlugin(ref: ApiPackageRef): Promise<Plugin | undefined> {
+  public async findPublicPlugin(ref: ApiPackageRef): Promise<PublicPlugin | undefined> {
+    if (ref.type === 'id') {
+      return this.client
+        .getPublicPluginById(ref)
+        .then((r) => ({ ...r.plugin, public: true }) as const)
+        .catch(this._returnUndefinedOnError('ResourceNotFound'))
+    }
+
+    return this.client
+      .getPublicPlugin(ref)
+      .then((r) => ({ ...r.plugin, public: true }) as const)
+      .catch(this._returnUndefinedOnError('ResourceNotFound'))
+  }
+
+  public async findPublicOrPrivatePlugin(ref: ApiPackageRef): Promise<PublicOrPrivatePlugin | undefined> {
+    const formatted = formatPackageRef(ref)
+
+    const privatePlugin = await this.findPrivatePlugin(ref)
+    if (privatePlugin) {
+      this._logger.debug(`Found plugin "${formatted}" in workspace`)
+      return privatePlugin
+    }
+
+    const publicPlugin = await this.findPublicPlugin(ref)
+    if (publicPlugin) {
+      this._logger.debug(`Found plugin "${formatted}" in hub`)
+      return publicPlugin
+    }
+
+    return
+  }
+
+  public async findPrivatePlugin(ref: ApiPackageRef): Promise<PrivatePlugin | undefined> {
+    const { workspaceId } = this
     if (ref.type === 'id') {
       return this.client
         .getPlugin(ref)
-        .then((r) => r.plugin)
+        .then((r) => ({ ...r.plugin, workspaceId }))
         .catch(this._returnUndefinedOnError('ResourceNotFound'))
     }
-
-    if (isLatest(ref)) {
-      // TODO: handle latest keyword in backend
-      return this._findLatestPluginVersion(ref)
-    }
-
     return this.client
       .getPluginByName(ref)
-      .then((r) => r.plugin)
+      .then((r) => ({ ...r.plugin, workspaceId }))
       .catch(this._returnUndefinedOnError('ResourceNotFound'))
-  }
-
-  private _findLatestInterfaceVersion = async ({ name }: NamePackageRef): Promise<Interface | undefined> => {
-    const { interfaces: allVersions } = await this.client.listInterfaces({ name })
-    const sorted = allVersions.sort((a, b) => semver.compare(b.version, a.version))
-    const latestVersion = sorted[0]
-    if (!latestVersion) {
-      return
-    }
-    return this.client.getInterface({ id: latestVersion.id }).then((r) => r.interface)
-  }
-
-  private _findLatestPluginVersion = async ({ name }: NamePackageRef): Promise<Plugin | undefined> => {
-    const { plugins: allVersions } = await this.client.listPlugins({ name })
-    const sorted = allVersions.sort((a, b) => semver.compare(b.version, a.version))
-    const latestVersion = sorted[0]
-    if (!latestVersion) {
-      return
-    }
-    return this.client.getPlugin({ id: latestVersion.id }).then((r) => r.plugin)
   }
 
   public async testLogin(): Promise<void> {
@@ -207,12 +244,12 @@ export class ApiClient {
 
   public listAllPages = paging.listAllPages
 
-  public async findPreviousIntegrationVersion(ref: NamePackageRef): Promise<Integration | undefined> {
+  public async findPreviousIntegrationVersion(ref: NamePackageRef): Promise<PublicOrPrivateIntegration | undefined> {
     const previous = await findPreviousIntegrationVersion(this.client, ref)
     if (!previous) {
       return
     }
-    return this.findIntegration({ type: 'id', id: previous.id })
+    return this.findPublicOrPrivateIntegration({ type: 'id', id: previous.id })
   }
 
   public async findBotByName(name: string): Promise<BotSummary | undefined> {

--- a/packages/cli/src/api/types.ts
+++ b/packages/cli/src/api/types.ts
@@ -14,13 +14,17 @@ export type ApiClientFactory = {
   newClient: (props: ApiClientProps, logger: Logger) => ApiClient
 }
 
-export type PublicIntegration = client.Integration
+export type PublicIntegration = client.Integration & { public: true }
 export type PrivateIntegration = client.Integration & { workspaceId: string }
-export type Integration = client.Integration & { workspaceId?: string }
+export type PublicOrPrivateIntegration = client.Integration & { workspaceId?: string }
 export type IntegrationSummary = client.ClientOutputs['listIntegrations']['integrations'][number]
 export type BotSummary = client.ClientOutputs['listBots']['bots'][number]
-export type Interface = client.Interface
-export type Plugin = client.Plugin
+export type PublicInterface = client.Interface & { public: true }
+export type PrivateInterface = client.Interface & { workspaceId: string }
+export type PublicOrPrivateInterface = client.Interface & { workspaceId?: string }
+export type PublicPlugin = client.Plugin & { public: true }
+export type PrivatePlugin = client.Plugin & { workspaceId: string }
+export type PublicOrPrivatePlugin = client.Plugin & { workspaceId?: string }
 
 export type CreateBotRequestBody = client.ClientInputs['createBot']
 export type UpdateBotRequestBody = client.ClientInputs['updateBot']

--- a/packages/cli/src/command-implementations/add-command.ts
+++ b/packages/cli/src/command-implementations/add-command.ts
@@ -131,23 +131,25 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
   private async _findRemotePackage(ref: pkgRef.ApiPackageRef): Promise<InstallablePackage | undefined> {
     const api = await this.ensureLoginAndCreateClient(this.argv)
     if (this._pkgCouldBe(ref, 'integration')) {
-      const integration = await api.findIntegration(ref)
+      const integration = await api.findPublicOrPrivateIntegration(ref)
       if (integration) {
         const { name, version } = integration
         return { type: 'integration', pkg: { integration, name, version } }
       }
     }
     if (this._pkgCouldBe(ref, 'interface')) {
-      const intrface = await api.findPublicInterface(ref)
+      const intrface = await api.findPublicOrPrivateInterface(ref)
       if (intrface) {
         const { name, version } = intrface
         return { type: 'interface', pkg: { interface: intrface, name, version } }
       }
     }
     if (this._pkgCouldBe(ref, 'plugin')) {
-      const plugin = await api.findPublicPlugin(ref)
+      const plugin = await api.findPublicOrPrivatePlugin(ref)
       if (plugin) {
-        const { code } = await api.client.getPluginCode({ id: plugin.id, platform: 'node' })
+        const { code } = plugin.public
+          ? await api.client.getPublicPluginCode({ id: plugin.id, platform: 'node' })
+          : await api.client.getPluginCode({ id: plugin.id, platform: 'node' })
         const { name, version } = plugin
         return {
           type: 'plugin',

--- a/packages/cli/src/command-implementations/deploy-command.ts
+++ b/packages/cli/src/command-implementations/deploy-command.ts
@@ -58,7 +58,7 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
       throw new errors.BotpressCLIError('Readme must be a Markdown file')
     }
 
-    const integration = await api.findIntegration({ type: 'name', name, version })
+    const integration = await api.findPublicOrPrivateIntegration({ type: 'name', name, version })
     if (integration && integration.workspaceId !== api.workspaceId) {
       throw new errors.BotpressCLIError(
         `Public integration ${name} v${version} is already deployed in another workspace.`
@@ -170,7 +170,7 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
     }
 
     const { name, version } = interfaceDeclaration
-    const intrface = await api.findPublicInterface({ type: 'name', name, version })
+    const intrface = await api.findPublicOrPrivateInterface({ type: 'name', name, version })
 
     let message: string
     if (intrface) {
@@ -249,7 +249,7 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
       throw new errors.BotpressCLIError('Readme must be a Markdown file')
     }
 
-    const plugin = await api.findPublicPlugin({ type: 'name', name, version })
+    const plugin = await api.findPublicOrPrivatePlugin({ type: 'name', name, version })
 
     let message: string
     if (plugin) {

--- a/packages/cli/src/command-implementations/integration-commands.ts
+++ b/packages/cli/src/command-implementations/integration-commands.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import _ from 'lodash'
-import { ApiClient, Integration } from 'src/api/client'
+import { ApiClient, PublicOrPrivateIntegration } from 'src/api/client'
 import type commandDefinitions from '../command-definitions'
 import * as errors from '../errors'
 import { NamePackageRef, parsePackageRef } from '../package-ref'
@@ -19,7 +19,7 @@ export class GetIntegrationCommand extends GlobalCommand<GetIntegrationCommandDe
     }
 
     try {
-      const integration = await api.findIntegration(parsedRef)
+      const integration = await api.findPublicOrPrivateIntegration(parsedRef)
       if (integration) {
         this.logger.success(`Integration ${chalk.bold(this.argv.integrationRef)}:`)
         this.logger.json(integration)
@@ -92,7 +92,7 @@ export class DeleteIntegrationCommand extends GlobalCommand<DeleteIntegrationCom
   }
 
   private _findIntegration = async (api: ApiClient, parsedRef: NamePackageRef) => {
-    let integration: Integration | undefined
+    let integration: PublicOrPrivateIntegration | undefined
 
     try {
       integration = await api.findPrivateIntegration(parsedRef)

--- a/packages/cli/src/command-implementations/project-command.ts
+++ b/packages/cli/src/command-implementations/project-command.ts
@@ -343,7 +343,7 @@ export abstract class ProjectCommand<C extends ProjectCommandDefinition> extends
     api: apiUtils.ApiClient
   ): Promise<Partial<apiUtils.UpdateBotRequestBody>> {
     const integrations = await this._fetchDependencies(botDef.integrations ?? {}, ({ name, version }) =>
-      api.getIntegration({ type: 'name', name, version })
+      api.getPublicOrPrivateIntegration({ type: 'name', name, version })
     )
     return {
       integrations: _(integrations)
@@ -367,7 +367,7 @@ export abstract class ProjectCommand<C extends ProjectCommandDefinition> extends
     api: apiUtils.ApiClient
   ): Promise<Partial<apiUtils.CreatePluginRequestBody>> {
     const integrations = await this._fetchDependencies(pluginDef.integrations ?? {}, ({ name, version }) =>
-      api.getIntegration({ type: 'name', name, version })
+      api.getPublicOrPrivateIntegration({ type: 'name', name, version })
     )
     const interfaces = await this._fetchDependencies(pluginDef.interfaces ?? {}, ({ name, version }) =>
       api.getPublicInterface({ type: 'name', name, version })

--- a/packages/cli/src/package-ref.ts
+++ b/packages/cli/src/package-ref.ts
@@ -32,8 +32,6 @@ export type PackageRef = ApiPackageRef | LocalPackageRef
 
 const LATEST_TAG = 'latest'
 
-export const isLatest = (ref: NamePackageRef): boolean => ref.version === LATEST_TAG
-
 export const formatPackageRef = (ref: PackageRef): string => {
   if (ref.type === 'path') {
     return ref.path


### PR DESCRIPTION
Turns out `bp add` was completely broken if the user was logged in to a personal workspace and trying to add a public plugin since the cdm operation no longer returns plugins from other workspaces.