### PR TITLE
feat(cli): add support for plugin instances

### DIFF
--- a/integrations/monday/package.json
+++ b/integrations/monday/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.13.0",
+    "@botpress/client": "workspace:*",
     "@botpress/sdk": "workspace:*",
     "axios": "^1.4.0"
   }

--- a/integrations/monday/package.json
+++ b/integrations/monday/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.12.0",
+    "@botpress/client": "1.13.0",
     "@botpress/sdk": "workspace:*",
     "axios": "^1.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.564.0",
-    "@botpress/api": "1.15.0",
+    "@botpress/api": "1.16.0",
     "@botpress/cli": "workspace:*",
     "@botpress/client": "workspace:*",
     "@botpress/sdk": "workspace:*",

--- a/packages/cli/e2e/index.ts
+++ b/packages/cli/e2e/index.ts
@@ -5,7 +5,7 @@ import { createDeployBot } from './tests/create-deploy-bot'
 import { createDeployIntegration } from './tests/create-deploy-integration'
 import { devBot } from './tests/dev-bot'
 import { installAllInterfaces } from './tests/install-interfaces'
-import { addIntegration } from './tests/install-package'
+import { addIntegration, addPlugin } from './tests/install-package'
 import { requiredSecrets } from './tests/integration-secrets'
 import { prependWorkspaceHandle, enforceWorkspaceHandle } from './tests/manage-workspace-handle'
 import { Test } from './typings'
@@ -19,6 +19,7 @@ const tests: Test[] = [
   prependWorkspaceHandle,
   enforceWorkspaceHandle,
   addIntegration,
+  addPlugin,
   installAllInterfaces,
 ]
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.1",
-    "@botpress/client": "1.12.0",
+    "@botpress/client": "1.13.0",
     "@botpress/sdk": "4.7.0",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",

--- a/packages/cli/src/api/bot-body.ts
+++ b/packages/cli/src/api/bot-body.ts
@@ -72,4 +72,5 @@ export const prepareUpdateBotBody = (
     tags: utils.records.setNullOnMissingValues(localBot.message?.tags, remoteBot.message?.tags),
   },
   integrations: utils.records.setNullOnMissingValues(localBot.integrations, remoteBot.integrations),
+  plugins: utils.records.setNullOnMissingValues(localBot.plugins, remoteBot.plugins),
 })

--- a/packages/cli/src/api/client.ts
+++ b/packages/cli/src/api/client.ts
@@ -206,6 +206,14 @@ export class ApiClient {
       .catch(this._returnUndefinedOnError('ResourceNotFound'))
   }
 
+  public async getPublicOrPrivatePlugin(ref: ApiPackageRef): Promise<PublicOrPrivatePlugin> {
+    const plugin = await this.findPublicOrPrivatePlugin(ref)
+    if (!plugin) {
+      throw new Error(`Plugin "${formatPackageRef(ref)}" not found`)
+    }
+    return plugin
+  }
+
   public async findPublicOrPrivatePlugin(ref: ApiPackageRef): Promise<PublicOrPrivatePlugin | undefined> {
     const formatted = formatPackageRef(ref)
 

--- a/packages/cli/src/command-implementations/plugin-commands.ts
+++ b/packages/cli/src/command-implementations/plugin-commands.ts
@@ -18,7 +18,7 @@ export class GetPluginCommand extends GlobalCommand<GetPluginCommandDefinition> 
     }
 
     try {
-      const plugin = await api.findPublicPlugin(parsedRef)
+      const plugin = await api.findPublicOrPrivatePlugin(parsedRef)
       if (plugin) {
         this.logger.success(`Plugin ${chalk.bold(this.argv.pluginRef)}:`)
         this.logger.json(plugin)
@@ -64,7 +64,7 @@ export class DeletePluginCommand extends GlobalCommand<DeletePluginCommandDefini
 
     let plugin: client.Plugin | undefined
     try {
-      plugin = await api.findPublicPlugin(parsedRef)
+      plugin = await api.findPublicOrPrivatePlugin(parsedRef)
     } catch (thrown) {
       throw errors.BotpressCLIError.wrap(thrown, `Could not get plugin ${this.argv.pluginRef}`)
     }

--- a/packages/cli/src/command-implementations/project-command.ts
+++ b/packages/cli/src/command-implementations/project-command.ts
@@ -345,10 +345,14 @@ export abstract class ProjectCommand<C extends ProjectCommandDefinition> extends
     const integrations = await this._fetchDependencies(botDef.integrations ?? {}, ({ name, version }) =>
       api.getPublicOrPrivateIntegration({ type: 'name', name, version })
     )
+    const plugins = await this._fetchDependencies(botDef.plugins ?? {}, ({ name, version }) =>
+      api.getPublicOrPrivatePlugin({ type: 'name', name, version })
+    )
     return {
       integrations: _(integrations)
         .keyBy((i) => i.id)
         .value(),
+      plugins,
     }
   }
 

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -5,7 +5,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.12.0",
+    "@botpress/client": "1.13.0",
     "@botpress/sdk": "4.7.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.12.0",
+    "@botpress/client": "1.13.0",
     "@botpress/sdk": "4.7.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.12.0",
+    "@botpress/client": "1.13.0",
     "@botpress/sdk": "4.7.0"
   },
   "devDependencies": {

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.12.0",
+    "@botpress/client": "1.13.0",
     "@botpress/sdk": "4.7.0",
     "axios": "^1.6.8"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "1.12.0",
+    "@botpress/client": "1.13.0",
     "browser-or-node": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -36,7 +36,7 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "@botpress/client": "1.12.0",
+    "@botpress/client": "1.13.0",
     "@bpinternal/thicktoken": "^1.0.1",
     "@bpinternal/zui": "^0.13.4",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1128,7 +1128,7 @@ importers:
   integrations/monday:
     dependencies:
       '@botpress/client':
-        specifier: 1.13.0
+        specifier: workspace:*
         version: link:../../packages/client
       '@botpress/sdk':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^3.564.0
         version: 3.709.0
       '@botpress/api':
-        specifier: 1.15.0
-        version: 1.15.0(openapi-types@12.1.3)
+        specifier: 1.16.0
+        version: 1.16.0(openapi-types@12.1.3)
       '@botpress/cli':
         specifier: workspace:*
         version: link:packages/cli
@@ -1128,7 +1128,7 @@ importers:
   integrations/monday:
     dependencies:
       '@botpress/client':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../../packages/client
       '@botpress/sdk':
         specifier: workspace:*
@@ -1911,7 +1911,7 @@ importers:
         specifier: 0.5.1
         version: link:../chat-client
       '@botpress/client':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../client
       '@botpress/sdk':
         specifier: 4.7.0
@@ -2023,7 +2023,7 @@ importers:
   packages/cli/templates/empty-bot:
     dependencies:
       '@botpress/client':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 4.7.0
@@ -2039,7 +2039,7 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 4.7.0
@@ -2068,7 +2068,7 @@ importers:
   packages/cli/templates/hello-world:
     dependencies:
       '@botpress/client':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 4.7.0
@@ -2084,7 +2084,7 @@ importers:
   packages/cli/templates/webhook-message:
     dependencies:
       '@botpress/client':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 4.7.0
@@ -2198,7 +2198,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../client
       '@bpinternal/zui':
         specifier: ^0.13.5
@@ -2229,7 +2229,7 @@ importers:
   packages/vai:
     dependencies:
       '@botpress/client':
-        specifier: 1.12.0
+        specifier: 1.13.0
         version: link:../client
       '@bpinternal/thicktoken':
         specifier: ^1.0.1
@@ -4163,8 +4163,8 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@botpress/api@1.15.0(openapi-types@12.1.3):
-    resolution: {integrity: sha512-rkGuCjC1DXS/W6DafaJ7+ukgB+7Ixn/Eu4KJIUktJJ8y3EgWpP6vVyjBqrthl0xMfuH0xBbqe7ZC5zBgMhaNfw==}
+  /@botpress/api@1.16.0(openapi-types@12.1.3):
+    resolution: {integrity: sha512-9Y/fV6szNJDIb08Qi0s15uYswytl/LGMMzVyxjFP9VTYhWlTuxYXWB7xt5bXYF2slNGbduPYCgZDDL7t3z1j0g==}
     dependencies:
       '@bpinternal/opapi': 0.14.0(openapi-types@12.1.3)
     transitivePeerDependencies:


### PR DESCRIPTION
Sends installed plugins to the backend when deploying bots-as-code.

Resolves DEV-3012