### PR TITLE
chore: remove format on save option for settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
-  "editor.codeActionsOnSave": {
-    "source.fixAll": "explicit"
-  },
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },


### PR DESCRIPTION
We've decided that the format on save option shouldn't be enforced and is a matter of preference. We'll let each developer add it to their own global VS Code settings file.