### PR TITLE
fix(integrations/stripe): payment link not being properly created

### DIFF
--- a/integrations/stripe/integration.definition.ts
+++ b/integrations/stripe/integration.definition.ts
@@ -35,7 +35,7 @@ import {
 
 export default new IntegrationDefinition({
   name: 'stripe',
-  version: '0.5.0',
+  version: '0.5.1',
   title: 'Stripe',
   readme: 'hub.md',
   icon: 'icon.svg',

--- a/integrations/stripe/src/actions/create-paymentlink.ts
+++ b/integrations/stripe/src/actions/create-paymentlink.ts
@@ -2,9 +2,20 @@ import { getClient } from '../client'
 import { createPaymentLinkInputSchema } from '../misc/custom-schemas'
 import type { IntegrationProps } from '../misc/types'
 
+type ProductBasic = {
+  id: string
+  name: string
+}
+
+type PriceBasic = {
+  id: string
+  unit_amount: number | null
+  currency: string
+}
+
 const findOrCreateProduct = async (StripeClient: any, productName: string) => {
   const products = await StripeClient.listAllProductsBasic()
-  let product = products.find((p: any) => p.name === productName)
+  let product = products.find((p: ProductBasic) => p.name === productName)
 
   if (!product) {
     product = await StripeClient.createProduct(productName)
@@ -20,7 +31,7 @@ const findOrCreatePrice = async (StripeClient: any, productId: string, unitAmoun
     return prices.data[0]
   }
 
-  let price = prices.data.find((p: any) => p.unit_amount === unitAmount && p.currency === currency)
+  let price = prices.data.find((p: PriceBasic) => p.unit_amount === unitAmount && p.currency === currency)
 
   if (!price) {
     price = await StripeClient.createPrice(productId, unitAmount, currency)

--- a/integrations/stripe/src/actions/create-paymentlink.ts
+++ b/integrations/stripe/src/actions/create-paymentlink.ts
@@ -2,53 +2,77 @@ import { getClient } from '../client'
 import { createPaymentLinkInputSchema } from '../misc/custom-schemas'
 import type { IntegrationProps } from '../misc/types'
 
+const findOrCreateProduct = async (StripeClient: any, productName: string) => {
+  const products = await StripeClient.listAllProductsBasic()
+  let product = products.find((p: any) => p.name === productName)
+
+  if (!product) {
+    product = await StripeClient.createProduct(productName)
+  }
+
+  return product
+}
+
+const findOrCreatePrice = async (StripeClient: any, productId: string, unitAmount: number, currency: string) => {
+  const prices = await StripeClient.listPrices(productId)
+
+  if (!unitAmount) {
+    return prices.data[0]
+  }
+
+  let price = prices.data.find((p: any) => p.unit_amount === unitAmount && p.currency === currency)
+
+  if (!price) {
+    price = await StripeClient.createPrice(productId, unitAmount, currency)
+  }
+
+  return price
+}
+
+const buildLineItem = (
+  priceId: string,
+  quantity: number,
+  adjustableQuantity: boolean,
+  adjustableQuantityMaximum: number,
+  adjustableQuantityMinimum: number
+) => {
+  return {
+    price: priceId,
+    quantity: quantity || 1,
+    adjustable_quantity: {
+      enabled: adjustableQuantity || false,
+      maximum: adjustableQuantity ? adjustableQuantityMaximum || 99 : undefined,
+      minimum: adjustableQuantity ? adjustableQuantityMinimum || 1 : undefined,
+    },
+  }
+}
+
 export const createPaymentLink: IntegrationProps['actions']['createPaymentLink'] = async ({ ctx, logger, input }) => {
   const validatedInput = createPaymentLinkInputSchema.parse(input)
   const StripeClient = getClient(ctx.configuration)
-  let response
+
   try {
-    const products = await StripeClient.listAllProductsBasic()
-    let product = products.find((p) => p.name === validatedInput.productName)
+    const product = await findOrCreateProduct(StripeClient, validatedInput.productName)
+    const price = await findOrCreatePrice(StripeClient, product.id, validatedInput.unit_amount, validatedInput.currency)
 
-    if (!product) {
-      product = await StripeClient.createProduct(validatedInput.productName)
-    }
+    const lineItem = buildLineItem(
+      price.id,
+      validatedInput.quantity,
+      validatedInput.adjustableQuantity,
+      validatedInput.adjustableQuantityMaximum,
+      validatedInput.adjustableQuantityMinimum
+    )
 
-    const prices = await StripeClient.listPrices(product.id)
-    let price
-    if (!validatedInput.unit_amount) {
-      price = prices.data[0]
-    } else {
-      price = prices.data.find(
-        (p: any) => p.unit_amount === validatedInput.unit_amount && p.currency === validatedInput.currency
-      )
-    }
-
-    if (!price) {
-      price = await StripeClient.createPrice(product.id, validatedInput.unit_amount, validatedInput.currency)
-    }
-
-    const adjustableQuantity = validatedInput.adjustableQuantity || false
-    const lineItem = {
-      price: price.id,
-      quantity: validatedInput.quantity || 1,
-      adjustable_quantity: {
-        enabled: adjustableQuantity,
-        maximum: adjustableQuantity ? validatedInput.adjustableQuantityMaximum || 99 : undefined,
-        minimum: adjustableQuantity ? validatedInput.adjustableQuantityMinimum || 1 : undefined,
-      },
-    }
     const paymentLink = await StripeClient.createPaymentLink(lineItem)
 
-    response = {
+    logger.forBot().info(`Successful - Create Payment Link - ${paymentLink.id}`)
+
+    return {
       id: paymentLink.id,
       url: paymentLink.url,
     }
-    logger.forBot().info(`Successful - Create Payment Link - ${paymentLink.id}`)
   } catch (error) {
-    response = {}
     logger.forBot().debug(`'Create Payment Link' exception ${JSON.stringify(error)}`)
+    throw error
   }
-
-  return response
 }

--- a/integrations/stripe/src/misc/custom-schemas.ts
+++ b/integrations/stripe/src/misc/custom-schemas.ts
@@ -15,7 +15,13 @@ const partialCustomer = z
 
 export const createPaymentLinkInputSchema = z.object({
   productName: z.string().placeholder('ex: T-Shirt').describe('The name of the product to be sold'),
-  unit_amount: z.number().title('Unit Price').optional().default(0).describe('The unit price in cents'),
+  unit_amount: z
+    .number()
+    .title('Unit Price')
+    .min(50, 'Amount must be at least 50 cents ($0.50 USD)')
+    .optional()
+    .default(50)
+    .describe('The unit price in cents (minimum 50 cents for USD)'),
   currency: z.string().optional().default('usd').describe('The currency in which the price will be expressed'),
   quantity: z.number().optional().default(1).describe('The quantity of the product being purchased'),
   adjustableQuantity: z.boolean().optional().default(false).describe('Whether or not the quantity can be adjusted'),

--- a/integrations/stripe/src/misc/stripe-client.ts
+++ b/integrations/stripe/src/misc/stripe-client.ts
@@ -1,0 +1,89 @@
+import type Stripe from 'stripe'
+
+export type ProductBasic = {
+  id: string
+  name: string
+}
+
+export type PriceBasic = {
+  id: string
+  unit_amount: number | null
+  currency: string
+  recurring?: Stripe.Price.Recurring
+  product: ProductBasic
+}
+
+export type CustomerBasic = {
+  id: string
+  email: string | null
+  name: string | null | undefined
+  description: string | null
+  phone: string | null | undefined
+  address: Stripe.Address | null | undefined
+  created: number
+  delinquent: boolean | null | undefined
+}
+
+export type PaymentLinkBasic = {
+  id: string
+  url: string
+}
+
+export type WebhookBasic = {
+  id: string
+  url: string
+}
+
+export type StripeClient = {
+  createProduct(name: string): Promise<Stripe.Product>
+
+  listProducts(startingAfter?: string): Promise<Stripe.ApiList<Stripe.Product>>
+
+  listAllProductsBasic(startingAfter?: string): Promise<ProductBasic[]>
+
+  createPrice(product: string, unit_amount: number, currency: string): Promise<Stripe.Price>
+
+  createSubsPrice(
+    product: string,
+    unit_amount: number,
+    currency: string,
+    recurring: Stripe.PriceCreateParams.Recurring
+  ): Promise<Stripe.Price>
+
+  listPrices(productId?: string, isExpand?: boolean, startingAfter?: string): Promise<Stripe.ApiList<Stripe.Price>>
+
+  listAllPricesBasic(productId?: string, isExpand?: boolean, startingAfter?: string): Promise<PriceBasic[]>
+
+  createPaymentLink(lineItem: Stripe.PaymentLinkCreateParams.LineItem): Promise<Stripe.PaymentLink>
+
+  listPaymentLink(startingAfter?: string): Promise<Stripe.ApiList<Stripe.PaymentLink>>
+
+  listAllPaymentLinksBasic(startingAfter?: string): Promise<PaymentLinkBasic[]>
+
+  createSubsLink(
+    lineItem: Stripe.PaymentLinkCreateParams.LineItem,
+    subscriptionData: Stripe.PaymentLinkCreateParams.SubscriptionData | undefined
+  ): Promise<Stripe.PaymentLink>
+
+  deactivatePaymentLink(paymentLinkId: string): Promise<Stripe.PaymentLink>
+
+  listCustomer(email?: string, startingAfter?: string): Promise<Stripe.ApiList<Stripe.Customer>>
+
+  listAllCustomerBasic(email?: string, startingAfter?: string): Promise<CustomerBasic[]>
+
+  searchCustomers(email?: string, name?: string, phone?: string): Promise<Stripe.Customer[]>
+
+  createCustomer(params: Stripe.CustomerCreateParams): Promise<Stripe.Customer>
+
+  createWebhook(webhookData: Stripe.WebhookEndpointCreateParams): Promise<Stripe.WebhookEndpoint>
+
+  listWebhooks(startingAfter?: string): Promise<Stripe.ApiList<Stripe.WebhookEndpoint>>
+
+  listAllWebhooksBasic(startingAfter?: string): Promise<WebhookBasic[]>
+
+  createOrRetrieveWebhookId(webhookData: Stripe.WebhookEndpointCreateParams): Promise<string>
+
+  deleteWebhook(webhookId: string): Promise<Stripe.DeletedWebhookEndpoint>
+
+  retrieveCustomer(id: string): Promise<Stripe.Customer | Stripe.DeletedCustomer>
+}


### PR DESCRIPTION
It was previously returning an empty { } and silently logging it in the integration logs.

Error fixed now.


Proof here:
<img width="1342" alt="Screenshot 2025-06-16 at 11 58 07 PM" src="https://github.com/user-attachments/assets/12a79940-7126-476f-ae07-d760590700c3" />
<img width="1018" alt="Screenshot 2025-06-16 at 11 56 57 PM" src="https://github.com/user-attachments/assets/d0bedcd4-5deb-445f-9bf6-19ad97c8533b" />
