### PR TITLE
feat(sdk,cli): add support for workflow states

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.5.4",
+  "version": "4.6.0",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -22,7 +22,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.1",
     "@botpress/client": "1.12.0",
-    "@botpress/sdk": "4.6.1",
+    "@botpress/sdk": "4.7.0",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/src/api/bot-body.ts
+++ b/packages/cli/src/api/bot-body.ts
@@ -34,10 +34,13 @@ export const prepareCreateBotBody = async (bot: sdk.BotDefinition): Promise<type
       }))
     : undefined,
   states: bot.states
-    ? await utils.records.mapValuesAsync(bot.states, async (state) => ({
-        ...state,
-        schema: await utils.schema.mapZodToJsonSchema(state),
-      }))
+    ? (utils.records.filterValues(
+        await utils.records.mapValuesAsync(bot.states, async (state) => ({
+          ...state,
+          schema: await utils.schema.mapZodToJsonSchema(state),
+        })),
+        ({ type }) => type !== 'workflow'
+      ) as types.CreateBotRequestBody['states'])
     : undefined,
 })
 

--- a/packages/cli/src/api/plugin-body.ts
+++ b/packages/cli/src/api/plugin-body.ts
@@ -42,10 +42,13 @@ export const prepareCreatePluginBody = async (
       }))
     : undefined,
   states: plugin.states
-    ? await utils.records.mapValuesAsync(plugin.states, async (state) => ({
-        ...state,
-        schema: await utils.schema.mapZodToJsonSchema(state),
-      }))
+    ? (utils.records.filterValues(
+        await utils.records.mapValuesAsync(plugin.states, async (state) => ({
+          ...state,
+          schema: await utils.schema.mapZodToJsonSchema(state),
+        })),
+        ({ type }) => type !== 'workflow'
+      ) as types.CreatePluginRequestBody['states'])
     : undefined,
 })
 

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.12.0",
-    "@botpress/sdk": "4.6.1"
+    "@botpress/sdk": "4.7.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.12.0",
-    "@botpress/sdk": "4.6.1"
+    "@botpress/sdk": "4.7.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "4.6.1"
+    "@botpress/sdk": "4.7.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.12.0",
-    "@botpress/sdk": "4.6.1"
+    "@botpress/sdk": "4.7.0"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.12.0",
-    "@botpress/sdk": "4.6.1",
+    "@botpress/sdk": "4.7.0",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/bot/definition.ts
+++ b/packages/sdk/src/bot/definition.ts
@@ -19,7 +19,7 @@ export type TagDefinition = {
   description?: string
 }
 
-export type StateType = 'conversation' | 'user' | 'bot'
+export type StateType = 'conversation' | 'user' | 'bot' | 'workflow'
 
 export type StateDefinition<TState extends BaseStates[string] = BaseStates[string]> = SchemaDefinition<TState> & {
   type: StateType

--- a/packages/sdk/src/fixtures.ts
+++ b/packages/sdk/src/fixtures.ts
@@ -236,6 +236,10 @@ export type FooBarBazPlugin = DefaultPlugin<{
       type: 'conversation'
       payload: { delta: null }
     }
+    epsilon: {
+      type: 'workflow'
+      payload: { epsilon: null }
+    }
   }
 }>
 

--- a/packages/sdk/src/plugin/state-proxy/types.test.ts
+++ b/packages/sdk/src/plugin/state-proxy/types.test.ts
@@ -16,6 +16,9 @@ test('StateProxy of FooBarBazPlugin should reflect states of bot, integration an
     bot: {
       gamma: StateRepo<FooBarBazPlugin['states']['gamma']['payload']>
     }
+    workflow: {
+      epsilon: StateRepo<FooBarBazPlugin['states']['epsilon']['payload']>
+    }
   }>
 
   type Actual = StateProxy<FooBarBazPlugin>
@@ -36,6 +39,7 @@ test('StateProxy of EmptyPlugin should be almost empty', async () => {
     conversation: {}
     user: {}
     bot: {}
+    workflow: {}
   }
 
   type _assertion = utils.AssertAll<
@@ -54,6 +58,7 @@ test('StateProxy of BasePlugin should be a record', async () => {
     conversation: Record<string, StateRepo<any>>
     user: Record<string, StateRepo<any>>
     bot: Record<string, StateRepo<any>>
+    workflow: Record<string, StateRepo<any>>
   }
   type _assertion = utils.AssertAll<
     [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1902,7 +1902,7 @@ importers:
         specifier: 1.12.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 4.6.1
+        specifier: 4.7.0
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2014,7 +2014,7 @@ importers:
         specifier: 1.12.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.6.1
+        specifier: 4.7.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2030,7 +2030,7 @@ importers:
         specifier: 1.12.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.6.1
+        specifier: 4.7.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2043,7 +2043,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 4.6.1
+        specifier: 4.7.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2059,7 +2059,7 @@ importers:
         specifier: 1.12.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.6.1
+        specifier: 4.7.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2075,7 +2075,7 @@ importers:
         specifier: 1.12.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.6.1
+        specifier: 4.7.0
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
This is already fully supported by the backend. In this PR, workflow states are explicitly removed from the plugin/bot body since the state definitions are created by the backend in the `setState`/`getOrSetState` operations. When we add workflow definitions to the backend, we'll have to modify the cli so that it _does_ send workflow state definitions when creating bots/plugins.

Resolves DEV-3005