### PR TITLE
fix(freshchat): handle empty events

### DIFF
--- a/integrations/freshchat/integration.definition.ts
+++ b/integrations/freshchat/integration.definition.ts
@@ -6,7 +6,7 @@ import { events, configuration, channels, states, user } from './src/definitions
 export default new sdk.IntegrationDefinition({
   name: INTEGRATION_NAME,
   title: 'Freshchat',
-  version: '1.5.0',
+  version: '1.5.1',
   icon: 'icon.svg',
   description: 'This integration allows your bot to use Freshchat as a HITL Provider',
   readme: 'hub.md',


### PR DESCRIPTION
For an specific client, Freshchat was sending empty texts to the webhook handler, causing some issues, this handles it