### PR TITLE
feat(messenger): add user media support

### DIFF
--- a/integrations/messenger/integration.definition.ts
+++ b/integrations/messenger/integration.definition.ts
@@ -24,7 +24,7 @@ const commonConfigSchema = z.object({
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '3.0.3',
+  version: '3.4.0',
   title: 'Messenger',
   description: 'Give your bot access to one of the world’s largest messaging platform.',
   icon: 'icon.svg',

--- a/integrations/messenger/integration.definition.ts
+++ b/integrations/messenger/integration.definition.ts
@@ -24,7 +24,7 @@ const commonConfigSchema = z.object({
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '3.4.0',
+  version: '3.1.0',
   title: 'Messenger',
   description: 'Give your bot access to one of the world’s largest messaging platform.',
   icon: 'icon.svg',

--- a/integrations/messenger/integration.definition.ts
+++ b/integrations/messenger/integration.definition.ts
@@ -4,9 +4,27 @@ import typingIndicator from 'bp_modules/typing-indicator'
 
 export const INTEGRATION_NAME = 'messenger'
 
+const commonConfigSchema = z.object({
+  downloadMedia: z
+    .boolean()
+    .default(false)
+    .title('Download Media')
+    .describe(
+      'Automatically download media files using the Files API for content access. If disabled, Messenger media URLs will be used.'
+    ),
+  downloadedMediaExpiry: z
+    .number()
+    .default(24)
+    .optional()
+    .title('Downloaded Media Expiry')
+    .describe(
+      'Expiry time in hours for downloaded media files. An expiry time of 0 means the files will never expire.'
+    ),
+})
+
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '3.0.2',
+  version: '3.0.3',
   title: 'Messenger',
   description: 'Give your bot access to one of the world’s largest messaging platform.',
   icon: 'icon.svg',
@@ -16,33 +34,35 @@ export default new IntegrationDefinition({
       linkTemplateScript: 'linkTemplate.vrl',
       required: true,
     },
-    schema: z.object({}),
+    schema: commonConfigSchema,
   },
   configurations: {
     manualApp: {
       title: 'Manual Configuration',
       description: 'Manual Configuration, use your own Meta app (for advanced use cases only)',
-      schema: z.object({
-        verifyToken: z
-          .string()
-          .title('Verify Token')
-          .min(1)
-          .describe(
-            'Token used for verification when subscribing to webhooks on the Meta app (type any random string)'
-          ),
-        accessToken: z
-          .string()
-          .title('Access Token')
-          .min(1)
-          .describe('Access Token from a System Account that has permission to the Meta app'),
-        clientId: z.string().title('Client ID').min(1).describe('Meta app client id'),
-        clientSecret: z
-          .string()
-          .title('Client Secret')
-          .optional()
-          .describe('Meta app secret used for webhook signature check'),
-        pageId: z.string().min(1).describe('Id from the Facebook page').title('Page ID'),
-      }),
+      schema: z
+        .object({
+          verifyToken: z
+            .string()
+            .title('Verify Token')
+            .min(1)
+            .describe(
+              'Token used for verification when subscribing to webhooks on the Meta app (type any random string)'
+            ),
+          accessToken: z
+            .string()
+            .title('Access Token')
+            .min(1)
+            .describe('Access Token from a System Account that has permission to the Meta app'),
+          clientId: z.string().title('Client ID').min(1).describe('Meta app client id'),
+          clientSecret: z
+            .string()
+            .title('Client Secret')
+            .optional()
+            .describe('Meta app secret used for webhook signature check'),
+          pageId: z.string().min(1).describe('Id from the Facebook page').title('Page ID'),
+        })
+        .merge(commonConfigSchema),
     },
   },
   identifier: {

--- a/integrations/messenger/src/misc/incoming-message.ts
+++ b/integrations/messenger/src/misc/incoming-message.ts
@@ -1,9 +1,9 @@
 import { RuntimeError } from '@botpress/client'
+import { ValueOf } from '@botpress/sdk/dist/utils/type-utils'
+import axios from 'axios'
 import { MessengerMessage } from './types'
 import { FileMetadata, generateIdFromUrl, getMediaMetadata, getMessengerClient } from './utils'
 import * as bp from '.botpress'
-import axios from 'axios'
-import { ValueOf } from '@botpress/sdk/dist/utils/type-utils'
 
 type IntegrationLogger = bp.Logger
 

--- a/integrations/messenger/src/misc/incoming-message.ts
+++ b/integrations/messenger/src/misc/incoming-message.ts
@@ -127,19 +127,19 @@ export async function handleMessage(
           type: 'image',
           payload: { imageUrl },
         })
-      } else if (attachment.type == 'audio') {
+      } else if (attachment.type === 'audio') {
         const { url: audioUrl } = await _getOrDownloadMedia(attachment.payload.url, client, ctx)
         await createMessage({
           type: 'audio',
           payload: { audioUrl },
         })
-      } else if (attachment.type == 'video') {
+      } else if (attachment.type === 'video') {
         const { url: videoUrl } = await _getOrDownloadMedia(attachment.payload.url, client, ctx)
         await createMessage({
           type: 'video',
           payload: { videoUrl },
         })
-      } else if (attachment.type == 'file') {
+      } else if (attachment.type === 'file') {
         const { url: fileUrl, fileName } = await _getOrDownloadMedia(attachment.payload.url, client, ctx)
         await createMessage({
           type: 'file',

--- a/integrations/messenger/src/misc/incoming-message.ts
+++ b/integrations/messenger/src/misc/incoming-message.ts
@@ -1,8 +1,78 @@
 import { MessengerMessage } from './types'
-import { getMessengerClient } from './utils'
+import { FileMetadata, generateIdFromUrl, getMediaMetadata, getMessengerClient } from './utils'
 import * as bp from '.botpress'
+import { RuntimeError } from '@botpress/client'
+import axios from 'axios'
+import { ValueOf } from '@botpress/sdk/dist/utils/type-utils'
 
 type IntegrationLogger = bp.Logger
+
+type IncomingMessages = {
+  [TMessage in keyof bp.channels.channel.Messages]: {
+    type: TMessage
+    payload: bp.channels.channel.Messages[TMessage]
+  }
+}
+
+function _getMediaExpiry(ctx: bp.Context) {
+  const expiryDelayHours = ctx.configuration.downloadedMediaExpiry || 0
+  if (expiryDelayHours === 0) {
+    return undefined
+  }
+  const expiresAt = new Date(Date.now() + expiryDelayHours * 60 * 60 * 1000)
+  return expiresAt.toISOString()
+}
+
+async function _getOrDownloadMedia(url: string, client: bp.Client, ctx: bp.Context) : Promise<FileMetadata & { url: string }> {
+  const metadata = await getMediaMetadata(url)
+  if (ctx.configuration.downloadMedia) {
+    return await _downloadMedia({ url, ...metadata }, client, ctx)
+  }
+
+  return { url, ...metadata }
+}
+
+async function _downloadMedia(params: { url: string } & FileMetadata, client: bp.Client, ctx: bp.Context) {
+  const { url, mimeType, fileSize, fileName } = params
+  const { file } = await client.upsertFile({
+    key: 'messenger-media_' + (await generateIdFromUrl(url)),
+    expiresAt: _getMediaExpiry(ctx),
+    contentType: mimeType,
+    accessPolicies: ['public_content'],
+    publicContentImmediatelyAccessible: true,
+    size: fileSize ?? 0,
+    tags: {
+      source: 'integration',
+      integration: 'messenger',
+      channel: 'channel',
+      originUrl: url,
+      ...(fileName?.length && { name: fileName })
+    },
+  })
+
+  const downloadResponse = await axios
+    .get(url, {
+      responseType: 'stream',
+    })
+    .catch((err) => {
+      throw new RuntimeError(`Failed to download media: ${err.message}`)
+    })
+
+  await axios
+    .put(file.uploadUrl, downloadResponse.data, {
+      headers: {
+        'Content-Type': mimeType,
+        'Content-Length': fileSize,
+        'x-amz-tagging': 'public=true',
+      },
+      maxBodyLength: fileSize,
+    })
+    .catch((err) => {
+      throw new RuntimeError(`Failed to upload media: ${err.message}`)
+    })
+
+  return { url: file.url, mimeType, fileSize, fileName }
+}
 
 export async function handleMessage(
   message: MessengerMessage,
@@ -12,18 +82,6 @@ export async function handleMessage(
 
   let text: string
   let messageId: string
-
-  if (textMessage?.text) {
-    text = textMessage.text
-    messageId = textMessage.mid
-    logger.forBot().debug(`Received text message from Messenger: ${textMessage.text}`)
-  } else if (postback?.payload) {
-    text = postback.payload
-    messageId = postback.mid
-    logger.forBot().debug(`Received postback from Messenger: ${postback.title}`)
-  } else {
-    return
-  }
 
   const { conversation } = await client.getOrCreateConversation({
     channel: 'channel',
@@ -40,6 +98,64 @@ export async function handleMessage(
     },
   })
 
+  const createMessage = async ({ type, payload }: ValueOf<IncomingMessages>) => {
+    logger.forBot().debug(`Received ${type} message from Messenger:`, payload)
+    return client.createMessage({
+      tags: {
+        id: messageId,
+        senderId: message.sender.id,
+        recipientId: message.recipient.id,
+      },
+      type,
+      payload,
+      userId: user.id,
+      conversationId: conversation.id,
+    })
+  }
+
+  messageId = textMessage?.mid || ''
+
+  if (textMessage?.attachments?.length) {
+    for (const attachment of textMessage.attachments) {
+      if (attachment.type === 'image') {
+        const { url: imageUrl } = await _getOrDownloadMedia(attachment.payload.url, client, ctx)
+        await createMessage({
+          type: 'image',
+          payload: { imageUrl },
+        })
+      } else if (attachment.type == 'audio') {
+        const { url: audioUrl } = await _getOrDownloadMedia(attachment.payload.url, client, ctx)
+        await createMessage({
+          type: 'audio',
+          payload: { audioUrl },
+        })
+      } else if (attachment.type == 'video') {
+        const { url: videoUrl } = await _getOrDownloadMedia(attachment.payload.url, client, ctx)
+        await createMessage({
+          type: 'video',
+          payload: { videoUrl },
+        })
+      } else if(attachment.type == 'file') {
+        const { url: fileUrl, fileName } = await _getOrDownloadMedia(attachment.payload.url, client, ctx)
+        await createMessage({
+          type: 'file',
+          payload: { fileUrl, title: fileName },
+        })
+      }
+    }
+  }
+
+  if (textMessage?.text) {
+    text = textMessage.text
+    logger.forBot().debug(`Received text message from Messenger: ${textMessage.text}`)
+  } else if (postback?.payload) {
+    text = postback.payload
+    messageId = postback.mid
+    logger.forBot().debug(`Received postback from Messenger: ${postback.title}`)
+  } else {
+    return
+  }
+
   if (!user.name || !user.pictureUrl) {
     try {
       const messengerClient = await getMessengerClient(client, ctx)
@@ -52,15 +168,5 @@ export async function handleMessage(
     }
   }
 
-  await client.createMessage({
-    tags: {
-      id: messageId,
-      senderId: message.sender.id,
-      recipientId: message.recipient.id,
-    },
-    type: 'text',
-    userId: user.id,
-    conversationId: conversation.id,
-    payload: { text },
-  })
+  await createMessage({ type: 'text', payload: { text } })
 }

--- a/integrations/messenger/src/misc/incoming-message.ts
+++ b/integrations/messenger/src/misc/incoming-message.ts
@@ -23,7 +23,11 @@ function _getMediaExpiry(ctx: bp.Context) {
   return expiresAt.toISOString()
 }
 
-async function _getOrDownloadMedia(url: string, client: bp.Client, ctx: bp.Context) : Promise<FileMetadata & { url: string }> {
+async function _getOrDownloadMedia(
+  url: string,
+  client: bp.Client,
+  ctx: bp.Context
+): Promise<FileMetadata & { url: string }> {
   const metadata = await getMediaMetadata(url)
   if (ctx.configuration.downloadMedia) {
     return await _downloadMedia({ url, ...metadata }, client, ctx)
@@ -46,7 +50,7 @@ async function _downloadMedia(params: { url: string } & FileMetadata, client: bp
       integration: 'messenger',
       channel: 'channel',
       originUrl: url,
-      ...(fileName?.length && { name: fileName })
+      ...(fileName?.length && { name: fileName }),
     },
   })
 
@@ -135,7 +139,7 @@ export async function handleMessage(
           type: 'video',
           payload: { videoUrl },
         })
-      } else if(attachment.type == 'file') {
+      } else if (attachment.type == 'file') {
         const { url: fileUrl, fileName } = await _getOrDownloadMedia(attachment.payload.url, client, ctx)
         await createMessage({
           type: 'file',

--- a/integrations/messenger/src/misc/incoming-message.ts
+++ b/integrations/messenger/src/misc/incoming-message.ts
@@ -1,7 +1,7 @@
+import { RuntimeError } from '@botpress/client'
 import { MessengerMessage } from './types'
 import { FileMetadata, generateIdFromUrl, getMediaMetadata, getMessengerClient } from './utils'
 import * as bp from '.botpress'
-import { RuntimeError } from '@botpress/client'
 import axios from 'axios'
 import { ValueOf } from '@botpress/sdk/dist/utils/type-utils'
 

--- a/integrations/messenger/src/misc/utils.ts
+++ b/integrations/messenger/src/misc/utils.ts
@@ -91,28 +91,28 @@ export function getChoiceMessage(payload: Choice | Dropdown): MessengerTypes.Tex
 export type FileMetadata = { mimeType: string; fileSize?: number; fileName?: string }
 
 export async function getMediaMetadata(url: string): Promise<FileMetadata> {
-  const response = await fetch(url, { method: 'HEAD' });
+  const response = await fetch(url, { method: 'HEAD' })
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch metadata for URL: ${url}`);
+    throw new Error(`Failed to fetch metadata for URL: ${url}`)
   }
 
-  const mimeType = response.headers.get('content-type') ?? 'application/octet-stream';
-  const contentLength = response.headers.get('content-length');
-  const contentDisposition = response.headers.get('content-disposition');
+  const mimeType = response.headers.get('content-type') ?? 'application/octet-stream'
+  const contentLength = response.headers.get('content-length')
+  const contentDisposition = response.headers.get('content-disposition')
 
-  const fileSize = contentLength ? Number(contentLength) : undefined;
+  const fileSize = contentLength ? Number(contentLength) : undefined
   if (fileSize !== undefined && isNaN(fileSize)) {
-    throw new Error(`Failed to parse file size from response: ${contentLength}`);
+    throw new Error(`Failed to parse file size from response: ${contentLength}`)
   }
 
   // Try to extract filename from content-disposition
-  let fileName: string | undefined;
+  let fileName: string | undefined
   if (contentDisposition) {
-    const match = contentDisposition.match(/filename\*?=(?:UTF-8'')?"?([^"]+)"?/i);
-    const rawFileName = match?.[1];
+    const match = contentDisposition.match(/filename\*?=(?:UTF-8'')?"?([^"]+)"?/i)
+    const rawFileName = match?.[1]
     if (rawFileName) {
-      fileName = decodeURIComponent(rawFileName);
+      fileName = decodeURIComponent(rawFileName)
     }
   }
 
@@ -120,7 +120,7 @@ export async function getMediaMetadata(url: string): Promise<FileMetadata> {
     mimeType,
     fileSize,
     fileName,
-  };
+  }
 }
 
 export async function generateIdFromUrl(url: string): Promise<string> {

--- a/integrations/messenger/src/misc/utils.ts
+++ b/integrations/messenger/src/misc/utils.ts
@@ -87,3 +87,46 @@ export function getChoiceMessage(payload: Choice | Dropdown): MessengerTypes.Tex
     })),
   }
 }
+
+export type FileMetadata = { mimeType: string; fileSize?: number; fileName?: string }
+
+export async function getMediaMetadata(url: string): Promise<FileMetadata> {
+  const response = await fetch(url, { method: 'HEAD' });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch metadata for URL: ${url}`);
+  }
+
+  const mimeType = response.headers.get('content-type') ?? 'application/octet-stream';
+  const contentLength = response.headers.get('content-length');
+  const contentDisposition = response.headers.get('content-disposition');
+
+  const fileSize = contentLength ? Number(contentLength) : undefined;
+  if (fileSize !== undefined && isNaN(fileSize)) {
+    throw new Error(`Failed to parse file size from response: ${contentLength}`);
+  }
+
+  // Try to extract filename from content-disposition
+  let fileName: string | undefined;
+  if (contentDisposition) {
+    const match = contentDisposition.match(/filename\*?=(?:UTF-8'')?"?([^"]+)"?/i);
+    const rawFileName = match?.[1];
+    if (rawFileName) {
+      fileName = decodeURIComponent(rawFileName);
+    }
+  }
+
+  return {
+    mimeType,
+    fileSize,
+    fileName,
+  };
+}
+
+export async function generateIdFromUrl(url: string): Promise<string> {
+  const buffer = await crypto.subtle.digest('SHA-1', new TextEncoder().encode(url))
+  return Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, 24)
+}


### PR DESCRIPTION
This adds supports for the bot to receive file/image/video/audio on Messenger, just like WhatsApp and Instagram

I tried to keep as similar as possible to the WhatsApp implementation, for better maintainability, I just added some 'closure' for better code readability to the current Messenger code
 
By default it will not send files to the Files API since Messenger urls are public