### PR TITLE
feat(zai): added .group operation

### DIFF
--- a/packages/zai/CLAUDE.md
+++ b/packages/zai/CLAUDE.md
@@ -1,0 +1,696 @@
+# Zai Library - Technical Documentation for Claude
+
+## Overview
+
+**Zai** (Zui AI) is an LLM utility library built on top of Zod schemas (@bpinternal/zui) and the Botpress API (@botpress/cognitive). It provides a type-safe, production-ready abstraction layer for common AI operations with built-in features like active learning, automatic chunking, retries, and usage tracking.
+
+**Main Entry Point**: `src/index.ts`
+**Build Output**: `dist/` directory
+**Package Manager**: pnpm
+
+## Core Architecture
+
+### 1. Main Classes
+
+#### `Zai` Class (src/zai.ts)
+
+The primary interface users interact with. Key responsibilities:
+
+- Configuration management (model selection, namespace, active learning)
+- Client wrapper around `@botpress/cognitive`
+- Provides chainable API through `with()` and `learn()` methods
+- Manages tokenizer initialization (WASM-based)
+- Delegates to operation-specific implementations
+
+**Key Properties**:
+
+- `client: Cognitive` - Wrapped Botpress cognitive client
+- `Model: Models` - Model identifier (e.g., 'best', 'fast', or specific model)
+- `adapter: Adapter` - Storage adapter for active learning (TableAdapter or MemoryAdapter)
+- `namespace: string` - Namespace for organizing tasks (default: 'zai')
+- `activeLearning: ActiveLearning` - Active learning configuration
+
+**Key Methods**:
+
+- `with(options)` - Creates new Zai instance with merged config (for chaining)
+- `learn(taskId)` - Enables active learning for specific task
+- `callModel(props)` - Internal method to invoke cognitive API
+- `getTokenizer()` - Lazy-loads WASM tokenizer with retry logic
+
+#### `ZaiContext` Class (src/context.ts)
+
+Request execution context that tracks a single operation's lifecycle:
+
+- Wraps Cognitive client with event listeners
+- Tracks usage metrics (tokens, cost, latency, requests)
+- Manages AbortController for cancellation
+- Emits progress events during execution
+- Handles retry logic and error recovery
+
+**Key Features**:
+
+- Clones cognitive client per operation for isolation
+- Automatic retry with error feedback to LLM (up to maxRetries)
+- Injects metadata (integrationName, promptCategory, promptSource)
+- Real-time usage tracking via event emitters
+
+#### `Response` Class (src/response.ts)
+
+Promise-like wrapper that adds observability and control:
+
+- Implements `PromiseLike` interface for `await` compatibility
+- Event emitter for progress/complete/error events
+- Dual value system: simplified value (for await) and full result
+- Signal binding for external abort control
+- Result caching with elapsed time tracking
+
+**Simplification Pattern**:
+
+```typescript
+// Full result
+const full = await response.result() // { output, usage, elapsed }
+
+// Simplified (default await)
+const simple = await response // Just the value (e.g., boolean for check)
+```
+
+#### `EventEmitter` Class (src/emitter.ts)
+
+Lightweight typed event emitter used throughout the library:
+
+- Type-safe event dispatch and subscription
+- Supports `on()`, `once()`, `off()`, `emit()`, `clear()`
+- No external dependencies
+
+### 2. Adapters (Active Learning Storage)
+
+#### `Adapter` Abstract Class (src/adapters/adapter.ts)
+
+Defines interface for storing and retrieving learning examples:
+
+- `getExamples<TInput, TOutput>(props)` - Retrieve similar examples
+- `saveExample<TInput, TOutput>(props)` - Store new examples
+
+#### `TableAdapter` (src/adapters/botpress-table.ts)
+
+Botpress Table API implementation for persistent storage:
+
+- Creates/validates table schema on first use
+- Stores examples with metadata (cost, tokens, model, latency)
+- Supports similarity search via table search API
+- Schema includes: taskType, taskId, key, input, output, explanation, metadata, status, feedback
+- Only retrieves 'approved' status examples
+- Handles schema validation and migration checking
+
+**Table Schema**:
+
+```typescript
+{
+  taskType: string       // e.g., 'zai.extract'
+  taskId: string        // e.g., 'zai/sentiment-analysis'
+  key: string           // Hash of input + taskId + taskType + instructions
+  instructions: string
+  input: Record         // Searchable
+  output: Record
+  explanation: string | null
+  metadata: {
+    model: string
+    cost: { input, output }
+    latency: number
+    tokens: { input, output }
+  }
+  status: 'pending' | 'rejected' | 'approved'
+  feedback: { rating, comment } | null
+}
+```
+
+#### `MemoryAdapter` (src/adapters/memory.ts)
+
+No-op implementation for when active learning is disabled:
+
+- Returns empty examples array
+- Does not persist anything
+
+### 3. Operations
+
+All operations follow a similar pattern:
+
+1. Parse and validate options using Zod schemas
+2. Create `ZaiContext` for the operation
+3. Execute async operation function
+4. Wrap in `Response` with simplification function
+5. Optionally save examples to adapter
+
+#### Extract Operation (src/operations/extract.ts)
+
+**Purpose**: Extract structured data from unstructured text using Zod schemas
+
+**Key Features**:
+
+- Supports objects, arrays of objects, and primitive types
+- Automatic schema wrapping for non-objects
+- Multi-chunk processing for large inputs (parallel with p-limit)
+- Recursive merging of chunked results
+- JSON repair and parsing (json5, jsonrepair)
+- Few-shot learning with examples
+- Strict/non-strict mode
+
+**Special Markers**:
+
+- `■json_start■` / `■json_end■` - JSON boundaries
+- `■NO_MORE_ELEMENT■` - Signals completion for arrays
+- `■ZERO_ELEMENTS■` - Empty array indicator
+
+**Chunking Strategy**:
+
+1. If input exceeds chunkLength, split into chunks
+2. Process chunks in parallel (max 10 concurrent)
+3. Recursively merge results into final schema
+4. Handles conflicting data by taking most frequent/reasonable value
+
+**Example Flow**:
+
+```typescript
+zai.extract(text, z.object({ name: z.string(), age: z.number() }))
+→ Context creation
+→ Tokenize + chunk if needed
+→ Generate prompt with examples
+→ LLM extraction with JSON markers
+→ Parse + validate with schema
+→ Save example (if learning enabled)
+→ Return via Response wrapper
+```
+
+#### Check Operation (src/operations/check.ts)
+
+**Purpose**: Boolean condition verification with explanation
+
+**Return Type**: `{ value: boolean, explanation: string }` (simplified to `boolean`)
+
+**Markers**: `■TRUE■`, `■FALSE■`, `■END■`
+
+**Handling Ambiguity**: If both TRUE and FALSE appear, uses the last occurrence
+
+**Example Storage**: Stores boolean output with explanation for future reference
+
+#### Label Operation (src/operations/label.ts)
+
+**Purpose**: Multi-label classification with confidence levels
+
+**Labels**:
+
+- `ABSOLUTELY_NOT` (confidence: 1, value: false)
+- `PROBABLY_NOT` (confidence: 0.5, value: false)
+- `AMBIGUOUS` (confidence: 0, value: false)
+- `PROBABLY_YES` (confidence: 0.5, value: true)
+- `ABSOLUTELY_YES` (confidence: 1, value: true)
+
+**Return Type**:
+
+```typescript
+Record<
+  LabelKey,
+  {
+    explanation: string
+    value: boolean
+    confidence: number
+  }
+>
+```
+
+Simplified to `Record<LabelKey, boolean>`
+
+**Format**: `■label:【explanation】:LABEL_VALUE■`
+
+**Chunking**: For large inputs, processes in chunks and merges with OR logic (any true → true)
+
+#### Rewrite Operation (src/operations/rewrite.ts)
+
+**Purpose**: Transform text according to instructions
+
+**Use Cases**:
+
+- Translation
+- Tone adjustment
+- Format conversion
+- Content modification
+
+**Markers**: `■START■`, `■END■`
+
+**Length Control**: Optionally enforces token length limits
+
+**Examples**: Supports custom examples for format learning
+
+#### Filter Operation (src/operations/filter.ts)
+
+**Purpose**: Filter array elements based on natural language condition
+
+**Strategy**:
+
+- Chunks arrays (max 50 items per chunk, max tokens per chunk)
+- Processes chunks in parallel (max 10 concurrent)
+- Returns filtered subset
+
+**Format**: `■0:true■1:false■2:true` (indices with boolean decisions)
+
+**Token Budget Allocation**:
+
+- 50% for examples
+- 25% for condition
+- Remainder for input array
+
+#### Text Operation (src/operations/text.ts)
+
+**Purpose**: Generate text content based on prompt
+
+**Features**:
+
+- Direct text generation
+- Length constraints with enforcement
+- Token-to-word approximation table for short texts
+- Higher temperature (0.7) for creativity
+
+**Simplest Operation**: No complex parsing, just prompt → text
+
+#### Summarize Operation (src/operations/summarize.ts)
+
+**Purpose**: Summarize documents of any length to target length
+
+**Strategies**:
+
+1. **Sliding Window**: For moderate documents
+
+   - Iteratively processes overlapping windows
+   - Updates summary incrementally
+   - Final pass ensures target length
+
+2. **Merge Sort**: For very large documents
+   - Recursively splits into sub-chunks
+   - Summarizes each independently (parallel)
+   - Merges summaries bottom-up
+
+**Options**:
+
+- `length`: Target token count
+- `intermediateFactor`: Allows intermediate summaries to be longer (default: 4x)
+- `sliding.window`: Window size for sliding strategy
+- `sliding.overlap`: Overlap between windows
+- `prompt`: What to focus on
+- `format`: Output formatting instructions
+
+**Markers**: `■START■`, `■END■`
+
+### 4. Utilities
+
+#### src/utils.ts
+
+- `stringify(input, beautify)` - Converts any input to string (handles null/undefined)
+- `fastHash(str)` - Simple 32-bit hash for cache keys
+- `takeUntilTokens(arr, tokens, count)` - Takes items until token budget exhausted
+
+#### src/tokenizer.ts
+
+- Lazy-loads `@bpinternal/thicktoken` WASM tokenizer
+- Retry logic for WASM initialization race conditions
+- Singleton pattern for tokenizer instance
+
+#### src/operations/constants.ts
+
+- `PROMPT_INPUT_BUFFER = 1048` - Safety buffer for input token calculations
+- `PROMPT_OUTPUT_BUFFER = 512` - Safety buffer for output token calculations
+
+#### src/operations/errors.ts
+
+- `JsonParsingError` - Specialized error for JSON parsing failures
+- Formats Zod validation errors in human-readable way
+- Shows JSON excerpt and specific validation issues
+
+## Token Budget Management
+
+All operations carefully manage token budgets to stay within model limits:
+
+```typescript
+const PROMPT_COMPONENT = model.input.maxTokens - PROMPT_INPUT_BUFFER
+
+// Typical allocation strategy:
+{
+  input: 50% of PROMPT_COMPONENT,
+  condition/instruction: 20% of PROMPT_COMPONENT,
+  examples: 30% of PROMPT_COMPONENT,
+}
+```
+
+Chunking triggers when:
+
+- Input exceeds configured `chunkLength`
+- Calculated budget exceeded
+
+## Active Learning Flow
+
+When enabled (`activeLearning.enable = true`):
+
+1. **Task Execution**:
+
+   - Generate unique key: `fastHash(taskType + taskId + input + instructions)`
+   - Check adapter for exact match (cache hit)
+   - If no match, generate examples from adapter.getExamples()
+   - Execute LLM operation with examples as few-shot learning
+   - Save result to adapter if not aborted
+
+2. **Example Retrieval**:
+
+   - Adapter searches by similarity (semantic search via Table API)
+   - Only returns 'approved' status examples
+   - Limited to top 10 results
+   - Filtered by token budget (takeUntilTokens)
+
+3. **Example Format**:
+
+   - Each operation formats examples differently
+   - Generally: User message (input + context) → Assistant message (expected output)
+   - Includes metadata for tracking cost/performance
+
+4. **Learning Curve**:
+   - First calls: No examples (uses defaults or no examples)
+   - Subsequent calls: Uses approved examples as guidance
+   - Improves format consistency and accuracy over time
+
+## Error Handling
+
+### Retry Mechanism (ZaiContext)
+
+```typescript
+maxRetries = 3 (default)
+for (attempt in 0..maxRetries) {
+  try {
+    response = await cognitive.generateContent(...)
+    return transform(response)
+  } catch (error) {
+    if (attempt === maxRetries) throw error
+    // Add error as user message for LLM to fix
+    messages.push({ role: 'user', content: ERROR_PARSING_OUTPUT })
+  }
+}
+```
+
+### Transform Errors
+
+- Operations throw errors in transform function when output invalid
+- Error message fed back to LLM with context
+- Common issues: missing markers, invalid JSON, wrong format
+
+### Abort Handling
+
+- All operations check `ctx.controller.signal.throwIfAborted()`
+- Examples not saved if aborted
+- Clean abort via Response.abort() or signal binding
+
+## Usage Tracking
+
+### Metrics Collected (Usage type)
+
+```typescript
+{
+  requests: {
+    requests: number        // Total requests initiated
+    errors: number          // Failed requests
+    responses: number       // Successful responses
+    cached: number          // Cached responses (no tokens used)
+    percentage: number      // Completion percentage
+  },
+  cost: {
+    input: number          // USD cost for input tokens
+    output: number         // USD cost for output tokens
+    total: number          // Total cost
+  },
+  tokens: {
+    input: number          // Input tokens consumed
+    output: number         // Output tokens generated
+    total: number          // Total tokens
+  }
+}
+```
+
+### Access Patterns
+
+```typescript
+// During execution (progress events)
+response.on('progress', (usage) => {
+  console.log(usage.tokens.total)
+})
+
+// After completion
+const { output, usage, elapsed } = await response.result()
+```
+
+### Metadata Stored with Examples
+
+```typescript
+{
+  model: string // Model used
+  cost: {
+    input, output
+  }
+  latency: number // ms
+  tokens: {
+    input, output
+  }
+}
+```
+
+## Configuration
+
+### ZaiConfig
+
+```typescript
+{
+  client: BotpressClientLike | Cognitive  // Required
+  userId?: string                         // For tracking/attribution
+  modelId?: Models                        // 'best' | 'fast' | 'provider:model'
+  activeLearning?: {
+    enable: boolean
+    tableName: string                     // Must match /^[A-Za-z0-9_/-]{1,100}Table$/
+    taskId: string                        // Must match /^[A-Za-z0-9_/-]{1,100}$/
+  }
+  namespace?: string                      // Default: 'zai'
+}
+```
+
+### Model Selection
+
+- `'best'` - Best available model (default)
+- `'fast'` - Fastest/cheapest model
+- `'provider:model'` - Specific model (e.g., 'openai:gpt-4')
+
+Model details fetched lazily via `cognitive.getModelDetails()`
+
+## Testing
+
+Test files located in `e2e/` directory:
+
+- Uses Vitest framework
+- Real API calls to Botpress (requires .env with credentials)
+- Snapshot testing for validation
+- Includes active learning tests with table cleanup
+
+**Key Test Utilities** (e2e/utils.ts):
+
+- `getCachedClient()` - Reuses cognitive client across tests
+- `getZai()` - Creates Zai instance
+- `getClient()` - Gets raw Botpress client
+- Loads `BotpressDocumentation` for large document tests
+
+## Build System
+
+- **TypeScript**: Compiled with tsup (types) and custom esbuild script (build.ts)
+- **Type Generation**: `tsup` generates .d.ts files
+- **Neutral Build**: `ts-node -T ./build.ts` for platform-neutral JS
+- **Size Limit**: Max 50 kB (enforced by size-limit)
+- **Peer Dependencies**: @bpinternal/thicktoken, @bpinternal/zui
+
+## Extension Points
+
+### Adding New Operations
+
+1. **Create operation file**: `src/operations/my-operation.ts`
+
+2. **Declare module augmentation**:
+
+```typescript
+declare module '@botpress/zai' {
+  interface Zai {
+    myOperation(input: T, options?: Options): Response<Output, Simplified>
+  }
+}
+```
+
+3. **Implement operation function**:
+
+```typescript
+const myOperation = async (input: T, options: Options, ctx: ZaiContext): Promise<Output> => {
+  // Implementation
+}
+```
+
+4. **Add prototype method**:
+
+```typescript
+Zai.prototype.myOperation = function (input, options) {
+  const context = new ZaiContext({
+    client: this.client,
+    modelId: this.Model,
+    taskId: this.taskId,
+    taskType: 'zai.myOperation',
+    adapter: this.adapter,
+  })
+
+  return new Response(context, myOperation(input, options, context), simplify)
+}
+```
+
+5. **Import in src/index.ts**: `import './operations/my-operation'`
+
+### Custom Adapters
+
+Implement `Adapter` abstract class:
+
+```typescript
+export class MyAdapter extends Adapter {
+  async getExamples<TInput, TOutput>(props: GetExamplesProps<TInput>) {
+    // Return array of { key, input, output, explanation?, similarity }
+  }
+
+  async saveExample<TInput, TOutput>(props: SaveExampleProps<TInput, TOutput>) {
+    // Persist example
+  }
+}
+```
+
+## Dependencies
+
+### Runtime
+
+- `@botpress/cognitive` (0.1.50) - Core LLM client
+- `json5` (^2.2.3) - Relaxed JSON parsing
+- `jsonrepair` (^3.10.0) - Fix malformed JSON
+- `lodash-es` (^4.17.21) - Utilities (chunk, isArray, clamp)
+- `p-limit` (^7.2.0) - Concurrency control
+
+### Peer Dependencies
+
+- `@bpinternal/thicktoken` (^1.0.0) - WASM tokenizer
+- `@bpinternal/zui` (^1.2.2) - Zod wrapper with transforms
+
+### Dev Dependencies
+
+- `@botpress/client` (workspace) - Botpress API client
+- `@botpress/common` (workspace) - Shared utilities
+- `@botpress/vai` (workspace) - Validation utilities
+- `tsup`, `esbuild` - Build tools
+- `vitest` - Testing framework
+
+## Common Patterns
+
+### Chaining Configuration
+
+```typescript
+const result = await zai.with({ modelId: 'fast' }).learn('my-task').extract(text, schema)
+```
+
+### Abort Control
+
+```typescript
+const controller = new AbortController()
+const response = zai.check(text, condition)
+response.bindSignal(controller.signal)
+
+setTimeout(() => controller.abort(), 5000)
+```
+
+### Progress Tracking
+
+```typescript
+const response = zai.summarize(longDoc)
+response.on('progress', (usage) => {
+  console.log(`Progress: ${usage.requests.percentage * 100}%`)
+})
+const summary = await response
+```
+
+### Detailed Results
+
+```typescript
+const { output, usage, elapsed } = await zai.extract(text, schema).result()
+console.log(`Took ${elapsed}ms, used ${usage.tokens.total} tokens, cost $${usage.cost.total}`)
+```
+
+## Debugging Tips
+
+1. **Enable request logging**:
+
+```typescript
+cognitive.on('request', (req) => console.log(req.input))
+cognitive.on('response', (req, res) => console.log(res.output))
+```
+
+2. **Check token counts**:
+
+```typescript
+const tokenizer = await getTokenizer()
+console.log(tokenizer.count(text))
+```
+
+3. **Inspect examples**:
+
+```typescript
+const examples = await adapter.getExamples({ taskType, taskId, input })
+console.log(examples)
+```
+
+4. **Monitor retries**: Watch for multiple requests in usage stats
+
+```typescript
+const { usage } = await response.result()
+if (usage.requests.requests > usage.requests.responses) {
+  console.warn('Retries occurred')
+}
+```
+
+## Performance Considerations
+
+- **Chunking**: Use smaller chunks for better parallelization, larger for better context
+- **Concurrency**: Limited to 10 parallel operations (p-limit)
+- **Caching**: Active learning provides cache via exact key matches
+- **Token Estimation**: Tokenizer used for accurate counting, not char-based estimation
+- **Model Selection**: 'fast' model significantly cheaper but lower quality
+
+## Security Notes
+
+- Input validation via Zod schemas
+- No arbitrary code execution
+- Table names/taskIds validated with regex
+- Frozen table schema prevents accidental modifications
+- No sensitive data in default table tags
+
+## Known Issues & Limitations
+
+1. **WASM Loading**: Tokenizer requires retry logic due to race condition
+2. **Table Search**: Limited to 1024 characters for search query
+3. **Chunk Merging**: May lose information if chunks have conflicting data
+4. **Max Retries**: Fixed at 3, not configurable per operation
+5. **Concurrency**: Fixed at 10 parallel operations
+6. **Schema Changes**: Table adapter doesn't auto-migrate schemas
+
+## Future Enhancement Ideas
+
+- Configurable retry strategies
+- Custom similarity functions for example retrieval
+- Streaming support for long-running operations
+- Cache layer beyond exact match
+- Multi-model fallback strategies
+- Cost optimization recommendations
+- Token usage prediction before execution
+
+---
+
+**Last Updated**: Based on codebase analysis at commit `7d073b6de` on branch `sp/zai-fix-empty-arr`

--- a/packages/zai/README.md
+++ b/packages/zai/README.md
@@ -104,7 +104,32 @@ const techCompanies = await zai.filter(companies, 'are technology companies')
 const recentPosts = await zai.filter(posts, 'were published this week')
 ```
 
-### 6. Text - Generate content
+### 6. Group - Organize items into categories
+
+```typescript
+// Group items automatically
+const grouped = await zai.group(tasks, {
+  instructions: 'Group by priority level',
+})
+// Result: { 'High Priority': [...], 'Medium Priority': [...], 'Low Priority': [...] }
+
+// Group with initial categories
+const categorized = await zai.group(emails, {
+  instructions: 'Group by topic',
+  initialGroups: [
+    { id: 'work', label: 'Work' },
+    { id: 'personal', label: 'Personal' },
+  ],
+})
+
+// Group large datasets efficiently
+const organized = await zai.group(largeArray, {
+  instructions: 'Group by date',
+  chunkLength: 8000, // Process in chunks for better performance
+})
+```
+
+### 7. Text - Generate content
 
 ```typescript
 const blogPost = await zai.text('Write about the future of AI', {
@@ -113,7 +138,7 @@ const blogPost = await zai.text('Write about the future of AI', {
 })
 ```
 
-### 7. Summarize - Create summaries
+### 8. Summarize - Create summaries
 
 ```typescript
 // Simple summary
@@ -237,6 +262,7 @@ setTimeout(() => controller.abort(), 5000)
 - `.label(content, criteria, options?)` - Apply multiple labels
 - `.rewrite(content, instruction, options?)` - Transform text
 - `.filter(items, condition, options?)` - Filter array items
+- `.group(items, options?)` - Organize items into categories
 - `.text(prompt, options?)` - Generate text
 - `.summarize(content, options?)` - Create summary
 

--- a/packages/zai/e2e/group.test.ts
+++ b/packages/zai/e2e/group.test.ts
@@ -1,0 +1,855 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { Zai } from '../src'
+import { getZai } from './utils'
+
+describe('group', () => {
+  let zai: Zai
+
+  beforeEach(async () => {
+    zai = await getZai()
+  })
+
+  describe('basic grouping', () => {
+    it('should group simple strings by category', async () => {
+      const items = ['apple', 'banana', 'carrot', 'broccoli', 'orange', 'spinach']
+
+      const result = await zai.group(items, {
+        instructions: 'Group these items into fruits and vegetables',
+      })
+
+      expect(Object.keys(result).length).toBeGreaterThanOrEqual(2)
+      expect(Object.keys(result).length).toBeLessThanOrEqual(3) // fruits, vegetables, maybe ambiguous
+    })
+
+    it('should handle empty array', async () => {
+      const items: string[] = []
+
+      const result = await zai.group(items)
+
+      expect(result).toEqual({})
+    })
+
+    it('should handle single element', async () => {
+      const items = ['apple']
+
+      const result = await zai.group(items, {
+        instructions: 'Group by category',
+      })
+
+      expect(Object.keys(result).length).toBe(1)
+      expect(Object.values(result).flat().length).toBe(1)
+    })
+
+    it('should group all items into single group when very similar', async () => {
+      const items = ['apple', 'red apple', 'green apple', 'apple fruit']
+
+      const result = await zai.group(items, {
+        instructions: 'Group similar items',
+      })
+
+      // Should recognize these are all apples
+      expect(Object.keys(result).length).toBeLessThanOrEqual(2)
+    })
+  })
+
+  describe('complex object grouping', () => {
+    it('should group objects by semantic similarity', async () => {
+      const items = [
+        { text: 'I love this product!', rating: 5 },
+        { text: 'Terrible experience', rating: 1 },
+        { text: 'Amazing quality', rating: 5 },
+        { text: 'Worst purchase ever', rating: 1 },
+        { text: 'Pretty good', rating: 4 },
+        { text: 'Disappointed', rating: 2 },
+      ]
+
+      const result = await zai.group(items, {
+        instructions: 'Group by sentiment (positive, negative, neutral)',
+      })
+
+      expect(Object.keys(result).length).toBeGreaterThanOrEqual(2) // At least positive and negative
+      expect(Object.keys(result).length).toBeLessThanOrEqual(3) // At most positive, negative, neutral
+    })
+
+    it('should group by multiple criteria', async () => {
+      const items = [
+        { name: 'Alice', department: 'Engineering', level: 'Senior' },
+        { name: 'Bob', department: 'Engineering', level: 'Junior' },
+        { name: 'Carol', department: 'Sales', level: 'Senior' },
+        { name: 'Dave', department: 'Sales', level: 'Junior' },
+        { name: 'Eve', department: 'Engineering', level: 'Senior' },
+      ]
+
+      const result = await zai.group(items, {
+        instructions: 'Group by department',
+      })
+
+      expect(Object.keys(result).length).toBe(2) // Engineering and Sales
+      expect(Object.values(result).every((group) => group.length > 0)).toBe(true)
+    })
+  })
+
+  describe('large arrays and chunking', () => {
+    it('should handle large arrays (50+ elements)', async () => {
+      const items = Array.from({ length: 100 }, (_, i) => {
+        if (i % 3 === 0) return `fruit ${i}`
+        if (i % 3 === 1) return `vegetable ${i}`
+        return `grain ${i}`
+      })
+
+      const result = await zai.group(items, {
+        instructions: 'Group by food category',
+      })
+
+      expect(Object.keys(result).length).toBe(3)
+      expect(Object.values(result).flat().length).toBe(100)
+    })
+
+    it('should handle very long text elements', async () => {
+      const items = [
+        'A'.repeat(1000) + ' - this is about topic A',
+        'B'.repeat(1000) + ' - this is about topic B',
+        'A'.repeat(1000) + ' - also about topic A',
+        'C'.repeat(1000) + ' - different topic C',
+        'B'.repeat(1000) + ' - more on topic B',
+      ]
+
+      const result = await zai.group(items, {
+        instructions: 'Group by topic',
+        tokensPerElement: 100, // Truncate long elements
+      })
+
+      expect(Object.keys(result).length).toBeGreaterThanOrEqual(2)
+      expect(Object.keys(result).length).toBeLessThanOrEqual(3)
+    })
+
+    it('should handle array that requires multiple group window slides', async () => {
+      // Create enough items to require sliding groups window
+      const items = Array.from({ length: 200 }, (_, i) => `item ${i % 10}`)
+
+      const result = await zai.group(items, {
+        instructions: 'Group identical or very similar items together',
+      })
+
+      // Should recognize patterns and group similar items
+      expect(Object.keys(result).length).toBeLessThanOrEqual(15) // Should find patterns
+      expect(Object.values(result).flat().length).toBe(200) // All items accounted for
+    })
+  })
+
+  describe('initial groups', () => {
+    it('should use initial groups as starting point', async () => {
+      const items = ['apple', 'banana', 'carrot', 'orange', 'broccoli']
+
+      const result = await zai.group(items, {
+        instructions: 'Assign items to existing groups or create new ones',
+        initialGroups: [
+          { id: 'fruits', label: 'Fruits', elements: [] },
+          { id: 'vegetables', label: 'Vegetables', elements: [] },
+        ],
+      })
+
+      expect(Object.keys(result)).toContain('Fruits')
+      expect(Object.keys(result)).toContain('Vegetables')
+    })
+
+    it('should create new groups when initial groups do not fit', async () => {
+      const items = ['apple', 'banana', 'chicken', 'beef', 'carrot']
+
+      const result = await zai.group(items, {
+        instructions: 'Assign to existing groups or create new ones',
+        initialGroups: [{ id: 'fruits', label: 'Fruits', elements: [] }],
+      })
+
+      // Should create new groups for meat and vegetables
+      expect(Object.keys(result).length).toBeGreaterThan(1)
+    })
+  })
+
+  describe('edge cases and error handling', () => {
+    it('should handle items with null/undefined values', async () => {
+      const items = ['apple', null, 'banana', undefined, 'carrot'] as any[]
+
+      const result = await zai.group(items, {
+        instructions: 'Group by type',
+      })
+
+      expect(Object.values(result).flat().length).toBeLessThanOrEqual(5)
+    })
+
+    it('should handle duplicate items', async () => {
+      const items = ['apple', 'apple', 'apple', 'banana', 'banana']
+
+      const result = await zai.group(items, {
+        instructions: 'Group identical items',
+      })
+
+      expect(Object.keys(result).length).toBeLessThanOrEqual(2)
+      // All apples should be together
+      const appleGroup = Object.values(result).find((group) => group.includes('apple'))
+      expect(appleGroup?.filter((item) => item === 'apple').length).toBe(3)
+    })
+
+    it('should handle mixed types in array', async () => {
+      const items = ['string', 123, { key: 'value' }, ['array'], true, null] as any[]
+
+      const result = await zai.group(items, {
+        instructions: 'Group by data type',
+      })
+
+      expect(Object.keys(result).length).toBeGreaterThanOrEqual(2)
+    })
+
+    it('should respect token limits per element', async () => {
+      const items = [
+        'Short text',
+        'A'.repeat(10000), // Very long
+        'Another short',
+      ]
+
+      const result = await zai.group(items, {
+        tokensPerElement: 50, // Limit tokens per element
+      })
+
+      expect(Object.values(result).flat().length).toBe(3)
+    })
+  })
+
+  describe('result format', () => {
+    it('should return detailed result format with .result()', async () => {
+      const items = ['apple', 'banana', 'carrot']
+      const response = zai.group(items, {
+        instructions: 'Group by food type',
+      })
+
+      const { output, usage, elapsed } = await response.result()
+
+      expect(output).toBeInstanceOf(Array)
+      expect(output.length).toBeGreaterThan(0)
+
+      // Check group structure
+      output.forEach((group) => {
+        expect(group).toHaveProperty('id')
+        expect(group).toHaveProperty('label')
+        expect(group).toHaveProperty('elements')
+        expect(Array.isArray(group.elements)).toBe(true)
+        expect(typeof group.id).toBe('string')
+        expect(typeof group.label).toBe('string')
+      })
+
+      expect(elapsed).toBeGreaterThan(0)
+    })
+
+    it('should return simplified format on await', async () => {
+      const items = ['apple', 'banana', 'carrot']
+      const result = await zai.group(items, {
+        instructions: 'Group by food type',
+      })
+
+      // Simplified format: Record<string, T[]>
+      expect(typeof result).toBe('object')
+      expect(Array.isArray(result)).toBe(false)
+
+      Object.entries(result).forEach(([label, elements]) => {
+        expect(typeof label).toBe('string')
+        expect(Array.isArray(elements)).toBe(true)
+      })
+    })
+  })
+
+  describe('performance and concurrency', () => {
+    it('should process large arrays efficiently with parallel chunks', async () => {
+      const items = Array.from({ length: 500 }, (_, i) => `item ${i % 25}`)
+
+      const start = Date.now()
+      const result = await zai.group(items, {
+        instructions: 'Group similar items',
+      })
+      const elapsed = Date.now() - start
+
+      expect(Object.values(result).flat().length).toBe(500)
+      // Should complete in reasonable time (parallel processing)
+      expect(elapsed).toBeLessThan(120000) // 2 minutes max
+    })
+  })
+
+  describe('refinement and pruning', () => {
+    it('should handle elements that could belong to multiple groups', async () => {
+      const items = [
+        'tomato', // Could be fruit or vegetable
+        'apple',
+        'carrot',
+        'avocado', // Could be fruit or vegetable
+        'banana',
+      ]
+
+      const result = await zai.group(items, {
+        instructions: 'Group into fruits or vegetables (make best judgment for ambiguous items)',
+      })
+
+      // Each item should belong to exactly one group
+      const allItems = Object.values(result).flat()
+      expect(allItems.length).toBe(items.length)
+
+      // Check for duplicates (shouldn't happen after pruning)
+      const uniqueItems = new Set(allItems)
+      expect(uniqueItems.size).toBe(items.length)
+    })
+  })
+
+  describe('active learning', () => {
+    it('should support active learning with task id', async () => {
+      const items = ['apple', 'banana', 'carrot', 'broccoli']
+
+      const zaiWithLearning = zai.learn('group-food-categories')
+
+      const result = await zaiWithLearning.group(items, {
+        instructions: 'Group into fruits and vegetables',
+      })
+
+      expect(Object.keys(result).length).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  describe('no instructions provided', () => {
+    it('should group by natural similarity without instructions', async () => {
+      const items = ['cat', 'dog', 'lion', 'tiger', 'parrot', 'eagle']
+
+      const result = await zai.group(items)
+
+      // Should naturally group by animal type (pets, wild cats, birds)
+      expect(Object.keys(result).length).toBeGreaterThanOrEqual(2)
+      expect(Object.keys(result).length).toBeLessThanOrEqual(4)
+    })
+  })
+
+  describe('date-based grouping with window slides', () => {
+    it('should group 1000 large elements by date with window sliding', async () => {
+      // Generate dates (500 dates = 1000 elements / 2 elements per date)
+      const startDate = new Date('2024-01-01').getTime()
+      const dates: string[] = []
+
+      for (let i = 0; i < 500; i++) {
+        const date = new Date(startDate + i * 24 * 60 * 60 * 1000)
+        const dateStr = date.toISOString().split('T')[0] // YYYY-MM-DD format
+        dates.push(dateStr)
+      }
+
+      // Create 2 elements per date (A and B), each with large padding text
+      const items: Array<{ id: string; date: string; content: string }> = []
+
+      dates.forEach((date) => {
+        // Element A - large content about morning
+        items.push({
+          id: `${date}-A`,
+          date,
+          content: `
+            Date: ${date}
+            Type: A (Morning Entry)
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+            Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            Morning activities: breakfast, exercise, reading news, checking emails, planning the day ahead.
+            Weather: sunny and bright. Temperature: comfortable. Mood: energetic and ready to tackle challenges.
+            Additional notes about the morning routine and various observations throughout the early hours.
+            Multiple paragraphs of content to ensure each element is sufficiently large for token budget testing.
+            This helps simulate real-world scenarios where elements contain substantial information.
+          `.trim(),
+        })
+
+        // Element B - large content about evening
+        items.push({
+          id: `${date}-B`,
+          date,
+          content: `
+            Date: ${date}
+            Type: B (Evening Entry)
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.
+            Totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+            Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores.
+            Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit.
+            Evening activities: dinner preparation, family time, watching shows, journaling, reflecting on the day's events.
+            Weather: cooling down as night approaches. Temperature: pleasant. Mood: relaxed and contemplative.
+            Additional reflections about the evening routine and observations from the later hours of the day.
+            Multiple paragraphs of evening content to match the morning entry size and ensure consistent token usage.
+            This creates a balanced dataset for comprehensive grouping algorithm testing.
+          `.trim(),
+        })
+      })
+
+      // Seeded random for consistent test results
+      let seed = 12345
+      const seededRandom = () => {
+        seed = (seed * 9301 + 49297) % 233280
+        return seed / 233280
+      }
+
+      // Shuffle the array to make grouping more challenging (with seed for deterministic results)
+      const shuffled = items.sort(() => seededRandom() - 0.5)
+
+      const result = await zai.group(shuffled, {
+        instructions: 'Group by date field (YYYY-MM-DD). Each date should have its own group.',
+        tokensPerElement: 300, // Allow sufficient tokens for the large content
+        chunkLength: 8000, // Smaller chunks to force window sliding
+      })
+
+      // Should have exactly 500 groups (one per date)
+      expect(Object.keys(result).length).toBeGreaterThanOrEqual(450) // Allow some margin
+      expect(Object.keys(result).length).toBeLessThanOrEqual(550)
+
+      // Each group should have exactly 2 elements (A and B)
+      const groupSizes = Object.values(result).map((group) => group.length)
+      const averageGroupSize = groupSizes.reduce((a, b) => a + b, 0) / groupSizes.length
+
+      // Average should be close to 2
+      expect(averageGroupSize).toBeGreaterThan(1.8)
+      expect(averageGroupSize).toBeLessThan(2.2)
+
+      // Verify all 1000 elements are accounted for
+      const totalElements = Object.values(result).flat().length
+      expect(totalElements).toBe(1000)
+
+      // Verify no element appears in multiple groups (proper pruning)
+      const allElements = Object.values(result).flat()
+      const uniqueIds = new Set(allElements.map((el) => el.id))
+      expect(uniqueIds.size).toBe(1000)
+
+      // Sample check: verify a few random dates have both A and B elements
+      const sampleDate = dates[100] // Check date at index 100
+      const groupForSampleDate = Object.entries(result).find(([_label, elements]) =>
+        elements.some((el) => el.date === sampleDate)
+      )
+
+      if (groupForSampleDate) {
+        const [_label, elements] = groupForSampleDate
+        const idsForSampleDate = elements.filter((el) => el.date === sampleDate).map((el) => el.id)
+
+        // Should contain both A and B for this date
+        expect(idsForSampleDate.some((id) => id.includes('-A'))).toBe(true)
+        expect(idsForSampleDate.some((id) => id.includes('-B'))).toBe(true)
+      }
+    }, 180000) // 3 minute timeout for this large test
+  })
+
+  describe('multi-criteria complex grouping', () => {
+    it('should group by multiple elaborate criteria considering multiple properties', async () => {
+      // Create a dataset of customer transactions with multiple properties
+      const transactions = [
+        // High-value, urgent, technical products - VIP customers
+        {
+          id: 'txn-001',
+          customer: 'Alice Corp',
+          amount: 15000,
+          priority: 'urgent',
+          category: 'software',
+          region: 'NA',
+          renewalStatus: 'expiring-soon',
+        },
+        {
+          id: 'txn-002',
+          customer: 'Bob Industries',
+          amount: 22000,
+          priority: 'urgent',
+          category: 'hardware',
+          region: 'NA',
+          renewalStatus: 'active',
+        },
+        {
+          id: 'txn-003',
+          customer: 'Charlie LLC',
+          amount: 18000,
+          priority: 'high',
+          category: 'software',
+          region: 'EU',
+          renewalStatus: 'expiring-soon',
+        },
+
+        // High-value but standard priority - Key accounts
+        {
+          id: 'txn-004',
+          customer: 'Delta Systems',
+          amount: 12000,
+          priority: 'standard',
+          category: 'consulting',
+          region: 'APAC',
+          renewalStatus: 'active',
+        },
+        {
+          id: 'txn-005',
+          customer: 'Echo Partners',
+          amount: 14000,
+          priority: 'standard',
+          category: 'software',
+          region: 'NA',
+          renewalStatus: 'active',
+        },
+        {
+          id: 'txn-006',
+          customer: 'Foxtrot Ltd',
+          amount: 16000,
+          priority: 'standard',
+          category: 'hardware',
+          region: 'EU',
+          renewalStatus: 'new',
+        },
+
+        // Low-value but urgent - Small urgent matters
+        {
+          id: 'txn-007',
+          customer: 'Golf Inc',
+          amount: 800,
+          priority: 'urgent',
+          category: 'support',
+          region: 'NA',
+          renewalStatus: 'active',
+        },
+        {
+          id: 'txn-008',
+          customer: 'Hotel Co',
+          amount: 1200,
+          priority: 'urgent',
+          category: 'maintenance',
+          region: 'EU',
+          renewalStatus: 'expiring-soon',
+        },
+        {
+          id: 'txn-009',
+          customer: 'India Tech',
+          amount: 950,
+          priority: 'urgent',
+          category: 'support',
+          region: 'APAC',
+          renewalStatus: 'active',
+        },
+
+        // Expiring renewals regardless of amount - Retention focus
+        {
+          id: 'txn-010',
+          customer: 'Juliet Ventures',
+          amount: 5000,
+          priority: 'standard',
+          category: 'software',
+          region: 'NA',
+          renewalStatus: 'expiring-soon',
+        },
+        {
+          id: 'txn-011',
+          customer: 'Kilo Systems',
+          amount: 3500,
+          priority: 'low',
+          category: 'hardware',
+          region: 'EU',
+          renewalStatus: 'expiring-soon',
+        },
+        {
+          id: 'txn-012',
+          customer: 'Lima Corp',
+          amount: 7800,
+          priority: 'high',
+          category: 'consulting',
+          region: 'APAC',
+          renewalStatus: 'expiring-soon',
+        },
+
+        // New customers - Onboarding focus
+        {
+          id: 'txn-013',
+          customer: 'Mike Industries',
+          amount: 4500,
+          priority: 'standard',
+          category: 'software',
+          region: 'NA',
+          renewalStatus: 'new',
+        },
+        {
+          id: 'txn-014',
+          customer: 'November Ltd',
+          amount: 6200,
+          priority: 'standard',
+          category: 'consulting',
+          region: 'EU',
+          renewalStatus: 'new',
+        },
+        {
+          id: 'txn-015',
+          customer: 'Oscar Partners',
+          amount: 3900,
+          priority: 'low',
+          category: 'hardware',
+          region: 'APAC',
+          renewalStatus: 'new',
+        },
+
+        // Regional concentrations - APAC expansion
+        {
+          id: 'txn-016',
+          customer: 'Papa Tech',
+          amount: 2500,
+          priority: 'standard',
+          category: 'software',
+          region: 'APAC',
+          renewalStatus: 'active',
+        },
+        {
+          id: 'txn-017',
+          customer: 'Quebec Co',
+          amount: 3100,
+          priority: 'standard',
+          category: 'hardware',
+          region: 'APAC',
+          renewalStatus: 'active',
+        },
+        {
+          id: 'txn-018',
+          customer: 'Romeo Systems',
+          amount: 2800,
+          priority: 'low',
+          category: 'support',
+          region: 'APAC',
+          renewalStatus: 'active',
+        },
+
+        // Low-value, low-priority - Standard processing
+        {
+          id: 'txn-019',
+          customer: 'Sierra Inc',
+          amount: 600,
+          priority: 'low',
+          category: 'maintenance',
+          region: 'NA',
+          renewalStatus: 'active',
+        },
+        {
+          id: 'txn-020',
+          customer: 'Tango Ltd',
+          amount: 750,
+          priority: 'low',
+          category: 'support',
+          region: 'EU',
+          renewalStatus: 'active',
+        },
+        {
+          id: 'txn-021',
+          customer: 'Uniform Corp',
+          amount: 550,
+          priority: 'low',
+          category: 'maintenance',
+          region: 'NA',
+          renewalStatus: 'active',
+        },
+
+        // Consulting services - Strategic projects
+        {
+          id: 'txn-022',
+          customer: 'Victor Consulting',
+          amount: 9500,
+          priority: 'high',
+          category: 'consulting',
+          region: 'NA',
+          renewalStatus: 'active',
+        },
+        {
+          id: 'txn-023',
+          customer: 'Whiskey Advisory',
+          amount: 11000,
+          priority: 'high',
+          category: 'consulting',
+          region: 'EU',
+          renewalStatus: 'new',
+        },
+        {
+          id: 'txn-024',
+          customer: 'Xray Partners',
+          amount: 8700,
+          priority: 'standard',
+          category: 'consulting',
+          region: 'APAC',
+          renewalStatus: 'active',
+        },
+
+        // Edge cases - mixed signals
+        {
+          id: 'txn-025',
+          customer: 'Yankee Mixed',
+          amount: 10500,
+          priority: 'low',
+          category: 'software',
+          region: 'NA',
+          renewalStatus: 'active',
+        }, // High value but low priority
+        {
+          id: 'txn-026',
+          customer: 'Zulu Odd',
+          amount: 500,
+          priority: 'high',
+          category: 'consulting',
+          region: 'EU',
+          renewalStatus: 'new',
+        }, // Low value but high priority
+        {
+          id: 'txn-027',
+          customer: 'Alpha Edge',
+          amount: 15000,
+          priority: 'urgent',
+          category: 'maintenance',
+          region: 'APAC',
+          renewalStatus: 'expiring-soon',
+        }, // High value maintenance
+      ]
+
+      const complexInstructions = `
+Group these business transactions into strategic cohorts based on the following elaborate multi-criteria framework:
+
+**Priority Framework (combine these factors):**
+
+1. **VIP Urgent Track**:
+   - Transactions with amount > $10,000 AND priority = 'urgent'
+   - OR amount > $15,000 AND (priority = 'high' OR priority = 'urgent')
+   - These need immediate executive attention
+
+2. **Retention Critical**:
+   - Any transaction with renewalStatus = 'expiring-soon'
+   - Especially if amount > $3,000 OR priority != 'low'
+   - Customer retention is key priority
+
+3. **New Customer Onboarding**:
+   - renewalStatus = 'new'
+   - If amount > $5,000, this is "Strategic Onboarding"
+   - If amount <= $5,000, this is "Standard Onboarding"
+
+4. **Regional Growth Focus**:
+   - Region = 'APAC' with amount > $2,000
+   - OR region = 'APAC' with category = 'software' or 'consulting'
+   - Supporting regional expansion initiative
+
+5. **Strategic Consulting**:
+   - category = 'consulting' with amount > $8,000
+   - OR category = 'consulting' with priority = 'high'
+   - High-value strategic engagements
+
+6. **Small Urgent Matters**:
+   - priority = 'urgent' with amount < $2,000
+   - Quick wins for urgent but low-value items
+
+7. **Standard Processing Queue**:
+   - Everything else that doesn't fit the above criteria
+   - Normal business flow
+
+**Important**: A transaction should be assigned to the MOST SPECIFIC group it qualifies for.
+For example, if a transaction qualifies for both "VIP Urgent Track" and "Retention Critical",
+choose "VIP Urgent Track" as it's more urgent. Use business judgment for priority.
+      `.trim()
+
+      const result = await zai.group(transactions, {
+        instructions: complexInstructions,
+        tokensPerElement: 150,
+      })
+
+      // Should have multiple strategic groups
+      const groupLabels = Object.keys(result)
+      expect(groupLabels.length).toBeGreaterThanOrEqual(5) // At least 5 different strategic groups
+      expect(groupLabels.length).toBeLessThanOrEqual(10) // Not too many groups
+
+      // All transactions should be accounted for
+      const totalElements = Object.values(result).flat().length
+      expect(totalElements).toBe(27)
+
+      // Verify no duplicates (proper pruning with complex criteria)
+      const allIds = Object.values(result)
+        .flat()
+        .map((txn) => txn.id)
+      const uniqueIds = new Set(allIds)
+      expect(uniqueIds.size).toBe(27)
+
+      // Verify specific expected groupings based on criteria
+
+      // VIP Urgent Track should include high-value urgent items
+      const vipUrgentGroup = Object.entries(result).find(
+        ([label]) =>
+          label.toLowerCase().includes('vip') ||
+          (label.toLowerCase().includes('urgent') && label.toLowerCase().includes('track'))
+      )
+      if (vipUrgentGroup) {
+        const [, elements] = vipUrgentGroup
+        // Should contain txn-001, txn-002 (high value + urgent)
+        const hasHighValueUrgent = elements.some((txn) => txn.amount > 10000 && txn.priority === 'urgent')
+        expect(hasHighValueUrgent).toBe(true)
+      }
+
+      // Retention Critical should include expiring-soon items
+      const retentionGroup = Object.entries(result).find(
+        ([label]) =>
+          label.toLowerCase().includes('retention') ||
+          label.toLowerCase().includes('expiring') ||
+          label.toLowerCase().includes('renewal')
+      )
+      if (retentionGroup) {
+        const [, elements] = retentionGroup
+        const hasExpiringSoon = elements.some((txn) => txn.renewalStatus === 'expiring-soon')
+        expect(hasExpiringSoon).toBe(true)
+      }
+
+      // New Customer groups should exist
+      const onboardingGroups = Object.entries(result).filter(
+        ([label]) => label.toLowerCase().includes('onboarding') || label.toLowerCase().includes('new customer')
+      )
+      const totalOnboarding = onboardingGroups.reduce((sum, [, elements]) => sum + elements.length, 0)
+
+      // Should have several new customer transactions
+      expect(totalOnboarding).toBeGreaterThanOrEqual(3)
+
+      // APAC regional focus should be grouped
+      const apacGroup = Object.entries(result).find(
+        ([label]) =>
+          label.toLowerCase().includes('apac') ||
+          label.toLowerCase().includes('regional') ||
+          label.toLowerCase().includes('asia')
+      )
+      if (apacGroup) {
+        const [, elements] = apacGroup
+        const allApac = elements.every((txn) => txn.region === 'APAC')
+        // Should be heavily APAC-focused (allow some mixed grouping)
+        const apacPercentage = elements.filter((txn) => txn.region === 'APAC').length / elements.length
+        expect(apacPercentage).toBeGreaterThan(0.6) // At least 60% APAC
+      }
+
+      // Strategic consulting should be grouped
+      const consultingGroup = Object.entries(result).find(
+        ([label]) => label.toLowerCase().includes('consulting') || label.toLowerCase().includes('strategic')
+      )
+      if (consultingGroup) {
+        const [, elements] = consultingGroup
+        const hasHighValueConsulting = elements.some(
+          (txn) => txn.category === 'consulting' && (txn.amount > 8000 || txn.priority === 'high')
+        )
+        expect(hasHighValueConsulting).toBe(true)
+      }
+
+      // Verify that high-value, low-priority edge case (txn-025) is handled reasonably
+      const txn025 = Object.values(result)
+        .flat()
+        .find((txn) => txn.id === 'txn-025')
+      expect(txn025).toBeDefined()
+
+      // Verify complex edge case (txn-027: high value + urgent + maintenance + expiring)
+      const txn027 = Object.values(result)
+        .flat()
+        .find((txn) => txn.id === 'txn-027')
+      expect(txn027).toBeDefined()
+
+      // This should be in VIP or Retention (both high priority groups)
+      const txn027Group = Object.entries(result).find(([, elements]) =>
+        elements.some((txn) => txn.id === 'txn-027')
+      )?.[0]
+
+      expect(txn027Group?.toLowerCase()).toMatch(/vip|urgent|retention|critical|expiring/)
+
+      console.log('\n=== Group Distribution ===')
+      Object.entries(result).forEach(([label, elements]) => {
+        console.log(`${label}: ${elements.length} transactions`)
+        console.log(`  IDs: ${elements.map((t) => t.id).join(', ')}`)
+      })
+    }, 120000) // 2 minute timeout
+  })
+})

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "2.1.20",
+  "version": "2.2.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/zai/src/index.ts
+++ b/packages/zai/src/index.ts
@@ -7,5 +7,6 @@ import './operations/check'
 import './operations/filter'
 import './operations/extract'
 import './operations/label'
+import './operations/group'
 
 export { Zai }

--- a/packages/zai/src/operations/group.ts
+++ b/packages/zai/src/operations/group.ts
@@ -1,4 +1,4 @@
-// Simplified group implementation
+// eslint-disable consistent-type-definitions
 import { z } from '@bpinternal/zui'
 import { clamp } from 'lodash-es'
 import pLimit from 'p-limit'

--- a/packages/zai/src/operations/group.ts
+++ b/packages/zai/src/operations/group.ts
@@ -42,7 +42,6 @@ const _Options = z.object({
 })
 
 declare module '@botpress/zai' {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface Zai {
     group<T>(input: Array<T>, options?: Options): Response<Array<Group<T>>, Record<string, T[]>>
   }

--- a/packages/zai/src/operations/group.ts
+++ b/packages/zai/src/operations/group.ts
@@ -1,0 +1,414 @@
+// Simplified group implementation
+import { z } from '@bpinternal/zui'
+import { clamp } from 'lodash-es'
+import pLimit from 'p-limit'
+import { ZaiContext } from '../context'
+import { Response } from '../response'
+import { getTokenizer } from '../tokenizer'
+import { stringify } from '../utils'
+import { Zai } from '../zai'
+import { PROMPT_INPUT_BUFFER, PROMPT_OUTPUT_BUFFER } from './constants'
+
+export type Group<T> = {
+  id: string
+  label: string
+  elements: T[]
+}
+
+type InitialGroup = {
+  id: string
+  label: string
+  elements?: unknown[]
+}
+
+const _InitialGroup = z.object({
+  id: z.string().min(1).max(100),
+  label: z.string().min(1).max(250),
+  elements: z.array(z.any()).optional().default([]),
+})
+
+export type Options = {
+  instructions?: string
+  tokensPerElement?: number
+  chunkLength?: number
+  initialGroups?: Array<InitialGroup>
+}
+
+const _Options = z.object({
+  instructions: z.string().optional(),
+  tokensPerElement: z.number().min(1).max(100_000).optional().default(250),
+  chunkLength: z.number().min(100).max(100_000).optional().default(16_000),
+  initialGroups: z.array(_InitialGroup).optional().default([]),
+})
+
+declare module '@botpress/zai' {
+  interface Zai {
+    group<T>(input: Array<T>, options?: Options): Response<Array<Group<T>>, Record<string, T[]>>
+  }
+}
+
+const END = '■END■'
+
+// Simplified data structures
+type GroupInfo = {
+  id: string
+  label: string
+  normalizedLabel: string
+}
+
+const normalizeLabel = (label: string): string => {
+  return label
+    .trim()
+    .toLowerCase()
+    .replace(/^(group|new group|new)\s*[-:]\s*/i, '')
+    .replace(/^(group|new group|new)\s+/i, '')
+    .trim()
+}
+
+const group = async <T>(input: Array<T>, _options: Options | undefined, ctx: ZaiContext): Promise<Array<Group<T>>> => {
+  ctx.controller.signal.throwIfAborted()
+
+  const options = _Options.parse(_options ?? {})
+  const tokenizer = await getTokenizer()
+  const model = await ctx.getModel()
+
+  if (input.length === 0) {
+    return []
+  }
+
+  // Simple data structures
+  const groups = new Map<string, GroupInfo>() // groupId -> GroupInfo
+  const groupElements = new Map<string, Set<number>>() // groupId -> Set of element indices
+  const elementGroups = new Map<number, Set<string>>() // elementIndex -> Set of groupIds seen/assigned
+  const labelToGroupId = new Map<string, string>() // normalized label -> groupId
+  let groupIdCounter = 0
+
+  // Initialize with provided groups
+  options.initialGroups.forEach((ig) => {
+    const normalized = normalizeLabel(ig.label)
+    groups.set(ig.id, { id: ig.id, label: ig.label, normalizedLabel: normalized })
+    groupElements.set(ig.id, new Set())
+    labelToGroupId.set(normalized, ig.id)
+  })
+
+  // Prepare elements
+  const elements = input.map((element, idx) => ({
+    element,
+    index: idx,
+    stringified: stringify(element, false),
+  }))
+
+  // Token budget
+  const TOKENS_TOTAL_MAX = model.input.maxTokens - PROMPT_INPUT_BUFFER - PROMPT_OUTPUT_BUFFER
+  const TOKENS_INSTRUCTIONS_MAX = options.instructions
+    ? clamp(tokenizer.count(options.instructions), 100, TOKENS_TOTAL_MAX * 0.2)
+    : 0
+  const TOKENS_AVAILABLE = TOKENS_TOTAL_MAX - TOKENS_INSTRUCTIONS_MAX
+  const TOKENS_FOR_GROUPS_MAX = Math.floor(TOKENS_AVAILABLE * 0.4)
+  const TOKENS_FOR_ELEMENTS_MAX = Math.floor(TOKENS_AVAILABLE * 0.6)
+
+  // Chunk elements by token budget
+  const MAX_ELEMENTS_PER_CHUNK = 50
+  const elementChunks: number[][] = [] // Array of element indices
+  let currentChunk: number[] = []
+  let currentTokens = 0
+
+  for (const elem of elements) {
+    const truncated = tokenizer.truncate(elem.stringified, options.tokensPerElement)
+    const elemTokens = tokenizer.count(truncated)
+
+    if (
+      (currentTokens + elemTokens > TOKENS_FOR_ELEMENTS_MAX || currentChunk.length >= MAX_ELEMENTS_PER_CHUNK) &&
+      currentChunk.length > 0
+    ) {
+      elementChunks.push(currentChunk)
+      currentChunk = []
+      currentTokens = 0
+    }
+
+    currentChunk.push(elem.index)
+    currentTokens += elemTokens
+  }
+
+  if (currentChunk.length > 0) {
+    elementChunks.push(currentChunk)
+  }
+
+  // Helper to chunk groups
+  const getGroupChunks = (): string[][] => {
+    const allGroupIds = Array.from(groups.keys())
+    if (allGroupIds.length === 0) return [[]]
+
+    const chunks: string[][] = []
+    let currentChunk: string[] = []
+    let currentTokens = 0
+
+    for (const groupId of allGroupIds) {
+      const group = groups.get(groupId)!
+      const groupTokens = tokenizer.count(`${group.label}`) + 10
+
+      if (currentTokens + groupTokens > TOKENS_FOR_GROUPS_MAX && currentChunk.length > 0) {
+        chunks.push(currentChunk)
+        currentChunk = []
+        currentTokens = 0
+      }
+
+      currentChunk.push(groupId)
+      currentTokens += groupTokens
+    }
+
+    if (currentChunk.length > 0) {
+      chunks.push(currentChunk)
+    }
+
+    return chunks.length > 0 ? chunks : [[]]
+  }
+
+  // Process elements against groups and get assignments
+  const processChunk = async (
+    elementIndices: number[],
+    groupIds: string[]
+  ): Promise<Array<{ elementIndex: number; label: string }>> => {
+    const elementsText = elementIndices
+      .map((idx, i) => {
+        const elem = elements[idx]
+        const truncated = tokenizer.truncate(elem.stringified, options.tokensPerElement)
+        return `■${i}: ${truncated}■`
+      })
+      .join('\n')
+
+    const groupsList = groupIds.map((gid) => groups.get(gid)!.label)
+    const groupsText =
+      groupsList.length > 0
+        ? `**Existing Groups (prefer reusing these):**\n${groupsList.map((l) => `- ${l}`).join('\n')}\n\n`
+        : ''
+
+    const systemPrompt = `You are grouping elements into cohesive groups.
+
+${options.instructions ? `**Instructions:** ${options.instructions}\n` : '**Instructions:** Group similar elements together.'}
+
+**Important:**
+- Each element gets exactly ONE group label
+- Use EXACT SAME label for similar items (case-sensitive)
+- Create new descriptive labels when needed
+
+**Output Format:**
+One line per element:
+■0:Group Label■
+■1:Group Label■
+${END}`.trim()
+
+    const userPrompt = `${groupsText}**Elements (■0 to ■${elementIndices.length - 1}):**
+${elementsText}
+
+**Task:** For each element, output one line with its group label.
+${END}`.trim()
+
+    const { extracted } = await ctx.generateContent({
+      systemPrompt,
+      stopSequences: [END],
+      messages: [{ type: 'text', role: 'user', content: userPrompt }],
+      transform: (text) => {
+        const assignments: Array<{ elementIndex: number; label: string }> = []
+        const regex = /■(\d+):([^■]+)■/g
+        let match: RegExpExecArray | null
+
+        while ((match = regex.exec(text)) !== null) {
+          const idx = parseInt(match[1] ?? '', 10)
+          if (isNaN(idx) || idx < 0 || idx >= elementIndices.length) continue
+
+          const label = (match[2] ?? '').trim()
+          if (!label) continue
+
+          assignments.push({
+            elementIndex: elementIndices[idx],
+            label: label.slice(0, 250),
+          })
+        }
+
+        return assignments
+      },
+    })
+
+    return extracted
+  }
+
+  // Phase 1: Process all element chunks against current groups IN PARALLEL
+  const elementLimit = pLimit(10) // Separate limiter for element chunks
+  const groupLimit = pLimit(10) // Separate limiter for group chunks
+
+  // Collect all assignments from parallel processing
+  const allChunkResults = await Promise.all(
+    elementChunks.map((elementChunk) =>
+      elementLimit(async () => {
+        const groupChunks = getGroupChunks()
+
+        const allAssignments = await Promise.all(
+          groupChunks.map((groupChunk) => groupLimit(() => processChunk(elementChunk, groupChunk)))
+        )
+
+        return allAssignments.flat()
+      })
+    )
+  )
+
+  // Process all assignments sequentially to avoid race conditions
+  for (const assignments of allChunkResults) {
+    for (const { elementIndex, label } of assignments) {
+      const normalized = normalizeLabel(label)
+      let groupId = labelToGroupId.get(normalized)
+
+      if (!groupId) {
+        // Create new group
+        groupId = `group_${groupIdCounter++}`
+        groups.set(groupId, { id: groupId, label, normalizedLabel: normalized })
+        groupElements.set(groupId, new Set())
+        labelToGroupId.set(normalized, groupId)
+      }
+
+      // Add element to group
+      groupElements.get(groupId)!.add(elementIndex)
+
+      // Track that element saw this group
+      if (!elementGroups.has(elementIndex)) {
+        elementGroups.set(elementIndex, new Set())
+      }
+      elementGroups.get(elementIndex)!.add(groupId)
+    }
+  }
+
+  // Phase 2: Ensure all elements saw all groups (coverage guarantee)
+  const allGroupIds = Array.from(groups.keys())
+
+  if (allGroupIds.length > 0) {
+    const elementsNeedingReview: number[] = []
+
+    for (const elem of elements) {
+      const seenGroups = elementGroups.get(elem.index) ?? new Set()
+      const unseenCount = allGroupIds.filter((gid) => !seenGroups.has(gid)).length
+
+      if (unseenCount > 0) {
+        elementsNeedingReview.push(elem.index)
+      }
+    }
+
+    if (elementsNeedingReview.length > 0) {
+      // Chunk elements needing review
+      const reviewChunks: number[][] = []
+      let reviewChunk: number[] = []
+      let reviewTokens = 0
+
+      for (const elemIdx of elementsNeedingReview) {
+        const elem = elements[elemIdx]
+        const truncated = tokenizer.truncate(elem.stringified, options.tokensPerElement)
+        const elemTokens = tokenizer.count(truncated)
+
+        if (reviewTokens + elemTokens > TOKENS_FOR_ELEMENTS_MAX || reviewChunk.length >= MAX_ELEMENTS_PER_CHUNK) {
+          if (reviewChunk.length > 0) {
+            reviewChunks.push(reviewChunk)
+          }
+          reviewChunk = []
+          reviewTokens = 0
+        }
+
+        reviewChunk.push(elemIdx)
+        reviewTokens += elemTokens
+      }
+
+      if (reviewChunk.length > 0) {
+        reviewChunks.push(reviewChunk)
+      }
+
+      // Process review chunks IN PARALLEL
+      const reviewResults = await Promise.all(
+        reviewChunks.map((chunk) =>
+          elementLimit(async () => {
+            const groupChunks = getGroupChunks()
+
+            const allAssignments = await Promise.all(
+              groupChunks.map((groupChunk) => groupLimit(() => processChunk(chunk, groupChunk)))
+            )
+
+            return allAssignments.flat()
+          })
+        )
+      )
+
+      // Mark groups as seen and update assignments (sequential to avoid races)
+      for (const assignments of reviewResults) {
+        for (const { elementIndex, label } of assignments) {
+          const normalized = normalizeLabel(label)
+          const groupId = labelToGroupId.get(normalized)
+
+          if (groupId) {
+            // Add to group and mark as seen
+            groupElements.get(groupId)!.add(elementIndex)
+
+            if (!elementGroups.has(elementIndex)) {
+              elementGroups.set(elementIndex, new Set())
+            }
+            elementGroups.get(elementIndex)!.add(groupId)
+          }
+        }
+      }
+    }
+  }
+
+  // Phase 3: Resolve conflicts (elements in multiple groups)
+  for (const [elementIndex, groupSet] of elementGroups.entries()) {
+    if (groupSet.size > 1) {
+      // Element is in multiple groups, keep only the most common assignment
+      const groupIds = Array.from(groupSet)
+
+      // Remove from all groups
+      for (const gid of groupIds) {
+        groupElements.get(gid)?.delete(elementIndex)
+      }
+
+      // Re-assign to first group (or could use LLM to decide)
+      const finalGroupId = groupIds[0]
+      groupElements.get(finalGroupId)!.add(elementIndex)
+    }
+  }
+
+  // Build final result
+  const result: Array<Group<T>> = []
+
+  for (const [groupId, elementIndices] of groupElements.entries()) {
+    if (elementIndices.size > 0) {
+      const groupInfo = groups.get(groupId)!
+      result.push({
+        id: groupInfo.id,
+        label: groupInfo.label,
+        elements: Array.from(elementIndices).map((idx) => elements[idx].element),
+      })
+    }
+  }
+
+  return result
+}
+
+Zai.prototype.group = function <T>(
+  this: Zai,
+  input: Array<T>,
+  _options?: Options
+): Response<Array<Group<T>>, Record<string, T[]>> {
+  const context = new ZaiContext({
+    client: this.client,
+    modelId: this.Model,
+    taskId: this.taskId,
+    taskType: 'zai.group',
+    adapter: this.adapter,
+  })
+
+  return new Response<Array<Group<T>>, Record<string, T[]>>(context, group(input, _options, context), (result) => {
+    const merged: Record<string, T[]> = {}
+    result.forEach((group) => {
+      if (!merged[group.label]) {
+        merged[group.label] = []
+      }
+      merged[group.label].push(...group.elements)
+    })
+    return merged
+  })
+}


### PR DESCRIPTION
## `.group`

Groups arbitrarily long arrays of items together.

```typescript
// Group items automatically
const grouped = await zai.group(tasks, {
  instructions: 'Group by priority level',
})
// Result: { 'High Priority': [...], 'Medium Priority': [...], 'Low Priority': [...] }

// Group with initial categories
const categorized = await zai.group(emails, {
  instructions: 'Group by topic',
  initialGroups: [
    { id: 'work', label: 'Work' },
    { id: 'personal', label: 'Personal' },
  ],
})

// Group large datasets efficiently
const organized = await zai.group(largeArray, {
  instructions: 'Group by date',
  chunkLength: 8000, // Process in chunks for better performance
})
```