### PR TITLE
chore: upgrade zui

### DIFF
--- a/packages/cli/src/code-generation/generators.ts
+++ b/packages/cli/src/code-generation/generators.ts
@@ -8,7 +8,7 @@ import * as consts from './consts'
 export type Primitive = string | number | boolean | null | undefined
 
 export const zuiSchemaToTypeScriptType = async (zuiSchema: sdk.z.Schema, name: string): Promise<string> => {
-  let code = zuiSchema.toTypescriptType()
+  let code = zuiSchema.toTypescriptType({ treatDefaultAsOptional: true })
   code = `export type ${name} = ${code}`
   code = await prettier.format(code, { parser: 'typescript' })
   return [

--- a/packages/cognitive/build.ts
+++ b/packages/cognitive/build.ts
@@ -14,11 +14,11 @@ const common: esbuild.BuildOptions = {
 
 async function generateTypes() {
   const code =
-    `export type GenerateContentInput = ${llm.schemas.GenerateContentInputSchema(z.any()).toTypescriptType()};
+    `export type GenerateContentInput = ${llm.schemas.GenerateContentInputSchema(z.any()).toTypescriptType({ treatDefaultAsOptional: true })};
 
-export type GenerateContentOutput = ${llm.schemas.GenerateContentOutputSchema.toTypescriptType()};
+export type GenerateContentOutput = ${llm.schemas.GenerateContentOutputSchema.toTypescriptType({ treatDefaultAsOptional: true })};
 
-export type Model = ${llm.schemas.ModelSchema.toTypescriptType()};
+export type Model = ${llm.schemas.ModelSchema.toTypescriptType({ treatDefaultAsOptional: true })};
 `.trim()
 
   const filePath = './src/schemas.gen.ts'

--- a/packages/cognitive/package.json
+++ b/packages/cognitive/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@botpress/client": "workspace:*",
     "@botpress/common": "workspace:*",
-    "@bpinternal/zui": "^1.0.1",
+    "@bpinternal/zui": "1.2.1",
     "@size-limit/file": "^11.1.6",
     "@types/axios": "^0.14.4",
     "@types/debug": "^4.1.12",

--- a/packages/cognitive/src/schemas.gen.ts
+++ b/packages/cognitive/src/schemas.gen.ts
@@ -31,7 +31,7 @@ export type GenerateContentInput = {
           type: 'text' | 'image'
           /** Indicates the MIME type of the content. If not provided it will be detected from the content-type header of the provided URL. */
           mimeType?: string
-          /** Required if part type is "text"  */
+          /** Required if part type is "text" */
           text?: string
           /** Required if part type is "image" */
           url?: string
@@ -103,7 +103,7 @@ export type GenerateContentOutput = {
           type: 'text' | 'image'
           /** Indicates the MIME type of the content. If not provided it will be detected from the content-type header of the provided URL. */
           mimeType?: string
-          /** Required if part type is "text"  */
+          /** Required if part type is "text" */
           text?: string
           /** Required if part type is "image" */
           url?: string

--- a/packages/llmz/examples/package.json
+++ b/packages/llmz/examples/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@botpress/client": "workspace:^",
     "@botpress/zai": "^2.0.8",
-    "@bpinternal/zui": "^1.0.1",
+    "@bpinternal/zui": "1.2.1",
     "chalk": "^4.1.2",
     "llmz": "link:..",
     "lodash": "^4.17.21",

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -72,7 +72,7 @@
     "@botpress/client": "1.26.0",
     "@botpress/cognitive": "0.1.47",
     "@bpinternal/thicktoken": "^1.0.5",
-    "@bpinternal/zui": "^1.0.1"
+    "@bpinternal/zui": "1.2.1"
   },
   "dependenciesMeta": {
     "@bpinternal/zui": {

--- a/packages/llmz/src/prompts/dual-modes.ts
+++ b/packages/llmz/src/prompts/dual-modes.ts
@@ -71,7 +71,7 @@ const getSystemMessage: Prompt['getSystemMessage'] = async (props) => {
         name: exit.name,
         description: exit.description,
         has_typings: true,
-        typings: exit.zSchema.toTypescriptType(),
+        typings: exit.zSchema.toTypescriptType({ treatDefaultAsOptional: true }),
       })
     } else {
       exits.push({

--- a/packages/llmz/src/typings.ts
+++ b/packages/llmz/src/typings.ts
@@ -299,7 +299,7 @@ ${typeof schema.value === 'string' ? escapeString(schema.value) : schema.value}`
   }
 
   try {
-    let typings = schema?.toTypescriptType()
+    let typings = schema?.toTypescriptType({ treatDefaultAsOptional: true })
     typings ??= 'unknown'
 
     return stripSpaces(typings)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -28,7 +28,7 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "@bpinternal/zui": "^1.0.1",
+    "@bpinternal/zui": "1.2.1",
     "esbuild": "^0.16.12"
   },
   "peerDependenciesMeta": {

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -41,7 +41,7 @@
   "peerDependencies": {
     "@botpress/client": "1.26.0",
     "@bpinternal/thicktoken": "^1.0.1",
-    "@bpinternal/zui": "^1.0.1",
+    "@bpinternal/zui": "1.2.1",
     "lodash": "^4.17.21",
     "vitest": "^2 || ^3 || ^4 || ^5"
   },

--- a/packages/vai/src/utils/predictJson.ts
+++ b/packages/vai/src/utils/predictJson.ts
@@ -84,7 +84,7 @@ ${options.systemMessage}
 ---
 Please generate a JSON response with the following format:
 \`\`\`typescript
-${outputSchema.toTypescriptType()}
+${outputSchema.toTypescriptType({ treatDefaultAsOptional: true })}
 \`\`\`
 `.trim(),
       messages: [

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "@bpinternal/thicktoken": "^1.0.0",
-    "@bpinternal/zui": "^1.0.1"
+    "@bpinternal/zui": "1.2.1"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/zai/src/operations/extract.ts
+++ b/packages/zai/src/operations/extract.ts
@@ -100,7 +100,7 @@ const extract = async <S extends OfType<AnyObjectOrArray>>(
     } catch {}
   }
 
-  const schemaTypescript = schema.toTypescriptType({ declaration: false })
+  const schemaTypescript = schema.toTypescriptType({ declaration: false, treatDefaultAsOptional: true })
   const schemaLength = tokenizer.count(schemaTypescript)
 
   options.chunkLength = Math.min(options.chunkLength, model.input.maxTokens - PROMPT_INPUT_BUFFER - schemaLength)

--- a/plugins/knowledge/src/question-prompt.ts
+++ b/plugins/knowledge/src/question-prompt.ts
@@ -98,7 +98,7 @@ Questions should be extracted with the following JSON format:
 If there are no questions in the USER MESSAGE, return an empty array.
 
 Always respond in JSON with the following format:
-type OutputFormat = ${ExtractedQuestion.toTypescriptType()}
+type OutputFormat = ${ExtractedQuestion.toTypescriptType({ treatDefaultAsOptional: true })}
 
 The below examples are for illustrative purposes only. Your responses will be evaluated based on the quality of the questions extracted.
 Please extract the questions found on line L${args.line} only. If there are no questions, return an empty array.

--- a/plugins/personality/src/rewrite-prompt.ts
+++ b/plugins/personality/src/rewrite-prompt.ts
@@ -31,7 +31,7 @@ const userPrompt = (args: PromptArgs): string => dedent`
 { "payload": ${args.payload} }
 \`\`\`
 
-type OutputFormat = ${responseSchema.toTypescriptType()}
+type OutputFormat = ${responseSchema.toTypescriptType({ treatDefaultAsOptional: true })}
 `
 
 export const prompt = (args: PromptArgs): LLMInput => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2449,8 +2449,8 @@ importers:
         specifier: workspace:*
         version: link:../common
       '@bpinternal/zui':
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: 1.2.1
+        version: 1.2.1
       '@size-limit/file':
         specifier: ^11.1.6
         version: 11.1.6(size-limit@11.1.6)
@@ -2536,8 +2536,8 @@ importers:
         specifier: ^1.0.5
         version: 1.0.5
       '@bpinternal/zui':
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: 1.2.1
+        version: 1.2.1
       bytes:
         specifier: ^3.1.2
         version: 3.1.2
@@ -2633,8 +2633,8 @@ importers:
         specifier: 1.26.0
         version: link:../client
       '@bpinternal/zui':
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: 1.2.1
+        version: 1.2.1
       browser-or-node:
         specifier: ^2.1.1
         version: 2.1.1
@@ -2667,8 +2667,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.2
       '@bpinternal/zui':
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: 1.2.1
+        version: 1.2.1
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -2710,8 +2710,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.2
       '@bpinternal/zui':
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: 1.2.1
+        version: 1.2.1
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -3699,8 +3699,8 @@ packages:
   '@bpinternal/yargs-extra@0.0.3':
     resolution: {integrity: sha512-e/unlq0LX4CJUv1jGOv1UgwB/h2M0NCXnwD4lEw496GpkQikO668RS+BBlRhkqdGfZmvKDkXZZ96xJCn+i6Ymg==}
 
-  '@bpinternal/zui@1.0.1':
-    resolution: {integrity: sha512-uIT0BwsPXkjP9PbBnN0i4Yvk5tKaR69U3yVDsTW0QwoUbNXKcLCGXGjffZWy+wZ2O1qOXBmdlgXUGUUIJkMgEg==}
+  '@bpinternal/zui@1.2.1':
+    resolution: {integrity: sha512-zx5/IXu6OBwDlAyfQcm2PctBweMxrKYhGZno/dh7hKinyKK8wJKNbOD/weDLG0RDpvffekv/Nxyx240wTLmY4Q==}
     engines: {node: '>=16.0.0', pnpm: 8.6.2}
 
   '@colors/colors@1.6.0':
@@ -12685,7 +12685,7 @@ snapshots:
       yargs: 17.7.2
       yn: 4.0.0
 
-  '@bpinternal/zui@1.0.1': {}
+  '@bpinternal/zui@1.2.1': {}
 
   '@colors/colors@1.6.0': {}
 


### PR DESCRIPTION
Upgrading from zui `1.0.1` to `1.2.1`

zui changes:
- [1.0.2](https://github.com/botpress/packages/pull/628)
- [1.0.3](https://github.com/botpress/packages/pull/629)
- [1.1.0](https://github.com/botpress/packages/pull/632) --> this one drastically changed transformers behavior
- [1.1.1](https://github.com/botpress/packages/pull/639)
- [1.2.0](https://github.com/botpress/packages/pull/643) --> this one allows bypassing the behavior changes of `1.1.0`
- [1.2.1](https://github.com/botpress/packages/pull/644) --> this one fixes behavior changes from `1.1.0`

It took me a while to ensure we could upgrade ZUI to the latest version with no breaking changes

**I'll bump all relevant package versions in another PR to prevent obfuscating this one**