### PR TITLE
fix(common): error handling decorator enforces methods to be async

### DIFF
--- a/integrations/dropbox/src/dropbox-api/error-handling.ts
+++ b/integrations/dropbox/src/dropbox-api/error-handling.ts
@@ -15,7 +15,7 @@ const COMMON_ERRORS: Readonly<Record<string, string>> = {
   'to/conflict/': 'The target path already exists',
 } as const
 
-const _errorRedactor = (error: Error, customMessage: string): sdk.RuntimeError => {
+const _errorRedactor = (error: Error, customMessage: string) => {
   if (error instanceof sdk.RuntimeError) {
     return error
   }
@@ -25,7 +25,7 @@ const _errorRedactor = (error: Error, customMessage: string): sdk.RuntimeError =
   return _tryToHandleDropboxError(error, customMessage) ?? new sdk.RuntimeError(customMessage)
 }
 
-const _tryToHandleDropboxError = (error: Error, customMessage: string): sdk.RuntimeError | undefined => {
+const _tryToHandleDropboxError = (error: Error, customMessage: string) => {
   if (!(error instanceof DropboxResponseError && 'error_summary' in error.error)) {
     return
   }

--- a/integrations/dropbox/src/dropbox-api/error-handling.ts
+++ b/integrations/dropbox/src/dropbox-api/error-handling.ts
@@ -15,7 +15,7 @@ const COMMON_ERRORS: Readonly<Record<string, string>> = {
   'to/conflict/': 'The target path already exists',
 } as const
 
-const _errorRedactor = (error: Error, customMessage: string) => {
+const _errorRedactor = (error: Error, customMessage: string): sdk.RuntimeError => {
   if (error instanceof sdk.RuntimeError) {
     return error
   }
@@ -25,7 +25,7 @@ const _errorRedactor = (error: Error, customMessage: string) => {
   return _tryToHandleDropboxError(error, customMessage) ?? new sdk.RuntimeError(customMessage)
 }
 
-const _tryToHandleDropboxError = (error: Error, customMessage: string) => {
+const _tryToHandleDropboxError = (error: Error, customMessage: string): sdk.RuntimeError | undefined => {
   if (!(error instanceof DropboxResponseError && 'error_summary' in error.error)) {
     return
   }

--- a/packages/common/src/error-handling/try-catch-wrapper.test.ts
+++ b/packages/common/src/error-handling/try-catch-wrapper.test.ts
@@ -1,0 +1,64 @@
+import { RuntimeError } from '@botpress/sdk'
+import {
+  createAsyncFnWrapperWithErrorRedaction,
+  createErrorHandlingDecorator,
+  InvalidAsyncFunctionArgumentError,
+} from './try-catch-wrapper'
+import { expect, test } from 'vitest'
+
+const _errorRedactor = (error: Error, customMessage: string): RuntimeError =>
+  new RuntimeError(`${error.message}: ${customMessage}`)
+
+export const wrapAsyncFnWithTryCatch = createAsyncFnWrapperWithErrorRedaction(_errorRedactor)
+export const handleErrors = createErrorHandlingDecorator(wrapAsyncFnWithTryCatch)
+
+export class MyClient {
+  @handleErrors('hello1')
+  public syncSuccessMethod() {
+    return 'banana'
+  }
+
+  @handleErrors('hello2')
+  public syncFailureMethod() {
+    throw new Error('oops')
+  }
+
+  @handleErrors('hello3')
+  public async asyncSuccessMethod() {
+    return 'apple'
+  }
+
+  @handleErrors('hello4')
+  public async asyncFailureMethod() {
+    throw new Error('oops')
+  }
+}
+
+test('decorating successfull async methods shouldnt change their behavior', async () => {
+  const client = new MyClient()
+  expect(await client.asyncSuccessMethod()).toBe('apple')
+})
+
+test('decorating failed async methods should redact the error', async () => {
+  const client = new MyClient()
+
+  let thrown: unknown | undefined = undefined
+  try {
+    await client.asyncFailureMethod()
+  } catch (e) {
+    thrown = e
+  }
+
+  expect(thrown).toBeInstanceOf(RuntimeError)
+  expect((thrown as Error).message).toBe('oops: hello4')
+})
+
+test('decorating successfull sync methods should throw', () => {
+  const client = new MyClient()
+  expect(() => client.syncSuccessMethod()).toThrowError(InvalidAsyncFunctionArgumentError)
+})
+
+test('decorating failed sync methods should throw', () => {
+  const client = new MyClient()
+  expect(() => client.syncFailureMethod()).toThrowError(InvalidAsyncFunctionArgumentError)
+})

--- a/packages/common/src/error-handling/try-catch-wrapper.test.ts
+++ b/packages/common/src/error-handling/try-catch-wrapper.test.ts
@@ -1,9 +1,5 @@
 import { RuntimeError } from '@botpress/sdk'
-import {
-  createAsyncFnWrapperWithErrorRedaction,
-  createErrorHandlingDecorator,
-  InvalidAsyncFunctionArgumentError,
-} from './try-catch-wrapper'
+import { createAsyncFnWrapperWithErrorRedaction, createErrorHandlingDecorator } from './try-catch-wrapper'
 import { expect, test } from 'vitest'
 
 const _errorRedactor = (error: Error, customMessage: string): RuntimeError =>
@@ -34,31 +30,48 @@ export class MyClient {
   }
 }
 
-test('decorating successfull async methods shouldnt change their behavior', async () => {
+test("decorating successful async methods shouldn't change their behavior", async () => {
+  // Arrange
   const client = new MyClient()
-  expect(await client.asyncSuccessMethod()).toBe('apple')
+
+  // Act
+  const promise = client.asyncSuccessMethod()
+
+  // Assert
+  await expect(promise).resolves.toBe('apple')
 })
 
 test('decorating failed async methods should redact the error', async () => {
+  // Arrange
   const client = new MyClient()
 
-  let thrown: unknown | undefined = undefined
-  try {
-    await client.asyncFailureMethod()
-  } catch (e) {
-    thrown = e
-  }
+  // Act
+  const promise = client.asyncFailureMethod()
 
-  expect(thrown).toBeInstanceOf(RuntimeError)
-  expect((thrown as Error).message).toBe('oops: hello4')
+  // Assert
+  await expect(promise).rejects.toThrow(RuntimeError)
+  await expect(promise).rejects.toThrow('oops: hello4')
 })
 
-test('decorating successfull sync methods should throw', () => {
+test("decorating successful sync methods shouldn't change their behaviour", () => {
+  // Arrange
   const client = new MyClient()
-  expect(() => client.syncSuccessMethod()).toThrowError(InvalidAsyncFunctionArgumentError)
+
+  // Act
+  const result = client.syncSuccessMethod()
+
+  // Assert
+  expect(result).toBe('banana')
 })
 
-test('decorating failed sync methods should throw', () => {
+test('decorating failed sync methods should redact the error', () => {
+  // Arrange
   const client = new MyClient()
-  expect(() => client.syncFailureMethod()).toThrowError(InvalidAsyncFunctionArgumentError)
+
+  // Act
+  const call = () => client.syncFailureMethod()
+
+  // Assert
+  expect(call).toThrow(RuntimeError)
+  expect(call).toThrow('oops: hello2')
 })

--- a/packages/common/src/error-handling/try-catch-wrapper.ts
+++ b/packages/common/src/error-handling/try-catch-wrapper.ts
@@ -1,6 +1,12 @@
 import * as sdk from '@botpress/sdk'
 
 type RedactFn = (originalError: Error, customErrorMessage: string) => sdk.RuntimeError
+type AnyFunction = (...args: unknown[]) => unknown
+
+const _isPromise = (x: unknown): x is Promise<unknown> =>
+  x instanceof Promise || (x !== null && typeof x === 'object' && 'then' in x && typeof x.then === 'function')
+
+export class InvalidAsyncFunctionArgumentError extends Error {}
 
 /**
  * Creates a wrapper function for asynchronous functions that catches errors and
@@ -32,19 +38,34 @@ export const createAsyncFnWrapperWithErrorRedaction =
    * logs them as a `sdk.RuntimeError` after redacting them with a redactor
    * function to remove sensitive information.
    *
-   * @param asyncFn - The function to wrap
-   * @param errorCustomMessage - The error message to log
+   * @param fn - The function to wrap
+   * @param customErrorMessage - The error message to log
    * @returns A function identical to the input function, but wrapped with a try-catch block
    */
-  <WrappedFn extends (...args: any[]) => Promise<any>>(asyncFn: WrappedFn, errorCustomMessage: string): WrappedFn => {
-    return (async (...args: Parameters<WrappedFn>): Promise<Awaited<ReturnType<WrappedFn>>> => {
+  <WrappedFn extends AnyFunction>(fn: WrappedFn, customErrorMessage: string): WrappedFn => {
+    return ((...args: Parameters<WrappedFn>): ReturnType<WrappedFn> => {
+      let output: unknown
       try {
-        return await asyncFn(...args)
-      } catch (thrown: unknown) {
-        const originalError = thrown instanceof Error ? thrown : new Error(`${thrown}`)
-        const runtimeError = redactorFn(originalError, errorCustomMessage)
-        throw runtimeError
+        output = fn(...args)
+      } catch {
+        // TODO: handle non-async functions too
+        throw new InvalidAsyncFunctionArgumentError(
+          'This decorator only works with async functions, but an error was thrown synchronously. Please pass an async function'
+        )
       }
+
+      if (!_isPromise(output)) {
+        // TODO: handle non-async functions too
+        throw new InvalidAsyncFunctionArgumentError(
+          'This decorator only works with async functions. Please pass an async function'
+        )
+      }
+
+      return output.catch(async (thrown: unknown) => {
+        const originalError = thrown instanceof Error ? thrown : new Error(`${thrown}`)
+        const runtimeError = redactorFn(originalError, customErrorMessage)
+        throw runtimeError
+      }) as ReturnType<WrappedFn>
     }) as WrappedFn
   }
 

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -6,7 +6,9 @@
     "outDir": "dist",
     "baseUrl": ".",
     "rootDir": "src",
-    "types": ["preact"]
+    "types": ["preact"],
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Ideally, this would be done at compile time by TypeScript, but this is better than nothing. It could help us find such problems earlier in the dev process.

I could have handled synchronous functions, too, but with the retry logic, it was getting very complicated. TBH, I don't think this function should be responsible for retrying at all.

Waiting for Monday to merge, as I'm not very confident