### PR TITLE
fix(cli): improve format of bloc message in chat command

### DIFF
--- a/packages/cli/src/chat/index.ts
+++ b/packages/cli/src/chat/index.ts
@@ -207,7 +207,14 @@ export class Chat {
       case 'markdown':
         return prefix + message.payload.markdown
       case 'bloc':
-        return prefix + '\n' + message.payload.items.map((item) => this._messageToText({ payload: item })).join('\n')
+        return (
+          prefix +
+          '\n' +
+          message.payload.items
+            .map((item) => this._messageToText({ payload: item }))
+            .map((l) => `\t${l}`)
+            .join('\n')
+        )
       default:
         type _assertion = utils.types.AssertNever<typeof message.payload>
         return '<unknown>'

--- a/packages/cli/src/chat/index.ts
+++ b/packages/cli/src/chat/index.ts
@@ -207,14 +207,10 @@ export class Chat {
       case 'markdown':
         return prefix + message.payload.markdown
       case 'bloc':
-        return (
-          prefix +
-          '\n' +
-          message.payload.items
-            .map((item) => this._messageToText({ payload: item }))
-            .map((l) => `\t${l}`)
-            .join('\n')
-        )
+        return [
+          prefix,
+          ...message.payload.items.map((item) => this._messageToText({ payload: item })).map((l) => `\t${l}`),
+        ].join('\n')
       default:
         type _assertion = utils.types.AssertNever<typeof message.payload>
         return '<unknown>'


### PR DESCRIPTION
<img width="310" height="118" alt="image" src="https://github.com/user-attachments/assets/a6b97ebe-6ac8-4b76-a5c4-305fbf554120" />
