### PR TITLE
docs(slack): add missing scope to readme

### DIFF
--- a/integrations/slack/hub.md
+++ b/integrations/slack/hub.md
@@ -51,6 +51,7 @@ If you prefer to manually configure the integration, you can provide a bot token
    - `team:read`: needed to obtain metadata on your team in order to operate on the right instance of your bot.
    - `users.profile:read`: needed to retrieve profile information for channel and DM members.
    - `users:read`: needed to obtain a list of all members of the workspace and to receive notifications when new members join the workspace.
+   - `users:read.email`: needed for the `Get User Profile` action.
 6. **IMPORTANT:** install your Slack app to your workspace. This is a crucial step to ensure that the bot can send and receive messages. To do this, scroll up to the "OAuth Tokens for Your Workspace" section and click "Install App to Workspace". Follow the on-screen instructions to authorize the app.
 7. Scroll up to the "Advanced token security via token rotation " section and click "Opt In" to enable token rotation. Confirm you wish to opt in.
 8. Copy the Refresh Token (starts with `xoxe-1-`) or legacy Bot Token (starts with `xoxb-`). You will need it to set up the integration on Botpress. You may need to refresh the page in the Slack API portal to see the token.

--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -17,7 +17,7 @@ export default new IntegrationDefinition({
   name: 'slack',
   title: 'Slack',
   description: 'Automate interactions with your team.',
-  version: '2.5.4',
+  version: '2.5.5',
   icon: 'icon.svg',
   readme: 'hub.md',
   configuration,


### PR DESCRIPTION
The `users:read.email` scope was added as part of https://github.com/botpress/botpress/pull/13954, but it wasn't properly documented in the integration's readme.