### PR TITLE
fix(integrations/anthropic): max output tokens are correctly limited when using reasoning models

### DIFF
--- a/integrations/anthropic/integration.definition.ts
+++ b/integrations/anthropic/integration.definition.ts
@@ -7,7 +7,7 @@ export default new IntegrationDefinition({
   name: 'anthropic',
   title: 'Anthropic',
   description: 'Access a curated list of Claude models to set as your chosen LLM.',
-  version: '9.0.1',
+  version: '9.0.2',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/anthropic/src/actions/generate-content.ts
+++ b/integrations/anthropic/src/actions/generate-content.ts
@@ -109,7 +109,7 @@ export async function generateContent(
     request.top_p = undefined
   }
 
-  if (request.max_tokens >= model.output.maxTokens) {
+  if (request.max_tokens > model.output.maxTokens) {
     request.max_tokens = model.output.maxTokens
     logger
       .forBot()

--- a/integrations/anthropic/src/actions/generate-content.ts
+++ b/integrations/anthropic/src/actions/generate-content.ts
@@ -65,23 +65,9 @@ export async function generateContent(
 
   let response: Anthropic.Messages.Message | undefined
 
-  let maxTokens = model.output.maxTokens
-
-  if (input.maxTokens) {
-    if (input.maxTokens <= model.output.maxTokens) {
-      maxTokens = input.maxTokens
-    } else {
-      logger
-        .forBot()
-        .warn(
-          `Received maxTokens parameter greater than the maximum output tokens allowed for model "${modelId}", capping maxTokens to ${maxTokens}`
-        )
-    }
-  }
-
   const request: MessageCreateParamsNonStreaming = {
     model: modelId,
-    max_tokens: maxTokens,
+    max_tokens: input.maxTokens ?? model.output.maxTokens,
     temperature: input.temperature,
     top_p: input.topP,
     system: input.systemPrompt,
@@ -121,6 +107,15 @@ export async function generateContent(
     request.temperature = undefined
     request.top_k = undefined
     request.top_p = undefined
+  }
+
+  if (request.max_tokens >= model.output.maxTokens) {
+    request.max_tokens = model.output.maxTokens
+    logger
+      .forBot()
+      .warn(
+        `Received maxTokens parameter greater than the maximum output tokens allowed for model "${modelId}", capped parameter value to ${request.max_tokens}`
+      )
   }
 
   if (input.debug) {


### PR DESCRIPTION
Using a reasoning model overrides the max output tokens to accommodate for the additional "thinking" tokens required, so we need to apply the limit after the logic that handles this.