### PR TITLE
fix(sdk): type of getMessage response should be discriminated union

### DIFF
--- a/packages/sdk/src/integration/client/index.ts
+++ b/packages/sdk/src/integration/client/index.ts
@@ -53,10 +53,10 @@ export class IntegrationSpecificClient<TIntegration extends common.BaseIntegrati
     this._client.createMessage(x)) as types.CreateMessage<TIntegration>
   public getOrCreateMessage: types.GetOrCreateMessage<TIntegration> = ((x) =>
     this._client.getOrCreateMessage(x)) as types.GetOrCreateMessage<TIntegration>
-  public getMessage: types.GetMessage<TIntegration> = ((x) =>
-    this._client.getMessage(x)) as types.GetMessage<TIntegration>
-  public updateMessage: types.UpdateMessage<TIntegration> = ((x) =>
-    this._client.updateMessage(x)) as types.UpdateMessage<TIntegration>
+  public getMessage: types.GetMessage<TIntegration> = ((x: any) =>
+    this._client.getMessage(x)) as unknown as types.GetMessage<TIntegration>
+  public updateMessage: types.UpdateMessage<TIntegration> = ((x: any) =>
+    this._client.updateMessage(x)) as unknown as types.UpdateMessage<TIntegration>
   public listMessages: types.ListMessages<TIntegration> = ((x) =>
     this._client.listMessages(x)) as types.ListMessages<TIntegration>
   public deleteMessage: types.DeleteMessage<TIntegration> = ((x) =>

--- a/packages/sdk/src/integration/client/index.ts
+++ b/packages/sdk/src/integration/client/index.ts
@@ -53,10 +53,10 @@ export class IntegrationSpecificClient<TIntegration extends common.BaseIntegrati
     this._client.createMessage(x)) as types.CreateMessage<TIntegration>
   public getOrCreateMessage: types.GetOrCreateMessage<TIntegration> = ((x) =>
     this._client.getOrCreateMessage(x)) as types.GetOrCreateMessage<TIntegration>
-  public getMessage: types.GetMessage<TIntegration> = ((x: any) =>
-    this._client.getMessage(x)) as unknown as types.GetMessage<TIntegration>
-  public updateMessage: types.UpdateMessage<TIntegration> = ((x: any) =>
-    this._client.updateMessage(x)) as unknown as types.UpdateMessage<TIntegration>
+  public getMessage: types.GetMessage<TIntegration> = ((x) =>
+    this._client.getMessage(x).then((r) => r)) as types.GetMessage<TIntegration>
+  public updateMessage: types.UpdateMessage<TIntegration> = ((x) =>
+    this._client.updateMessage(x).then((r) => r)) as types.UpdateMessage<TIntegration>
   public listMessages: types.ListMessages<TIntegration> = ((x) =>
     this._client.listMessages(x)) as types.ListMessages<TIntegration>
   public deleteMessage: types.DeleteMessage<TIntegration> = ((x) =>

--- a/packages/sdk/src/integration/client/sub-types.test.ts
+++ b/packages/sdk/src/integration/client/sub-types.test.ts
@@ -61,6 +61,53 @@ test('TagsOfMessage with specific message', () => {
   type _assertion = utils.AssertTrue<utils.IsEqual<Actual, Expected>>
 })
 
+test('EnumerateMessages of FooBarBazIntegration returns union of all message types', () => {
+  type Actual = EnumerateMessages<FooBarBazIntegration>
+  type Expected = {
+    messageFoo: {
+      type: 'messageFoo'
+      tags: {
+        fooMessageTag1?: string
+        fooMessageTag2?: string
+        fooMessageTag3?: string
+      }
+      payload: {
+        foo: string
+      }
+    }
+    messageBar: {
+      type: 'messageBar'
+      tags: {
+        barMessageTag1?: string
+        barMessageTag2?: string
+        barMessageTag3?: string
+      }
+      payload: {
+        bar: number
+      }
+    }
+    messageBaz: {
+      type: 'messageBaz'
+      tags: {
+        bazMessageTag1?: string
+        bazMessageTag2?: string
+        bazMessageTag3?: string
+      }
+      payload: {
+        baz: boolean
+      }
+    }
+  }
+
+  type _assertion = utils.AssertAll<
+    [
+      utils.AssertExtends<Actual, Expected>,
+      utils.AssertExtends<Expected, Actual>,
+      utils.AssertTrue<utils.IsEqual<Actual, Expected>>,
+    ]
+  >
+})
+
 test('GetChannelByName', () => {
   type Actual = GetChannelByName<FooBarBazIntegration, 'channelFoo'>
   type Expected = {
@@ -90,10 +137,11 @@ test('GetChannelByName', () => {
 test('GetMessageByName', () => {
   type Actual = GetMessageByName<FooBarBazIntegration, 'messageFoo'>
   type Expected = {
+    type: 'messageFoo'
     tags: {
-      fooMessageTag1: ''
-      fooMessageTag2: ''
-      fooMessageTag3: ''
+      fooMessageTag1?: string
+      fooMessageTag2?: string
+      fooMessageTag3?: string
     }
     payload: {
       foo: string

--- a/packages/sdk/src/integration/client/sub-types.ts
+++ b/packages/sdk/src/integration/client/sub-types.ts
@@ -5,7 +5,10 @@ export type EnumerateMessages<TIntegration extends common.BaseIntegration> = uti
   utils.ValueOf<{
     [TChannelName in keyof TIntegration['channels']]: {
       [TMessageName in keyof TIntegration['channels'][TChannelName]['messages']]: {
-        tags: TIntegration['channels'][TChannelName]['message']['tags']
+        type: TMessageName
+        tags: {
+          [Tag in keyof TIntegration['channels'][TChannelName]['message']['tags']]?: string
+        }
         payload: TIntegration['channels'][TChannelName]['messages'][TMessageName]
       }
     }
@@ -23,6 +26,7 @@ export type GetMessageByName<
 > = utils.Cast<
   EnumerateMessages<TIntegration>[TMessageName],
   {
+    type: string
     tags: Record<string, any>
     payload: any
   }

--- a/packages/sdk/src/integration/client/types.ts
+++ b/packages/sdk/src/integration/client/types.ts
@@ -1,14 +1,7 @@
 import * as client from '@botpress/client'
 import * as utils from '../../utils/type-utils'
 import * as common from '../common'
-import {
-  EnumerateMessages,
-  ConversationTags,
-  GetChannelByName,
-  GetMessageByName,
-  MessageTags,
-  TagsOfMessage,
-} from './sub-types'
+import { EnumerateMessages, ConversationTags, GetChannelByName, GetMessageByName, MessageTags } from './sub-types'
 
 type Arg<F extends (...args: any[]) => any> = Parameters<F>[number]
 type Res<F extends (...args: any[]) => any> = ReturnType<F>
@@ -119,12 +112,8 @@ type MessageResponse<
   TMessage extends keyof EnumerateMessages<TIntegration> = keyof EnumerateMessages<TIntegration>,
 > = {
   message: utils.Merge<
-    Awaited<Res<client.Client['createMessage']>>['message'],
-    {
-      type: utils.Cast<TMessage, string>
-      payload: GetMessageByName<TIntegration, TMessage>['payload']
-      tags: common.ToTags<TagsOfMessage<TIntegration, TMessage>>
-    }
+    Awaited<Res<client.Client['getMessage']>>['message'],
+    utils.Cast<EnumerateMessages<TIntegration>[TMessage], object>
   >
 }
 


### PR DESCRIPTION
in an integration:
```ts
const { message } = await props.client.getMessage({ id: msgId })
if (message.type === "text") {
  message.payload.text // typescript currently fails, but should work
}
```