### PR TITLE
feat(integrations/workable): new webhooks for creating and moving candidates

### DIFF
--- a/integrations/workable/definitions/events/candidates.ts
+++ b/integrations/workable/definitions/events/candidates.ts
@@ -6,7 +6,7 @@ export const eventTypes = z.enum(['candidate_created', 'candidate_moved'])
 
 export const candidateCreatedSchema = webhookEvent
   .extend({
-    data: candidateSchema,
+    data: candidateSchema.title('Data').describe('The candidate that was created'),
     eventType: z.literal(eventTypes.Enum.candidate_created).title('Event Type').describe('The type of event'),
   })
   .title('Data')
@@ -14,7 +14,7 @@ export const candidateCreatedSchema = webhookEvent
 
 export const candidateMovedSchema = webhookEvent
   .extend({
-    data: candidateSchema,
+    data: candidateSchema.title('Data').describe('The candidate that was moved'),
     eventType: z.literal(eventTypes.Enum.candidate_moved).title('Event Type').describe('The type of event'),
   })
   .title('Data')

--- a/integrations/workable/definitions/events/candidates.ts
+++ b/integrations/workable/definitions/events/candidates.ts
@@ -1,0 +1,31 @@
+import { EventDefinition, z } from '@botpress/sdk'
+import { candidateSchema } from 'definitions/models/candidates'
+import { webhookEvent } from './common'
+
+export const candidateCreatedSchema = webhookEvent
+  .extend({
+    data: candidateSchema,
+    eventType: z.literal('candidate_created').title('Event Type').describe('The type of event'),
+  })
+  .title('Data')
+  .describe('Event data')
+
+export const candidateMovedSchema = webhookEvent
+  .extend({
+    data: candidateSchema,
+    eventType: z.literal('candidate_moved').title('Event Type').describe('The type of event'),
+  })
+  .title('Data')
+  .describe('Event data')
+
+export const candidateCreated = {
+  title: 'Candidate Created',
+  description: 'A candidate was created on a job.',
+  schema: candidateCreatedSchema,
+} satisfies EventDefinition
+
+export const candidateMoved = {
+  title: 'Candidate Moved',
+  description: 'A candidate was moved on a job.',
+  schema: candidateMovedSchema,
+} satisfies EventDefinition

--- a/integrations/workable/definitions/events/candidates.ts
+++ b/integrations/workable/definitions/events/candidates.ts
@@ -15,7 +15,7 @@ export const candidateCreatedSchema = webhookEvent
 export const candidateMovedSchema = webhookEvent
   .extend({
     data: candidateSchema,
-    eventType: z.literal(eventTypes.Enum.candidate_created).title('Event Type').describe('The type of event'),
+    eventType: z.literal(eventTypes.Enum.candidate_moved).title('Event Type').describe('The type of event'),
   })
   .title('Data')
   .describe('Event data')

--- a/integrations/workable/definitions/events/candidates.ts
+++ b/integrations/workable/definitions/events/candidates.ts
@@ -2,10 +2,12 @@ import { EventDefinition, z } from '@botpress/sdk'
 import { candidateSchema } from 'definitions/models/candidates'
 import { webhookEvent } from './common'
 
+export const eventTypes = z.enum(['candidate_created', 'candidate_moved'])
+
 export const candidateCreatedSchema = webhookEvent
   .extend({
     data: candidateSchema,
-    eventType: z.literal('candidate_created').title('Event Type').describe('The type of event'),
+    eventType: z.literal(eventTypes.Enum.candidate_created).title('Event Type').describe('The type of event'),
   })
   .title('Data')
   .describe('Event data')
@@ -13,7 +15,7 @@ export const candidateCreatedSchema = webhookEvent
 export const candidateMovedSchema = webhookEvent
   .extend({
     data: candidateSchema,
-    eventType: z.literal('candidate_moved').title('Event Type').describe('The type of event'),
+    eventType: z.literal(eventTypes.Enum.candidate_created).title('Event Type').describe('The type of event'),
   })
   .title('Data')
   .describe('Event data')

--- a/integrations/workable/definitions/events/common.ts
+++ b/integrations/workable/definitions/events/common.ts
@@ -1,0 +1,7 @@
+import { z } from '@botpress/sdk'
+
+export const webhookEvent = z.object({
+  firedAt: z.string().title('Fired At').describe('The date and time the event was triggered'),
+  id: z.string().title('Id').describe('The event identifier'),
+  resourceType: z.string().title('Resource Type').describe('The type of the payload resource'),
+})

--- a/integrations/workable/integration.definition.ts
+++ b/integrations/workable/integration.definition.ts
@@ -1,6 +1,6 @@
 import { z, IntegrationDefinition } from '@botpress/sdk'
 import { getCandidate, listCandidates } from 'definitions/actions/candidates'
-import { candidateCreated, candidateMoved } from 'definitions/events/candidates'
+import { candidateCreated, candidateMoved, eventTypes } from 'definitions/events/candidates'
 
 export default new IntegrationDefinition({
   name: 'workable',
@@ -24,10 +24,19 @@ export default new IntegrationDefinition({
     }),
   },
   states: {
-    webhookIds: {
+    webhooks: {
       type: 'integration',
       schema: z.object({
-        ids: z.array(z.number()).title('IDs').describe('The IDs of the registered webhooks'),
+        webhooks: z
+          .array(
+            z.object({
+              id: z.number().title('ID').describe('The ID of the webhook'),
+              url: z.string().title('Url').describe('The url of the webhook'),
+              eventType: eventTypes.title('Event Type').describe('The event type of the webhook'),
+            })
+          )
+          .title('Webhooks')
+          .describe('The registered webhooks'),
       }),
     },
   },

--- a/integrations/workable/integration.definition.ts
+++ b/integrations/workable/integration.definition.ts
@@ -23,6 +23,14 @@ export default new IntegrationDefinition({
         .title('Account subdomain'),
     }),
   },
+  states: {
+    webhookIds: {
+      type: 'integration',
+      schema: z.object({
+        ids: z.array(z.number()),
+      }),
+    },
+  },
   actions: {
     listCandidates,
     getCandidate,

--- a/integrations/workable/integration.definition.ts
+++ b/integrations/workable/integration.definition.ts
@@ -1,5 +1,6 @@
 import { z, IntegrationDefinition } from '@botpress/sdk'
 import { getCandidate, listCandidates } from 'definitions/actions/candidates'
+import { candidateCreated, candidateMoved } from 'definitions/events/candidates'
 
 export default new IntegrationDefinition({
   name: 'workable',
@@ -25,5 +26,9 @@ export default new IntegrationDefinition({
   actions: {
     listCandidates,
     getCandidate,
+  },
+  events: {
+    candidateCreated,
+    candidateMoved,
   },
 })

--- a/integrations/workable/integration.definition.ts
+++ b/integrations/workable/integration.definition.ts
@@ -1,6 +1,6 @@
 import { z, IntegrationDefinition } from '@botpress/sdk'
 import { getCandidate, listCandidates } from 'definitions/actions/candidates'
-import { candidateCreated, candidateMoved, eventTypes } from 'definitions/events/candidates'
+import { candidateCreated, candidateMoved } from 'definitions/events/candidates'
 
 export default new IntegrationDefinition({
   name: 'workable',
@@ -27,16 +27,7 @@ export default new IntegrationDefinition({
     webhooks: {
       type: 'integration',
       schema: z.object({
-        webhooks: z
-          .array(
-            z.object({
-              id: z.number().title('ID').describe('The ID of the webhook'),
-              url: z.string().title('Url').describe('The url of the webhook'),
-              eventType: eventTypes.title('Event Type').describe('The event type of the webhook'),
-            })
-          )
-          .title('Webhooks')
-          .describe('The registered webhooks'),
+        ids: z.array(z.number()).title('ID').describe('The ID of the webhook'),
       }),
     },
   },

--- a/integrations/workable/integration.definition.ts
+++ b/integrations/workable/integration.definition.ts
@@ -27,7 +27,7 @@ export default new IntegrationDefinition({
     webhookIds: {
       type: 'integration',
       schema: z.object({
-        ids: z.array(z.number()),
+        ids: z.array(z.number()).title('IDs').describe('The IDs of the registered webhooks'),
       }),
     },
   },

--- a/integrations/workable/package.json
+++ b/integrations/workable/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "4.16.0"
+    "@botpress/sdk": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/integrations/workable/src/handler.ts
+++ b/integrations/workable/src/handler.ts
@@ -1,9 +1,9 @@
 import { Request, z } from '@botpress/sdk'
 import crypto from 'crypto'
+import { eventTypes } from 'definitions/events/candidates'
 import { toCandidateCreatedEventModel, toCandidateMovedEventModel } from './mapping/candidate-mapper'
 import { webhookRequestSchema } from './workable-schemas/events'
 import * as bp from '.botpress'
-import { eventTypes } from 'definitions/events/candidates'
 
 const isEventTypeHandled = (request: z.infer<typeof webhookRequestSchema>) => {
   return eventTypes.options.includes(request.event_type)

--- a/integrations/workable/src/handler.ts
+++ b/integrations/workable/src/handler.ts
@@ -1,0 +1,60 @@
+import { z } from '@botpress/sdk'
+import { toCandidateCreatedEventModel, toCandidateMovedEventModel } from './mapping/candidate-mapper'
+import { webhookRequestSchema } from './workable-schemas/events'
+import * as bp from '.botpress'
+
+const isEventTypeHandled = (request: z.infer<typeof webhookRequestSchema>) => {
+  const topics: string[] = webhookRequestSchema.options.map((option) => option.shape.event_type.value)
+  return topics.includes(request.event_type)
+}
+
+export const handler: bp.IntegrationProps['handler'] = async (props) => {
+  if (!props.req.body) {
+    props.logger.error('Handler received an empty body')
+    return
+  }
+
+  let json: unknown | null = null
+  try {
+    json = JSON.parse(props.req.body)
+  } catch {
+    props.logger.error('Failed to parse request body as JSON')
+    return
+  }
+
+  const webhookInfoResult = webhookRequestSchema.safeParse(json)
+
+  if (!webhookInfoResult.success) {
+    props.logger.error(`Failed to validate request body: ${webhookInfoResult.error.message}`)
+    return
+  }
+
+  if (!isEventTypeHandled(webhookInfoResult.data)) {
+    props.logger.forBot().info(`Event ${webhookInfoResult.data} filtered out`)
+    return
+  }
+
+  const { success, error, data: webhookRequestPayload } = webhookRequestSchema.safeParse(json)
+
+  if (!success) {
+    props.logger.error(`Failed to validate request body: ${error.message}`)
+    return
+  }
+
+  switch (webhookRequestPayload.event_type) {
+    case 'candidate_created':
+      await props.client.createEvent({
+        type: 'candidateCreated',
+        payload: toCandidateCreatedEventModel(webhookRequestPayload),
+      })
+      break
+    case 'candidate_moved':
+      await props.client.createEvent({
+        type: 'candidateMoved',
+        payload: toCandidateMovedEventModel(webhookRequestPayload),
+      })
+      break
+    default:
+      break
+  }
+}

--- a/integrations/workable/src/handler.ts
+++ b/integrations/workable/src/handler.ts
@@ -49,12 +49,12 @@ const _verifyWebhookSignature = (encryptionKey: string, request: Request): Verif
 export const handler: bp.IntegrationProps['handler'] = async (props) => {
   const { isSignatureValid, signatureError } = _verifyWebhookSignature(props.ctx.configuration.apiToken, props.req)
   if (!isSignatureValid) {
-    props.logger.error(`Webhook Signature Verification: ${signatureError}`)
+    props.logger.forBot().error(`Webhook Signature Verification: ${signatureError}`)
     return
   }
 
   if (!props.req.body) {
-    props.logger.error('Handler received an empty body')
+    props.logger.forBot().error('Handler received an empty body')
     return
   }
 
@@ -62,14 +62,14 @@ export const handler: bp.IntegrationProps['handler'] = async (props) => {
   try {
     json = JSON.parse(props.req.body)
   } catch {
-    props.logger.error('Failed to parse request body as JSON')
+    props.logger.forBot().error('Failed to parse request body as JSON')
     return
   }
 
   const webhookInfoResult = webhookRequestSchema.safeParse(json)
 
   if (!webhookInfoResult.success) {
-    props.logger.error(`Failed to validate request body: ${webhookInfoResult.error.message}`)
+    props.logger.forBot().error(`Failed to validate request body: ${webhookInfoResult.error.message}`)
     return
   }
 
@@ -81,7 +81,7 @@ export const handler: bp.IntegrationProps['handler'] = async (props) => {
   const { success, error, data: webhookRequestPayload } = webhookRequestSchema.safeParse(json)
 
   if (!success) {
-    props.logger.error(`Failed to validate request body: ${error.message}`)
+    props.logger.forBot().error(`Failed to validate request body: ${error.message}`)
     return
   }
 

--- a/integrations/workable/src/handler.ts
+++ b/integrations/workable/src/handler.ts
@@ -3,10 +3,10 @@ import crypto from 'crypto'
 import { toCandidateCreatedEventModel, toCandidateMovedEventModel } from './mapping/candidate-mapper'
 import { webhookRequestSchema } from './workable-schemas/events'
 import * as bp from '.botpress'
+import { eventTypes } from 'definitions/events/candidates'
 
 const isEventTypeHandled = (request: z.infer<typeof webhookRequestSchema>) => {
-  const topics: string[] = webhookRequestSchema.options.map((option) => option.shape.event_type.value)
-  return topics.includes(request.event_type)
+  return eventTypes.options.includes(request.event_type)
 }
 
 type VerifyWebhookSignatureReturn =

--- a/integrations/workable/src/index.ts
+++ b/integrations/workable/src/index.ts
@@ -17,6 +17,8 @@ async function _registerWebhook(
   subDomain: string
 ): Promise<number> {
   const response = await client.registerWebhook({
+    // The query param is a workaround to enable registering the same url for each event.
+    // The Workable API will not allow registering the same url twice, even for different events.
     target: `${url}?event_type=${eventType}`,
     event: eventType,
     args: {

--- a/integrations/workable/src/index.ts
+++ b/integrations/workable/src/index.ts
@@ -79,13 +79,17 @@ export default new bp.Integration({
     })
     const client = new WorkableClient(props.ctx.configuration.apiToken, props.ctx.configuration.subDomain)
 
-    try {
-      for (const webhook of webhooksIds.state.payload.webhooks) {
+    const errors: string[] = []
+
+    for (const webhook of webhooksIds.state.payload.webhooks) {
+      try {
         await client.unregisterWebhook(webhook.id)
+      } catch (thrown) {
+        errors.push(thrown instanceof Error ? thrown.message : String(thrown))
       }
-    } catch (thrown) {
-      const msg = thrown instanceof Error ? thrown.message : String(thrown)
-      throw new RuntimeError(`Failed to unregister the integration: ${msg}`)
+    }
+    if (errors.length > 0) {
+      throw new RuntimeError(`Failed to unregister the integration: ${errors.join(', ')}`)
     }
   },
   actions: {

--- a/integrations/workable/src/index.ts
+++ b/integrations/workable/src/index.ts
@@ -48,7 +48,10 @@ export default new bp.Integration({
       })
 
       for (const id of ids) {
-        await client.unregisterWebhook(id)
+        await client.unregisterWebhook(id).catch((thrown) => {
+          const msg = thrown instanceof Error ? thrown.message : String(thrown)
+          props.logger.forBot().warn(`Failed to unregister webhook: ${msg}`)
+        })
       }
 
       const newIds: number[] = []

--- a/integrations/workable/src/index.ts
+++ b/integrations/workable/src/index.ts
@@ -1,4 +1,4 @@
-import { RuntimeError } from '@botpress/sdk'
+import { RuntimeError, z } from '@botpress/sdk'
 import { handler } from './handler'
 import {
   fromGetCandidateInputModel,
@@ -7,19 +7,75 @@ import {
   toListCandidatesOutputModel,
 } from './mapping/candidate-mapper'
 import { WorkableClient } from './workable-api/client'
+import { eventTypes } from './workable-schemas/events'
 import * as bp from '.botpress'
+
+async function _registerWebhook(
+  client: WorkableClient,
+  url: string,
+  eventType: z.infer<typeof eventTypes>,
+  subDomain: string
+): Promise<number> {
+  const response = await client.registerWebhook({
+    target: `${url}?event_type=${eventType}`,
+    event: eventType,
+    args: {
+      account_id: subDomain,
+      job_shortcode: '',
+      stage_slug: '',
+    },
+  })
+  return response.id
+}
 
 export default new bp.Integration({
   register: async (props) => {
     const client = new WorkableClient(props.ctx.configuration.apiToken, props.ctx.configuration.subDomain)
     try {
-      await client.listCandidates()
+      const webhooks = await client.getWebhooks()
+      for (const webhook of webhooks.subscriptions) {
+        if (webhook.target.includes(props.webhookUrl)) {
+          await client.unregisterWebhook(webhook.id)
+        }
+      }
+
+      const ids: number[] = []
+
+      for (const eventType of eventTypes.options) {
+        const id = await _registerWebhook(client, props.webhookUrl, eventType, props.ctx.configuration.subDomain)
+        ids.push(id)
+      }
+
+      await props.client.setState({
+        id: props.ctx.integrationId,
+        name: 'webhookIds',
+        type: 'integration',
+        payload: {
+          ids,
+        },
+      })
     } catch (thrown) {
       const msg = thrown instanceof Error ? thrown.message : String(thrown)
       throw new RuntimeError(`Failed to register the integration: ${msg}`)
     }
   },
-  unregister: async () => {},
+  unregister: async (props) => {
+    const webhooksIds = await props.client.getState({
+      name: 'webhookIds',
+      id: props.ctx.integrationId,
+      type: 'integration',
+    })
+    const client = new WorkableClient(props.ctx.configuration.apiToken, props.ctx.configuration.subDomain)
+
+    try {
+      for (const id of webhooksIds.state.payload.ids) {
+        await client.unregisterWebhook(id)
+      }
+    } catch (thrown) {
+      const msg = thrown instanceof Error ? thrown.message : String(thrown)
+      throw new RuntimeError(`Failed to unregister the integration: ${msg}`)
+    }
+  },
   actions: {
     listCandidates: async (props) => {
       const client = new WorkableClient(props.ctx.configuration.apiToken, props.ctx.configuration.subDomain)

--- a/integrations/workable/src/index.ts
+++ b/integrations/workable/src/index.ts
@@ -1,4 +1,5 @@
 import { RuntimeError, z } from '@botpress/sdk'
+import { eventTypes } from 'definitions/events/candidates'
 import { handler } from './handler'
 import {
   fromGetCandidateInputModel,
@@ -7,7 +8,6 @@ import {
   toListCandidatesOutputModel,
 } from './mapping/candidate-mapper'
 import { WorkableClient } from './workable-api/client'
-import { eventTypes } from './workable-schemas/events'
 import * as bp from '.botpress'
 
 async function _registerWebhook(

--- a/integrations/workable/src/index.ts
+++ b/integrations/workable/src/index.ts
@@ -1,4 +1,5 @@
 import { RuntimeError } from '@botpress/sdk'
+import { handler } from './handler'
 import {
   fromGetCandidateInputModel,
   fromListCandidatesInputModel,
@@ -44,5 +45,5 @@ export default new bp.Integration({
     },
   },
   channels: {},
-  handler: async () => {},
+  handler,
 })

--- a/integrations/workable/src/index.ts
+++ b/integrations/workable/src/index.ts
@@ -34,7 +34,11 @@ export default new bp.Integration({
   register: async (props) => {
     const client = new WorkableClient(props.ctx.configuration.apiToken, props.ctx.configuration.subDomain)
     try {
-      const webhooks = await props.client.getOrSetState({
+      const {
+        state: {
+          payload: { webhooks },
+        },
+      } = await props.client.getOrSetState({
         id: props.ctx.integrationId,
         name: 'webhooks',
         type: 'integration',
@@ -45,13 +49,13 @@ export default new bp.Integration({
 
       let eventsToRegister = Array.from(eventTypes.options)
 
-      for (const webhook of webhooks.state.payload.webhooks) {
+      for (const webhook of webhooks) {
         if (webhook.url.includes(props.webhookUrl) && eventsToRegister.includes(webhook.eventType)) {
           eventsToRegister = eventsToRegister.filter((event) => event !== webhook.eventType)
         }
       }
 
-      const newWebhooks = webhooks.state.payload.webhooks
+      const newWebhooks = webhooks
 
       for (const eventType of eventsToRegister) {
         const id = await _registerWebhook(client, props.webhookUrl, eventType, props.ctx.configuration.subDomain)

--- a/integrations/workable/src/index.ts
+++ b/integrations/workable/src/index.ts
@@ -17,8 +17,8 @@ async function _registerWebhook(
   subDomain: string
 ): Promise<number> {
   const response = await client.registerWebhook({
-    // The query param is a workaround to enable registering the same url for each event.
-    // The Workable API will not allow registering the same url twice, even for different events.
+    // The query param is a workaround to allow registering the same url for each event.
+    // The Workable API will not allow registering the same url string twice, even for different events.
     target: `${url}?event_type=${eventType}`,
     event: eventType,
     args: {

--- a/integrations/workable/src/mapping/candidate-mapper.ts
+++ b/integrations/workable/src/mapping/candidate-mapper.ts
@@ -1,6 +1,8 @@
 import { z } from '@botpress/sdk'
+import * as defEvents from 'definitions/events/candidates'
 import * as def from 'definitions/models/candidates'
 import * as workable from 'src/workable-schemas/candidates'
+import * as workableEvents from 'src/workable-schemas/events'
 import { parseNextToken } from './pagination'
 
 export function fromListCandidatesInputModel(
@@ -158,5 +160,33 @@ export function toGetCandidateModel(
 ): z.infer<typeof def.getCandidateOutputSchema> {
   return {
     candidate: schema.candidate === undefined ? undefined : toDetailedCandidateModel(schema.candidate),
+  }
+}
+
+export function toCandidateCreatedEventModel(
+  schema: z.infer<typeof workableEvents.candidateCreatedSchema>
+): z.infer<typeof defEvents.candidateCreatedSchema> {
+  const candidateModel = toDetailedCandidateModel(schema.data)
+  const { event_type, fired_at, resource_type, ...rest } = schema
+  return {
+    ...rest,
+    eventType: event_type,
+    firedAt: fired_at,
+    resourceType: resource_type,
+    data: candidateModel,
+  }
+}
+
+export function toCandidateMovedEventModel(
+  schema: z.infer<typeof workableEvents.candidateMovedSchema>
+): z.infer<typeof defEvents.candidateMovedSchema> {
+  const candidateModel = toDetailedCandidateModel(schema.data)
+  const { event_type, fired_at, resource_type, ...rest } = schema
+  return {
+    ...rest,
+    eventType: event_type,
+    firedAt: fired_at,
+    resourceType: resource_type,
+    data: candidateModel,
   }
 }

--- a/integrations/workable/src/workable-api/client.ts
+++ b/integrations/workable/src/workable-api/client.ts
@@ -6,6 +6,11 @@ import {
   listCandidatesInputSchema,
   listCandidatesOutputSchema,
 } from 'src/workable-schemas/candidates'
+import {
+  getWebhooksOutputSchema,
+  registerWebhookInputSchema,
+  registerWebhookOutputSchema,
+} from 'src/workable-schemas/events'
 
 export type ErrorResponse = {
   error: string | undefined
@@ -38,6 +43,28 @@ export class WorkableClient {
       throw new Error(thrown.response?.data?.message || thrown.message)
     }
     throw thrown
+  }
+
+  public async unregisterWebhook(id: number): Promise<void> {
+    await this._client.delete(`/subscriptions/${id}`).catch(this._handleAxiosError)
+  }
+
+  public async registerWebhook(
+    params: z.infer<typeof registerWebhookInputSchema>
+  ): Promise<z.infer<typeof registerWebhookOutputSchema>> {
+    const response: AxiosResponse<z.infer<typeof registerWebhookOutputSchema>> = await this._client
+      // The query param is a workaround to enable registering the same url for each event.
+      // The Workable API will not allow registering the same url twice, even for different events.
+      .post(`/subscriptions?event_type=${params.event}`, params)
+      .catch(this._handleAxiosError)
+    return this._unwrapResponse(response.data)
+  }
+
+  public async getWebhooks(): Promise<z.infer<typeof getWebhooksOutputSchema>> {
+    const response: AxiosResponse<z.infer<typeof getWebhooksOutputSchema>> = await this._client
+      .get('/subscriptions')
+      .catch(this._handleAxiosError)
+    return this._unwrapResponse(response.data)
   }
 
   public async listCandidates(

--- a/integrations/workable/src/workable-api/client.ts
+++ b/integrations/workable/src/workable-api/client.ts
@@ -53,9 +53,7 @@ export class WorkableClient {
     params: z.infer<typeof registerWebhookInputSchema>
   ): Promise<z.infer<typeof registerWebhookOutputSchema>> {
     const response: AxiosResponse<z.infer<typeof registerWebhookOutputSchema>> = await this._client
-      // The query param is a workaround to enable registering the same url for each event.
-      // The Workable API will not allow registering the same url twice, even for different events.
-      .post(`/subscriptions?event_type=${params.event}`, params)
+      .post('/subscriptions', params)
       .catch(this._handleAxiosError)
     return this._unwrapResponse(response.data)
   }

--- a/integrations/workable/src/workable-schemas/events.ts
+++ b/integrations/workable/src/workable-schemas/events.ts
@@ -1,6 +1,8 @@
 import { z } from '@botpress/sdk'
 import { candidateSchema } from './candidates'
 
+export const eventTypes = z.enum(['candidate_created', 'candidate_moved'])
+
 export const webhookEvent = z.object({
   fired_at: z.string(),
   id: z.string(),
@@ -9,12 +11,40 @@ export const webhookEvent = z.object({
 
 export const candidateCreatedSchema = webhookEvent.extend({
   data: candidateSchema,
-  event_type: z.literal('candidate_created'),
+  event_type: z.literal(eventTypes.Values.candidate_created),
 })
 
 export const candidateMovedSchema = webhookEvent.extend({
   data: candidateSchema,
-  event_type: z.literal('candidate_moved'),
+  event_type: z.literal(eventTypes.Values.candidate_moved),
+})
+
+export const registerWebhookInputSchema = z.object({
+  target: z.string(),
+  event: eventTypes,
+  args: z.object({
+    account_id: z.string(),
+    job_shortcode: z.string(),
+    stage_slug: z.string(),
+  }),
+})
+
+export const registerWebhookOutputSchema = z.object({
+  id: z.number(),
+})
+
+export const getWebhooksOutputSchema = z.object({
+  subscriptions: z.array(
+    z.object({
+      id: z.number(),
+      event: z.string(),
+      target: z.string(),
+      valid_util: z.string().nullable(),
+      created_at: z.string().nullable(),
+      stage_slug: z.string().nullable(),
+      job_shortcode: z.string().nullable(),
+    })
+  ),
 })
 
 export const webhookRequestSchema = z.union([candidateCreatedSchema, candidateMovedSchema])

--- a/integrations/workable/src/workable-schemas/events.ts
+++ b/integrations/workable/src/workable-schemas/events.ts
@@ -1,0 +1,20 @@
+import { z } from '@botpress/sdk'
+import { candidateSchema } from './candidates'
+
+export const webhookEvent = z.object({
+  fired_at: z.string(),
+  id: z.string(),
+  resource_type: z.string(),
+})
+
+export const candidateCreatedSchema = webhookEvent.extend({
+  data: candidateSchema,
+  event_type: z.literal('candidate_created'),
+})
+
+export const candidateMovedSchema = webhookEvent.extend({
+  data: candidateSchema,
+  event_type: z.literal('candidate_moved'),
+})
+
+export const webhookRequestSchema = z.union([candidateCreatedSchema, candidateMovedSchema])

--- a/integrations/workable/src/workable-schemas/events.ts
+++ b/integrations/workable/src/workable-schemas/events.ts
@@ -1,7 +1,6 @@
 import { z } from '@botpress/sdk'
+import { eventTypes } from 'definitions/events/candidates'
 import { candidateSchema } from './candidates'
-
-export const eventTypes = z.enum(['candidate_created', 'candidate_moved'])
 
 export const webhookEvent = z.object({
   fired_at: z.string(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1877,7 +1877,7 @@ importers:
   integrations/workable:
     dependencies:
       '@botpress/sdk':
-        specifier: 4.16.0
+        specifier: workspace:*
         version: link:../../packages/sdk
     devDependencies:
       '@types/node':


### PR DESCRIPTION
The integration now allows listening to `candidate_created` and `candidate_moved` events.