### PR TITLE
chore(plugins): set `isDirty` tag to false when ai is disabled

### DIFF
--- a/plugins/conversation-insights/src/onNewMessageHandler.ts
+++ b/plugins/conversation-insights/src/onNewMessageHandler.ts
@@ -14,7 +14,7 @@ export const onNewMessage = async (props: OnNewMessageProps) => {
   const tags = {
     message_count: message_count.toString(),
     participant_count: participant_count.toString(),
-    isDirty: 'true',
+    isDirty: props.configuration.aiEnabled ? 'true' : 'false',
   }
 
   await props.client.updateConversation({

--- a/plugins/conversation-insights/src/tagsUpdater.ts
+++ b/plugins/conversation-insights/src/tagsUpdater.ts
@@ -46,6 +46,7 @@ export const updateTitleAndSummary = async (props: UpdateTitleAndSummaryProps) =
       isDirty: 'false',
     },
   })
+  props.logger.info(`The AI insight was updated for conversation ${props.conversation.id}`)
 }
 
 type ParsePromptProps = {


### PR DESCRIPTION
Product team requested that reactivating AI insight not update all conversations that were changed while it was disabled.

My solution was to set all conversations receiving messages to `isDirty = false`

Also added log when updating insight for a conversation