### PR TITLE
chore(cli): added a warning when publishing a private interface

### DIFF
--- a/packages/cli/src/command-implementations/deploy-command.ts
+++ b/packages/cli/src/command-implementations/deploy-command.ts
@@ -214,6 +214,10 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
     const icon = await this.readProjectFile(interfaceDeclaration.icon, 'base64')
     const readme = await this.readProjectFile(interfaceDeclaration.readme, 'base64')
 
+    if (this._visibility !== 'public'){
+      this.logger.warn('You are currently publishing a private interface, which cannot be used by integrations and plugins. To fix this, change the visibility to "public"')
+    }
+
     const createBody = {
       ...(await apiUtils.prepareCreateInterfaceBody(interfaceDeclaration)),
       public: this._visibility === 'public',

--- a/packages/cli/src/command-implementations/deploy-command.ts
+++ b/packages/cli/src/command-implementations/deploy-command.ts
@@ -214,8 +214,10 @@ export class DeployCommand extends ProjectCommand<DeployCommandDefinition> {
     const icon = await this.readProjectFile(interfaceDeclaration.icon, 'base64')
     const readme = await this.readProjectFile(interfaceDeclaration.readme, 'base64')
 
-    if (this._visibility !== 'public'){
-      this.logger.warn('You are currently publishing a private interface, which cannot be used by integrations and plugins. To fix this, change the visibility to "public"')
+    if (this._visibility !== 'public') {
+      this.logger.warn(
+        'You are currently publishing a private interface, which cannot be used by integrations and plugins. To fix this, change the visibility to "public"'
+      )
     }
 
     const createBody = {


### PR DESCRIPTION
A private interface cannot be used by an integration or a plugin, so it is almost completely useless.