### PR TITLE
feat(sdk,cli): add support for multiple integrations

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.19.0",
+  "version": "4.20.0",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",
@@ -27,7 +27,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.2",
     "@botpress/client": "1.26.0",
-    "@botpress/sdk": "4.16.0",
+    "@botpress/sdk": "4.17.0",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/src/api/client.ts
+++ b/packages/cli/src/api/client.ts
@@ -47,6 +47,7 @@ export class ApiClient {
       workspaceId,
       botId,
       retry: retry.config,
+      headers: { 'x-multiple-integrations': 'true' },
     })
     this.url = apiUrl
     this.token = token

--- a/packages/cli/src/command-implementations/chat-command.ts
+++ b/packages/cli/src/command-implementations/chat-command.ts
@@ -10,7 +10,7 @@ import * as utils from '../utils'
 import { GlobalCommand } from './global-command'
 
 type IntegrationInstance = {
-  id: string
+  alias: string
   instance: client.Bot['integrations'][string]
 }
 
@@ -112,7 +112,8 @@ export class ChatCommand extends GlobalCommand<ChatCommandDefinition> {
     const { bot } = await api.client.updateBot({
       id: botId,
       integrations: {
-        [integration.id]: {
+        [integration.name]: {
+          integrationId: integration.id,
           enabled: true,
           configuration: {}, // empty object will always be a valid chat integration configuration
         },
@@ -131,8 +132,8 @@ export class ChatCommand extends GlobalCommand<ChatCommandDefinition> {
   }
 
   private _findChatInstance = (bot: client.Bot): IntegrationInstance | undefined => {
-    const integrationInstances = Object.entries(bot.integrations).map(([integrationId, integrationInstance]) => ({
-      id: integrationId,
+    const integrationInstances = Object.entries(bot.integrations).map(([alias, integrationInstance]) => ({
+      alias,
       instance: integrationInstance,
     }))
 

--- a/packages/cli/src/command-implementations/project-command.ts
+++ b/packages/cli/src/command-implementations/project-command.ts
@@ -451,18 +451,17 @@ export abstract class ProjectCommand<C extends ProjectCommandDefinition> extends
     }))
 
     return {
-      integrations: _(integrations)
-        .keyBy((i) => i.id)
-        .mapValues(
-          ({ enabled, configurationType, configuration, disabledChannels }) =>
-            ({
-              enabled,
-              configurationType,
-              configuration,
-              disabledChannels,
-            }) satisfies NonNullable<apiUtils.UpdateBotRequestBody['integrations']>[string]
-        )
-        .value(),
+      integrations: utils.records.mapValues(
+        integrations,
+        ({ enabled, configurationType, configuration, disabledChannels, id }) =>
+          ({
+            enabled,
+            configurationType,
+            configuration,
+            disabledChannels,
+            integrationId: id,
+          }) satisfies NonNullable<apiUtils.UpdateBotRequestBody['integrations']>[string]
+      ),
       plugins: utils.records.mapValues(pluginsWithBackingIntegrations, (plugin) => ({
         ...plugin,
         interfaces: utils.records.mapValues(plugin.interfaces ?? {}, (iface) => ({

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.26.0",
-    "@botpress/sdk": "4.16.0"
+    "@botpress/sdk": "4.17.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.26.0",
-    "@botpress/sdk": "4.16.0"
+    "@botpress/sdk": "4.17.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "4.16.0"
+    "@botpress/sdk": "4.17.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.26.0",
-    "@botpress/sdk": "4.16.0"
+    "@botpress/sdk": "4.17.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.26.0",
-    "@botpress/sdk": "4.16.0",
+    "@botpress/sdk": "4.17.0",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "4.16.0",
+  "version": "4.17.0",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/integration/server/context.ts
+++ b/packages/sdk/src/integration/server/context.ts
@@ -27,8 +27,7 @@ export const extractContext = (headers: Record<string, string | undefined>): Int
   botId: headers[BOT_ID_HEADER] || throwError('Missing bot header'),
   botUserId: headers[BOT_USER_ID_HEADER] || throwError('Missing bot user header'),
   integrationId: headers[INTEGRATION_ID_HEADER] || throwError('Missing integration header'),
-  // TODO: make this non-nullable once the backend sends this header
-  integrationAlias: headers[INTEGRATION_ALIAS_HEADER],
+  integrationAlias: headers[INTEGRATION_ALIAS_HEADER] || throwError('Missing integration alias header'),
   webhookId: headers[WEBHOOK_ID_HEADER] || throwError('Missing webhook header'),
   operation: headers[OPERATION_TYPE_HEADER] || throwError('Missing operation header'),
   configurationType: headers[CONFIGURATION_TYPE_HEADER] ?? null,

--- a/packages/sdk/src/integration/server/types.ts
+++ b/packages/sdk/src/integration/server/types.ts
@@ -21,7 +21,7 @@ export type IntegrationContext<TIntegration extends BaseIntegration = BaseIntegr
   botId: string
   botUserId: string
   integrationId: string
-  integrationAlias: string | undefined
+  integrationAlias: string
   webhookId: string
   operation: string
 } & IntegrationContextConfig<TIntegration>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2194,7 +2194,7 @@ importers:
         specifier: 1.26.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 4.16.0
+        specifier: 4.17.0
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2309,7 +2309,7 @@ importers:
         specifier: 1.26.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.16.0
+        specifier: 4.17.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2325,7 +2325,7 @@ importers:
         specifier: 1.26.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.16.0
+        specifier: 4.17.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2338,7 +2338,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 4.16.0
+        specifier: 4.17.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2354,7 +2354,7 @@ importers:
         specifier: 1.26.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.16.0
+        specifier: 4.17.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2370,7 +2370,7 @@ importers:
         specifier: 1.26.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.16.0
+        specifier: 4.17.0
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
Contributes to SQD-2779.

Leaving this as draft until the cdm supports x-multiple-integrations for updatebot inputs (it's currently supported for output only)