### PR TITLE
fix(cli): use --visibility for interfaces and plugins

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.14.5",
+  "version": "4.14.6",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/command-implementations/deploy-command.ts
+++ b/packages/cli/src/command-implementations/deploy-command.ts
@@ -212,7 +212,7 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
 
     const createBody = {
       ...(await apiUtils.prepareCreateInterfaceBody(interfaceDeclaration)),
-      public: this.argv.public,
+      public: this._visibility === 'public',
       icon,
       readme,
     }
@@ -300,7 +300,7 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
     const createBody = {
       ...(await apiUtils.prepareCreatePluginBody(pluginDef)),
       ...(await this.preparePluginDependencies(pluginDef, api)),
-      public: this.argv.public,
+      public: this._visibility === 'public',
       icon,
       readme,
       code: {


### PR DESCRIPTION
I encountered weird behaviours whilst testing breaking change detection for plugins and interfaces. When I added the `--visibility` parameter in #14027, I marked `--public` as deprecated, but I forgot to make the deploy command actually _use_ the new `--visibility` parameter. This means doing `bp deploy my-interface --visibility public` would deploy the interface as private, so you're forced to use the deprecated `--public` parameter instead.

Now it works no matter whether you're using `--visibility` or `--public`