### PR TITLE
feat(integrations/telegram): rm support for proactive user and conv

### DIFF
--- a/integrations/telegram/integration.definition.ts
+++ b/integrations/telegram/integration.definition.ts
@@ -5,7 +5,7 @@ import typingIndicator from './bp_modules/typing-indicator'
 
 export default new IntegrationDefinition({
   name: 'telegram',
-  version: '0.7.4',
+  version: '1.0.0',
   title: 'Telegram',
   description: 'Engage with your audience in real-time.',
   icon: 'icon.svg',
@@ -30,7 +30,6 @@ export default new IntegrationDefinition({
       message: { tags: { id: {}, chatId: {} } },
       conversation: {
         tags: { id: {}, fromUserId: {}, fromUserUsername: {}, fromUserName: {}, chatId: {} },
-        creation: { enabled: true, requiredTags: ['id'] },
       },
     },
   },
@@ -41,7 +40,6 @@ export default new IntegrationDefinition({
     tags: {
       id: {},
     },
-    creation: { enabled: true, requiredTags: ['id'] },
   },
 }).extend(typingIndicator, () => ({
   entities: {},

--- a/integrations/telegram/src/index.ts
+++ b/integrations/telegram/src/index.ts
@@ -240,45 +240,6 @@ const integration = new bp.Integration({
       conversationId: conversation.id,
     })
   }),
-  createUser: async ({ client, tags, ctx }) => {
-    const strId = tags.id
-    const userId = Number(strId)
-
-    if (isNaN(userId)) {
-      return
-    }
-
-    const telegraf = new Telegraf(ctx.configuration.botToken)
-    const member = await telegraf.telegram.getChatMember(userId, userId)
-
-    const { user } = await client.getOrCreateUser({ tags: { id: `${member.user.id}` } })
-
-    return {
-      body: JSON.stringify({ user: { id: user.id } }),
-      headers: {},
-      statusCode: 200,
-    }
-  },
-  createConversation: async ({ client, channel, tags, ctx }) => {
-    const chatId = tags.id
-    if (!chatId) {
-      return
-    }
-
-    const telegraf = new Telegraf(ctx.configuration.botToken)
-    const chat = await telegraf.telegram.getChat(chatId)
-
-    const { conversation } = await client.getOrCreateConversation({
-      channel,
-      tags: { id: chat.id.toString() },
-    })
-
-    return {
-      body: JSON.stringify({ conversation: { id: conversation.id } }),
-      headers: {},
-      statusCode: 200,
-    }
-  },
 })
 
 export default sentryHelpers.wrapIntegration(integration, {


### PR DESCRIPTION
It seems that proactively sending a direct message to a Telegram user with a Bot is not supported by Telegram. My plan was to migrate the deprecated built-in `createUser` and `createConversation` to the new interfaces, but instead I'll simply remove the support for the feature.

fixes DEV-2821

This PR is not opened on master