### PR TITLE
fix(integrations/zendesk): ignore picture url when too long

### DIFF
--- a/integrations/zendesk/integration.definition.ts
+++ b/integrations/zendesk/integration.definition.ts
@@ -7,7 +7,7 @@ import { actions, events, configuration, channels, states, user } from './src/de
 export default new IntegrationDefinition({
   name: 'zendesk',
   title: 'Zendesk',
-  version: '2.2.3',
+  version: '2.5.0',
   icon: 'icon.svg',
   description:
     'Optimize your support workflow. Trigger workflows from ticket updates as well as manage tickets, access conversations, and engage with customers.',

--- a/integrations/zendesk/src/actions/create-user.ts
+++ b/integrations/zendesk/src/actions/create-user.ts
@@ -26,9 +26,14 @@ export const createUser: bp.IntegrationProps['actions']['createUser'] = async ({
   let remote_photo_url = pictureUrl
 
   const urlLength = _getEncodedLength(encodedPictureUrl)
-  if (urlLength && urlLength > 255) {
+  const maxUrlLength = 255
+  if (urlLength && urlLength > maxUrlLength) {
     // Zendesk has a limit of 255 characters for the remote_photo_url
-    logger.forBot().warn(`Picture URL is too long (${urlLength} characters). It will not be set in Zendesk.`)
+    logger
+      .forBot()
+      .warn(
+        `Picture URL is too long (${urlLength} characters, but max is ${maxUrlLength}). It will not be set in Zendesk.`
+      )
     remote_photo_url = ''
   }
 

--- a/integrations/zendesk/src/actions/create-user.ts
+++ b/integrations/zendesk/src/actions/create-user.ts
@@ -1,7 +1,12 @@
 import { getZendeskClient } from '../client'
 import * as bp from '.botpress'
 
-export const createUser: bp.IntegrationProps['actions']['createUser'] = async ({ ctx, client: bpClient, input }) => {
+export const createUser: bp.IntegrationProps['actions']['createUser'] = async ({
+  ctx,
+  client: bpClient,
+  input,
+  logger,
+}) => {
   const zendeskClient = getZendeskClient(ctx.configuration)
 
   const { name, email, pictureUrl } = input
@@ -16,11 +21,22 @@ export const createUser: bp.IntegrationProps['actions']['createUser'] = async ({
     discriminateByTags: ['email'],
   })
 
+  const encodedPictureUrl = pictureUrl && encodeURI(pictureUrl)
+
+  let remote_photo_url = pictureUrl
+
+  const urlLength = _getEncodedLength(encodedPictureUrl)
+  if (urlLength && urlLength > 255) {
+    // Zendesk has a limit of 255 characters for the remote_photo_url
+    logger.forBot().warn(`Picture URL is too long (${urlLength} characters). It will not be set in Zendesk.`)
+    remote_photo_url = ''
+  }
+
   const zendeskUser = await zendeskClient.createOrUpdateUser({
     role: 'end-user',
     external_id: user.id,
     name,
-    remote_photo_url: pictureUrl,
+    remote_photo_url,
     email,
   })
 
@@ -37,3 +53,5 @@ export const createUser: bp.IntegrationProps['actions']['createUser'] = async ({
     userId: user.id,
   }
 }
+
+const _getEncodedLength = (url: string | undefined): number | undefined => (url ? encodeURI(url).length : undefined)


### PR DESCRIPTION
I was able to reproduce the bug. This fix stinks, but it works fine.

fixes CLS-3061