### PR TITLE
fix(integrations/messenger): Unsubscribe from OAuth webhook requests when manual config is selected and refactor

### DIFF
--- a/integrations/messenger/src/index.ts
+++ b/integrations/messenger/src/index.ts
@@ -1,12 +1,13 @@
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import actions from './actions'
 import channels from './channels'
+import { register, unregister } from './setup'
 import { handler } from './webhook'
 import * as bp from '.botpress'
 
 const integration = new bp.Integration({
-  register: async () => {},
-  unregister: async () => {},
+  register,
+  unregister,
   actions,
   channels,
   handler,

--- a/integrations/messenger/src/misc/auth.ts
+++ b/integrations/messenger/src/misc/auth.ts
@@ -1,4 +1,6 @@
+import { RuntimeError } from '@botpress/sdk'
 import * as bp from '.botpress'
+import { Oauth as OAuthState } from '.botpress/implementation/typings/states/oauth'
 
 export async function getMessengerClientCredentials(
   client: bp.Client,
@@ -24,6 +26,39 @@ export async function getMessengerClientCredentials(
     clientSecret: bp.secrets.CLIENT_SECRET,
     clientId: bp.secrets.CLIENT_ID,
   }
+}
+
+export async function getPartialMetaClientCredentials(client: bp.Client, ctx: bp.Context) {
+  return await client
+    .getState({ type: 'integration', name: 'oauth', id: ctx.integrationId })
+    .then((result) => result.state.payload)
+}
+
+export async function getMetaClientCredentials(client: bp.Client, ctx: bp.Context) {
+  const { accessToken, pageToken, pageId } = await getPartialMetaClientCredentials(client, ctx)
+  if (!accessToken || !pageToken || !pageId) {
+    throw new RuntimeError('Access token, page token, or page ID is missing, please reauthorize')
+  }
+  return { accessToken, pageToken, pageId }
+}
+
+// client.patchState is not working correctly
+export async function patchMetaClientCredentials(
+  client: bp.Client,
+  ctx: bp.Context,
+  newState: Partial<OAuthState['payload']>
+) {
+  const currentState = await getPartialMetaClientCredentials(client, ctx).catch(() => ({}))
+
+  await client.setState({
+    type: 'integration',
+    name: 'oauth',
+    id: ctx.integrationId,
+    payload: {
+      ...currentState,
+      ...newState,
+    },
+  })
 }
 
 export function getVerifyToken(ctx: bp.Context): string {

--- a/integrations/messenger/src/misc/meta-client.ts
+++ b/integrations/messenger/src/misc/meta-client.ts
@@ -1,6 +1,9 @@
-import { z } from '@botpress/sdk'
+import { z, RuntimeError } from '@botpress/sdk'
 import axios from 'axios'
 import * as bp from '.botpress'
+
+const ERROR_SUBSCRIBE_TO_WEBHOOKS = 'Failed to subscribe to webhooks'
+const ERROR_UNSUBSCRIBE_FROM_WEBHOOKS = 'Failed to unsubscribe from webhooks'
 
 export class MetaClient {
   private _clientId: string
@@ -13,7 +16,7 @@ export class MetaClient {
     this._clientSecret = bp.secrets.CLIENT_SECRET
   }
 
-  public async getAccessToken(code: string, redirectUri: string) {
+  public async exchangeAuthorizationCodeForAccessToken(code: string, redirectUri: string) {
     const query = new URLSearchParams({
       client_id: this._clientId,
       client_secret: this._clientSecret,
@@ -79,15 +82,15 @@ export class MetaClient {
       .parse(res.data)
 
     if (!data.access_token) {
-      throw new Error('Unable to find the page token for the specified page')
+      throw new RuntimeError('Unable to find the page token for the specified page')
     }
 
     return data.access_token
   }
 
   public async subscribeToWebhooks(pageToken: string, pageId: string) {
-    try {
-      const { data } = await axios.post(
+    const { data } = await axios
+      .post(
         `${this._baseGraphApiUrl}/${this._version}/${pageId}/subscribed_apps`,
         {
           subscribed_fields: ['messages', 'messaging_postbacks'],
@@ -98,17 +101,30 @@ export class MetaClient {
           },
         }
       )
+      .catch((err) => {
+        this._logger.error(`Error subscribing to webhooks for Page ${pageId}: ${err}`)
+        throw new RuntimeError(ERROR_SUBSCRIBE_TO_WEBHOOKS)
+      })
 
-      if (!data.success) {
-        throw new Error('No Success')
-      }
-    } catch (e: any) {
-      this._logger
-        .forBot()
-        .error(
-          `(OAuth registration) Error subscribing to webhooks for Page ${pageId}: ${e.message} -> ${e.response?.data}`
-        )
-      throw new Error('Issue subscribing to Webhooks for Page, please try again.')
+    if (!data.success) {
+      throw new RuntimeError(ERROR_SUBSCRIBE_TO_WEBHOOKS)
+    }
+  }
+
+  public async unsubscribeFromWebhooks(pageToken: string, pageId: string) {
+    const { data } = await axios
+      .delete(`${this._baseGraphApiUrl}/${this._version}/${pageId}/subscribed_apps`, {
+        headers: {
+          Authorization: 'Bearer ' + pageToken,
+        },
+      })
+      .catch((err) => {
+        this._logger.error(`Error unsubscribing from webhooks for Page ${pageId}: ${err}`)
+        throw new RuntimeError(ERROR_UNSUBSCRIBE_FROM_WEBHOOKS)
+      })
+
+    if (!data.success) {
+      throw new RuntimeError(ERROR_UNSUBSCRIBE_FROM_WEBHOOKS)
     }
   }
 
@@ -121,20 +137,19 @@ export class MetaClient {
     })
     let url = `${this._baseGraphApiUrl}/${this._version}/me/accounts?${query.toString()}`
 
-    try {
-      while (url) {
-        const response = await axios.get(url)
+    while (url) {
+      const response = await axios.get(url).catch((err) => {
+        this._logger.error(`Error fetching pages: ${err}`)
+        throw new RuntimeError('Error fetching pages')
+      })
 
-        // Add the pages to the allPages array
-        allPages = allPages.concat(response.data.data)
+      // Add the pages to the allPages array
+      allPages = allPages.concat(response.data.data)
 
-        // Check if there's a next page
-        url = response.data.paging && response.data.paging.next ? response.data.paging.next : null
-      }
-
-      return allPages
-    } catch (err: any) {
-      throw new Error('Error fetching pages:' + err.response ? err.response.data : err.message)
+      // Check if there's a next page
+      url = response.data.paging && response.data.paging.next ? response.data.paging.next : null
     }
+
+    return allPages
   }
 }

--- a/integrations/messenger/src/setup.ts
+++ b/integrations/messenger/src/setup.ts
@@ -2,16 +2,22 @@ import { getMetaClientCredentials } from './misc/auth'
 import { MetaClient } from './misc/meta-client'
 import * as bp from '.botpress'
 
-export const register: bp.IntegrationProps['register'] = async () => {}
+type RegisterProps = Parameters<bp.IntegrationProps['register']>[0]
 
-export const unregister: bp.IntegrationProps['unregister'] = async ({ ctx, logger, client }) => {
-  if (ctx.configurationType === null) {
+export const register: bp.IntegrationProps['register'] = async (props) => {
+  const { ctx, client } = props
+  if (ctx.configurationType === 'manualApp') {
     await client.configureIntegration({
       identifier: null,
     })
-
-    const metaClient = new MetaClient(logger)
-    const { pageToken, pageId } = await getMetaClientCredentials(client, ctx)
-    await metaClient.unsubscribeFromWebhooks(pageToken, pageId)
+    await _unsubscribeFromWebhooks(props)
   }
+}
+
+export const unregister: bp.IntegrationProps['unregister'] = async () => {}
+
+const _unsubscribeFromWebhooks = async ({ ctx, logger, client }: RegisterProps) => {
+  const metaClient = new MetaClient(logger)
+  const { pageToken, pageId } = await getMetaClientCredentials(client, ctx)
+  await metaClient.unsubscribeFromWebhooks(pageToken, pageId)
 }

--- a/integrations/messenger/src/setup.ts
+++ b/integrations/messenger/src/setup.ts
@@ -1,0 +1,17 @@
+import { getMetaClientCredentials } from './misc/auth'
+import { MetaClient } from './misc/meta-client'
+import * as bp from '.botpress'
+
+export const register: bp.IntegrationProps['register'] = async () => {}
+
+export const unregister: bp.IntegrationProps['unregister'] = async ({ ctx, logger, client }) => {
+  if (ctx.configurationType === null) {
+    await client.configureIntegration({
+      identifier: null,
+    })
+
+    const metaClient = new MetaClient(logger)
+    const { pageToken, pageId } = await getMetaClientCredentials(client, ctx)
+    await metaClient.unsubscribeFromWebhooks(pageToken, pageId)
+  }
+}


### PR DESCRIPTION
Also refactored `MetaClient` credentials management and error handling in the meantime

**Note**: This PR merges into the `messenger-sandbox-n-refactor` branch
