### PR TITLE
feat(sdk): integrations can't set name as prefix when calling createEvent

### DIFF
--- a/integrations/webhook/integration.definition.ts
+++ b/integrations/webhook/integration.definition.ts
@@ -4,7 +4,7 @@ import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 
 export default new IntegrationDefinition({
   name: 'webhook',
-  version: '1.1.0',
+  version: '1.1.1',
   title: 'Webhook',
   description: 'Use webhooks to send and receive data from external systems and trigger workflows.',
   icon: 'icon.svg',

--- a/integrations/webhook/src/index.ts
+++ b/integrations/webhook/src/index.ts
@@ -56,12 +56,12 @@ const integration = new bp.Integration({
     } catch {}
 
     await client.createEvent({
-      type: 'webhook:event',
+      type: 'event',
       payload: {
         body,
         query: query as Record<string, any>,
         method,
-        headers: req.headers as Record<string, any>,
+        headers: req.headers as Record<string, string>,
         path: req.path,
       },
     })

--- a/integrations/zapier/integration.definition.ts
+++ b/integrations/zapier/integration.definition.ts
@@ -5,7 +5,7 @@ import { TriggerSchema, EventSchema, ZapierTriggersStateName, ZapierTriggersStat
 
 export default new IntegrationDefinition({
   name: 'zapier',
-  version: '0.3.4',
+  version: '0.3.1',
   title: 'Zapier',
   description:
     "Trigger workflows from Zapier or let Zapier trigger your workflows to automate tasks and enhance your bot's capabilities.",

--- a/integrations/zapier/integration.definition.ts
+++ b/integrations/zapier/integration.definition.ts
@@ -5,7 +5,7 @@ import { TriggerSchema, EventSchema, ZapierTriggersStateName, ZapierTriggersStat
 
 export default new IntegrationDefinition({
   name: 'zapier',
-  version: '0.3.1',
+  version: '0.3.5',
   title: 'Zapier',
   description:
     "Trigger workflows from Zapier or let Zapier trigger your workflows to automate tasks and enhance your bot's capabilities.",

--- a/integrations/zapier/src/index.ts
+++ b/integrations/zapier/src/index.ts
@@ -105,7 +105,7 @@ async function handleIntegrationEvent(event: IntegrationEvent, ctx: bp.Context, 
 
 export async function handleEvent(event: Event, client: Client) {
   await client.createEvent({
-    type: 'zapier:event',
+    type: 'event',
     payload: event,
   })
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -22,7 +22,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.1",
     "@botpress/client": "1.12.0",
-    "@botpress/sdk": "4.5.0",
+    "@botpress/sdk": "4.6.0",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.12.0",
-    "@botpress/sdk": "4.5.0"
+    "@botpress/sdk": "4.6.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.12.0",
-    "@botpress/sdk": "4.5.0"
+    "@botpress/sdk": "4.6.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "4.5.0"
+    "@botpress/sdk": "4.6.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.12.0",
-    "@botpress/sdk": "4.5.0"
+    "@botpress/sdk": "4.6.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.12.0",
-    "@botpress/sdk": "4.5.0",
+    "@botpress/sdk": "4.6.0",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/integration/client/sub-types.ts
+++ b/packages/sdk/src/integration/client/sub-types.ts
@@ -48,13 +48,6 @@ export type TagsOfMessage<
 /**
  * @deprecated Integration's should no longer use their name as prefix for event types or tags.
  */
-export type WithRequiredPrefix<TTags extends string, TPrefix extends string> = string extends TTags
+export type WithPrefix<TTags extends string, TPrefix extends string> = string extends TTags
   ? string
   : utils.Join<[TPrefix, ':', TTags]>
-
-/**
- * @deprecated Integration's should no longer use their name as prefix for event types or tags.
- */
-export type WithOptionalPrefix<TTags extends string, TPrefix extends string> =
-  | TTags
-  | WithRequiredPrefix<TTags, TPrefix>

--- a/packages/sdk/src/integration/client/types.ts
+++ b/packages/sdk/src/integration/client/types.ts
@@ -7,7 +7,6 @@ import {
   GetChannelByName,
   GetMessageByName,
   MessageTags,
-  WithOptionalPrefix,
   WithRequiredPrefix,
   TagsOfMessage,
 } from './sub-types'
@@ -95,7 +94,7 @@ export type CreateEvent<TIntegration extends common.BaseIntegration> = <TEvent e
   x: utils.Merge<
     Arg<client.Client['createEvent']>,
     {
-      type: WithOptionalPrefix<utils.Cast<TEvent, string>, TIntegration['name']>
+      type: utils.Cast<TEvent, string>
       payload: TIntegration['events'][TEvent]
     }
   >

--- a/packages/sdk/src/integration/client/types.ts
+++ b/packages/sdk/src/integration/client/types.ts
@@ -110,7 +110,7 @@ export type ListEvents<TIntegration extends common.BaseIntegration> = (
   x: utils.Merge<
     Arg<client.Client['listEvents']>,
     {
-      type?: WithPrefix<utils.Cast<keyof TIntegration['events'], string>, TIntegration['name']>
+      type?: utils.Cast<keyof TIntegration['events'], string>
     }
   >
 ) => Res<client.Client['listEvents']>

--- a/packages/sdk/src/integration/client/types.ts
+++ b/packages/sdk/src/integration/client/types.ts
@@ -7,7 +7,7 @@ import {
   GetChannelByName,
   GetMessageByName,
   MessageTags,
-  WithRequiredPrefix,
+  WithPrefix,
   TagsOfMessage,
 } from './sub-types'
 
@@ -84,7 +84,7 @@ type EventResponse<TIntegration extends common.BaseIntegration, TEvent extends k
   event: utils.Merge<
     Awaited<Res<client.Client['getEvent']>>['event'],
     {
-      type: WithRequiredPrefix<utils.Cast<TEvent, string>, TIntegration['name']>
+      type: WithPrefix<utils.Cast<TEvent, string>, TIntegration['name']>
       payload: TIntegration['events'][TEvent]
     }
   >
@@ -110,7 +110,7 @@ export type ListEvents<TIntegration extends common.BaseIntegration> = (
   x: utils.Merge<
     Arg<client.Client['listEvents']>,
     {
-      type?: WithRequiredPrefix<utils.Cast<keyof TIntegration['events'], string>, TIntegration['name']>
+      type?: WithPrefix<utils.Cast<keyof TIntegration['events'], string>, TIntegration['name']>
     }
   >
 ) => Res<client.Client['listEvents']>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1899,7 +1899,7 @@ importers:
         specifier: 1.12.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 4.5.0
+        specifier: 4.6.0
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2011,7 +2011,7 @@ importers:
         specifier: 1.12.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.5.0
+        specifier: 4.6.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2027,7 +2027,7 @@ importers:
         specifier: 1.12.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.5.0
+        specifier: 4.6.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2040,7 +2040,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 4.5.0
+        specifier: 4.6.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2056,7 +2056,7 @@ importers:
         specifier: 1.12.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.5.0
+        specifier: 4.6.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2072,7 +2072,7 @@ importers:
         specifier: 1.12.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.5.0
+        specifier: 4.6.0
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
This is to prepare the field for [multi instance](https://github.com/botpress/engineering-handbook/pull/39)

I need to bump SDK version before merging