### PR TITLE
fix(bots/hit-looper): type check fail caused by useHumanAgentInfo config property

### DIFF
--- a/bots/hit-looper/bot.definition.ts
+++ b/bots/hit-looper/bot.definition.ts
@@ -37,7 +37,10 @@ export default new sdk.BotDefinition({
     },
   })
   .addPlugin(hitl, {
-    configuration: { flowOnHitlStopped: false },
+    configuration: {
+      useHumanAgentInfo: false,
+      flowOnHitlStopped: false,
+    },
     interfaces: {
       hitl: {
         id: zendesk.id,


### PR DESCRIPTION
Before the fix it caused intermittent check:type failures despite the config property having a default value