### PR TITLE
fix(hitl): format event types with plugin alias prefix when calling the API

### DIFF
--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -85,7 +85,7 @@ const PLUGIN_CONFIG_SCHEMA = sdk.z.object({
 
 export default new sdk.PluginDefinition({
   name: 'hitl',
-  version: '0.10.2',
+  version: '0.10.3',
   title: 'Human In The Loop',
   description: 'Seamlessly transfer conversations to human agents',
   icon: 'icon.svg',

--- a/plugins/hitl/src/actions/start-hitl.ts
+++ b/plugins/hitl/src/actions/start-hitl.ts
@@ -155,8 +155,10 @@ const _startHitlTimeout = async (
     return
   }
 
+  const eventType = 'humanAgentAssignedTimeout'
+  const prefixedType = props.alias ? `${props.alias}#${eventType}` : eventType
   await props.client.createEvent({
-    type: 'humanAgentAssignedTimeout',
+    type: prefixedType,
     payload: {
       sessionStartedAt: new Date().toISOString(),
       downstreamConversationId: downstreamCm.conversationId,

--- a/plugins/hitl/src/conv-manager.ts
+++ b/plugins/hitl/src/conv-manager.ts
@@ -57,8 +57,10 @@ export class ConversationManager {
   }
 
   public async continueWorkflow(): Promise<void> {
+    const eventType = 'continueWorkflow'
+    const prefixedType = this._props.alias ? `${this._props.alias}#${eventType}` : eventType
     await this._props.client.createEvent({
-      type: 'continueWorkflow',
+      type: prefixedType,
       conversationId: this._convId,
       payload: {
         conversationId: this._convId,


### PR DESCRIPTION
Eventually the SDK will inject an event proxy, but in the meantime, this fixes an issue we will soon have with plugin aliases