### PR TITLE
chore(client): added a new line after response in debug mode

### DIFF
--- a/packages/client/src/common/debug-interceptors.ts
+++ b/packages/client/src/common/debug-interceptors.ts
@@ -76,7 +76,8 @@ const _formatResponseLog = (response: AxiosResponseWithMetadata): string => {
       duration,
       headers,
       body: data,
-    })
+    }) +
+    '\n'
   )
 }
 


### PR DESCRIPTION
I was getting tilted because I couldn't separate the request from the response when making multiple requests in a row using client debug flag. It looked like this before
<img width="1311" height="163" alt="image" src="https://github.com/user-attachments/assets/48a2ae0c-99ae-4fa9-8d03-7532ee1d3748" />
