### PR TITLE
feat(integrations/whatsapp): Automatically download media in messages

### DIFF
--- a/integrations/whatsapp/hub.md
+++ b/integrations/whatsapp/hub.md
@@ -6,7 +6,7 @@ The WhatsApp integration allows your AI-powered chatbot to seamlessly connect wi
 
 ### Automatic downloading of media files
 
-Previously, accessing the content of media messages (such as images, videos, and audio) required authenticating with the WhatsApp API using a valid token. In version 4.0 of WhatsApp, the _Download Media_ parameter enables automatic downloading of media files. These downloaded files do not require authentication for access. However, they do count against your workspace's file storage. To continue using the WhatsApp API URLs, set the _Download Media_ parameter to disabled. The _Downloaded Media Expiry_ parameter allows you to set an expiry time for downloaded files.
+Previously, accessing the content of media messages (such as images, videos, audio and documents) required authenticating with the WhatsApp API using a valid token. In version 4.0 of WhatsApp, the _Download Media_ parameter enables automatic downloading of media files. These downloaded files do not require authentication for access. However, they do count against your workspace's file storage. To continue using the WhatsApp API URLs, set the _Download Media_ parameter to disabled. The _Downloaded Media Expiry_ parameter allows you to set an expiry time for downloaded files.
 
 ### Interactive messages values
 

--- a/integrations/whatsapp/hub.md
+++ b/integrations/whatsapp/hub.md
@@ -4,6 +4,10 @@ The WhatsApp integration allows your AI-powered chatbot to seamlessly connect wi
 
 ## Migrating from 3.x to 4.x
 
+### Automatic downloading of media files
+
+Previously, accessing the content of media messages (such as images, videos, and audio) required authenticating with the WhatsApp API using a valid token. In version 4.0 of WhatsApp, the _Download Media_ parameter enables automatic downloading of media files. These downloaded files do not require authentication for access. However, they do count against your workspace's file storage. To continue using the WhatsApp API URLs, set the _Download Media_ parameter to disabled. The _Downloaded Media Expiry_ parameter allows you to set an expiry time for downloaded files.
+
 ### Interactive messages values
 
 In version 4.0 of WhatsApp, all incoming button and list reply messages will include both the text displayed to the user (_text_) and the payload (_value_). Use `event.payload.text` to retrieve the label of a button or choice, and use `event.payload.value` to access the underlying value.

--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -11,6 +11,21 @@ const commonConfigSchema = z.object({
     .default(false)
     .title('Typing Indicator Emoji')
     .describe('Temporarily add an emoji to received messages to indicate when bot is processing message'),
+  downloadMedia: z
+    .boolean()
+    .default(true)
+    .title('Download Media')
+    .describe(
+      'Automatically download media files using the Files API for content access. If disabled, temporary WhatsApp media URLs will be used, which require authentication with a valid access token.'
+    ),
+  downloadedMediaExpiry: z
+    .number()
+    .default(24)
+    .optional()
+    .title('Downloaded Media Expiry')
+    .describe(
+      'Expiry time in hours for downloaded media files. An expiry time of 0 means the files will never expire.'
+    ),
 })
 
 const startConversationProps = {

--- a/integrations/whatsapp/src/misc/whatsapp-utils.ts
+++ b/integrations/whatsapp/src/misc/whatsapp-utils.ts
@@ -2,11 +2,31 @@ import { RuntimeError } from '@botpress/sdk'
 import { getAuthenticatedWhatsappClient } from '../auth'
 import * as bp from '.botpress'
 
-export async function getMediaUrl(whatsappMediaId: string, client: bp.Client, ctx: bp.Context): Promise<string> {
+export async function getMediaInfos(whatsappMediaId: string, client: bp.Client, ctx: bp.Context) {
   const whatsapp = await getAuthenticatedWhatsappClient(client, ctx)
   const media = await whatsapp.retrieveMedia(whatsappMediaId)
-  if (!('url' in media)) {
-    throw new RuntimeError(`Failed to retrieve media URL for media ID "${whatsappMediaId}": ${media.error.message}`)
+  if ('error' in media) {
+    throw new RuntimeError(
+      `Failed to retrieve media URL for media ID "${whatsappMediaId}": ${media.error?.message ?? 'unknown error'}`
+    )
+  } else if (!('messaging_product' in media)) {
+    throw new RuntimeError('Failed to retrieve media URL: invalid response from WhatsApp API')
   }
-  return media.url
+
+  const { url, mime_type: mimeType, file_size: fileSizeStr } = media
+  const fileSize = Number(fileSizeStr)
+  if (isNaN(fileSize)) {
+    throw new RuntimeError(`Failed to parse file size from media response: ${fileSizeStr}`)
+  }
+
+  return {
+    url,
+    mimeType,
+    fileSize,
+  }
+}
+
+export const getMediaUrl = async (whatsappMediaId: string, client: bp.Client, ctx: bp.Context) => {
+  const { url } = await getMediaInfos(whatsappMediaId, client, ctx)
+  return url
 }

--- a/integrations/whatsapp/src/webhook/handlers/messages.ts
+++ b/integrations/whatsapp/src/webhook/handlers/messages.ts
@@ -1,7 +1,9 @@
+import { RuntimeError } from '@botpress/client'
 import { ValueOf } from '@botpress/sdk/dist/utils/type-utils'
-import { getAuthenticatedWhatsappClient } from 'src/auth'
+import axios from 'axios'
+import { getAccessToken, getAuthenticatedWhatsappClient } from 'src/auth'
 import { WhatsAppMessage, WhatsAppValue, WhatsAppPayloadSchema } from '../../misc/types'
-import { getMediaUrl } from '../../misc/whatsapp-utils'
+import { getMediaInfos } from '../../misc/whatsapp-utils'
 import * as bp from '.botpress'
 
 type IncomingMessages = {
@@ -106,16 +108,16 @@ async function _handleIncomingMessage(
       payload: { latitude: Number(latitude), longitude: Number(longitude), title: name, address },
     })
   } else if (type === 'image') {
-    const imageUrl = await getMediaUrl(message.image.id, client, ctx)
+    const imageUrl = await downloadWhatsappMedia(message.image.id, client, ctx)
     await createMessage({ type, payload: { imageUrl } })
   } else if (type === 'audio') {
-    const audioUrl = await getMediaUrl(message.audio.id, client, ctx)
+    const audioUrl = await downloadWhatsappMedia(message.audio.id, client, ctx)
     await createMessage({ type, payload: { audioUrl } })
   } else if (type === 'document') {
-    const documentUrl = await getMediaUrl(message.document.id, client, ctx)
+    const documentUrl = await downloadWhatsappMedia(message.document.id, client, ctx)
     await createMessage({ type: 'file', payload: { fileUrl: documentUrl, filename: message.document.filename } })
   } else if (type === 'video') {
-    const videoUrl = await getMediaUrl(message.video.id, client, ctx)
+    const videoUrl = await downloadWhatsappMedia(message.video.id, client, ctx)
     await createMessage({ type, payload: { videoUrl } })
   } else if (message.type === 'interactive') {
     if (message.interactive.type === 'button_reply') {
@@ -136,4 +138,49 @@ async function _handleIncomingMessage(
   } else {
     logger.forBot().warn(`Unhandled message type ${type}: ${JSON.stringify(message)}`)
   }
+}
+
+// TODO: Add config to prevent downloading and use Meta's URL instead
+async function downloadWhatsappMedia(whatsappMediaId: string, client: bp.Client, ctx: bp.Context) {
+  const { url, mimeType, fileSize } = await getMediaInfos(whatsappMediaId, client, ctx)
+  const { file } = await client.upsertFile({
+    key: 'whatsapp-media_' + whatsappMediaId,
+    expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString(), // TODO: Make this configurable
+    contentType: mimeType,
+    accessPolicies: ['public_content'],
+    publicContentImmediatelyAccessible: true,
+    size: fileSize,
+    tags: {
+      source: 'integration',
+      integration: 'whatsapp',
+      channel: 'channel',
+      whatsappMediaId,
+    },
+  })
+
+  const downloadResponse = await axios
+    .get(url, {
+      responseType: 'stream',
+      headers: {
+        Authorization: `Bearer ${await getAccessToken(client, ctx)}`,
+      },
+    })
+    .catch((err) => {
+      throw new RuntimeError(`Failed to download media: ${err.message}`)
+    })
+
+  await axios
+    .put(file.uploadUrl, downloadResponse.data, {
+      headers: {
+        'Content-Type': mimeType,
+        'Content-Length': fileSize,
+        'x-amz-tagging': 'public=true',
+      },
+      maxBodyLength: fileSize,
+    })
+    .catch((err) => {
+      throw new RuntimeError(`Failed to upload media: ${err.message}`)
+    })
+
+  return file.url
 }


### PR DESCRIPTION
The media URLs returned by the WhatsApp API require authentication.
These modifications allow users to access content without intermediary
requests to authenticate with the API and download data. 

A parameter was added to disable this behavior if a user prefers not to use their file storage for media files.
Another parameter lets users set a custom expiry for downloaded files or remove the expiry entirely.
