### PR TITLE
fix(sdk): fix props injection

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.2",
     "@botpress/client": "1.25.0",
-    "@botpress/sdk": "4.15.11",
+    "@botpress/sdk": "4.15.12",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.25.0",
-    "@botpress/sdk": "4.15.11"
+    "@botpress/sdk": "4.15.12"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.25.0",
-    "@botpress/sdk": "4.15.11"
+    "@botpress/sdk": "4.15.12"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "4.15.11"
+    "@botpress/sdk": "4.15.12"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.25.0",
-    "@botpress/sdk": "4.15.11"
+    "@botpress/sdk": "4.15.12"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.25.0",
-    "@botpress/sdk": "4.15.11",
+    "@botpress/sdk": "4.15.12",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "4.15.11",
+  "version": "4.15.12",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/bot/implementation.ts
+++ b/packages/sdk/src/bot/implementation.ts
@@ -25,8 +25,8 @@ import {
   BotHandlers,
   UnimplementedActionHandlers,
   WorkflowUpdateType,
-  ActionHandlersMap,
   InjectedHandlerProps,
+  InjectedBotHandlers,
 } from './server'
 import { proxyWorkflows, wrapWorkflowInstance } from './workflow-proxy'
 
@@ -38,7 +38,7 @@ export type BotImplementationProps<TBot extends BaseBot = BaseBot, TPlugins exte
 }
 
 export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends Record<string, BasePlugin> = {}>
-  implements BotHandlers<TBot>
+  implements InjectedBotHandlers<TBot>
 {
   private _actionHandlers: ActionHandlers<any>
   private _messageHandlers: OrderedMessageHandlersMap<any> = {}
@@ -71,7 +71,7 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
     this._plugins = props.plugins
   }
 
-  public get actionHandlers(): ActionHandlersMap<TBot> {
+  public get actionHandlers(): InjectedBotHandlers<TBot>['actionHandlers'] {
     return new Proxy(
       {},
       {
@@ -96,10 +96,10 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
           return undefined
         },
       }
-    ) as ActionHandlersMap<TBot>
+    ) as InjectedBotHandlers<TBot>['actionHandlers']
   }
 
-  public get messageHandlers(): MessageHandlersMap<TBot> {
+  public get messageHandlers(): InjectedBotHandlers<TBot>['messageHandlers'] {
     return new Proxy(
       {},
       {
@@ -121,10 +121,10 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
             )
         },
       }
-    ) as MessageHandlersMap<TBot>
+    ) as InjectedBotHandlers<TBot>['messageHandlers']
   }
 
-  public get eventHandlers(): EventHandlersMap<TBot> {
+  public get eventHandlers(): InjectedBotHandlers<TBot>['eventHandlers'] {
     return new Proxy(
       {},
       {
@@ -144,10 +144,10 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
             )
         },
       }
-    ) as EventHandlersMap<TBot>
+    ) as InjectedBotHandlers<TBot>['eventHandlers']
   }
 
-  public get stateExpiredHandlers(): StateExpiredHandlersMap<TBot> {
+  public get stateExpiredHandlers(): InjectedBotHandlers<TBot>['stateExpiredHandlers'] {
     return new Proxy(
       {},
       {
@@ -170,10 +170,10 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
             )
         },
       }
-    ) as StateExpiredHandlersMap<TBot>
+    ) as InjectedBotHandlers<TBot>['stateExpiredHandlers']
   }
 
-  public get hookHandlers(): HookHandlersMap<TBot> {
+  public get hookHandlers(): InjectedBotHandlers<TBot>['hookHandlers'] {
     return new Proxy(
       {},
       {
@@ -206,10 +206,10 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
           )
         },
       }
-    ) as HookHandlersMap<TBot>
+    ) as InjectedBotHandlers<TBot>['hookHandlers']
   }
 
-  public get workflowHandlers(): WorkflowHandlersMap<TBot> {
+  public get workflowHandlers(): InjectedBotHandlers<TBot>['workflowHandlers'] {
     return new Proxy(
       {},
       {
@@ -254,7 +254,7 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
           )
         },
       }
-    ) as WorkflowHandlersMap<TBot>
+    ) as InjectedBotHandlers<TBot>['workflowHandlers']
   }
 
   public readonly on = {
@@ -429,7 +429,7 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
     },
   }
 
-  public readonly handler = botHandler(this as BotHandlers<any>)
+  public readonly handler = botHandler(this as unknown as BotHandlers<any>)
 
   public readonly start = (port?: number): Promise<Server> => serve(this.handler, port)
 }

--- a/packages/sdk/src/bot/implementation.ts
+++ b/packages/sdk/src/bot/implementation.ts
@@ -88,8 +88,11 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
             }
             action = plugin.actionHandlers[nameWithoutPrefix]
             if (action) {
-              return (props: Omit<Parameters<NonNullable<typeof action>>[0], keyof InjectedHandlerProps<TBot>>) =>
-                action!({ ...props, workflows: proxyWorkflows(props.client) })
+              return utils.functions.setName(
+                (props: Omit<Parameters<NonNullable<typeof action>>[0], keyof InjectedHandlerProps<TBot>>) =>
+                  action!({ ...props, workflows: proxyWorkflows(props.client) }),
+                action.name
+              )
             }
           }
 
@@ -115,9 +118,12 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
             .map(({ handler }) => handler)
           return utils.arrays
             .unique([...pluginHandlers, ...selfHandlers])
-            .map(
-              (handler) => (props: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TBot>>) =>
-                handler({ ...props, workflows: proxyWorkflows(props.client) })
+            .map((handler) =>
+              utils.functions.setName(
+                (props: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TBot>>) =>
+                  handler({ ...props, workflows: proxyWorkflows(props.client) }),
+                handler.name
+              )
             )
         },
       }
@@ -138,9 +144,12 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
             .map(({ handler }) => handler)
           return utils.arrays
             .unique([...pluginHandlers, ...selfHandlers])
-            .map(
-              (handler) => (props: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TBot>>) =>
-                handler({ ...props, workflows: proxyWorkflows(props.client) })
+            .map((handler) =>
+              utils.functions.setName(
+                (props: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TBot>>) =>
+                  handler({ ...props, workflows: proxyWorkflows(props.client) }),
+                handler.name
+              )
             )
         },
       }
@@ -164,9 +173,12 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
             .map(({ handler }) => handler)
           return utils.arrays
             .unique([...pluginHandlers, ...selfHandlers])
-            .map(
-              (handler) => (props: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TBot>>) =>
-                handler({ ...props, workflows: proxyWorkflows(props.client) })
+            .map((handler) =>
+              utils.functions.setName(
+                (props: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TBot>>) =>
+                  handler({ ...props, workflows: proxyWorkflows(props.client) }),
+                handler.name
+              )
             )
         },
       }
@@ -200,7 +212,12 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
 
                 return utils.arrays
                   .unique([...pluginHandlers, ...selfHandlers])
-                  .map((handler) => (props: any) => handler({ ...props, workflows: proxyWorkflows(props.client) }))
+                  .map((handler) =>
+                    utils.functions.setName(
+                      (props: any) => handler({ ...props, workflows: proxyWorkflows(props.client) }),
+                      handler.name
+                    )
+                  )
               },
             }
           )
@@ -230,25 +247,25 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
                   (plugin) => plugin.workflowHandlers[updateType]?.[workflowName] ?? []
                 )
 
-                return utils.arrays
-                  .unique([...selfHandlers, ...pluginHandlers])
-                  .map(
-                    (handler) =>
-                      async (props: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TBot>>) => {
-                        let currentWorkflowState = props.workflow
-                        await handler({
+                return utils.arrays.unique([...selfHandlers, ...pluginHandlers]).map((handler) =>
+                  utils.functions.setName(
+                    async (props: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TBot>>) => {
+                      let currentWorkflowState = props.workflow
+                      await handler({
+                        ...props,
+                        workflow: wrapWorkflowInstance({
                           ...props,
-                          workflow: wrapWorkflowInstance({
-                            ...props,
-                            onWorkflowUpdate(newState) {
-                              currentWorkflowState = newState
-                            },
-                          }),
-                          workflows: proxyWorkflows(props.client),
-                        })
-                        return currentWorkflowState
-                      }
+                          onWorkflowUpdate(newState) {
+                            currentWorkflowState = newState
+                          },
+                        }),
+                        workflows: proxyWorkflows(props.client),
+                      })
+                      return currentWorkflowState
+                    },
+                    handler.name
                   )
+                )
               },
             }
           )

--- a/packages/sdk/src/bot/server/workflows/update-handler.ts
+++ b/packages/sdk/src/bot/server/workflows/update-handler.ts
@@ -90,7 +90,7 @@ const _dispatchToHandlers = async (
 
   let currentWorkflowState: WorkflowState = structuredClone(event.payload.workflow)
 
-  for (const handler of handlers!) {
+  for (const handler of handlers ?? []) {
     currentWorkflowState = await handler({
       ...props,
       event,

--- a/packages/sdk/src/bot/server/workflows/update-handler.ts
+++ b/packages/sdk/src/bot/server/workflows/update-handler.ts
@@ -1,5 +1,4 @@
 import { Response } from '../../../serve'
-import { proxyWorkflows, wrapWorkflowInstance } from '../../workflow-proxy'
 import { SUCCESS_RESPONSE } from '../responses'
 import * as types from '../types'
 import { bridgeUpdateTypeToSnakeCase } from './update-type-conv'
@@ -92,20 +91,12 @@ const _dispatchToHandlers = async (
   let currentWorkflowState: WorkflowState = structuredClone(event.payload.workflow)
 
   for (const handler of handlers!) {
-    await handler({
+    currentWorkflowState = await handler({
       ...props,
       event,
       conversation: event.payload.conversation,
       user: event.payload.user,
-      workflow: wrapWorkflowInstance({
-        ...props,
-        workflow: currentWorkflowState,
-        event,
-        onWorkflowUpdate(newState) {
-          currentWorkflowState = newState
-        },
-      }),
-      workflows: proxyWorkflows(props.client),
+      workflow: currentWorkflowState,
     })
   }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -44,7 +44,7 @@ export {
   BotImplementation as Bot,
   BotImplementationProps as BotProps,
   BotSpecificClient,
-  BotHandlers,
+  InjectedBotHandlers as BotHandlers,
   TagDefinition as BotTagDefinition,
   StateType as BotStateType,
   StateDefinition as BotStateDefinition,
@@ -74,7 +74,7 @@ export {
   PluginImplementation as Plugin,
   PluginImplementationProps as PluginProps,
   PluginRuntimeProps,
-  PluginHandlers,
+  InjectedPluginHandlers as PluginHandlers,
 } from './plugin'
 
 export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2166,7 +2166,7 @@ importers:
         specifier: 1.25.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 4.15.11
+        specifier: 4.15.12
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2281,7 +2281,7 @@ importers:
         specifier: 1.25.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.15.11
+        specifier: 4.15.12
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2297,7 +2297,7 @@ importers:
         specifier: 1.25.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.15.11
+        specifier: 4.15.12
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2310,7 +2310,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 4.15.11
+        specifier: 4.15.12
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2326,7 +2326,7 @@ importers:
         specifier: 1.25.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.15.11
+        specifier: 4.15.12
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2342,7 +2342,7 @@ importers:
         specifier: 1.25.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.15.11
+        specifier: 4.15.12
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
Because of typings issues, SDK consumers that wanted to call a bot's plugin handlers were forced to manually inject the `workflow` and `workflows` properties into every handlers. This means that the studio was forced to ship its own workflow proxy and was expected to keep it up-to-date with the one from the SDK. It also meant that in the bot server I needed to also wrap workflow instances prior to calling handlers. This is a bad design on my part, and this PR aims to address this.

Now, workflows are wrapped by the various handler getters and the bot server no longer needs to do any wrapping.

To accomplish this, `CommonHandlerProps` was split such that injected props (such as `workflows`) are now in `InjectedHandlerProps` and the union of the two is `type ExtendedHandlerProps = CommonHandlerProps & InjectedHandlerProps`.

Inside `BotImplementation`, handlers only have `CommonHandlerProps` and so `BotImplementation` is responsible for injecting `InjectedHandlerProps` such that the outside type conforms to `ExtendedHandlerProps`. The same is true for `PluginImplementation`.

This change is non-breaking for existing plugins and bots-as-code: they continue to see the same properties and behaviour as before.