### PR TITLE
fix(plugins/hitl): default email must be allowed by zendesk

### DIFF
--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -85,7 +85,7 @@ const PLUGIN_CONFIG_SCHEMA = sdk.z.object({
 
 export default new sdk.PluginDefinition({
   name: 'hitl',
-  version: '0.10.4',
+  version: '0.12.0',
   title: 'Human In The Loop',
   description: 'Seamlessly transfer conversations to human agents',
   icon: 'icon.svg',

--- a/plugins/hitl/src/user-linker.ts
+++ b/plugins/hitl/src/user-linker.ts
@@ -86,6 +86,6 @@ export class UserLinker {
 
   private _generateFakeEmail(user: client.User) {
     const botId = this._props.ctx.botId.replaceAll('_', '-')
-    return `${user.id}@${botId}.botpress.invalid`
+    return `${user.id}@no-reply.${botId}.botpress.com`
   }
 }


### PR DESCRIPTION
I was able to reproduce the bug and I confirm that this fixes the issue with zendesk.

fixes DEV-3074