### PR TITLE
feat(slack): add Slack user ID support to workflow webhooks

### DIFF
--- a/integrations/slack/definitions/actions.ts
+++ b/integrations/slack/definitions/actions.ts
@@ -124,4 +124,22 @@ export const actions = {
       schema: sdk.z.object({}),
     },
   },
+
+  getUserProfile: {
+    title: 'Get User Profile',
+    description: 'Get information about a user',
+    input: {
+      schema: sdk.z.object({
+        userId: sdk.z.string().title('User ID').describe('The ID of the user to retrieve information about'),
+      }),
+    },
+    output: {
+      schema: sdk.z.object({
+        firstName: sdk.z.string().optional().title('Firstname').describe('The first name of the user'),
+        lastName: sdk.z.string().optional().title('Lastname').describe('The last name of the user'),
+        email: sdk.z.string().optional().title('Email').describe('The email of the user'),
+        displayName: sdk.z.string().optional().title('Display Name').describe('The display name of the user'),
+      }),
+    },
+  },
 } as const satisfies sdk.IntegrationDefinitionProps['actions']

--- a/integrations/slack/definitions/events.ts
+++ b/integrations/slack/definitions/events.ts
@@ -136,6 +136,11 @@ export const events = {
     description: 'Triggered when the workflow webhook is triggered',
     schema: sdk.z.object({
       value: sdk.z.any().title('Value').describe('The value of the workflow webhook'),
+      userId: sdk.z
+        .string()
+        .optional()
+        .title('Slack User ID')
+        .describe('The Slack ID of the user who triggered the workflow'),
     }),
   },
 } as const satisfies sdk.IntegrationDefinitionProps['events']

--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -17,7 +17,7 @@ export default new IntegrationDefinition({
   name: 'slack',
   title: 'Slack',
   description: 'Automate interactions with your team.',
-  version: '2.3.0',
+  version: '2.3.1',
   icon: 'icon.svg',
   readme: 'hub.md',
   configuration,

--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -17,7 +17,7 @@ export default new IntegrationDefinition({
   name: 'slack',
   title: 'Slack',
   description: 'Automate interactions with your team.',
-  version: '2.3.1',
+  version: '2.4.0',
   icon: 'icon.svg',
   readme: 'hub.md',
   configuration,

--- a/integrations/slack/src/actions/get-user-profile.ts
+++ b/integrations/slack/src/actions/get-user-profile.ts
@@ -1,0 +1,15 @@
+import { wrapActionAndInjectSlackClient } from 'src/actions/action-wrapper'
+
+export const getUserProfile = wrapActionAndInjectSlackClient(
+  { actionName: 'getUserProfile', errorMessage: 'Failed to retrieve user profile' },
+  async ({ slackClient }, { userId }) => {
+    const userProfile = await slackClient.getUserProfile({ userId })
+
+    return {
+      firstName: userProfile?.first_name,
+      lastName: userProfile?.last_name,
+      email: userProfile?.email,
+      displayName: userProfile?.display_name,
+    }
+  }
+)

--- a/integrations/slack/src/actions/index.ts
+++ b/integrations/slack/src/actions/index.ts
@@ -1,12 +1,12 @@
+import type * as bp from '.botpress'
 import { addReaction } from './add-reaction'
 import { findTarget } from './find-target'
+import { getUserProfile } from './get-user-profile'
 import { retrieveMessage } from './retrieve-message'
 import { startDmConversation } from './start-dm'
 import { syncMembers } from './sync-members'
 import { startTypingIndicator, stopTypingIndicator } from './typing-indicator'
 import { updateChannelTopic } from './update-channel-topic'
-
-import * as bp from '.botpress'
 
 export default {
   addReaction,
@@ -17,4 +17,5 @@ export default {
   updateChannelTopic,
   startTypingIndicator,
   stopTypingIndicator,
+  getUserProfile,
 } satisfies bp.IntegrationProps['actions']

--- a/integrations/slack/src/setup.ts
+++ b/integrations/slack/src/setup.ts
@@ -1,7 +1,7 @@
+import type * as bp from '.botpress'
 import * as sdk from '@botpress/client'
 import { isValidUrl } from './misc/utils'
 import { SlackClient } from './slack-api'
-import * as bp from '.botpress'
 
 const REQUIRED_SLACK_SCOPES = [
   'channels:history',
@@ -22,6 +22,7 @@ const REQUIRED_SLACK_SCOPES = [
   'team:read',
   'users.profile:read',
   'users:read',
+  'users:read.email',
 ]
 
 export const register: bp.IntegrationProps['register'] = async ({ client, ctx, logger }) => {

--- a/integrations/slack/src/webhook-events/handlers/function-executed.ts
+++ b/integrations/slack/src/webhook-events/handlers/function-executed.ts
@@ -1,5 +1,5 @@
-import { FunctionExecutedEvent } from '@slack/types'
-import * as bp from '.botpress'
+import type * as bp from '.botpress'
+import type { FunctionExecutedEvent } from '@slack/types'
 
 export const handleEvent = async ({
   slackEvent,
@@ -16,9 +16,17 @@ export const handleEvent = async ({
   }
 
   const inputValues = slackEvent.inputs.value
+  const inputUserId = slackEvent.inputs.userId
 
   if (!Array.isArray(inputValues)) {
     logger.forBot().debug(`Ignoring unsupported workflow function input value type ${typeof inputValues}`)
+    return
+  }
+
+  const userId = typeof inputUserId === 'string' ? inputUserId : undefined
+
+  if (inputUserId && typeof inputUserId !== 'string') {
+    logger.forBot().debug(`Ignoring unsupported workflow function input userId type ${typeof inputUserId}`)
     return
   }
 
@@ -27,6 +35,7 @@ export const handleEvent = async ({
   await client.createEvent({
     type: 'workflowWebhook',
     payload: {
+      userId,
       value: inputValue,
     },
   })


### PR DESCRIPTION
This PR adds the ability to pass the Slack user ID from workflow webhooks to the integration, enhancing user context tracking.

## Overview of Changes

- Added an optional `userId` field to the workflow webhook event schema to capture the Slack user ID who triggered the workflow
- Incremented the integration version from `2.3.0` to `2.3.1` for this enhancement
