### PR TITLE
fix(integrations/whatsapp): handle correctly entered mexican numbers

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -96,7 +96,7 @@ const defaultBotPhoneNumberId = {
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '4.5.8',
+  version: '4.5.9',
   title: 'WhatsApp',
   description: 'Send and receive messages through WhatsApp.',
   icon: 'icon.svg',

--- a/integrations/whatsapp/src/misc/phone-number-to-whatsapp.test.ts
+++ b/integrations/whatsapp/src/misc/phone-number-to-whatsapp.test.ts
@@ -1,8 +1,12 @@
 import { test, expect } from 'vitest'
 import { formatPhoneNumber } from './phone-number-to-whatsapp'
 
-test('throws on invalid phone number', () => {
+test('throws on invalid text', () => {
   expect(() => formatPhoneNumber('garbage')).toThrow('Invalid phone number')
+})
+
+test('throws on invalid phone number', () => {
+  expect(() => formatPhoneNumber('1')).toThrow('Invalid phone number')
 })
 
 test('Argentina: removes "15" prefix, trims leading zeros, and inserts +549 (mobile)', () => {
@@ -23,6 +27,13 @@ test('Mexico: ensures +521 prefix', () => {
   const input = '+52 55 1234 5678'
   const actual = formatPhoneNumber(input)
   const expected = '+5215512345678'
+  expect(actual).toBe(expected)
+})
+
+test('Mexico: +521 already entered correctly', () => {
+  const input = '+5211234567890'
+  const actual = formatPhoneNumber(input)
+  const expected = '+5211234567890'
   expect(actual).toBe(expected)
 })
 

--- a/integrations/whatsapp/src/misc/phone-number-to-whatsapp.ts
+++ b/integrations/whatsapp/src/misc/phone-number-to-whatsapp.ts
@@ -6,15 +6,15 @@ const ARGENTINA_COUNTRY_CODE_AFTER_PREFIX = 9
 const MEXICO_COUNTRY_CODE = 52
 const MEXICO_COUNTRY_CODE_AFTER_PREFIX = 1
 
-export function formatPhoneNumber(rawPhoneNumber: string) {
-  if (!rawPhoneNumber.startsWith('+')) {
-    rawPhoneNumber = `+${rawPhoneNumber}`
+export function formatPhoneNumber(phoneNumber: string) {
+  if (!phoneNumber.startsWith('+')) {
+    // TODO log to use international phone number
+    phoneNumber = `+${phoneNumber}`
   }
-  const parsed = parsePhoneNumber(rawPhoneNumber)
-  if (!parsed?.valid) {
+  const parsed = parsePhoneNumber(phoneNumber)
+  if (parsed.possibility === 'invalid-country-code' || !parsed.number) {
     throw new RuntimeError('Invalid phone number, try adding the country code (e.g. +81 for Japan)')
   }
-
   let phone = parsed.number.e164
   phone = _handleWhatsAppEdgeCases(phone, parsed)
 
@@ -29,7 +29,7 @@ function _handleWhatsAppEdgeCases(phone: string, parsed: ParsedPhoneNumber): str
   if (parsed.countryCode === ARGENTINA_COUNTRY_CODE) {
     phone = _handleArgentinaEdgeCases(phone, parsed.countryCode)
   } else if (parsed.countryCode === MEXICO_COUNTRY_CODE) {
-    phone = _handleMexicoEdgeCases(phone, parsed.countryCode)
+    phone = _handleMexicoEdgeCases(parsed)
   } else {
     let nationalNumber = _stripCountryCode(phone, parsed.countryCode)
     nationalNumber = _stripLeadingZeros(nationalNumber)
@@ -53,9 +53,15 @@ const _handleArgentinaEdgeCases = (phone: string, countryCode: number): string =
 
 // This needs to remove leading zeros and make sure the number starts with +521
 // Note: Mexico phone number should never have leading zeros to begin with since they follow the E.164 recommendation
-const _handleMexicoEdgeCases = (phone: string, countryCode: number): string => {
-  let nationalNumber = _stripCountryCode(phone, countryCode)
+const _handleMexicoEdgeCases = (parsedPhoneNumber: ParsedPhoneNumber): string => {
+  if (!parsedPhoneNumber.number || !parsedPhoneNumber.countryCode) {
+    throw new RuntimeError('Invalid phone number, try adding the country code (e.g. +52 55 1234 5678)')
+  }
+  let nationalNumber = _stripCountryCode(parsedPhoneNumber.number.e164, parsedPhoneNumber.countryCode)
   nationalNumber = _stripLeadingZeros(nationalNumber)
+  if (parsedPhoneNumber.possibility === 'too-long') {
+    nationalNumber = nationalNumber?.slice(1, nationalNumber.length)
+  }
   return `+${MEXICO_COUNTRY_CODE}${MEXICO_COUNTRY_CODE_AFTER_PREFIX}${nationalNumber}`
 }
 


### PR DESCRIPTION
This PR fixes all phone numbers that have been throwing errors since the deployment of WhatsApp 4.5.6.