### PR TITLE
fix(hitl): allow impersonation when webchat is the upstream integration

### DIFF
--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -85,7 +85,7 @@ const PLUGIN_CONFIG_SCHEMA = sdk.z.object({
 
 export default new sdk.PluginDefinition({
   name: 'hitl',
-  version: '0.9.0',
+  version: '0.10.0',
   title: 'Human In The Loop',
   description: 'Seamlessly transfer conversations to human agents',
   icon: 'icon.svg',


### PR DESCRIPTION
Small bug. I probably forgot to build the last time I did QA.