### PR TITLE
fix(integrations/telegram): uploading a sticker caused an infinite loop in bot

### DIFF
--- a/integrations/telegram/integration.definition.ts
+++ b/integrations/telegram/integration.definition.ts
@@ -5,7 +5,7 @@ import typingIndicator from './bp_modules/typing-indicator'
 
 export default new IntegrationDefinition({
   name: 'telegram',
-  version: '0.7.2',
+  version: '0.7.3',
   title: 'Telegram',
   description: 'Engage with your audience in real-time.',
   icon: 'icon.svg',

--- a/integrations/telegram/integration.definition.ts
+++ b/integrations/telegram/integration.definition.ts
@@ -30,7 +30,6 @@ export default new IntegrationDefinition({
       message: { tags: { id: {}, chatId: {} } },
       conversation: {
         tags: { id: {}, fromUserId: {}, fromUserUsername: {}, fromUserName: {}, chatId: {} },
-        creation: { enabled: true, requiredTags: ['id'] },
       },
     },
   },
@@ -41,7 +40,6 @@ export default new IntegrationDefinition({
     tags: {
       id: {},
     },
-    creation: { enabled: true, requiredTags: ['id'] },
   },
 }).extend(typingIndicator, () => ({
   entities: {},

--- a/integrations/telegram/integration.definition.ts
+++ b/integrations/telegram/integration.definition.ts
@@ -30,6 +30,7 @@ export default new IntegrationDefinition({
       message: { tags: { id: {}, chatId: {} } },
       conversation: {
         tags: { id: {}, fromUserId: {}, fromUserUsername: {}, fromUserName: {}, chatId: {} },
+        creation: { enabled: true, requiredTags: ['id'] },
       },
     },
   },
@@ -40,6 +41,7 @@ export default new IntegrationDefinition({
     tags: {
       id: {},
     },
+    creation: { enabled: true, requiredTags: ['id'] },
   },
 }).extend(typingIndicator, () => ({
   entities: {},

--- a/integrations/telegram/src/misc/utils.ts
+++ b/integrations/telegram/src/misc/utils.ts
@@ -3,7 +3,7 @@ import { Response, RuntimeError } from '@botpress/sdk'
 import { ok } from 'assert'
 import _ from 'lodash'
 import { Context, Markup, Telegraf, Telegram } from 'telegraf'
-import { PhotoSize, Update, User } from 'telegraf/typings/core/types/typegram'
+import { PhotoSize, Update, User, Sticker } from 'telegraf/typings/core/types/typegram'
 import { Card, AckFunction, Logger, MessageHandlerProps, BotpressMessage, TelegramMessage } from './types'
 import * as bp from '.botpress'
 
@@ -162,6 +162,17 @@ export const convertTelegramMessageToBotpressMessage = async ({
     ok(photo, 'No photo found in message')
     const fileUrl = await telegram.getFileLink(photo.file_id)
 
+    return {
+      type: 'image',
+      payload: {
+        imageUrl: fileUrl.toString(),
+      },
+    }
+  }
+
+  if ('sticker' in message) {
+    const stickerMessage = message as TelegramMessage & { sticker: Sticker }
+    const fileUrl = await telegram.getFileLink(stickerMessage.sticker.file_id)
     return {
       type: 'image',
       payload: {


### PR DESCRIPTION
**Problem**

The "convertTelegramMessageToBotpressMessage" function in the utils.ts file for the telegram integration handles everything except stickers. If a user sends a sticker, the bot stops answering messages (even if you try to reset the conversation state). The logs just keep repeating the same error on loop: [telegram] Unsupported message type from Telegram

**Reproduce**

Send a sticker to a telegram bot.

**Fix**
Check if sticker. If so, send url to sticker in bot.
Should resolve DEV-2781