### PR TITLE
fix(integrations/calendly): fix hub.md header text

### DIFF
--- a/integrations/calendly/hub.md
+++ b/integrations/calendly/hub.md
@@ -14,6 +14,6 @@
 4. Under "Your personal access tokens" click "Generate New Token"
 5. Give the token a name (e.g. 'Botpress Chatbot') and click "Create token"
 6. Validate your account by providing the verification code (typically sent to the account's email address)
-   1. If you don't see it in your inbox be sure to also check your Junk/Spam folder
+   - If you don't see it in your inbox be sure to also check your Junk/Spam folder
 7. Click the "Copy token" button and save it to a secure location as it will only be shown once.
 8. Finally, paste the Personal Access Token into the Botpress config

--- a/integrations/calendly/hub.md
+++ b/integrations/calendly/hub.md
@@ -1,4 +1,4 @@
-# Resend Integration
+# Calendly Integration
 
 ## Overview
 

--- a/integrations/calendly/integration.definition.ts
+++ b/integrations/calendly/integration.definition.ts
@@ -5,7 +5,7 @@ import { inviteeEventOutputSchema } from 'definitions/events'
 export default new IntegrationDefinition({
   name: 'calendly',
   title: 'Calendly',
-  version: '0.0.2',
+  version: '0.0.1',
   readme: 'hub.md',
   icon: 'icon.svg',
   description: 'Schedule meetings and manage events using the Calendly scheduling platform.',

--- a/integrations/calendly/integration.definition.ts
+++ b/integrations/calendly/integration.definition.ts
@@ -5,7 +5,7 @@ import { inviteeEventOutputSchema } from 'definitions/events'
 export default new IntegrationDefinition({
   name: 'calendly',
   title: 'Calendly',
-  version: '0.0.1',
+  version: '0.0.2',
   readme: 'hub.md',
   icon: 'icon.svg',
   description: 'Schedule meetings and manage events using the Calendly scheduling platform.',


### PR DESCRIPTION
The header text said "Resend" instead of "Calendly"