### PR TITLE
feat(integrations/messenger): Remove unneeded prefix from `postback` and `say` payloads in cards

### DIFF
--- a/integrations/messenger/src/misc/utils.ts
+++ b/integrations/messenger/src/misc/utils.ts
@@ -26,14 +26,14 @@ export function formatCardElement(payload: Card) {
         buttons.push({
           type: 'postback',
           title: action.label,
-          payload: `postback:${action.value}`,
+          payload: action.value,
         })
         break
       case 'say':
         buttons.push({
           type: 'postback',
           title: action.label,
-          payload: `say:${action.value}`,
+          payload: action.value,
         })
         break
       case 'url':


### PR DESCRIPTION
**Note**: This PR merges in the `messenger-sandbox-n-refactor` branch
