### PR TITLE
feat(integrations/messenger): Fetch user profile pic and name in proactive-user and other changes

### DIFF
--- a/integrations/messenger/hub.md
+++ b/integrations/messenger/hub.md
@@ -1,3 +1,9 @@
 <iframe src="https://www.youtube.com/embed/pOIrLMpZZqc"></iframe>
 
 The Messenger integration empowers your chatbot to seamlessly interact with Facebook Messenger, one of the most popular messaging platforms. Connect your AI-powered chatbot to Messenger and engage with your audience in real-time conversations. With this integration, you can automate customer support, provide personalized recommendations, send notifications, and handle inquiries directly within Messenger. Leverage Messenger's rich features, including text, images, buttons, quick replies, and more, to create dynamic and engaging chatbot experiences. Take your customer engagement to the next level with the Messenger Integration for Botpress.
+
+## Migrating from 3.x to 4.x
+
+### _postback_ and _say_ messages prefix
+
+In version 4.0 of Messenger, _postback_ and _say_ messages no longer use the prefixes `postback:` or `say:`. If your bot relied on these prefixes for logic or transitions, you can update it to depend solely on the value set for the postback.

--- a/integrations/messenger/integration.definition.ts
+++ b/integrations/messenger/integration.definition.ts
@@ -24,7 +24,7 @@ const commonConfigSchema = z.object({
 
 export default new IntegrationDefinition({
   name: 'messenger',
-  version: '4.0.0',
+  version: '4.1.0',
   title: 'Messenger',
   description: 'Give your bot access to one of the world’s largest messaging platform.',
   icon: 'icon.svg',

--- a/integrations/messenger/src/actions/proactive-conversation.ts
+++ b/integrations/messenger/src/actions/proactive-conversation.ts
@@ -1,5 +1,6 @@
 import { RuntimeError } from '@botpress/sdk'
 import { create as createMessengerClient } from '../misc/messenger-client'
+import { tryGetUserProfile } from '../misc/utils'
 import * as bp from '.botpress'
 
 const getOrCreateConversation: bp.IntegrationProps['actions']['getOrCreateConversation'] = async ({
@@ -7,13 +8,22 @@ const getOrCreateConversation: bp.IntegrationProps['actions']['getOrCreateConver
   ctx,
   input,
 }) => {
+  if (ctx.configurationType === 'sandbox') {
+    throw new RuntimeError('Starting a conversation is not supported in sandbox mode')
+  }
+
   const userId = input.conversation.id
   if (!userId) {
     throw new RuntimeError('User ID is required')
   }
 
   const messengerClient = await createMessengerClient(client, ctx)
-  const profile = await messengerClient.getUserProfile(userId)
+  const profile = await tryGetUserProfile(messengerClient, ctx, userId)
+  if (!profile) {
+    throw new RuntimeError(
+      'Could not fetch user profile from Messenger, make sure your app was granted the necessary permissions or enable the "Get user profile" option.'
+    )
+  }
 
   const { conversation } = await client.getOrCreateConversation({
     channel: 'channel',

--- a/integrations/messenger/src/actions/proactive-conversation.ts
+++ b/integrations/messenger/src/actions/proactive-conversation.ts
@@ -21,7 +21,7 @@ const getOrCreateConversation: bp.IntegrationProps['actions']['getOrCreateConver
   const profile = await tryGetUserProfile(messengerClient, ctx, userId)
   if (!profile) {
     throw new RuntimeError(
-      'Could not fetch user profile from Messenger, make sure your app was granted the necessary permissions or enable the "Get user profile" option.'
+      'Could not fetch user profile from Messenger, make sure you are using a configuration with the necessary permissions or enable the "Get user profile" option.'
     )
   }
 

--- a/integrations/messenger/src/actions/proactive-user.ts
+++ b/integrations/messenger/src/actions/proactive-user.ts
@@ -1,17 +1,31 @@
 import { RuntimeError } from '@botpress/sdk'
 import { create as createMessengerClient } from '../misc/messenger-client'
+import { tryGetUserProfile } from '../misc/utils'
 import * as bp from '.botpress'
 
 const getOrCreateUser: bp.IntegrationProps['actions']['getOrCreateUser'] = async ({ client, ctx, input }) => {
+  if (ctx.configurationType === 'sandbox') {
+    throw new RuntimeError('Creating a user is not supported in sandbox mode')
+  }
+
   const userId = input.user.id
   if (!userId) {
     throw new RuntimeError('User ID is required')
   }
 
   const messengerClient = await createMessengerClient(client, ctx)
-  const profile = await messengerClient.getUserProfile(userId)
+  const profile = await tryGetUserProfile(messengerClient, ctx, userId)
+  if (!profile) {
+    throw new RuntimeError(
+      'Could not fetch user profile from Messenger, make sure your app was granted the necessary permissions or enable the "Get user profile" option.'
+    )
+  }
 
-  const { user } = await client.getOrCreateUser({ tags: { id: profile.id } })
+  const { user } = await client.getOrCreateUser({
+    tags: { id: profile.id },
+    name: profile.name,
+    pictureUrl: profile.profilePic,
+  })
 
   return {
     userId: user.id,

--- a/integrations/messenger/src/actions/proactive-user.ts
+++ b/integrations/messenger/src/actions/proactive-user.ts
@@ -17,7 +17,7 @@ const getOrCreateUser: bp.IntegrationProps['actions']['getOrCreateUser'] = async
   const profile = await tryGetUserProfile(messengerClient, ctx, userId)
   if (!profile) {
     throw new RuntimeError(
-      'Could not fetch user profile from Messenger, make sure your app was granted the necessary permissions or enable the "Get user profile" option.'
+      'Could not fetch user profile from Messenger, make sure you are using a configuration with the necessary permissions or enable the "Get user profile" option.'
     )
   }
 

--- a/integrations/messenger/src/misc/utils.ts
+++ b/integrations/messenger/src/misc/utils.ts
@@ -1,3 +1,4 @@
+import { RuntimeError } from '@botpress/sdk'
 import { MessengerClient, MessengerTypes } from 'messaging-api-messenger'
 import { Location, SendMessageProps } from './types'
 import * as bp from '.botpress'
@@ -10,7 +11,7 @@ export function getRecipientId(conversation: SendMessageProps['conversation']): 
   const recipientId = conversation.tags.id
 
   if (!recipientId) {
-    throw Error(`No recipient id found for user ${conversation.id}`)
+    throw new RuntimeError(`No recipient id found for conversation ${conversation.id}`)
   }
 
   return recipientId
@@ -30,7 +31,7 @@ export async function getMediaMetadata(url: string): Promise<FileMetadata> {
   const response = await fetch(url, { method: 'HEAD' })
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch metadata for URL: ${url}`)
+    throw new RuntimeError(`Failed to fetch metadata for URL: ${url}`)
   }
 
   const mimeType = response.headers.get('content-type') ?? 'application/octet-stream'
@@ -39,7 +40,7 @@ export async function getMediaMetadata(url: string): Promise<FileMetadata> {
 
   const fileSize = contentLength ? Number(contentLength) : undefined
   if (fileSize !== undefined && isNaN(fileSize)) {
-    throw new Error(`Failed to parse file size from response: ${contentLength}`)
+    throw new RuntimeError(`Failed to parse file size from response: ${contentLength}`)
   }
 
   // Try to extract filename from content-disposition


### PR DESCRIPTION
User profile picture and name are now set when proactively creating a
user.
The following changes/fixes have also been implemented:
- Prevent proactive user and conversation creation when in sandbox mode
- Prevent fetching user profile picture and name when proactively
creating a user or conversation when the current config's API access
doesn't allow for user infos access
- Add migration guide to `hub.md`
- Changed some errors for runtime errors