### PR TITLE
feat(integrations/whatsapp): retry for whatsapp throughput errors

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -85,7 +85,7 @@ const defaultBotPhoneNumberId = {
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '4.2.5',
+  version: '4.2.6',
   title: 'WhatsApp',
   description: 'Send and receive messages through WhatsApp.',
   icon: 'icon.svg',

--- a/integrations/whatsapp/src/channels/channel.ts
+++ b/integrations/whatsapp/src/channels/channel.ts
@@ -16,13 +16,13 @@ import { getAuthenticatedWhatsappClient } from '../auth'
 import { WHATSAPP } from '../misc/constants'
 import { convertMarkdownToWhatsApp } from '../misc/markdown-to-whatsapp-rtf'
 import { sleep } from '../misc/util'
+import { repeat } from '../repeat'
 import * as card from './message-types/card'
 import * as carousel from './message-types/carousel'
 import * as choice from './message-types/choice'
 import * as dropdown from './message-types/dropdown'
 import * as image from './message-types/image'
 import * as bp from '.botpress'
-import { repeat } from '../repeat'
 
 export const channel: bp.IntegrationProps['channels']['channel'] = {
   messages: {

--- a/integrations/whatsapp/src/repeat.test.ts
+++ b/integrations/whatsapp/src/repeat.test.ts
@@ -1,0 +1,68 @@
+import { test, expect, vi } from 'vitest'
+import { repeat } from './repeat'
+
+test('repeat calls the function the specified number of times', async () => {
+  const callback = vi
+    .fn()
+    .mockResolvedValueOnce({ repeat: true, result: 1 })
+    .mockResolvedValueOnce({ repeat: true, result: 2 })
+    .mockResolvedValueOnce({ repeat: false, result: 3 })
+
+  const backoff = vi.fn().mockReturnValue(0)
+
+  const result = await repeat<number>(callback, { maxIterations: 5, backoff })
+
+  expect(result).toBe(3)
+  expect(callback).toHaveBeenCalledTimes(3)
+  expect(backoff).toHaveBeenCalledTimes(2)
+  expect(backoff).toHaveBeenNthCalledWith(1, 1, 1)
+  expect(backoff).toHaveBeenNthCalledWith(2, 2, 2)
+})
+
+test('repeat stops after maxIterations', async () => {
+  const callback = vi
+    .fn()
+    .mockResolvedValueOnce({ repeat: true, result: 1 })
+    .mockResolvedValueOnce({ repeat: true, result: 2 })
+    .mockResolvedValueOnce({ repeat: false, result: 3 })
+
+  const backoff = vi.fn().mockReturnValue(0)
+
+  const result = await repeat<number>(callback, { maxIterations: 2, backoff })
+
+  expect(result).toBe(2)
+  expect(callback).toHaveBeenCalledTimes(2)
+  expect(backoff).toHaveBeenCalledTimes(1)
+  expect(backoff).toHaveBeenNthCalledWith(1, 1, 1)
+})
+
+test('repeat uses the backoff function to determine delay', async () => {
+  const timestamps: number[] = []
+
+  let t0 = Date.now()
+  let iteration = 0
+  let cb = async () => {
+    timestamps.push(Date.now() - t0)
+    t0 = Date.now()
+
+    iteration++
+    if (iteration < 3) {
+      return { repeat: true, result: 'failure' }
+    }
+    return { repeat: false, result: 'success' }
+  }
+
+  const backoff = (iteration: number) => iteration * 100
+
+  const result = await repeat<string>(cb, { maxIterations: 5, backoff })
+
+  expect(result).toBe('success')
+  expect(timestamps.length).toBe(3)
+  expect(timestamps[0]).toBeLessThan(50) // First call, no delay
+
+  expect(timestamps[1]).toBeGreaterThanOrEqual(100)
+  expect(timestamps[1]).toBeLessThan(150)
+
+  expect(timestamps[2]).toBeGreaterThanOrEqual(200)
+  expect(timestamps[2]).toBeLessThan(250)
+})

--- a/integrations/whatsapp/src/repeat.ts
+++ b/integrations/whatsapp/src/repeat.ts
@@ -1,0 +1,36 @@
+import { sleep } from './misc/util'
+
+export type RepeatResult<T> = {
+  repeat: boolean
+  result: T
+}
+
+export type RepeatCallback<T> = (iteration: number) => Promise<RepeatResult<T>>
+export type BackoffCallback<T> = (iteration: number, result: T) => number
+
+export type RepeatOptions<T> = {
+  maxIterations: number
+  backoff: BackoffCallback<T>
+}
+
+/**
+ * Like a retry function, but with a slightly different semantics.
+ * The callback function is repeated based on its return value, not on whether it throws or not.
+ */
+export const repeat = async <T>(callback: RepeatCallback<T>, options: RepeatOptions<T>): Promise<T> => {
+  let iteration = 0
+  for (;;) {
+    const res = await callback(iteration)
+    if (!res.repeat) {
+      return res.result
+    }
+
+    iteration++
+    if (iteration >= options.maxIterations) {
+      return res.result
+    }
+
+    const delay = options.backoff(iteration, res.result)
+    await sleep(delay)
+  }
+}


### PR DESCRIPTION
This PR was originally opened by @Gordon-BP [here](https://github.com/botpress/botpress/pull/14224)

## Original Description

Adds logic to retry sending messages after an exponential delay.

WhatsApp CloudAPI will rate-limit the number of messages sent from a specific business number to both a single user and in general. It is easy to hit this rate limit when sending multiple messages to a single user, or when multiple users are speaking to the bot at once.

This PR adds:

A helper function to calculate exponential backoff delay ms
Hard-coded 4 retry attempts, with delay of 1, 4, 16, and 64 seconds (plus jitter)

## My refactor

The operation is now called at most 3 times instead of 5 (1 initial attempt + 4 retries).

I extracted my retry logic in a dedicated module so I can unit test it.

The backoff logic and retry codes are unchanged. 