### PR TITLE
fix(plugins): fix deployment

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.17.2",
+  "version": "4.17.3",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/command-implementations/add-command.ts
+++ b/packages/cli/src/command-implementations/add-command.ts
@@ -117,7 +117,8 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
     if (ref.type === 'name' && ref.version === pkgRef.LATEST_TAG) {
       // If the semver version expression is 'latest', we assume the project
       // is compatible with all versions of the latest major:
-      targetPackage.pkg.version = `^${semver.major(targetPackage.pkg.version)}.0.0`
+      const major = semver.major(targetPackage.pkg.version)
+      targetPackage.pkg.version = `>=${major}.0.0 <${major + 1}.0.0`
 
       this.logger.log(
         `Dependency "${packageName}" will be installed with version "${targetPackage.pkg.version}". ` +

--- a/plugins/file-synchronizer/plugin.definition.ts
+++ b/plugins/file-synchronizer/plugin.definition.ts
@@ -198,6 +198,9 @@ export default new sdk.PluginDefinition({
     },
   },
   interfaces: {
-    'files-readonly': { ...filesReadonly, version: `^${semver.major(filesReadonly.version)}.0.0` },
+    'files-readonly': {
+      ...filesReadonly,
+      version: `>=${semver.major(filesReadonly.version)}.0.0 <${semver.major(filesReadonly.version) + 1}.0.0`,
+    },
   },
 })

--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -209,7 +209,7 @@ export default new sdk.PluginDefinition({
     },
   },
   interfaces: {
-    hitl: { ...hitl, version: `^${semver.major(hitl.version)}.0.0` },
+    hitl: { ...hitl, version: `>=${semver.major(hitl.version)}.0.0 <${semver.major(hitl.version) + 1}.0.0` },
   },
   events: {
     humanAgentAssignedTimeout: {

--- a/plugins/knowledge/plugin.definition.ts
+++ b/plugins/knowledge/plugin.definition.ts
@@ -7,6 +7,6 @@ export default new sdk.PluginDefinition({
   version: '1.0.0',
   configuration: { schema: sdk.z.object({}) },
   interfaces: {
-    llm: { ...llm, version: `^${semver.major(llm.version)}.0.0` },
+    llm: { ...llm, version: `>=${semver.major(llm.version)}.0.0 <${semver.major(llm.version) + 1}.0.0` },
   },
 })

--- a/plugins/personality/plugin.definition.ts
+++ b/plugins/personality/plugin.definition.ts
@@ -17,6 +17,6 @@ export default new sdk.PluginDefinition({
     }),
   },
   interfaces: {
-    llm: { ...llm, version: `^${semver.major(llm.version)}.0.0` },
+    llm: { ...llm, version: `>=${semver.major(llm.version)}.0.0 <${semver.major(llm.version) + 1}.0.0` },
   },
 })

--- a/plugins/record-synchronizer/package.json
+++ b/plugins/record-synchronizer/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "record-synchronizer",
+  "version": "0.0.0",
+  "private": true
+}

--- a/plugins/synchronizer/plugin.definition.ts
+++ b/plugins/synchronizer/plugin.definition.ts
@@ -69,7 +69,13 @@ export default new sdk.PluginDefinition({
     },
   },
   interfaces: {
-    listable: { ...listable, version: `^${semver.major(listable.version)}.0.0` },
-    deletable: { ...deletable, version: `^${semver.major(deletable.version)}.0.0` },
+    listable: {
+      ...listable,
+      version: `>=${semver.major(listable.version)}.0.0 <${semver.major(listable.version) + 1}.0.0`,
+    },
+    deletable: {
+      ...deletable,
+      version: `>=${semver.major(deletable.version)}.0.0 <${semver.major(deletable.version) + 1}.0.0`,
+    },
   },
 })


### PR DESCRIPTION
#14140 has been merged, but it has broken deployment for the file-synchronizer plugin: https://github.com/botpress/botpress/actions/runs/17072395758/job/48404587416

```
❌ Interface "files-readonly@^0.0.0" not found
```

The problem lies with the fact that [caret ranges](https://github.com/npm/node-semver?tab=readme-ov-file#caret-ranges-123-025-004) in node-semver "_allow changes that do not modify the left-most non-zero element_". However, since there's no left-most non-zero element in `^0.0.0`, it essentially resolves to `>=0.0.0 <0.0.0`, which does not match any known interface version.

We could bump our interfaces that have `0` as major to `1.0.0`, but I believe this change is less disruptive: use explicit ranges instead of caret expressions: `>=${major}.0.0 <${major + 1}.0.0`