### PR TITLE
fix(file-synchronizer): ignore max size when set to 0

### DIFF
--- a/plugins/file-synchronizer/plugin.definition.ts
+++ b/plugins/file-synchronizer/plugin.definition.ts
@@ -1,70 +1,62 @@
 import * as sdk from '@botpress/sdk'
 import filesReadonly from './bp_modules/files-readonly'
 
-const FILE_FILTER_PROPS = {
-  includeFiles: sdk.z
-    .array(
-      sdk.z
-        .object({
-          pathGlobPattern: sdk.z
-            .string()
-            .describe(
-              'A glob pattern to match against the file path. Only files that match the pattern will be synchronized. Any pattern supported by picomatch is supported.'
-            ),
-          maxSizeInBytes: sdk.z
-            .number()
-            .optional()
-            .describe(
-              'Filter by maximum size (in bytes). Only files smaller than the specified size will be synchronized.'
-            ),
-          modifiedAfter: sdk.z
-            .string()
-            .datetime()
-            .optional()
-            .describe(
-              'Filter the items by modified date. Only files modified after the specified date will be synchronized.'
-            ),
-          applyOptionsToMatchedFiles: sdk.z
-            .object({
-              addToKbId: sdk.z
-                .string()
-                .optional()
-                .title('Knowledge Base ID')
-                .describe(
-                  'The ID of the knowledge base to add the file to. Note that files added to knowledge bases will count towards both the Vector DB Storage quota and the File Storage quota of the workspace.'
-                ),
-            })
-            .optional()
-            .title('Apply to Matched Files')
-            .describe('Options to apply to the matched files.'),
-        })
-        .title('Include Criteria')
-        .describe('A file must match all criteria to be synchronized.')
-    )
-    .title('Include Rules')
-    .describe('A list of rules to include files. Only files that match one or more rules will be synchronized.'),
-  excludeFiles: sdk.z
-    .array(
-      sdk.z
-        .object({
-          pathGlobPattern: sdk.z
-            .string()
-            .describe(
-              'A glob pattern to match against the file path. Files that match the pattern will be ignored, even if they match the includeFiles configuration.'
-            ),
-        })
-        .title('Exclude Criteria')
-        .describe('A file must match all exclude criteria to be ignored.')
-    )
-    .title('Exclude Rules')
-    .describe(
-      'A list of rules to exclude files. Files that match one or more rules will be ignored. This takes precedence over Include Rules.'
-    ),
-} as const
+const FILE_FILTER_PROPS = sdk.z.object({
+  includeFiles: sdk.z.array(
+    sdk.z
+      .object({
+        pathGlobPattern: sdk.z
+          .string()
+          .describe(
+            'A glob pattern to match against the file path. Only files that match the pattern will be synchronized. Any pattern supported by picomatch is supported.'
+          ),
+        maxSizeInBytes: sdk.z
+          .number()
+          .optional()
+          .describe(
+            'Filter by maximum size (in bytes). Only files smaller than the specified size will be synchronized.'
+          ),
+        modifiedAfter: sdk.z
+          .string()
+          .datetime()
+          .optional()
+          .describe(
+            'Filter the items by modified date. Only files modified after the specified date will be synchronized.'
+          ),
+        applyOptionsToMatchedFiles: sdk.z
+          .object({
+            addToKbId: sdk.z
+              .string()
+              .optional()
+              .title('Knowledge Base ID')
+              .describe(
+                'The ID of the knowledge base to add the file to. Note that files added to knowledge bases will count towards both the Vector DB Storage quota and the File Storage quota of the workspace.'
+              ),
+          })
+          .optional()
+          .title('Apply to Matched Files')
+          .describe('Options to apply to the matched files.'),
+      })
+      .title('Include Criteria')
+      .describe('A file must match all criteria to be synchronized.')
+  ),
+  excludeFiles: sdk.z.array(
+    sdk.z
+      .object({
+        pathGlobPattern: sdk.z
+          .string()
+          .describe(
+            'A glob pattern to match against the file path. Files that match the pattern will be ignored, even if they match the includeFiles configuration.'
+          ),
+      })
+      .title('Exclude Criteria')
+      .describe('A file must match all exclude criteria to be ignored.')
+  ),
+})
 
 export default new sdk.PluginDefinition({
   name: 'file-synchronizer',
-  version: '0.6.0',
+  version: '0.6.1',
   title: 'File Synchronizer',
   description: 'Synchronize files from external services to Botpress',
   icon: 'icon.svg',
@@ -77,7 +69,14 @@ export default new sdk.PluginDefinition({
         .describe(
           'Enable real-time synchronization. Whever a file is created, updated, or deleted, synchronize it to Botpress immediately. This does not work with every integration.'
         ),
-      ...FILE_FILTER_PROPS,
+      includeFiles: FILE_FILTER_PROPS.shape.includeFiles
+        .title('Include Rules')
+        .describe('A list of rules to include files. Only files that match one or more rules will be synchronized.'),
+      excludeFiles: FILE_FILTER_PROPS.shape.excludeFiles
+        .title('Exclude Rules')
+        .describe(
+          'A list of rules to exclude files. Files that match one or more rules will be ignored. This takes precedence over Include Rules.'
+        ),
     }),
   },
   actions: {
@@ -86,11 +85,11 @@ export default new sdk.PluginDefinition({
       description: 'Start synchronization of files from the external service to Botpress',
       input: {
         schema: sdk.z.object({
-          includeFiles: FILE_FILTER_PROPS.includeFiles
+          includeFiles: FILE_FILTER_PROPS.shape.includeFiles
             .title('Include Rules Override')
             .describe('If omitted, the global Include Rules will be used.')
             .optional(),
-          excludeFiles: FILE_FILTER_PROPS.excludeFiles
+          excludeFiles: FILE_FILTER_PROPS.shape.excludeFiles
             .title('Exclude Rules Override')
             .describe('If omitted, the global Exclude Rules will be used')
             .optional(),

--- a/plugins/file-synchronizer/src/actions/sync-files-to-botpress.ts
+++ b/plugins/file-synchronizer/src/actions/sync-files-to-botpress.ts
@@ -10,10 +10,18 @@ export const callAction: bp.PluginHandlers['actionHandlers']['syncFilesToBotpess
     return { status: 'already-running' }
   }
 
+  const includeFiles = props.input.includeFiles ?? props.configuration.includeFiles
+  const excludeFiles = props.input.excludeFiles ?? props.configuration.excludeFiles
+
+  props.logger.info('Syncing files to Botpress...', {
+    includeFiles,
+    excludeFiles,
+  })
+
   props.logger.info('Enumerating files...')
   const allFiles = await _enumerateAllFilesRecursive(props, {
-    includeFiles: props.input.includeFiles ?? props.configuration.includeFiles,
-    excludeFiles: props.input.excludeFiles ?? props.configuration.excludeFiles,
+    includeFiles,
+    excludeFiles,
   })
 
   if (allFiles.length === 0) {

--- a/plugins/file-synchronizer/src/sync-queue/glob-matcher.test.ts
+++ b/plugins/file-synchronizer/src/sync-queue/glob-matcher.test.ts
@@ -105,6 +105,32 @@ describe.concurrent('matchItem', () => {
       })
     })
 
+    it('should ignore maxSizeInBytes when set to 0', () => {
+      // Arrange
+      const itemPath = 'src/data/valid-file.txt'
+      const maxSizeInBytes = 0
+      const configuration = createConfiguration({
+        includeFiles: [
+          {
+            pathGlobPattern: '**/valid-*.txt',
+            maxSizeInBytes,
+          },
+        ],
+      })
+      const item = createFileItem({
+        name: 'valid-file.txt',
+        sizeInBytes: 100,
+      })
+
+      // Act
+      const result = matchItem({ configuration, item, itemPath })
+
+      // Assert
+      expect(result).toMatchObject({
+        shouldBeIgnored: false,
+      })
+    })
+
     it('should exclude when file size exceeds MAX_FILE_SIZE_BYTES', () => {
       // Arrange
       const itemPath = 'src/data/large-file.txt'

--- a/plugins/file-synchronizer/src/sync-queue/glob-matcher.ts
+++ b/plugins/file-synchronizer/src/sync-queue/glob-matcher.ts
@@ -46,7 +46,10 @@ export const matchItem = ({ configuration, item, itemPath }: GlobMatcherProps): 
 
     const isFileWithUnmetRequirements =
       item.type === 'file' &&
-      ((maxSizeInBytes !== undefined && item.sizeInBytes !== undefined && item.sizeInBytes > maxSizeInBytes) ||
+      ((maxSizeInBytes !== undefined &&
+        maxSizeInBytes > 0 &&
+        item.sizeInBytes !== undefined &&
+        item.sizeInBytes > maxSizeInBytes) ||
         (item.sizeInBytes !== undefined && item.sizeInBytes > MAX_FILE_SIZE_BYTES) ||
         (modifiedAfter !== undefined &&
           item.lastModifiedDate !== undefined &&


### PR DESCRIPTION
I was encountering an issue whilst testing google drive with the File Synchronizer plugin where it would ignore all files because they do not match include criteria, even though I did not set any criterion. Turns out the studio automagically inserts `0` as a value into fields defined as `z.number().optional()` instead of setting the value to `undefined`. This, in turn, made it so that we're effectively asking to include all files, but saying those files must have 0 bytes in size, which ends up excluding all files.

This PR thus ignores the max size when set to 0 bytes.