### PR TITLE
fix(googledrive): never prune the drive root

### DIFF
--- a/integrations/googledrive/integration.definition.ts
+++ b/integrations/googledrive/integration.definition.ts
@@ -24,7 +24,7 @@ export default new sdk.IntegrationDefinition({
   name: 'googledrive',
   title: 'Google Drive',
   description: 'Access and manage your Google Drive files from your bot.',
-  version: '0.3.3',
+  version: '0.3.4',
   readme: 'hub.md',
   icon: 'icon.svg',
   configuration: {

--- a/integrations/googledrive/src/files-readonly/google-drive-file-tree.test.ts
+++ b/integrations/googledrive/src/files-readonly/google-drive-file-tree.test.ts
@@ -330,4 +330,61 @@ describe.concurrent('GoogleDriveFileTree', () => {
       })
     })
   })
+
+  describe.concurrent('empty folder pruning', () => {
+    it('should remove nested empty folders when calling removeAllEmptyFoldersRecursively', () => {
+      // Arrange
+      const tree = _createMockTree()
+      const parentEmptyFolder = _createMockFolder({
+        parents: [DUMMY_ROOT_FOLDER_ID],
+        id: '1parentempty123',
+        name: 'Parent Empty Folder',
+      })
+      const nestedEmptyFolder = _createMockFolder({
+        parents: [parentEmptyFolder.id],
+        id: '1nestedempty123',
+        name: 'Nested Empty Folder',
+      })
+      const nonEmptyFolder = _createMockFolder({
+        parents: [DUMMY_ROOT_FOLDER_ID],
+        id: '1nonempty123',
+        name: 'Non-Empty Folder',
+      })
+      const fileInNonEmptyFolder = _createMockFile({
+        parents: [nonEmptyFolder.id],
+        id: '1file123',
+        name: 'file.txt',
+      })
+
+      // Act
+      tree.upsertNode(parentEmptyFolder)
+      tree.upsertNode(nestedEmptyFolder)
+      tree.upsertNode(nonEmptyFolder)
+      tree.upsertNode(fileInNonEmptyFolder)
+
+      // Pre-Assert
+      expect(tree.getRootNode().children).toHaveLength(2)
+
+      tree.removeAllEmptyFoldersRecursively()
+      const root = tree.getRootNode()
+
+      // Assert
+      expect(root.children).toHaveLength(1)
+      expect(root).toMatchObject({
+        children: [expect.objectContaining(nonEmptyFolder)],
+      })
+    })
+
+    it('should not remove the root folder when calling removeAllEmptyFoldersRecursively', () => {
+      // Arrange
+      const tree = _createMockTree()
+
+      // Act
+      tree.removeAllEmptyFoldersRecursively()
+      const root = tree.getRootNode()
+
+      // Assert
+      expect(root.id).toBe(DUMMY_ROOT_FOLDER_ID)
+    })
+  })
 })

--- a/integrations/googledrive/src/files-readonly/google-drive-file-tree.ts
+++ b/integrations/googledrive/src/files-readonly/google-drive-file-tree.ts
@@ -142,6 +142,7 @@ export class GoogleDriveNodeTree {
 
   private _removeEmptyFoldersFromTheirParents(emptyFolderIds: Set<string>): void {
     for (const emptyFolderId of emptyFolderIds) {
+      if (emptyFolderId === this._rootFolderId) continue
       const emptyFolderNode = this._nodeByIdMap.get(emptyFolderId)
       if (!emptyFolderNode) continue
 
@@ -152,6 +153,7 @@ export class GoogleDriveNodeTree {
 
   private _deleteEmptyFoldersFromMaps(emptyFolderIds: Set<string>): void {
     for (const emptyFolderId of emptyFolderIds) {
+      if (emptyFolderId === this._rootFolderId) continue
       const emptyFolderNode = this._nodeByIdMap.get(emptyFolderId)
       if (!emptyFolderNode) continue
 


### PR DESCRIPTION
Contributes to SQD-3297.

We do tree-shaking on the discovered file tree in order to remove empty folders. However, this risks removing the tree root if the tree is completely empty (no children under the root). This causes an issue because we need the root in order to serialize the tree.