### PR TITLE
fix(zendesk): do not attribute tickets to Botpress

### DIFF
--- a/integrations/zendesk/integration.definition.ts
+++ b/integrations/zendesk/integration.definition.ts
@@ -7,7 +7,7 @@ import { actions, events, configuration, channels, states, user } from './src/de
 export default new sdk.IntegrationDefinition({
   name: 'zendesk',
   title: 'Zendesk',
-  version: '2.8.1',
+  version: '2.8.2',
   icon: 'icon.svg',
   description:
     'Optimize your support workflow. Trigger workflows from ticket updates as well as manage tickets, access conversations, and engage with customers.',


### PR DESCRIPTION
Restores the previous behaviour where the user that sends the transcript is the downstream end user