### PR TITLE
fix(cli): `bp chat` should be able to use dev chat integration

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.18.1",
+  "version": "4.18.2",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/command-implementations/chat-command.ts
+++ b/packages/cli/src/command-implementations/chat-command.ts
@@ -138,7 +138,9 @@ export class ChatCommand extends GlobalCommand<ChatCommandDefinition> {
 
     const targetChatVersion = this._getChatApiTargetVersionRange()
     return integrationInstances.find(
-      (i) => i.instance.name === 'chat' && semver.satisfies(i.instance.version, targetChatVersion)
+      (i) =>
+        i.instance.name === 'chat' &&
+        (semver.satisfies(i.instance.version, targetChatVersion) || i.instance.version === 'dev')
     )
   }
 


### PR DESCRIPTION
Resolves SQD-3330

`bp chat` is currently not able to use the dev chat integration when installed in a bot. This PR adds the ability to detect that the dev integration is installed, and skip installing the published version.

This helps while developing the chat integration.