### PR TITLE
feat(zendesk): allow to customize hitl bot name

### DIFF
--- a/integrations/zendesk/integration.definition.ts
+++ b/integrations/zendesk/integration.definition.ts
@@ -7,7 +7,7 @@ import { actions, events, configuration, channels, states, user } from './src/de
 export default new sdk.IntegrationDefinition({
   name: 'zendesk',
   title: 'Zendesk',
-  version: '2.7.0',
+  version: '2.8.0',
   icon: 'icon.svg',
   description:
     'Optimize your support workflow. Trigger workflows from ticket updates as well as manage tickets, access conversations, and engage with customers.',
@@ -32,6 +32,18 @@ export default new sdk.IntegrationDefinition({
           .title('Via Channel')
           .describe(
             'Via Channel to use (example: "whatsapp", "instagram_dm" ), only use values documented by Zendesk, check the "Info" tab at the Zendesk integration configuration page for more details. Leave empty or use an invalid channel type and you will get "API".'
+          )
+          .optional(),
+        chatbotName: sdk.z
+          .string()
+          .title('Chatbot Name')
+          .describe('Name of the chatbot that will be used in the Zendesk ticket. Defaults to "Botpress".')
+          .optional(),
+        chatbotPhotoUrl: sdk.z
+          .string()
+          .title('Chatbot Photo URL')
+          .describe(
+            'Photo URL of the chatbot that will be used in the Zendesk ticket. Must be a publicly-accessible PNG image. Defaults to Botpress logo.'
           )
           .optional(),
       }),

--- a/integrations/zendesk/src/actions/hitl.ts
+++ b/integrations/zendesk/src/actions/hitl.ts
@@ -8,8 +8,12 @@ export const startHitl: bp.IntegrationProps['actions']['startHitl'] = async (pro
 
   const { viaChannel, priority } = input.hitlSession || {}
 
-  const chatbotName = input.hitlSession?.chatbotName ?? 'Botpress'
-  const chatbotPhotoUrl = input.hitlSession?.chatbotPhotoUrl ?? 'https://app.botpress.dev/favicon/bp.svg'
+  const downstreamBotpressUser = await client.getUser({ id: ctx.botUserId })
+  const chatbotName = input.hitlSession?.chatbotName ?? downstreamBotpressUser.user.name ?? 'Botpress'
+  const chatbotPhotoUrl =
+    input.hitlSession?.chatbotPhotoUrl ??
+    downstreamBotpressUser.user.pictureUrl ??
+    'https://app.botpress.dev/favicon/bp.svg'
 
   const zendeskClient = getZendeskClient(ctx.configuration)
   const zendeskBotpressUser = await _retrieveAndUpdateZendeskBotpressUser(props, {

--- a/integrations/zendesk/src/actions/hitl.ts
+++ b/integrations/zendesk/src/actions/hitl.ts
@@ -1,27 +1,28 @@
 import { buildConversationTranscript } from '@botpress/common'
 import * as sdk from '@botpress/sdk'
-import { getZendeskClient } from '../client'
+import { getZendeskClient, type ZendeskClient } from '../client'
 import * as bp from '.botpress'
 
 export const startHitl: bp.IntegrationProps['actions']['startHitl'] = async (props) => {
   const { ctx, input, client } = props
-  const zendeskClient = getZendeskClient(ctx.configuration)
-
-  const { user } = await client.getUser({
-    id: input.userId,
-  })
-  const zendeskAuthorId = user.tags.id
-  if (!zendeskAuthorId) {
-    throw new sdk.RuntimeError(`User ${user.id} not linked in Zendesk`)
-  }
 
   const { viaChannel, priority } = input.hitlSession || {}
 
+  const chatbotName = input.hitlSession?.chatbotName ?? 'Botpress'
+  const chatbotPhotoUrl = input.hitlSession?.chatbotPhotoUrl ?? 'https://app.botpress.dev/favicon/bp.svg'
+
+  const zendeskClient = getZendeskClient(ctx.configuration)
+  const zendeskBotpressUser = await _retrieveAndUpdateZendeskBotpressUser(props, {
+    zendeskClient,
+    chatbotName,
+    chatbotPhotoUrl,
+  })
+
   const ticket = await zendeskClient.createTicket(
     input.title ?? 'Untitled Ticket',
-    await _buildTicketBody(props),
+    await _buildTicketBody(props, { chatbotName }),
     {
-      id: zendeskAuthorId,
+      id: zendeskBotpressUser,
     },
     {
       priority,
@@ -48,9 +49,34 @@ export const startHitl: bp.IntegrationProps['actions']['startHitl'] = async (pro
   }
 }
 
-const _buildTicketBody = async ({ input, client, ctx }: bp.ActionProps['startHitl']) => {
-  const description = input.description?.trim() || 'Someone opened a ticket using your Botpress chatbot.'
+const _retrieveAndUpdateZendeskBotpressUser = async (
+  { client, ctx }: bp.ActionProps['startHitl'],
+  {
+    zendeskClient,
+    chatbotName,
+    chatbotPhotoUrl,
+  }: { zendeskClient: ZendeskClient; chatbotName: string; chatbotPhotoUrl: string }
+) => {
+  await client.updateUser({
+    id: ctx.botUserId,
+    pictureUrl: chatbotPhotoUrl,
+    name: chatbotName,
+  })
 
+  const zendeskUser = await zendeskClient.createOrUpdateUser({
+    external_id: ctx.botUserId,
+    name: chatbotName,
+    remote_photo_url: chatbotPhotoUrl,
+  })
+
+  return String(zendeskUser.id)
+}
+
+const _buildTicketBody = async (
+  { input, client, ctx }: bp.ActionProps['startHitl'],
+  { chatbotName }: { chatbotName: string }
+) => {
+  const description = input.description?.trim() || `Someone opened a ticket using your ${chatbotName} chatbot.`
   const messageHistory = await buildConversationTranscript({ client, ctx, messages: input.messageHistory })
 
   return description + (messageHistory.length ? `\n\n---\n\n${messageHistory}` : '')


### PR DESCRIPTION
Resolves SQD-3172.

Adds `chatbotName` and `chatbotPhotoUrl` to the `startHitl` card. When specified, the Botpress system user on Zendesk gets renamed to match this value. The matching Downstream user also gets renamed, so the name is reflected in the transcript.

<img width="568" height="307" alt="image" src="https://github.com/user-attachments/assets/53219cc0-de98-4fd5-a1a1-e77a8f183cde" />
