### PR TITLE
feat(teams): fetch message sender email adress when available

### DIFF
--- a/integrations/teams/integration.definition.ts
+++ b/integrations/teams/integration.definition.ts
@@ -6,7 +6,7 @@ import { configuration, channels, user, states } from './src/definitions'
 
 export default new IntegrationDefinition({
   name: 'teams',
-  version: '0.4.2',
+  version: '0.5.0',
   title: 'Microsoft Teams',
   description: 'Interact with users, deliver notifications, and perform actions within Microsoft Teams.',
   icon: 'icon.svg',

--- a/integrations/teams/src/definitions/index.ts
+++ b/integrations/teams/src/definitions/index.ts
@@ -40,5 +40,9 @@ export const user = {
       title: 'ID',
       description: 'Teams user ID',
     },
+    email: {
+      title: 'Email',
+      description: 'Email address',
+    },
   },
 } satisfies IntegrationDefinitionProps['user']

--- a/integrations/teams/src/utils.ts
+++ b/integrations/teams/src/utils.ts
@@ -26,3 +26,9 @@ export const getConversationReference = async ({
   const { state } = stateRes
   return state.payload as ConversationReference
 }
+
+export const sleep = (ms: number) => {
+  return new Promise<undefined>((resolve) => {
+    setTimeout(() => resolve(undefined), ms)
+  })
+}


### PR DESCRIPTION
I have no clue if this will work, but I don't think it can break the existing integration. I plan to release it and browse the logs in a couple of days to see if it worked.