### PR TITLE
fix(sdk): Fix typing error in `ConversationResponse`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.20.1",
+  "version": "4.20.2",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",
@@ -27,7 +27,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.2",
     "@botpress/client": "1.26.0",
-    "@botpress/sdk": "4.17.1",
+    "@botpress/sdk": "4.17.2",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/yargs-extra": "^0.0.3",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.26.0",
-    "@botpress/sdk": "4.17.1"
+    "@botpress/sdk": "4.17.2"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.26.0",
-    "@botpress/sdk": "4.17.1"
+    "@botpress/sdk": "4.17.2"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "4.17.1"
+    "@botpress/sdk": "4.17.2"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.26.0",
-    "@botpress/sdk": "4.17.1"
+    "@botpress/sdk": "4.17.2"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.26.0",
-    "@botpress/sdk": "4.17.1",
+    "@botpress/sdk": "4.17.2",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "4.17.1",
+  "version": "4.17.2",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/integration/client/types.test.ts
+++ b/packages/sdk/src/integration/client/types.test.ts
@@ -273,6 +273,39 @@ describe.concurrent('ClientOperations', () => {
     type _assertion = utils.AssertTrue<utils.IsEquivalent<Actual, Expected>>
   })
 
+  test('getConversation response should include all possible conversation tags', () => {
+    type Expected =
+      | {
+          fooConversationTag1?: string | undefined
+          fooConversationTag2?: string | undefined
+          fooConversationTag3?: string | undefined
+        }
+      | {
+          barConversationTag1?: string | undefined
+          barConversationTag2?: string | undefined
+          barConversationTag3?: string | undefined
+        }
+      | {
+          bazConversationTag1?: string | undefined
+          bazConversationTag2?: string | undefined
+          bazConversationTag3?: string | undefined
+        }
+    type ActualGetConversation = types.ClientOutputs<FooBarBazIntegration>['getConversation']['conversation']['tags']
+    type _assertionGet = utils.AssertTrue<utils.IsEqual<ActualGetConversation, Expected>>
+
+    type ActualCreateConversation =
+      types.ClientOutputs<FooBarBazIntegration>['createConversation']['conversation']['tags']
+    type _assertionCreate = utils.AssertTrue<utils.IsEqual<ActualCreateConversation, Expected>>
+
+    type ActualGetOrCreateConversation =
+      types.ClientOutputs<FooBarBazIntegration>['getOrCreateConversation']['conversation']['tags']
+    type _assertionGetOrCreate = utils.AssertTrue<utils.IsEqual<ActualGetOrCreateConversation, Expected>>
+
+    type ActualUpdateConversation =
+      types.ClientOutputs<FooBarBazIntegration>['updateConversation']['conversation']['tags']
+    type _assertionUpdate = utils.AssertTrue<utils.IsEqual<ActualUpdateConversation, Expected>>
+  })
+
   test('getOrCreateConversation with FooBarBazIntegration stricly enforces allowed tags', () => {
     const client = _mockClient<FooBarBazIntegration>()
 

--- a/packages/sdk/src/integration/client/types.test.ts
+++ b/packages/sdk/src/integration/client/types.test.ts
@@ -273,7 +273,7 @@ describe.concurrent('ClientOperations', () => {
     type _assertion = utils.AssertTrue<utils.IsEquivalent<Actual, Expected>>
   })
 
-  test('getConversation response should include all possible conversation tags', () => {
+  test('Conversation operations responses should include all possible conversation tags', () => {
     type Expected =
       | {
           fooConversationTag1?: string | undefined
@@ -304,6 +304,39 @@ describe.concurrent('ClientOperations', () => {
     type ActualUpdateConversation =
       types.ClientOutputs<FooBarBazIntegration>['updateConversation']['conversation']['tags']
     type _assertionUpdate = utils.AssertTrue<utils.IsEqual<ActualUpdateConversation, Expected>>
+  })
+
+  test('createConversation and getOrCreateConversation response should only include conversation tags for the provided channel', async () => {
+    type Expected = {
+      fooConversationTag1?: string | undefined
+      fooConversationTag2?: string | undefined
+      fooConversationTag3?: string | undefined
+    }
+
+    const client = _mockClient<FooBarBazIntegration>()
+    const _resultCreate = await client.createConversation({
+      channel: 'channelFoo',
+      tags: {
+        fooConversationTag1: '1',
+        fooConversationTag2: '2',
+        fooConversationTag3: '3',
+      },
+    })
+
+    type ActualCreateConversation = (typeof _resultCreate)['conversation']['tags']
+
+    const _resultGetOrCreate = await client.getOrCreateConversation({
+      channel: 'channelFoo',
+      tags: {
+        fooConversationTag1: '1',
+        fooConversationTag2: '2',
+        fooConversationTag3: '3',
+      },
+    })
+    type ActualGetOrCreateConversation = (typeof _resultGetOrCreate)['conversation']['tags']
+
+    type _assertionCreate = utils.AssertTrue<utils.IsEqual<ActualCreateConversation, Expected>>
+    type _assertionGetOrCreate = utils.AssertTrue<utils.IsEqual<ActualGetOrCreateConversation, Expected>>
   })
 
   test('getOrCreateConversation with FooBarBazIntegration stricly enforces allowed tags', () => {

--- a/packages/sdk/src/integration/client/types.ts
+++ b/packages/sdk/src/integration/client/types.ts
@@ -9,15 +9,17 @@ type Res<F extends (...args: any[]) => any> = ReturnType<F>
 type ConversationResponse<
   TIntegration extends common.BaseIntegration,
   ChannelName extends keyof TIntegration['channels'] = keyof TIntegration['channels'],
-> = {
-  conversation: utils.Merge<
-    Awaited<Res<client.Client['getConversation']>>['conversation'],
-    {
-      channel: ChannelName
-      tags: common.ToTags<keyof TIntegration['channels'][ChannelName]['conversation']['tags']>
-    }
-  >
-}
+> = utils.ValueOf<{
+  [TChannelName in ChannelName]: {
+    conversation: utils.Merge<
+      Awaited<Res<client.Client['getConversation']>>['conversation'],
+      {
+        channel: TChannelName
+        tags: common.ToTags<keyof TIntegration['channels'][TChannelName]['conversation']['tags']>
+      }
+    >
+  }
+}>
 
 export type CreateConversation<TIntegration extends common.BaseIntegration> = <
   ChannelName extends keyof TIntegration['channels'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2216,7 +2216,7 @@ importers:
         specifier: 1.26.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 4.17.1
+        specifier: 4.17.2
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2331,7 +2331,7 @@ importers:
         specifier: 1.26.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.17.1
+        specifier: 4.17.2
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2347,7 +2347,7 @@ importers:
         specifier: 1.26.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.17.1
+        specifier: 4.17.2
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2360,7 +2360,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 4.17.1
+        specifier: 4.17.2
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2376,7 +2376,7 @@ importers:
         specifier: 1.26.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.17.1
+        specifier: 4.17.2
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2392,7 +2392,7 @@ importers:
         specifier: 1.26.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 4.17.1
+        specifier: 4.17.2
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
This fixes an issue where we could not discriminate between channel tags with channel name on conversation operations responses in integration specific client.
