### PR TITLE
feat(plugins/hitl): allow disabling messages and features

### DIFF
--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -19,55 +19,61 @@ const PLUGIN_CONFIG_SCHEMA = sdk.z.object({
   onHitlHandoffMessage: sdk.z
     .string()
     .title('Escalation Started Message')
-    .describe('The message to send to the user when transferring to a human agent')
+    .describe('The message to send to the user when transferring to a human agent. Leave empty to disable')
     .optional()
-    .placeholder(DEFAULT_HITL_HANDOFF_MESSAGE),
+    .default(DEFAULT_HITL_HANDOFF_MESSAGE),
   onHumanAgentAssignedMessage: sdk.z
     .string()
     .title('Human Agent Assigned Message')
-    .describe('The message to send to the user when a human agent is assigned')
+    .describe('The message to send to the user when a human agent is assigned. Leave empty to disable')
     .optional()
-    .placeholder(DEFAULT_HUMAN_AGENT_ASSIGNED_MESSAGE),
+    .default(DEFAULT_HUMAN_AGENT_ASSIGNED_MESSAGE),
   onHitlStoppedMessage: sdk.z
     .string()
     .title('Escalation Terminated Message')
-    .describe('The message to send to the user when the HITL session stops and control is transferred back to bot')
+    .describe(
+      'The message to send to the user when the HITL session stops and control is transferred back to bot. Leave empty to disable'
+    )
     .optional()
-    .placeholder(DEFAULT_HITL_STOPPED_MESSAGE),
+    .default(DEFAULT_HITL_STOPPED_MESSAGE),
   onUserHitlCancelledMessage: sdk.z
     .string()
     .title('Escalation Aborted Message')
-    .describe('The message to send to the human agent when the user abruptly ends the HITL session')
+    .describe('The message to send to the human agent when the user abruptly ends the HITL session. Cannot be disabled')
     .optional()
-    .placeholder(DEFAULT_USER_HITL_CANCELLED_MESSAGE),
+    .default(DEFAULT_USER_HITL_CANCELLED_MESSAGE),
   onIncompatibleMsgTypeMessage: sdk.z
     .string()
     .title('Incompatible Message Type Warning')
     .describe(
-      'The warning to send to the human agent when they send a message that is not supported by the hitl session'
+      'The warning to send to the human agent when they send a message that is not supported by the hitl session. Cannot be disabled'
     )
     .optional()
-    .placeholder(DEFAULT_INCOMPATIBLE_MSGTYPE_MESSAGE),
+    .default(DEFAULT_INCOMPATIBLE_MSGTYPE_MESSAGE),
   userHitlCloseCommand: sdk.z
     .string()
     .title('Termination Command')
     .describe(
-      'Users may send this command to end the HITL session at any time. It is case-insensitive, so it works regardless of letter casing.'
+      'Users may send this command to end the HITL session at any time. It is case-insensitive. Leave empty to disable the command'
     )
     .optional()
-    .placeholder(DEFAULT_USER_HITL_CLOSE_COMMAND),
+    .default(DEFAULT_USER_HITL_CLOSE_COMMAND),
   onUserHitlCloseMessage: sdk.z
     .string()
     .title('Termination Command Message')
-    .describe('The message to send to the user when they end the HITL session using the termination command')
+    .describe(
+      'The message to send to the user when they end the HITL session using the termination command. Does not apply if the command is disabled'
+    )
     .optional()
-    .placeholder(DEFAULT_USER_HITL_COMMAND_MESSAGE),
+    .default(DEFAULT_USER_HITL_COMMAND_MESSAGE),
   onAgentAssignedTimeoutMessage: sdk.z
     .string()
     .title('Agent Assigned Timeout Message')
-    .describe('The message to send to the user when no human agent is assigned within the timeout period')
+    .describe(
+      'The message to send to the user when no human agent is assigned within the timeout period. Leave empty to disable'
+    )
     .optional()
-    .placeholder(DEFAULT_AGENT_ASSIGNED_TIMEOUT_MESSAGE),
+    .default(DEFAULT_AGENT_ASSIGNED_TIMEOUT_MESSAGE),
   agentAssignedTimeoutSeconds: sdk.z
     .number()
     .title('Agent Assigned Timeout')
@@ -76,7 +82,7 @@ const PLUGIN_CONFIG_SCHEMA = sdk.z.object({
     )
     .nonnegative()
     .optional()
-    .placeholder('0'),
+    .default(0),
   flowOnHitlStopped: sdk.z
     .boolean()
     .default(true)
@@ -86,7 +92,7 @@ const PLUGIN_CONFIG_SCHEMA = sdk.z.object({
 
 export default new sdk.PluginDefinition({
   name: 'hitl',
-  version: '1.0.0',
+  version: '1.1.0',
   title: 'Human In The Loop',
   description: 'Seamlessly transfer conversations to human agents',
   icon: 'icon.svg',

--- a/plugins/hitl/src/actions/start-hitl.ts
+++ b/plugins/hitl/src/actions/start-hitl.ts
@@ -1,5 +1,4 @@
 import * as sdk from '@botpress/sdk'
-import { DEFAULT_HITL_HANDOFF_MESSAGE } from '../../plugin.definition'
 import * as configuration from '../configuration'
 import * as conv from '../conv-manager'
 import * as user from '../user-linker'
@@ -75,12 +74,12 @@ const _sendHandoffMessage = (
   upstreamCm: conv.ConversationManager,
   sessionConfig: bp.configuration.Configuration
 ): Promise<void> =>
-  upstreamCm.respond({
-    type: 'text',
-    text: sessionConfig.onHitlHandoffMessage?.length
-      ? sessionConfig.onHitlHandoffMessage
-      : DEFAULT_HITL_HANDOFF_MESSAGE,
-  })
+  sessionConfig.onHitlHandoffMessage?.trim()?.length
+    ? upstreamCm.respond({
+        type: 'text',
+        text: sessionConfig.onHitlHandoffMessage,
+      })
+    : Promise.resolve()
 
 const _buildMessageHistory = async (
   props: Props,

--- a/plugins/hitl/src/actions/stop-hitl.ts
+++ b/plugins/hitl/src/actions/stop-hitl.ts
@@ -30,7 +30,7 @@ export const stopHitl: bp.PluginProps['actions']['stopHitl'] = async (props) => 
 
   await downstreamCm.respond({
     type: 'text',
-    text: sessionConfig.onUserHitlCancelledMessage?.length
+    text: sessionConfig.onUserHitlCancelledMessage?.trim()?.length
       ? sessionConfig.onUserHitlCancelledMessage
       : DEFAULT_USER_HITL_CANCELLED_MESSAGE,
   })

--- a/plugins/hitl/src/hooks/before-incoming-event/hitl-assigned.ts
+++ b/plugins/hitl/src/hooks/before-incoming-event/hitl-assigned.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_HUMAN_AGENT_ASSIGNED_MESSAGE } from '../../../plugin.definition'
 import * as configuration from '../../configuration'
 import * as conv from '../../conv-manager'
 import { tryLinkWebchatUser } from '../../webchat'
@@ -30,15 +29,15 @@ export const handleEvent: bp.HookHandlers['before_incoming_event']['hitl:hitlAss
   })
 
   const { user: humanAgentUser } = await props.client.getUser({ id: humanAgentUserId })
-  const humanAgentName = humanAgentUser?.name?.length ? humanAgentUser.name : 'A Human Agent'
+  const humanAgentName = humanAgentUser?.name?.trim()?.length ? humanAgentUser.name : 'A Human Agent'
 
   await Promise.all([
-    upstreamCm.respond({
-      type: 'text',
-      text: sessionConfig.onHumanAgentAssignedMessage?.length
-        ? sessionConfig.onHumanAgentAssignedMessage
-        : DEFAULT_HUMAN_AGENT_ASSIGNED_MESSAGE,
-    }),
+    sessionConfig.onHumanAgentAssignedMessage?.trim()?.length
+      ? upstreamCm.respond({
+          type: 'text',
+          text: sessionConfig.onHumanAgentAssignedMessage,
+        })
+      : Promise.resolve(),
     downstreamCm.setHumanAgent(humanAgentUserId, humanAgentName),
     upstreamCm.setHumanAgent(humanAgentUserId, humanAgentName),
     tryLinkWebchatUser(props, { downstreamUserId: humanAgentUserId, upstreamConversationId, forceLink: true }),

--- a/plugins/hitl/src/hooks/before-incoming-event/hitl-stopped.ts
+++ b/plugins/hitl/src/hooks/before-incoming-event/hitl-stopped.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_HITL_STOPPED_MESSAGE } from '../../../plugin.definition'
 import * as configuration from '../../configuration'
 import * as conv from '../../conv-manager'
 import * as consts from '../consts'
@@ -29,12 +28,12 @@ export const handleEvent: bp.HookHandlers['before_incoming_event']['hitl:hitlSto
   })
 
   await Promise.allSettled([
-    upstreamCm.respond({
-      type: 'text',
-      text: sessionConfig.onHitlStoppedMessage?.length
-        ? sessionConfig.onHitlStoppedMessage
-        : DEFAULT_HITL_STOPPED_MESSAGE,
-    }),
+    sessionConfig.onHitlStoppedMessage?.trim()?.length
+      ? upstreamCm.respond({
+          type: 'text',
+          text: sessionConfig.onHitlStoppedMessage,
+        })
+      : Promise.resolve(),
     downstreamCm.setHitlInactive(conv.HITL_END_REASON.AGENT_CLOSED_TICKET),
     upstreamCm.setHitlInactive(conv.HITL_END_REASON.AGENT_CLOSED_TICKET),
   ])

--- a/plugins/hitl/src/hooks/before-incoming-event/human-agent-assigned-timeout.ts
+++ b/plugins/hitl/src/hooks/before-incoming-event/human-agent-assigned-timeout.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_AGENT_ASSIGNED_TIMEOUT_MESSAGE, DEFAULT_USER_HITL_CANCELLED_MESSAGE } from '../../../plugin.definition'
+import { DEFAULT_USER_HITL_CANCELLED_MESSAGE } from '../../../plugin.definition'
 import * as configuration from '../../configuration'
 import * as conv from '../../conv-manager'
 import * as consts from '../consts'
@@ -80,7 +80,7 @@ const _handleTimeout = async (
   await downstreamCm.respond({
     // TODO: We might want to add a custom message for the human agent.
     type: 'text',
-    text: sessionConfig.onUserHitlCancelledMessage?.length
+    text: sessionConfig.onUserHitlCancelledMessage?.trim()?.length
       ? sessionConfig.onUserHitlCancelledMessage
       : DEFAULT_USER_HITL_CANCELLED_MESSAGE,
   })
@@ -98,10 +98,10 @@ const _handleTimeout = async (
   // Call stopHitl in the hitl integration (zendesk, etc.):
   await props.actions.hitl.stopHitl({ conversationId: downstreamCm.conversationId })
 
-  await upstreamCm.respond({
-    type: 'text',
-    text: sessionConfig.onAgentAssignedTimeoutMessage?.length
-      ? sessionConfig.onAgentAssignedTimeoutMessage
-      : DEFAULT_AGENT_ASSIGNED_TIMEOUT_MESSAGE,
-  })
+  if (sessionConfig.onAgentAssignedTimeoutMessage?.trim()?.length) {
+    await upstreamCm.respond({
+      type: 'text',
+      text: sessionConfig.onAgentAssignedTimeoutMessage,
+    })
+  }
 }

--- a/plugins/hitl/src/hooks/before-incoming-message/all.ts
+++ b/plugins/hitl/src/hooks/before-incoming-message/all.ts
@@ -2,7 +2,6 @@ import * as client from '@botpress/client'
 import {
   DEFAULT_INCOMPATIBLE_MSGTYPE_MESSAGE,
   DEFAULT_USER_HITL_CANCELLED_MESSAGE,
-  DEFAULT_USER_HITL_CLOSE_COMMAND,
   DEFAULT_USER_HITL_COMMAND_MESSAGE,
 } from 'plugin.definition'
 import { tryLinkWebchatUser } from 'src/webchat'
@@ -56,7 +55,7 @@ const _handleDownstreamMessage = async (
     props.logger.with(props.data).error('Downstream conversation received a non-text message')
     await downstreamCm.respond({
       type: 'text',
-      text: sessionConfig.onIncompatibleMsgTypeMessage?.length
+      text: sessionConfig.onIncompatibleMsgTypeMessage?.trim()?.length
         ? sessionConfig.onIncompatibleMsgTypeMessage
         : DEFAULT_INCOMPATIBLE_MSGTYPE_MESSAGE,
     })
@@ -166,9 +165,11 @@ const _isHitlCloseCommand = (
   props: bp.HookHandlerProps['before_incoming_message'],
   sessionConfig: bp.configuration.Configuration
 ) => {
-  const closeCommand = sessionConfig.userHitlCloseCommand?.length
-    ? sessionConfig.userHitlCloseCommand
-    : DEFAULT_USER_HITL_CLOSE_COMMAND
+  const closeCommand = sessionConfig.userHitlCloseCommand
+
+  if (!closeCommand?.trim()?.length) {
+    return false
+  }
 
   const inputText: string | undefined = props.data.payload.text
   return inputText && inputText.trim().toLowerCase() === closeCommand.trim().toLowerCase()
@@ -188,7 +189,7 @@ const _handleHitlCloseCommand = async (
 ) => {
   await downstreamCm.respond({
     type: 'text',
-    text: sessionConfig.onUserHitlCancelledMessage?.length
+    text: sessionConfig.onUserHitlCancelledMessage?.trim()?.length
       ? sessionConfig.onUserHitlCancelledMessage
       : DEFAULT_USER_HITL_CANCELLED_MESSAGE,
   })
@@ -210,7 +211,7 @@ const _handleHitlCloseCommand = async (
 
   await upstreamCm.respond({
     type: 'text',
-    text: sessionConfig.onUserHitlCloseMessage?.length
+    text: sessionConfig.onUserHitlCloseMessage?.trim()?.length
       ? sessionConfig.onUserHitlCloseMessage
       : DEFAULT_USER_HITL_COMMAND_MESSAGE,
   })


### PR DESCRIPTION
- Allows disabling the following status messages:
  - Escalation Started Message
  - Human Agent Assigned Message
  - Escalation Terminated Message
  - Agent Assigned Timeout Message
- Allows disabling the user end command (`/end`)

**This PR is DANGEROUS:** to allow users to disable status messages, I changed the `.placeholder()` for `.default()` and when the user clears the field we disable the message. **However**, if the user previously installed the hitl plugin, put a value in those fields, and then removed it to use the default value, the fields are not back to `undefined`: they're empty strings. So updating to this new version of the HITL plugin would cause a change of behaviour.

We could alleviate this by bumping a major, since the Studio forcefully clears the config when upgrading across majors.

Resolves SQD-3104