### PR TITLE
feat(integrations/line): Implement proactiveUser and proactiveConversation interfaces

### DIFF
--- a/integrations/line/integration.definition.ts
+++ b/integrations/line/integration.definition.ts
@@ -92,6 +92,7 @@ export default new IntegrationDefinition({
       schema: z
         .object({
           id: z.string().title('User ID').describe('The Line ID of the user in the conversation'),
+          destinationId: z.string().title('Destination ID').describe('Line user ID of the bot'),
         })
         .title('Conversation')
         .describe('The conversation object fields'),

--- a/integrations/line/integration.definition.ts
+++ b/integrations/line/integration.definition.ts
@@ -1,5 +1,7 @@
 import { z, IntegrationDefinition, messages } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
+import proactiveConversation from 'bp_modules/proactive-conversation'
+import proactiveUser from 'bp_modules/proactive-user'
 import typingIndicator from 'bp_modules/typing-indicator'
 
 export default new IntegrationDefinition({
@@ -75,7 +77,40 @@ export default new IntegrationDefinition({
     },
     creation: { enabled: true, requiredTags: ['usrId'] },
   },
+  entities: {
+    user: {
+      schema: z
+        .object({
+          id: z.string().title('User ID').describe('The Line ID of the user'),
+        })
+        .title('User')
+        .describe('The user object fields'),
+      title: 'User',
+      description: 'A Line user',
+    },
+    conversation: {
+      schema: z
+        .object({
+          id: z.string().title('User ID').describe('The Line ID of the user in the conversation'),
+        })
+        .title('Conversation')
+        .describe('The conversation object fields'),
+      title: 'Conversation',
+      description: 'A conversation with a Line user',
+    },
+  },
   __advanced: {
     useLegacyZuiTransformer: true,
   },
-}).extend(typingIndicator, ({}) => ({ entities: {} }))
+})
+  .extend(typingIndicator, ({}) => ({ entities: {} }))
+  .extend(proactiveUser, ({ entities }) => ({
+    entities: {
+      user: entities.user,
+    },
+  }))
+  .extend(proactiveConversation, ({ entities }) => ({
+    entities: {
+      conversation: entities.conversation,
+    },
+  }))

--- a/integrations/line/integration.definition.ts
+++ b/integrations/line/integration.definition.ts
@@ -6,7 +6,7 @@ import typingIndicator from 'bp_modules/typing-indicator'
 
 export default new IntegrationDefinition({
   name: 'line',
-  version: '1.0.3',
+  version: '1.0.4',
   title: 'Line',
   description: 'Interact with customers using a rich set of features.',
   icon: 'icon.svg',

--- a/integrations/line/package.json
+++ b/integrations/line/package.json
@@ -20,6 +20,8 @@
     "@sentry/cli": "^2.39.1"
   },
   "bpDependencies": {
-    "typing-indicator": "../../interfaces/typing-indicator"
+    "typing-indicator": "../../interfaces/typing-indicator",
+    "proactive-user": "../../interfaces/proactive-user",
+    "proactive-conversation": "../../interfaces/proactive-conversation"
   }
 }

--- a/integrations/line/src/index.ts
+++ b/integrations/line/src/index.ts
@@ -2,6 +2,8 @@ import { RuntimeError } from '@botpress/client'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { messagingApi as lineMessagingApi } from '@line/bot-sdk'
 import crypto from 'crypto'
+import getOrCreateConversation from './proactive-conversation'
+import getOrCreateUser from './proactive-user'
 import * as bp from '.botpress'
 
 type MessageHandlerProps = bp.AnyMessageProps
@@ -85,6 +87,8 @@ const integration = new bp.Integration({
       return {}
     },
     stopTypingIndicator: async () => ({}),
+    getOrCreateConversation,
+    getOrCreateUser,
   },
   channels: {
     channel: {

--- a/integrations/line/src/index.ts
+++ b/integrations/line/src/index.ts
@@ -448,48 +448,6 @@ const integration = new bp.Integration({
 
     return
   },
-  createUser: async ({ client, tags, ctx }) => {
-    const userId = tags.usrId
-    if (!userId) {
-      return
-    }
-
-    const lineClient = new lineMessagingApi.MessagingApiClient({
-      channelAccessToken: ctx.configuration.channelAccessToken,
-    })
-    const profile = await lineClient.getProfile(userId)
-
-    const { user } = await client.getOrCreateUser({ tags: { usrId: `${profile.userId}` } })
-
-    return {
-      body: JSON.stringify({ user: { id: user.id } }),
-      headers: {},
-      statusCode: 200,
-    }
-  },
-  createConversation: async ({ client, channel, tags, ctx }) => {
-    const usrId = tags.usrId
-    const destId = tags.destId
-    if (!(usrId && destId)) {
-      return
-    }
-
-    const lineClient = new lineMessagingApi.MessagingApiClient({
-      channelAccessToken: ctx.configuration.channelAccessToken,
-    })
-    const profile = await lineClient.getProfile(usrId)
-
-    const { conversation } = await client.getOrCreateConversation({
-      channel,
-      tags: { usrId: `${profile.userId}`, destId },
-    })
-
-    return {
-      body: JSON.stringify({ conversation: { id: conversation.id } }),
-      headers: {},
-      statusCode: 200,
-    }
-  },
 })
 
 export default sentryHelpers.wrapIntegration(integration, {

--- a/integrations/line/src/proactive-conversation.ts
+++ b/integrations/line/src/proactive-conversation.ts
@@ -1,17 +1,29 @@
 import { RuntimeError } from '@botpress/sdk'
+import { messagingApi as lineMessagingApi } from '@line/bot-sdk'
 import * as bp from '.botpress'
 
 const getOrCreateConversation: bp.IntegrationProps['actions']['getOrCreateConversation'] = async ({
   client,
+  ctx,
   input,
 }) => {
-  const userId = input.conversation.id
-  if (!userId) {
+  const usrId = input.conversation.id
+  const destId = input.conversation.destinationId
+  if (!usrId) {
     throw new RuntimeError('User ID is required')
   }
+  if (!destId) {
+    throw new RuntimeError('Destination ID is required')
+  }
+
+  const lineClient = new lineMessagingApi.MessagingApiClient({
+    channelAccessToken: ctx.configuration.channelAccessToken,
+  })
+  const profile = await lineClient.getProfile(usrId)
+
   const { conversation } = await client.getOrCreateConversation({
     channel: 'channel',
-    tags: { usrId: userId },
+    tags: { usrId: `${profile.userId}`, destId },
   })
 
   return {

--- a/integrations/line/src/proactive-conversation.ts
+++ b/integrations/line/src/proactive-conversation.ts
@@ -1,0 +1,22 @@
+import { RuntimeError } from '@botpress/sdk'
+import * as bp from '.botpress'
+
+const getOrCreateConversation: bp.IntegrationProps['actions']['getOrCreateConversation'] = async ({
+  client,
+  input,
+}) => {
+  const userId = input.conversation.id
+  if (!userId) {
+    throw new RuntimeError('User ID is required')
+  }
+  const { conversation } = await client.getOrCreateConversation({
+    channel: 'channel',
+    tags: { usrId: userId },
+  })
+
+  return {
+    conversationId: conversation.id,
+  }
+}
+
+export default getOrCreateConversation

--- a/integrations/line/src/proactive-user.ts
+++ b/integrations/line/src/proactive-user.ts
@@ -1,21 +1,20 @@
 import { RuntimeError } from '@botpress/sdk'
+import { messagingApi as lineMessagingApi } from '@line/bot-sdk'
 import * as bp from '.botpress'
 
 const getOrCreateUser: bp.IntegrationProps['actions']['getOrCreateUser'] = async ({ client, ctx, input }) => {
-  if (ctx.configurationType === 'sandbox') {
-    throw new RuntimeError('Creating a user is not supported in sandbox mode')
-  }
-
   const userId = input.user.id
   if (!userId) {
     throw new RuntimeError('User ID is required')
   }
 
-  const { user } = await client.getOrCreateUser({
-    tags: {
-      usrId: userId,
-    },
+  const lineClient = new lineMessagingApi.MessagingApiClient({
+    channelAccessToken: ctx.configuration.channelAccessToken,
   })
+
+  const profile = await lineClient.getProfile(userId)
+
+  const { user } = await client.getOrCreateUser({ tags: { usrId: `${profile.userId}` } })
 
   return {
     userId: user.id,

--- a/integrations/line/src/proactive-user.ts
+++ b/integrations/line/src/proactive-user.ts
@@ -1,0 +1,25 @@
+import { RuntimeError } from '@botpress/sdk'
+import * as bp from '.botpress'
+
+const getOrCreateUser: bp.IntegrationProps['actions']['getOrCreateUser'] = async ({ client, ctx, input }) => {
+  if (ctx.configurationType === 'sandbox') {
+    throw new RuntimeError('Creating a user is not supported in sandbox mode')
+  }
+
+  const userId = input.user.id
+  if (!userId) {
+    throw new RuntimeError('User ID is required')
+  }
+
+  const { user } = await client.getOrCreateUser({
+    tags: {
+      usrId: userId,
+    },
+  })
+
+  return {
+    userId: user.id,
+  }
+}
+
+export default getOrCreateUser


### PR DESCRIPTION
Resolves SQD-2800

The Line integration now implements the `proactiveUser` and `proactiveConversation` interfaces. 

When getting the user, we receive his ID in this format: `user_01K9583VJXQEAA5WH6TF4RKMS1`
When getting the conversation we receive its ID in this format: `conv_01K9583VDQ0TJ8JZ7JGVR8QY7F`