### PR TITLE
fix(cli): keep files located in node_modules dir

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.15.1",
+  "version": "4.15.2",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/command-implementations/init-command.ts
+++ b/packages/cli/src/command-implementations/init-command.ts
@@ -195,7 +195,7 @@ export class InitCommand extends GlobalCommand<InitCommandDefinition> {
       throw new errors.AbortedOperationError()
     }
 
-    await fs.promises.cp(srcDir, destination, { recursive: true, filter: (src) => !src.includes('node_modules') })
+    await fs.promises.cp(srcDir, destination, { recursive: true })
 
     const pkgJsonPath = pathlib.join(destination, 'package.json')
     const strContent = await fs.promises.readFile(pkgJsonPath, 'utf-8')


### PR DESCRIPTION
This bug was created here: https://github.com/botpress/botpress/pull/14093/files (`v4.14.5`)

Once the CLI is published and installed by users, the templates are located in a `node_modules` folder.

fixes SQD-3173