### PR TITLE
feat(integrations/workable): New actoin to update candidates

### DIFF
--- a/integrations/workable/definitions/actions/candidates.ts
+++ b/integrations/workable/definitions/actions/candidates.ts
@@ -8,6 +8,8 @@ import {
   postCandidateInJobOutputSchema,
   postCandidateInTalentPoolInputSchema,
   postCandidateInTalentPoolOutputSchema,
+  updateCandidateInputSchema,
+  updateCandidateOutputSchema,
 } from 'definitions/models/candidates'
 
 export const listCandidates = {
@@ -51,5 +53,16 @@ export const createCandidateInTalentPool = {
   },
   output: {
     schema: postCandidateInTalentPoolOutputSchema,
+  },
+} satisfies ActionDefinition
+
+export const updateCandidate = {
+  title: 'Update candidate',
+  description: 'Update an existing candidate. Omitted fields will remain unchanged.',
+  input: {
+    schema: updateCandidateInputSchema,
+  },
+  output: {
+    schema: updateCandidateOutputSchema,
   },
 } satisfies ActionDefinition

--- a/integrations/workable/definitions/models/candidates.ts
+++ b/integrations/workable/definitions/models/candidates.ts
@@ -411,30 +411,30 @@ export const updateCandidateInputSchema = z.object({
         .describe('The source of the image (if not provided by the candidate)'),
       image: z.object({
         name: z.string().title('Name').describe("The candidate's image name"),
-        data: z.string().title('data').describe("The candidate's image encodede in base64"),
+        data: z.string().title('Data').describe("The candidate's image encodede in base64"),
         source: imageSource.title('Image Source').describe('The image source'),
-        educationEntries: z.array(
-          educationEntrySchema.extend({
-            id: z
-              .string()
-              .optional()
-              .title('ID')
-              .describe('The education ID. If provided, updates the existing entry. If not, creates a new one.'),
-          })
-        ),
-        experienceEntries: z.array(
-          experienceEntrySchema.extend({
-            id: z
-              .string()
-              .optional()
-              .title('ID')
-              .describe('The experience ID. If provided, updates the existing entry. If not, creates a new one.'),
-          })
-        ),
-        socialProfiles: postCandidateInTalentPoolSchema.shape.socialProfiles.describe(
-          'Existing profiles will be deleted if not included in the new array.'
-        ),
       }),
+      educationEntries: z.array(
+        educationEntrySchema.extend({
+          id: z
+            .string()
+            .optional()
+            .title('ID')
+            .describe('The education ID. If provided, updates the existing entry. If not, creates a new one.'),
+        })
+      ),
+      experienceEntries: z.array(
+        experienceEntrySchema.extend({
+          id: z
+            .string()
+            .optional()
+            .title('ID')
+            .describe('The experience ID. If provided, updates the existing entry. If not, creates a new one.'),
+        })
+      ),
+      socialProfiles: postCandidateInTalentPoolSchema.shape.socialProfiles.describe(
+        'Existing profiles will be deleted if not included in the new array.'
+      ),
     })
     .omit({
       disqualified: true,

--- a/integrations/workable/definitions/models/candidates.ts
+++ b/integrations/workable/definitions/models/candidates.ts
@@ -445,3 +445,7 @@ export const updateCandidateInputSchema = z.object({
     })
     .partial(),
 })
+
+export const updateCandidateOutputSchema = z.object({
+  candidate: detailedCandidateSchema.title('Candidate').describe('The candidate updated'),
+})

--- a/integrations/workable/definitions/models/candidates.ts
+++ b/integrations/workable/definitions/models/candidates.ts
@@ -350,3 +350,98 @@ export const postCandidateInJobInputSchema = z.object({
   candidate: postCandidateInJobSchema.title('Candidate').describe('The candidate to create'),
   shortCode: z.string().title('Short Code').describe('The shortcode of the job the candidate is applying to'),
 })
+
+export const imageSource = z.enum([
+  'academiaedu',
+  'angellist',
+  'behance',
+  'bitbucket',
+  'blogger',
+  'crunchbase',
+  'dandyid',
+  'delicious',
+  'deviantart',
+  'digg',
+  'doyoubuzz',
+  'dribble',
+  'dribbble',
+  'econsultancy',
+  'facebook',
+  'flavorsme',
+  'flickr',
+  'fullcontact',
+  'getglue',
+  'gist',
+  'github',
+  'goodreads',
+  'googleplus',
+  'gravatar',
+  'hackernews',
+  'hiim',
+  'klout',
+  'lanyrd',
+  'linkedin',
+  'myspace',
+  'ohloh',
+  'orkut',
+  'pinterest',
+  'quora',
+  'reddit',
+  'scribd',
+  'skype',
+  'slideshare',
+  'stackexchange',
+  'stackoverflow',
+  'tumblr',
+  'twitter',
+  'typepad',
+  'vk',
+  'wordpress',
+  'xing',
+])
+
+export const updateCandidateInputSchema = z.object({
+  id: z.string().title('ID').describe("The candidate to update's id"),
+  candidate: postCandidateInTalentPoolSchema
+    .extend({
+      textingConsent: z.enum(['forced', 'declined']).title('Texting Consent'),
+      imageUrl: z.string().title('Image Url').describe("A url pointing to the candidate's image"),
+      imageSource: imageSource
+        .title('Image Source')
+        .describe('The source of the image (if not provided by the candidate)'),
+      image: z.object({
+        name: z.string().title('Name').describe("The candidate's image name"),
+        data: z.string().title('data').describe("The candidate's image encodede in base64"),
+        source: imageSource.title('Image Source').describe('The image source'),
+        educationEntries: z.array(
+          educationEntrySchema.extend({
+            id: z
+              .string()
+              .optional()
+              .title('ID')
+              .describe('The education ID. If provided, updates the existing entry. If not, creates a new one.'),
+          })
+        ),
+        experienceEntries: z.array(
+          experienceEntrySchema.extend({
+            id: z
+              .string()
+              .optional()
+              .title('ID')
+              .describe('The experience ID. If provided, updates the existing entry. If not, creates a new one.'),
+          })
+        ),
+        socialProfiles: postCandidateInTalentPoolSchema.shape.socialProfiles.describe(
+          'Existing profiles will be deleted if not included in the new array.'
+        ),
+      }),
+    })
+    .omit({
+      disqualified: true,
+      disqualificationReason: true,
+      disqualifiedAt: true,
+      domain: true,
+      recruiterKey: true,
+    })
+    .partial(),
+})

--- a/integrations/workable/definitions/models/candidates.ts
+++ b/integrations/workable/definitions/models/candidates.ts
@@ -150,6 +150,33 @@ export const experienceEntrySchema = z
   })
   .partial()
 
+export const updateEducationEntrySchema = z.object({
+  id: z.string().optional().title('Id').describe('The education entry identifier'),
+  degree: z.string().optional().title('Degree').describe('The graduation degree'),
+  school: z.string().title('School').describe('The name of the school graduated'),
+  fieldOfStudy: z.string().optional().title('Field Of Study').describe('The field of study'),
+  startDate: z.string().optional().title('Start Date').describe('The date started'),
+  endDate: z.string().optional().title('End Date').describe('The date ended'),
+})
+
+export const updateSocialProfileSchema = z.object({
+  type: socialProfileTypesSchema.title('Type').describe('The slug name of the social profile'),
+  name: z.string().optional().title('Name').describe('The full name of the social profile'),
+  username: z.string().optional().title('Username').describe('The username of the social profile'),
+  url: z.string().title('Url').describe("Url to the candidate's social profile page"),
+})
+
+export const updateExperienceEntrySchema = z.object({
+  id: z.string().optional().title('Id').describe('The experience entry identifier'),
+  title: z.string().title('Title').describe('The title of the experience entry'),
+  summary: z.string().optional().title('Summary').describe('The summary of the experience entry'),
+  startDate: z.string().optional().title('Start Date').describe('The date started'),
+  endDate: z.string().optional().title('End Date').describe('The date ended'),
+  company: z.string().optional().title('Company').describe('The company name'),
+  industry: z.string().optional().title('Industry').describe('The industry of the company'),
+  current: z.boolean().optional().title('Current').describe('Indicates if currently works there'),
+})
+
 export const locationSchema = z
   .object({
     locationString: z
@@ -409,32 +436,22 @@ export const updateCandidateInputSchema = z.object({
       imageSource: imageSource
         .title('Image Source')
         .describe('The source of the image (if not provided by the candidate)'),
-      image: z.object({
-        name: z.string().title('Name').describe("The candidate's image name"),
-        data: z.string().title('Data').describe("The candidate's image encodede in base64"),
-        source: imageSource.title('Image Source').describe('The image source'),
-      }),
-      educationEntries: z.array(
-        educationEntrySchema.extend({
-          id: z
-            .string()
-            .optional()
-            .title('ID')
-            .describe('The education ID. If provided, updates the existing entry. If not, creates a new one.'),
+      image: z
+        .object({
+          name: z.string().title('Name').describe("The candidate's image name"),
+          data: z.string().title('Data').describe("The candidate's image encodede in base64"),
+          source: imageSource.title('Image Source').describe('The image source'),
         })
-      ),
-      experienceEntries: z.array(
-        experienceEntrySchema.extend({
-          id: z
-            .string()
-            .optional()
-            .title('ID')
-            .describe('The experience ID. If provided, updates the existing entry. If not, creates a new one.'),
-        })
-      ),
-      socialProfiles: postCandidateInTalentPoolSchema.shape.socialProfiles.describe(
-        'Existing profiles will be deleted if not included in the new array.'
-      ),
+        .partial(),
+      educationEntries: z
+        .array(updateEducationEntrySchema)
+        .describe('Existing entries will be deleted if not included in the new array.'),
+      experienceEntries: z
+        .array(updateExperienceEntrySchema)
+        .describe('Existing entries will be deleted if not included in the new array.'),
+      socialProfiles: z
+        .array(updateSocialProfileSchema)
+        .describe('Existing profiles will be deleted if not included in the new array.'),
     })
     .omit({
       disqualified: true,

--- a/integrations/workable/definitions/models/candidates.ts
+++ b/integrations/workable/definitions/models/candidates.ts
@@ -460,7 +460,9 @@ export const updateCandidateInputSchema = z.object({
       domain: true,
       recruiterKey: true,
     })
-    .partial(),
+    .partial()
+    .title('Candidate')
+    .describe('The candidate to update'),
 })
 
 export const updateCandidateOutputSchema = z.object({

--- a/integrations/workable/integration.definition.ts
+++ b/integrations/workable/integration.definition.ts
@@ -4,6 +4,7 @@ import {
   createCandidateInTalentPool,
   getCandidate,
   listCandidates,
+  updateCandidate,
 } from 'definitions/actions/candidates'
 import { candidateCreated, candidateMoved } from 'definitions/events/candidates'
 
@@ -41,6 +42,7 @@ export default new IntegrationDefinition({
     getCandidate,
     createCandidateInJob,
     createCandidateInTalentPool,
+    updateCandidate,
   },
   events: {
     candidateCreated,

--- a/integrations/workable/src/index.ts
+++ b/integrations/workable/src/index.ts
@@ -6,10 +6,12 @@ import {
   fromListCandidatesInputModel,
   fromPostCandidateInJobInputModel,
   fromPostCandidateInTalentPoolInputModel,
+  fromUpdateCandidateInputModel,
   toGetCandidateModel,
   toListCandidatesOutputModel,
   toPostCandidateInJobOutputModel,
   toPostCandidateInTalentPoolOutputModel,
+  toUpdateCandidateOutputModel,
 } from './mapping/candidate-mapper'
 import { WorkableClient } from './workable-api/client'
 import * as bp from '.botpress'
@@ -145,6 +147,17 @@ export default new bp.Integration({
       try {
         const raw = await client.postCandidateInTalentPool(fromPostCandidateInTalentPoolInputModel(props.input))
         return toPostCandidateInTalentPoolOutputModel(raw)
+      } catch (thrown: unknown) {
+        const msg = thrown instanceof Error ? thrown.message : String(thrown)
+        throw new RuntimeError(`Failed to create candidate: ${msg}`)
+      }
+    },
+    updateCandidate: async (props) => {
+      const client = new WorkableClient(props.ctx.configuration.apiToken, props.ctx.configuration.subDomain)
+
+      try {
+        const raw = await client.updateCandidate(fromUpdateCandidateInputModel(props.input))
+        return toUpdateCandidateOutputModel(raw)
       } catch (thrown: unknown) {
         const msg = thrown instanceof Error ? thrown.message : String(thrown)
         throw new RuntimeError(`Failed to create candidate: ${msg}`)

--- a/integrations/workable/src/index.ts
+++ b/integrations/workable/src/index.ts
@@ -160,7 +160,7 @@ export default new bp.Integration({
         return toUpdateCandidateOutputModel(raw)
       } catch (thrown: unknown) {
         const msg = thrown instanceof Error ? thrown.message : String(thrown)
-        throw new RuntimeError(`Failed to create candidate: ${msg}`)
+        throw new RuntimeError(`Failed to update candidate: ${msg}`)
       }
     },
   },

--- a/integrations/workable/src/mapping/candidate-mapper.ts
+++ b/integrations/workable/src/mapping/candidate-mapper.ts
@@ -363,3 +363,16 @@ export function fromUpdateCandidateInputModel(
     },
   }
 }
+
+export function toUpdateCandidateOutputModel(
+  schema: z.infer<typeof workable.updateCandidateOutputSchema>
+): z.infer<typeof def.updateCandidateOutputSchema> {
+  const { candidate, ...rest } = schema
+
+  return {
+    ...rest,
+    candidate: {
+      ...toBaseDetailedCandidateModel(candidate),
+    },
+  }
+}

--- a/integrations/workable/src/mapping/candidate-mapper.ts
+++ b/integrations/workable/src/mapping/candidate-mapper.ts
@@ -323,3 +323,43 @@ export function fromPostCandidateInJobInputModel(
     shortCode,
   }
 }
+
+export function fromUpdateCandidateInputModel(
+  schema: z.infer<typeof def.updateCandidateInputSchema>
+): z.infer<typeof workable.updateCandidateInputSchema> {
+  const { candidate, ...rest } = schema
+  const {
+    textingConsent,
+    imageUrl,
+    imageSource,
+    educationEntries,
+    experienceEntries,
+    firstName,
+    lastName,
+    socialProfiles,
+    coverLetter,
+    resumeUrl,
+    ...restCandidate
+  } = candidate
+
+  return {
+    ...rest,
+    body: {
+      candidate: {
+        ...restCandidate,
+        image_source: imageSource,
+        image_url: imageUrl,
+        texting_consent: textingConsent,
+        firstname: firstName,
+        lastname: lastName,
+        education_entries:
+          educationEntries === undefined ? [] : educationEntries.map((entry) => fromPostEducationEntryModel(entry)),
+        experience_entries:
+          experienceEntries === undefined ? [] : experienceEntries.map((entry) => fromPostExperienceEntryModel(entry)),
+        social_profiles: socialProfiles === undefined ? [] : socialProfiles,
+        cover_letter: coverLetter,
+        resume_url: resumeUrl,
+      },
+    },
+  }
+}

--- a/integrations/workable/src/mapping/candidate-mapper.ts
+++ b/integrations/workable/src/mapping/candidate-mapper.ts
@@ -339,6 +339,7 @@ export function fromUpdateCandidateInputModel(
     socialProfiles,
     coverLetter,
     resumeUrl,
+    resume,
     ...restCandidate
   } = candidate
 
@@ -359,6 +360,7 @@ export function fromUpdateCandidateInputModel(
         social_profiles: socialProfiles === undefined ? [] : socialProfiles,
         cover_letter: coverLetter,
         resume_url: resumeUrl,
+        ...(resume?.data && resume.name ? { resume } : {}),
       },
     },
   }

--- a/integrations/workable/src/mapping/candidate-mapper.ts
+++ b/integrations/workable/src/mapping/candidate-mapper.ts
@@ -216,8 +216,8 @@ export function fromPostEducationEntryModel(
 }
 
 export function fromEducationEntryModel(
-  schema: z.infer<typeof def.educationEntrySchema>
-): z.infer<typeof workable.educationEntrySchema> {
+  schema: z.infer<typeof def.updateEducationEntrySchema>
+): z.infer<typeof workable.updateEducationEntrySchema> {
   const { endDate, startDate, fieldOfStudy, ...rest } = schema
   return {
     ...rest,
@@ -239,8 +239,8 @@ export function fromPostExperienceEntryModel(
 }
 
 export function fromExperienceEntryModel(
-  schema: z.infer<typeof def.experienceEntrySchema>
-): z.infer<typeof workable.experienceEntrySchema> {
+  schema: z.infer<typeof def.updateExperienceEntrySchema>
+): z.infer<typeof workable.updateExperienceEntrySchema> {
   const { startDate, endDate, ...rest } = schema
   return {
     ...rest,
@@ -363,6 +363,7 @@ export function fromUpdateCandidateInputModel(
     coverLetter,
     resumeUrl,
     resume,
+    image,
     ...restCandidate
   } = candidate
 
@@ -389,6 +390,7 @@ export function fromUpdateCandidateInputModel(
           cover_letter: coverLetter,
           resume_url: resumeUrl,
           ...(resume?.data && resume.name ? { resume } : {}),
+          ...(image?.data && image.name ? { resume } : {}),
         }),
       },
     },

--- a/integrations/workable/src/workable-api/client.ts
+++ b/integrations/workable/src/workable-api/client.ts
@@ -46,7 +46,7 @@ export class WorkableClient {
 
   private _handleAxiosError(thrown: unknown): never {
     if (axios.isAxiosError(thrown)) {
-      throw new Error(thrown.response?.data?.error || thrown.message)
+      throw new Error(JSON.stringify(thrown.response?.data?.error, null, 2) || thrown.message)
     }
     throw thrown
   }
@@ -111,7 +111,7 @@ export class WorkableClient {
     params: z.infer<typeof updateCandidateInputSchema>
   ): Promise<z.infer<typeof updateCandidateOutputSchema>> {
     const response: AxiosResponse<z.infer<typeof updateCandidateOutputSchema>> = await this._client
-      .post(`/candidates/${params.id}`, params.body)
+      .patch(`/candidates/${params.id}`, params.body)
       .catch(this._handleAxiosError)
     return this._unwrapResponse(response.data)
   }

--- a/integrations/workable/src/workable-api/client.ts
+++ b/integrations/workable/src/workable-api/client.ts
@@ -110,7 +110,6 @@ export class WorkableClient {
   public async updateCandidate(
     params: z.infer<typeof updateCandidateInputSchema>
   ): Promise<z.infer<typeof updateCandidateOutputSchema>> {
-    console.log(params.body.candidate)
     const response: AxiosResponse<z.infer<typeof updateCandidateOutputSchema>> = await this._client
       .patch(`/candidates/${params.id}`, params.body)
       .catch(this._handleAxiosError)

--- a/integrations/workable/src/workable-api/client.ts
+++ b/integrations/workable/src/workable-api/client.ts
@@ -110,6 +110,7 @@ export class WorkableClient {
   public async updateCandidate(
     params: z.infer<typeof updateCandidateInputSchema>
   ): Promise<z.infer<typeof updateCandidateOutputSchema>> {
+    console.log(params.body.candidate)
     const response: AxiosResponse<z.infer<typeof updateCandidateOutputSchema>> = await this._client
       .patch(`/candidates/${params.id}`, params.body)
       .catch(this._handleAxiosError)

--- a/integrations/workable/src/workable-api/client.ts
+++ b/integrations/workable/src/workable-api/client.ts
@@ -9,6 +9,8 @@ import {
   postCandidateInJobOutputSchema,
   postCandidateInTalentPoolInputSchema,
   postCandidateInTalentPoolOutputSchema,
+  updateCandidateInputSchema,
+  updateCandidateOutputSchema,
 } from 'src/workable-schemas/candidates'
 import {
   getWebhooksOutputSchema,
@@ -101,6 +103,15 @@ export class WorkableClient {
   ): Promise<z.infer<typeof postCandidateInTalentPoolOutputSchema>> {
     const response: AxiosResponse<z.infer<typeof postCandidateInTalentPoolOutputSchema>> = await this._client
       .post('/talent_pool/candidates', params)
+      .catch(this._handleAxiosError)
+    return this._unwrapResponse(response.data)
+  }
+
+  public async updateCandidate(
+    params: z.infer<typeof updateCandidateInputSchema>
+  ): Promise<z.infer<typeof updateCandidateOutputSchema>> {
+    const response: AxiosResponse<z.infer<typeof updateCandidateOutputSchema>> = await this._client
+      .post(`/candidates/${params.id}`, params.body)
       .catch(this._handleAxiosError)
     return this._unwrapResponse(response.data)
   }

--- a/integrations/workable/src/workable-schemas/candidates.ts
+++ b/integrations/workable/src/workable-schemas/candidates.ts
@@ -252,3 +252,6 @@ export const updateCandidateInputSchema = z.object({
       .partial(),
   }),
 })
+export const updateCandidateOutputSchema = z.object({
+  candidate: detailedCandidateSchema,
+})

--- a/integrations/workable/src/workable-schemas/candidates.ts
+++ b/integrations/workable/src/workable-schemas/candidates.ts
@@ -1,5 +1,5 @@
 import { z } from '@botpress/sdk'
-import { socialProfileTypesSchema } from 'definitions/models/candidates'
+import { imageSource, socialProfileTypesSchema } from 'definitions/models/candidates'
 import { answerSchema, postAnswerSchema } from './answers'
 
 export const baseCandidateSchema = z
@@ -216,4 +216,39 @@ export const postCandidateInTalentPoolOutputSchema = z.object({
 export const postCandidateInJobOutputSchema = z.object({
   status: z.string(),
   candidate: detailedCandidateSchema,
+})
+
+export const updateCandidateInputSchema = z.object({
+  id: z.string(),
+  body: z.object({
+    candidate: postCandidateInTalentPoolSchema
+      .extend({
+        texting_consent: z.enum(['forced', 'declined']),
+        image_url: z.string(),
+        image_source: imageSource,
+        image: z.object({
+          name: z.string(),
+          data: z.string(),
+          source: imageSource,
+          education_entries: z.array(
+            educationEntrySchema.extend({
+              id: z.string().optional(),
+            })
+          ),
+          experience_entries: z.array(
+            experienceEntrySchema.extend({
+              id: z.string().optional(),
+            })
+          ),
+        }),
+      })
+      .omit({
+        disqualified: true,
+        disqualification_reason: true,
+        disqualified_at: true,
+        domain: true,
+        recruiter_key: true,
+      })
+      .partial(),
+  }),
 })

--- a/integrations/workable/src/workable-schemas/candidates.ts
+++ b/integrations/workable/src/workable-schemas/candidates.ts
@@ -91,6 +91,33 @@ export const experienceEntrySchema = z
   })
   .partial()
 
+export const updateEducationEntrySchema = z.object({
+  id: z.string().optional(),
+  degree: z.string().optional(),
+  school: z.string(),
+  field_of_study: z.string().optional(),
+  start_date: z.string().optional(),
+  end_date: z.string().optional(),
+})
+
+export const updateSocialProfileSchema = z.object({
+  type: z.string(),
+  name: z.string().optional(),
+  username: z.string().optional(),
+  url: z.string(),
+})
+
+export const updateExperienceEntrySchema = z.object({
+  id: z.string().optional(),
+  title: z.string(),
+  summary: z.string().optional(),
+  start_date: z.string().optional(),
+  end_date: z.string().optional(),
+  company: z.string().optional(),
+  industry: z.string().optional(),
+  current: z.boolean().optional(),
+})
+
 export const locationSchema = z
   .object({
     location_str: z.string().nullable(),
@@ -226,21 +253,16 @@ export const updateCandidateInputSchema = z.object({
         texting_consent: z.enum(['forced', 'declined']),
         image_url: z.string(),
         image_source: imageSource,
-        image: z.object({
-          name: z.string(),
-          data: z.string(),
-          source: imageSource,
-        }),
-        education_entries: z.array(
-          educationEntrySchema.extend({
-            id: z.string().optional(),
+        image: z
+          .object({
+            name: z.string(),
+            data: z.string(),
+            source: imageSource,
           })
-        ),
-        experience_entries: z.array(
-          experienceEntrySchema.extend({
-            id: z.string().optional(),
-          })
-        ),
+          .partial(),
+        education_entries: z.array(updateEducationEntrySchema),
+        experience_entries: z.array(updateExperienceEntrySchema),
+        social_profiles: z.array(updateSocialProfileSchema),
       })
       .omit({
         disqualified: true,

--- a/integrations/workable/src/workable-schemas/candidates.ts
+++ b/integrations/workable/src/workable-schemas/candidates.ts
@@ -230,17 +230,17 @@ export const updateCandidateInputSchema = z.object({
           name: z.string(),
           data: z.string(),
           source: imageSource,
-          education_entries: z.array(
-            educationEntrySchema.extend({
-              id: z.string().optional(),
-            })
-          ),
-          experience_entries: z.array(
-            experienceEntrySchema.extend({
-              id: z.string().optional(),
-            })
-          ),
         }),
+        education_entries: z.array(
+          educationEntrySchema.extend({
+            id: z.string().optional(),
+          })
+        ),
+        experience_entries: z.array(
+          experienceEntrySchema.extend({
+            id: z.string().optional(),
+          })
+        ),
       })
       .omit({
         disqualified: true,


### PR DESCRIPTION
An action for updating candidates is now available in the Workable integration.

A couple details:
- Updating the social profiles of a candidate in any way does not work right now, although I think it's an issue on Workable's side. I get a 422 error with an empty error message every time, even when calling the route with the example payload in Workable's API documentation.
- The call to the `_omitEmptyStrings` function in `integrations/workable/src/mapping/candidate-mapper.ts` is necessary because in the studio, empty strings will sometimes be sent when leaving a field empty, which means the actual data in fields would get erased.
- Now using `JSON.stringify` on errors returned by the API, because it sometimes contains multiple errors in a string array.