### PR TITLE
fix(integrations/linear): Fix event error in Linear integration

### DIFF
--- a/integrations/linear/integration.definition.ts
+++ b/integrations/linear/integration.definition.ts
@@ -7,7 +7,7 @@ import { actions, channels, events, configuration, configurations, user, states,
 
 export default new IntegrationDefinition({
   name: 'linear',
-  version: '1.1.1',
+  version: '1.1.2',
   title: 'Linear',
   description:
     'Manage your projects autonomously. Have your bot participate in discussions, manage issues and teams, and track progress.',

--- a/integrations/linear/src/handler.ts
+++ b/integrations/linear/src/handler.ts
@@ -64,7 +64,7 @@ export const handler: bp.IntegrationProps['handler'] = async ({ req, ctx, client
     (linearEvent.data.issue || linearEvent.data.issueId)
   ) {
     const linearCommentId = linearEvent.data.id
-    const issueConversationId = linearEvent.data.issueId || linearEvent.data.issue?.id
+    const issueConversationId = linearEvent.data.issueId || linearEvent.data.issue.id
     const content = linearEvent.data.body
 
     const { userId, conversationId } = await getUserAndConversation({

--- a/integrations/linear/src/handler.ts
+++ b/integrations/linear/src/handler.ts
@@ -56,9 +56,15 @@ export const handler: bp.IntegrationProps['handler'] = async ({ req, ctx, client
     return
   }
 
-  if (linearEvent.type === 'comment' && linearEvent.action === 'create') {
+  if (
+    linearEvent.type === 'comment' &&
+    linearEvent.action === 'create' &&
+    // Comment can be added in projects which are not issues. Therefore they don't have issueId or
+    // issue.id. Comments in projects are currently ignored.
+    (linearEvent.data.issue || linearEvent.data.issueId)
+  ) {
     const linearCommentId = linearEvent.data.id
-    const issueConversationId = linearEvent.data.issueId || linearEvent.data.issue.id
+    const issueConversationId = linearEvent.data.issueId || linearEvent.data.issue?.id
     const content = linearEvent.data.body
 
     const { userId, conversationId } = await getUserAndConversation({


### PR DESCRIPTION
Resolves SQD-3243

Resolves this error from the integration's event handler:
```
Sep 11, 2025, 2:39:33 PM
An unexpected error occurred in the integration. Bot owners: Check logs for more informations. Integration owners: throw a RuntimeError to return a custom error message instead.
Sep 11, 2025, 2:39:33 PM
TypeError: Cannot read properties of undefined (reading 'id')
    at Xk.handler [as webhook] (/var/task/customer_code.js:141:13268)
    at Zy (/var/task/customer_code.js:80:40559)
    at Oy (/var/task/customer_code.js:80:39407)
    at /var/task/customer_code.js:80:39908
    at async /var/task/index.js:20:13839
    at async handleHTTPEvent (/var/task/index.js:20:13815)
    at async Runtime.handler (/var/task/index.js:20:13660)
```