### PR TITLE
feat(zendesk): allow specifying via channel types on ticket

### DIFF
--- a/integrations/zendesk/hub.md
+++ b/integrations/zendesk/hub.md
@@ -1,6 +1,6 @@
 Optimize your customer support workflow with the Zendesk integration for your chatbot. Seamlessly manage tickets, engage customers, and access critical information—all within your bot. Elevate your customer service game and improve internal processes by triggering automations from real-time ticket updates.
 
-> 🤝 **Usage with HITL (Human in the Loop)**  
+> 🤝 **Usage with HITL (Human in the Loop)**
 > If you intend to use the Zendesk integration with HITL, ensure that you have the HITL plugin installed.
 
 ## Installation and Configuration
@@ -26,3 +26,8 @@ Password: `API_TOKEN`
 3.  Enable the integration to complete the setup.
 
 Once these steps are completed, your Zendesk articles will automatically sync to the specified knowledge base in Botpress. You can manually sync by using the "Sync KB" action.
+
+### HITL
+
+#### Via Channel Types
+On the "Start HITL" card you can use only "via channel" types documented by [Zendesk Docs](https://developer.zendesk.com/documentation/ticketing/reference-guides/via-types)

--- a/integrations/zendesk/hub.md
+++ b/integrations/zendesk/hub.md
@@ -30,4 +30,5 @@ Once these steps are completed, your Zendesk articles will automatically sync to
 ### HITL
 
 #### Via Channel Types
+
 On the "Start HITL" card you can use only "via channel" types documented by [Zendesk Docs](https://developer.zendesk.com/documentation/ticketing/reference-guides/via-types)

--- a/integrations/zendesk/integration.definition.ts
+++ b/integrations/zendesk/integration.definition.ts
@@ -7,7 +7,7 @@ import { actions, events, configuration, channels, states, user } from './src/de
 export default new sdk.IntegrationDefinition({
   name: 'zendesk',
   title: 'Zendesk',
-  version: '2.6.0',
+  version: '2.7.0',
   icon: 'icon.svg',
   description:
     'Optimize your support workflow. Trigger workflows from ticket updates as well as manage tickets, access conversations, and engage with customers.',
@@ -26,6 +26,13 @@ export default new sdk.IntegrationDefinition({
           .enum(['low', 'normal', 'high', 'urgent'])
           .title('Ticket Priority')
           .describe('Priority of the ticket. Leave empty for default priority.')
+          .optional(),
+        viaChannel: sdk.z
+          .string()
+          .title('Via Channel')
+          .describe(
+            'Via Channel to use (example: "whatsapp", "instagram_dm" ), only use values documented by Zendesk, check the "Info" tab at the Zendesk integration configuration page for more details. Leave empty or use an invalid channel type and you will get "API".'
+          )
           .optional(),
       }),
     },

--- a/integrations/zendesk/src/actions/hitl.ts
+++ b/integrations/zendesk/src/actions/hitl.ts
@@ -15,13 +15,20 @@ export const startHitl: bp.IntegrationProps['actions']['startHitl'] = async (pro
     throw new sdk.RuntimeError(`User ${user.id} not linked in Zendesk`)
   }
 
+  const { viaChannel, priority } = input.hitlSession || {}
+
   const ticket = await zendeskClient.createTicket(
     input.title ?? 'Untitled Ticket',
     await _buildTicketBody(props),
     {
       id: zendeskAuthorId,
     },
-    { priority: input.hitlSession?.priority }
+    {
+      priority,
+      via: {
+        channel: viaChannel,
+      },
+    }
   )
 
   const zendeskTicketId = `${ticket.id}`

--- a/integrations/zendesk/src/definitions/schemas.ts
+++ b/integrations/zendesk/src/definitions/schemas.ts
@@ -14,6 +14,7 @@ export const ticketSchema = z.object({
   tags: z.array(z.string()),
   externalId: z.string().nullable(),
   comment: z.record(z.any()).optional(),
+  via: z.record(z.any()).optional(),
 })
 
 const _zdTicketSchema = ticketSchema.transform((data) => ({

--- a/integrations/zendesk/src/definitions/schemas.ts
+++ b/integrations/zendesk/src/definitions/schemas.ts
@@ -14,7 +14,7 @@ export const ticketSchema = z.object({
   tags: z.array(z.string()),
   externalId: z.string().nullable(),
   comment: z.record(z.any()).optional(),
-  via: z.record(z.any()).optional(),
+  via: z.object({ channel: z.string().optional() }).optional(),
 })
 
 const _zdTicketSchema = ticketSchema.transform((data) => ({


### PR DESCRIPTION
This PR uses the new entities feature to allow the bot builder to specify the Via channel type during the creation of the HITL TIcket

<img width="777" height="163" alt="image" src="https://github.com/user-attachments/assets/9a3bcb91-8fec-4f61-ba71-46c8dcbc3d93" />

<img width="730" height="227" alt="image" src="https://github.com/user-attachments/assets/c0d8a7d9-548f-409d-9e4e-8011310e8e1b" />

I kept as a string to allow variable assignment and since Zendesk can always add new types there.

<sub> Resolves SQD-3110 </sub>