### PR TITLE
feat(integrations/chat): persist foreign ids in tags

### DIFF
--- a/integrations/chat/integration.definition.ts
+++ b/integrations/chat/integration.definition.ts
@@ -64,20 +64,20 @@ export default new sdk.IntegrationDefinition({
       conversation: {
         tags: {
           owner: { title: 'Conversation Owner', description: 'ID of the user who created the conversation' },
-          fid: { title: 'fid', description: 'This tag is of no use and only exists for historical reasons' },
+          fid: { title: 'Foreign ID', description: 'Copy of the foreign ID of the conversation' },
         },
       },
       messages,
       message: {
         tags: {
-          fid: { title: 'fid', description: 'This tag is of no use and only exists for historical reasons' },
+          fid: { title: 'Foreign ID', description: 'This tag is of no use and only exists for historical reasons' },
         },
       },
     },
   },
   user: {
     tags: {
-      fid: { title: 'fid', description: 'This tag is of no use and only exists for historical reasons' },
+      fid: { title: 'Foreign ID', description: 'Copy of the foreign ID of the user' },
       profile: {
         title: 'User Profile',
         description: 'Custom profile data of the user encoded as a string',

--- a/integrations/chat/src/api/operations/conversation.ts
+++ b/integrations/chat/src/api/operations/conversation.ts
@@ -16,6 +16,7 @@ export const createConversation: types.AuthenticatedOperations['createConversati
     channel: 'channel',
     tags: {
       owner: userId,
+      fid: req.body.id, // Readonly copy of the conversation's foreign ID; useful for users of the Runtime API
     },
   })
 

--- a/integrations/chat/src/api/operations/user.ts
+++ b/integrations/chat/src/api/operations/user.ts
@@ -23,6 +23,7 @@ export const createUser: types.Operations['createUser'] = async (props, foreignR
     pictureUrl,
     tags: {
       profile,
+      fid: req.body.id, // Readonly copy of the user's foreign ID; useful for users of the Runtime API
     },
   })
 


### PR DESCRIPTION
For users of both the [Chat API](https://botpress.com/docs/api-reference/chat-api/introduction) and [Runtime API](https://botpress.com/docs/api-reference/runtime-api/getting-started).

It keeps a trace of the foreign ID associated with a user or conversation inside Botpress. This can later be accessed by querying the Runtime API.

fixes SQD-3230
