### PR TITLE
feat(client): Add Bot Allowlist operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.564.0",
-    "@botpress/api": "1.30.0",
+    "@botpress/api": "1.33.0",
     "@botpress/cli": "workspace:*",
     "@botpress/client": "workspace:*",
     "@botpress/sdk": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.1",
-    "@botpress/client": "1.19.0",
+    "@botpress/client": "1.20.0",
     "@botpress/sdk": "4.14.3",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -5,7 +5,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.19.0",
+    "@botpress/client": "1.20.0",
     "@botpress/sdk": "4.14.3"
   },
   "devDependencies": {

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.19.0",
+    "@botpress/client": "1.20.0",
     "@botpress/sdk": "4.14.3"
   },
   "devDependencies": {

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.19.0",
+    "@botpress/client": "1.20.0",
     "@botpress/sdk": "4.14.3"
   },
   "devDependencies": {

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.19.0",
+    "@botpress/client": "1.20.0",
     "@botpress/sdk": "4.14.3",
     "axios": "^1.6.8"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -32,7 +32,7 @@
     "@babel/standalone": "^7.26.4",
     "@babel/traverse": "^7.26.4",
     "@babel/types": "^7.26.3",
-    "@botpress/client": "1.19.0",
+    "@botpress/client": "1.20.0",
     "bytes": "^3.1.2",
     "exponential-backoff": "^3.1.1",
     "handlebars": "^4.7.8",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "1.19.0",
+    "@botpress/client": "1.20.0",
     "browser-or-node": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -36,7 +36,7 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "@botpress/client": "1.19.0",
+    "@botpress/client": "1.20.0",
     "@bpinternal/thicktoken": "^1.0.1",
     "@bpinternal/zui": "^1.0.1",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1982,7 +1982,7 @@ importers:
         specifier: 0.5.1
         version: link:../chat-client
       '@botpress/client':
-        specifier: 1.19.0
+        specifier: 1.20.0
         version: link:../client
       '@botpress/sdk':
         specifier: 4.14.3
@@ -2094,7 +2094,7 @@ importers:
   packages/cli/templates/empty-bot:
     dependencies:
       '@botpress/client':
-        specifier: 1.19.0
+        specifier: 1.20.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 4.14.3
@@ -2110,7 +2110,7 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 1.19.0
+        specifier: 1.20.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 4.14.3
@@ -2139,7 +2139,7 @@ importers:
   packages/cli/templates/hello-world:
     dependencies:
       '@botpress/client':
-        specifier: 1.19.0
+        specifier: 1.20.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 4.14.3
@@ -2155,7 +2155,7 @@ importers:
   packages/cli/templates/webhook-message:
     dependencies:
       '@botpress/client':
-        specifier: 1.19.0
+        specifier: 1.20.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 4.14.3
@@ -2293,7 +2293,7 @@ importers:
         specifier: ^7.26.3
         version: 7.26.9
       '@botpress/client':
-        specifier: 1.19.0
+        specifier: 1.20.0
         version: link:../client
       '@botpress/cognitive':
         specifier: 0.1.31
@@ -2396,7 +2396,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 1.19.0
+        specifier: 1.20.0
         version: link:../client
       '@bpinternal/zui':
         specifier: ^1.0.1
@@ -2427,7 +2427,7 @@ importers:
   packages/vai:
     dependencies:
       '@botpress/client':
-        specifier: 1.19.0
+        specifier: 1.20.0
         version: link:../client
       '@bpinternal/thicktoken':
         specifier: ^1.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^3.564.0
         version: 3.709.0
       '@botpress/api':
-        specifier: 1.30.0
-        version: 1.30.0(openapi-types@12.1.3)
+        specifier: 1.33.0
+        version: 1.33.0(openapi-types@12.1.3)
       '@botpress/cli':
         specifier: workspace:*
         version: link:packages/cli
@@ -4439,8 +4439,8 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@botpress/api@1.30.0(openapi-types@12.1.3):
-    resolution: {integrity: sha512-mDNR48/31YmSDsdrukpFBvJt3TjSbNxmqIhwA8kRe9mFHXMJuMbyNxNUzdac0fqSs/ztlR1xq9hkdRn4odSNWw==}
+  /@botpress/api@1.33.0(openapi-types@12.1.3):
+    resolution: {integrity: sha512-qWeJ4iUpm6vxjTuJJThfJ5gs6aOH09iEXt0nv8xu5l/zOLIdG4FW7Do9mjDl8fY0XHjgAMJAePu8okv31h4bVQ==}
     dependencies:
       '@bpinternal/opapi': 0.14.0(openapi-types@12.1.3)
     transitivePeerDependencies:


### PR DESCRIPTION
Bumps `@botpress/api`.

The Botpress client in `@botpress/client` now has `getBotAllowlist` and `updateBotAllowlist` operations.