### PR TITLE
feat(cli): preserve relative version expressions in codegen

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.16.2",
+  "version": "4.17.0",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/command-implementations/add-command.ts
+++ b/packages/cli/src/command-implementations/add-command.ts
@@ -113,6 +113,11 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
       await this._uninstall(installPath)
     }
 
+    if (ref.type === 'name') {
+      // Preserve the semver version expression in the generated code:
+      targetPackage.pkg.version = ref.version
+    }
+
     let files: codegen.File[]
     if (targetPackage.type === 'integration') {
       files = await codegen.generateIntegrationPackage(targetPackage.pkg)


### PR DESCRIPTION
Requires #14107. Preserves relative versions in codegen:

<img width="411" height="158" alt="image" src="https://github.com/user-attachments/assets/ca1fd882-cd77-481f-aed3-625c8e073c18" />


Ref SQD-3155, SQD-3116