### PR TITLE
feat(integrations/workable): New actions for creating candidates

### DIFF
--- a/integrations/workable/definitions/actions/candidates.ts
+++ b/integrations/workable/definitions/actions/candidates.ts
@@ -5,8 +5,9 @@ import {
   listCandidatesInputSchema,
   listCandidatesOutputSchema,
   postCandidateInJobInputSchema,
+  postCandidateInJobOutputSchema,
   postCandidateInTalentPoolInputSchema,
-  postCandidateOutputSchema,
+  postCandidateInTalentPoolOutputSchema,
 } from 'definitions/models/candidates'
 
 export const listCandidates = {
@@ -38,7 +39,7 @@ export const createCandidateInJob = {
     schema: postCandidateInJobInputSchema,
   },
   output: {
-    schema: postCandidateOutputSchema,
+    schema: postCandidateInJobOutputSchema,
   },
 } satisfies ActionDefinition
 
@@ -49,6 +50,6 @@ export const createCandidateInTalentPool = {
     schema: postCandidateInTalentPoolInputSchema,
   },
   output: {
-    schema: postCandidateOutputSchema,
+    schema: postCandidateInTalentPoolOutputSchema,
   },
 } satisfies ActionDefinition

--- a/integrations/workable/definitions/actions/candidates.ts
+++ b/integrations/workable/definitions/actions/candidates.ts
@@ -1,11 +1,11 @@
 import { ActionDefinition } from '@botpress/sdk'
 import {
-  createCandidateInJobInputSchema,
-  createCandidateInJobOutputSchema,
   getCandidateInputSchema,
   getCandidateOutputSchema,
   listCandidatesInputSchema,
   listCandidatesOutputSchema,
+  postCandidateInJobInputSchema,
+  postCandidateInJobOutputSchema,
 } from 'definitions/models/candidates'
 
 export const listCandidates = {
@@ -34,9 +34,9 @@ export const createCandidateInJob = {
   title: 'Create candidate in job',
   description: 'Create a candidate in the specified job',
   input: {
-    schema: createCandidateInJobInputSchema,
+    schema: postCandidateInJobInputSchema,
   },
   output: {
-    schema: createCandidateInJobOutputSchema,
+    schema: postCandidateInJobOutputSchema,
   },
 } satisfies ActionDefinition

--- a/integrations/workable/definitions/actions/candidates.ts
+++ b/integrations/workable/definitions/actions/candidates.ts
@@ -5,7 +5,8 @@ import {
   listCandidatesInputSchema,
   listCandidatesOutputSchema,
   postCandidateInJobInputSchema,
-  postCandidateInJobOutputSchema,
+  postCandidateInTalentPoolInputSchema,
+  postCandidateOutputSchema,
 } from 'definitions/models/candidates'
 
 export const listCandidates = {
@@ -37,6 +38,17 @@ export const createCandidateInJob = {
     schema: postCandidateInJobInputSchema,
   },
   output: {
-    schema: postCandidateInJobOutputSchema,
+    schema: postCandidateOutputSchema,
+  },
+} satisfies ActionDefinition
+
+export const createCandidateInTalentPool = {
+  title: 'Create candidate in talent pool',
+  description: 'Create a candidate in the talent pool',
+  input: {
+    schema: postCandidateInTalentPoolInputSchema,
+  },
+  output: {
+    schema: postCandidateOutputSchema,
   },
 } satisfies ActionDefinition

--- a/integrations/workable/definitions/actions/candidates.ts
+++ b/integrations/workable/definitions/actions/candidates.ts
@@ -1,5 +1,7 @@
 import { ActionDefinition } from '@botpress/sdk'
 import {
+  createCandidateInJobInputSchema,
+  createCandidateInJobOutputSchema,
   getCandidateInputSchema,
   getCandidateOutputSchema,
   listCandidatesInputSchema,
@@ -25,5 +27,16 @@ export const getCandidate = {
   },
   output: {
     schema: getCandidateOutputSchema,
+  },
+} satisfies ActionDefinition
+
+export const createCandidateInJob = {
+  title: 'Create candidate in job',
+  description: 'Create a candidate in the specified job',
+  input: {
+    schema: createCandidateInJobInputSchema,
+  },
+  output: {
+    schema: createCandidateInJobOutputSchema,
   },
 } satisfies ActionDefinition

--- a/integrations/workable/definitions/models/answers.ts
+++ b/integrations/workable/definitions/models/answers.ts
@@ -1,0 +1,71 @@
+import { z } from '@botpress/sdk'
+
+const baseAnswerSchema = z.object({
+  questionKey: z.string().title('Question Key').describe('The question key'),
+})
+
+const freeTextAnswerSchema = z.object({
+  body: z.string().title('Body').describe("The candidate's response"),
+})
+
+const shortTextAnswerSchema = z.object({
+  body: z.string().max(128).title('Body').describe("The candidate's response"),
+})
+
+const booleanAnswerSchema = z.object({
+  checked: z.boolean().title('Checked').describe("The candidate's response"),
+})
+
+const multipleChoiceAnswerSchema = z.object({
+  choices: z.array(z.string()).title('Choices').describe('The IDs of the choice(s) selected'),
+})
+
+const dropdownAnswerSchema = z.object({
+  choice: z.string().title('Choice').describe('The ID of the choice selected'),
+})
+
+const dateAnswerSchema = z.object({
+  date: z.string().title('Date').describe('The date in ISO 8601 format'),
+})
+
+const numericAnswerSchema = z.object({
+  number: z.number().title('Number').describe('The value may be an integer or a decimal number'),
+})
+
+const fileAnswerUrlSchema = z.object({
+  fileUrl: z.string().title('File Url').describe("A url pointing to the candidate's answer"),
+})
+const fileAnswerBase64Schema = z.object({
+  data: z.string().title('Data').describe("The candidate's answer encoded in base64"),
+})
+
+export const postAnswerSchema = z.union([
+  baseAnswerSchema.merge(freeTextAnswerSchema),
+  baseAnswerSchema.merge(shortTextAnswerSchema),
+  baseAnswerSchema.merge(booleanAnswerSchema),
+  baseAnswerSchema.merge(multipleChoiceAnswerSchema),
+  baseAnswerSchema.merge(dropdownAnswerSchema),
+  baseAnswerSchema.merge(dateAnswerSchema),
+  baseAnswerSchema.merge(numericAnswerSchema),
+  z.union([baseAnswerSchema.merge(fileAnswerUrlSchema), baseAnswerSchema.merge(fileAnswerBase64Schema)]),
+])
+
+export const answerSchema = z.object({
+  question: z.object({
+    body: z.string().nullable().title('Question').describe('The question'),
+  }),
+  answer: z
+    .union([
+      freeTextAnswerSchema,
+      shortTextAnswerSchema,
+      booleanAnswerSchema,
+      multipleChoiceAnswerSchema,
+      dropdownAnswerSchema,
+      dateAnswerSchema,
+      numericAnswerSchema,
+      z.union([fileAnswerUrlSchema, fileAnswerBase64Schema]),
+    ])
+    .nullable()
+    .title('Answer')
+    .describe('The answer'),
+})

--- a/integrations/workable/definitions/models/answers.ts
+++ b/integrations/workable/definitions/models/answers.ts
@@ -28,6 +28,10 @@ const dateAnswerSchema = z.object({
   date: z.string().title('Date').describe('The date in ISO 8601 format'),
 })
 
+const postNumericAnswerSchema = z.object({
+  value: z.number().title('Value').describe('The value may be an integer or a decimal number'),
+})
+
 const numericAnswerSchema = z.object({
   number: z.number().title('Number').describe('The value may be an integer or a decimal number'),
 })
@@ -46,7 +50,7 @@ export const postAnswerSchema = z.union([
   baseAnswerSchema.merge(multipleChoiceAnswerSchema),
   baseAnswerSchema.merge(dropdownAnswerSchema),
   baseAnswerSchema.merge(dateAnswerSchema),
-  baseAnswerSchema.merge(numericAnswerSchema),
+  baseAnswerSchema.merge(postNumericAnswerSchema),
   z.union([baseAnswerSchema.merge(fileAnswerUrlSchema), baseAnswerSchema.merge(fileAnswerBase64Schema)]),
 ])
 

--- a/integrations/workable/definitions/models/answers.ts
+++ b/integrations/workable/definitions/models/answers.ts
@@ -1,9 +1,5 @@
 import { z } from '@botpress/sdk'
 
-const baseAnswerSchema = z.object({
-  questionKey: z.string().title('Question Key').describe('The question key'),
-})
-
 const freeTextAnswerSchema = z.object({
   body: z.string().title('Body').describe("The candidate's response"),
 })
@@ -28,10 +24,6 @@ const dateAnswerSchema = z.object({
   date: z.string().title('Date').describe('The date in ISO 8601 format'),
 })
 
-const postNumericAnswerSchema = z.object({
-  value: z.number().title('Value').describe('The value may be an integer or a decimal number'),
-})
-
 const numericAnswerSchema = z.object({
   number: z.number().title('Number').describe('The value may be an integer or a decimal number'),
 })
@@ -42,18 +34,6 @@ const fileAnswerUrlSchema = z.object({
 const fileAnswerBase64Schema = z.object({
   data: z.string().title('Data').describe("The candidate's answer encoded in base64"),
 })
-
-export const postAnswerSchema = z.union([
-  baseAnswerSchema.merge(freeTextAnswerSchema),
-  baseAnswerSchema.merge(shortTextAnswerSchema),
-  baseAnswerSchema.merge(booleanAnswerSchema),
-  baseAnswerSchema.merge(multipleChoiceAnswerSchema),
-  baseAnswerSchema.merge(dropdownAnswerSchema),
-  baseAnswerSchema.merge(dateAnswerSchema),
-  baseAnswerSchema.merge(postNumericAnswerSchema),
-  baseAnswerSchema.merge(fileAnswerUrlSchema),
-  baseAnswerSchema.merge(fileAnswerBase64Schema),
-])
 
 export const answerSchema = z.object({
   question: z.object({
@@ -74,4 +54,15 @@ export const answerSchema = z.object({
     .nullable()
     .title('Answer')
     .describe('The answer'),
+})
+
+export const postAnswerSchema = z.object({
+  questionKey: z.string().title('Question Key').describe('The question key'),
+  body: z.string().optional().title('Body').describe("The candidate's response"),
+  checked: z.boolean().optional().title('Checked').describe("The candidate's response"),
+  choices: z.array(z.string()).optional().title('Choices').describe('The IDs of the choice(s) selected'),
+  date: z.string().optional().title('Date').describe('The date in ISO 8601 format'),
+  value: z.number().optional().title('Value').describe('The value may be an integer or a decimal number'),
+  fileUrl: z.string().optional().title('File Url').describe("A url pointing to the candidate's answer"),
+  data: z.string().optional().title('Data').describe("The candidate's answer encoded in base64"),
 })

--- a/integrations/workable/definitions/models/answers.ts
+++ b/integrations/workable/definitions/models/answers.ts
@@ -51,7 +51,8 @@ export const postAnswerSchema = z.union([
   baseAnswerSchema.merge(dropdownAnswerSchema),
   baseAnswerSchema.merge(dateAnswerSchema),
   baseAnswerSchema.merge(postNumericAnswerSchema),
-  z.union([baseAnswerSchema.merge(fileAnswerUrlSchema), baseAnswerSchema.merge(fileAnswerBase64Schema)]),
+  baseAnswerSchema.merge(fileAnswerUrlSchema),
+  baseAnswerSchema.merge(fileAnswerBase64Schema),
 ])
 
 export const answerSchema = z.object({
@@ -67,7 +68,8 @@ export const answerSchema = z.object({
       dropdownAnswerSchema,
       dateAnswerSchema,
       numericAnswerSchema,
-      z.union([fileAnswerUrlSchema, fileAnswerBase64Schema]),
+      fileAnswerUrlSchema,
+      fileAnswerBase64Schema,
     ])
     .nullable()
     .title('Answer')

--- a/integrations/workable/definitions/models/candidates.ts
+++ b/integrations/workable/definitions/models/candidates.ts
@@ -307,6 +307,13 @@ export const postCandidateInTalentPoolSchema = z.object({
     .optional()
     .title('Recruiter Key')
     .describe('The key corresponding to the recruiter who sourced the candidate'),
+  resumeUrl: z.string().optional().title('Resume Url').describe('Url to the candidate resume'),
+  resume: z
+    .object({
+      name: z.string().title('Name').describe('The name of the file'),
+      data: z.string().title('Data').describe('The base64 encoded data'),
+    })
+    .optional(),
 })
 
 export const postCandidateInJobSchema = postCandidateInTalentPoolSchema.extend({

--- a/integrations/workable/definitions/models/candidates.ts
+++ b/integrations/workable/definitions/models/candidates.ts
@@ -1,7 +1,7 @@
 import { z } from '@botpress/sdk'
 import { answerSchema } from './answers'
 
-const socialProfileTypesSchema = z.enum([
+export const socialProfileTypesSchema = z.enum([
   'academiaedu',
   'angellist',
   'behance',
@@ -299,14 +299,14 @@ export const postCandidateSchema = z.object({
   domain: z.string().optional().title('Domain').describe('Where the candidate came from'),
 })
 
-export const createCandidateInJobOutputSchema = z
+export const postCandidateInJobOutputSchema = z
   .object({
     status: z.string().title('Status').describe('The status of the candidate'),
     candidate: detailedCandidateSchema.title('Candidate').describe('The candidate found'),
   })
   .partial()
 
-export const createCandidateInJobInputSchema = z.object({
+export const postCandidateInJobInputSchema = z.object({
   sourced: z.boolean().optional().title('Sourced').describe('Indicates if the candidate is sourced or applied'),
   candidate: postCandidateSchema.title('Candidate').describe('The candidate to create'),
 })

--- a/integrations/workable/definitions/models/candidates.ts
+++ b/integrations/workable/definitions/models/candidates.ts
@@ -1,4 +1,53 @@
 import { z } from '@botpress/sdk'
+import { answerSchema } from './answers'
+
+const socialProfileTypesSchema = z.enum([
+  'academiaedu',
+  'angellist',
+  'behance',
+  'bitbucket',
+  'blogger',
+  'crunchbase',
+  'dandyid',
+  'delicious',
+  'deviantart',
+  'digg',
+  'doyoubuzz',
+  'dribble',
+  'dribbble',
+  'econsultancy',
+  'facebook',
+  'flavorsme',
+  'flickr',
+  'fullcontact',
+  'getglue',
+  'gist',
+  'github',
+  'goodreads',
+  'googleplus',
+  'gravatar',
+  'hackernews',
+  'hiim',
+  'klout',
+  'lanyrd',
+  'linkedin',
+  'myspace',
+  'ohloh',
+  'orkut',
+  'pinterest',
+  'quora',
+  'reddit',
+  'scribd',
+  'slideshare',
+  'stackexchange',
+  'stackoverflow',
+  'tumblr',
+  'twitter',
+  'typepad',
+  'vk',
+  'wordpress',
+  'xing',
+])
 
 export const candidateSchema = z
   .object({
@@ -96,13 +145,6 @@ export const experienceEntrySchema = z
   })
   .partial()
 
-export const answerSchema = z.object({
-  question: z.object({
-    body: z.string().nullable().title('Question').describe('The question'),
-  }),
-  answer: z.unknown().nullable().title('Answer').describe('The answer'),
-})
-
 export const locationSchema = z
   .object({
     locationString: z
@@ -181,4 +223,90 @@ export const getCandidateOutputSchema = z
 
 export const getCandidateInputSchema = z.object({
   id: z.string().title('ID').describe("The candidate's ID"),
+})
+
+export const postEducationEntrySchema = z.object({
+  degree: z.string().optional().title('Degree').describe('The graduation degree'),
+  school: z.string().title('School').describe('The name of the school graduated'),
+  fieldOfStudy: z.string().optional().title('Field Of Study').describe('The field of study'),
+  startDate: z.string().optional().title('Start Date').describe('The date started'),
+  endDate: z.string().optional().title('End Date').describe('The date ended'),
+})
+
+export const postSocialProfileSchema = z.object({
+  type: socialProfileTypesSchema.title('Type').describe('The slug name of the social profile'),
+  username: z.string().optional().title('Username').describe('The username of the social profile'),
+  url: z.string().title('Url').describe("Url to the candidate's social profile page"),
+})
+
+export const postExperienceEntrySchema = z.object({
+  title: z.string().title('Title').describe('The title of the experience entry'),
+  summary: z.string().optional().title('Summary').describe('The summary of the experience entry'),
+  startDate: z.string().optional().title('Start Date').describe('The date started'),
+  endDate: z.string().optional().title('End Date').describe('The date ended'),
+  company: z.string().optional().title('Company').describe('The company name'),
+  current: z.boolean().optional().title('Current').describe('Indicates if currently works there'),
+  industry: z.string().optional().title('Industry').describe('The industry of the company'),
+})
+
+export const postCandidateSchema = z.object({
+  firstName: z.string().title('First Name').describe("The candidate's first name"),
+  lastName: z.string().title('Last Name').describe("The candidate's last name"),
+  email: z.string().title('Email').describe("The candidate's email address"),
+  headline: z.string().optional().title('Headline').describe("The candidate's headline"),
+  summary: z.string().optional().title('Summary').describe('The summary of the candidate'),
+  address: z.string().optional().title('Address').describe("The candidate's address"),
+  phone: z.string().optional().title('Phone Number').describe("The candidate's phone number"),
+  coverLetter: z
+    .string()
+    .optional()
+    .title('Cover Letter')
+    .describe('The cover letter provided when the candidate applied'),
+  educationEntries: z
+    .array(postEducationEntrySchema)
+    .title('Education Entries')
+    .describe('A collection with education entries'),
+  experienceEntries: z
+    .array(postExperienceEntrySchema)
+    .title('Experience Entries')
+    .describe('A collection with experience entries'),
+  skills: z
+    .array(z.object({ name: z.string().title('Name') }))
+    .optional()
+    .title('Skills')
+    .describe('A collection of skills with names'),
+  answers: z.array(answerSchema).optional().title('Answers').describe('A collection with answers provided'),
+  tags: z.array(z.string()).optional().title('Tags').describe('A collection of tags'),
+  disqualified: z
+    .boolean()
+    .optional()
+    .title('Disqualified')
+    .describe('Flag indicating whether the candidate is disqualified'),
+  disqualificationReason: z
+    .string()
+    .optional()
+    .title('Disqualification Reason')
+    .describe('Reason for disqualification, if applicable'),
+  disqualifiedAt: z
+    .string()
+    .optional()
+    .title('Disqualified At')
+    .describe('The timestamp the candidate was disqualified'),
+  socialProfiles: z
+    .array(postSocialProfileSchema)
+    .title('Social Profiles')
+    .describe('A collection with social profiles of candidates'),
+  domain: z.string().optional().title('Domain').describe('Where the candidate came from'),
+})
+
+export const createCandidateInJobOutputSchema = z
+  .object({
+    status: z.string().title('Status').describe('The status of the candidate'),
+    candidate: detailedCandidateSchema.title('Candidate').describe('The candidate found'),
+  })
+  .partial()
+
+export const createCandidateInJobInputSchema = z.object({
+  sourced: z.boolean().optional().title('Sourced').describe('Indicates if the candidate is sourced or applied'),
+  candidate: postCandidateSchema.title('Candidate').describe('The candidate to create'),
 })

--- a/integrations/workable/definitions/models/candidates.ts
+++ b/integrations/workable/definitions/models/candidates.ts
@@ -49,7 +49,7 @@ export const socialProfileTypesSchema = z.enum([
   'xing',
 ])
 
-export const candidateSchema = z
+export const baseCandidateSchema = z
   .object({
     id: z.string().title('Id').describe('The candidate identifier'),
     name: z.string().title('Name').describe("The candidate's full name"),
@@ -65,13 +65,6 @@ export const candidateSchema = z
       .partial()
       .nullable()
       .describe('The account details'),
-    job: z
-      .object({
-        shortCode: z.string().title('Shortcode').describe("The job's system generated code"),
-        title: z.string().title('Job Title').describe('The job title'),
-      })
-      .partial()
-      .describe('The job details'),
     stage: z.string().nullable().title('Stage').describe("The candidate's current stage slug"),
     stageKind: z.string().nullable().title('Stage').describe("The candidate's current stage kind"),
     disqualified: z.boolean().title('Disqualified').describe('Flag indicating whether the candidate is disqualified'),
@@ -89,6 +82,18 @@ export const candidateSchema = z
     hiredAt: z.string().nullable().title('Hired At').describe('The date the candidate was moved to the hired stage'),
     address: z.string().nullable().title('Address').describe("The candidate's address"),
     phone: z.string().nullable().title('Phone Number').describe("The candidate's phone number"),
+  })
+  .partial()
+
+export const candidateSchema = baseCandidateSchema
+  .extend({
+    job: z
+      .object({
+        shortCode: z.string().title('Shortcode').describe("The job's system generated code"),
+        title: z.string().title('Job Title').describe('The job title'),
+      })
+      .partial()
+      .describe('The job details'),
   })
   .partial()
 
@@ -161,59 +166,61 @@ export const locationSchema = z
   })
   .partial()
 
-export const detailedCandidateSchema = candidateSchema
-  .extend({
-    imageUrl: z
-      .string()
-      .nullable()
-      .title('Image Url')
-      .describe("Url of candidate's avatar. Available only if provided by the candidate"),
-    disqualifiedAt: z
-      .string()
-      .nullable()
-      .title('Disqualified At')
-      .describe('The timestamp the candidate was disqualified'),
-    outboundMailbox: z
-      .string()
-      .nullable()
-      .title('Outbound Mailbox')
-      .describe(
-        'Mailbox that can be used to communicate with the candidate and inform the recruitment team of the job as well'
-      ),
-    uploaderId: z.string().nullable().title('Uploader Id').describe('The ID of the member who uploaded the candidate'),
-    coverLetter: z
-      .string()
-      .nullable()
-      .title('Cover Letter')
-      .describe('The cover letter provided when the candidate applied'),
-    summary: z.string().nullable().title('Summary').describe('The summary of the candidate'),
-    educationEntries: z
-      .array(educationEntrySchema)
-      .title('Education Entries')
-      .describe('A collection with education entries'),
-    experienceEntries: z
-      .array(experienceEntrySchema)
-      .title('Experience Entries')
-      .describe('A collection with experience entries'),
-    skills: z
-      .array(z.object({ name: z.string().title('Name') }).partial())
-      .title('Skills')
-      .describe('A collection of skills with names'),
-    answers: z.array(answerSchema).title('Answers').describe('A collection with answers provided'),
-    resumeUrl: z.string().nullable().title('Resume Url').describe('Url to the candidate resume'),
-    socialProfiles: z
-      .array(socialProfileSchema)
-      .title('Social Profiles')
-      .describe('A collection with social profiles of candidates'),
-    tags: z.array(z.string()).title('Tags').describe('A collection of tags'),
-    location: locationSchema.title('Location').nullable().describe('The location of the candidate'),
-    originatingCandidateId: z
-      .string()
-      .nullable()
-      .title('Originating Candidate Id')
-      .describe('The ID this candidate originated from'),
-  })
-  .partial()
+const detailedCandidateSchemaExtraFields = {
+  imageUrl: z
+    .string()
+    .nullable()
+    .title('Image Url')
+    .describe("Url of candidate's avatar. Available only if provided by the candidate"),
+  disqualifiedAt: z
+    .string()
+    .nullable()
+    .title('Disqualified At')
+    .describe('The timestamp the candidate was disqualified'),
+  outboundMailbox: z
+    .string()
+    .nullable()
+    .title('Outbound Mailbox')
+    .describe(
+      'Mailbox that can be used to communicate with the candidate and inform the recruitment team of the job as well'
+    ),
+  uploaderId: z.string().nullable().title('Uploader Id').describe('The ID of the member who uploaded the candidate'),
+  coverLetter: z
+    .string()
+    .nullable()
+    .title('Cover Letter')
+    .describe('The cover letter provided when the candidate applied'),
+  summary: z.string().nullable().title('Summary').describe('The summary of the candidate'),
+  educationEntries: z
+    .array(educationEntrySchema)
+    .title('Education Entries')
+    .describe('A collection with education entries'),
+  experienceEntries: z
+    .array(experienceEntrySchema)
+    .title('Experience Entries')
+    .describe('A collection with experience entries'),
+  skills: z
+    .array(z.object({ name: z.string().title('Name') }).partial())
+    .title('Skills')
+    .describe('A collection of skills with names'),
+  answers: z.array(answerSchema).title('Answers').describe('A collection with answers provided'),
+  resumeUrl: z.string().nullable().title('Resume Url').describe('Url to the candidate resume'),
+  socialProfiles: z
+    .array(socialProfileSchema)
+    .title('Social Profiles')
+    .describe('A collection with social profiles of candidates'),
+  tags: z.array(z.string()).title('Tags').describe('A collection of tags'),
+  location: locationSchema.title('Location').nullable().describe('The location of the candidate'),
+  originatingCandidateId: z
+    .string()
+    .nullable()
+    .title('Originating Candidate Id')
+    .describe('The ID this candidate originated from'),
+}
+
+export const baseDetailedCandidateSchema = baseCandidateSchema.extend(detailedCandidateSchemaExtraFields).partial()
+
+export const detailedCandidateSchema = candidateSchema.extend(detailedCandidateSchemaExtraFields).partial()
 
 export const getCandidateOutputSchema = z
   .object({
@@ -302,9 +309,24 @@ export const postCandidateSchema = z.object({
   domain: z.string().optional().title('Domain').describe('Where the candidate came from'),
 })
 
-export const postCandidateOutputSchema = z.object({
+export const postCandidateInJobOutputSchema = z.object({
   status: z.string().title('Status').describe('The status of the candidate'),
   candidate: detailedCandidateSchema.title('Candidate').describe('The candidate found'),
+})
+
+export const postCandidateInTalentPoolOutputSchema = z.object({
+  status: z.string().title('Status').describe('The status of the candidate'),
+  candidate: baseDetailedCandidateSchema
+    .extend({
+      talentPool: z
+        .object({
+          talentPoolId: z.number().title('Talent Pool ID').describe('The ID of the candidate in the talent pool'),
+        })
+        .title('Talent Pool')
+        .describe('The talent pool fields'),
+    })
+    .title('Candidate')
+    .describe('The candidate found'),
 })
 
 export const postCandidateInTalentPoolInputSchema = z.object({

--- a/integrations/workable/definitions/models/candidates.ts
+++ b/integrations/workable/definitions/models/candidates.ts
@@ -1,5 +1,5 @@
 import { z } from '@botpress/sdk'
-import { answerSchema } from './answers'
+import { answerSchema, postAnswerSchema } from './answers'
 
 export const socialProfileTypesSchema = z.enum([
   'academiaedu',
@@ -275,7 +275,7 @@ export const postCandidateSchema = z.object({
     .optional()
     .title('Skills')
     .describe('A collection of skills with names'),
-  answers: z.array(answerSchema).optional().title('Answers').describe('A collection with answers provided'),
+  answers: z.array(postAnswerSchema).optional().title('Answers').describe('A collection with answers provided'),
   tags: z.array(z.string()).optional().title('Tags').describe('A collection of tags'),
   disqualified: z
     .boolean()
@@ -308,5 +308,6 @@ export const postCandidateInJobOutputSchema = z
 
 export const postCandidateInJobInputSchema = z.object({
   sourced: z.boolean().optional().title('Sourced').describe('Indicates if the candidate is sourced or applied'),
+  shortCode: z.string().title('Short Code').describe('The shortcode of the job the candidate is applying to'),
   candidate: postCandidateSchema.title('Candidate').describe('The candidate to create'),
 })

--- a/integrations/workable/definitions/models/candidates.ts
+++ b/integrations/workable/definitions/models/candidates.ts
@@ -256,7 +256,7 @@ export const postExperienceEntrySchema = z.object({
   industry: z.string().optional().title('Industry').describe('The industry of the company'),
 })
 
-export const postCandidateSchema = z.object({
+export const postCandidateInTalentPoolSchema = z.object({
   firstName: z.string().title('First Name').describe("The candidate's first name"),
   lastName: z.string().title('Last Name').describe("The candidate's last name"),
   email: z.string().title('Email').describe("The candidate's email address"),
@@ -279,12 +279,7 @@ export const postCandidateSchema = z.object({
     .optional()
     .title('Experience Entries')
     .describe('A collection with experience entries'),
-  skills: z
-    .array(z.object({ name: z.string().title('Name') }))
-    .optional()
-    .title('Skills')
-    .describe('A collection of skills with names'),
-  answers: z.array(postAnswerSchema).optional().title('Answers').describe('A collection with answers provided'),
+  skills: z.array(z.string()).optional().title('Skills').describe('A collection of skills with names'),
   tags: z.array(z.string()).optional().title('Tags').describe('A collection of tags'),
   disqualified: z
     .boolean()
@@ -307,6 +302,15 @@ export const postCandidateSchema = z.object({
     .title('Social Profiles')
     .describe('A collection with social profiles of candidates'),
   domain: z.string().optional().title('Domain').describe('Where the candidate came from'),
+  recruiterKey: z
+    .string()
+    .optional()
+    .title('Recruiter Key')
+    .describe('The key corresponding to the recruiter who sourced the candidate'),
+})
+
+export const postCandidateInJobSchema = postCandidateInTalentPoolSchema.extend({
+  answers: z.array(postAnswerSchema).optional().title('Answers').describe('A collection with answers provided'),
 })
 
 export const postCandidateInJobOutputSchema = z.object({
@@ -331,9 +335,11 @@ export const postCandidateInTalentPoolOutputSchema = z.object({
 
 export const postCandidateInTalentPoolInputSchema = z.object({
   sourced: z.boolean().optional().title('Sourced').describe('Indicates if the candidate is sourced or applied'),
-  candidate: postCandidateSchema.title('Candidate').describe('The candidate to create'),
+  candidate: postCandidateInTalentPoolSchema.title('Candidate').describe('The candidate to create'),
 })
 
-export const postCandidateInJobInputSchema = postCandidateInTalentPoolInputSchema.extend({
+export const postCandidateInJobInputSchema = z.object({
+  sourced: z.boolean().optional().title('Sourced').describe('Indicates if the candidate is sourced or applied'),
+  candidate: postCandidateInJobSchema.title('Candidate').describe('The candidate to create'),
   shortCode: z.string().title('Short Code').describe('The shortcode of the job the candidate is applying to'),
 })

--- a/integrations/workable/definitions/models/candidates.ts
+++ b/integrations/workable/definitions/models/candidates.ts
@@ -264,10 +264,12 @@ export const postCandidateSchema = z.object({
     .describe('The cover letter provided when the candidate applied'),
   educationEntries: z
     .array(postEducationEntrySchema)
+    .optional()
     .title('Education Entries')
     .describe('A collection with education entries'),
   experienceEntries: z
     .array(postExperienceEntrySchema)
+    .optional()
     .title('Experience Entries')
     .describe('A collection with experience entries'),
   skills: z
@@ -294,20 +296,22 @@ export const postCandidateSchema = z.object({
     .describe('The timestamp the candidate was disqualified'),
   socialProfiles: z
     .array(postSocialProfileSchema)
+    .optional()
     .title('Social Profiles')
     .describe('A collection with social profiles of candidates'),
   domain: z.string().optional().title('Domain').describe('Where the candidate came from'),
 })
 
-export const postCandidateInJobOutputSchema = z
-  .object({
-    status: z.string().title('Status').describe('The status of the candidate'),
-    candidate: detailedCandidateSchema.title('Candidate').describe('The candidate found'),
-  })
-  .partial()
+export const postCandidateOutputSchema = z.object({
+  status: z.string().title('Status').describe('The status of the candidate'),
+  candidate: detailedCandidateSchema.title('Candidate').describe('The candidate found'),
+})
 
-export const postCandidateInJobInputSchema = z.object({
+export const postCandidateInTalentPoolInputSchema = z.object({
   sourced: z.boolean().optional().title('Sourced').describe('Indicates if the candidate is sourced or applied'),
-  shortCode: z.string().title('Short Code').describe('The shortcode of the job the candidate is applying to'),
   candidate: postCandidateSchema.title('Candidate').describe('The candidate to create'),
+})
+
+export const postCandidateInJobInputSchema = postCandidateInTalentPoolInputSchema.extend({
+  shortCode: z.string().title('Short Code').describe('The shortcode of the job the candidate is applying to'),
 })

--- a/integrations/workable/definitions/models/candidates.ts
+++ b/integrations/workable/definitions/models/candidates.ts
@@ -322,7 +322,7 @@ export const postCandidateInJobSchema = postCandidateInTalentPoolSchema.extend({
 
 export const postCandidateInJobOutputSchema = z.object({
   status: z.string().title('Status').describe('The status of the candidate'),
-  candidate: detailedCandidateSchema.title('Candidate').describe('The candidate found'),
+  candidate: detailedCandidateSchema.title('Candidate').describe('The candidate created'),
 })
 
 export const postCandidateInTalentPoolOutputSchema = z.object({
@@ -337,7 +337,7 @@ export const postCandidateInTalentPoolOutputSchema = z.object({
         .describe('The talent pool fields'),
     })
     .title('Candidate')
-    .describe('The candidate found'),
+    .describe('The candidate created'),
 })
 
 export const postCandidateInTalentPoolInputSchema = z.object({

--- a/integrations/workable/integration.definition.ts
+++ b/integrations/workable/integration.definition.ts
@@ -1,5 +1,5 @@
 import { z, IntegrationDefinition } from '@botpress/sdk'
-import { getCandidate, listCandidates } from 'definitions/actions/candidates'
+import { createCandidateInJob, getCandidate, listCandidates } from 'definitions/actions/candidates'
 import { candidateCreated, candidateMoved } from 'definitions/events/candidates'
 
 export default new IntegrationDefinition({
@@ -34,6 +34,7 @@ export default new IntegrationDefinition({
   actions: {
     listCandidates,
     getCandidate,
+    createCandidateInJob,
   },
   events: {
     candidateCreated,

--- a/integrations/workable/integration.definition.ts
+++ b/integrations/workable/integration.definition.ts
@@ -1,5 +1,10 @@
 import { z, IntegrationDefinition } from '@botpress/sdk'
-import { createCandidateInJob, getCandidate, listCandidates } from 'definitions/actions/candidates'
+import {
+  createCandidateInJob,
+  createCandidateInTalentPool,
+  getCandidate,
+  listCandidates,
+} from 'definitions/actions/candidates'
 import { candidateCreated, candidateMoved } from 'definitions/events/candidates'
 
 export default new IntegrationDefinition({
@@ -35,6 +40,7 @@ export default new IntegrationDefinition({
     listCandidates,
     getCandidate,
     createCandidateInJob,
+    createCandidateInTalentPool,
   },
   events: {
     candidateCreated,

--- a/integrations/workable/src/index.ts
+++ b/integrations/workable/src/index.ts
@@ -4,8 +4,11 @@ import { handler } from './handler'
 import {
   fromGetCandidateInputModel,
   fromListCandidatesInputModel,
+  fromPostCandidateInJobInputModel,
+  fromPostCandidateInTalentPoolInputModel,
   toGetCandidateModel,
   toListCandidatesOutputModel,
+  toPostCandidateOutputModel,
 } from './mapping/candidate-mapper'
 import { WorkableClient } from './workable-api/client'
 import * as bp from '.botpress'
@@ -120,6 +123,28 @@ export default new bp.Integration({
       } catch (thrown: unknown) {
         const msg = thrown instanceof Error ? thrown.message : String(thrown)
         throw new RuntimeError(`Failed to get candidate with id ${props.input.id}: ${msg}`)
+      }
+    },
+    createCandidateInJob: async (props) => {
+      const client = new WorkableClient(props.ctx.configuration.apiToken, props.ctx.configuration.subDomain)
+
+      try {
+        const raw = await client.postCandidateInJob(fromPostCandidateInJobInputModel(props.input))
+        return toPostCandidateOutputModel(raw)
+      } catch (thrown: unknown) {
+        const msg = thrown instanceof Error ? thrown.message : String(thrown)
+        throw new RuntimeError(`Failed to create candidate: ${msg}`)
+      }
+    },
+    createCandidateInTalentPool: async (props) => {
+      const client = new WorkableClient(props.ctx.configuration.apiToken, props.ctx.configuration.subDomain)
+
+      try {
+        const raw = await client.postCandidateInTalentPool(fromPostCandidateInTalentPoolInputModel(props.input))
+        return toPostCandidateOutputModel(raw)
+      } catch (thrown: unknown) {
+        const msg = thrown instanceof Error ? thrown.message : String(thrown)
+        throw new RuntimeError(`Failed to create candidate: ${msg}`)
       }
     },
   },

--- a/integrations/workable/src/index.ts
+++ b/integrations/workable/src/index.ts
@@ -8,7 +8,8 @@ import {
   fromPostCandidateInTalentPoolInputModel,
   toGetCandidateModel,
   toListCandidatesOutputModel,
-  toPostCandidateOutputModel,
+  toPostCandidateInJobOutputModel,
+  toPostCandidateInTalentPoolOutputModel,
 } from './mapping/candidate-mapper'
 import { WorkableClient } from './workable-api/client'
 import * as bp from '.botpress'
@@ -130,7 +131,7 @@ export default new bp.Integration({
 
       try {
         const raw = await client.postCandidateInJob(fromPostCandidateInJobInputModel(props.input))
-        return toPostCandidateOutputModel(raw)
+        return toPostCandidateInJobOutputModel(raw)
       } catch (thrown: unknown) {
         const msg = thrown instanceof Error ? thrown.message : String(thrown)
         throw new RuntimeError(`Failed to create candidate: ${msg}`)
@@ -141,7 +142,7 @@ export default new bp.Integration({
 
       try {
         const raw = await client.postCandidateInTalentPool(fromPostCandidateInTalentPoolInputModel(props.input))
-        return toPostCandidateOutputModel(raw)
+        return toPostCandidateInTalentPoolOutputModel(raw)
       } catch (thrown: unknown) {
         const msg = thrown instanceof Error ? thrown.message : String(thrown)
         throw new RuntimeError(`Failed to create candidate: ${msg}`)

--- a/integrations/workable/src/index.ts
+++ b/integrations/workable/src/index.ts
@@ -51,11 +51,13 @@ export default new bp.Integration({
         },
       })
 
-      for (const id of ids) {
-        await client.unregisterWebhook(id).catch((thrown) => {
-          const msg = thrown instanceof Error ? thrown.message : String(thrown)
-          props.logger.forBot().warn(`Failed to unregister webhook: ${msg}`)
-        })
+      if (ids !== undefined) {
+        for (const id of ids) {
+          await client.unregisterWebhook(id).catch((thrown) => {
+            const msg = thrown instanceof Error ? thrown.message : String(thrown)
+            props.logger.forBot().warn(`Failed to unregister webhook: ${msg}`)
+          })
+        }
       }
 
       const newIds: number[] = []

--- a/integrations/workable/src/mapping/answers-mapper.ts
+++ b/integrations/workable/src/mapping/answers-mapper.ts
@@ -6,7 +6,7 @@ export function fromPostAnswerModel(
   schema: z.infer<typeof defs.postAnswerSchema>
 ): z.infer<typeof workable.postAnswerSchema> {
   const { questionKey, ...answers } = schema
-  console.log(JSON.stringify(answers, null, 2))
+
   const definedValues = Object.entries(answers).filter(([, value]) => {
     if (value === undefined) {
       return false

--- a/integrations/workable/src/mapping/answers-mapper.ts
+++ b/integrations/workable/src/mapping/answers-mapper.ts
@@ -1,0 +1,51 @@
+import { z } from '@botpress/sdk'
+import * as defs from 'definitions/models/answers'
+import * as workable from 'src/workable-schemas/answers'
+
+export function fromPostAnswerModel(
+  schema: z.infer<typeof defs.postAnswerSchema>
+): z.infer<typeof workable.postAnswerSchema> {
+  const { questionKey, ...rest } = schema
+  if ('fileUrl' in rest) {
+    const { fileUrl, ...newRest } = rest
+    return { ...newRest, question_key: schema.questionKey, file_url: fileUrl }
+  } else if ('choice' in rest) {
+    const { choice, ...newRest } = rest
+    return {
+      ...newRest,
+      question_key: schema.questionKey,
+      choices: [choice],
+    }
+  }
+  return { ...rest, question_key: questionKey }
+}
+
+export function toAnswerModel(schema: z.infer<typeof workable.answerSchema>): z.infer<typeof defs.answerSchema> {
+  const { answer, ...rest } = schema
+  if (answer === null) {
+    return {
+      ...rest,
+      answer,
+    }
+  }
+  if ('file_url' in answer) {
+    const { file_url, ...answerRest } = answer
+    return {
+      ...rest,
+      answer: {
+        ...answerRest,
+        fileUrl: file_url,
+      },
+    }
+  } else if ('choices' in answer) {
+    const { choices, ...answerRest } = answer
+    return {
+      ...rest,
+      answer: {
+        ...answerRest,
+        choices: choices.map((choice) => choice.body),
+      },
+    }
+  }
+  return { ...rest, answer }
+}

--- a/integrations/workable/src/mapping/candidate-mapper.ts
+++ b/integrations/workable/src/mapping/candidate-mapper.ts
@@ -3,6 +3,7 @@ import * as defEvents from 'definitions/events/candidates'
 import * as def from 'definitions/models/candidates'
 import * as workable from 'src/workable-schemas/candidates'
 import * as workableEvents from 'src/workable-schemas/events'
+import { toAnswerModel } from './answers-mapper'
 import { parseNextToken } from './pagination'
 
 export function fromListCandidatesInputModel(
@@ -90,6 +91,7 @@ export function toDetailedCandidateModel(
     social_profiles,
     location,
     originating_candidate_id,
+    answers,
     ...rest
   } = schema
 
@@ -118,6 +120,7 @@ export function toDetailedCandidateModel(
     socialProfiles: social_profiles,
     location: location === null || location === undefined ? undefined : toLocationModel(location),
     originatingCandidateId: originating_candidate_id,
+    answers: answers?.map((answer) => toAnswerModel(answer)),
   }
 }
 

--- a/integrations/workable/src/mapping/candidate-mapper.ts
+++ b/integrations/workable/src/mapping/candidate-mapper.ts
@@ -216,13 +216,13 @@ export function fromPostEducationEntryModel(
 }
 
 export function fromPostExperienceEntryModel(
-  schema: z.infer<typeof workable.postExperienceEntrySchema>
-): z.infer<typeof def.postExperienceEntrySchema> {
-  const { start_date, end_date, ...rest } = schema
+  schema: z.infer<typeof def.postExperienceEntrySchema>
+): z.infer<typeof workable.postExperienceEntrySchema> {
+  const { startDate, endDate, ...rest } = schema
   return {
     ...rest,
-    startDate: start_date,
-    endDate: end_date,
+    start_date: startDate,
+    end_date: endDate,
   }
 }
 
@@ -254,49 +254,61 @@ export function toPostCandidateInTalentPoolOutputModel(
   }
 }
 
-export function fromPostCandidateInTalentPoolInputModel(
-  schema: z.infer<typeof def.postCandidateInTalentPoolInputSchema>
-): z.infer<typeof workable.postCandidateInTalentPoolInputSchema> {
-  const { candidate, ...rest } = schema
-
+export function fromPostCandidateInTalentPoolModel(
+  schema: z.infer<typeof def.postCandidateInTalentPoolSchema>
+): z.infer<typeof workable.postCandidateInTalentPoolSchema> {
   const {
     educationEntries,
     experienceEntries,
     firstName,
     lastName,
     socialProfiles,
-    answers,
     coverLetter,
     disqualificationReason,
     disqualifiedAt,
-    ...candidateRest
-  } = candidate
+    ...rest
+  } = schema
 
   return {
     ...rest,
-    body: {
-      candidate: {
-        ...candidateRest,
-        firstname: firstName,
-        lastname: lastName,
-        education_entries:
-          educationEntries === undefined ? [] : educationEntries.map((entry) => fromPostEducationEntryModel(entry)),
-        experience_entries:
-          experienceEntries === undefined ? [] : experienceEntries.map((entry) => fromPostExperienceEntryModel(entry)),
-        social_profiles: socialProfiles === undefined ? [] : socialProfiles,
-        answers: answers?.map((answer) => fromPostAnswerModel(answer)),
-        cover_letter: coverLetter,
-        disqualification_reason: disqualificationReason,
-        disqualified_at: disqualifiedAt,
-      },
-    },
+    firstname: firstName,
+    lastname: lastName,
+    education_entries:
+      educationEntries === undefined ? [] : educationEntries.map((entry) => fromPostEducationEntryModel(entry)),
+    experience_entries:
+      experienceEntries === undefined ? [] : experienceEntries.map((entry) => fromPostExperienceEntryModel(entry)),
+    social_profiles: socialProfiles === undefined ? [] : socialProfiles,
+    cover_letter: coverLetter,
+    disqualification_reason: disqualificationReason,
+    disqualified_at: disqualifiedAt,
+  }
+}
+
+export function fromPostCandidateInTalentPoolInputModel(
+  schema: z.infer<typeof def.postCandidateInTalentPoolInputSchema>
+): z.infer<typeof workable.postCandidateInTalentPoolInputSchema> {
+  const { candidate, ...rest } = schema
+
+  return {
+    ...rest,
+    candidate: fromPostCandidateInTalentPoolModel(candidate),
   }
 }
 
 export function fromPostCandidateInJobInputModel(
   schema: z.infer<typeof def.postCandidateInJobInputSchema>
 ): z.infer<typeof workable.postCandidateInJobInputSchema> {
-  const { shortCode, ...rest } = schema
+  const { shortCode, candidate, ...rest } = schema
+  const { answers, ...restCandidate } = candidate
 
-  return { ...fromPostCandidateInTalentPoolInputModel({ ...rest }), shortCode }
+  return {
+    body: {
+      ...rest,
+      candidate: {
+        ...fromPostCandidateInTalentPoolModel(restCandidate),
+        answers: answers?.map((answer) => fromPostAnswerModel(answer)),
+      },
+    },
+    shortCode,
+  }
 }

--- a/integrations/workable/src/mapping/candidate-mapper.ts
+++ b/integrations/workable/src/mapping/candidate-mapper.ts
@@ -217,9 +217,20 @@ export function fromPostExperienceEntryModel(
   }
 }
 
-export function fromPostCandidateInJobInputModel(
-  schema: z.infer<typeof def.postCandidateInJobInputSchema>
-): z.infer<typeof workable.postCandidateInJobInputSchema> {
+export function toPostCandidateOutputModel(
+  schema: z.infer<typeof workable.postCandidateOutputSchema>
+): z.infer<typeof def.postCandidateOutputSchema> {
+  const { candidate, ...rest } = schema
+
+  return {
+    candidate: toDetailedCandidateModel(candidate),
+    ...rest,
+  }
+}
+
+export function fromPostCandidateInTalentPoolInputModel(
+  schema: z.infer<typeof def.postCandidateInTalentPoolInputSchema>
+): z.infer<typeof workable.postCandidateInTalentPoolInputSchema> {
   const { candidate, ...rest } = schema
 
   const {
@@ -242,9 +253,11 @@ export function fromPostCandidateInJobInputModel(
         ...candidateRest,
         firstname: firstName,
         lastname: lastName,
-        education_entries: educationEntries.map((entry) => fromPostEducationEntryModel(entry)),
-        experience_entries: experienceEntries.map((entry) => fromPostExperienceEntryModel(entry)),
-        social_profiles: socialProfiles,
+        education_entries:
+          educationEntries === undefined ? [] : educationEntries.map((entry) => fromPostEducationEntryModel(entry)),
+        experience_entries:
+          experienceEntries === undefined ? [] : experienceEntries.map((entry) => fromPostExperienceEntryModel(entry)),
+        social_profiles: socialProfiles === undefined ? [] : socialProfiles,
         answers: answers?.map((answer) => fromPostAnswerModel(answer)),
         cover_letter: coverLetter,
         disqualification_reason: disqualificationReason,
@@ -252,4 +265,12 @@ export function fromPostCandidateInJobInputModel(
       },
     },
   }
+}
+
+export function fromPostCandidateInJobInputModel(
+  schema: z.infer<typeof def.postCandidateInJobInputSchema>
+): z.infer<typeof workable.postCandidateInJobInputSchema> {
+  const { shortCode, ...rest } = schema
+
+  return { ...fromPostCandidateInTalentPoolInputModel({ ...rest }), shortCode }
 }

--- a/integrations/workable/src/mapping/candidate-mapper.ts
+++ b/integrations/workable/src/mapping/candidate-mapper.ts
@@ -266,6 +266,8 @@ export function fromPostCandidateInTalentPoolModel(
     coverLetter,
     disqualificationReason,
     disqualifiedAt,
+    recruiterKey,
+    resumeUrl,
     ...rest
   } = schema
 
@@ -281,6 +283,8 @@ export function fromPostCandidateInTalentPoolModel(
     cover_letter: coverLetter,
     disqualification_reason: disqualificationReason,
     disqualified_at: disqualifiedAt,
+    recruiter_key: recruiterKey,
+    resume_url: resumeUrl,
   }
 }
 

--- a/integrations/workable/src/mapping/candidate-mapper.ts
+++ b/integrations/workable/src/mapping/candidate-mapper.ts
@@ -67,13 +67,12 @@ export function fromGetCandidateInputModel(
   return model
 }
 
-export function toDetailedCandidateModel(
-  schema: z.infer<typeof workable.detailedCandidateSchema>
-): z.infer<typeof def.detailedCandidateSchema> {
+export function toBaseDetailedCandidateModel(
+  schema: z.infer<typeof workable.baseDetailedCandidateSchema>
+): z.infer<typeof def.baseDetailedCandidateSchema> {
   const {
     firstname,
     lastname,
-    job,
     stage_kind,
     disqualification_reason,
     profile_url,
@@ -99,10 +98,6 @@ export function toDetailedCandidateModel(
     ...rest,
     firstName: firstname,
     lastName: lastname,
-    job: {
-      title: job?.title,
-      shortCode: job?.shortcode,
-    },
     stageKind: stage_kind,
     disqualificationReason: disqualification_reason,
     profileUrl: profile_url,
@@ -121,6 +116,20 @@ export function toDetailedCandidateModel(
     location: location === null || location === undefined ? undefined : toLocationModel(location),
     originatingCandidateId: originating_candidate_id,
     answers: answers?.map((answer) => toAnswerModel(answer)),
+  }
+}
+
+export function toDetailedCandidateModel(
+  schema: z.infer<typeof workable.detailedCandidateSchema>
+): z.infer<typeof def.detailedCandidateSchema> {
+  const { job, ...rest } = schema
+
+  return {
+    ...toBaseDetailedCandidateModel(rest),
+    job: {
+      title: job?.title,
+      shortCode: job?.shortcode,
+    },
   }
 }
 
@@ -217,13 +226,30 @@ export function fromPostExperienceEntryModel(
   }
 }
 
-export function toPostCandidateOutputModel(
-  schema: z.infer<typeof workable.postCandidateOutputSchema>
-): z.infer<typeof def.postCandidateOutputSchema> {
+export function toPostCandidateInJobOutputModel(
+  schema: z.infer<typeof workable.postCandidateInJobOutputSchema>
+): z.infer<typeof def.postCandidateInJobOutputSchema> {
   const { candidate, ...rest } = schema
 
   return {
     candidate: toDetailedCandidateModel(candidate),
+    ...rest,
+  }
+}
+
+export function toPostCandidateInTalentPoolOutputModel(
+  schema: z.infer<typeof workable.postCandidateInTalentPoolOutputSchema>
+): z.infer<typeof def.postCandidateInTalentPoolOutputSchema> {
+  const { candidate, ...rest } = schema
+  const { talent_pool, ...candidateRest } = candidate
+
+  return {
+    candidate: {
+      ...toBaseDetailedCandidateModel(candidateRest),
+      talentPool: {
+        talentPoolId: talent_pool.talent_pool_id,
+      },
+    },
     ...rest,
   }
 }

--- a/integrations/workable/src/mapping/candidate-mapper.ts
+++ b/integrations/workable/src/mapping/candidate-mapper.ts
@@ -268,10 +268,11 @@ export function fromPostCandidateInTalentPoolModel(
     disqualifiedAt,
     recruiterKey,
     resumeUrl,
+    resume,
     ...rest
   } = schema
 
-  return {
+  const result = {
     ...rest,
     firstname: firstName,
     lastname: lastName,
@@ -286,6 +287,12 @@ export function fromPostCandidateInTalentPoolModel(
     recruiter_key: recruiterKey,
     resume_url: resumeUrl,
   }
+
+  if (resume?.name && resume?.data) {
+    return { ...result, resume }
+  }
+
+  return result
 }
 
 export function fromPostCandidateInTalentPoolInputModel(

--- a/integrations/workable/src/mapping/candidate-mapper.ts
+++ b/integrations/workable/src/mapping/candidate-mapper.ts
@@ -3,7 +3,7 @@ import * as defEvents from 'definitions/events/candidates'
 import * as def from 'definitions/models/candidates'
 import * as workable from 'src/workable-schemas/candidates'
 import * as workableEvents from 'src/workable-schemas/events'
-import { toAnswerModel } from './answers-mapper'
+import { fromPostAnswerModel, toAnswerModel } from './answers-mapper'
 import { parseNextToken } from './pagination'
 
 export function fromListCandidatesInputModel(
@@ -191,5 +191,65 @@ export function toCandidateMovedEventModel(
     firedAt: fired_at,
     resourceType: resource_type,
     data: candidateModel,
+  }
+}
+
+export function fromPostEducationEntryModel(
+  schema: z.infer<typeof def.postEducationEntrySchema>
+): z.infer<typeof workable.postEducationEntrySchema> {
+  const { endDate, startDate, fieldOfStudy, ...rest } = schema
+  return {
+    ...rest,
+    end_date: endDate,
+    start_date: startDate,
+    field_of_study: fieldOfStudy,
+  }
+}
+
+export function fromPostExperienceEntryModel(
+  schema: z.infer<typeof workable.postExperienceEntrySchema>
+): z.infer<typeof def.postExperienceEntrySchema> {
+  const { start_date, end_date, ...rest } = schema
+  return {
+    ...rest,
+    startDate: start_date,
+    endDate: end_date,
+  }
+}
+
+export function fromPostCandidateInJobInputModel(
+  schema: z.infer<typeof def.postCandidateInJobInputSchema>
+): z.infer<typeof workable.postCandidateInJobInputSchema> {
+  const { candidate, ...rest } = schema
+
+  const {
+    educationEntries,
+    experienceEntries,
+    firstName,
+    lastName,
+    socialProfiles,
+    answers,
+    coverLetter,
+    disqualificationReason,
+    disqualifiedAt,
+    ...candidateRest
+  } = candidate
+
+  return {
+    ...rest,
+    body: {
+      candidate: {
+        ...candidateRest,
+        firstname: firstName,
+        lastname: lastName,
+        education_entries: educationEntries.map((entry) => fromPostEducationEntryModel(entry)),
+        experience_entries: experienceEntries.map((entry) => fromPostExperienceEntryModel(entry)),
+        social_profiles: socialProfiles,
+        answers: answers?.map((answer) => fromPostAnswerModel(answer)),
+        cover_letter: coverLetter,
+        disqualification_reason: disqualificationReason,
+        disqualified_at: disqualifiedAt,
+      },
+    },
   }
 }

--- a/integrations/workable/src/workable-api/client.ts
+++ b/integrations/workable/src/workable-api/client.ts
@@ -44,7 +44,7 @@ export class WorkableClient {
 
   private _handleAxiosError(thrown: unknown): never {
     if (axios.isAxiosError(thrown)) {
-      throw new Error(thrown.response?.data?.message || thrown.message)
+      throw new Error(thrown.response?.data?.error || thrown.message)
     }
     throw thrown
   }
@@ -99,8 +99,9 @@ export class WorkableClient {
   public async postCandidateInTalentPool(
     params: z.infer<typeof postCandidateInTalentPoolInputSchema>
   ): Promise<z.infer<typeof postCandidateInTalentPoolOutputSchema>> {
+    console.log(JSON.stringify(params, null, 2))
     const response: AxiosResponse<z.infer<typeof postCandidateInTalentPoolOutputSchema>> = await this._client
-      .post('/talent_pool/candidates', params.body)
+      .post('/talent_pool/candidates', params)
       .catch(this._handleAxiosError)
     return this._unwrapResponse(response.data)
   }

--- a/integrations/workable/src/workable-api/client.ts
+++ b/integrations/workable/src/workable-api/client.ts
@@ -6,7 +6,8 @@ import {
   listCandidatesInputSchema,
   listCandidatesOutputSchema,
   postCandidateInJobInputSchema,
-  postCandidateInJobOutputSchema,
+  postCandidateInTalentPoolInputSchema,
+  postCandidateOutputSchema,
 } from 'src/workable-schemas/candidates'
 import {
   getWebhooksOutputSchema,
@@ -85,11 +86,20 @@ export class WorkableClient {
     return this._unwrapResponse(response.data)
   }
 
-  public async postCandidate(
+  public async postCandidateInJob(
     params: z.infer<typeof postCandidateInJobInputSchema>
-  ): Promise<z.infer<typeof postCandidateInJobOutputSchema>> {
-    const response: AxiosResponse<z.infer<typeof postCandidateInJobOutputSchema>> = await this._client
+  ): Promise<z.infer<typeof postCandidateOutputSchema>> {
+    const response: AxiosResponse<z.infer<typeof postCandidateOutputSchema>> = await this._client
       .post(`/jobs/${params.shortCode}/candidates`, params.body)
+      .catch(this._handleAxiosError)
+    return this._unwrapResponse(response.data)
+  }
+
+  public async postCandidateInTalentPool(
+    params: z.infer<typeof postCandidateInTalentPoolInputSchema>
+  ): Promise<z.infer<typeof postCandidateOutputSchema>> {
+    const response: AxiosResponse<z.infer<typeof postCandidateOutputSchema>> = await this._client
+      .post('/talent_pool/candidates', params.body)
       .catch(this._handleAxiosError)
     return this._unwrapResponse(response.data)
   }

--- a/integrations/workable/src/workable-api/client.ts
+++ b/integrations/workable/src/workable-api/client.ts
@@ -6,8 +6,9 @@ import {
   listCandidatesInputSchema,
   listCandidatesOutputSchema,
   postCandidateInJobInputSchema,
+  postCandidateInJobOutputSchema,
   postCandidateInTalentPoolInputSchema,
-  postCandidateOutputSchema,
+  postCandidateInTalentPoolOutputSchema,
 } from 'src/workable-schemas/candidates'
 import {
   getWebhooksOutputSchema,
@@ -88,8 +89,8 @@ export class WorkableClient {
 
   public async postCandidateInJob(
     params: z.infer<typeof postCandidateInJobInputSchema>
-  ): Promise<z.infer<typeof postCandidateOutputSchema>> {
-    const response: AxiosResponse<z.infer<typeof postCandidateOutputSchema>> = await this._client
+  ): Promise<z.infer<typeof postCandidateInJobOutputSchema>> {
+    const response: AxiosResponse<z.infer<typeof postCandidateInJobOutputSchema>> = await this._client
       .post(`/jobs/${params.shortCode}/candidates`, params.body)
       .catch(this._handleAxiosError)
     return this._unwrapResponse(response.data)
@@ -97,8 +98,8 @@ export class WorkableClient {
 
   public async postCandidateInTalentPool(
     params: z.infer<typeof postCandidateInTalentPoolInputSchema>
-  ): Promise<z.infer<typeof postCandidateOutputSchema>> {
-    const response: AxiosResponse<z.infer<typeof postCandidateOutputSchema>> = await this._client
+  ): Promise<z.infer<typeof postCandidateInTalentPoolOutputSchema>> {
+    const response: AxiosResponse<z.infer<typeof postCandidateInTalentPoolOutputSchema>> = await this._client
       .post('/talent_pool/candidates', params.body)
       .catch(this._handleAxiosError)
     return this._unwrapResponse(response.data)

--- a/integrations/workable/src/workable-api/client.ts
+++ b/integrations/workable/src/workable-api/client.ts
@@ -5,6 +5,8 @@ import {
   getCandidateOutputSchema,
   listCandidatesInputSchema,
   listCandidatesOutputSchema,
+  postCandidateInJobInputSchema,
+  postCandidateInJobOutputSchema,
 } from 'src/workable-schemas/candidates'
 import {
   getWebhooksOutputSchema,
@@ -79,6 +81,15 @@ export class WorkableClient {
   ): Promise<z.infer<typeof getCandidateOutputSchema>> {
     const response: AxiosResponse<z.infer<typeof getCandidateOutputSchema>> = await this._client
       .get(`/candidates/${params.id}`)
+      .catch(this._handleAxiosError)
+    return this._unwrapResponse(response.data)
+  }
+
+  public async postCandidate(
+    params: z.infer<typeof postCandidateInJobInputSchema>
+  ): Promise<z.infer<typeof postCandidateInJobOutputSchema>> {
+    const response: AxiosResponse<z.infer<typeof postCandidateInJobOutputSchema>> = await this._client
+      .post(`/jobs/${params.shortCode}/candidates`, params.body)
       .catch(this._handleAxiosError)
     return this._unwrapResponse(response.data)
   }

--- a/integrations/workable/src/workable-api/client.ts
+++ b/integrations/workable/src/workable-api/client.ts
@@ -99,7 +99,6 @@ export class WorkableClient {
   public async postCandidateInTalentPool(
     params: z.infer<typeof postCandidateInTalentPoolInputSchema>
   ): Promise<z.infer<typeof postCandidateInTalentPoolOutputSchema>> {
-    console.log(JSON.stringify(params, null, 2))
     const response: AxiosResponse<z.infer<typeof postCandidateInTalentPoolOutputSchema>> = await this._client
       .post('/talent_pool/candidates', params)
       .catch(this._handleAxiosError)

--- a/integrations/workable/src/workable-schemas/answers.ts
+++ b/integrations/workable/src/workable-schemas/answers.ts
@@ -32,6 +32,10 @@ const numericAnswerSchema = z.object({
   number: z.number(),
 })
 
+const postNumericAnswerSchema = z.object({
+  value: z.number(),
+})
+
 const fileAnswerUrlSchema = z.object({
   file_url: z.string(),
 })
@@ -45,7 +49,7 @@ export const postAnswerSchema = z.union([
   basePostAnswerSchema.merge(booleanAnswerSchema),
   basePostAnswerSchema.merge(postMultipleChoiceAnswerSchema),
   basePostAnswerSchema.merge(dateAnswerSchema),
-  basePostAnswerSchema.merge(numericAnswerSchema),
+  basePostAnswerSchema.merge(postNumericAnswerSchema),
   z.union([basePostAnswerSchema.merge(fileAnswerUrlSchema), basePostAnswerSchema.merge(fileAnswerBase64Schema)]),
 ])
 

--- a/integrations/workable/src/workable-schemas/answers.ts
+++ b/integrations/workable/src/workable-schemas/answers.ts
@@ -1,0 +1,67 @@
+import { z } from '@botpress/sdk'
+
+const basePostAnswerSchema = z.object({
+  question_key: z.string(),
+})
+
+const freeTextAnswerSchema = z.object({
+  body: z.string(),
+})
+
+const shortTextAnswerSchema = z.object({
+  body: z.string().max(128),
+})
+
+const booleanAnswerSchema = z.object({
+  checked: z.boolean(),
+})
+
+const multipleChoiceAnswerSchema = z.object({
+  choices: z.array(z.object({ body: z.string() })),
+})
+
+const postMultipleChoiceAnswerSchema = z.object({
+  choices: z.array(z.string()),
+})
+
+const dateAnswerSchema = z.object({
+  date: z.string(),
+})
+
+const numericAnswerSchema = z.object({
+  number: z.number(),
+})
+
+const fileAnswerUrlSchema = z.object({
+  file_url: z.string(),
+})
+const fileAnswerBase64Schema = z.object({
+  data: z.string(),
+})
+
+export const postAnswerSchema = z.union([
+  basePostAnswerSchema.merge(freeTextAnswerSchema),
+  basePostAnswerSchema.merge(shortTextAnswerSchema),
+  basePostAnswerSchema.merge(booleanAnswerSchema),
+  basePostAnswerSchema.merge(postMultipleChoiceAnswerSchema),
+  basePostAnswerSchema.merge(dateAnswerSchema),
+  basePostAnswerSchema.merge(numericAnswerSchema),
+  z.union([basePostAnswerSchema.merge(fileAnswerUrlSchema), basePostAnswerSchema.merge(fileAnswerBase64Schema)]),
+])
+
+export const answerSchema = z.object({
+  question: z.object({
+    body: z.string().nullable(),
+  }),
+  answer: z
+    .union([
+      freeTextAnswerSchema,
+      shortTextAnswerSchema,
+      booleanAnswerSchema,
+      multipleChoiceAnswerSchema,
+      dateAnswerSchema,
+      numericAnswerSchema,
+      z.union([fileAnswerUrlSchema, fileAnswerBase64Schema]),
+    ])
+    .nullable(),
+})

--- a/integrations/workable/src/workable-schemas/answers.ts
+++ b/integrations/workable/src/workable-schemas/answers.ts
@@ -50,7 +50,8 @@ export const postAnswerSchema = z.union([
   basePostAnswerSchema.merge(postMultipleChoiceAnswerSchema),
   basePostAnswerSchema.merge(dateAnswerSchema),
   basePostAnswerSchema.merge(postNumericAnswerSchema),
-  z.union([basePostAnswerSchema.merge(fileAnswerUrlSchema), basePostAnswerSchema.merge(fileAnswerBase64Schema)]),
+  basePostAnswerSchema.merge(fileAnswerUrlSchema),
+  basePostAnswerSchema.merge(fileAnswerBase64Schema),
 ])
 
 export const answerSchema = z.object({
@@ -65,7 +66,8 @@ export const answerSchema = z.object({
       multipleChoiceAnswerSchema,
       dateAnswerSchema,
       numericAnswerSchema,
-      z.union([fileAnswerUrlSchema, fileAnswerBase64Schema]),
+      fileAnswerUrlSchema,
+      fileAnswerBase64Schema,
     ])
     .nullable(),
 })

--- a/integrations/workable/src/workable-schemas/candidates.ts
+++ b/integrations/workable/src/workable-schemas/candidates.ts
@@ -175,17 +175,18 @@ export const postCandidateSchema = z.object({
   domain: z.string().optional(),
 })
 
-export const postCandidateInJobInputSchema = z.object({
-  shortCode: z.string(),
+export const postCandidateInTalentPoolInputSchema = z.object({
   body: z.object({
     sourced: z.boolean().optional(),
     candidate: postCandidateSchema,
   }),
 })
 
-export const postCandidateInJobOutputSchema = z
-  .object({
-    status: z.string(),
-    candidate: detailedCandidateSchema,
-  })
-  .partial()
+export const postCandidateInJobInputSchema = postCandidateInTalentPoolInputSchema.extend({
+  shortCode: z.string(),
+})
+
+export const postCandidateOutputSchema = z.object({
+  status: z.string(),
+  candidate: detailedCandidateSchema,
+})

--- a/integrations/workable/src/workable-schemas/candidates.ts
+++ b/integrations/workable/src/workable-schemas/candidates.ts
@@ -178,6 +178,13 @@ export const postCandidateInTalentPoolSchema = z.object({
   social_profiles: z.array(postSocialProfileSchema),
   domain: z.string().optional(),
   recruiter_key: z.string().optional(),
+  resume_url: z.string().optional(),
+  resume: z
+    .object({
+      name: z.string(),
+      data: z.string(),
+    })
+    .optional(),
 })
 
 export const postCandidateInJobSchema = postCandidateInTalentPoolSchema.extend({

--- a/integrations/workable/src/workable-schemas/candidates.ts
+++ b/integrations/workable/src/workable-schemas/candidates.ts
@@ -1,4 +1,5 @@
 import { z } from '@botpress/sdk'
+import { socialProfileTypesSchema } from 'definitions/models/candidates'
 import { answerSchema } from './answers'
 
 export const candidateSchema = z
@@ -128,3 +129,63 @@ export const getCandidateOutputSchema = z
 export const getCandidateInputSchema = z.object({
   id: z.string(),
 })
+
+export const postEducationEntrySchema = z.object({
+  degree: z.string().optional(),
+  school: z.string(),
+  field_of_study: z.string().optional(),
+  start_date: z.string().optional(),
+  end_date: z.string().optional(),
+})
+
+export const postSocialProfileSchema = z.object({
+  type: socialProfileTypesSchema,
+  username: z.string().optional(),
+  url: z.string(),
+})
+
+export const postExperienceEntrySchema = z.object({
+  title: z.string(),
+  summary: z.string().optional(),
+  start_date: z.string().optional(),
+  end_date: z.string().optional(),
+  company: z.string().optional(),
+  current: z.boolean().optional(),
+  industry: z.string().optional(),
+})
+
+export const postCandidateSchema = z.object({
+  firstname: z.string(),
+  lastname: z.string(),
+  email: z.string(),
+  headline: z.string().optional(),
+  summary: z.string().optional(),
+  address: z.string().optional(),
+  phone: z.string().optional(),
+  cover_letter: z.string().optional(),
+  education_entries: z.array(postEducationEntrySchema),
+  experience_entries: z.array(postExperienceEntrySchema),
+  skills: z.array(z.object({ name: z.string().title('Name') })).optional(),
+  answers: z.array(answerSchema).optional(),
+  tags: z.array(z.string()).optional(),
+  disqualified: z.boolean().optional(),
+  disqualification_reason: z.string().optional(),
+  disqualified_at: z.string().optional(),
+  social_profiles: z.array(postSocialProfileSchema),
+  domain: z.string().optional(),
+})
+
+export const postCandidateInJobInputSchema = z.object({
+  shortCode: z.string(),
+  body: z.object({
+    sourced: z.boolean().optional(),
+    candidate: postCandidateSchema,
+  }),
+})
+
+export const postCandidateInJobOutputSchema = z
+  .object({
+    status: z.string(),
+    candidate: detailedCandidateSchema,
+  })
+  .partial()

--- a/integrations/workable/src/workable-schemas/candidates.ts
+++ b/integrations/workable/src/workable-schemas/candidates.ts
@@ -1,6 +1,6 @@
 import { z } from '@botpress/sdk'
 import { socialProfileTypesSchema } from 'definitions/models/candidates'
-import { answerSchema } from './answers'
+import { answerSchema, postAnswerSchema } from './answers'
 
 export const candidateSchema = z
   .object({
@@ -166,7 +166,7 @@ export const postCandidateSchema = z.object({
   education_entries: z.array(postEducationEntrySchema),
   experience_entries: z.array(postExperienceEntrySchema),
   skills: z.array(z.object({ name: z.string().title('Name') })).optional(),
-  answers: z.array(answerSchema).optional(),
+  answers: z.array(postAnswerSchema).optional(),
   tags: z.array(z.string()).optional(),
   disqualified: z.boolean().optional(),
   disqualification_reason: z.string().optional(),

--- a/integrations/workable/src/workable-schemas/candidates.ts
+++ b/integrations/workable/src/workable-schemas/candidates.ts
@@ -1,4 +1,5 @@
 import { z } from '@botpress/sdk'
+import { answerSchema } from './answers'
 
 export const candidateSchema = z
   .object({
@@ -97,13 +98,6 @@ export const locationSchema = z
     zip_code: z.string().nullable(),
   })
   .partial()
-
-export const answerSchema = z.object({
-  question: z.object({
-    body: z.string(),
-  }),
-  answer: z.object({}).nullable(),
-})
 
 export const detailedCandidateSchema = candidateSchema
   .extend({

--- a/integrations/workable/src/workable-schemas/candidates.ts
+++ b/integrations/workable/src/workable-schemas/candidates.ts
@@ -159,7 +159,7 @@ export const postExperienceEntrySchema = z.object({
   industry: z.string().optional(),
 })
 
-export const postCandidateSchema = z.object({
+export const postCandidateInTalentPoolSchema = z.object({
   firstname: z.string(),
   lastname: z.string(),
   email: z.string(),
@@ -170,24 +170,30 @@ export const postCandidateSchema = z.object({
   cover_letter: z.string().optional(),
   education_entries: z.array(postEducationEntrySchema),
   experience_entries: z.array(postExperienceEntrySchema),
-  skills: z.array(z.object({ name: z.string().title('Name') })).optional(),
-  answers: z.array(postAnswerSchema).optional(),
+  skills: z.array(z.string()).optional(),
   tags: z.array(z.string()).optional(),
   disqualified: z.boolean().optional(),
   disqualification_reason: z.string().optional(),
   disqualified_at: z.string().optional(),
   social_profiles: z.array(postSocialProfileSchema),
   domain: z.string().optional(),
+  recruiter_key: z.string().optional(),
+})
+
+export const postCandidateInJobSchema = postCandidateInTalentPoolSchema.extend({
+  answers: z.array(postAnswerSchema).optional(),
 })
 
 export const postCandidateInTalentPoolInputSchema = z.object({
-  body: z.object({
-    sourced: z.boolean().optional(),
-    candidate: postCandidateSchema,
-  }),
+  sourced: z.boolean().optional(),
+  candidate: postCandidateInTalentPoolSchema,
 })
 
-export const postCandidateInJobInputSchema = postCandidateInTalentPoolInputSchema.extend({
+export const postCandidateInJobInputSchema = z.object({
+  body: z.object({
+    sourced: z.boolean().optional(),
+    candidate: postCandidateInJobSchema,
+  }),
   shortCode: z.string(),
 })
 

--- a/integrations/workable/src/workable-schemas/candidates.ts
+++ b/integrations/workable/src/workable-schemas/candidates.ts
@@ -2,7 +2,7 @@ import { z } from '@botpress/sdk'
 import { socialProfileTypesSchema } from 'definitions/models/candidates'
 import { answerSchema, postAnswerSchema } from './answers'
 
-export const candidateSchema = z
+export const baseCandidateSchema = z
   .object({
     id: z.string(),
     name: z.string(),
@@ -13,12 +13,6 @@ export const candidateSchema = z
       .object({
         subdomain: z.string().nullable(),
         name: z.string().nullable(),
-      })
-      .partial(),
-    job: z
-      .object({
-        shortcode: z.string(),
-        title: z.string(),
       })
       .partial(),
     stage: z.string().nullable(),
@@ -37,6 +31,15 @@ export const candidateSchema = z
     phone: z.string().nullable(),
   })
   .partial()
+
+export const candidateSchema = baseCandidateSchema.extend({
+  job: z
+    .object({
+      shortcode: z.string(),
+      title: z.string(),
+    })
+    .partial(),
+})
 
 export const listCandidatesOutputSchema = z.object({
   candidates: z.array(candidateSchema),
@@ -100,25 +103,27 @@ export const locationSchema = z
   })
   .partial()
 
-export const detailedCandidateSchema = candidateSchema
-  .extend({
-    image_url: z.string().nullable(),
-    disqualified_at: z.string().nullable(),
-    outbound_mailbox: z.string().nullable(),
-    uploader_id: z.string().nullable(),
-    cover_letter: z.string().nullable(),
-    summary: z.string().nullable(),
-    education_entries: z.array(educationEntrySchema),
-    experience_entries: z.array(experienceEntrySchema),
-    skills: z.array(z.object({ name: z.string() }).partial()),
-    answers: z.array(answerSchema),
-    resume_url: z.string().nullable(),
-    social_profiles: z.array(socialProfileSchema),
-    tags: z.array(z.string()),
-    location: locationSchema.nullable(),
-    originating_candidate_id: z.string().nullable(),
-  })
-  .partial()
+const detailedCandidateSchemaExtraFields = {
+  image_url: z.string().nullable(),
+  disqualified_at: z.string().nullable(),
+  outbound_mailbox: z.string().nullable(),
+  uploader_id: z.string().nullable(),
+  cover_letter: z.string().nullable(),
+  summary: z.string().nullable(),
+  education_entries: z.array(educationEntrySchema),
+  experience_entries: z.array(experienceEntrySchema),
+  skills: z.array(z.object({ name: z.string() }).partial()),
+  answers: z.array(answerSchema),
+  resume_url: z.string().nullable(),
+  social_profiles: z.array(socialProfileSchema),
+  tags: z.array(z.string()),
+  location: locationSchema.nullable(),
+  originating_candidate_id: z.string().nullable(),
+}
+
+export const baseDetailedCandidateSchema = baseCandidateSchema.extend(detailedCandidateSchemaExtraFields).partial()
+
+export const detailedCandidateSchema = candidateSchema.extend(detailedCandidateSchemaExtraFields).partial()
 
 export const getCandidateOutputSchema = z
   .object({
@@ -186,7 +191,16 @@ export const postCandidateInJobInputSchema = postCandidateInTalentPoolInputSchem
   shortCode: z.string(),
 })
 
-export const postCandidateOutputSchema = z.object({
+export const postCandidateInTalentPoolOutputSchema = z.object({
+  status: z.string(),
+  candidate: baseDetailedCandidateSchema.extend({
+    talent_pool: z.object({
+      talent_pool_id: z.number(),
+    }),
+  }),
+})
+
+export const postCandidateInJobOutputSchema = z.object({
   status: z.string(),
   candidate: detailedCandidateSchema,
 })


### PR DESCRIPTION
Two new actions are now available for creating candidates. One in the talent pool, and one on a posted job.

A few fixes are included in this PR:
- Now checking if `ids` is `undefined` before iterating on it in `integrations/workable/src/index.ts`.
- The field we look at for an error message after a request to the Workable api fails has been changed to `error` in `integrations/workable/src/workable-api/client.ts`.

