### PR TITLE
feat(plugins/hitl): Add a boolean to use human agent info

### DIFF
--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -79,7 +79,7 @@ const PLUGIN_CONFIG_SCHEMA = sdk.z.object({
     .placeholder('0'),
   useHumanAgentInfo: sdk.z
     .boolean()
-    .default(false)
+    .default(true)
     .title('Use Human Agent Info')
     .describe(
       '(Works only with webchat) Enable this to use the human agent name and photo (if available) as the bot name and photo while in HITL mode.'

--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -77,6 +77,13 @@ const PLUGIN_CONFIG_SCHEMA = sdk.z.object({
     .nonnegative()
     .optional()
     .placeholder('0'),
+  useHumanAgentInfo: sdk.z
+    .boolean()
+    .default(false)
+    .title('Use Human Agent Info')
+    .describe(
+      '(Works only with webchat) Enable this to use the human agent name and photo (if available) as the bot name and photo while in HITL mode.'
+    ),
   flowOnHitlStopped: sdk.z
     .boolean()
     .default(true)
@@ -85,7 +92,7 @@ const PLUGIN_CONFIG_SCHEMA = sdk.z.object({
 })
 
 export default new sdk.PluginDefinition({
-  name: 'hitl',
+  name: 'faucon-hitl',
   version: '1.0.0',
   title: 'Human In The Loop',
   description: 'Seamlessly transfer conversations to human agents',

--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -92,7 +92,7 @@ const PLUGIN_CONFIG_SCHEMA = sdk.z.object({
 })
 
 export default new sdk.PluginDefinition({
-  name: 'faucon-hitl',
+  name: 'hitl',
   version: '1.0.0',
   title: 'Human In The Loop',
   description: 'Seamlessly transfer conversations to human agents',

--- a/plugins/hitl/src/webchat.ts
+++ b/plugins/hitl/src/webchat.ts
@@ -1,3 +1,4 @@
+import * as configuration from './configuration'
 import * as bp from '.botpress'
 
 type WebchatGetOrCreateUserInput = {
@@ -40,11 +41,16 @@ export const tryLinkWebchatUser = async (
     id: upstreamConversationId,
   })
 
+  const sessionConfig = await configuration.retrieveSessionConfig({
+    ...props,
+    upstreamConversationId,
+  })
+
   const {
     conversation: { integration: upstreamIntegration },
   } = upstreamConversation
 
-  if (upstreamIntegration !== 'webchat') {
+  if (upstreamIntegration !== 'webchat' || !sessionConfig.useHumanAgentInfo) {
     // this only works when the hitl frontend is webchat
     return undefined
   }


### PR DESCRIPTION
I added a boolean to use or not the integration's human agent info or not.
The configuration is enabled by default to keep the last behavior, but it is only accessible by the webchat integration. The description says so, but it looks contradictory by default.

Resolves SQD-3137