### PR TITLE
feat(integrations/line): Event for when the bot account gets added as a friend

### DIFF
--- a/integrations/line/integration.definition.ts
+++ b/integrations/line/integration.definition.ts
@@ -54,7 +54,16 @@ export default new IntegrationDefinition({
     },
   },
   actions: {},
-  events: {},
+  events: {
+    followed: {
+      title: 'Followed',
+      description: 'The bot was followed by someone.',
+      schema: z.object({
+        destinationId: z.string().title('Destination ID').describe('The Line user ID of the bot'),
+        userId: z.string().title('User ID').describe('The Line ID of the user'),
+      }),
+    },
+  },
   states: {
     conversation: {
       type: 'conversation',

--- a/integrations/line/src/index.ts
+++ b/integrations/line/src/index.ts
@@ -443,6 +443,14 @@ const integration = new bp.Integration({
     for (const event of data.events) {
       if (event.type === 'message') {
         await handleMessage(event, data.destination, client)
+      } else if (event.type === 'follow') {
+        await client.createEvent({
+          type: 'followed',
+          payload: {
+            destinationId: data.destination,
+            userId: event.source.userId,
+          },
+        })
       }
     }
 


### PR DESCRIPTION
Resolves SQD-3377

When a user adds the bot account as a friend on Line, an event is now triggered in the integration. This can be used to send a message proactively.

Here's an example of how this might be useful:
<img width="583" height="425" alt="image" src="https://github.com/user-attachments/assets/7c6d0ede-752b-40cc-b0f7-bc2aac0b8ecf" />
