### PR TITLE
feat(cli): added dependency to package.json when using `bp add`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.18.0",
+  "version": "4.19.0",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/command-implementations/add-command.ts
+++ b/packages/cli/src/command-implementations/add-command.ts
@@ -363,7 +363,7 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
     }
 
     pkgJson.bpDependencies = {
-      ...(typeof bpDependencies === 'object' && bpDependencies !== null ? bpDependencies : {}),
+      ...parseResult.data,
       [packageName]: version,
     }
 

--- a/packages/cli/src/command-implementations/add-command.ts
+++ b/packages/cli/src/command-implementations/add-command.ts
@@ -333,6 +333,7 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
 
   private async _addDependencyToPackage(packageName: string, targetPackage: InstallablePackage) {
     const pkgJson = await utils.pkgJson.readPackageJson(this.argv.installPath)
+    const packageJsonPath = `${this.argv.installPath}/package.json`
     const version = targetPackage.pkg.path ?? targetPackage.pkg.version
     if (!pkgJson) {
       this.logger.warn('No package.json found in the install path')
@@ -342,7 +343,7 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
     const { bpDependencies } = pkgJson
     if (!bpDependencies) {
       pkgJson.bpDependencies = { [packageName]: version }
-      await fs.promises.writeFile(this.argv.installPath, JSON.stringify(pkgJson, null, 2))
+      await fs.promises.writeFile(packageJsonPath, JSON.stringify(pkgJson, null, 2))
       return
     }
 
@@ -362,7 +363,8 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
       ...Object.entries(bpDependencies),
       [packageName]: version,
     }
-    await fs.promises.writeFile(this.argv.installPath, JSON.stringify(pkgJson, null, 2))
+
+    await fs.promises.writeFile(packageJsonPath, JSON.stringify(pkgJson, null, 2))
   }
 }
 

--- a/packages/cli/src/command-implementations/add-command.ts
+++ b/packages/cli/src/command-implementations/add-command.ts
@@ -1,5 +1,5 @@
 import * as sdk from '@botpress/sdk'
-import * as fs from 'fs'
+import * as fslib from 'fs'
 import * as pathlib from 'path'
 import semver from 'semver'
 import * as apiUtils from '../api'
@@ -108,7 +108,7 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
     const packageDirName = utils.casing.to.kebabCase(packageName)
     const installPath = utils.path.join(baseInstallPath, consts.installDirName, packageDirName)
 
-    const alreadyInstalled = fs.existsSync(installPath)
+    const alreadyInstalled = fslib.existsSync(installPath)
     if (alreadyInstalled) {
       this.logger.warn(`Package with name "${packageName}" already installed.`)
       const res = await this.prompt.confirm('Do you want to overwrite the existing package?')
@@ -274,8 +274,8 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
       for (const file of files) {
         const filePath = utils.path.absoluteFrom(installPath, file.path)
         const dirPath = pathlib.dirname(filePath)
-        await fs.promises.mkdir(dirPath, { recursive: true })
-        await fs.promises.writeFile(filePath, file.content)
+        await fslib.promises.mkdir(dirPath, { recursive: true })
+        await fslib.promises.writeFile(filePath, file.content)
       }
       line.success(`Installed ${files.length} files to "${installPath}"`)
     } finally {
@@ -284,7 +284,7 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
   }
 
   private async _uninstall(installPath: utils.path.AbsolutePath): Promise<void> {
-    await fs.promises.rm(installPath, { recursive: true })
+    await fslib.promises.rm(installPath, { recursive: true })
   }
 
   private async _readProject(workDir: utils.path.AbsolutePath): Promise<{
@@ -305,11 +305,11 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
     const devId = await cmd.projectCache.get('devId')
 
     const implementationAbsPath = utils.path.join(workDir, consts.fromWorkDir.outFileCJS)
-    if (!fs.existsSync(implementationAbsPath)) {
+    if (!fslib.existsSync(implementationAbsPath)) {
       return { definition, devId }
     }
 
-    const implementation = await fs.promises.readFile(implementationAbsPath, 'utf8')
+    const implementation = await fslib.promises.readFile(implementationAbsPath, 'utf8')
     return { definition, implementation, devId }
   }
 
@@ -343,7 +343,7 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
     const { bpDependencies } = pkgJson
     if (!bpDependencies) {
       pkgJson.bpDependencies = { [packageName]: version }
-      await fs.promises.writeFile(packageJsonPath, JSON.stringify(pkgJson, null, 2))
+      await fslib.promises.writeFile(packageJsonPath, JSON.stringify(pkgJson, null, 2))
       return
     }
 
@@ -368,7 +368,7 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
       [packageName]: version,
     }
 
-    await fs.promises.writeFile(packageJsonPath, JSON.stringify(pkgJson, null, 2))
+    await fslib.promises.writeFile(packageJsonPath, JSON.stringify(pkgJson, null, 2))
   }
 }
 

--- a/packages/cli/src/command-implementations/add-command.ts
+++ b/packages/cli/src/command-implementations/add-command.ts
@@ -352,7 +352,7 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
     if (!parseResults.success) {
       throw new errors.BotpressCLIError('Invalid bpDependencies found in package.json')
     }
-    if (Object.keys(bpDependencies).find((key) => key === packageName)) {
+    if (Object.entries(bpDependencies).find(([key, value]) => key === packageName && value !== version)) {
       this.logger.warn(
         `The dependency ${packageName} is already present in the bpDependencies of package.json. It will not be replaced`
       )
@@ -360,7 +360,7 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
     }
 
     pkgJson.bpDependencies = {
-      ...Object.entries(bpDependencies),
+      ...(typeof bpDependencies === 'object' && bpDependencies !== null ? bpDependencies : {}),
       [packageName]: version,
     }
 

--- a/packages/cli/src/command-implementations/add-command.ts
+++ b/packages/cli/src/command-implementations/add-command.ts
@@ -333,7 +333,6 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
 
   private async _addDependencyToPackage(packageName: string, targetPackage: InstallablePackage) {
     const pkgJson = await utils.pkgJson.readPackageJson(this.argv.installPath)
-    const packageJsonPath = `${this.argv.installPath}/package.json`
     const version = targetPackage.pkg.path ?? targetPackage.pkg.version
     if (!pkgJson) {
       this.logger.warn('No package.json found in the install path')
@@ -343,13 +342,13 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
     const { bpDependencies } = pkgJson
     if (!bpDependencies) {
       pkgJson.bpDependencies = { [packageName]: version }
-      await fslib.promises.writeFile(packageJsonPath, JSON.stringify(pkgJson, null, 2))
+      await utils.pkgJson.writePackageJson(this.argv.installPath, pkgJson)
       return
     }
 
     const bpDependenciesSchema = sdk.z.record(sdk.z.string())
-    const parseResults = bpDependenciesSchema.safeParse(bpDependencies)
-    if (!parseResults.success) {
+    const parseResult = bpDependenciesSchema.safeParse(bpDependencies)
+    if (!parseResult.success) {
       throw new errors.BotpressCLIError('Invalid bpDependencies found in package.json')
     }
 
@@ -357,7 +356,7 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
     if (alreadyPresentDep) {
       if (alreadyPresentDep[1] !== version) {
         this.logger.warn(
-          `The dependency ${packageName} is already present in the bpDependencies of package.json. It will not be replaced`
+          `The dependency ${packageName} is already present in the bpDependencies of package.json. It will not be replaced.`
         )
       }
       return
@@ -368,7 +367,7 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
       [packageName]: version,
     }
 
-    await fslib.promises.writeFile(packageJsonPath, JSON.stringify(pkgJson, null, 2))
+    await utils.pkgJson.writePackageJson(this.argv.installPath, pkgJson)
   }
 }
 

--- a/packages/cli/src/command-implementations/add-command.ts
+++ b/packages/cli/src/command-implementations/add-command.ts
@@ -352,7 +352,9 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
       throw new errors.BotpressCLIError('Invalid bpDependencies found in package.json')
     }
 
-    const alreadyPresentDep = Object.entries(bpDependencies).find(([key]) => key === packageName)
+    const { data: validatedBpDeps } = parseResult
+
+    const alreadyPresentDep = Object.entries(validatedBpDeps).find(([key]) => key === packageName)
     if (alreadyPresentDep) {
       if (alreadyPresentDep[1] !== version) {
         this.logger.warn(
@@ -363,7 +365,7 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
     }
 
     pkgJson.bpDependencies = {
-      ...parseResult.data,
+      ...validatedBpDeps,
       [packageName]: version,
     }
 

--- a/packages/cli/src/command-implementations/add-command.ts
+++ b/packages/cli/src/command-implementations/add-command.ts
@@ -352,10 +352,14 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
     if (!parseResults.success) {
       throw new errors.BotpressCLIError('Invalid bpDependencies found in package.json')
     }
-    if (Object.entries(bpDependencies).find(([key, value]) => key === packageName && value !== version)) {
-      this.logger.warn(
-        `The dependency ${packageName} is already present in the bpDependencies of package.json. It will not be replaced`
-      )
+
+    const alreadyPresentDep = Object.entries(bpDependencies).find(([key]) => key === packageName)
+    if (alreadyPresentDep) {
+      if (alreadyPresentDep[1] !== version) {
+        this.logger.warn(
+          `The dependency ${packageName} is already present in the bpDependencies of package.json. It will not be replaced`
+        )
+      }
       return
     }
 

--- a/packages/cli/src/command-implementations/add-command.ts
+++ b/packages/cli/src/command-implementations/add-command.ts
@@ -1,5 +1,5 @@
 import * as sdk from '@botpress/sdk'
-import * as fslib from 'fs'
+import * as fs from 'fs'
 import * as pathlib from 'path'
 import semver from 'semver'
 import * as apiUtils from '../api'
@@ -108,7 +108,7 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
     const packageDirName = utils.casing.to.kebabCase(packageName)
     const installPath = utils.path.join(baseInstallPath, consts.installDirName, packageDirName)
 
-    const alreadyInstalled = fslib.existsSync(installPath)
+    const alreadyInstalled = fs.existsSync(installPath)
     if (alreadyInstalled) {
       this.logger.warn(`Package with name "${packageName}" already installed.`)
       const res = await this.prompt.confirm('Do you want to overwrite the existing package?')
@@ -149,6 +149,7 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
     }
 
     await this._install(installPath, files)
+    await this._addDependencyToPackage(packageName, targetPackage)
   }
 
   private async _findRemotePackage(ref: pkgRef.ApiPackageRef): Promise<InstallablePackage | undefined> {
@@ -273,8 +274,8 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
       for (const file of files) {
         const filePath = utils.path.absoluteFrom(installPath, file.path)
         const dirPath = pathlib.dirname(filePath)
-        await fslib.promises.mkdir(dirPath, { recursive: true })
-        await fslib.promises.writeFile(filePath, file.content)
+        await fs.promises.mkdir(dirPath, { recursive: true })
+        await fs.promises.writeFile(filePath, file.content)
       }
       line.success(`Installed ${files.length} files to "${installPath}"`)
     } finally {
@@ -283,7 +284,7 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
   }
 
   private async _uninstall(installPath: utils.path.AbsolutePath): Promise<void> {
-    await fslib.promises.rm(installPath, { recursive: true })
+    await fs.promises.rm(installPath, { recursive: true })
   }
 
   private async _readProject(workDir: utils.path.AbsolutePath): Promise<{
@@ -304,11 +305,11 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
     const devId = await cmd.projectCache.get('devId')
 
     const implementationAbsPath = utils.path.join(workDir, consts.fromWorkDir.outFileCJS)
-    if (!fslib.existsSync(implementationAbsPath)) {
+    if (!fs.existsSync(implementationAbsPath)) {
       return { definition, devId }
     }
 
-    const implementation = await fslib.promises.readFile(implementationAbsPath, 'utf8')
+    const implementation = await fs.promises.readFile(implementationAbsPath, 'utf8')
     return { definition, implementation, devId }
   }
 
@@ -328,6 +329,40 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
       ...this.argv,
       workDir,
     })
+  }
+
+  private async _addDependencyToPackage(packageName: string, targetPackage: InstallablePackage) {
+    const pkgJson = await utils.pkgJson.readPackageJson(this.argv.installPath)
+    const version = targetPackage.pkg.path ?? targetPackage.pkg.version
+    if (!pkgJson) {
+      this.logger.warn('No package.json found in the install path')
+      return
+    }
+
+    const { bpDependencies } = pkgJson
+    if (!bpDependencies) {
+      pkgJson.bpDependencies = { [packageName]: version }
+      await fs.promises.writeFile(this.argv.installPath, JSON.stringify(pkgJson, null, 2))
+      return
+    }
+
+    const bpDependenciesSchema = sdk.z.record(sdk.z.string())
+    const parseResults = bpDependenciesSchema.safeParse(bpDependencies)
+    if (!parseResults.success) {
+      throw new errors.BotpressCLIError('Invalid bpDependencies found in package.json')
+    }
+    if (Object.keys(bpDependencies).find((key) => key === packageName)) {
+      this.logger.warn(
+        `The dependency ${packageName} is already present in the bpDependencies of package.json. It will not be replaced`
+      )
+      return
+    }
+
+    pkgJson.bpDependencies = {
+      ...Object.entries(bpDependencies),
+      [packageName]: version,
+    }
+    await fs.promises.writeFile(this.argv.installPath, JSON.stringify(pkgJson, null, 2))
   }
 }
 

--- a/packages/cli/src/utils/pkgjson-utils.ts
+++ b/packages/cli/src/utils/pkgjson-utils.ts
@@ -18,7 +18,7 @@ export type PackageJson = {
 const FILE_NAME = 'package.json'
 
 export const readPackageJson = async (path: string): Promise<PackageJson | undefined> => {
-  const filePath = pathlib.basename(path) === FILE_NAME ? path : pathlib.join(path, FILE_NAME)
+  const filePath = _resolveFilePath(path)
   if (!fs.existsSync(filePath)) {
     return undefined
   }
@@ -35,6 +35,10 @@ export const findDependency = (pkgJson: PackageJson, name: string): string | und
 }
 
 export const writePackageJson = async (path: string, pkgJson: PackageJson) => {
-  const filePath = pathlib.basename(path) === FILE_NAME ? path : pathlib.join(path, FILE_NAME)
+  const filePath = _resolveFilePath(path)
   await fs.promises.writeFile(filePath, JSON.stringify(pkgJson, null, 2))
+}
+
+function _resolveFilePath(path: string) {
+  return pathlib.basename(path) === FILE_NAME ? path : pathlib.join(path, FILE_NAME)
 }

--- a/packages/cli/src/utils/pkgjson-utils.ts
+++ b/packages/cli/src/utils/pkgjson-utils.ts
@@ -33,3 +33,8 @@ export const findDependency = (pkgJson: PackageJson, name: string): string | und
   const allDependencies = { ...(dependencies ?? {}), ...(devDependencies ?? {}), ...(peerDependencies ?? {}) }
   return allDependencies[name]
 }
+
+export const writePackageJson = async (path: string, pkgJson: PackageJson) => {
+  const filePath = pathlib.basename(path) === FILE_NAME ? path : pathlib.join(path, FILE_NAME)
+  await fs.promises.writeFile(filePath, JSON.stringify(pkgJson, null, 2))
+}


### PR DESCRIPTION
When using `bp add`, will add package to `package.json` under `bpDependencies`. It should use the same version as installed (ex. if you specify `chat@0.7.1` it adds `bpDependencies: {"chat": "0.7.1"}`)
In case you already have the dependency in `bpDepencencies`, it will not overwrite, nor prompt to overwrite it since that would be breaking. It will, however, log a warning.

Resolves SQD-3145