### PR TITLE
chore: per package eslint config

### DIFF
--- a/bots/bugbuster/eslint.config.mjs
+++ b/bots/bugbuster/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/bots/echo/eslint.config.mjs
+++ b/bots/echo/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/bots/hello-world/eslint.config.mjs
+++ b/bots/hello-world/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/bots/hit-looper/eslint.config.mjs
+++ b/bots/hit-looper/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/bots/knowledgiani/eslint.config.mjs
+++ b/bots/knowledgiani/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/bots/notionaut/eslint.config.mjs
+++ b/bots/notionaut/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/bots/sheetzy/eslint.config.mjs
+++ b/bots/sheetzy/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/bots/sinlin/eslint.config.mjs
+++ b/bots/sinlin/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/bots/synchrotron/eslint.config.mjs
+++ b/bots/synchrotron/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,7 +24,6 @@ const ignores = [
   '**/.genenv/',
   '**/.ignore.me.*',
   '**/*.md.ts',
-  'packages/llmz/examples/',
 ]
 
 const oxlintRules = oxlint

--- a/integrations/airtable/eslint.config.mjs
+++ b/integrations/airtable/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/anthropic/eslint.config.mjs
+++ b/integrations/anthropic/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/asana/eslint.config.mjs
+++ b/integrations/asana/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/bigcommerce-sync/eslint.config.mjs
+++ b/integrations/bigcommerce-sync/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/browser/eslint.config.mjs
+++ b/integrations/browser/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/calcom/eslint.config.mjs
+++ b/integrations/calcom/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/calendly/eslint.config.mjs
+++ b/integrations/calendly/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/cerebras/eslint.config.mjs
+++ b/integrations/cerebras/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/charts/eslint.config.mjs
+++ b/integrations/charts/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/chat/eslint.config.mjs
+++ b/integrations/chat/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/chat/tsconfig.json
+++ b/integrations/chat/tsconfig.json
@@ -4,5 +4,5 @@
     "baseUrl": ".",
     "noErrorTruncation": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "integration.definition.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "./*.ts"]
 }

--- a/integrations/clickup/eslint.config.mjs
+++ b/integrations/clickup/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/confluence/eslint.config.mjs
+++ b/integrations/confluence/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/dalle/eslint.config.mjs
+++ b/integrations/dalle/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/dropbox/eslint.config.mjs
+++ b/integrations/dropbox/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/email/eslint.config.mjs
+++ b/integrations/email/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/fireworks-ai/eslint.config.mjs
+++ b/integrations/fireworks-ai/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/freshchat/eslint.config.mjs
+++ b/integrations/freshchat/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/github/eslint.config.mjs
+++ b/integrations/github/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/gmail/eslint.config.mjs
+++ b/integrations/gmail/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/google-ai/eslint.config.mjs
+++ b/integrations/google-ai/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/googlecalendar/eslint.config.mjs
+++ b/integrations/googlecalendar/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/googledrive/eslint.config.mjs
+++ b/integrations/googledrive/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/googledrive/src/handler.ts
+++ b/integrations/googledrive/src/handler.ts
@@ -87,7 +87,7 @@ const _handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Response>
         await updateRefreshTokenFromAuthorizationCode({ authorizationCode, client, ctx })
 
         // Done in order to correctly display the authorization status in the UI (not used for webhooks)
-        client.configureIntegration({
+        await client.configureIntegration({
           identifier: ctx.webhookId,
         })
 

--- a/integrations/groq/eslint.config.mjs
+++ b/integrations/groq/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/gsheets/eslint.config.mjs
+++ b/integrations/gsheets/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/hubspot/eslint.config.mjs
+++ b/integrations/hubspot/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/instagram/eslint.config.mjs
+++ b/integrations/instagram/eslint.config.mjs
@@ -1,0 +1,14 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    ignores: ['vitest.config.ts', 'refreshTokens.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/intercom/eslint.config.mjs
+++ b/integrations/intercom/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/line/eslint.config.mjs
+++ b/integrations/line/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/linear/eslint.config.mjs
+++ b/integrations/linear/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/mailchimp/eslint.config.mjs
+++ b/integrations/mailchimp/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/make/eslint.config.mjs
+++ b/integrations/make/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/messenger/eslint.config.mjs
+++ b/integrations/messenger/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/monday/eslint.config.mjs
+++ b/integrations/monday/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/notion/eslint.config.mjs
+++ b/integrations/notion/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/openai/eslint.config.mjs
+++ b/integrations/openai/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/pdf-generator/eslint.config.mjs
+++ b/integrations/pdf-generator/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/resend/eslint.config.mjs
+++ b/integrations/resend/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/sendgrid/eslint.config.mjs
+++ b/integrations/sendgrid/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/slack/eslint.config.mjs
+++ b/integrations/slack/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/stripe/eslint.config.mjs
+++ b/integrations/stripe/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/sunco/eslint.config.mjs
+++ b/integrations/sunco/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/teams/eslint.config.mjs
+++ b/integrations/teams/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/telegram/eslint.config.mjs
+++ b/integrations/telegram/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/telegram/src/misc/message-handlers.ts
+++ b/integrations/telegram/src/misc/message-handlers.ts
@@ -126,9 +126,9 @@ export const handleCarouselMessage = async ({
   const client = new Telegraf(ctx.configuration.botToken)
   const chat = getChat(conversation)
   logger.forBot().debug(`Sending carousel message to Telegram chat ${chat}:`, payload)
-  payload.items.forEach(async (item) => {
+  for (const item of payload.items) {
     await sendCard(item, client, chat, ack)
-  })
+  }
 }
 
 export const handleDropdownMessage = async ({

--- a/integrations/todoist/eslint.config.mjs
+++ b/integrations/todoist/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/todoist/src/webhook-events/handlers/oauth-callback.ts
+++ b/integrations/todoist/src/webhook-events/handlers/oauth-callback.ts
@@ -19,7 +19,7 @@ export const oauthCallbackHandler = async ({ client, ctx, req, logger }: bp.Hand
 
   const userIdentity = await todoistClient.getAuthenticatedUserIdentity()
 
-  client.configureIntegration({
+  await client.configureIntegration({
     identifier: userIdentity.id,
   })
 

--- a/integrations/trello/eslint.config.mjs
+++ b/integrations/trello/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/twilio/eslint.config.mjs
+++ b/integrations/twilio/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/viber/eslint.config.mjs
+++ b/integrations/viber/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/vonage/eslint.config.mjs
+++ b/integrations/vonage/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/webflow/eslint.config.mjs
+++ b/integrations/webflow/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/webhook/eslint.config.mjs
+++ b/integrations/webhook/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/whatsapp/eslint.config.mjs
+++ b/integrations/whatsapp/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/whatsapp/vitest.config.ts
+++ b/integrations/whatsapp/vitest.config.ts
@@ -1,6 +1,0 @@
-// vitest.config.js
-import { defineConfig } from 'vitest/config'
-
-export default defineConfig({
-  test: {},
-})

--- a/integrations/zapier/eslint.config.mjs
+++ b/integrations/zapier/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/zendesk/eslint.config.mjs
+++ b/integrations/zendesk/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/zoho/eslint.config.mjs
+++ b/integrations/zoho/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/interfaces/creatable/eslint.config.mjs
+++ b/interfaces/creatable/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/interfaces/deletable/eslint.config.mjs
+++ b/interfaces/deletable/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/interfaces/files-readonly/eslint.config.mjs
+++ b/interfaces/files-readonly/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/interfaces/hitl/eslint.config.mjs
+++ b/interfaces/hitl/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/interfaces/listable/eslint.config.mjs
+++ b/interfaces/listable/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/interfaces/llm/eslint.config.mjs
+++ b/interfaces/llm/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/interfaces/proactive-conversation/eslint.config.mjs
+++ b/interfaces/proactive-conversation/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/interfaces/proactive-user/eslint.config.mjs
+++ b/interfaces/proactive-user/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/interfaces/readable/eslint.config.mjs
+++ b/interfaces/readable/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/interfaces/speech-to-text/eslint.config.mjs
+++ b/interfaces/speech-to-text/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/interfaces/text-to-image/eslint.config.mjs
+++ b/interfaces/text-to-image/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/interfaces/typing-indicator/eslint.config.mjs
+++ b/interfaces/typing-indicator/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/interfaces/updatable/eslint.config.mjs
+++ b/interfaces/updatable/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check:dep": "depsynky check --ignore-dev",
     "check:sherif": "sherif -i zod -i axios -i query-string -i googleapis -i @linear/sdk -i openai",
     "check:format": "prettier --check .",
-    "check:eslint": "eslint ./ --max-warnings=0",
+    "check:eslint": "pnpm -r --no-bail exec eslint --max-warnings 0",
     "check:oxlint": "oxlint -c .oxlintrc.json",
     "check:lint": "pnpm check:bplint && pnpm check:oxlint && pnpm check:eslint",
     "check:type": "turbo check:type",

--- a/packages/chat-api/eslint.config.mjs
+++ b/packages/chat-api/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/packages/chat-client/eslint.config.mjs
+++ b/packages/chat-client/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/packages/chat-client/tsconfig.json
+++ b/packages/chat-client/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "baseUrl": "."
   },
-  "include": ["src/**/*", "e2e/**/*", "openapi.ts", "build.ts", "package.json"]
+  "include": ["src/**/*", "e2e/**/*", "package.json", "./*.ts"]
 }

--- a/packages/cli/eslint.config.mjs
+++ b/packages/cli/eslint.config.mjs
@@ -1,0 +1,14 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    ignores: ['templates/**/*', 'e2e/fixtures/**/*', 'build.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/packages/client/eslint.config.mjs
+++ b/packages/client/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "baseUrl": "."
   },
-  "include": ["src/**/*", "./e2e/**/*"]
+  "include": ["src/**/*", "./e2e/**/*", "./*.ts"]
 }

--- a/packages/cognitive/eslint.config.mjs
+++ b/packages/cognitive/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/packages/cognitive/tsconfig.json
+++ b/packages/cognitive/tsconfig.json
@@ -4,5 +4,5 @@
     "baseUrl": ".",
     "strict": false
   },
-  "include": ["src/**/*", "./e2e/**/*"]
+  "include": ["src/**/*", "./e2e/**/*", "./*.ts"]
 }

--- a/packages/common/eslint.config.mjs
+++ b/packages/common/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/packages/llmz/eslint.config.mjs
+++ b/packages/llmz/eslint.config.mjs
@@ -1,0 +1,17 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    ignores: ['examples/**/*', 'src/__tests__/**/*', 'tsup.config.ts', 'vitest.*.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    ignores: ['examples/**/*'],
+  },
+]

--- a/packages/sdk-addons/eslint.config.mjs
+++ b/packages/sdk-addons/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/packages/sdk/eslint.config.mjs
+++ b/packages/sdk/eslint.config.mjs
@@ -1,0 +1,14 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    ignores: ['build.ts'],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/packages/vai/eslint.config.mjs
+++ b/packages/vai/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/packages/vai/tsconfig.json
+++ b/packages/vai/tsconfig.json
@@ -4,5 +4,5 @@
     "strict": false
   },
   "exclude": ["node_modules", "dist"],
-  "include": ["src/**/*", "vitest.d.ts", "e2e/**/*"]
+  "include": ["src/**/*", "vitest.d.ts", "e2e/**/*", "./*.ts"]
 }

--- a/packages/zai/eslint.config.mjs
+++ b/packages/zai/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/packages/zai/tsconfig.json
+++ b/packages/zai/tsconfig.json
@@ -8,5 +8,5 @@
     }
   },
   "exclude": ["node_modules", "dist"],
-  "include": ["src/**/*", "vitest.d.ts", "e2e/**/*"]
+  "include": ["src/**/*", "vitest.d.ts", "e2e/**/*", "./*.ts"]
 }

--- a/plugins/analytics/eslint.config.mjs
+++ b/plugins/analytics/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/plugins/conversation-insights/eslint.config.mjs
+++ b/plugins/conversation-insights/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/plugins/conversation-insights/src/index.ts
+++ b/plugins/conversation-insights/src/index.ts
@@ -51,7 +51,7 @@ plugin.on.event('updateAiInsight', async (props) => {
   })
 
   if (workflows.workflows.length === 0) {
-    props.workflows.updateAllConversations.startNewInstance({ input: {} })
+    await props.workflows.updateAllConversations.startNewInstance({ input: {} })
   }
 })
 

--- a/plugins/file-synchronizer/eslint.config.mjs
+++ b/plugins/file-synchronizer/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/plugins/hitl/eslint.config.mjs
+++ b/plugins/hitl/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/plugins/knowledge/eslint.config.mjs
+++ b/plugins/knowledge/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/plugins/logger/eslint.config.mjs
+++ b/plugins/logger/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/plugins/personality/eslint.config.mjs
+++ b/plugins/personality/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/plugins/synchronizer/eslint.config.mjs
+++ b/plugins/synchronizer/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]


### PR DESCRIPTION
fixes SQD-3183

## The Problem

- in the CLI:
```ts
sleep({ id: "..." }) // eslint raising an error
client.getMessage({ id: "..." }) // eslint raising an error
```

- in integrations:
```ts
sleep({ id: "..." }) // eslint raising an error
client.getMessage({ id: "..." }) // eslint **not** raising an error
```

Additionally, it's worth noting that I experienced the same issue using both Biome and Oxc.

## The Reason

We had a single eslint config file at the repo's root and we ran a single eslint command from the repo's root. When linting a file in `integrations/telegram/src/**/*.ts`, the linter was unable to read from the directory `.botpress`, because it's an absolute import computed from the integration's root.

## The Solution

**Solution A:** I first thought about replacing all absolute imports of `.botpress` with relative imports. This worked, but left us exposed to other similar issues. We needed a way to have per-package typescript/eslint options.

**Solution B:** This is the solution presented in this PR; There is an eslint config for each package and eslint is ran individually per package.

In VSCode, the intellisense works just as well, if not better:

<img width="1170" height="427" alt="image" src="https://github.com/user-attachments/assets/2dac0836-c7b3-4b78-8538-ea9546f3219f" />

It's worth noting, however, that the ESLint step is now twice as slow as it previously was.

## What's left

Now that we run the eslint command per package, it could be interesting to use turbo for linting.







