### PR TITLE
fix(cli): plugin init overwrite bug

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.14.4",
+  "version": "4.14.5",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.14.3",
+  "version": "4.14.4",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/command-implementations/init-command.ts
+++ b/packages/cli/src/command-implementations/init-command.ts
@@ -187,7 +187,7 @@ export class InitCommand extends GlobalCommand<InitCommandDefinition> {
       return
     }
 
-    await fs.promises.cp(srcDir, destination, { recursive: true })
+    await fs.promises.cp(srcDir, destination, { recursive: true, filter: (src) => !src.includes('node_modules') })
 
     const pkgJsonPath = pathlib.join(destination, 'package.json')
     const strContent = await fs.promises.readFile(pkgJsonPath, 'utf-8')


### PR DESCRIPTION
When overwriting a plugin with `bp init`, the copy was failing if the plugin modules had been installed with `pnpm` (attached image). This is likely due to the modules pointing to the same directory.
<img width="1665" height="135" alt="image" src="https://github.com/user-attachments/assets/753552c8-1599-4ff5-ba48-61b7c6773e93" />
