### PR TITLE
chore(integrations/anthropic): deprecate "reasoning" model IDs and use reasoning effort param instead

### DIFF
--- a/integrations/anthropic/integration.definition.ts
+++ b/integrations/anthropic/integration.definition.ts
@@ -1,19 +1,19 @@
 /* bplint-disable */
 import { z, IntegrationDefinition } from '@botpress/sdk'
-import { modelId } from 'src/schemas'
+import { ModelId } from 'src/schemas'
 import llm from './bp_modules/llm'
 
 export default new IntegrationDefinition({
   name: 'anthropic',
   title: 'Anthropic',
   description: 'Access a curated list of Claude models to set as your chosen LLM.',
-  version: '9.0.3',
+  version: '10.0.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {
     modelRef: {
       schema: z.object({
-        id: modelId,
+        id: ModelId,
       }),
     },
   },

--- a/integrations/anthropic/src/actions/generate-content.ts
+++ b/integrations/anthropic/src/actions/generate-content.ts
@@ -5,7 +5,7 @@ import { InvalidPayloadError } from '@botpress/client'
 import { llm } from '@botpress/common'
 import { z, IntegrationLogger } from '@botpress/sdk'
 import assert from 'assert'
-import { DeprecatedReasoningModelIds, ThinkingModeBudgetTokens } from 'src'
+import { DeprecatedReasoningModelIdReplacements, ThinkingModeBudgetTokens } from 'src'
 import { ModelId } from 'src/schemas'
 
 // Reference: https://docs.anthropic.com/en/api/errors
@@ -25,8 +25,8 @@ export async function generateContent(
 ): Promise<llm.GenerateContentOutput> {
   let modelId = (input.model?.id || params.defaultModel) as ModelId
 
-  if (modelId in DeprecatedReasoningModelIds) {
-    const replacementModelId = DeprecatedReasoningModelIds[modelId]!
+  if (modelId in DeprecatedReasoningModelIdReplacements) {
+    const replacementModelId = DeprecatedReasoningModelIdReplacements[modelId]!
 
     if (input.reasoningEffort === undefined) {
       input.reasoningEffort = 'medium'

--- a/integrations/anthropic/src/actions/generate-content.ts
+++ b/integrations/anthropic/src/actions/generate-content.ts
@@ -39,6 +39,7 @@ export async function generateContent(
       )
 
     modelId = replacementModelId
+    input.model = { id: modelId }
   }
 
   const model = params.models[modelId]

--- a/integrations/anthropic/src/actions/generate-content.ts
+++ b/integrations/anthropic/src/actions/generate-content.ts
@@ -5,7 +5,7 @@ import { InvalidPayloadError } from '@botpress/client'
 import { llm } from '@botpress/common'
 import { z, IntegrationLogger } from '@botpress/sdk'
 import assert from 'assert'
-import { DefaultReasoningEffort, ThinkingModeBudgetTokens } from 'src'
+import { DeprecatedReasoningModelIds, ThinkingModeBudgetTokens } from 'src'
 import { ModelId } from 'src/schemas'
 
 // Reference: https://docs.anthropic.com/en/api/errors
@@ -24,7 +24,24 @@ export async function generateContent(
   }
 ): Promise<llm.GenerateContentOutput> {
   let modelId = (input.model?.id || params.defaultModel) as ModelId
-  let model = params.models[modelId]
+
+  if (modelId in DeprecatedReasoningModelIds) {
+    const replacementModelId = DeprecatedReasoningModelIds[modelId]!
+
+    if (input.reasoningEffort === undefined) {
+      input.reasoningEffort = 'medium'
+    }
+
+    logger
+      .forBot()
+      .warn(
+        `The model "${modelId}" has been deprecated, using "${replacementModelId}" instead with a "${input.reasoningEffort}" reasoning effort`
+      )
+
+    modelId = replacementModelId
+  }
+
+  const model = params.models[modelId]
 
   if (!model) {
     throw new InvalidPayloadError(
@@ -80,24 +97,14 @@ export async function generateContent(
     messages,
   }
 
-  const isReasoningModel =
-    modelId === 'claude-3-7-sonnet-reasoning-20250219' || modelId === 'claude-sonnet-4-reasoning-20250514'
+  const thinkingBudgetTokens = ThinkingModeBudgetTokens[input.reasoningEffort ?? 'none'] // Default to not use reasoning as Claude models use optional reasoning
 
-  if (isReasoningModel) {
-    // NOTE: The "reasoning" model IDs don't really exist in Anthropic, we use it as a simple way for users to switch between the reasoning mode and the standard mode.
-    if (modelId === 'claude-3-7-sonnet-reasoning-20250219') {
-      modelId = 'claude-3-7-sonnet-20250219'
-    } else if (modelId === 'claude-sonnet-4-reasoning-20250514') {
-      modelId = 'claude-sonnet-4-20250514'
-    }
-
-    request.model = modelId
-    model = params.models[modelId]
-
-    // Reference: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
+  if (thinkingBudgetTokens) {
+    // Claude requires a non-zero thinking budget when thinking mode is enabled.
     request.thinking = {
+      // Reference: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
       type: 'enabled',
-      budget_tokens: ThinkingModeBudgetTokens[input.reasoningEffort ?? DefaultReasoningEffort],
+      budget_tokens: thinkingBudgetTokens,
     }
 
     // IMPORTANT: Thinking mode requires the max tokens to be greater than the thinking budget tokens, and we assume here that the max tokens indicated in the action input don't take into account the thinking budget tokens.

--- a/integrations/anthropic/src/index.ts
+++ b/integrations/anthropic/src/index.ts
@@ -10,9 +10,7 @@ const anthropic = new Anthropic({
   timeout: 10 * 60 * 1000, // 10 minute timeout, we set it here to avoid the error thrown by the Anthropic SDK when not using streaming if the request maxTokens parameters is too high (see: https://github.com/anthropics/anthropic-sdk-typescript?tab=readme-ov-file#long-requests)
 })
 
-type ReasoningEffort = NonNullable<GenerateContentInput['reasoningEffort']>
-
-export const DefaultReasoningEffort: ReasoningEffort = 'medium'
+export type ReasoningEffort = NonNullable<GenerateContentInput['reasoningEffort']>
 
 export const ThinkingModeBudgetTokens: Record<ReasoningEffort, number> = {
   none: 0,
@@ -24,13 +22,19 @@ export const ThinkingModeBudgetTokens: Record<ReasoningEffort, number> = {
   // https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#important-considerations-when-using-extended-thinking
 }
 
+export const DeprecatedReasoningModelIds: Record<string, ModelId> = {
+  // These "reasoning" model IDs didn't really exist in Anthropic, we used it as a simple way for users to switch between the reasoning mode and the standard mode, but this approach has been deprecated in favor of specifying a reasoning effort in the request to activate reasoning in the model.
+  'claude-sonnet-4-reasoning-20250514': 'claude-sonnet-4-20250514',
+  'claude-3-7-sonnet-reasoning-20250219': 'claude-3-7-sonnet-20250219',
+}
+
 const LanguageModels: Record<ModelId, llm.ModelDetails> = {
   // Reference: https://docs.anthropic.com/en/docs/about-claude/models
   // NOTE: We don't support returning "thinking" blocks from Claude in the integration action output as the concept of "thinking" blocks is a Claude-specific feature that other providers don't have. For now we won't support this as an official feature in the integration so it needs to be taken into account when using reasoning mode and passing a multi-turn conversation history in the generateContent action input.
   // For more information, see: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#preserving-thinking-blocks
   // NOTE: We intentionally didn't include the Opus model as it's the most expensive model in the market, it's not very popular, and no users have ever requested it so far.
   'claude-sonnet-4-20250514': {
-    name: 'Claude Sonnet 4 (Standard Mode)',
+    name: 'Claude Sonnet 4',
     description:
       'Claude Sonnet 4 significantly enhances the capabilities of its predecessor, Sonnet 3.7, excelling in both coding and reasoning tasks with improved precision and controllability. Sonnet 4 balances capability and computational efficiency, making it suitable for a broad range of applications from routine coding tasks to complex software development projects. Key enhancements include improved autonomous codebase navigation, reduced error rates in agent-driven workflows, and increased reliability in following intricate instructions.',
     tags: ['recommended', 'vision', 'general-purpose', 'agents', 'coding', 'function-calling', 'storytelling'],
@@ -43,57 +47,11 @@ const LanguageModels: Record<ModelId, llm.ModelDetails> = {
       maxTokens: 64_000,
     },
   },
-  'claude-sonnet-4-reasoning-20250514': {
-    name: 'Claude Sonnet 4 (Reasoning Mode)',
-    description:
-      'This model uses the "Extended Thinking" mode and will use a significantly higher amount of output tokens than the Standard Mode, so this model should only be used for tasks that actually require it.\n\nClaude Sonnet 4 significantly enhances the capabilities of its predecessor, Sonnet 3.7, excelling in both coding and reasoning tasks with improved precision and controllability. Sonnet 4 balances capability and computational efficiency, making it suitable for a broad range of applications from routine coding tasks to complex software development projects. Key enhancements include improved autonomous codebase navigation, reduced error rates in agent-driven workflows, and increased reliability in following intricate instructions.',
-    tags: [
-      'recommended',
-      'vision',
-      'reasoning',
-      'general-purpose',
-      'agents',
-      'coding',
-      'function-calling',
-      'storytelling',
-    ],
-    input: {
-      costPer1MTokens: 3,
-      maxTokens: 200_000,
-    },
-    output: {
-      costPer1MTokens: 15,
-      maxTokens: 64_000,
-    },
-  },
   'claude-3-7-sonnet-20250219': {
-    name: 'Claude 3.7 Sonnet (Standard Mode)',
+    name: 'Claude 3.7 Sonnet',
     description:
       'Claude 3.7 Sonnet is an advanced large language model with improved reasoning, coding, and problem-solving capabilities. The model demonstrates notable improvements in coding, particularly in front-end development and full-stack updates, and excels in agentic workflows, where it can autonomously navigate multi-step processes.',
     tags: ['recommended', 'vision', 'general-purpose', 'agents', 'coding', 'function-calling', 'storytelling'],
-    input: {
-      costPer1MTokens: 3,
-      maxTokens: 200_000,
-    },
-    output: {
-      costPer1MTokens: 15,
-      maxTokens: 64_000,
-    },
-  },
-  'claude-3-7-sonnet-reasoning-20250219': {
-    name: 'Claude 3.7 Sonnet (Reasoning Mode)',
-    description:
-      'This model uses the "Extended Thinking" mode and will use a significantly higher amount of output tokens than the Standard Mode, so this model should only be used for tasks that actually require it.\n\nClaude 3.7 Sonnet is an advanced large language model with improved reasoning, coding, and problem-solving capabilities. The model demonstrates notable improvements in coding, particularly in front-end development and full-stack updates, and excels in agentic workflows, where it can autonomously navigate multi-step processes.',
-    tags: [
-      'recommended',
-      'vision',
-      'reasoning',
-      'general-purpose',
-      'agents',
-      'coding',
-      'function-calling',
-      'storytelling',
-    ],
     input: {
       costPer1MTokens: 3,
       maxTokens: 200_000,

--- a/integrations/anthropic/src/index.ts
+++ b/integrations/anthropic/src/index.ts
@@ -22,7 +22,7 @@ export const ThinkingModeBudgetTokens: Record<ReasoningEffort, number> = {
   // https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#important-considerations-when-using-extended-thinking
 }
 
-export const DeprecatedReasoningModelIds: Record<string, ModelId> = {
+export const DeprecatedReasoningModelIdReplacements: Record<string, ModelId> = {
   // These "reasoning" model IDs didn't really exist in Anthropic, we used it as a simple way for users to switch between the reasoning mode and the standard mode, but this approach has been deprecated in favor of specifying a reasoning effort in the request to activate reasoning in the model.
   'claude-sonnet-4-reasoning-20250514': 'claude-sonnet-4-20250514',
   'claude-3-7-sonnet-reasoning-20250219': 'claude-3-7-sonnet-20250219',

--- a/integrations/anthropic/src/schemas.ts
+++ b/integrations/anthropic/src/schemas.ts
@@ -1,15 +1,13 @@
 import { z } from '@botpress/sdk'
 
-export type ModelId = z.infer<typeof modelId>
+export type ModelId = z.infer<typeof ModelId>
 
 export const DefaultModel: ModelId = 'claude-sonnet-4-20250514'
 
-export const modelId = z
+export const ModelId = z
   .enum([
     'claude-sonnet-4-20250514',
-    'claude-sonnet-4-reasoning-20250514',
     'claude-3-7-sonnet-20250219',
-    'claude-3-7-sonnet-reasoning-20250219',
     'claude-3-5-haiku-20241022',
     'claude-3-5-sonnet-20241022',
     'claude-3-5-sonnet-20240620',

--- a/integrations/google-ai/integration.definition.ts
+++ b/integrations/google-ai/integration.definition.ts
@@ -7,7 +7,7 @@ export default new IntegrationDefinition({
   name: 'google-ai',
   title: 'Google AI',
   description: 'Gain access to Gemini models for content generation, chat responses, and advanced language tasks.',
-  version: '6.0.0',
+  version: '6.0.1',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/google-ai/src/actions/generate-content.ts
+++ b/integrations/google-ai/src/actions/generate-content.ts
@@ -47,6 +47,7 @@ export async function generateContent(
         `The model "${modelId}" has been discontinued, using "${DefaultModelId}" instead. Please update your bot to use the latest models from Google AI.`
       )
     modelId = DefaultModelId
+    input.model = { id: modelId }
   }
 
   const model = params.models[modelId]

--- a/integrations/google-ai/src/actions/generate-content.ts
+++ b/integrations/google-ai/src/actions/generate-content.ts
@@ -134,7 +134,7 @@ async function buildGenerateContentRequest(
       tools: buildTools(input),
       maxOutputTokens,
       thinkingConfig: {
-        thinkingBudget: ThinkingModeBudgetTokens[input.reasoningEffort ?? llm.schemas.DefaultReasoningEffort],
+        thinkingBudget: ThinkingModeBudgetTokens[input.reasoningEffort ?? 'none'], // Default to not use reasoning as Gemini 2.5+ models use optional reasoning
         includeThoughts: false,
       },
       topP: input.topP,

--- a/integrations/openai/integration.definition.ts
+++ b/integrations/openai/integration.definition.ts
@@ -18,7 +18,7 @@ export default new IntegrationDefinition({
   title: 'OpenAI',
   description:
     'Gain access to OpenAI models for text generation, speech synthesis, audio transcription, and image generation.',
-  version: '15.0.3',
+  version: '15.0.4',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/packages/common/src/llm/schemas.ts
+++ b/packages/common/src/llm/schemas.ts
@@ -81,16 +81,13 @@ export const ModelSchema = ModelRefSchema.extend({
 })
 
 const ReasoningEffortSchema = z.enum(['low', 'medium', 'high', 'dynamic', 'none'])
-type ReasoningEffort = z.infer<typeof ReasoningEffortSchema>
-
-export const DefaultReasoningEffort = 'none' satisfies ReasoningEffort
 
 export const GenerateContentInputSchema = <S extends z.ZodSchema>(modelRefSchema: S) =>
   z.object({
     model: modelRefSchema.describe('Model to use for content generation').optional(),
     reasoningEffort: ReasoningEffortSchema.optional().describe(
       dedent`
-          Reasoning effort level to use for models that support reasoning. Specifying "none" will indicate the LLM to not use reasoning. If not provided the model will default to "${DefaultReasoningEffort}". A "dynamic" effort will indicate the provider to automatically determine the reasoning effort (if the provider supports it, otherwise it will default to "medium").
+          Reasoning effort level to use for models that support reasoning. Specifying "none" will indicate the LLM to not use reasoning (for models that support optional reasoning). A "dynamic" effort will indicate the provider to automatically determine the reasoning effort (if supported by the provider). If not provided the model will not use reasoning for models with optional reasoning or use the default reasoning effort specified by the provider for reasoning-only models.
           Note: A higher reasoning effort will incurr in higher output token charges from the LLM provider.
         `
     ),

--- a/packages/common/src/llm/schemas.ts
+++ b/packages/common/src/llm/schemas.ts
@@ -88,7 +88,7 @@ export const GenerateContentInputSchema = <S extends z.ZodSchema>(modelRefSchema
     reasoningEffort: ReasoningEffortSchema.optional().describe(
       dedent`
           Reasoning effort level to use for models that support reasoning. Specifying "none" will indicate the LLM to not use reasoning (for models that support optional reasoning). A "dynamic" effort will indicate the provider to automatically determine the reasoning effort (if supported by the provider). If not provided the model will not use reasoning for models with optional reasoning or use the default reasoning effort specified by the provider for reasoning-only models.
-          Note: A higher reasoning effort will incurr in higher output token charges from the LLM provider.
+          Note: A higher reasoning effort will incur in higher output token charges from the LLM provider.
         `
     ),
     systemPrompt: z.string().optional().describe('Optional system prompt to guide the model'),


### PR DESCRIPTION
This PR removes the "reasoning" model IDs hack for Anthropic in favor of using the `reasoningEffort` parameter to request the model to perform reasoning.