### PR TITLE
chore(ci): use OIDC for NPM publishing

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,14 +9,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: pnpm/action-setup@v4
-      with:
-        version: 10.12.4
+    - uses: pnpm/action-setup@v4 # uses the version from package.json
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v6
       with:
-        node-version: '22.17.0'
-        check-latest: true
+        node-version-file: '.tool-versions'
+        package-manager-cache: false
 
     - name: Install Node Gyp Build
       shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -23,43 +23,39 @@ jobs:
         with:
           extra_filters: '-F @botpress/* -F llmz'
 
+      - name: update npm
+        shell: bash
+        run: npm install -g npm@^11.5.1 # Required for OIDC login
+
       - name: Publish Client
         uses: botpress/gh-actions/publish-if-not-exists@master
         with:
           path: './packages/client'
-          token: '${{ secrets.NPM_ACCESS_TOKEN }}'
       - name: Publish SDK
         uses: botpress/gh-actions/publish-if-not-exists@master
         with:
           path: './packages/sdk'
-          token: '${{ secrets.NPM_ACCESS_TOKEN }}'
       - name: Publish CLI
         uses: botpress/gh-actions/publish-if-not-exists@master
         with:
           path: './packages/cli'
-          token: '${{ secrets.NPM_ACCESS_TOKEN }}'
       - name: Publish Chat Client
         uses: botpress/gh-actions/publish-if-not-exists@master
         with:
           path: './packages/chat-client'
-          token: '${{ secrets.NPM_ACCESS_TOKEN }}'
       - name: Publish Cognitive Client
         uses: botpress/gh-actions/publish-if-not-exists@master
         with:
           path: './packages/cognitive'
-          token: '${{ secrets.NPM_ACCESS_TOKEN }}'
       - name: Publish Vai
         uses: botpress/gh-actions/publish-if-not-exists@master
         with:
           path: './packages/vai'
-          token: '${{ secrets.NPM_ACCESS_TOKEN }}'
       - name: Publish Zai
         uses: botpress/gh-actions/publish-if-not-exists@master
         with:
           path: './packages/zai'
-          token: '${{ secrets.NPM_ACCESS_TOKEN }}'
       - name: Publish LLMz
         uses: botpress/gh-actions/publish-if-not-exists@master
         with:
           path: './packages/llmz'
-          token: '${{ secrets.NPM_ACCESS_TOKEN }}'

--- a/packages/chat-client/package.json
+++ b/packages/chat-client/package.json
@@ -6,6 +6,9 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "license": "MIT",
+  "repository": {
+    "url": "https://github.com/botpress/botpress"
+  },
   "scripts": {
     "check:type": "tsc --noEmit",
     "generate": "ts-node -T ./openapi.ts ./src/gen",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,9 @@
     "template:gen": "pnpm -r --stream -F @bp-templates/* exec bp gen",
     "test:e2e": "ts-node -T ./e2e"
   },
+  "repository": {
+    "url": "https://github.com/botpress/botpress"
+  },
   "keywords": [],
   "author": "",
   "license": "MIT",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -6,6 +6,9 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "license": "MIT",
+  "repository": {
+    "url": "https://github.com/botpress/botpress"
+  },
   "browser": {
     "crypto": false,
     "http": false,

--- a/packages/cognitive/package.json
+++ b/packages/cognitive/package.json
@@ -6,6 +6,9 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "license": "MIT",
+  "repository": {
+    "url": "https://github.com/botpress/botpress"
+  },
   "scripts": {
     "check:type": "tsc --noEmit",
     "build:type": "tsup --tsconfig tsconfig.build.json ./src/index.ts --dts-resolve --dts-only --clean",

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -12,6 +12,9 @@
       "require": "./dist/index.cjs"
     }
   },
+  "repository": {
+    "url": "https://github.com/botpress/botpress"
+  },
   "scripts": {
     "generate": "pnpm build:markdown",
     "build": "tsup && pnpm tsc --emitDeclarationOnly",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -5,6 +5,9 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "repository": {
+    "url": "https://github.com/botpress/botpress"
+  },
   "scripts": {
     "check:type": "tsc -p ./tsconfig.json --noEmit",
     "build:type": "tsc -p ./tsconfig.package.json --emitDeclarationOnly --declaration",

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -10,6 +10,9 @@
       "require": "./dist/index.js"
     }
   },
+  "repository": {
+    "url": "https://github.com/botpress/botpress"
+  },
   "scripts": {
     "check:type": "tsc --noEmit",
     "build": "pnpm run build:types && pnpm run build:neutral",

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -9,6 +9,9 @@
     "require": "./dist/index.js",
     "import": "./dist/index.js"
   },
+  "repository": {
+    "url": "https://github.com/botpress/botpress"
+  },
   "scripts": {
     "check:type": "tsc --noEmit",
     "build": "bp add -y && pnpm run build:types && pnpm run build:neutral && size-limit",


### PR DESCRIPTION
Uses Trusted Publishing to publish packages to NPM. (successfully [tested here](https://github.com/botpress/botpress/actions/runs/18574618503/job/52956866305))

Contributes to SQD-3323