### PR TITLE
fix(integrations/whatsapp): clarify template variables field description

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -75,7 +75,7 @@ const startConversationProps = {
             .optional()
             .title('Message Template variables')
             .describe(
-              'JSON array representation of variable values to pass to the WhatsApp Message Template (if required by the template)'
+              'JSON array representation of variable values to pass to the WhatsApp Message Template (if required by the template). Currently, only positional parameters are supported.'
             ),
           botPhoneNumberId: z
             .string()


### PR DESCRIPTION
Clarifies the field for message template variables, since the integration currently only supports message templates with positional parameters.