### PR TITLE
feat(integrations/twilio): Support markdown from bot

### DIFF
--- a/integrations/twilio/package.json
+++ b/integrations/twilio/package.json
@@ -13,6 +13,9 @@
     "@botpress/sdk": "workspace:*",
     "@botpress/sdk-addons": "workspace:*",
     "axios": "^1.6.0",
+    "markdown-it": "^14.1.0",
+    "markdown-it-sub": "^2.0.0",
+    "markdown-it-sup": "^2.0.0",
     "query-string": "^6.14.1",
     "twilio": "^3.84.0"
   },
@@ -21,7 +24,8 @@
     "@botpress/common": "workspace:*",
     "@botpresshub/proactive-conversation": "workspace:*",
     "@botpresshub/proactive-user": "workspace:*",
-    "@sentry/cli": "^2.39.1"
+    "@sentry/cli": "^2.39.1",
+    "@types/markdown-it": "^14.1.2"
   },
   "bpDependencies": {
     "proactive-conversation": "../../interfaces/proactive-conversation",

--- a/integrations/twilio/src/index.ts
+++ b/integrations/twilio/src/index.ts
@@ -5,6 +5,7 @@ import axios from 'axios'
 import * as crypto from 'crypto'
 import queryString from 'query-string'
 import { Twilio } from 'twilio'
+import { markdownToTwilio } from './markdown-to-twilio'
 import * as types from './types'
 import * as bp from '.botpress'
 
@@ -56,7 +57,7 @@ const integration = new bp.Integration({
   channels: {
     channel: {
       messages: {
-        text: async (props) => void (await sendMessage({ ...props, text: props.payload.text })),
+        text: async (props) => void (await sendMessage({ ...props, text: markdownToTwilio(props.payload.text) })),
         image: async (props) => void (await sendMessage({ ...props, mediaUrl: props.payload.imageUrl })),
         audio: async (props) => void (await sendMessage({ ...props, mediaUrl: props.payload.audioUrl })),
         video: async (props) => void (await sendMessage({ ...props, mediaUrl: props.payload.videoUrl })),

--- a/integrations/twilio/src/markdown-to-twilio.test.ts
+++ b/integrations/twilio/src/markdown-to-twilio.test.ts
@@ -1,0 +1,93 @@
+import { test, expect } from 'vitest'
+import { markdownToTwilio } from './markdown-to-twilio'
+
+const mdTests = {
+  Title_1: { input: '# H1', expected: 'H1' },
+  Title_2: { input: '## H2', expected: 'H2' },
+  Title_3: { input: '### H3', expected: 'H3' },
+  Bold_with_asterisk: { input: '**bold-asterisk**', expected: 'bold-asterisk' },
+  Bold_with_underscore: { input: '__bold-underscore__', expected: 'bold-underscore' },
+  Italic_with_asterisk: { input: '*italic-asterisk*', expected: 'italic-asterisk' },
+  Italic_with_underscore: { input: '_italic-underscore_', expected: 'italic-underscore' },
+  Blockquote: { input: '> blockquote', expected: '> blockquote' },
+  Ordered_list: { input: '1. orderedListItem1\n2. item2', expected: '1. orderedListItem1\n2. item2' },
+  Unordered_list: { input: '- unorderedListItem1\n- item2', expected: '- unorderedListItem1\n- item2' },
+  Code: { input: '`code`', expected: 'code' },
+  Horizontal_rule: { input: 'horizontal\n\n---\n\nrule', expected: 'horizontal\n---\nrule' },
+  Link: { input: '[title](https://www.example.com)', expected: '[title](https://www.example.com)' },
+  Image: { input: '![image](https://tinyurl.com/mrv4bmyk)', expected: 'https://tinyurl.com/mrv4bmyk' },
+  Table: { input: '| 1 | 2 |\n| - | - |\n| a | b |', expected: '| 1 | 2 |\n| - | - |\n| a | b |' },
+  Code_snippet: { input: '```\n{\n\ta: null\n}\n```', expected: '{\n\ta: null\n}' },
+  Footnote: { input: 'footnote[^1]\n\n[^1]: the footnote', expected: 'footnote[^1]\n[^1]: the footnote' },
+  Definition: { input: 'term\n: definition', expected: 'term\n: definition' },
+  Strikethrough: { input: '~~strikethrough~~', expected: 'strikethrough' },
+  Task_list: { input: '- [x] taskListItem1\n- [ ] item2', expected: '- [x] taskListItem1\n- [ ] item2' },
+  Emoji_direct: { input: 'emoji direct 😂', expected: 'emoji direct 😂' },
+  // Highlight: { input: '==Highlight==', expected: 'Highlight' }, // chatGPT does not seem to send these
+  Subscript: { input: 'H~2~O', expected: 'H2O' },
+  Superscript: { input: 'X^2^', expected: 'X2' },
+}
+
+test.each(Object.entries(mdTests))(
+  'Test %s',
+  (_testName: string, testValues: { input: string; expected: string }): void => {
+    const actual = markdownToTwilio(testValues.input)
+    expect(actual).toBe(testValues.expected)
+  }
+)
+
+const bigInput = `# H1
+## H2
+### H3
+**bold-asterisk**
+__bold-underscore__
+*italic-asterisk*
+_italic-underscore_
+> blockquote
+1. orderedListItem1\n2. item2
+- unorderedListItem1\n- item2
+\`code\`
+horizontal\n\n---\n\nrule
+[title](https://www.example.com)
+![image](https://tinyurl.com/mrv4bmyk)
+| 1 | 2 |\n| - | - |\n| a | b |
+\`\`\`\n{\n\ta: null\n}\n\`\`\`
+footnote[^1]\n\n[^1]: the footnote
+term\n: definition
+~~strikethrough~~
+- [x] taskListItem1\n- [ ] item2
+emoji direct 😂
+H~2~0
+X^2^`
+
+// the \n in the middle is due to a tag that is added and removed in its own multi-line
+// The code to do this would be more confusing so it will stay that way
+const expectedForBigInput = `H1
+H2
+H3
+bold-asterisk
+bold-underscore
+italic-asterisk
+italic-underscore
+&gt; blockquote
+1. orderedListItem1\n2. item2
+- unorderedListItem1\n- item2
+code
+horizontal\n---\nrule
+[title](https://www.example.com)
+https://tinyurl.com/mrv4bmyk
+| 1 | 2 |\n| - | - |\n| a | b |
+{\n\ta: null\n}
+
+footnote[^1]\n[^1]: the footnote
+term\n: definition
+strikethrough
+- [x] taskListItem1\n- [ ] item2
+emoji direct 😂
+H20
+X2`
+
+test('multi-line multi markup test', () => {
+  const actual = markdownToTwilio(bigInput)
+  expect(actual).toBe(expectedForBigInput)
+})

--- a/integrations/twilio/src/markdown-to-twilio.test.ts
+++ b/integrations/twilio/src/markdown-to-twilio.test.ts
@@ -1,18 +1,15 @@
 import { test, expect } from 'vitest'
-import { markdownToMessenger, markdownToTwilio } from './markdown-to-twilio'
+import { markdownToMessenger, markdownToTwilio, markdownToWhatsApp } from './markdown-to-twilio'
 
 const mdGenericTests = {
   Title_1: { input: '# H1', expected: 'H1' },
   Title_2: { input: '## H2', expected: 'H2' },
   Title_3: { input: '### H3', expected: 'H3' },
-  Blockquote: { input: '> blockquote', expected: 'blockquote' },
   Ordered_list: { input: '1. orderedListItem1\n2. item2', expected: '1. orderedListItem1\n2. item2' },
   Unordered_list: { input: '- unorderedListItem1\n- item2', expected: '- unorderedListItem1\n- item2' },
-  Code: { input: '`code`', expected: 'code' },
   Horizontal_rule: { input: 'horizontal\n\n---\n\nrule', expected: 'horizontal\n---\nrule' },
   Image: { input: '![image](https://tinyurl.com/mrv4bmyk)', expected: 'https://tinyurl.com/mrv4bmyk' },
   Table: { input: '| 1 | 2 |\n| - | - |\n| a | b |', expected: '| 1 | 2 |\n| - | - |\n| a | b |' },
-  Code_snippet: { input: '```\n{\n\ta: null\n}\n```', expected: '{\n\ta: null\n}' },
   Footnote: { input: 'footnote[^1]\n\n[^1]: the footnote', expected: 'footnote[^1]\n[^1]: the footnote' },
   Definition: { input: 'term\n: definition', expected: 'term\n: definition' },
   Task_list: { input: '- [x] taskListItem1\n- [ ] item2', expected: '- [x] taskListItem1\n- [ ] item2' },
@@ -23,6 +20,9 @@ const mdGenericTests = {
 }
 
 const smsSpecificTests = {
+  Blockquote: { input: '> blockquote', expected: 'blockquote' },
+  Code: { input: '`code`', expected: 'code' },
+  Code_snippet: { input: '```\n{\n\ta: null\n}\n```', expected: '{\n\ta: null\n}' },
   Bold_with_asterisk: { input: '**bold-asterisk**', expected: 'bold-asterisk' },
   Bold_with_underscore: { input: '__bold-underscore__', expected: 'bold-underscore' },
   Italic_with_asterisk: { input: '*italic-asterisk*', expected: 'italic-asterisk' },
@@ -33,6 +33,9 @@ const smsSpecificTests = {
 const smsTests = { ...mdGenericTests, ...smsSpecificTests }
 
 const messengerSpecificTests = {
+  Blockquote: { input: '> blockquote', expected: 'blockquote' },
+  Code: { input: '`code`', expected: '`code`' },
+  Code_snippet: { input: '```\n{\n\ta: null\n}\n```', expected: '```\n{\n\ta: null\n}\n```' },
   Bold_with_asterisk: { input: '**bold-asterisk**', expected: '*bold-asterisk*' },
   Bold_with_underscore: { input: '__bold-underscore__', expected: '*bold-underscore*' },
   Italic_with_asterisk: { input: '*italic-asterisk*', expected: '_italic-asterisk_' },
@@ -41,6 +44,19 @@ const messengerSpecificTests = {
   Link: { input: '[title](https://www.example.com)', expected: 'https://www.example.com' },
 }
 const messengerTests = { ...mdGenericTests, ...messengerSpecificTests }
+
+const whatsappSpecificTests = {
+  Blockquote: { input: '> blockquote', expected: '> blockquote' },
+  Code: { input: '`code`', expected: '`code`' },
+  Code_snippet: { input: '```\n{\n\ta: null\n}\n```', expected: '```{\n\ta: null\n}```' },
+  Bold_with_asterisk: { input: '**bold-asterisk**', expected: '*bold-asterisk*' },
+  Bold_with_underscore: { input: '__bold-underscore__', expected: '*bold-underscore*' },
+  Italic_with_asterisk: { input: '*italic-asterisk*', expected: '_italic-asterisk_' },
+  Italic_with_underscore: { input: '_italic-underscore_', expected: '_italic-underscore_' },
+  Strikethrough: { input: '~~strikethrough~~', expected: '~strikethrough~' },
+  Link: { input: '[title](https://www.example.com)', expected: 'https://www.example.com' },
+}
+const whatsappTests = { ...mdGenericTests, ...whatsappSpecificTests }
 
 test.each(Object.entries(smsTests))(
   '[SMS, MMS, RCS] Test %s',
@@ -54,6 +70,14 @@ test.each(Object.entries(messengerTests))(
   '[Messenger] Test %s',
   (_testName: string, testValues: { input: string; expected: string }): void => {
     const actual = markdownToMessenger(testValues.input)
+    expect(actual).toBe(testValues.expected)
+  }
+)
+
+test.each(Object.entries(whatsappTests))(
+  '[WhatsApp] Test %s',
+  (_testName: string, testValues: { input: string; expected: string }): void => {
+    const actual = markdownToWhatsApp(testValues.input)
     expect(actual).toBe(testValues.expected)
   }
 )
@@ -116,12 +140,12 @@ _italic-underscore_
 blockquote
 1. orderedListItem1\n2. item2
 - unorderedListItem1\n- item2
-code
+\`code\`
 horizontal\n---\nrule
 https://www.example.com
 https://tinyurl.com/mrv4bmyk
 | 1 | 2 |\n| - | - |\n| a | b |
-{\n\ta: null\n}
+\`\`\`\n{\n\ta: null\n}\n\`\`\`
 footnote[^1]\n[^1]: the footnote
 term\n: definition
 ~strikethrough~
@@ -130,12 +154,41 @@ emoji direct 😂
 H20
 X2`
 
-test('[SMS, MMS, RCS] multi-line multi markup test', () => {
+const expectedForBigInputWhatsApp = `H1
+H2
+H3
+*bold-asterisk*
+_italic-asterisk_
+*bold-underscore*
+_italic-underscore_
+> blockquote
+1. orderedListItem1\n2. item2
+- unorderedListItem1\n- item2
+\`code\`
+horizontal\n---\nrule
+https://www.example.com
+https://tinyurl.com/mrv4bmyk
+| 1 | 2 |\n| - | - |\n| a | b |
+\`\`\`{\n\ta: null\n}\`\`\`
+footnote[^1]\n[^1]: the footnote
+term\n: definition
+~strikethrough~
+- [x] taskListItem1\n- [ ] item2
+emoji direct 😂
+H20
+X2`
+
+test('[SMS, MMS, RCS] Multi-line multi markup test', () => {
   const actual = markdownToTwilio(bigInput)
   expect(actual).toBe(expectedForBigInputSMS)
 })
 
-test('[Messenger] multi-line multi markup test', () => {
+test('[Messenger] Multi-line multi markup test', () => {
   const actual = markdownToMessenger(bigInput)
   expect(actual).toBe(expectedForBigInputMessenger)
+})
+
+test('[WhatsApp] Multi-line multi markup test', () => {
+  const actual = markdownToWhatsApp(bigInput)
+  expect(actual).toBe(expectedForBigInputWhatsApp)
 })

--- a/integrations/twilio/src/markdown-to-twilio.test.ts
+++ b/integrations/twilio/src/markdown-to-twilio.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import { markdownToMessenger, markdownToTwilio, markdownToWhatsApp } from './markdown-to-twilio'
+import { parseMarkdown } from './markdown-to-twilio'
 
 const mdGenericTests = {
   Title_1: { input: '# H1', expected: 'H1' },
@@ -17,6 +17,7 @@ const mdGenericTests = {
   // Highlight: { input: '==Highlight==', expected: 'Highlight' }, // chatGPT does not seem to send these
   Subscript: { input: 'H~2~O', expected: 'H2O' },
   Superscript: { input: 'X^2^', expected: 'X2' },
+  Link_only: { input: 'https://www.example.com', expected: 'https://www.example.com' },
 }
 
 const smsSpecificTests = {
@@ -61,15 +62,17 @@ const whatsappTests = { ...mdGenericTests, ...whatsappSpecificTests }
 test.each(Object.entries(smsTests))(
   '[SMS, MMS, RCS] Test %s',
   (_testName: string, testValues: { input: string; expected: string }): void => {
-    const actual = markdownToTwilio(testValues.input)
+    const actual = parseMarkdown(testValues.input, 'sms/mms')
+    const actualRcs = parseMarkdown(testValues.input, 'rcs')
     expect(actual).toBe(testValues.expected)
+    expect(actualRcs).toBe(testValues.expected)
   }
 )
 
 test.each(Object.entries(messengerTests))(
   '[Messenger] Test %s',
   (_testName: string, testValues: { input: string; expected: string }): void => {
-    const actual = markdownToMessenger(testValues.input)
+    const actual = parseMarkdown(testValues.input, 'messenger')
     expect(actual).toBe(testValues.expected)
   }
 )
@@ -77,7 +80,7 @@ test.each(Object.entries(messengerTests))(
 test.each(Object.entries(whatsappTests))(
   '[WhatsApp] Test %s',
   (_testName: string, testValues: { input: string; expected: string }): void => {
-    const actual = markdownToWhatsApp(testValues.input)
+    const actual = parseMarkdown(testValues.input, 'whatsapp')
     expect(actual).toBe(testValues.expected)
   }
 )
@@ -179,16 +182,18 @@ H20
 X2`
 
 test('[SMS, MMS, RCS] Multi-line multi markup test', () => {
-  const actual = markdownToTwilio(bigInput)
+  const actual = parseMarkdown(bigInput, 'sms/mms')
+  const actualRcs = parseMarkdown(bigInput, 'rcs')
   expect(actual).toBe(expectedForBigInputSMS)
+  expect(actualRcs).toBe(expectedForBigInputSMS)
 })
 
 test('[Messenger] Multi-line multi markup test', () => {
-  const actual = markdownToMessenger(bigInput)
+  const actual = parseMarkdown(bigInput, 'messenger')
   expect(actual).toBe(expectedForBigInputMessenger)
 })
 
 test('[WhatsApp] Multi-line multi markup test', () => {
-  const actual = markdownToWhatsApp(bigInput)
+  const actual = parseMarkdown(bigInput, 'whatsapp')
   expect(actual).toBe(expectedForBigInputWhatsApp)
 })

--- a/integrations/twilio/src/markdown-to-twilio.test.ts
+++ b/integrations/twilio/src/markdown-to-twilio.test.ts
@@ -1,26 +1,20 @@
 import { test, expect } from 'vitest'
-import { markdownToTwilio } from './markdown-to-twilio'
+import { markdownToMessenger, markdownToTwilio } from './markdown-to-twilio'
 
-const mdTests = {
+const mdGenericTests = {
   Title_1: { input: '# H1', expected: 'H1' },
   Title_2: { input: '## H2', expected: 'H2' },
   Title_3: { input: '### H3', expected: 'H3' },
-  Bold_with_asterisk: { input: '**bold-asterisk**', expected: 'bold-asterisk' },
-  Bold_with_underscore: { input: '__bold-underscore__', expected: 'bold-underscore' },
-  Italic_with_asterisk: { input: '*italic-asterisk*', expected: 'italic-asterisk' },
-  Italic_with_underscore: { input: '_italic-underscore_', expected: 'italic-underscore' },
   Blockquote: { input: '> blockquote', expected: 'blockquote' },
   Ordered_list: { input: '1. orderedListItem1\n2. item2', expected: '1. orderedListItem1\n2. item2' },
   Unordered_list: { input: '- unorderedListItem1\n- item2', expected: '- unorderedListItem1\n- item2' },
   Code: { input: '`code`', expected: 'code' },
   Horizontal_rule: { input: 'horizontal\n\n---\n\nrule', expected: 'horizontal\n---\nrule' },
-  Link: { input: '[title](https://www.example.com)', expected: '[title](https://www.example.com)' },
   Image: { input: '![image](https://tinyurl.com/mrv4bmyk)', expected: 'https://tinyurl.com/mrv4bmyk' },
   Table: { input: '| 1 | 2 |\n| - | - |\n| a | b |', expected: '| 1 | 2 |\n| - | - |\n| a | b |' },
   Code_snippet: { input: '```\n{\n\ta: null\n}\n```', expected: '{\n\ta: null\n}' },
   Footnote: { input: 'footnote[^1]\n\n[^1]: the footnote', expected: 'footnote[^1]\n[^1]: the footnote' },
   Definition: { input: 'term\n: definition', expected: 'term\n: definition' },
-  Strikethrough: { input: '~~strikethrough~~', expected: 'strikethrough' },
   Task_list: { input: '- [x] taskListItem1\n- [ ] item2', expected: '- [x] taskListItem1\n- [ ] item2' },
   Emoji_direct: { input: 'emoji direct 😂', expected: 'emoji direct 😂' },
   // Highlight: { input: '==Highlight==', expected: 'Highlight' }, // chatGPT does not seem to send these
@@ -28,10 +22,38 @@ const mdTests = {
   Superscript: { input: 'X^2^', expected: 'X2' },
 }
 
-test.each(Object.entries(mdTests))(
-  'Test %s',
+const smsSpecificTests = {
+  Bold_with_asterisk: { input: '**bold-asterisk**', expected: 'bold-asterisk' },
+  Bold_with_underscore: { input: '__bold-underscore__', expected: 'bold-underscore' },
+  Italic_with_asterisk: { input: '*italic-asterisk*', expected: 'italic-asterisk' },
+  Italic_with_underscore: { input: '_italic-underscore_', expected: 'italic-underscore' },
+  Strikethrough: { input: '~~strikethrough~~', expected: 'strikethrough' },
+  Link: { input: '[title](https://www.example.com)', expected: '[title](https://www.example.com)' },
+}
+const smsTests = { ...mdGenericTests, ...smsSpecificTests }
+
+const messengerSpecificTests = {
+  Bold_with_asterisk: { input: '**bold-asterisk**', expected: '*bold-asterisk*' },
+  Bold_with_underscore: { input: '__bold-underscore__', expected: '*bold-underscore*' },
+  Italic_with_asterisk: { input: '*italic-asterisk*', expected: '_italic-asterisk_' },
+  Italic_with_underscore: { input: '_italic-underscore_', expected: '_italic-underscore_' },
+  Strikethrough: { input: '~~strikethrough~~', expected: '~strikethrough~' },
+  Link: { input: '[title](https://www.example.com)', expected: 'https://www.example.com' },
+}
+const messengerTests = { ...mdGenericTests, ...messengerSpecificTests }
+
+test.each(Object.entries(smsTests))(
+  '[SMS, MMS, RCS] Test %s',
   (_testName: string, testValues: { input: string; expected: string }): void => {
     const actual = markdownToTwilio(testValues.input)
+    expect(actual).toBe(testValues.expected)
+  }
+)
+
+test.each(Object.entries(messengerTests))(
+  '[Messenger] Test %s',
+  (_testName: string, testValues: { input: string; expected: string }): void => {
+    const actual = markdownToMessenger(testValues.input)
     expect(actual).toBe(testValues.expected)
   }
 )
@@ -40,8 +62,8 @@ const bigInput = `# H1
 ## H2
 ### H3
 **bold-asterisk**
-__bold-underscore__
 *italic-asterisk*
+__bold-underscore__
 _italic-underscore_
 > blockquote
 1. orderedListItem1\n2. item2
@@ -60,14 +82,12 @@ emoji direct 😂
 H~2~0
 X^2^`
 
-// the \n in the middle is due to a tag that is added and removed in its own multi-line
-// The code to do this would be more confusing so it will stay that way
-const expectedForBigInput = `H1
+const expectedForBigInputSMS = `H1
 H2
 H3
 bold-asterisk
-bold-underscore
 italic-asterisk
+bold-underscore
 italic-underscore
 blockquote
 1. orderedListItem1\n2. item2
@@ -86,7 +106,36 @@ emoji direct 😂
 H20
 X2`
 
-test('multi-line multi markup test', () => {
+const expectedForBigInputMessenger = `H1
+H2
+H3
+*bold-asterisk*
+_italic-asterisk_
+*bold-underscore*
+_italic-underscore_
+blockquote
+1. orderedListItem1\n2. item2
+- unorderedListItem1\n- item2
+code
+horizontal\n---\nrule
+https://www.example.com
+https://tinyurl.com/mrv4bmyk
+| 1 | 2 |\n| - | - |\n| a | b |
+{\n\ta: null\n}
+footnote[^1]\n[^1]: the footnote
+term\n: definition
+~strikethrough~
+- [x] taskListItem1\n- [ ] item2
+emoji direct 😂
+H20
+X2`
+
+test('[SMS, MMS, RCS] multi-line multi markup test', () => {
   const actual = markdownToTwilio(bigInput)
-  expect(actual).toBe(expectedForBigInput)
+  expect(actual).toBe(expectedForBigInputSMS)
+})
+
+test('[Messenger] multi-line multi markup test', () => {
+  const actual = markdownToMessenger(bigInput)
+  expect(actual).toBe(expectedForBigInputMessenger)
 })

--- a/integrations/twilio/src/markdown-to-twilio.test.ts
+++ b/integrations/twilio/src/markdown-to-twilio.test.ts
@@ -9,7 +9,7 @@ const mdTests = {
   Bold_with_underscore: { input: '__bold-underscore__', expected: 'bold-underscore' },
   Italic_with_asterisk: { input: '*italic-asterisk*', expected: 'italic-asterisk' },
   Italic_with_underscore: { input: '_italic-underscore_', expected: 'italic-underscore' },
-  Blockquote: { input: '> blockquote', expected: '> blockquote' },
+  Blockquote: { input: '> blockquote', expected: 'blockquote' },
   Ordered_list: { input: '1. orderedListItem1\n2. item2', expected: '1. orderedListItem1\n2. item2' },
   Unordered_list: { input: '- unorderedListItem1\n- item2', expected: '- unorderedListItem1\n- item2' },
   Code: { input: '`code`', expected: 'code' },
@@ -69,7 +69,7 @@ bold-asterisk
 bold-underscore
 italic-asterisk
 italic-underscore
-&gt; blockquote
+blockquote
 1. orderedListItem1\n2. item2
 - unorderedListItem1\n- item2
 code
@@ -78,7 +78,6 @@ horizontal\n---\nrule
 https://tinyurl.com/mrv4bmyk
 | 1 | 2 |\n| - | - |\n| a | b |
 {\n\ta: null\n}
-
 footnote[^1]\n[^1]: the footnote
 term\n: definition
 strikethrough

--- a/integrations/twilio/src/markdown-to-twilio.ts
+++ b/integrations/twilio/src/markdown-to-twilio.ts
@@ -1,0 +1,26 @@
+import MarkdownIt from 'markdown-it'
+// @ts-ignore
+import MarkdownItSub from 'markdown-it-sub'
+// @ts-ignore
+import MarkdownItSup from 'markdown-it-sup'
+
+const md = MarkdownIt({
+  html: false,
+  xhtmlOut: false,
+  breaks: false,
+})
+  .disable(['table', 'list', 'hr', 'link', 'blockquote'])
+  .use(MarkdownItSub)
+  .use(MarkdownItSup)
+
+export const markdownToTwilio = (markdown: string): string => {
+  return _removeHTMLTags(_extractImagesUrl(md.render(markdown))).trim()
+}
+
+const _removeHTMLTags = (input: string): string => {
+  return input.replace(/<[^>]*>/g, '')
+}
+
+const _extractImagesUrl = (input: string): string => {
+  return input.replace('<img src="', '').replace('" alt="image">', '')
+}

--- a/integrations/twilio/src/markdown-to-twilio.ts
+++ b/integrations/twilio/src/markdown-to-twilio.ts
@@ -9,12 +9,12 @@ const md = MarkdownIt({
   xhtmlOut: false,
   breaks: false,
 })
-  .disable(['table', 'list', 'hr', 'link', 'blockquote'])
+  .disable(['table', 'list', 'hr', 'link'])
   .use(MarkdownItSub)
   .use(MarkdownItSup)
 
 export const markdownToTwilio = (markdown: string): string => {
-  return _removeHTMLTags(_extractImagesUrl(md.render(markdown))).trim()
+  return _removeEmptyLinesFromText(_removeHTMLTags(_extractImagesUrl(md.render(markdown))).trim())
 }
 
 const _removeHTMLTags = (input: string): string => {
@@ -23,4 +23,12 @@ const _removeHTMLTags = (input: string): string => {
 
 const _extractImagesUrl = (input: string): string => {
   return input.replace('<img src="', '').replace('" alt="image">', '')
+}
+
+function _isNonEmptyLine(line: string): boolean {
+  return line.trim() !== ''
+}
+
+function _removeEmptyLinesFromText(text: string): string {
+  return text.split('\n').filter(_isNonEmptyLine).join('\n')
 }

--- a/integrations/twilio/src/markdown-to-twilio.ts
+++ b/integrations/twilio/src/markdown-to-twilio.ts
@@ -3,6 +3,7 @@ import MarkdownIt from 'markdown-it'
 import MarkdownItSub from 'markdown-it-sub'
 // @ts-ignore
 import MarkdownItSup from 'markdown-it-sup'
+import { TwilioChannel } from './types'
 
 const md = MarkdownIt({
   html: false,
@@ -13,11 +14,27 @@ const md = MarkdownIt({
   .use(MarkdownItSub)
   .use(MarkdownItSup)
 
-export const markdownToTwilio = (markdown: string): string => {
+export const parseMarkdown = (markdown: string, channel: TwilioChannel): string => {
+  switch (channel) {
+    case 'messenger':
+      return markdownToMessenger(markdown)
+    case 'whatsapp':
+      return markdownToWhatsApp(markdown)
+    case 'rcs':
+      return downRenderMarkdown(markdown)
+    case 'sms/mms':
+      return downRenderMarkdown(markdown)
+    default:
+      channel satisfies never
+      return downRenderMarkdown(markdown)
+  }
+}
+
+const downRenderMarkdown = (markdown: string): string => {
   return _removeEmptyLinesFromText(_removeHTMLTags(_extractImagesUrl(md.render(markdown)))).trim()
 }
 
-export const markdownToMessenger = (markdown: string): string => {
+const markdownToMessenger = (markdown: string): string => {
   const a = markdown
   const b = md.render(a)
   const c = _changeMessengerSpecificTags(b)
@@ -29,7 +46,7 @@ export const markdownToMessenger = (markdown: string): string => {
   return h
 }
 
-export const markdownToWhatsApp = (markdown: string): string => {
+const markdownToWhatsApp = (markdown: string): string => {
   const a = markdown
   const b = md.render(a)
   const c = _changeWhatsAppSpecificTags(b)

--- a/integrations/twilio/src/markdown-to-twilio.ts
+++ b/integrations/twilio/src/markdown-to-twilio.ts
@@ -17,45 +17,33 @@ const md = MarkdownIt({
 export const parseMarkdown = (markdown: string, channel: TwilioChannel): string => {
   switch (channel) {
     case 'messenger':
-      return markdownToMessenger(markdown)
+      return _markdownToMessenger(markdown)
     case 'whatsapp':
-      return markdownToWhatsApp(markdown)
+      return _markdownToWhatsApp(markdown)
     case 'rcs':
-      return downRenderMarkdown(markdown)
+      return _markdownToPlainText(markdown)
     case 'sms/mms':
-      return downRenderMarkdown(markdown)
+      return _markdownToPlainText(markdown)
     default:
       channel satisfies never
-      return downRenderMarkdown(markdown)
+      return _markdownToPlainText(markdown)
   }
 }
 
-const downRenderMarkdown = (markdown: string): string => {
+const _markdownToPlainText = (markdown: string): string => {
   return _removeEmptyLinesFromText(_removeHTMLTags(_extractImagesUrl(md.render(markdown)))).trim()
 }
 
-const markdownToMessenger = (markdown: string): string => {
-  const a = markdown
-  const b = md.render(a)
-  const c = _changeMessengerSpecificTags(b)
-  const d = _extractImagesUrl(c)
-  const e = _extractUrl(d)
-  const f = _removeHTMLTags(e)
-  const g = _removeEmptyLinesFromText(f)
-  const h = g.trim()
-  return h
+const _markdownToMessenger = (markdown: string): string => {
+  return _removeEmptyLinesFromText(
+    _removeHTMLTags(_extractUrl(_extractImagesUrl(_changeMessengerSpecificTags(md.render(markdown)))))
+  ).trim()
 }
 
-const markdownToWhatsApp = (markdown: string): string => {
-  const a = markdown
-  const b = md.render(a)
-  const c = _changeWhatsAppSpecificTags(b)
-  const d = _extractImagesUrl(c)
-  const e = _extractUrl(d)
-  const f = _removeHTMLTags(e)
-  const g = _removeEmptyLinesFromText(f)
-  const h = g.trim()
-  return h
+const _markdownToWhatsApp = (markdown: string): string => {
+  return _removeEmptyLinesFromText(
+    _removeHTMLTags(_extractUrl(_extractImagesUrl(_changeWhatsAppSpecificTags(md.render(markdown)))))
+  ).trim()
 }
 
 const _removeHTMLTags = (input: string): string => {

--- a/integrations/twilio/src/markdown-to-twilio.ts
+++ b/integrations/twilio/src/markdown-to-twilio.ts
@@ -29,31 +29,86 @@ export const markdownToMessenger = (markdown: string): string => {
   return h
 }
 
+export const markdownToWhatsApp = (markdown: string): string => {
+  const a = markdown
+  const b = md.render(a)
+  const c = _changeWhatsAppSpecificTags(b)
+  const d = _extractImagesUrl(c)
+  const e = _extractUrl(d)
+  const f = _removeHTMLTags(e)
+  const g = _removeEmptyLinesFromText(f)
+  const h = g.trim()
+  return h
+}
+
 const _removeHTMLTags = (input: string): string => {
   return input.replace(/<[^>]*>/g, '')
+}
+
+const _extractUrl = (input: string): string => {
+  return input.replace(/\[.*?\]\((https?:\/\/[^)]+)\)/g, '$1')
 }
 
 const _extractImagesUrl = (input: string): string => {
   return input.replace('<img src="', '').replace('" alt="image">', '')
 }
 
-const _isNonEmptyLine = (line: string): boolean => {
-  return line.trim() !== ''
-}
-
 const _removeEmptyLinesFromText = (input: string): string => {
   return input.split('\n').filter(_isNonEmptyLine).join('\n')
 }
 
+const _isNonEmptyLine = (line: string): boolean => {
+  return line.trim() !== ''
+}
+
+// https://www.facebook.com/help/147348452522644
 const _changeMessengerSpecificTags = (input: string): string => {
-  const replaceRecord: Record<string, string> = {
+  const firstPass: Record<string, string> = {
+    '<pre><code>': '```\n',
+    '</code></pre>': '```',
+  }
+  const secondPass: Record<string, string> = {
     '<strong>': '*',
     '</strong>': '*',
     '<em>': '_',
     '</em>': '_',
     '<s>': '~',
     '</s>': '~',
+    '<code>': '`',
+    '</code>': '`',
   }
+
+  let tmp: string
+  tmp = _replaceTagsByValue(input, firstPass)
+  tmp = _replaceTagsByValue(tmp, secondPass)
+  return tmp
+}
+
+// https://faq.whatsapp.com/539178204879377
+const _changeWhatsAppSpecificTags = (input: string): string => {
+  const firstPass: Record<string, string> = {
+    '<pre><code>': '```',
+    '\n</code></pre>': '```',
+  }
+  const secondPass: Record<string, string> = {
+    '<strong>': '*',
+    '</strong>': '*',
+    '<em>': '_',
+    '</em>': '_',
+    '<s>': '~',
+    '</s>': '~',
+    '<code>': '`',
+    '</code>': '`',
+    '<blockquote>\n<p>': '> ',
+  }
+
+  let tmp: string
+  tmp = _replaceTagsByValue(input, firstPass)
+  tmp = _replaceTagsByValue(tmp, secondPass)
+  return tmp
+}
+
+const _replaceTagsByValue = (input: string, replaceRecord: Record<string, string>): string => {
   Object.keys(replaceRecord).forEach((replace) => {
     if (!replaceRecord[replace]) {
       return
@@ -61,8 +116,4 @@ const _changeMessengerSpecificTags = (input: string): string => {
     input = input.replaceAll(replace, replaceRecord[replace])
   })
   return input
-}
-
-const _extractUrl = (input: string): string => {
-  return input.replace(/\[.*?\]\((https?:\/\/[^)]+)\)/g, '$1')
 }

--- a/integrations/twilio/src/markdown-to-twilio.ts
+++ b/integrations/twilio/src/markdown-to-twilio.ts
@@ -14,7 +14,19 @@ const md = MarkdownIt({
   .use(MarkdownItSup)
 
 export const markdownToTwilio = (markdown: string): string => {
-  return _removeEmptyLinesFromText(_removeHTMLTags(_extractImagesUrl(md.render(markdown))).trim())
+  return _removeEmptyLinesFromText(_removeHTMLTags(_extractImagesUrl(md.render(markdown)))).trim()
+}
+
+export const markdownToMessenger = (markdown: string): string => {
+  const a = markdown
+  const b = md.render(a)
+  const c = _changeMessengerSpecificTags(b)
+  const d = _extractImagesUrl(c)
+  const e = _extractUrl(d)
+  const f = _removeHTMLTags(e)
+  const g = _removeEmptyLinesFromText(f)
+  const h = g.trim()
+  return h
 }
 
 const _removeHTMLTags = (input: string): string => {
@@ -25,10 +37,32 @@ const _extractImagesUrl = (input: string): string => {
   return input.replace('<img src="', '').replace('" alt="image">', '')
 }
 
-function _isNonEmptyLine(line: string): boolean {
+const _isNonEmptyLine = (line: string): boolean => {
   return line.trim() !== ''
 }
 
-function _removeEmptyLinesFromText(text: string): string {
-  return text.split('\n').filter(_isNonEmptyLine).join('\n')
+const _removeEmptyLinesFromText = (input: string): string => {
+  return input.split('\n').filter(_isNonEmptyLine).join('\n')
+}
+
+const _changeMessengerSpecificTags = (input: string): string => {
+  const replaceRecord: Record<string, string> = {
+    '<strong>': '*',
+    '</strong>': '*',
+    '<em>': '_',
+    '</em>': '_',
+    '<s>': '~',
+    '</s>': '~',
+  }
+  Object.keys(replaceRecord).forEach((replace) => {
+    if (!replaceRecord[replace]) {
+      return
+    }
+    input = input.replaceAll(replace, replaceRecord[replace])
+  })
+  return input
+}
+
+const _extractUrl = (input: string): string => {
+  return input.replace(/\[.*?\]\((https?:\/\/[^)]+)\)/g, '$1')
 }

--- a/integrations/twilio/src/types.ts
+++ b/integrations/twilio/src/types.ts
@@ -20,3 +20,5 @@ export type MessageDefinition = sdk.MessageDefinition
 export type ActionProps = bp.AnyActionProps
 export type MessageHandlerProps = bp.AnyMessageProps
 export type AckFunction = bp.AnyAckFunction
+
+export type TwilioChannel = 'sms/mms' | 'rcs' | 'whatsapp' | 'messenger'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1674,6 +1674,15 @@ importers:
       axios:
         specifier: ^1.6.0
         version: 1.8.4
+      markdown-it:
+        specifier: ^14.1.0
+        version: 14.1.0
+      markdown-it-sub:
+        specifier: ^2.0.0
+        version: 2.0.0
+      markdown-it-sup:
+        specifier: ^2.0.0
+        version: 2.0.0
       query-string:
         specifier: ^6.14.1
         version: 6.14.1
@@ -1696,6 +1705,9 @@ importers:
       '@sentry/cli':
         specifier: ^2.39.1
         version: 2.39.1
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.1.2
 
   integrations/viber:
     dependencies:
@@ -8749,6 +8761,12 @@ packages:
   map-obj@4.3.0:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
+
+  markdown-it-sub@2.0.0:
+    resolution: {integrity: sha512-iCBKgwCkfQBRg2vApy9vx1C1Tu6D8XYo8NvevI3OlwzBRmiMtsJ2sXupBgEA7PPxiDwNni3qIUkhZ6j5wofDUA==}
+
+  markdown-it-sup@2.0.0:
+    resolution: {integrity: sha512-5VgmdKlkBd8sgXuoDoxMpiU+BiEt3I49GItBzzw7Mxq9CxvnhE/k09HFli09zgfFDRixDQDfDxi0mgBCXtaTvA==}
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
@@ -18774,6 +18792,10 @@ snapshots:
       tmpl: 1.0.5
 
   map-obj@4.3.0: {}
+
+  markdown-it-sub@2.0.0: {}
+
+  markdown-it-sup@2.0.0: {}
 
   markdown-it@14.1.0:
     dependencies:


### PR DESCRIPTION
> Using markdown-it

Resolves SQD-3316
I reworked the Markdown parsing for WhatsApp in Twilio, without using what we have in the WhatsApp integration. This version is a bit simpler, but it doesn’t support nested lists (ordered, unordered, or checklists), since WhatsApp doesn’t support them in general. Markdown lists are left untouched, so their output will remain the same as the input.