### PR TITLE
fix(cli): skip table deployment when working in local

### DIFF
--- a/packages/cli/src/api/client.ts
+++ b/packages/cli/src/api/client.ts
@@ -66,6 +66,25 @@ export class ApiClient {
     ].includes(this.workspaceId)
   }
 
+  public async safeListTables(req: client.ClientInputs['listTables']): Promise<
+    | {
+        success: true
+        tables: client.ClientOutputs['listTables']['tables']
+      }
+    | {
+        success: false
+        error: Error
+      }
+  > {
+    try {
+      const result = await this.client.listTables(req)
+      return { success: true, tables: result.tables }
+    } catch (thrown) {
+      const error = thrown instanceof Error ? thrown : new Error(String(thrown))
+      return { success: false, error }
+    }
+  }
+
   public async getWorkspace(): Promise<client.ClientOutputs['getWorkspace']> {
     return this.client.getWorkspace({ id: this.workspaceId })
   }

--- a/packages/cli/src/tables/tables-publisher.ts
+++ b/packages/cli/src/tables/tables-publisher.ts
@@ -30,8 +30,14 @@ export class TablesPublisher {
     this._logger.log('Synchronizing tables...')
 
     const tablesFromBotDef = Object.entries(botDefinition.tables ?? {})
-    const { tables: existingTables } = await api.client.listTables({})
+    const listTableResult = await api.safeListTables({})
 
+    if (!listTableResult.success) {
+      this._logger.warn('Tables API is not available, skipping table deployment.')
+      return
+    }
+
+    const { tables: existingTables } = listTableResult
     for (const [tableName, tableDef] of tablesFromBotDef) {
       const existingTable = existingTables.find((t) => t.name === tableName)
 


### PR DESCRIPTION
When working in local we often omit the table service. In that case, I think logging a warning is acceptable. There's no need to bump a cli version as this fix will only benefit us internally.