### PR TITLE
fix(integrations/whatsapp): Fix email format in markdown conversion

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -85,7 +85,7 @@ const defaultBotPhoneNumberId = {
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '4.2.2',
+  version: '4.2.3',
   title: 'WhatsApp',
   description: 'Send and receive messages through WhatsApp.',
   icon: 'icon.svg',

--- a/integrations/whatsapp/src/misc/markdown-to-whatsapp-rtf.test.ts
+++ b/integrations/whatsapp/src/misc/markdown-to-whatsapp-rtf.test.ts
@@ -132,6 +132,10 @@ describe('WhatsApp Markdown Converter', () => {
       expect(convertMarkdownToWhatsApp('<test@test.com>')).toBe('test@test.com (mailto:test@test.com)')
     })
 
+    it('should not convert normal email text to link', () => {
+      expect(convertMarkdownToWhatsApp('test@test.com')).toBe('test@test.com')
+    })
+
     it('should convert links with title', () => {
       const input = '[Link with title](https://example.com "Title")'
       const expected = 'Link with title (https://example.com)'

--- a/integrations/whatsapp/src/misc/markdown-to-whatsapp-rtf.ts
+++ b/integrations/whatsapp/src/misc/markdown-to-whatsapp-rtf.ts
@@ -158,6 +158,11 @@ function _processInlineToken(token: Token, ctx: Context): string {
     case 'link':
       // Links: [text](url) -> text (url)
       const linkText = _processInlineTokens(_convertMarkedTokensToTokens(token.tokens), ctx)
+      const isTrueAutolink = /^<.*>$/.test(token.raw)
+      const isEmail = token.href.startsWith('mailto:')
+      if (isEmail && !isTrueAutolink) {
+        return linkText
+      }
       return linkText !== token.href ? `${linkText} (${token.href})` : token.href
 
     case 'image':


### PR DESCRIPTION
When converting to Markdown, emails are treated as links regardless of whether they are surrounded by `<>` or not. This PR ensures that emails not explicitly formatted using the autolink format remain unchanged.