### PR TITLE
fix(sdk): Fix error in global integration operation handler when operation is unknown

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",
@@ -22,7 +22,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.1",
     "@botpress/client": "1.15.3",
-    "@botpress/sdk": "4.11.0",
+    "@botpress/sdk": "4.11.1",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.15.3",
-    "@botpress/sdk": "4.11.0"
+    "@botpress/sdk": "4.11.1"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.15.3",
-    "@botpress/sdk": "4.11.0"
+    "@botpress/sdk": "4.11.1"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "4.11.0"
+    "@botpress/sdk": "4.11.1"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.15.3",
-    "@botpress/sdk": "4.11.0"
+    "@botpress/sdk": "4.11.1"
   },
   "devDependencies": {
     "@types/node": "^18.19.67",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.15.3",
-    "@botpress/sdk": "4.11.0",
+    "@botpress/sdk": "4.11.1",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/integration/implementation.ts
+++ b/packages/sdk/src/integration/implementation.ts
@@ -9,7 +9,7 @@ import {
   CreateConversationHandler as CreateConversationFunction,
   ActionHandlers as ActionFunctions,
   ChannelHandlers as ChannelFunctions,
-  IntegrationOperationHandler as IntegrationOperationFunction,
+  UnknownOperationHandler as UnknownOperationFunction,
   integrationHandler,
 } from './server'
 
@@ -28,7 +28,7 @@ export type IntegrationImplementationProps<TIntegration extends BaseIntegration 
   actions: ActionFunctions<TIntegration>
   channels: ChannelFunctions<TIntegration>
   __advanced?: {
-    integrationOperationHandler?: IntegrationOperationFunction<TIntegration>
+    unknownOperationHandler?: UnknownOperationFunction<TIntegration>
   }
 }
 
@@ -40,9 +40,9 @@ export class IntegrationImplementation<TIntegration extends BaseIntegration = Ba
   public readonly createUser: IntegrationImplementationProps<TIntegration>['createUser']
   public readonly createConversation: IntegrationImplementationProps<TIntegration>['createConversation']
   public readonly webhook: IntegrationImplementationProps<TIntegration>['handler']
-  public readonly integrationOperationHandler: NonNullable<
+  public readonly unknownOperationHandler: NonNullable<
     IntegrationImplementationProps<TIntegration>['__advanced']
-  >['integrationOperationHandler']
+  >['unknownOperationHandler']
 
   public constructor(public readonly props: IntegrationImplementationProps<TIntegration>) {
     this.actions = props.actions
@@ -52,7 +52,7 @@ export class IntegrationImplementation<TIntegration extends BaseIntegration = Ba
     this.createUser = props.createUser
     this.createConversation = props.createConversation
     this.webhook = props.handler
-    this.integrationOperationHandler = props.__advanced?.integrationOperationHandler
+    this.unknownOperationHandler = props.__advanced?.unknownOperationHandler
   }
 
   public readonly handler = integrationHandler(this as IntegrationImplementation<any>)

--- a/packages/sdk/src/integration/server/context.ts
+++ b/packages/sdk/src/integration/server/context.ts
@@ -8,7 +8,7 @@ import {
   operationHeader,
   webhookIdHeader,
 } from '../../consts'
-import { IntegrationContext, UnknownOperationIntegrationContext } from './types'
+import { IntegrationContext } from './types'
 
 export const integrationOperationSchema = z.enum([
   'webhook_received',
@@ -21,9 +21,7 @@ export const integrationOperationSchema = z.enum([
   'create_conversation',
 ])
 
-export const extractUnknownOperationContext = (
-  headers: Record<string, string | undefined>
-): UnknownOperationIntegrationContext => {
+export const extractContext = (headers: Record<string, string | undefined>): IntegrationContext => {
   const botId = headers[botIdHeader]
   const botUserId = headers[botUserIdHeader]
   const integrationId = headers[integrationIdHeader]
@@ -64,18 +62,5 @@ export const extractUnknownOperationContext = (
     operation,
     configurationType: configurationType ?? null,
     configuration: base64Configuration ? JSON.parse(Buffer.from(base64Configuration, 'base64').toString('utf-8')) : {},
-  }
-}
-
-export const extractContext = (headers: Record<string, string | undefined>): IntegrationContext => {
-  const unknownOperationContext = extractUnknownOperationContext(headers)
-  const operationParseResult = integrationOperationSchema.safeParse(unknownOperationContext.operation)
-  if (!operationParseResult.success) {
-    throw new Error('Invalid operation')
-  }
-
-  return {
-    ...unknownOperationContext,
-    operation: operationParseResult.data,
   }
 }

--- a/packages/sdk/src/integration/server/index.ts
+++ b/packages/sdk/src/integration/server/index.ts
@@ -1,6 +1,7 @@
 import { isApiError, Client, RuntimeError } from '@botpress/client'
 import { retryConfig } from '../../retry'
 import { Request, Response, parseBody } from '../../serve'
+import { Merge } from '../../utils/type-utils'
 import { IntegrationSpecificClient } from '../client'
 import { BaseIntegration } from '../common'
 import { ActionMetadataStore } from './action-metadata'
@@ -23,14 +24,14 @@ import {
 export * from './types'
 export * from './integration-logger'
 
-type ServerProps<T extends IntegrationContext | UnknownOperationIntegrationContext = IntegrationContext> = Omit<
+type ServerProps<T extends IntegrationContext | UnknownOperationIntegrationContext = IntegrationContext> = Merge<
   CommonHandlerProps<BaseIntegration>,
-  'ctx'
-> & {
-  req: Request
-  instance: IntegrationHandlers<BaseIntegration>
-  ctx: T
-}
+  {
+    req: Request
+    instance: IntegrationHandlers<BaseIntegration>
+    ctx: T
+  }
+>
 
 const extractTracingHeaders = (headers: Record<string, string | undefined>) => {
   return ['traceparent', 'tracestate', 'sentry-trace'].reduce<Record<string, string>>((acc, header) => {

--- a/packages/sdk/src/integration/server/index.ts
+++ b/packages/sdk/src/integration/server/index.ts
@@ -1,4 +1,4 @@
-import { isApiError, Client, RuntimeError } from '@botpress/client'
+import { isApiError, Client, RuntimeError, InvalidPayloadError } from '@botpress/client'
 import { retryConfig } from '../../retry'
 import { Request, Response, parseBody } from '../../serve'
 import { IntegrationSpecificClient } from '../client'
@@ -81,7 +81,7 @@ const handleOperation = async (props: ServerProps) => {
     case 'create_conversation':
       return await onCreateConversation(props)
     default:
-      throw new Error(`Unknown operation ${ctx.operation}`)
+      throw new InvalidPayloadError(`Unknown operation ${ctx.operation}`)
   }
 }
 

--- a/packages/sdk/src/integration/server/index.ts
+++ b/packages/sdk/src/integration/server/index.ts
@@ -104,7 +104,7 @@ export const integrationHandler =
     } catch (error) {
       if (isApiError(error)) {
         const runtimeError = error.type === 'Runtime' ? error : new RuntimeError(error.message, error)
-        props.logger.forBot().error(runtimeError.message)
+        logger.forBot().error(runtimeError.message)
 
         return { status: runtimeError.code, body: JSON.stringify(runtimeError.toJSON()) }
       }

--- a/packages/sdk/src/integration/server/index.ts
+++ b/packages/sdk/src/integration/server/index.ts
@@ -1,7 +1,6 @@
 import { isApiError, Client, RuntimeError } from '@botpress/client'
 import { retryConfig } from '../../retry'
 import { Request, Response, parseBody } from '../../serve'
-import { Merge } from '../../utils/type-utils'
 import { IntegrationSpecificClient } from '../client'
 import { BaseIntegration } from '../common'
 import { ActionMetadataStore } from './action-metadata'
@@ -23,14 +22,10 @@ import {
 export * from './types'
 export * from './integration-logger'
 
-type ServerProps = Merge<
-  CommonHandlerProps<BaseIntegration>,
-  {
-    req: Request
-    instance: IntegrationHandlers<BaseIntegration>
-    ctx: IntegrationContext
-  }
->
+type ServerProps = CommonHandlerProps<BaseIntegration> & {
+  req: Request
+  instance: IntegrationHandlers<BaseIntegration>
+}
 
 const extractTracingHeaders = (headers: Record<string, string | undefined>) => {
   return ['traceparent', 'tracestate', 'sentry-trace'].reduce<Record<string, string>>((acc, header) => {
@@ -66,10 +61,6 @@ const getServerProps = (
   }
 }
 
-const handleUnknownOperation = async (props: ServerProps) => {
-  return await onUnknownOperationHandler(props)
-}
-
 const handleOperation = async (props: ServerProps) => {
   const { ctx } = props
   switch (ctx.operation) {
@@ -103,7 +94,7 @@ export const integrationHandler =
 
     try {
       let response: Response | void
-      response = await handleUnknownOperation(props)
+      response = await onUnknownOperationHandler(props)
       if (response) {
         return { ...response, status: response.status ?? 200 }
       }

--- a/packages/sdk/src/integration/server/index.ts
+++ b/packages/sdk/src/integration/server/index.ts
@@ -67,7 +67,7 @@ const getServerProps = <T extends IntegrationContext | UnknownOperationIntegrati
 }
 
 const handleUnknownOperation = async (props: ServerProps<UnknownOperationIntegrationContext>) => {
-  return await onIntegrationOperationHandler(props)
+  return await onUnknownOperationHandler(props)
 }
 
 const handleOperation = async (props: ServerProps<IntegrationContext>) => {
@@ -103,11 +103,12 @@ export const integrationHandler =
     try {
       let response: Response | void
       response = await handleUnknownOperation(unknownOperationProps)
-      if (!response) {
-        const props = getServerProps(extractContext(req.headers), req, instance)
-        response = await handleOperation(props)
+      if (response) {
+        return { ...response, status: response.status ?? 200 }
       }
 
+      const props = getServerProps(extractContext(req.headers), req, instance)
+      response = await handleOperation(props)
       return response ? { ...response, status: response.status ?? 200 } : { status: 200 }
     } catch (error) {
       if (isApiError(error)) {
@@ -215,14 +216,14 @@ const onActionTriggered = async ({ req, ctx, client, logger, instance }: ServerP
   }
 }
 
-const onIntegrationOperationHandler = async ({
+const onUnknownOperationHandler = async ({
   instance,
   client,
   ctx,
   logger,
   req,
 }: ServerProps<UnknownOperationIntegrationContext>): Promise<Response | void> => {
-  const handler = instance.integrationOperationHandler
+  const handler = instance.unknownOperationHandler
   if (!handler) {
     return
   }

--- a/packages/sdk/src/integration/server/types.ts
+++ b/packages/sdk/src/integration/server/types.ts
@@ -152,10 +152,13 @@ export type ChannelHandlers<TIntegration extends BaseIntegration> = {
 }
 
 export type UnknownOperationHandler<TIntegration extends BaseIntegration> = (
-  props: Omit<CommonHandlerProps<TIntegration>, 'ctx'> & {
-    req: Request
-    ctx: UnknownOperationIntegrationContext<TIntegration>
-  }
+  props: Merge<
+    CommonHandlerProps<TIntegration>,
+    {
+      req: Request
+      ctx: UnknownOperationIntegrationContext<TIntegration>
+    }
+  >
 ) => Promise<Response | void>
 
 export type IntegrationHandlers<TIntegration extends BaseIntegration> = {

--- a/packages/sdk/src/integration/server/types.ts
+++ b/packages/sdk/src/integration/server/types.ts
@@ -151,7 +151,7 @@ export type ChannelHandlers<TIntegration extends BaseIntegration> = {
   }
 }
 
-export type IntegrationOperationHandler<TIntegration extends BaseIntegration> = (
+export type UnknownOperationHandler<TIntegration extends BaseIntegration> = (
   props: Omit<CommonHandlerProps<TIntegration>, 'ctx'> & {
     req: Request
     ctx: UnknownOperationIntegrationContext<TIntegration>
@@ -166,5 +166,5 @@ export type IntegrationHandlers<TIntegration extends BaseIntegration> = {
   createConversation?: CreateConversationHandler<TIntegration>
   actions: ActionHandlers<TIntegration>
   channels: ChannelHandlers<TIntegration>
-  integrationOperationHandler?: IntegrationOperationHandler<TIntegration>
+  unknownOperationHandler?: UnknownOperationHandler<TIntegration>
 }

--- a/packages/sdk/src/integration/server/types.ts
+++ b/packages/sdk/src/integration/server/types.ts
@@ -5,15 +5,6 @@ import { IntegrationSpecificClient } from '../client'
 import { BaseIntegration, ToTags } from '../common'
 import { type IntegrationLogger } from './integration-logger'
 
-type IntegrationOperation =
-  | 'webhook_received'
-  | 'message_created'
-  | 'action_triggered'
-  | 'register'
-  | 'unregister'
-  | 'ping'
-  | 'create_user'
-  | 'create_conversation'
 type IntegrationContextConfig<TIntegration extends BaseIntegration> =
   | {
       configurationType: null
@@ -26,23 +17,13 @@ type IntegrationContextConfig<TIntegration extends BaseIntegration> =
       }
     }>
 
-export type GenericIntegrationContext<
-  TIntegration extends BaseIntegration = BaseIntegration,
-  TOperation extends string = string,
-> = {
+export type IntegrationContext<TIntegration extends BaseIntegration = BaseIntegration> = {
   botId: string
   botUserId: string
   integrationId: string
   webhookId: string
-  operation: TOperation
+  operation: string
 } & IntegrationContextConfig<TIntegration>
-
-export type UnknownOperationIntegrationContext<TIntegration extends BaseIntegration = BaseIntegration> =
-  GenericIntegrationContext<TIntegration, string>
-export type IntegrationContext<TIntegration extends BaseIntegration = BaseIntegration> = GenericIntegrationContext<
-  TIntegration,
-  IntegrationOperation
->
 
 export type CommonHandlerProps<TIntegration extends BaseIntegration> = {
   ctx: IntegrationContext<TIntegration>
@@ -156,7 +137,7 @@ export type UnknownOperationHandler<TIntegration extends BaseIntegration> = (
     CommonHandlerProps<TIntegration>,
     {
       req: Request
-      ctx: UnknownOperationIntegrationContext<TIntegration>
+      ctx: IntegrationContext<TIntegration>
     }
   >
 ) => Promise<Response | void>

--- a/packages/sdk/src/integration/server/types.ts
+++ b/packages/sdk/src/integration/server/types.ts
@@ -26,13 +26,23 @@ type IntegrationContextConfig<TIntegration extends BaseIntegration> =
       }
     }>
 
-export type IntegrationContext<TIntegration extends BaseIntegration = BaseIntegration> = {
+export type GenericIntegrationContext<
+  TIntegration extends BaseIntegration = BaseIntegration,
+  TOperation extends string = string,
+> = {
   botId: string
   botUserId: string
   integrationId: string
   webhookId: string
-  operation: IntegrationOperation
+  operation: TOperation
 } & IntegrationContextConfig<TIntegration>
+
+export type UnknownOperationIntegrationContext<TIntegration extends BaseIntegration = BaseIntegration> =
+  GenericIntegrationContext<TIntegration, string>
+export type IntegrationContext<TIntegration extends BaseIntegration = BaseIntegration> = GenericIntegrationContext<
+  TIntegration,
+  IntegrationOperation
+>
 
 export type CommonHandlerProps<TIntegration extends BaseIntegration> = {
   ctx: IntegrationContext<TIntegration>
@@ -142,8 +152,9 @@ export type ChannelHandlers<TIntegration extends BaseIntegration> = {
 }
 
 export type IntegrationOperationHandler<TIntegration extends BaseIntegration> = (
-  props: CommonHandlerProps<TIntegration> & {
+  props: Omit<CommonHandlerProps<TIntegration>, 'ctx'> & {
     req: Request
+    ctx: UnknownOperationIntegrationContext<TIntegration>
   }
 ) => Promise<Response | void>
 

--- a/packages/sdk/src/integration/server/types.ts
+++ b/packages/sdk/src/integration/server/types.ts
@@ -133,13 +133,9 @@ export type ChannelHandlers<TIntegration extends BaseIntegration> = {
 }
 
 export type UnknownOperationHandler<TIntegration extends BaseIntegration> = (
-  props: Merge<
-    CommonHandlerProps<TIntegration>,
-    {
-      req: Request
-      ctx: IntegrationContext<TIntegration>
-    }
-  >
+  props: CommonHandlerProps<TIntegration> & {
+    req: Request
+  }
 ) => Promise<Response | void>
 
 export type IntegrationHandlers<TIntegration extends BaseIntegration> = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1957,7 +1957,7 @@ importers:
         specifier: 1.15.3
         version: link:../client
       '@botpress/sdk':
-        specifier: 4.11.0
+        specifier: 4.11.1
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2069,7 +2069,7 @@ importers:
         specifier: 1.15.3
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.11.0
+        specifier: 4.11.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2085,7 +2085,7 @@ importers:
         specifier: 1.15.3
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.11.0
+        specifier: 4.11.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2098,7 +2098,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 4.11.0
+        specifier: 4.11.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2114,7 +2114,7 @@ importers:
         specifier: 1.15.3
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.11.0
+        specifier: 4.11.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2130,7 +2130,7 @@ importers:
         specifier: 1.15.3
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.11.0
+        specifier: 4.11.1
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
This fixes a parsing error that occurs when an integration operation unknown by the SDK is received by the integration. If the global integration operation handler returns a response, operation specific handlers are not called.
