### PR TITLE
feat(bots): add todoist multi-instance bot

### DIFF
--- a/bots/doppel-doer/bot.definition.ts
+++ b/bots/doppel-doer/bot.definition.ts
@@ -1,0 +1,30 @@
+/* bplint-disable */ // zui `toTypescriptSchema` does not preserve title and description properties
+import * as sdk from '@botpress/sdk'
+import * as genenv from './.genenv'
+import todoist from './bp_modules/todoist'
+
+export default new sdk.BotDefinition({
+  configuration: {
+    schema: sdk.z.object({}),
+  },
+  states: {},
+  events: {},
+  recurringEvents: {},
+  user: {},
+  conversation: {},
+  __advanced: {
+    useLegacyZuiTransformer: true,
+  },
+})
+  .addIntegration(todoist, {
+    alias: 'todoist-src',
+    enabled: true,
+    configurationType: 'apiToken',
+    configuration: { apiToken: genenv.TODOIST_SRC_API_TOKEN },
+  })
+  .addIntegration(todoist, {
+    alias: 'todoist-dst',
+    enabled: true,
+    configurationType: 'apiToken',
+    configuration: { apiToken: genenv.TODOIST_DST_API_TOKEN },
+  })

--- a/bots/doppel-doer/eslint.config.mjs
+++ b/bots/doppel-doer/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/bots/doppel-doer/package.json
+++ b/bots/doppel-doer/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@bp-bots/doppel-doer",
+  "scripts": {
+    "postinstall": "genenv -o ./.genenv/index.ts -e TODOIST_SRC_API_TOKEN -e TODOIST_DST_API_TOKEN",
+    "check:type": "tsc --noEmit",
+    "check:bplint": "bp lint",
+    "build": "bp add -y && bp build"
+  },
+  "private": true,
+  "dependencies": {
+    "@botpress/client": "workspace:*",
+    "@botpress/sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@botpress/cli": "workspace:*",
+    "@botpress/common": "workspace:*",
+    "@botpresshub/todoist": "workspace:*",
+    "@bpinternal/genenv": "0.0.1"
+  },
+  "bpDependencies": {
+    "todoist": "../../integrations/todoist"
+  }
+}

--- a/bots/doppel-doer/src/index.ts
+++ b/bots/doppel-doer/src/index.ts
@@ -1,0 +1,24 @@
+import * as bp from '.botpress'
+
+const bot = new bp.Bot({ actions: {} })
+
+bot.on.afterIncomingEvent('todoist-src:taskAdded', async (props) => {
+  props.logger.info(`Copying task "${props.data.payload.content}" from todoist-src to todoist-dst...`)
+
+  const newTask = await props.client.callAction({
+    type: 'todoist-dst:createNewTask',
+    input: {
+      content: props.data.payload.content,
+      description: props.data.payload.description,
+      priority: props.data.payload.priority,
+    },
+  })
+
+  const newTaskId = newTask.output.taskId
+
+  props.logger.info(`Created new task in todoist-dst with ID ${newTaskId}`)
+
+  return {}
+})
+
+export default bot

--- a/bots/doppel-doer/tsconfig.json
+++ b/bots/doppel-doer/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist"
+  },
+  "include": [".botpress/**/*", "src/**/*", "*.ts"]
+}

--- a/integrations/todoist/integration.definition.ts
+++ b/integrations/todoist/integration.definition.ts
@@ -16,7 +16,7 @@ export default new sdk.IntegrationDefinition({
   name: 'todoist',
   title: 'Todoist',
   description: 'Create and modify tasks, post comments and more.',
-  version: '1.0.1',
+  version: '1.0.2',
   readme: 'hub.md',
   icon: 'icon.svg',
   actions,

--- a/integrations/todoist/src/todoist-api/sync-client.ts
+++ b/integrations/todoist/src/todoist-api/sync-client.ts
@@ -16,8 +16,8 @@ export class TodoistSyncClient {
       endpoint: 'user',
       responseSchema: {
         id: z.string(),
-        avatar_medium: z.string(),
-        full_name: z.string(),
+        avatar_medium: z.string().optional(),
+        full_name: z.string().optional(),
       },
     })
 

--- a/integrations/todoist/src/webhook-events/handler-dispatcher.ts
+++ b/integrations/todoist/src/webhook-events/handler-dispatcher.ts
@@ -34,7 +34,9 @@ export const handler: bp.IntegrationProps['handler'] = async (props: bp.HandlerP
 
   console.debug(req)
 
-  await _ensureWebhookIsAuthenticated(props)
+  if (props.ctx.configurationType !== 'apiToken') {
+    await _ensureWebhookIsAuthenticated(props)
+  }
   await _dispatchEvent(props)
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,28 @@ importers:
         specifier: 0.0.1
         version: 0.0.1
 
+  bots/doppel-doer:
+    dependencies:
+      '@botpress/client':
+        specifier: workspace:*
+        version: link:../../packages/client
+      '@botpress/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+    devDependencies:
+      '@botpress/cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@botpress/common':
+        specifier: workspace:*
+        version: link:../../packages/common
+      '@botpresshub/todoist':
+        specifier: workspace:*
+        version: link:../../integrations/todoist
+      '@bpinternal/genenv':
+        specifier: 0.0.1
+        version: 0.0.1
+
   bots/echo:
     devDependencies:
       '@botpress/cli':


### PR DESCRIPTION
- Adds a bot that uses two instances of the Todoist integration: when a task is added in `todoist-src`, the bot calls the `createNewTask` action of `todoist-dst`. This effectively copies all new tasks from one Todoist workspace to another
- Fixes a couple issues I encountered in the Todoist integration

<img width="834" height="236" alt="image" src="https://github.com/user-attachments/assets/be00bc20-9d0d-4384-b439-2a8181c2876c" />


Resolves SQD-2779