### PR TITLE
chore(sdk): use the rate limit retry time provided by the backend

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.1",
     "@botpress/client": "1.11.0",
-    "@botpress/sdk": "4.4.1",
+    "@botpress/sdk": "4.4.2",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.11.0",
-    "@botpress/sdk": "4.4.1"
+    "@botpress/sdk": "4.4.2"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.11.0",
-    "@botpress/sdk": "4.4.1"
+    "@botpress/sdk": "4.4.2"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "4.4.1"
+    "@botpress/sdk": "4.4.2"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.11.0",
-    "@botpress/sdk": "4.4.1"
+    "@botpress/sdk": "4.4.2"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.11.0",
-    "@botpress/sdk": "4.4.1",
+    "@botpress/sdk": "4.4.2",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/retry.test.ts
+++ b/packages/sdk/src/retry.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { retryConfig } from './retry'
+
+const retryDelay = retryConfig.retryDelay!
+
+describe.concurrent('retryConfig', () => {
+  it.each([
+    {
+      headers: {
+        'RateLimit-Reset': '300',
+      },
+      expectedDelay: 300_000,
+    },
+    {
+      headers: {
+        'ratelimit-reset': '300',
+      },
+      expectedDelay: 300_000,
+    },
+    {
+      headers: {
+        'X-RateLimit-Reset': '300',
+      },
+      expectedDelay: 300_000,
+    },
+    {
+      headers: {
+        'x-ratelimit-reset': '300',
+      },
+      expectedDelay: 300_000,
+    },
+    {
+      headers: {
+        'Retry-After': '300',
+      },
+      expectedDelay: 300_000,
+    },
+    {
+      headers: {
+        'retry-after': '300',
+      },
+      expectedDelay: 300_000,
+    },
+  ])('should evaluate $headers to $expectedDelay ms', ({ headers, expectedDelay }) => {
+    // Arrange
+    const axiosError = { response: { headers } } as any
+
+    // Act
+    const result = retryDelay(1, axiosError)
+
+    // Assert
+    expect(result).toEqual(expectedDelay)
+  })
+
+  it('should evaluate a date string to the correct delay', () => {
+    // Arrange
+    const delay_seconds = 300
+    const delay_ms = delay_seconds * 1000
+    const futureDate = new Date(Date.now() + delay_ms)
+    const axiosError = { response: { headers: { 'Retry-After': futureDate.toString() } } } as any
+
+    // Act
+    const result = retryDelay(1, axiosError)
+
+    // Assert
+    const jitter = 1000 // 1 second of jitter
+    expect(result).toBeGreaterThanOrEqual(delay_ms - jitter)
+    expect(result).toBeLessThanOrEqual(delay_ms + jitter)
+  })
+
+  it.each([
+    { retryCount: 1, expectedDelay: 1000 },
+    { retryCount: 2, expectedDelay: 2000 },
+    { retryCount: 3, expectedDelay: 3000 },
+  ])('should evaluate no headers with $retryCount retries to $expectedDelay ms', ({ retryCount, expectedDelay }) => {
+    // Arrange
+    const axiosError = { response: { headers: {} } } as any
+
+    // Act
+    const result = retryDelay(retryCount, axiosError)
+
+    // Assert
+    expect(result).toEqual(expectedDelay)
+  })
+})

--- a/packages/sdk/src/retry.ts
+++ b/packages/sdk/src/retry.ts
@@ -1,8 +1,61 @@
-import { RetryConfig, axiosRetry } from '@botpress/client'
+import * as client from '@botpress/client'
 
-export const retryConfig: RetryConfig = {
+export const retryConfig: client.RetryConfig = {
   retries: 3,
   retryCondition: (err) =>
-    axiosRetry.isNetworkOrIdempotentRequestError(err) || [429, 502].includes(err.response?.status ?? 0),
-  retryDelay: (retryCount) => retryCount * 1000,
+    client.axiosRetry.isNetworkOrIdempotentRequestError(err) || [429, 502].includes(err.response?.status ?? 0),
+  retryDelay: (retryCount, axiosError) => {
+    const retryAfterSeconds = _getRetryAfterSeconds(axiosError.response?.headers ?? {})
+    return (retryAfterSeconds ?? retryCount) * 1000
+  },
 }
+
+const _getRetryAfterSeconds = (headers: client.axios.RawAxiosResponseHeaders) => {
+  const headerNames = [
+    // Standard rate limiting headers:
+    'RateLimit-Reset',
+    'X-RateLimit-Reset',
+    'Retry-After',
+
+    // Lowercase variants:
+    'ratelimit-reset',
+    'x-ratelimit-reset',
+    'retry-after',
+  ] as const
+
+  for (const headerName of headerNames) {
+    const headerValue: unknown = headers[headerName]
+
+    if (headerValue === undefined) {
+      continue
+    }
+
+    const headerValueString = String(headerValue)
+
+    try {
+      // NOTE: retry-after can be either a number of seconds or a date string:
+      if (_isDateString(headerValueString)) {
+        const futureDate = new Date(headerValueString)
+
+        if (isNaN(futureDate.getTime())) {
+          continue
+        }
+
+        const currentDate = new Date()
+        const secondsDiff = Math.max(0, Math.floor((futureDate.getTime() - currentDate.getTime()) / 1000))
+
+        return secondsDiff
+      }
+
+      // If it's a number, we assume it's in seconds:
+      else if (headerValueString.length > 0) {
+        return parseInt(headerValueString, 10)
+      }
+    } catch {
+      continue
+    }
+  }
+  return
+}
+
+const _isDateString = (value: string): boolean => value.includes(' ')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1902,7 +1902,7 @@ importers:
         specifier: 1.11.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 4.4.1
+        specifier: 4.4.2
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2014,7 +2014,7 @@ importers:
         specifier: 1.11.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.4.1
+        specifier: 4.4.2
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2030,7 +2030,7 @@ importers:
         specifier: 1.11.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.4.1
+        specifier: 4.4.2
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2043,7 +2043,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 4.4.1
+        specifier: 4.4.2
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2059,7 +2059,7 @@ importers:
         specifier: 1.11.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.4.1
+        specifier: 4.4.2
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2075,7 +2075,7 @@ importers:
         specifier: 1.11.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.4.1
+        specifier: 4.4.2
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
Implements [draft-ietf-httpapi-ratelimit-headers-09](https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/) in the SDK.
Contributes to DEV-2980.