### PR TITLE
chore(deps): update Botpress api to latest (1.23.0) and bump client version "1.16.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.564.0",
-    "@botpress/api": "1.18.0",
+    "@botpress/api": "1.22.0",
     "@botpress/cli": "workspace:*",
     "@botpress/client": "workspace:*",
     "@botpress/sdk": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.564.0",
-    "@botpress/api": "1.22.0",
+    "@botpress/api": "1.23.0",
     "@botpress/cli": "workspace:*",
     "@botpress/client": "workspace:*",
     "@botpress/sdk": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.8.5",
+  "version": "4.8.6",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -21,8 +21,8 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.1",
-    "@botpress/client": "1.15.1",
-    "@botpress/sdk": "4.8.4",
+    "@botpress/client": "1.16.0",
+    "@botpress/sdk": "4.8.5",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -5,8 +5,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.15.1",
-    "@botpress/sdk": "4.8.4"
+    "@botpress/client": "1.16.0",
+    "@botpress/sdk": "4.8.5"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.15.1",
-    "@botpress/sdk": "4.8.4"
+    "@botpress/client": "1.16.0",
+    "@botpress/sdk": "4.8.5"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "4.8.4"
+    "@botpress/sdk": "4.8.5"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.15.1",
-    "@botpress/sdk": "4.8.4"
+    "@botpress/client": "1.16.0",
+    "@botpress/sdk": "4.8.5"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.15.1",
-    "@botpress/sdk": "4.8.4",
+    "@botpress/client": "1.16.0",
+    "@botpress/sdk": "4.8.5",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/cognitive/package.json
+++ b/packages/cognitive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cognitive",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Wrapper around the Botpress Client to call LLMs",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -2,7 +2,7 @@
   "name": "llmz",
   "type": "module",
   "description": "LLMz – An LLM-native Typescript VM built on top of Zui",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
@@ -32,7 +32,7 @@
     "@babel/standalone": "^7.26.4",
     "@babel/traverse": "^7.26.4",
     "@babel/types": "^7.26.3",
-    "@botpress/client": "1.15.1",
+    "@botpress/client": "1.16.0",
     "bytes": "^3.1.2",
     "exponential-backoff": "^3.1.1",
     "handlebars": "^4.7.8",
@@ -65,7 +65,7 @@
     "tsx": "^4.19.2"
   },
   "peerDependencies": {
-    "@botpress/cognitive": "0.1.25",
+    "@botpress/cognitive": "0.1.26",
     "@bpinternal/thicktoken": "^1.0.5",
     "@bpinternal/zui": "^1.0.0"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "4.8.4",
+  "version": "4.8.5",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -16,7 +16,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "1.15.1",
+    "@botpress/client": "1.16.0",
     "browser-or-node": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -36,7 +36,7 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "@botpress/client": "1.15.1",
+    "@botpress/client": "1.16.0",
     "@bpinternal/thicktoken": "^1.0.1",
     "@bpinternal/zui": "^1.0.0",
     "lodash": "^4.17.21",

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -23,7 +23,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@botpress/cognitive": "0.1.25",
+    "@botpress/cognitive": "0.1.26",
     "json5": "^2.2.3",
     "jsonrepair": "^3.10.0",
     "lodash-es": "^4.17.21"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1926,10 +1926,10 @@ importers:
         specifier: 0.5.1
         version: link:../chat-client
       '@botpress/client':
-        specifier: 1.15.1
+        specifier: 1.16.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 4.8.4
+        specifier: 4.8.5
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2038,10 +2038,10 @@ importers:
   packages/cli/templates/empty-bot:
     dependencies:
       '@botpress/client':
-        specifier: 1.15.1
+        specifier: 1.16.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.8.4
+        specifier: 4.8.5
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2054,10 +2054,10 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 1.15.1
+        specifier: 1.16.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.8.4
+        specifier: 4.8.5
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2070,7 +2070,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 4.8.4
+        specifier: 4.8.5
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2083,10 +2083,10 @@ importers:
   packages/cli/templates/hello-world:
     dependencies:
       '@botpress/client':
-        specifier: 1.15.1
+        specifier: 1.16.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.8.4
+        specifier: 4.8.5
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2099,10 +2099,10 @@ importers:
   packages/cli/templates/webhook-message:
     dependencies:
       '@botpress/client':
-        specifier: 1.15.1
+        specifier: 1.16.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.8.4
+        specifier: 4.8.5
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8
@@ -2237,10 +2237,10 @@ importers:
         specifier: ^7.26.3
         version: 7.26.9
       '@botpress/client':
-        specifier: 1.15.1
+        specifier: 1.16.0
         version: link:../client
       '@botpress/cognitive':
-        specifier: 0.1.25
+        specifier: 0.1.26
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^1.0.5
@@ -2340,7 +2340,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 1.15.1
+        specifier: 1.16.0
         version: link:../client
       '@bpinternal/zui':
         specifier: ^1.0.0
@@ -2371,7 +2371,7 @@ importers:
   packages/vai:
     dependencies:
       '@botpress/client':
-        specifier: 1.15.1
+        specifier: 1.16.0
         version: link:../client
       '@bpinternal/thicktoken':
         specifier: ^1.0.1
@@ -2414,7 +2414,7 @@ importers:
   packages/zai:
     dependencies:
       '@botpress/cognitive':
-        specifier: 0.1.25
+        specifier: 0.1.26
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^3.564.0
         version: 3.709.0
       '@botpress/api':
-        specifier: 1.18.0
-        version: 1.18.0(openapi-types@12.1.3)
+        specifier: 1.23.0
+        version: 1.23.0(openapi-types@12.1.3)
       '@botpress/cli':
         specifier: workspace:*
         version: link:packages/cli
@@ -4310,7 +4310,7 @@ packages:
     resolution: {integrity: sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.26.2
+      '@babel/code-frame': 7.27.1
       '@babel/parser': 7.26.9
       '@babel/types': 7.26.9
 
@@ -4377,8 +4377,8 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@botpress/api@1.18.0(openapi-types@12.1.3):
-    resolution: {integrity: sha512-MCjcSPcQDF9SnupuLkKqOsyTD0TSzPLg15ff1cnX09yuK4X6sb9eWn1IesOdChvH2K4ua9F3C8Q1uj8287y+8g==}
+  /@botpress/api@1.23.0(openapi-types@12.1.3):
+    resolution: {integrity: sha512-MYpmt5q/tJ02qaosFbk95v8YJYCM6+7w2eOYKHEgJz22NSp+0GO7gOeLr6XvqZDZC3GjYYLCoJsyUebn5G3nsg==}
     dependencies:
       '@bpinternal/opapi': 0.14.0(openapi-types@12.1.3)
     transitivePeerDependencies:


### PR DESCRIPTION
Package Version Updates

This PR updates several package versions across the repository, primarily focusing on Botpress-related dependencies.

## Overview of Changes

### Primary Version Updates:
- Updated `@botpress/api` from `1.18.0` to `1.23.0`
- Updated `@botpress/client` from `1.15.1` to `1.16.0`
- Updated `@botpress/sdk` from `4.8.4` to `4.8.5`
- Updated `@botpress/cli` from `4.8.5` to `4.8.6`
- Updated `@botpress/cognitive` from `0.1.25` to `0.1.26`
- Updated `llmz` from `0.0.8` to `0.0.9`
- Updated `@botpress/zai` from `2.0.11` to `2.0.12`
