### PR TITLE
fix(integrations/facebook): Make sure `pageId` is set before unsubscribing from webhooks

### DIFF
--- a/integrations/facebook/src/setup.ts
+++ b/integrations/facebook/src/setup.ts
@@ -1,6 +1,5 @@
 import { getOAuthMetaClientCredentials } from './misc/auth'
 import { createAuthenticatedMetaClient } from './misc/meta-client'
-
 import * as bp from '.botpress'
 
 type RegisterProps = Parameters<bp.IntegrationProps['register']>[0]
@@ -27,7 +26,13 @@ const _unsubscribeFromOAuthWebhooks = async ({ ctx, logger, client }: RegisterPr
   }
 
   const { pageId } = credentials
+  if (!pageId) {
+    // No page ID means the OAuth flow was probably never fully completed
+    return
+  }
+
   const metaClient = await createAuthenticatedMetaClient({ configType: 'oauth', ctx, client, logger })
+
   if (await metaClient.isSubscribedToWebhooks(pageId)) {
     await metaClient.unsubscribeFromWebhooks(pageId)
   }


### PR DESCRIPTION
**Important**: This PR merges into the `integration-facebook` branch
We had a bug when registering a manual configuration after partially completing the OAuth flow. The credentials state was created but it was empty; so we tried to unsubscribe from OAuth webhooks using an undefined page ID
