### PR TITLE
fix(cli): fixed plugin init aborting

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.14.2",
+  "version": "4.14.3",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/command-implementations/init-command.ts
+++ b/packages/cli/src/command-implementations/init-command.ts
@@ -80,8 +80,6 @@ export class InitCommand extends GlobalCommand<InitCommandDefinition> {
     const name = await this._getName('plugin', template.defaultProjectName)
     const { fullName, shortName } = this._getFullNameAndShortName({ workspaceHandle, name })
 
-    console.log(`creating plugin at ${workDir}`)
-
     try {
       await this._copy({
         srcDir: template.absolutePath,

--- a/packages/cli/src/command-implementations/init-command.ts
+++ b/packages/cli/src/command-implementations/init-command.ts
@@ -80,14 +80,24 @@ export class InitCommand extends GlobalCommand<InitCommandDefinition> {
     const name = await this._getName('plugin', template.defaultProjectName)
     const { fullName, shortName } = this._getFullNameAndShortName({ workspaceHandle, name })
 
-    await this._copy({
-      srcDir: template.absolutePath,
-      destDir: workDir,
-      name: shortName,
-      pkgJson: {
-        pluginName: fullName,
-      },
-    })
+    console.log(`creating plugin at ${workDir}`)
+
+    try {
+      await this._copy({
+        srcDir: template.absolutePath,
+        destDir: workDir,
+        name: shortName,
+        pkgJson: {
+          pluginName: fullName,
+        },
+      })
+    } catch (error) {
+      if (error instanceof errors.AbortedOperationError) {
+        this.logger.log('Aborted')
+        return
+      }
+      throw error
+    }
     this.logger.success(`Plugin project initialized in ${chalk.bold(pathlib.join(workDir, shortName))}`)
   }
 
@@ -182,9 +192,9 @@ export class InitCommand extends GlobalCommand<InitCommandDefinition> {
     const dirName = utils.casing.to.kebabCase(name)
     const destination = pathlib.join(destDir, dirName)
 
-    const exist = await this._checkIfDestinationExists(destination)
-    if (exist) {
-      return
+    const destinationIsEmptyOrCanBeOverwritten = await this._isDestinationCanBeUsed(destination)
+    if (!destinationIsEmptyOrCanBeOverwritten) {
+      throw new errors.AbortedOperationError()
     }
 
     await fs.promises.cp(srcDir, destination, { recursive: true })
@@ -198,17 +208,16 @@ export class InitCommand extends GlobalCommand<InitCommandDefinition> {
     await fs.promises.writeFile(pkgJsonPath, JSON.stringify(updatedJson, null, 2))
   }
 
-  private _checkIfDestinationExists = async (destination: string) => {
+  private _isDestinationCanBeUsed = async (destination: string) => {
     if (fs.existsSync(destination)) {
       const override = await this.prompt.confirm(
         `Directory ${chalk.bold(destination)} already exists. Do you want to overwrite it?`
       )
       if (!override) {
-        this.logger.log('Aborting')
-        return true
+        return false
       }
     }
-    return false
+    return true
   }
 }
 

--- a/packages/cli/src/command-implementations/init-command.ts
+++ b/packages/cli/src/command-implementations/init-command.ts
@@ -192,8 +192,8 @@ export class InitCommand extends GlobalCommand<InitCommandDefinition> {
     const dirName = utils.casing.to.kebabCase(name)
     const destination = pathlib.join(destDir, dirName)
 
-    const destinationIsEmptyOrCanBeOverwritten = await this._isDestinationCanBeUsed(destination)
-    if (!destinationIsEmptyOrCanBeOverwritten) {
+    const destinationCanBeUsed = await this._checkIfDestinationCanBeUsed(destination)
+    if (!destinationCanBeUsed) {
       throw new errors.AbortedOperationError()
     }
 
@@ -208,7 +208,7 @@ export class InitCommand extends GlobalCommand<InitCommandDefinition> {
     await fs.promises.writeFile(pkgJsonPath, JSON.stringify(updatedJson, null, 2))
   }
 
-  private _isDestinationCanBeUsed = async (destination: string) => {
+  private _checkIfDestinationCanBeUsed = async (destination: string) => {
     if (fs.existsSync(destination)) {
       const override = await this.prompt.confirm(
         `Directory ${chalk.bold(destination)} already exists. Do you want to overwrite it?`

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -163,3 +163,9 @@ export class ProjectDefinitionNotFoundError extends BotpressCLIError {
     super(message)
   }
 }
+
+export class AbortedOperationError extends BotpressCLIError {
+  public constructor() {
+    super('Aborted')
+  }
+}


### PR DESCRIPTION
Aborting the creation of a plugin was giving a success message. I created an `AbortedOperationError` class, allowing to throw it from any level without polluting return logic. We might want to use this pattern everywhere in the CLI to handle operation aborting. 

Before:
<img width="970" height="142" alt="image" src="https://github.com/user-attachments/assets/5d3fc35c-5d0e-4e3f-927c-0685ddf59c80" />

After:
<img width="888" height="132" alt="image" src="https://github.com/user-attachments/assets/c8c3befa-89e7-434e-acde-9483b3287477" />
