### PR TITLE
feat(sdk,client): add support for integration aliases

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.2",
-    "@botpress/client": "1.25.0",
+    "@botpress/client": "1.26.0",
     "@botpress/sdk": "4.15.12",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.2",
     "@botpress/client": "1.26.0",
-    "@botpress/sdk": "4.15.12",
+    "@botpress/sdk": "4.16.0",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.26.0",
-    "@botpress/sdk": "4.15.12"
+    "@botpress/sdk": "4.16.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -5,7 +5,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.25.0",
+    "@botpress/client": "1.26.0",
     "@botpress/sdk": "4.15.12"
   },
   "devDependencies": {

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.25.0",
+    "@botpress/client": "1.26.0",
     "@botpress/sdk": "4.15.12"
   },
   "devDependencies": {

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.26.0",
-    "@botpress/sdk": "4.15.12"
+    "@botpress/sdk": "4.16.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "4.15.12"
+    "@botpress/sdk": "4.16.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.25.0",
+    "@botpress/client": "1.26.0",
     "@botpress/sdk": "4.15.12"
   },
   "devDependencies": {

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.26.0",
-    "@botpress/sdk": "4.15.12"
+    "@botpress/sdk": "4.16.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.26.0",
-    "@botpress/sdk": "4.15.12",
+    "@botpress/sdk": "4.16.0",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.25.0",
+    "@botpress/client": "1.26.0",
     "@botpress/sdk": "4.15.12",
     "axios": "^1.6.8"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/client/src/common/config.ts
+++ b/packages/client/src/common/config.ts
@@ -8,11 +8,13 @@ const defaultDebug = false
 const apiUrlEnvName = 'BP_API_URL'
 const botIdEnvName = 'BP_BOT_ID'
 const integrationIdEnvName = 'BP_INTEGRATION_ID'
+const integrationAliasEnvName = 'BP_INTEGRATION_ALIAS'
 const workspaceIdEnvName = 'BP_WORKSPACE_ID'
 const tokenEnvName = 'BP_TOKEN'
 
 type AnyClientProps = types.CommonClientProps & {
   integrationId?: string
+  integrationAlias?: string
   workspaceId?: string
   botId?: string
   token?: string
@@ -33,6 +35,10 @@ export function getClientConfig(clientProps: AnyClientProps): types.ClientConfig
 
   if (props.integrationId) {
     headers['x-integration-id'] = props.integrationId
+  }
+
+  if (props.integrationAlias) {
+    headers['x-integration-alias'] = props.integrationAlias
   }
 
   if (props.token) {
@@ -75,6 +81,7 @@ function getNodeConfig(props: AnyClientProps): AnyClientProps {
     apiUrl: props.apiUrl ?? process.env[apiUrlEnvName],
     botId: props.botId ?? process.env[botIdEnvName],
     integrationId: props.integrationId ?? process.env[integrationIdEnvName],
+    integrationAlias: props.integrationAlias ?? process.env[integrationAliasEnvName],
     workspaceId: props.workspaceId ?? process.env[workspaceIdEnvName],
   }
 

--- a/packages/client/src/common/config.ts
+++ b/packages/client/src/common/config.ts
@@ -8,7 +8,6 @@ const defaultDebug = false
 const apiUrlEnvName = 'BP_API_URL'
 const botIdEnvName = 'BP_BOT_ID'
 const integrationIdEnvName = 'BP_INTEGRATION_ID'
-const integrationAliasEnvName = 'BP_INTEGRATION_ALIAS'
 const workspaceIdEnvName = 'BP_WORKSPACE_ID'
 const tokenEnvName = 'BP_TOKEN'
 
@@ -81,7 +80,7 @@ function getNodeConfig(props: AnyClientProps): AnyClientProps {
     apiUrl: props.apiUrl ?? process.env[apiUrlEnvName],
     botId: props.botId ?? process.env[botIdEnvName],
     integrationId: props.integrationId ?? process.env[integrationIdEnvName],
-    integrationAlias: props.integrationAlias ?? process.env[integrationAliasEnvName],
+    integrationAlias: props.integrationAlias,
     workspaceId: props.workspaceId ?? process.env[workspaceIdEnvName],
   }
 

--- a/packages/client/src/files/index.ts
+++ b/packages/client/src/files/index.ts
@@ -18,6 +18,7 @@ export type ClientProps = common.types.CommonClientProps & {
   token: string
   botId: string
   integrationId?: string
+  integrationAlias?: string
 }
 
 export class Client extends gen.Client implements IClient {

--- a/packages/client/src/public/index.ts
+++ b/packages/client/src/public/index.ts
@@ -15,6 +15,7 @@ export type ClientOutputs = common.types.Outputs<IClient>
 
 export type ClientProps = common.types.CommonClientProps & {
   integrationId?: string
+  integrationAlias?: string
   workspaceId?: string
   botId?: string
   token?: string

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -12,6 +12,7 @@ export type ClientProps = common.types.CommonClientProps & {
   token: string
   botId: string
   integrationId?: string
+  integrationAlias?: string
 }
 
 export class Client extends gen.Client {

--- a/packages/client/src/tables/index.ts
+++ b/packages/client/src/tables/index.ts
@@ -12,6 +12,7 @@ export type ClientProps = common.types.CommonClientProps & {
   token: string
   botId: string
   integrationId?: string
+  integrationAlias?: string
 }
 
 export class Client extends gen.Client {

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -66,7 +66,7 @@
     "tsx": "^4.19.2"
   },
   "peerDependencies": {
-    "@botpress/client": "^1.25.0",
+    "@botpress/client": "1.26.0",
     "@botpress/cognitive": "0.1.47",
     "@bpinternal/thicktoken": "^1.0.5",
     "@bpinternal/zui": "^1.0.1"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "4.15.12",
+  "version": "4.16.0",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,7 +16,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "1.25.0",
+    "@botpress/client": "1.26.0",
     "browser-or-node": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/sdk/src/bot/definition.ts
+++ b/packages/sdk/src/bot/definition.ts
@@ -77,6 +77,7 @@ export type TableDefinition<TTable extends BaseTables[string] = BaseTables[strin
 
 export type IntegrationConfigInstance<I extends IntegrationPackage = IntegrationPackage> = {
   enabled: boolean
+  alias?: string
   disabledChannels?: StringKeys<NonNullable<I['definition']['channels']>>[]
 } & (
   | {
@@ -211,8 +212,15 @@ export class BotDefinition<
       self.integrations = {}
     }
 
-    self.integrations[integrationPkg.name] = {
+    const integrationAlias = config?.alias ?? integrationPkg.name.replace('/', '-')
+
+    if (self.integrations[integrationAlias]) {
+      throw new Error(`Another integration with alias "${integrationAlias}" is already installed in the bot`)
+    }
+
+    self.integrations[integrationAlias] = {
       ...integrationPkg,
+      alias: integrationAlias,
       enabled: config?.enabled,
       configurationType: config?.configurationType,
       configuration: config?.configuration,
@@ -228,6 +236,11 @@ export class BotDefinition<
     }
 
     const pluginAlias = config.alias ?? pluginPkg.name.replace('/', '-')
+
+    if (self.plugins[pluginAlias]) {
+      throw new Error(`Another plugin with alias "${pluginAlias}" is already installed in the bot`)
+    }
+
     self.plugins[pluginAlias] = {
       ...pluginPkg,
       alias: pluginAlias,

--- a/packages/sdk/src/bot/server/context.ts
+++ b/packages/sdk/src/bot/server/context.ts
@@ -14,7 +14,9 @@ export const extractContext = (headers: Record<string, string | undefined>): Bot
   botId: headers[BOT_ID_HEADER] || throwError('Missing bot id header'),
   operation: botOperationSchema.parse(headers[OPERATION_TYPE_HEADER]),
   type: headers[OPERATION_SUBTYPE_HEADER] || throwError('Missing type header'),
-  configuration: headers[CONFIGURATION_PAYLOAD_HEADER]
-    ? JSON.parse(Buffer.from(headers[CONFIGURATION_PAYLOAD_HEADER], 'base64').toString('utf-8'))
-    : {},
+  configuration: JSON.parse(
+    Buffer.from(headers[CONFIGURATION_PAYLOAD_HEADER] || throwError('Missing configuration header'), 'base64').toString(
+      'utf-8'
+    )
+  ),
 })

--- a/packages/sdk/src/bot/server/context.ts
+++ b/packages/sdk/src/bot/server/context.ts
@@ -1,34 +1,20 @@
 import { z } from '@bpinternal/zui'
-import { botIdHeader, configurationHeader, operationHeader, typeHeader } from '../../consts'
+import {
+  BOT_ID_HEADER,
+  CONFIGURATION_PAYLOAD_HEADER,
+  OPERATION_TYPE_HEADER,
+  OPERATION_SUBTYPE_HEADER,
+} from '../../consts'
+import { throwError } from '../../utils/error-utils'
 import { BotContext } from './types'
 
 const botOperationSchema = z.enum(['event_received', 'register', 'unregister', 'ping', 'action_triggered'])
-export const extractContext = (headers: Record<string, string | undefined>): BotContext => {
-  const botId = headers[botIdHeader]
-  const base64Configuration = headers[configurationHeader]
-  const type = headers[typeHeader]
-  const operation = botOperationSchema.parse(headers[operationHeader])
 
-  if (!botId) {
-    throw new Error('Missing bot headers')
-  }
-
-  if (!type) {
-    throw new Error('Missing type headers')
-  }
-
-  if (!base64Configuration) {
-    throw new Error('Missing configuration headers')
-  }
-
-  if (!operation) {
-    throw new Error('Missing operation headers')
-  }
-
-  return {
-    botId,
-    operation,
-    type,
-    configuration: base64Configuration ? JSON.parse(Buffer.from(base64Configuration, 'base64').toString('utf-8')) : {},
-  }
-}
+export const extractContext = (headers: Record<string, string | undefined>): BotContext => ({
+  botId: headers[BOT_ID_HEADER] || throwError('Missing bot id header'),
+  operation: botOperationSchema.parse(headers[OPERATION_TYPE_HEADER]),
+  type: headers[OPERATION_SUBTYPE_HEADER] || throwError('Missing type header'),
+  configuration: headers[CONFIGURATION_PAYLOAD_HEADER]
+    ? JSON.parse(Buffer.from(headers[CONFIGURATION_PAYLOAD_HEADER], 'base64').toString('utf-8'))
+    : {},
+})

--- a/packages/sdk/src/consts.ts
+++ b/packages/sdk/src/consts.ts
@@ -6,3 +6,14 @@ export * from './public-consts'
 // To export a constant, add it to the public-consts.ts file instead.
 
 export const PLUGIN_PREFIX_SEPARATOR = '#'
+
+export const BOT_ID_HEADER = 'x-bot-id'
+export const BOT_USER_ID_HEADER = 'x-bot-user-id'
+export const INTEGRATION_ID_HEADER = 'x-integration-id'
+export const INTEGRATION_ALIAS_HEADER = 'x-integration-alias'
+export const WEBHOOK_ID_HEADER = 'x-webhook-id'
+
+export const CONFIGURATION_TYPE_HEADER = 'x-bp-configuration-type'
+export const CONFIGURATION_PAYLOAD_HEADER = 'x-bp-configuration'
+export const OPERATION_TYPE_HEADER = 'x-bp-operation'
+export const OPERATION_SUBTYPE_HEADER = 'x-bp-type'

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -3,26 +3,6 @@ export * from './public-consts'
 export * from './serve'
 export * from './zui'
 
-// Backward-compatibility for old constants that were not SCREAMING_SNAKE_CASE:
-export {
-  /** @deprecated please use `BOT_ID_HEADER` instead */
-  BOT_ID_HEADER as botIdHeader,
-  /** @deprecated please use `BOT_USER_ID_HEADER` instead */
-  BOT_USER_ID_HEADER as botUserIdHeader,
-  /** @deprecated please use `INTEGRATION_ID_HEADER` instead */
-  INTEGRATION_ID_HEADER as integrationIdHeader,
-  /** @deprecated please use `WEBHOOK_ID_HEADER` instead */
-  WEBHOOK_ID_HEADER as webhookIdHeader,
-  /** @deprecated please use `CONFIGURATION_TYPE_HEADER` instead */
-  CONFIGURATION_TYPE_HEADER as configurationTypeHeader,
-  /** @deprecated please use `CONFIGURATION_PAYLOAD_HEADER` instead */
-  CONFIGURATION_PAYLOAD_HEADER as configurationHeader,
-  /** @deprecated please use `OPERATION_TYPE_HEADER` instead */
-  OPERATION_TYPE_HEADER as operationHeader,
-  /** @deprecated please use `OPERATION_SUBTYPE_HEADER` instead */
-  OPERATION_SUBTYPE_HEADER as typeHeader,
-} from './public-consts'
-
 export {
   //
   isApiError,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -3,6 +3,26 @@ export * from './public-consts'
 export * from './serve'
 export * from './zui'
 
+// Backward-compatibility for old constants that were not SCREAMING_SNAKE_CASE:
+export {
+  /** @deprecated please use `BOT_ID_HEADER` instead */
+  BOT_ID_HEADER as botIdHeader,
+  /** @deprecated please use `BOT_USER_ID_HEADER` instead */
+  BOT_USER_ID_HEADER as botUserIdHeader,
+  /** @deprecated please use `INTEGRATION_ID_HEADER` instead */
+  INTEGRATION_ID_HEADER as integrationIdHeader,
+  /** @deprecated please use `WEBHOOK_ID_HEADER` instead */
+  WEBHOOK_ID_HEADER as webhookIdHeader,
+  /** @deprecated please use `CONFIGURATION_TYPE_HEADER` instead */
+  CONFIGURATION_TYPE_HEADER as configurationTypeHeader,
+  /** @deprecated please use `CONFIGURATION_PAYLOAD_HEADER` instead */
+  CONFIGURATION_PAYLOAD_HEADER as configurationHeader,
+  /** @deprecated please use `OPERATION_TYPE_HEADER` instead */
+  OPERATION_TYPE_HEADER as operationHeader,
+  /** @deprecated please use `OPERATION_SUBTYPE_HEADER` instead */
+  OPERATION_SUBTYPE_HEADER as typeHeader,
+} from './public-consts'
+
 export {
   //
   isApiError,

--- a/packages/sdk/src/integration/server/context.ts
+++ b/packages/sdk/src/integration/server/context.ts
@@ -1,13 +1,15 @@
 import { z } from '@bpinternal/zui'
 import {
-  botIdHeader,
-  botUserIdHeader,
-  configurationHeader,
-  configurationTypeHeader,
-  integrationIdHeader,
-  operationHeader,
-  webhookIdHeader,
+  BOT_ID_HEADER,
+  BOT_USER_ID_HEADER,
+  CONFIGURATION_PAYLOAD_HEADER,
+  CONFIGURATION_TYPE_HEADER,
+  INTEGRATION_ALIAS_HEADER,
+  INTEGRATION_ID_HEADER,
+  OPERATION_TYPE_HEADER,
+  WEBHOOK_ID_HEADER,
 } from '../../consts'
+import { throwError } from '../../utils/error-utils'
 import { IntegrationContext } from './types'
 
 export const integrationOperationSchema = z.enum([
@@ -21,46 +23,16 @@ export const integrationOperationSchema = z.enum([
   'create_conversation',
 ])
 
-export const extractContext = (headers: Record<string, string | undefined>): IntegrationContext => {
-  const botId = headers[botIdHeader]
-  const botUserId = headers[botUserIdHeader]
-  const integrationId = headers[integrationIdHeader]
-  const webhookId = headers[webhookIdHeader]
-  const configurationType = headers[configurationTypeHeader]
-  const base64Configuration = headers[configurationHeader]
-  const operation = headers[operationHeader]
-
-  if (!botId) {
-    throw new Error('Missing bot headers')
-  }
-
-  if (!botUserId) {
-    throw new Error('Missing bot user headers')
-  }
-
-  if (!integrationId) {
-    throw new Error('Missing integration headers')
-  }
-
-  if (!webhookId) {
-    throw new Error('Missing webhook headers')
-  }
-
-  if (!base64Configuration) {
-    throw new Error('Missing configuration headers')
-  }
-
-  if (!operation) {
-    throw new Error('Missing operation headers')
-  }
-
-  return {
-    botId,
-    botUserId,
-    integrationId,
-    webhookId,
-    operation,
-    configurationType: configurationType ?? null,
-    configuration: base64Configuration ? JSON.parse(Buffer.from(base64Configuration, 'base64').toString('utf-8')) : {},
-  }
-}
+export const extractContext = (headers: Record<string, string | undefined>): IntegrationContext => ({
+  botId: headers[BOT_ID_HEADER] || throwError('Missing bot header'),
+  botUserId: headers[BOT_USER_ID_HEADER] || throwError('Missing bot user header'),
+  integrationId: headers[INTEGRATION_ID_HEADER] || throwError('Missing integration header'),
+  // TODO: make this non-nullable once the backend sends this header
+  integrationAlias: headers[INTEGRATION_ALIAS_HEADER],
+  webhookId: headers[WEBHOOK_ID_HEADER] || throwError('Missing webhook header'),
+  operation: headers[OPERATION_TYPE_HEADER] || throwError('Missing operation header'),
+  configurationType: headers[CONFIGURATION_TYPE_HEADER] ?? null,
+  configuration: headers[CONFIGURATION_PAYLOAD_HEADER]
+    ? JSON.parse(Buffer.from(headers[CONFIGURATION_PAYLOAD_HEADER], 'base64').toString('utf-8'))
+    : {},
+})

--- a/packages/sdk/src/integration/server/context.ts
+++ b/packages/sdk/src/integration/server/context.ts
@@ -32,7 +32,9 @@ export const extractContext = (headers: Record<string, string | undefined>): Int
   webhookId: headers[WEBHOOK_ID_HEADER] || throwError('Missing webhook header'),
   operation: headers[OPERATION_TYPE_HEADER] || throwError('Missing operation header'),
   configurationType: headers[CONFIGURATION_TYPE_HEADER] ?? null,
-  configuration: headers[CONFIGURATION_PAYLOAD_HEADER]
-    ? JSON.parse(Buffer.from(headers[CONFIGURATION_PAYLOAD_HEADER], 'base64').toString('utf-8'))
-    : {},
+  configuration: JSON.parse(
+    Buffer.from(headers[CONFIGURATION_PAYLOAD_HEADER] || throwError('Missing configuration header'), 'base64').toString(
+      'utf-8'
+    )
+  ),
 })

--- a/packages/sdk/src/integration/server/index.ts
+++ b/packages/sdk/src/integration/server/index.ts
@@ -46,6 +46,7 @@ const getServerProps = (
   const vanillaClient = new Client({
     botId: ctx.botId,
     integrationId: ctx.integrationId,
+    integrationAlias: ctx.integrationAlias,
     retry: retryConfig,
     headers: extractTracingHeaders(req.headers),
   })

--- a/packages/sdk/src/integration/server/types.ts
+++ b/packages/sdk/src/integration/server/types.ts
@@ -21,6 +21,7 @@ export type IntegrationContext<TIntegration extends BaseIntegration = BaseIntegr
   botId: string
   botUserId: string
   integrationId: string
+  integrationAlias: string | undefined
   webhookId: string
   operation: string
 } & IntegrationContextConfig<TIntegration>

--- a/packages/sdk/src/public-consts.ts
+++ b/packages/sdk/src/public-consts.ts
@@ -1,16 +1,5 @@
 // This file contains constants that are exported for public use.
 
-export const BOT_ID_HEADER = 'x-bot-id'
-export const BOT_USER_ID_HEADER = 'x-bot-user-id'
-export const INTEGRATION_ID_HEADER = 'x-integration-id'
-export const INTEGRATION_ALIAS_HEADER = 'x-integration-alias'
-export const WEBHOOK_ID_HEADER = 'x-webhook-id'
-
-export const CONFIGURATION_TYPE_HEADER = 'x-bp-configuration-type'
-export const CONFIGURATION_PAYLOAD_HEADER = 'x-bp-configuration'
-export const OPERATION_TYPE_HEADER = 'x-bp-operation'
-export const OPERATION_SUBTYPE_HEADER = 'x-bp-type'
-
 export const WELL_KNOWN_ATTRIBUTES = {
   HIDDEN_IN_STUDIO: { bpActionHiddenInStudio: 'true' },
   AWAIT_RETURN: { bpActionAwaitReturn: 'true' },

--- a/packages/sdk/src/public-consts.ts
+++ b/packages/sdk/src/public-consts.ts
@@ -1,14 +1,15 @@
 // This file contains constants that are exported for public use.
 
-export const botIdHeader = 'x-bot-id'
-export const botUserIdHeader = 'x-bot-user-id'
-export const integrationIdHeader = 'x-integration-id'
-export const webhookIdHeader = 'x-webhook-id'
+export const BOT_ID_HEADER = 'x-bot-id'
+export const BOT_USER_ID_HEADER = 'x-bot-user-id'
+export const INTEGRATION_ID_HEADER = 'x-integration-id'
+export const INTEGRATION_ALIAS_HEADER = 'x-integration-alias'
+export const WEBHOOK_ID_HEADER = 'x-webhook-id'
 
-export const configurationTypeHeader = 'x-bp-configuration-type'
-export const configurationHeader = 'x-bp-configuration'
-export const operationHeader = 'x-bp-operation'
-export const typeHeader = 'x-bp-type'
+export const CONFIGURATION_TYPE_HEADER = 'x-bp-configuration-type'
+export const CONFIGURATION_PAYLOAD_HEADER = 'x-bp-configuration'
+export const OPERATION_TYPE_HEADER = 'x-bp-operation'
+export const OPERATION_SUBTYPE_HEADER = 'x-bp-type'
 
 export const WELL_KNOWN_ATTRIBUTES = {
   HIDDEN_IN_STUDIO: { bpActionHiddenInStudio: 'true' },

--- a/packages/sdk/src/utils/error-utils.ts
+++ b/packages/sdk/src/utils/error-utils.ts
@@ -1,0 +1,7 @@
+/**
+ * Utility to throw an error in ternary or nullish coalescing expressions
+ */
+export const throwError = (thrown: string | Error): never => {
+  const error = thrown instanceof Error ? thrown : new Error(thrown)
+  throw error
+}

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -36,7 +36,7 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "@botpress/client": "1.25.0",
+    "@botpress/client": "1.26.0",
     "@bpinternal/thicktoken": "^1.0.1",
     "@bpinternal/zui": "^1.0.1",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2163,7 +2163,7 @@ importers:
         specifier: 0.5.2
         version: link:../chat-client
       '@botpress/client':
-        specifier: 1.25.0
+        specifier: 1.26.0
         version: link:../client
       '@botpress/sdk':
         specifier: 4.15.12
@@ -2278,7 +2278,7 @@ importers:
   packages/cli/templates/empty-bot:
     dependencies:
       '@botpress/client':
-        specifier: 1.25.0
+        specifier: 1.26.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 4.15.12
@@ -2294,7 +2294,7 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 1.25.0
+        specifier: 1.26.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 4.15.12
@@ -2323,7 +2323,7 @@ importers:
   packages/cli/templates/hello-world:
     dependencies:
       '@botpress/client':
-        specifier: 1.25.0
+        specifier: 1.26.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 4.15.12
@@ -2339,7 +2339,7 @@ importers:
   packages/cli/templates/webhook-message:
     dependencies:
       '@botpress/client':
-        specifier: 1.25.0
+        specifier: 1.26.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 4.15.12
@@ -2477,7 +2477,7 @@ importers:
         specifier: ^7.26.3
         version: 7.26.9
       '@botpress/client':
-        specifier: ^1.25.0
+        specifier: 1.26.0
         version: link:../client
       '@botpress/cognitive':
         specifier: 0.1.47
@@ -2580,7 +2580,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 1.25.0
+        specifier: 1.26.0
         version: link:../client
       '@bpinternal/zui':
         specifier: ^1.0.1
@@ -2611,7 +2611,7 @@ importers:
   packages/vai:
     dependencies:
       '@botpress/client':
-        specifier: 1.25.0
+        specifier: 1.26.0
         version: link:../client
       '@bpinternal/thicktoken':
         specifier: ^1.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2166,7 +2166,7 @@ importers:
         specifier: 1.26.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 4.15.12
+        specifier: 4.16.0
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2281,7 +2281,7 @@ importers:
         specifier: 1.26.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.15.12
+        specifier: 4.16.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2297,7 +2297,7 @@ importers:
         specifier: 1.26.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.15.12
+        specifier: 4.16.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2310,7 +2310,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 4.15.12
+        specifier: 4.16.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2326,7 +2326,7 @@ importers:
         specifier: 1.26.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.15.12
+        specifier: 4.16.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2342,7 +2342,7 @@ importers:
         specifier: 1.26.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.15.12
+        specifier: 4.16.0
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
- Updates the client so it's able to send `x-integration-alias`
- Updates the integration server so it's able to receive `x-integration-alias`
- Instantiates the client with the alias when present
- Updates constants in the SDK to be SCREAMING_SNAKE_CASE

Contributes to SQD-2779