### PR TITLE
Update BambooHR integration public readme

### DIFF
--- a/integrations/bamboohr/hub.md
+++ b/integrations/bamboohr/hub.md
@@ -1,37 +1,7 @@
-# TODO: Not done by Adrian yet
+# BambooHR Integration
 
-# Integration Title
+The BambooHR integration connects your Botpress agent with your company’s HR system, allowing it to access and manage employee data. It enables an agent to read and update employee information, fetch organizational details, and interact with key BambooHR resources like job titles, departments, and time-off balances.
 
-Connect with BambooHR to get employee information and more.
+With this integration, your agent can automate common HR tasks like looking up employee profiles, verifying job information, checking leave requests, or returning structured HR data to other connected systems. It provides endpoints for managing records, performing authenticated API calls, and handling responses in a consistent format.
 
-## Configuration
-
-Get subdomain from your URL: `https://subdomain.bamboohr.com`.
-
-2 options:
-
-- OAuth, redirected to link to sign in
-- API Key, generate at `https://subdomain.bamboohr.com/settings/permissions/api.php` (you must be an admin)
-
-## Usage
-
-- Listen on events to fire changes when a new employee is added or updated.
-- Use actions to get employee or company information for your bot.
-
-## Limitations
-
-- Only supports employee information. No support for files, benefits, time off, etc.
-
-## Changelog
-
-v1.0.0
-
-### Integration publication checklist
-
-- [x] The register handler is implemented and validates the configuration.
-- [x] Title and descriptions for all schemas are present in `integration.definition.ts`.
-- [x] Events store `conversationId`, `userId` and `messageId` when available.
-- [x] Implement events & actions that are related to `channels`, `entities`, `user`, `conversations` and `messages`.
-- [x] Events related to messages are implemented as messages.
-- [x] When an action is required by the bot developer, a `RuntimeError` is thrown with instructions to fix the problem.
-- [x] Bot name and bot avatar URL fields are available in the integration configuration.
+By bridging BambooHR and Botpress, your agent can directly participate in HR workflows by helping you find information faster and reducing manual data entry.


### PR DESCRIPTION
This PR updates the public readme for the BambooHR integration.

It replaces existing configuration details with informational copy. Configuration details and usage information are still available in the official documentation.