### PR TITLE
fix(googledrive): allow enumerating/downloading shared files

### DIFF
--- a/integrations/googledrive/integration.definition.ts
+++ b/integrations/googledrive/integration.definition.ts
@@ -24,7 +24,7 @@ export default new sdk.IntegrationDefinition({
   name: 'googledrive',
   title: 'Google Drive',
   description: 'Access and manage your Google Drive files from your bot.',
-  version: '0.3.0',
+  version: '0.3.1',
   readme: 'hub.md',
   icon: 'icon.svg',
   configuration: {

--- a/integrations/googledrive/src/validation.ts
+++ b/integrations/googledrive/src/validation.ts
@@ -75,13 +75,8 @@ export const parseBaseGeneric = (unvalidatedFile: UnvalidatedGoogleDriveFile): B
 export const parseBaseNormal = (unvalidatedFile: UnvalidatedGoogleDriveFile): BaseNormalFile => {
   const commmonFileAttr = parseCommonFileAttr(unvalidatedFile)
   const { size: sizeStr, sha256Checksum, md5Checksum, version, modifiedTime } = unvalidatedFile
-  if (!sizeStr) {
-    throw new RuntimeError(
-      `Size is missing in Schema$File from the API response for file with name=${commmonFileAttr.name}`
-    )
-  }
 
-  const size = parseInt(sizeStr)
+  const size = parseInt(sizeStr ?? '0')
   if (isNaN(size)) {
     throw new RuntimeError(
       `Invalid size returned in Schema$File from the API response for file with name=${commmonFileAttr.name} (size=${sizeStr})`


### PR DESCRIPTION
With this fix, I'm now able to sync shared files using the File Synchronizer plugin