### PR TITLE
feat(googledrive): implement file picker

### DIFF
--- a/integrations/googledrive/integration.definition.ts
+++ b/integrations/googledrive/integration.definition.ts
@@ -24,7 +24,7 @@ export default new sdk.IntegrationDefinition({
   name: 'googledrive',
   title: 'Google Drive',
   description: 'Access and manage your Google Drive files from your bot.',
-  version: '0.2.0',
+  version: '0.3.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   configuration: {
@@ -192,6 +192,9 @@ export default new sdk.IntegrationDefinition({
     },
     WEBHOOK_SECRET: {
       description: 'The secret used to sign webhook tokens. Should be a high-entropy string that only Botpress knows',
+    },
+    FILE_PICKER_API_KEY: {
+      description: 'The API key used to access the Google Picker API',
     },
   },
 }).extend(filesReadonly, ({}) => ({

--- a/integrations/googledrive/linkTemplate.vrl
+++ b/integrations/googledrive/linkTemplate.vrl
@@ -1,11 +1,4 @@
 webhookId = to_string!(.webhookId)
 webhookUrl = to_string!(.webhookUrl)
-env = to_string!(.env)
 
-clientId = "941322101941-derr0eqa571ubdb4oruinad4mds5lj5l.apps.googleusercontent.com"
-
-if env == "production" {
-  clientId = "33594073319-v5184rnc5m7rfsupek24frk6h7j30r24.apps.googleusercontent.com"
-}
-
-"https://accounts.google.com/o/oauth2/v2/auth?scope=https%3A//www.googleapis.com/auth/drive&access_type=offline&include_granted_scopes=true&response_type=code&prompt=consent&state={{ webhookId }}&redirect_uri={{ webhookUrl }}/oauth&client_id={{ clientId }}"
+"{{ webhookUrl }}/oauth/wizard/start?state={{ webhookId }}"

--- a/integrations/googledrive/package.json
+++ b/integrations/googledrive/package.json
@@ -19,7 +19,8 @@
     "@botpress/cli": "workspace:*",
     "@sentry/cli": "^2.39.1",
     "@types/jsonwebtoken": "^9.0.3",
-    "@types/uuid": "^9.0.1"
+    "@types/uuid": "^9.0.1",
+    "preact": "^10.26.6"
   },
   "bpDependencies": {
     "files-readonly": "../../interfaces/files-readonly"

--- a/integrations/googledrive/src/client.ts
+++ b/integrations/googledrive/src/client.ts
@@ -511,12 +511,19 @@ export class Client {
     return indexableContentType ?? defaultContentType
   }
 
-  private _getFilePath = async (file: BaseDiscriminatedFile): Promise<string[]> => {
+  private _getFilePath = async (file: BaseDiscriminatedFile, pathAcc?: string[]): Promise<string[]> => {
+    const path = [file.name, ...(pathAcc ?? [])]
+
     if (!file.parentId) {
-      return [file.name]
+      return path
     }
 
-    const parent = await this._getOrFetchFile(file.parentId)
-    return [...(await this._getFilePath(parent)), file.name]
+    try {
+      const parent = await this._getOrFetchFile(file.parentId)
+
+      return await this._getFilePath(parent, path)
+    } catch {
+      return path
+    }
   }
 }

--- a/integrations/googledrive/src/files-readonly/actions.ts
+++ b/integrations/googledrive/src/files-readonly/actions.ts
@@ -13,7 +13,7 @@ export const filesReadonlyActions = {
     } else if (props.input.filters?.itemType === 'folder') {
       query.push(`mimeType = '${APP_GOOGLE_FOLDER_MIMETYPE}'`)
     } else {
-      query.push(`mimeType != '${APP_GOOGLE_SHORTCUT_MIMETYPE}''`)
+      query.push(`mimeType != '${APP_GOOGLE_SHORTCUT_MIMETYPE}'`)
     }
 
     if (props.input.filters?.maxSizeInBytes) {

--- a/integrations/googledrive/src/handler.ts
+++ b/integrations/googledrive/src/handler.ts
@@ -1,4 +1,6 @@
-import { updateRefreshTokenFromAuthorizationCode } from './auth'
+import * as oauthWizard from '@botpress/common/src/oauth-wizard'
+import * as sdk from '@botpress/sdk'
+import { getAccessToken, updateRefreshTokenFromAuthorizationCode } from './auth'
 import { Client } from './client'
 import { FileChannelsCache } from './file-channels-cache'
 import { FileEventHandler } from './file-event-handler'
@@ -9,8 +11,9 @@ import * as bp from '.botpress'
 
 export const handler: bp.IntegrationProps['handler'] = async (props) => {
   const { req, client, ctx, logger } = props
-  if (req.path.startsWith('/oauth')) {
-    return await handleOAuth(props)
+
+  if (oauthWizard.isOAuthWizardUrl(req.path)) {
+    return await _handleOAuthWizard(props)
   }
 
   const notifParseResult = notificationSchema.safeParse(req)
@@ -35,21 +38,137 @@ export const handler: bp.IntegrationProps['handler'] = async (props) => {
   await notificationHandler.handle(notification)
   await filesCache.save()
   await fileChannelsCache.save()
+  return
 }
 
-export const handleOAuth = async ({ req, client, ctx }: bp.HandlerProps) => {
-  const searchParams = new URLSearchParams(req.query)
-  const authorizationCode = searchParams.get('code')
+const _handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Response> => {
+  const { client, ctx } = props
 
-  if (!authorizationCode) {
-    console.error('Error extracting code from url in OAuth handler')
-    return
-  }
+  const wizard = new oauthWizard.OAuthWizardBuilder(props)
 
-  await updateRefreshTokenFromAuthorizationCode({ authorizationCode, client, ctx })
+    .addStep({
+      id: 'start',
+      handler({ responses }) {
+        return responses.displayButtons({
+          pageTitle: 'Google Drive Integration',
+          htmlOrMarkdownPageContents: `
+              This wizard will reset your Google Drive integration. This means
+              that the integration will cease to function until you complete the
+              authorization process.
 
-  // Done in order to correctly display the authorization status in the UI (not used for webhooks)
-  client.configureIntegration({
-    identifier: ctx.webhookId,
-  })
+              Do you wish to continue?
+            `,
+          buttons: [
+            {
+              action: 'external',
+              label: 'Yes, continue',
+              navigateToUrl: _getOAuthAuthorizationUri(ctx),
+              buttonType: 'primary',
+            },
+            { action: 'close', label: 'No, cancel', buttonType: 'secondary' },
+          ],
+        })
+      },
+    })
+
+    .addStep({
+      id: 'oauth-callback',
+      async handler({ query, responses }) {
+        const authorizationCode = query.get('code')
+
+        if (!authorizationCode) {
+          console.error('Error extracting code from url in OAuth handler')
+          return responses.endWizard({
+            success: false,
+            errorMessage: 'Error extracting code from url in OAuth handler',
+          })
+        }
+
+        await updateRefreshTokenFromAuthorizationCode({ authorizationCode, client, ctx })
+
+        // Done in order to correctly display the authorization status in the UI (not used for webhooks)
+        client.configureIntegration({
+          identifier: ctx.webhookId,
+        })
+
+        return responses.redirectToStep('file-picker')
+      },
+    })
+
+    .addStep({
+      id: 'file-picker',
+      async handler({ responses, client, ctx }) {
+        return responses.displayButtons({
+          pageTitle: 'Google Drive Integration',
+          htmlOrMarkdownPageContents: `
+            You will now be asked to select the files and folders you wish to
+            grant access to. This is necessary for the integration to work
+            properly.
+
+            If you do not give access to any files or folders, the integration
+            will only be able to access files that are created through the
+            integration.
+
+            <script>
+              function createPicker() {
+                new google.picker.PickerBuilder()
+                    .addView(new google.picker.DocsView()
+                      .setIncludeFolders(true)
+                      .setSelectFolderEnabled(true)
+                      .setMode(google.picker.DocsViewMode.LIST))
+                    .enableFeature(google.picker.Feature.NAV_HIDDEN)
+                    .enableFeature(google.picker.Feature.MULTISELECT_ENABLED)
+                    .setTitle('Select the files and folders you wish to share with Botpress')
+                    .setOAuthToken('${await getAccessToken({ client, ctx })}')
+                    .setDeveloperKey('${bp.secrets.FILE_PICKER_API_KEY}')
+                    .setCallback((data) => {
+                      if (data[google.picker.Response.ACTION] == google.picker.Action.PICKED) {
+                        document.location.href = '${oauthWizard.getWizardStepUrl('end', ctx).href}';
+                      }})
+                    .setSize(640,790)
+                    .setAppId('${bp.secrets.CLIENT_ID.split('-')[0]}')
+                    .build().setVisible(true);
+              }
+            </script>
+            <script async defer src="https://apis.google.com/js/api.js" onload="gapi.load('picker')"></script>
+            `,
+          buttons: [
+            {
+              action: 'javascript',
+              label: 'Select files',
+              callFunction: 'createPicker',
+              buttonType: 'primary',
+            },
+            {
+              action: 'navigate',
+              label: 'Skip file selection',
+              navigateToStep: 'end',
+              buttonType: 'warning',
+            },
+          ],
+        })
+      },
+    })
+
+    .addStep({
+      id: 'end',
+      handler({ responses }) {
+        return responses.endWizard({
+          success: true,
+        })
+      },
+    })
+
+    .build()
+
+  return await wizard.handleRequest()
 }
+
+const _getOAuthAuthorizationUri = (ctx: { webhookId: string }) =>
+  'https://accounts.google.com/o/oauth2/v2/auth?scope=' +
+  'https%3A//www.googleapis.com/auth/drive.file&access_type=offline' +
+  '&include_granted_scopes=true&response_type=code&prompt=consent' +
+  `&state=${ctx.webhookId}&redirect_uri=${encodeURI(_getOAuthRedirectUri().href)}` +
+  `&client_id=${bp.secrets.CLIENT_ID}`
+
+const _getOAuthRedirectUri = () => oauthWizard.getWizardStepUrl('oauth-callback')

--- a/integrations/googledrive/tsconfig.json
+++ b/integrations/googledrive/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "types": ["preact"],
     "baseUrl": ".",
     "outDir": "dist"
   },

--- a/integrations/messenger/package.json
+++ b/integrations/messenger/package.json
@@ -13,10 +13,10 @@
     "@botpress/sdk": "workspace:*",
     "@botpress/sdk-addons": "workspace:*",
     "axios": "^1.6.2",
-    "marked": "^13.0.2",
+    "marked": "^15.0.1",
     "messaging-api-messenger": "^1.1.0",
-    "preact": "^10.23.1",
-    "preact-render-to-string": "^6.5.7",
+    "preact": "^10.26.6",
+    "preact-render-to-string": "^6.5.13",
     "query-string": "^6.14.1"
   },
   "devDependencies": {

--- a/integrations/pdf-generator/package.json
+++ b/integrations/pdf-generator/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@botpress/sdk": "workspace:*",
     "axios": "^1.7.2",
-    "marked": "^13.0.2"
+    "marked": "^15.0.1"
   },
   "devDependencies": {
     "@botpress/cli": "workspace:*",

--- a/integrations/whatsapp/package.json
+++ b/integrations/whatsapp/package.json
@@ -13,9 +13,9 @@
     "@botpress/sdk-addons": "workspace:*",
     "@segment/analytics-node": "^2.2.0",
     "axios": "^1.6.2",
-    "marked": "^13.0.2",
-    "preact": "^10.23.1",
-    "preact-render-to-string": "^6.5.7",
+    "marked": "^15.0.1",
+    "preact": "^10.26.6",
+    "preact-render-to-string": "^6.5.13",
     "whatsapp-api-js": "^5.3.0"
   },
   "devDependencies": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -8,6 +8,10 @@
   "dependencies": {
     "@botpress/client": "workspace:*",
     "@botpress/sdk": "workspace:*",
-    "openai": "^4.86.1"
+    "dedent": "^1.6.0",
+    "marked": "^15.0.1",
+    "openai": "^4.86.1",
+    "preact": "^10.26.6",
+    "preact-render-to-string": "^6.5.13"
   }
 }

--- a/packages/common/src/html-dialogs/components/index.ts
+++ b/packages/common/src/html-dialogs/components/index.ts
@@ -1,0 +1,2 @@
+export { default as ButtonDialogPage } from './pages/button-dialog'
+export { default as SelectDialogPage } from './pages/select-dialog'

--- a/packages/common/src/html-dialogs/components/markdown-div.tsx
+++ b/packages/common/src/html-dialogs/components/markdown-div.tsx
@@ -1,0 +1,11 @@
+import dedent from 'dedent'
+import { marked } from 'marked'
+import * as preact from 'preact'
+
+export default ({ children }: { children: preact.ComponentChild }) => (
+  <div
+    dangerouslySetInnerHTML={{
+      __html: marked.parse(dedent(String(children ?? '')), { async: false, breaks: false, gfm: true }),
+    }}
+  ></div>
+)

--- a/packages/common/src/html-dialogs/components/pages/button-dialog.tsx
+++ b/packages/common/src/html-dialogs/components/pages/button-dialog.tsx
@@ -1,0 +1,40 @@
+import MarkdownDiv from '../markdown-div'
+
+export default ({
+  helpText,
+  buttons,
+}: {
+  helpText: string
+  buttons: ({
+    label: string
+    type?: 'primary' | 'secondary' | 'danger' | 'success' | 'warning' | 'info'
+  } & ({ navigateTo: URL } | { closeWindow: true }))[]
+}) => {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+      <div style={{ maxWidth: 500, width: '100%' }}>
+        <MarkdownDiv>{helpText}</MarkdownDiv>
+        <div style={{ columnGap: 5, display: 'flex', justifyContent: 'center' }}>
+          {buttons.map((button) =>
+            'navigateTo' in button ? (
+              <a key={button.label} href={button.navigateTo.href} className={`btn btn-${button.type ?? 'primary'}`}>
+                {button.label}
+              </a>
+            ) : (
+              <a
+                key={button.label}
+                href="javascript:void(0);"
+                // @ts-ignore
+                // To allow interaction, not supported on SSR, use html attribute
+                onclick="window.close()"
+                className={`btn btn-${button.type ?? 'primary'}`}
+              >
+                {button.label}
+              </a>
+            )
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/common/src/html-dialogs/components/pages/select-dialog.tsx
+++ b/packages/common/src/html-dialogs/components/pages/select-dialog.tsx
@@ -1,0 +1,45 @@
+export default ({
+  pageTitle,
+  helpText,
+  formSubmitUrl,
+  formFieldName,
+  options,
+}: {
+  pageTitle: string
+  helpText: string
+  formSubmitUrl: URL
+  formFieldName: string
+  options: { label: string; value: string }[]
+}) => {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+      <div style={{ width: '100%', maxWidth: 500 }}>
+        <h1 className="text-center">{pageTitle}</h1>
+        <form action={formSubmitUrl.href} method="GET">
+          <div className="form-group">
+            <label htmlFor={formFieldName}>{helpText}</label>
+            <div>
+              {options.map((option) => (
+                <div key={option.value} className="form-check">
+                  <input
+                    className="form-check-input"
+                    type="radio"
+                    id={option.value}
+                    name={formFieldName}
+                    value={option.value}
+                  ></input>
+                  <label className="form-check-label" htmlFor={option.value}>
+                    {option.label}
+                  </label>
+                </div>
+              ))}
+            </div>
+          </div>
+          <button type="submit" className="btn btn-primary btn-block">
+            Submit
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/packages/common/src/html-dialogs/index.ts
+++ b/packages/common/src/html-dialogs/index.ts
@@ -1,0 +1,65 @@
+import * as sdk from '@botpress/sdk'
+import dedent from 'dedent'
+import * as preact from 'preact-render-to-string'
+import { DISABLE_INTERSTITIAL_HEADER } from '../oauth-wizard'
+import { ButtonDialogPage, SelectDialogPage } from './components'
+
+export const generateRedirection = (url: URL): sdk.Response => ({
+  status: 303,
+  headers: {
+    ...DISABLE_INTERSTITIAL_HEADER,
+    location: url.toString(),
+  },
+})
+
+type CommonDialogProps = {
+  pageTitle: string
+}
+
+export const generateButtonDialog = (props: Parameters<typeof ButtonDialogPage>[0] & CommonDialogProps): sdk.Response =>
+  _generateHtml({
+    bodyHtml: preact.render(ButtonDialogPage(props)),
+    pageTitle: props.pageTitle,
+  })
+
+export const generateSelectDialog = (props: Parameters<typeof SelectDialogPage>[0] & CommonDialogProps): sdk.Response =>
+  _generateHtml({
+    bodyHtml: preact.render(SelectDialogPage(props)),
+    pageTitle: props.pageTitle,
+  })
+
+export const generateRawHtmlDialog = (props: { bodyHtml: string; pageTitle?: string }): sdk.Response =>
+  _generateHtml({
+    bodyHtml: props.bodyHtml,
+    pageTitle: props.pageTitle,
+  })
+
+const _generateHtml = ({ bodyHtml, pageTitle }: { bodyHtml: string; pageTitle?: string }): sdk.Response => {
+  return {
+    headers: {
+      'content-type': 'text/html',
+      ...DISABLE_INTERSTITIAL_HEADER,
+    },
+    body: dedent`
+      <!DOCTYPE html>
+      <html lang="en">
+      <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>${pageTitle || 'Botpress'}</title>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css"
+          integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65"
+          rel="stylesheet" crossorigin="anonymous">
+        <style>
+          html, body {
+            height: 100%;
+          }
+        </style>
+      </head>
+      <body>
+        ${bodyHtml}
+      </body>
+      </html>
+    `,
+  }
+}

--- a/packages/common/src/oauth-wizard/consts.ts
+++ b/packages/common/src/oauth-wizard/consts.ts
@@ -1,0 +1,3 @@
+export const DISABLE_INTERSTITIAL_HEADER = { 'x-bp-disable-interstitial': 'true' } as const
+export const BASE_WIZARD_PATH = '/oauth/wizard/'
+export const CHOICE_PARAM = 'wizchoice'

--- a/packages/common/src/oauth-wizard/index.ts
+++ b/packages/common/src/oauth-wizard/index.ts
@@ -1,0 +1,4 @@
+export { OAuthWizardBuilder } from './wizard-builder'
+export { getWizardStepUrl, isOAuthWizardUrl } from './wizard-handler'
+export { CHOICE_PARAM, DISABLE_INTERSTITIAL_HEADER } from './consts'
+export type { WizardStep, WizardStepHandler } from './types'

--- a/packages/common/src/oauth-wizard/types.ts
+++ b/packages/common/src/oauth-wizard/types.ts
@@ -1,0 +1,44 @@
+import * as sdk from '@botpress/sdk'
+
+export type HandlerProps = {
+  req: { path: string; query: string }
+  ctx: {
+    webhookId: string
+  }
+}
+
+export type WizardStep<THandlerProps extends HandlerProps> = {
+  id: string
+  handler: WizardStepHandler<THandlerProps>
+}
+
+export type WizardStepHandler<THandlerProps extends HandlerProps> = (
+  props: THandlerProps & {
+    selectedChoice?: string
+    query: URLSearchParams
+    responses: {
+      redirectToStep: (stepId: string) => sdk.Response
+      redirectToExternalUrl: (url: string) => sdk.Response
+      displayChoices: (props: {
+        pageTitle: string
+        htmlOrMarkdownPageContents: string
+        choices: { label: string; value: string }[]
+        nextStepId: string
+      }) => sdk.Response
+      displayButtons: (props: {
+        pageTitle: string
+        htmlOrMarkdownPageContents: string
+        buttons: ({
+          label: string
+          buttonType?: 'primary' | 'secondary' | 'danger' | 'success' | 'warning' | 'info'
+        } & (
+          | { action: 'navigate'; navigateToStep: string }
+          | { action: 'external'; navigateToUrl: string }
+          | { action: 'javascript'; callFunction: string }
+          | { action: 'close' }
+        ))[]
+      }) => sdk.Response
+      endWizard: (result: { success: true } | { success: false; errorMessage: string }) => sdk.Response
+    }
+  }
+) => sdk.Response | Promise<sdk.Response>

--- a/packages/common/src/oauth-wizard/wizard-builder.ts
+++ b/packages/common/src/oauth-wizard/wizard-builder.ts
@@ -1,0 +1,30 @@
+import type * as types from './types'
+import * as wizardHandler from './wizard-handler'
+
+export class OAuthWizardBuilder<THandlerProps extends types.HandlerProps> {
+  private readonly _steps: Map<string, types.WizardStep<THandlerProps>> = new Map()
+
+  public constructor(private readonly _handlerProps: THandlerProps) {}
+
+  public addStep(step: types.WizardStep<THandlerProps>) {
+    this._steps.set(step.id, step)
+    return this
+  }
+
+  public removeStep(stepId: string) {
+    this._steps.delete(stepId)
+    return this
+  }
+
+  public reset() {
+    this._steps.clear()
+    return this
+  }
+
+  public build() {
+    return new wizardHandler.OAuthWizard({
+      steps: this._steps,
+      handlerProps: this._handlerProps,
+    })
+  }
+}

--- a/packages/common/src/oauth-wizard/wizard-handler.ts
+++ b/packages/common/src/oauth-wizard/wizard-handler.ts
@@ -1,0 +1,87 @@
+import * as sdk from '@botpress/sdk'
+import * as htmlDialogs from '../html-dialogs'
+import * as consts from './consts'
+import type * as types from './types'
+
+export class OAuthWizard<THandlerProps extends types.HandlerProps> {
+  private readonly _steps: Map<string, types.WizardStep<THandlerProps>>
+  private readonly _handlerProps: THandlerProps
+
+  public constructor({
+    steps,
+    handlerProps,
+  }: {
+    steps: Map<string, types.WizardStep<THandlerProps>>
+    handlerProps: THandlerProps
+  }) {
+    this._steps = steps
+    this._handlerProps = handlerProps
+  }
+
+  public async handleRequest(): Promise<sdk.Response> {
+    if (!isOAuthWizardUrl(this._handlerProps.req.path)) {
+      throw new sdk.RuntimeError('Invalid OAuth wizard URL')
+    }
+
+    const searchParams = new URLSearchParams(this._handlerProps.req.query)
+    const stepId = this._handlerProps.req.path.slice(consts.BASE_WIZARD_PATH.length)
+    const step = this._steps.get(stepId)
+
+    if (!step) {
+      throw new sdk.RuntimeError(`Unknown step ID: ${stepId}`)
+    }
+
+    return await step.handler({
+      ...this._handlerProps,
+      query: searchParams,
+      selectedChoice: searchParams.get(consts.CHOICE_PARAM) ?? undefined,
+      responses: {
+        displayButtons: ({ buttons, pageTitle, htmlOrMarkdownPageContents }) =>
+          htmlDialogs.generateButtonDialog({
+            pageTitle,
+            helpText: htmlOrMarkdownPageContents,
+            buttons: buttons.map((button) => ({
+              type: button.buttonType ?? 'primary',
+              label: button.label,
+              ...(button.action === 'close'
+                ? { closeWindow: true }
+                : button.action === 'navigate'
+                  ? { navigateTo: getWizardStepUrl(button.navigateToStep, this._handlerProps.ctx) }
+                  : button.action === 'external'
+                    ? { navigateTo: new URL(button.navigateToUrl) }
+                    : { navigateTo: new URL(`javascript:${button.callFunction}()`) }),
+            })),
+          }),
+        displayChoices: ({ choices, nextStepId, pageTitle, htmlOrMarkdownPageContents }) =>
+          htmlDialogs.generateSelectDialog({
+            formFieldName: consts.CHOICE_PARAM,
+            formSubmitUrl: getWizardStepUrl(nextStepId, this._handlerProps.ctx),
+            pageTitle,
+            helpText: htmlOrMarkdownPageContents,
+            options: choices.map((choice) => ({
+              label: choice.label,
+              value: choice.value,
+            })),
+          }),
+        redirectToStep: (stepId) => htmlDialogs.generateRedirection(getWizardStepUrl(stepId, this._handlerProps.ctx)),
+        redirectToExternalUrl: (url) => htmlDialogs.generateRedirection(new URL(url)),
+        endWizard: (result) =>
+          htmlDialogs.generateRedirection(
+            _getInterstitialUrl(result.success, result.success ? undefined : result.errorMessage)
+          ),
+      },
+    })
+  }
+}
+
+export const getWizardStepUrl = (stepId: string, ctx?: { webhookId: string }): URL =>
+  new URL(`${consts.BASE_WIZARD_PATH}${stepId}${ctx ? `?state=${ctx.webhookId}` : ''}`, process.env.BP_WEBHOOK_URL)
+
+export const isOAuthWizardUrl = (path: string): path is (typeof consts)['BASE_WIZARD_PATH'] =>
+  path.startsWith(consts.BASE_WIZARD_PATH)
+
+const _getInterstitialUrl = (success: boolean, message?: string) =>
+  new URL(
+    process.env.BP_WEBHOOK_URL?.replace('webhook', 'app') +
+      `/oauth/interstitial?success=${success}${message ? `&errorMessage=${message}` : ''}`
+  )

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,9 +1,12 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "outDir": "dist",
     "baseUrl": ".",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["preact"]
   },
   "include": ["src/**/*"]
 }

--- a/plugins/personality/package.json
+++ b/plugins/personality/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@botpress/client": "workspace:*",
     "@botpress/sdk": "workspace:*",
-    "dedent": "^1.5.3",
+    "dedent": "^1.6.0",
     "json5": "^2.2.3",
     "jsonrepair": "^3.10.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -872,6 +872,9 @@ importers:
       '@types/uuid':
         specifier: ^9.0.1
         version: 9.0.1
+      preact:
+        specifier: ^10.26.6
+        version: 10.26.6
 
   integrations/groq:
     dependencies:
@@ -1100,17 +1103,17 @@ importers:
         specifier: ^1.6.2
         version: 1.6.2
       marked:
-        specifier: ^13.0.2
-        version: 13.0.2
+        specifier: ^15.0.1
+        version: 15.0.1
       messaging-api-messenger:
         specifier: ^1.1.0
         version: 1.1.0
       preact:
-        specifier: ^10.23.1
-        version: 10.23.1
+        specifier: ^10.26.6
+        version: 10.26.6
       preact-render-to-string:
-        specifier: ^6.5.7
-        version: 6.5.7(preact@10.23.1)
+        specifier: ^6.5.13
+        version: 6.5.13(preact@10.26.6)
       query-string:
         specifier: ^6.14.1
         version: 6.14.1
@@ -1187,8 +1190,8 @@ importers:
         specifier: ^1.7.2
         version: 1.7.2
       marked:
-        specifier: ^13.0.2
-        version: 13.0.2
+        specifier: ^15.0.1
+        version: 15.0.1
     devDependencies:
       '@botpress/cli':
         specifier: workspace:*
@@ -1535,14 +1538,14 @@ importers:
         specifier: ^1.6.2
         version: 1.6.8
       marked:
-        specifier: ^13.0.2
-        version: 13.0.2
+        specifier: ^15.0.1
+        version: 15.0.1
       preact:
-        specifier: ^10.23.1
-        version: 10.23.1
+        specifier: ^10.26.6
+        version: 10.26.6
       preact-render-to-string:
-        specifier: ^6.5.7
-        version: 6.5.7(preact@10.23.1)
+        specifier: ^6.5.13
+        version: 6.5.13(preact@10.26.6)
       whatsapp-api-js:
         specifier: ^5.3.0
         version: 5.3.0
@@ -2164,9 +2167,21 @@ importers:
       '@botpress/sdk':
         specifier: workspace:*
         version: link:../sdk
+      dedent:
+        specifier: ^1.6.0
+        version: 1.6.0
+      marked:
+        specifier: ^15.0.1
+        version: 15.0.1
       openai:
         specifier: ^4.86.1
         version: 4.86.1(zod@3.22.4)
+      preact:
+        specifier: ^10.26.6
+        version: 10.26.6
+      preact-render-to-string:
+        specifier: ^6.5.13
+        version: 6.5.13(preact@10.26.6)
 
   packages/sdk:
     dependencies:
@@ -2410,8 +2425,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sdk
       dedent:
-        specifier: ^1.5.3
-        version: 1.5.3
+        specifier: ^1.6.0
+        version: 1.6.0
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -9683,8 +9698,8 @@ packages:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
     dev: true
 
-  /dedent@1.5.3:
-    resolution: {integrity: sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==}
+  /dedent@1.6.0:
+    resolution: {integrity: sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==}
     peerDependencies:
       babel-plugin-macros: ^3.1.0
     peerDependenciesMeta:
@@ -13333,8 +13348,8 @@ packages:
       uc.micro: 2.1.0
     dev: false
 
-  /marked@13.0.2:
-    resolution: {integrity: sha512-J6CPjP8pS5sgrRqxVRvkCIkZ6MFdRIjDkwUwgJ9nL2fbmM6qGQeB2C16hi8Cc9BOzj6xXzy0jyi0iPIfnMHYzA==}
+  /marked@15.0.1:
+    resolution: {integrity: sha512-VnnE19XO2Vb2oZeH8quAepfrb6Aaz4OoY8yZQACfuy/5KVJ0GxYC0Qxzz/iuc+g5UF7H0HJ+QROfvH26XeBdDA==}
     engines: {node: '>= 18'}
     hasBin: true
     dev: false
@@ -14309,17 +14324,16 @@ packages:
       xtend: 4.0.2
     dev: true
 
-  /preact-render-to-string@6.5.7(preact@10.23.1):
-    resolution: {integrity: sha512-nACZDdv/ZZciuldVYMcfGqr61DKJeaAfPx96hn6OXoBGhgtU2yGQkA0EpTzWH4SvnwF0syLsL4WK7AIp3Ruc1g==}
+  /preact-render-to-string@6.5.13(preact@10.26.6):
+    resolution: {integrity: sha512-iGPd+hKPMFKsfpR2vL4kJ6ZPcFIoWZEcBf0Dpm3zOpdVvj77aY8RlLiQji5OMrngEyaxGogeakTb54uS2FvA6w==}
     peerDependencies:
       preact: '>=10'
     dependencies:
-      preact: 10.23.1
+      preact: 10.26.6
     dev: false
 
-  /preact@10.23.1:
-    resolution: {integrity: sha512-O5UdRsNh4vdZaTieWe3XOgSpdMAmkIYBCT3VhQDlKrzyCm8lUYsk0fmVEvoQQifoOjFRTaHZO69ylrzTW2BH+A==}
-    dev: false
+  /preact@10.26.6:
+    resolution: {integrity: sha512-5SRRBinwpwkaD+OqlBDeITlRgvd8I8QlxHJw9AxSdMNV6O+LodN9nUyYGpSF7sadHjs6RzeFShMexC6DbtWr9g==}
 
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}


### PR DESCRIPTION
Resolves DEV-2975.

- Adds a generic OAuth wizard builder that can be reused for any integration.
  - I will open other PRs to update whatsapp and messenger to use the new wizard builder.
  - Updates preact to the latest version
- Implements the File Picker API, which will allow to synchronize Google Sites or any other GSuite app data
- Fixes a typo that prevented the file synchronizer plugin from enumerating files when no file type is specified