### PR TITLE
fix(integration/intercom): Added API call to get the Admin ID

### DIFF
--- a/integrations/intercom/integration.definition.ts
+++ b/integrations/intercom/integration.definition.ts
@@ -11,7 +11,7 @@ export default new IntegrationDefinition({
   readme: 'hub.md',
   configuration: {
     schema: z.object({
-      adminId: z.string().min(1).describe('The admin ID of the Bot'),
+      adminId: z.string().min(1).optional().describe('The admin ID of the Bot'),
       accessToken: z.string().min(1).describe('The access token of the Intercom app'),
       clientSecret: z
         .string()
@@ -81,6 +81,7 @@ export default new IntegrationDefinition({
     credentials: {
       type: 'integration',
       schema: z.object({
+        adminId: z.string().min(1).describe('The admin ID of the Bot'),
         accessToken: z.string().min(1).describe('The access token obtained from OAuth'),
       }),
     },

--- a/integrations/intercom/src/channels.ts
+++ b/integrations/intercom/src/channels.ts
@@ -146,14 +146,16 @@ async function sendMessage(
   }
 ) {
   const { body, attachmentUrls, client, ctx, conversation, ack } = props
-  const { configuration } = ctx
+  const { state } = await client.getState({ type: 'integration', name: 'credentials', id: ctx.integrationId })
+  const { adminId } = state.payload
+
   const intercomClient = await getAuthenticatedIntercomClient(client, ctx)
 
   const {
     conversation_parts: { conversation_parts: conversationParts },
   } = await intercomClient.conversations.replyByIdAsAdmin({
     id: conversation.tags.id ?? '',
-    adminId: configuration.adminId,
+    adminId,
     messageType: ReplyToConversationMessageType.COMMENT,
     body,
     attachmentUrls,

--- a/integrations/intercom/src/index.ts
+++ b/integrations/intercom/src/index.ts
@@ -1,12 +1,19 @@
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
-import { getAuthenticatedIntercomClient } from './auth'
+import { getAdminId, getAuthenticatedIntercomClient } from './auth'
 import { channels } from './channels'
 import { handler } from './handler'
 import * as bp from '.botpress'
 
 const integration = new bp.Integration({
   register: async ({ client, ctx }) => {
-    const adminId = ctx.configuration.adminId
+    const adminId = ctx.configuration.adminId ?? (await getAdminId(ctx))
+
+    await client.setState({
+      id: ctx.integrationId,
+      name: 'credentials',
+      type: 'integration',
+      payload: { adminId, accessToken: ctx.configuration.accessToken },
+    })
     await client.updateUser({
       id: ctx.botUserId,
       tags: { id: adminId },


### PR DESCRIPTION
The Admin Id  cannot be found through the UI and is typically found through the `/me` endpoint. I removed the Admin Id from the config and implemented the endpoint call. This ensures that the the admin id is always correct and all the user has to provide is the access token which is easy to find. 