### PR TITLE
feat(integrations/linear): Support for issue restored event

### DIFF
--- a/integrations/linear/integration.definition.ts
+++ b/integrations/linear/integration.definition.ts
@@ -7,7 +7,7 @@ import { actions, channels, events, configuration, configurations, user, states,
 
 export default new IntegrationDefinition({
   name: 'linear',
-  version: '1.1.2',
+  version: '1.1.3',
   title: 'Linear',
   description:
     'Manage your projects autonomously. Have your bot participate in discussions, manage issues and teams, and track progress.',

--- a/integrations/linear/src/handler.ts
+++ b/integrations/linear/src/handler.ts
@@ -32,8 +32,6 @@ export const handler: bp.IntegrationProps['handler'] = async ({ req, ctx, client
     throw new Error('Webhook event is not properly authenticated: the signing secret is invalid.')
   }
 
-  console.log(req.body)
-
   // ============ EVENTS ==============
   if (linearEvent.type === 'issue' && (linearEvent.action === 'create' || linearEvent.action === 'restore')) {
     await fireIssueCreated({ linearEvent, client, ctx })

--- a/integrations/linear/src/handler.ts
+++ b/integrations/linear/src/handler.ts
@@ -32,8 +32,10 @@ export const handler: bp.IntegrationProps['handler'] = async ({ req, ctx, client
     throw new Error('Webhook event is not properly authenticated: the signing secret is invalid.')
   }
 
+  console.log(req.body)
+
   // ============ EVENTS ==============
-  if (linearEvent.type === 'issue' && linearEvent.action === 'create') {
+  if (linearEvent.type === 'issue' && (linearEvent.action === 'create' || linearEvent.action === 'restore')) {
     await fireIssueCreated({ linearEvent, client, ctx })
     return
   }

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -5,7 +5,7 @@ import queryString from 'query-string'
 import * as bp from '.botpress'
 
 type BaseEvent = {
-  action: 'create' | 'update' | 'remove'
+  action: 'create' | 'update' | 'remove' | 'restore'
   type: string
   webhookTimestamp: number
   data: {
@@ -27,7 +27,7 @@ export type LinearIssueEvent = {
     title: string
     updatedAt: string
     createdAt: string
-    description: string
+    description: string | null
     priority: number
     labels: {
       name: string
@@ -44,7 +44,7 @@ export type LinearIssueEvent = {
     state: {
       name: string
     }
-    project: {
+    project?: {
       id: string
     }
   }


### PR DESCRIPTION
Resolves SQD-3254

When an issue is restored, it now fires an `issue_created` event. Restore event was previously ignored.