### PR TITLE
chore(plugins/conversation-insights): Enabled production deploy

### DIFF
--- a/.github/workflows/deploy-integrations-production.yml
+++ b/.github/workflows/deploy-integrations-production.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       force:
-        description: "Force re-deploying integrations"
+        description: 'Force re-deploying integrations'
         type: boolean
         required: false
         default: false
@@ -23,14 +23,14 @@ jobs:
       - name: Deploy Interfaces
         uses: ./.github/actions/deploy-interfaces
         with:
-          environment: "production"
+          environment: 'production'
           force: ${{ github.event.inputs.force == 'true' }}
           token_cloud_ops_account: ${{ secrets.PRODUCTION_TOKEN_CLOUD_OPS_ACCOUNT }}
           cloud_ops_workspace_id: ${{ secrets.PRODUCTION_CLOUD_OPS_WORKSPACE_ID }}
       - name: Deploy Integrations
         uses: ./.github/actions/deploy-integrations
         with:
-          environment: "production"
+          environment: 'production'
           extra_filter: "-F '!docusign'"
           force: ${{ github.event.inputs.force == 'true' }}
           sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -39,8 +39,8 @@ jobs:
       - name: Deploy Plugins
         uses: ./.github/actions/deploy-plugins
         with:
-          environment: "production"
           extra_filter: "-F '!analytics' -F '!logger' -F '!personality' -F '!synchronizer' -F '!knowledge'"
+          environment: 'production'
           force: ${{ github.event.inputs.force == 'true' }}
           token_cloud_ops_account: ${{ secrets.PRODUCTION_TOKEN_CLOUD_OPS_ACCOUNT }}
           cloud_ops_workspace_id: ${{ secrets.PRODUCTION_CLOUD_OPS_WORKSPACE_ID }}

--- a/.github/workflows/deploy-integrations-production.yml
+++ b/.github/workflows/deploy-integrations-production.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       force:
-        description: 'Force re-deploying integrations'
+        description: "Force re-deploying integrations"
         type: boolean
         required: false
         default: false
@@ -23,14 +23,14 @@ jobs:
       - name: Deploy Interfaces
         uses: ./.github/actions/deploy-interfaces
         with:
-          environment: 'production'
+          environment: "production"
           force: ${{ github.event.inputs.force == 'true' }}
           token_cloud_ops_account: ${{ secrets.PRODUCTION_TOKEN_CLOUD_OPS_ACCOUNT }}
           cloud_ops_workspace_id: ${{ secrets.PRODUCTION_CLOUD_OPS_WORKSPACE_ID }}
       - name: Deploy Integrations
         uses: ./.github/actions/deploy-integrations
         with:
-          environment: 'production'
+          environment: "production"
           extra_filter: "-F '!docusign'"
           force: ${{ github.event.inputs.force == 'true' }}
           sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -39,8 +39,8 @@ jobs:
       - name: Deploy Plugins
         uses: ./.github/actions/deploy-plugins
         with:
-          environment: 'production'
-          extra_filter: "-F '!analytics' -F '!logger' -F '!personality' -F '!synchronizer' -F '!knowledge' -F '!conversation-insights'"
+          environment: "production"
+          extra_filter: "-F '!analytics' -F '!logger' -F '!personality' -F '!synchronizer' -F '!knowledge'"
           force: ${{ github.event.inputs.force == 'true' }}
           token_cloud_ops_account: ${{ secrets.PRODUCTION_TOKEN_CLOUD_OPS_ACCOUNT }}
           cloud_ops_workspace_id: ${{ secrets.PRODUCTION_CLOUD_OPS_WORKSPACE_ID }}

--- a/plugins/conversation-insights/plugin.definition.ts
+++ b/plugins/conversation-insights/plugin.definition.ts
@@ -2,7 +2,7 @@ import { PluginDefinition, z } from '@botpress/sdk'
 
 export default new PluginDefinition({
   name: 'conversation-insights',
-  version: '0.4.0',
+  version: '0.4.1',
   configuration: {
     schema: z.object({
       aiEnabled: z.boolean().default(true).describe('Set to true to enable title, summary and sentiment ai generation'),


### PR DESCRIPTION
`conversation-insights@0.4.1` is already in prod.

Also bumped patch since a version with a shorter timer was already deployed in staging