### PR TITLE
feat(integrations/resend): implement ignored event types

### DIFF
--- a/integrations/resend/integration.definition.ts
+++ b/integrations/resend/integration.definition.ts
@@ -14,7 +14,7 @@ import {
 export default new IntegrationDefinition({
   name: 'resend',
   title: 'Resend',
-  version: '0.1.3',
+  version: '0.1.4',
   readme: 'hub.md',
   icon: 'icon.svg',
   description: 'Send markdown rich-text emails using the Resend email service.',

--- a/integrations/resend/src/index.ts
+++ b/integrations/resend/src/index.ts
@@ -40,7 +40,11 @@ export default new bp.Integration({
       return
     }
 
-    const eventPayload = webhookEventPayloadSchemas.parse(result.data.body)
-    await dispatchIntegrationEvent(props, eventPayload)
+    const payloadResult = webhookEventPayloadSchemas.safeParse(result.data.body)
+    if (!payloadResult.success) {
+      props.logger.forBot().error('Unexpected webhook event payload', payloadResult.error)
+      return
+    }
+    await dispatchIntegrationEvent(props, payloadResult.data)
   },
 })

--- a/integrations/resend/src/index.ts
+++ b/integrations/resend/src/index.ts
@@ -4,7 +4,7 @@ import actions from './actions'
 import { ResendError } from './misc/ResendError'
 import { parseWebhookData, verifyWebhookSignature } from './misc/webhook-utils'
 import { dispatchIntegrationEvent } from './webhook-events/event-dispatcher'
-import { emailWebhookEventPayloadSchemas } from './webhook-events/schemas/email'
+import { webhookEventPayloadSchemas } from './webhook-events/schemas'
 import * as bp from '.botpress'
 
 const FALLBACK_ERROR_RESP: ErrorResponse = { message: 'Unable to evaluate API key validity', name: 'application_error' }
@@ -40,7 +40,7 @@ export default new bp.Integration({
       return
     }
 
-    const eventPayload = emailWebhookEventPayloadSchemas.parse(result.data.body)
+    const eventPayload = webhookEventPayloadSchemas.parse(result.data.body)
     await dispatchIntegrationEvent(props, eventPayload)
   },
 })

--- a/integrations/resend/src/webhook-events/event-dispatcher.ts
+++ b/integrations/resend/src/webhook-events/event-dispatcher.ts
@@ -1,6 +1,5 @@
 import * as emailHandlers from './handlers/email'
 import { WebhookEventPayloads } from './schemas'
-import { ignoredEventTypes } from './schemas/ignored'
 import * as bp from '.botpress'
 
 export const dispatchIntegrationEvent = async (props: bp.HandlerProps, webhookEvent: WebhookEventPayloads) => {
@@ -22,10 +21,7 @@ export const dispatchIntegrationEvent = async (props: bp.HandlerProps, webhookEv
     case 'email.failed':
       return await emailHandlers.handleFailedToSendEvent(props, webhookEvent)
     default:
-      const result = ignoredEventTypes.safeParse(webhookEvent)
-      if (result.success) {
-        props.logger.info(`Ignoring unsupported webhook type: '${result.data}'`)
-      }
+      props.logger.info(`Ignoring unsupported webhook type: '${webhookEvent.type}'`)
       return null
   }
 }

--- a/integrations/resend/src/webhook-events/event-dispatcher.ts
+++ b/integrations/resend/src/webhook-events/event-dispatcher.ts
@@ -1,8 +1,9 @@
 import * as emailHandlers from './handlers/email'
-import { EmailWebhookEventPayloads } from './schemas/email'
+import { WebhookEventPayloads } from './schemas'
+import { ignoredEventTypes } from './schemas/ignored'
 import * as bp from '.botpress'
 
-export const dispatchIntegrationEvent = async (props: bp.HandlerProps, webhookEvent: EmailWebhookEventPayloads) => {
+export const dispatchIntegrationEvent = async (props: bp.HandlerProps, webhookEvent: WebhookEventPayloads) => {
   switch (webhookEvent.type) {
     case 'email.sent':
       return await emailHandlers.handleSentEvent(props, webhookEvent)
@@ -21,6 +22,10 @@ export const dispatchIntegrationEvent = async (props: bp.HandlerProps, webhookEv
     case 'email.failed':
       return await emailHandlers.handleFailedToSendEvent(props, webhookEvent)
     default:
+      const result = ignoredEventTypes.safeParse(webhookEvent)
+      if (result.success) {
+        props.logger.info(`Ignoring unsupported webhook type: '${result.data}'`)
+      }
       return null
   }
 }

--- a/integrations/resend/src/webhook-events/event-dispatcher.ts
+++ b/integrations/resend/src/webhook-events/event-dispatcher.ts
@@ -21,7 +21,7 @@ export const dispatchIntegrationEvent = async (props: bp.HandlerProps, webhookEv
     case 'email.failed':
       return await emailHandlers.handleFailedToSendEvent(props, webhookEvent)
     default:
-      props.logger.info(`Ignoring unsupported webhook type: '${webhookEvent.type}'`)
+      props.logger.warn(`Ignoring unsupported webhook type: '${webhookEvent.type}'`)
       return null
   }
 }

--- a/integrations/resend/src/webhook-events/schemas/email.ts
+++ b/integrations/resend/src/webhook-events/schemas/email.ts
@@ -119,7 +119,6 @@ const _emailFailedToSendWebhookSchema = z.object({
   created_at: z.coerce.date(),
 })
 
-export type EmailWebhookEventPayloads = z.infer<typeof emailWebhookEventPayloadSchemas>
 export const emailWebhookEventPayloadSchemas = z.union([
   _emailSentWebhookSchema,
   _emailDeliveredWebhookSchema,

--- a/integrations/resend/src/webhook-events/schemas/ignored.ts
+++ b/integrations/resend/src/webhook-events/schemas/ignored.ts
@@ -1,0 +1,16 @@
+import { z } from '@botpress/sdk'
+
+export const ignoredEventTypes = z.union([
+  z.literal('contact.created'),
+  z.literal('contact.updated'),
+  z.literal('contact.deleted'),
+  z.literal('domain.created'),
+  z.literal('domain.updated'),
+  z.literal('domain.deleted'),
+])
+
+export const ignoredWebhookEventPayloadSchemas = z
+  .object({
+    type: ignoredEventTypes,
+  })
+  .passthrough()

--- a/integrations/resend/src/webhook-events/schemas/ignored.ts
+++ b/integrations/resend/src/webhook-events/schemas/ignored.ts
@@ -1,16 +1,14 @@
 import { z } from '@botpress/sdk'
 
-export const ignoredEventTypes = z.union([
-  z.literal('contact.created'),
-  z.literal('contact.updated'),
-  z.literal('contact.deleted'),
-  z.literal('domain.created'),
-  z.literal('domain.updated'),
-  z.literal('domain.deleted'),
-])
-
 export const ignoredWebhookEventPayloadSchemas = z
   .object({
-    type: ignoredEventTypes,
+    type: z.union([
+      z.literal('contact.created'),
+      z.literal('contact.updated'),
+      z.literal('contact.deleted'),
+      z.literal('domain.created'),
+      z.literal('domain.updated'),
+      z.literal('domain.deleted'),
+    ]),
   })
   .passthrough()

--- a/integrations/resend/src/webhook-events/schemas/index.ts
+++ b/integrations/resend/src/webhook-events/schemas/index.ts
@@ -1,0 +1,6 @@
+import { z } from '@botpress/sdk'
+import { emailWebhookEventPayloadSchemas } from './email'
+import { ignoredWebhookEventPayloadSchemas } from './ignored'
+
+export const webhookEventPayloadSchemas = z.union([emailWebhookEventPayloadSchemas, ignoredWebhookEventPayloadSchemas])
+export type WebhookEventPayloads = z.infer<typeof webhookEventPayloadSchemas>


### PR DESCRIPTION
This is so ignored event types don't clutter the integration logs with huge zod errors