### PR TITLE
fix(sdk): event responses now remove integration name prefix from type

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -22,7 +22,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.1",
     "@botpress/client": "1.12.0",
-    "@botpress/sdk": "4.6.0",
+    "@botpress/sdk": "4.6.1",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.12.0",
-    "@botpress/sdk": "4.6.0"
+    "@botpress/sdk": "4.6.1"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.12.0",
-    "@botpress/sdk": "4.6.0"
+    "@botpress/sdk": "4.6.1"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "4.6.0"
+    "@botpress/sdk": "4.6.1"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.12.0",
-    "@botpress/sdk": "4.6.0"
+    "@botpress/sdk": "4.6.1"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.12.0",
-    "@botpress/sdk": "4.6.0",
+    "@botpress/sdk": "4.6.1",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/integration/client/sub-types.ts
+++ b/packages/sdk/src/integration/client/sub-types.ts
@@ -44,10 +44,3 @@ export type TagsOfMessage<
   TIntegration extends common.BaseIntegration,
   TMessageName extends keyof EnumerateMessages<TIntegration>,
 > = keyof utils.UnionToIntersection<GetMessageByName<TIntegration, TMessageName>['tags']>
-
-/**
- * @deprecated Integration's should no longer use their name as prefix for event types or tags.
- */
-export type WithPrefix<TTags extends string, TPrefix extends string> = string extends TTags
-  ? string
-  : utils.Join<[TPrefix, ':', TTags]>

--- a/packages/sdk/src/integration/client/types.ts
+++ b/packages/sdk/src/integration/client/types.ts
@@ -7,7 +7,6 @@ import {
   GetChannelByName,
   GetMessageByName,
   MessageTags,
-  WithPrefix,
   TagsOfMessage,
 } from './sub-types'
 
@@ -84,7 +83,7 @@ type EventResponse<TIntegration extends common.BaseIntegration, TEvent extends k
   event: utils.Merge<
     Awaited<Res<client.Client['getEvent']>>['event'],
     {
-      type: WithPrefix<utils.Cast<TEvent, string>, TIntegration['name']>
+      type: utils.Cast<TEvent, string>
       payload: TIntegration['events'][TEvent]
     }
   >

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1899,7 +1899,7 @@ importers:
         specifier: 1.12.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 4.6.0
+        specifier: 4.6.1
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2011,7 +2011,7 @@ importers:
         specifier: 1.12.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.6.0
+        specifier: 4.6.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2027,7 +2027,7 @@ importers:
         specifier: 1.12.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.6.0
+        specifier: 4.6.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2040,7 +2040,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 4.6.0
+        specifier: 4.6.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2056,7 +2056,7 @@ importers:
         specifier: 1.12.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.6.0
+        specifier: 4.6.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2072,7 +2072,7 @@ importers:
         specifier: 1.12.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.6.0
+        specifier: 4.6.1
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
I'm not sure whether to label this PR as a fix or a feat. Basically, since [this PR](https://github.com/botpress/skynet/pull/3010), the backend removes the event type prefix when requests are sent from an integration. This means the current SDK types are no longer valid. This PR fixes that.

This is to prepare the field for [multi instance](https://github.com/botpress/engineering-handbook/pull/39). The goal is to make the behavior of an integration **completely** independent of its name.