### PR TITLE
feat(integrations/fireworks-ai): add new DeepSeek R1/V3 and Llama 4 models

### DIFF
--- a/integrations/fireworks-ai/integration.definition.ts
+++ b/integrations/fireworks-ai/integration.definition.ts
@@ -9,7 +9,7 @@ export default new IntegrationDefinition({
   title: 'Fireworks AI',
   description:
     'Choose from curated Fireworks AI models for content generation, chat completions, and audio transcription.',
-  version: '7.0.0',
+  version: '8.0.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/fireworks-ai/src/index.ts
+++ b/integrations/fireworks-ai/src/index.ts
@@ -63,7 +63,7 @@ const languageModels: Record<LanguageModelId, llm.ModelDetails> = {
     tags: ['general-purpose', 'vision'],
     input: {
       costPer1MTokens: 0.15,
-      maxTokens: 1_000_000,
+      maxTokens: 1_048_576,
     },
     output: {
       costPer1MTokens: 0.6,

--- a/integrations/fireworks-ai/src/index.ts
+++ b/integrations/fireworks-ai/src/index.ts
@@ -14,11 +14,81 @@ const DEFAULT_LANGUAGE_MODEL_ID: LanguageModelId = 'accounts/fireworks/models/ll
 //  https://fireworks.ai/models
 //  https://fireworks.ai/pricing
 const languageModels: Record<LanguageModelId, llm.ModelDetails> = {
+  'accounts/fireworks/models/deepseek-r1-0528': {
+    name: 'DeepSeek R1 0528',
+    description:
+      'The updated DeepSeek R1 0528 model delivers major improvements in reasoning, inference, and accuracy through enhanced post-training optimization and greater computational resources. It now performs at a level approaching top-tier models like OpenAI o3 and Gemini 2.5 Pro, with notable gains in complex tasks such as math and programming. The update also reduces hallucinations, improves function calling, and enhances the coding experience.',
+    tags: ['recommended', 'reasoning', 'general-purpose', 'coding'],
+    input: {
+      costPer1MTokens: 3,
+      maxTokens: 160_000,
+    },
+    output: {
+      costPer1MTokens: 8,
+      maxTokens: 16_384,
+    },
+  },
+  'accounts/fireworks/models/deepseek-v3-0324': {
+    name: 'DeepSeek V3 0324',
+    description:
+      'DeepSeek V3, a 685B-parameter, mixture-of-experts model, is the latest iteration of the flagship chat model family from the DeepSeek team. It succeeds the DeepSeek V3 model and performs really well on a variety of tasks.',
+    tags: ['recommended', 'general-purpose'],
+    input: {
+      costPer1MTokens: 0.9,
+      maxTokens: 160_000,
+    },
+    output: {
+      costPer1MTokens: 0.9,
+      maxTokens: 16_384,
+    },
+  },
+  'accounts/fireworks/models/llama4-maverick-instruct-basic': {
+    name: 'Llama 4 Maverick Instruct (Basic)',
+    description:
+      'Llama 4 Maverick 17B Instruct (128E) is a high-capacity multimodal language model from Meta, built on a mixture-of-experts (MoE) architecture with 128 experts and 17 billion active parameters per forward pass (400B total). It supports multilingual text and image input, and produces multilingual text and code output across 12 supported languages. Optimized for vision-language tasks, Maverick is instruction-tuned for assistant-like behavior, image reasoning, and general-purpose multimodal interaction, and suited for research and commercial applications requiring advanced multimodal understanding and high model throughput.',
+    tags: ['general-purpose', 'vision'],
+    input: {
+      costPer1MTokens: 0.22,
+      maxTokens: 1_000_000,
+    },
+    output: {
+      costPer1MTokens: 0.88,
+      maxTokens: 16_384,
+    },
+  },
+  'accounts/fireworks/models/llama4-scout-instruct-basic': {
+    name: 'Llama 4 Scout Instruct (Basic)',
+    description:
+      'Llama 4 Scout 17B Instruct (16E) is a mixture-of-experts (MoE) language model developed by Meta, uses 16 experts per forward pass, activating 17 billion parameters out of a total of 109B. It supports native multimodal input (text and image) and multilingual output (text and code) across 12 supported languages. Designed for assistant-style interaction and visual reasoning, it is instruction-tuned for use in multilingual chat, captioning, and image understanding tasks.',
+    tags: ['general-purpose', 'vision'],
+    input: {
+      costPer1MTokens: 0.15,
+      maxTokens: 1_000_000,
+    },
+    output: {
+      costPer1MTokens: 0.6,
+      maxTokens: 16_384,
+    },
+  },
+  'accounts/fireworks/models/llama-v3p3-70b-instruct': {
+    name: 'Llama 3.3 70B Instruct',
+    description:
+      'Llama 3.3 70B Instruct is the December update of Llama 3.1 70B. The model improves upon Llama 3.1 70B (released July 2024) with advances in tool calling, multilingual text support, math and coding. The model achieves industry leading results in reasoning, math and instruction following and provides similar performance as 3.1 405B but with significant speed and cost improvements.',
+    tags: ['general-purpose'],
+    input: {
+      costPer1MTokens: 0.9,
+      maxTokens: 131_072,
+    },
+    output: {
+      costPer1MTokens: 0.9,
+      maxTokens: 16_384,
+    },
+  },
   'accounts/fireworks/models/deepseek-r1': {
     name: 'DeepSeek R1 (Fast)',
     description:
       'This version of the R1 model has a perfect balance between speed and cost-efficiency for real-time interactive experiences, with speeds up to 90 tokens per second.\n\nDeepSeek-R1 is a state-of-the-art large language model optimized with reinforcement learning and cold-start data for exceptional reasoning, math, and code performance. **Note**: This model will always use a temperature of 0.6 as recommended by DeepSeek.',
-    tags: ['recommended', 'reasoning', 'general-purpose', 'coding'],
+    tags: ['reasoning', 'general-purpose', 'coding'],
     input: {
       costPer1MTokens: 3,
       maxTokens: 128_000,
@@ -46,7 +116,7 @@ const languageModels: Record<LanguageModelId, llm.ModelDetails> = {
     name: 'DeepSeek V3',
     description:
       'A a strong Mixture-of-Experts (MoE) language model with 671B total parameters with 37B activated for each token from Deepseek.',
-    tags: ['general-purpose', 'coding'],
+    tags: ['deprecated', 'general-purpose'],
     input: {
       costPer1MTokens: 0.9,
       maxTokens: 128_000,
@@ -60,7 +130,7 @@ const languageModels: Record<LanguageModelId, llm.ModelDetails> = {
     name: 'Llama 3.1 405B Instruct',
     description:
       'The Meta Llama 3.1 collection of multilingual large language models (LLMs) is a collection of pretrained and instruction tuned generative models in 8B, 70B and 405B sizes. The Llama 3.1 instruction tuned text only models (8B, 70B, 405B) are optimized for multilingual dialogue use cases and outperform many of the available open source and closed chat models on common industry benchmarks.',
-    tags: ['recommended', 'general-purpose'],
+    tags: ['deprecated', 'general-purpose'],
     input: {
       costPer1MTokens: 3,
       maxTokens: 131_072,
@@ -74,7 +144,7 @@ const languageModels: Record<LanguageModelId, llm.ModelDetails> = {
     name: 'Llama 3.1 70B Instruct',
     description:
       'The Meta Llama 3.1 collection of multilingual large language models (LLMs) is a collection of pretrained and instruction tuned generative models in 8B, 70B and 405B sizes. The Llama 3.1 instruction tuned text only models (8B, 70B, 405B) are optimized for multilingual dialogue use cases and outperform many of the available open source and closed chat models on common industry benchmarks.',
-    tags: ['general-purpose'],
+    tags: ['deprecated', 'general-purpose'],
     input: {
       costPer1MTokens: 0.9,
       maxTokens: 131_072,
@@ -126,63 +196,6 @@ const languageModels: Record<LanguageModelId, llm.ModelDetails> = {
       maxTokens: 32_768,
     },
   },
-  'accounts/fireworks/models/firefunction-v2': {
-    name: 'Firefunction V2',
-    description:
-      "Fireworks' latest and most performant function-calling model. Firefunction-v2 is based on Llama-3 and trained to excel at function-calling as well as chat and instruction-following.",
-    tags: ['function-calling'],
-    input: {
-      // Note: pricing page incorrectly shows $0/1M tokens for this model but actual price is mentioned in this blog post: https://fireworks.ai/blog/firefunction-v2-launch-post
-      costPer1MTokens: 0.9,
-      maxTokens: 8192,
-    },
-    output: {
-      costPer1MTokens: 0.9,
-      maxTokens: 8192,
-    },
-  },
-  'accounts/fireworks/models/firellava-13b': {
-    name: 'FireLLaVA-13B',
-    description:
-      'Vision-language model allowing both image and text as inputs (single image is recommended), trained on OSS model generated training data.',
-    tags: ['low-cost', 'vision'],
-    input: {
-      costPer1MTokens: 0.2,
-      maxTokens: 4096,
-    },
-    output: {
-      costPer1MTokens: 0.2,
-      maxTokens: 4096,
-    },
-  },
-  'accounts/fireworks/models/deepseek-coder-v2-instruct': {
-    name: 'DeepSeek Coder V2 Instruct',
-    description:
-      'An open-source Mixture-of-Experts (MoE) code language model that achieves performance comparable to GPT4-Turbo in code-specific tasks from Deepseek.',
-    tags: ['coding'],
-    input: {
-      costPer1MTokens: 2.7,
-      maxTokens: 131_072,
-    },
-    output: {
-      costPer1MTokens: 2.7,
-      maxTokens: 131_072,
-    },
-  },
-  'accounts/fireworks/models/deepseek-coder-v2-lite-instruct': {
-    name: 'DeepSeek Coder V2 Lite',
-    description:
-      'DeepSeek-Coder-V2, an open-source Mixture-of-Experts (MoE) code language model that achieves performance comparable to GPT4-Turbo in code-specific tasks.',
-    tags: ['low-cost', 'coding'],
-    input: {
-      costPer1MTokens: 0.2,
-      maxTokens: 163_840,
-    },
-    output: {
-      costPer1MTokens: 0.2,
-      maxTokens: 163_840,
-    },
-  },
   'accounts/fireworks/models/mythomax-l2-13b': {
     name: 'MythoMax L2 13b',
     description:
@@ -197,25 +210,11 @@ const languageModels: Record<LanguageModelId, llm.ModelDetails> = {
       maxTokens: 4096,
     },
   },
-  'accounts/fireworks/models/qwen2-72b-instruct': {
-    name: 'Qwen2 72b Instruct',
-    description:
-      'Qwen 2 is the latest large language model series developed by the Qwen team at Alibaba Cloud. Key features and capabilities of Qwen 2 include multilingual proficiency with a particular strength in Asian languages, and enhanced performance in coding, mathematics, and long context understanding',
-    tags: ['general-purpose', 'function-calling'],
-    input: {
-      costPer1MTokens: 0.9,
-      maxTokens: 32_768,
-    },
-    output: {
-      costPer1MTokens: 0.9,
-      maxTokens: 32_768,
-    },
-  },
   'accounts/fireworks/models/gemma2-9b-it': {
     name: 'Gemma 2 9B Instruct',
     description:
       'Redesigned for outsized performance and unmatched efficiency, Gemma 2 optimizes for blazing-fast inference on diverse hardware. Gemma is a family of lightweight, state-of-the-art open models from Google, built from the same research and technology used to create the Gemini models. They are text-to-text, decoder-only large language models, available in English, with open weights, pre-trained variants, and instruction-tuned variants. Gemma models are well-suited for a variety of text generation tasks, including question answering, summarization, and reasoning.',
-    tags: ['low-cost', 'general-purpose'],
+    tags: ['deprecated', 'low-cost', 'general-purpose'],
     input: {
       costPer1MTokens: 0.2,
       maxTokens: 8192,

--- a/integrations/fireworks-ai/src/schemas.ts
+++ b/integrations/fireworks-ai/src/schemas.ts
@@ -2,6 +2,11 @@ import { z } from '@botpress/sdk'
 
 export const languageModelId = z
   .enum([
+    'accounts/fireworks/models/deepseek-r1-0528',
+    'accounts/fireworks/models/deepseek-v3-0324',
+    'accounts/fireworks/models/llama4-maverick-instruct-basic',
+    'accounts/fireworks/models/llama4-scout-instruct-basic',
+    'accounts/fireworks/models/llama-v3p3-70b-instruct',
     'accounts/fireworks/models/deepseek-r1',
     'accounts/fireworks/models/deepseek-r1-basic',
     'accounts/fireworks/models/deepseek-v3',
@@ -10,12 +15,7 @@ export const languageModelId = z
     'accounts/fireworks/models/llama-v3p1-8b-instruct',
     'accounts/fireworks/models/mixtral-8x22b-instruct',
     'accounts/fireworks/models/mixtral-8x7b-instruct',
-    'accounts/fireworks/models/firefunction-v2',
-    'accounts/fireworks/models/firellava-13b',
-    'accounts/fireworks/models/deepseek-coder-v2-instruct',
-    'accounts/fireworks/models/deepseek-coder-v2-lite-instruct',
     'accounts/fireworks/models/mythomax-l2-13b',
-    'accounts/fireworks/models/qwen2-72b-instruct',
     'accounts/fireworks/models/gemma2-9b-it',
   ])
   .describe('Model to use for content generation')


### PR DESCRIPTION
Some old models have also been removed as they're obsolete and are not being used ([checked here](https://botpress.com/llm-ranking)).