### PR TITLE
chore(sdk): update typings for injected plugin props

### DIFF
--- a/packages/sdk/src/bot/implementation.ts
+++ b/packages/sdk/src/bot/implementation.ts
@@ -1,3 +1,4 @@
+import { Workflow } from '@botpress/client'
 import type { Server } from 'node:http'
 import { PLUGIN_PREFIX_SEPARATOR } from '../consts'
 import { BasePlugin, PluginImplementation } from '../plugin'
@@ -76,9 +77,13 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
       {},
       {
         get: (_, actionName: string) => {
-          let action = this._actionHandlers[actionName]
+          const action = this._actionHandlers[actionName]
           if (action) {
-            return action
+            return utils.functions.setName(
+              (props: Omit<Parameters<typeof action>[0], keyof InjectedHandlerProps<TBot>>) =>
+                action({ ...props, workflows: proxyWorkflows(props.client) }),
+              action.name
+            )
           }
 
           for (const [pluginAlias, plugin] of Object.entries(this._plugins)) {
@@ -86,14 +91,7 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
             if (actionPrefix !== pluginAlias || !nameWithoutPrefix) {
               continue
             }
-            action = plugin.actionHandlers[nameWithoutPrefix]
-            if (action) {
-              return utils.functions.setName(
-                (props: Omit<Parameters<NonNullable<typeof action>>[0], keyof InjectedHandlerProps<TBot>>) =>
-                  action!({ ...props, workflows: proxyWorkflows(props.client) }),
-                action.name
-              )
-            }
+            return plugin.actionHandlers[nameWithoutPrefix]
           }
 
           return undefined
@@ -111,20 +109,19 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
           const pluginHandlers = Object.values(this._plugins).flatMap(
             (plugin) => plugin.messageHandlers[messageName] ?? []
           )
-          const selfSpecificHandlers = this._messageHandlers[messageName] ?? []
+          const selfSpecificHandlers = messageName === '*' ? [] : (this._messageHandlers[messageName] ?? [])
           const selfGlobalHandlers = this._messageHandlers['*'] ?? []
           const selfHandlers = [...selfSpecificHandlers, ...selfGlobalHandlers]
             .sort((a, b) => a.order - b.order)
-            .map(({ handler }) => handler)
-          return utils.arrays
-            .unique([...pluginHandlers, ...selfHandlers])
-            .map((handler) =>
+            .map(({ handler }) =>
               utils.functions.setName(
                 (props: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TBot>>) =>
                   handler({ ...props, workflows: proxyWorkflows(props.client) }),
                 handler.name
               )
             )
+
+          return utils.arrays.unique([...pluginHandlers, ...selfHandlers])
         },
       }
     ) as InjectedBotHandlers<TBot>['messageHandlers']
@@ -137,20 +134,20 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
         /** returns both the event handlers for the target type but global as well */
         get: (_, eventName: string) => {
           const pluginHandlers = Object.values(this._plugins).flatMap((plugin) => plugin.eventHandlers[eventName] ?? [])
-          const selfSpecificHandlers = this._eventHandlers[eventName as keyof EventHandlersMap<TBot>] ?? []
+
+          const selfSpecificHandlers = eventName === '*' ? [] : (this._eventHandlers[eventName] ?? [])
           const selfGlobalHandlers = this._eventHandlers['*'] ?? []
           const selfHandlers = [...selfSpecificHandlers, ...selfGlobalHandlers]
             .sort((a, b) => a.order - b.order)
-            .map(({ handler }) => handler)
-          return utils.arrays
-            .unique([...pluginHandlers, ...selfHandlers])
-            .map((handler) =>
+            .map(({ handler }) =>
               utils.functions.setName(
                 (props: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TBot>>) =>
                   handler({ ...props, workflows: proxyWorkflows(props.client) }),
                 handler.name
               )
             )
+
+          return utils.arrays.unique([...pluginHandlers, ...selfHandlers])
         },
       }
     ) as InjectedBotHandlers<TBot>['eventHandlers']
@@ -165,21 +162,20 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
           const pluginHandlers = Object.values(this._plugins).flatMap(
             (plugin) => plugin.stateExpiredHandlers[stateName] ?? []
           )
-          const selfSpecificHandlers =
-            this._stateExpiredHandlers[stateName as keyof StateExpiredHandlersMap<TBot>] ?? []
+
+          const selfSpecificHandlers = stateName === '*' ? [] : (this._stateExpiredHandlers[stateName] ?? [])
           const selfGlobalHandlers = this._stateExpiredHandlers['*'] ?? []
           const selfHandlers = [...selfSpecificHandlers, ...selfGlobalHandlers]
             .sort((a, b) => a.order - b.order)
-            .map(({ handler }) => handler)
-          return utils.arrays
-            .unique([...pluginHandlers, ...selfHandlers])
-            .map((handler) =>
+            .map(({ handler }) =>
               utils.functions.setName(
                 (props: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TBot>>) =>
                   handler({ ...props, workflows: proxyWorkflows(props.client) }),
                 handler.name
               )
             )
+
+          return utils.arrays.unique([...pluginHandlers, ...selfHandlers])
         },
       }
     ) as InjectedBotHandlers<TBot>['stateExpiredHandlers']
@@ -200,24 +196,22 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
             {
               get: (_, hookDataName: string) => {
                 const pluginHandlers = Object.values(this._plugins).flatMap(
-                  (plugin) => plugin.hookHandlers[hookType]?.[hookDataName] ?? ([] as typeof selfHandlers)
+                  (plugin) => (plugin.hookHandlers[hookType]?.[hookDataName] ?? []) as typeof selfHandlers
                 )
 
                 const selfHooks = this._hookHandlers[hookType] ?? {}
-                const selfSpecificHandlers = selfHooks[hookDataName] ?? []
+                const selfSpecificHandlers = hookDataName === '*' ? [] : (selfHooks[hookDataName] ?? [])
                 const selfGlobalHandlers = selfHooks['*'] ?? []
                 const selfHandlers = [...selfSpecificHandlers, ...selfGlobalHandlers]
                   .sort((a, b) => a.order - b.order)
-                  .map(({ handler }) => handler)
-
-                return utils.arrays
-                  .unique([...pluginHandlers, ...selfHandlers])
-                  .map((handler) =>
+                  .map(({ handler }) =>
                     utils.functions.setName(
                       (props: any) => handler({ ...props, workflows: proxyWorkflows(props.client) }),
                       handler.name
                     )
                   )
+
+                return utils.arrays.unique([...pluginHandlers, ...selfHandlers])
               },
             }
           )
@@ -241,31 +235,33 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
             {
               get: (_, workflowName: string) => {
                 const selfHandlers =
-                  handlersOfType[workflowName]?.sort((a, b) => a.order - b.order).map(({ handler }) => handler) ?? []
+                  handlersOfType[workflowName]
+                    ?.sort((a, b) => a.order - b.order)
+                    .map(({ handler }) =>
+                      utils.functions.setName(
+                        async (props: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TBot>>) => {
+                          let currentWorkflowState: Workflow = props.workflow
+                          await handler({
+                            ...props,
+                            workflow: wrapWorkflowInstance({
+                              ...props,
+                              onWorkflowUpdate(newState) {
+                                currentWorkflowState = newState
+                              },
+                            }),
+                            workflows: proxyWorkflows(props.client),
+                          })
+                          return currentWorkflowState
+                        },
+                        handler.name
+                      )
+                    ) ?? []
 
                 const pluginHandlers = Object.values(this._plugins).flatMap(
                   (plugin) => plugin.workflowHandlers[updateType]?.[workflowName] ?? []
                 )
 
-                return utils.arrays.unique([...selfHandlers, ...pluginHandlers]).map((handler) =>
-                  utils.functions.setName(
-                    async (props: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TBot>>) => {
-                      let currentWorkflowState = props.workflow
-                      await handler({
-                        ...props,
-                        workflow: wrapWorkflowInstance({
-                          ...props,
-                          onWorkflowUpdate(newState) {
-                            currentWorkflowState = newState
-                          },
-                        }),
-                        workflows: proxyWorkflows(props.client),
-                      })
-                      return currentWorkflowState
-                    },
-                    handler.name
-                  )
-                )
+                return utils.arrays.unique([...selfHandlers, ...pluginHandlers])
               },
             }
           )

--- a/packages/sdk/src/plugin/implementation.ts
+++ b/packages/sdk/src/plugin/implementation.ts
@@ -1,4 +1,3 @@
-import { Workflow } from '@botpress/client'
 import type {
   MessageHandlersMap as BotMessageHandlersMap,
   EventHandlersMap as BotEventHandlersMap,
@@ -13,7 +12,7 @@ import type {
 import { WorkflowProxy, proxyWorkflows, wrapWorkflowInstance } from '../bot/workflow-proxy'
 import * as utils from '../utils'
 import { ActionProxy, proxyActions } from './action-proxy'
-import { BasePlugin, PluginConfiguration, PluginInterfaceExtensions, PluginRuntimeProps } from './common'
+import { BasePlugin, PluginRuntimeProps } from './common'
 import { EventProxy, proxyEvents } from './event-proxy'
 import {
   ActionHandlers,
@@ -22,9 +21,6 @@ import {
   StateExpiredHandlers,
   HookHandlers,
   WorkflowHandlers,
-  MessageHandlersMap,
-  EventHandlersMap,
-  StateExpiredHandlersMap,
   HookHandlersMap,
   WorkflowHandlersMap,
   OrderedMessageHandlersMap,
@@ -32,7 +28,12 @@ import {
   OrderedStateExpiredHandlersMap,
   OrderedHookHandlersMap,
   OrderedWorkflowHandlersMap,
-  HookInputs as HookPayloads,
+  HookInputsWithoutInjectedProps,
+  ActionHandlerPayloadsWithoutInjectedProps,
+  StateExpiredPayloadsWithoutInjectedProps,
+  MessagePayloadsWithoutInjectedProps,
+  EventPayloadsWithoutInjectedProps,
+  WorkflowPayloadsWithoutInjectedProps,
   InjectedHandlerProps,
 } from './server/types'
 import { proxyStates, StateProxy } from './state-proxy'
@@ -41,15 +42,7 @@ export type PluginImplementationProps<TPlugin extends BasePlugin = BasePlugin> =
   actions: ActionHandlers<TPlugin>
 }
 
-type Tools<TPlugin extends BasePlugin = BasePlugin> = {
-  configuration: PluginConfiguration<TPlugin>
-  interfaces: PluginInterfaceExtensions<TPlugin>
-  actions: ActionProxy<TPlugin>
-  events: EventProxy<TPlugin>
-  states: StateProxy<TPlugin>
-  workflows: WorkflowProxy<TPlugin>
-  alias: string
-}
+type Tools<TPlugin extends BasePlugin = BasePlugin> = InjectedHandlerProps<TPlugin>
 
 export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> implements BotHandlers<TPlugin> {
   private _runtimeProps: PluginRuntimeProps<TPlugin> | undefined
@@ -125,7 +118,7 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
             return undefined
           }
           return utils.functions.setName(
-            (input: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TPlugin>>) =>
+            (input: utils.types.ValueOf<ActionHandlerPayloadsWithoutInjectedProps<TPlugin>>) =>
               handler({ ...input, ...this._getTools(input.client) }),
             handler.name
           )
@@ -140,15 +133,18 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
       {
         get: (_: unknown, messageName: string) => {
           messageName = this._stripAliasPrefix(messageName as string)
-          const specificHandlers = this._messageHandlers[messageName] ?? []
+          const specificHandlers = messageName === '*' ? [] : (this._messageHandlers[messageName] ?? [])
           const globalHandlers = this._messageHandlers['*'] ?? []
           const allHandlers = utils.arrays
             .unique([...specificHandlers, ...globalHandlers])
             .sort((a, b) => a.order - b.order)
           return allHandlers.map(({ handler }) =>
             utils.functions.setName(
-              (input: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TPlugin>>) =>
-                handler({ ...input, message: input.message, ...this._getTools(input.client) }),
+              (input: utils.types.ValueOf<MessagePayloadsWithoutInjectedProps<TPlugin>>) =>
+                handler({
+                  ...input,
+                  ...this._getTools(input.client),
+                }),
               handler.name
             )
           )
@@ -166,7 +162,7 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
 
           // if prop is "github:prOpened", include both "github:prOpened" and "creatable:itemCreated"
 
-          const specificHandlers = this._eventHandlers[eventName] ?? []
+          const specificHandlers = eventName === '*' ? [] : (this._eventHandlers[eventName] ?? [])
 
           const interfaceHandlers = Object.entries(this._eventHandlers)
             .filter(([e]) => this._eventResolvesTo(e, eventName))
@@ -179,8 +175,8 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
 
           return allHandlers.map(({ handler }) =>
             utils.functions.setName(
-              (input: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TPlugin>>) =>
-                handler({ ...input, event: input.event, ...this._getTools(input.client) }),
+              (input: utils.types.ValueOf<EventPayloadsWithoutInjectedProps<TPlugin>>) =>
+                handler({ ...input, ...this._getTools(input.client) }),
               handler.name
             )
           )
@@ -196,15 +192,15 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
         get: (_: unknown, stateName: string) => {
           stateName = this._stripAliasPrefix(stateName)
 
-          const specificHandlers = this._stateExpiredHandlers[stateName] ?? []
+          const specificHandlers = stateName === '*' ? [] : (this._stateExpiredHandlers[stateName] ?? [])
           const globalHandlers = this._stateExpiredHandlers['*'] ?? []
           const allHandlers = utils.arrays
             .unique([...specificHandlers, ...globalHandlers])
             .sort((a, b) => a.order - b.order)
           return allHandlers.map(({ handler }) =>
             utils.functions.setName(
-              (input: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TPlugin>>) =>
-                handler({ ...input, state: input.state as any, ...this._getTools(input.client) }),
+              (input: utils.types.ValueOf<StateExpiredPayloadsWithoutInjectedProps<TPlugin>>) =>
+                handler({ ...input, ...this._getTools(input.client) }),
               handler.name
             )
           )
@@ -228,7 +224,7 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
               get: (_: unknown, hookDataName: string) => {
                 hookDataName = this._stripAliasPrefix(hookDataName)
 
-                const specificHandlers = hooks[hookDataName] ?? []
+                const specificHandlers = hookDataName === '*' ? [] : (hooks[hookDataName] ?? [])
 
                 // for "before_incoming_event", "after_incoming_event" and other event related hooks
                 const interfaceHandlers = Object.entries(hooks)
@@ -242,8 +238,11 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
 
                 return handlers.map(({ handler }) =>
                   utils.functions.setName(
-                    (input: HookPayloads<TPlugin>[utils.types.StringKeys<HookHandlersMap<TPlugin>>]['*']) =>
-                      handler({ ...input, data: input.data, ...this._getTools(input.client) }),
+                    (input: utils.types.ValueOf<HookInputsWithoutInjectedProps<TPlugin>>['*']) =>
+                      handler({
+                        ...input,
+                        ...this._getTools(input.client),
+                      }),
                     handler.name
                   )
                 )
@@ -273,16 +272,13 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
 
                 return selfHandlers.map(({ handler }) =>
                   utils.functions.setName(
-                    async (
-                      input: Omit<Parameters<typeof handler>[0], keyof InjectedHandlerProps<TPlugin> | 'workflow'> & {
-                        workflow: Workflow
-                      }
-                    ) => {
+                    async (input: utils.types.ValueOf<WorkflowPayloadsWithoutInjectedProps<TPlugin>>) => {
                       let currentWorkflowState = input.workflow
                       await handler({
                         ...input,
                         workflow: wrapWorkflowInstance({
                           ...input,
+                          workflow: currentWorkflowState,
                           onWorkflowUpdate(newState) {
                             currentWorkflowState = newState
                           },
@@ -303,32 +299,32 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
   }
 
   public readonly on = {
-    message: <T extends utils.types.StringKeys<MessageHandlersMap<TPlugin>>>(
+    message: <T extends utils.types.StringKeys<MessageHandlers<TPlugin>>>(
       type: T,
       handler: MessageHandlers<TPlugin>[T]
     ): void => {
       this._messageHandlers[type] = utils.arrays.safePush(this._messageHandlers[type], {
-        handler: handler as MessageHandlers<any>[string],
+        handler: handler as unknown as MessageHandlers<any>[string],
         order: this._registerOrder++,
       })
     },
 
-    event: <T extends utils.types.StringKeys<EventHandlersMap<TPlugin>>>(
+    event: <T extends utils.types.StringKeys<EventHandlers<TPlugin>>>(
       type: T,
       handler: EventHandlers<TPlugin>[T]
     ): void => {
       this._eventHandlers[type] = utils.arrays.safePush(this._eventHandlers[type], {
-        handler: handler as EventHandlers<any>[string],
+        handler: handler as unknown as EventHandlers<any>[string],
         order: this._registerOrder++,
       })
     },
 
-    stateExpired: <T extends utils.types.StringKeys<StateExpiredHandlersMap<TPlugin>>>(
+    stateExpired: <T extends utils.types.StringKeys<StateExpiredHandlers<TPlugin>>>(
       type: T,
       handler: StateExpiredHandlers<TPlugin>[T]
     ): void => {
       this._stateExpiredHandlers[type] = utils.arrays.safePush(this._stateExpiredHandlers[type], {
-        handler: handler as StateExpiredHandlers<any>[string],
+        handler: handler as unknown as StateExpiredHandlers<any>[string],
         order: this._registerOrder++,
       })
     },
@@ -339,7 +335,10 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
     ) => {
       this._hookHandlers.before_incoming_event[type] = utils.arrays.safePush(
         this._hookHandlers.before_incoming_event[type],
-        { handler: handler as HookHandlers<any>['before_incoming_event'][string], order: this._registerOrder++ }
+        {
+          handler: handler as unknown as HookHandlers<any>['before_incoming_event'][string],
+          order: this._registerOrder++,
+        }
       )
     },
 
@@ -349,7 +348,10 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
     ) => {
       this._hookHandlers.before_incoming_message[type] = utils.arrays.safePush(
         this._hookHandlers.before_incoming_message[type],
-        { handler: handler as HookHandlers<any>['before_incoming_message'][string], order: this._registerOrder++ }
+        {
+          handler: handler as unknown as HookHandlers<any>['before_incoming_message'][string],
+          order: this._registerOrder++,
+        }
       )
     },
 
@@ -359,7 +361,10 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
     ) => {
       this._hookHandlers.before_outgoing_message[type] = utils.arrays.safePush(
         this._hookHandlers.before_outgoing_message[type],
-        { handler: handler as HookHandlers<any>['before_outgoing_message'][string], order: this._registerOrder++ }
+        {
+          handler: handler as unknown as HookHandlers<any>['before_outgoing_message'][string],
+          order: this._registerOrder++,
+        }
       )
     },
 
@@ -371,7 +376,10 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
     ) => {
       this._hookHandlers.before_outgoing_call_action[type] = utils.arrays.safePush(
         this._hookHandlers.before_outgoing_call_action[type],
-        { handler: handler as HookHandlers<any>['before_outgoing_call_action'][string], order: this._registerOrder++ }
+        {
+          handler: handler as unknown as HookHandlers<any>['before_outgoing_call_action'][string],
+          order: this._registerOrder++,
+        }
       )
     },
 
@@ -387,7 +395,10 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
     ) => {
       this._hookHandlers.before_incoming_call_action[type] = utils.arrays.safePush(
         this._hookHandlers.before_incoming_call_action[type],
-        { handler: handler as HookHandlers<any>['before_incoming_call_action'][string], order: this._registerOrder++ }
+        {
+          handler: handler as unknown as HookHandlers<any>['before_incoming_call_action'][string],
+          order: this._registerOrder++,
+        }
       )
     },
 
@@ -397,7 +408,10 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
     ) => {
       this._hookHandlers.after_incoming_event[type] = utils.arrays.safePush(
         this._hookHandlers.after_incoming_event[type],
-        { handler: handler as HookHandlers<any>['after_incoming_event'][string], order: this._registerOrder++ }
+        {
+          handler: handler as unknown as HookHandlers<any>['after_incoming_event'][string],
+          order: this._registerOrder++,
+        }
       )
     },
 
@@ -407,7 +421,10 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
     ) => {
       this._hookHandlers.after_incoming_message[type] = utils.arrays.safePush(
         this._hookHandlers.after_incoming_message[type],
-        { handler: handler as HookHandlers<any>['after_incoming_message'][string], order: this._registerOrder++ }
+        {
+          handler: handler as unknown as HookHandlers<any>['after_incoming_message'][string],
+          order: this._registerOrder++,
+        }
       )
     },
 
@@ -417,7 +434,10 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
     ) => {
       this._hookHandlers.after_outgoing_message[type] = utils.arrays.safePush(
         this._hookHandlers.after_outgoing_message[type],
-        { handler: handler as HookHandlers<any>['after_outgoing_message'][string], order: this._registerOrder++ }
+        {
+          handler: handler as unknown as HookHandlers<any>['after_outgoing_message'][string],
+          order: this._registerOrder++,
+        }
       )
     },
 
@@ -427,7 +447,10 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
     ) => {
       this._hookHandlers.after_outgoing_call_action[type] = utils.arrays.safePush(
         this._hookHandlers.after_outgoing_call_action[type],
-        { handler: handler as HookHandlers<any>['after_outgoing_call_action'][string], order: this._registerOrder++ }
+        {
+          handler: handler as unknown as HookHandlers<any>['after_outgoing_call_action'][string],
+          order: this._registerOrder++,
+        }
       )
     },
 
@@ -441,7 +464,10 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
     ) => {
       this._hookHandlers.after_incoming_call_action[type] = utils.arrays.safePush(
         this._hookHandlers.after_incoming_call_action[type],
-        { handler: handler as HookHandlers<any>['after_incoming_call_action'][string], order: this._registerOrder++ }
+        {
+          handler: handler as unknown as HookHandlers<any>['after_incoming_call_action'][string],
+          order: this._registerOrder++,
+        }
       )
     },
 
@@ -454,7 +480,7 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
       handler: WorkflowHandlers<TPlugin>[T]
     ): void => {
       this._workflowHandlers.started[type] = utils.arrays.safePush(this._workflowHandlers.started[type], {
-        handler: handler as WorkflowHandlers<any>[string],
+        handler: handler as unknown as WorkflowHandlers<any>[string],
         order: this._registerOrder++,
       })
     },
@@ -468,7 +494,7 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
       handler: WorkflowHandlers<TPlugin>[T]
     ): void => {
       this._workflowHandlers.continued[type] = utils.arrays.safePush(this._workflowHandlers.continued[type], {
-        handler: handler as WorkflowHandlers<any>[string],
+        handler: handler as unknown as WorkflowHandlers<any>[string],
         order: this._registerOrder++,
       })
     },
@@ -482,7 +508,7 @@ export class PluginImplementation<TPlugin extends BasePlugin = BasePlugin> imple
       handler: WorkflowHandlers<TPlugin>[T]
     ): void => {
       this._workflowHandlers.timed_out[type] = utils.arrays.safePush(this._workflowHandlers.timed_out[type], {
-        handler: handler as WorkflowHandlers<any>[string],
+        handler: handler as unknown as WorkflowHandlers<any>[string],
         order: this._registerOrder++,
       })
     },

--- a/packages/sdk/src/plugin/server/types.ts
+++ b/packages/sdk/src/plugin/server/types.ts
@@ -22,7 +22,7 @@ type _IncomingMessages<TPlugin extends common.BasePlugin> = {
   [K in utils.StringKeys<bot.GetMessages<TPlugin>>]: utils.Merge<
     //
     client.Message,
-    { type: K; payload: bot.GetMessages<TPlugin>[K] }
+    { type: Extract<K, string>; payload: bot.GetMessages<TPlugin>[K] }
   >
 }
 
@@ -140,11 +140,24 @@ export type InjectedHandlerProps<TPlugin extends common.BasePlugin> = {
   workflows: workflowProxy.WorkflowProxy<TPlugin>
 }
 
-export type ExtendedHandlerProps<TPlugin extends common.BasePlugin> = CommonHandlerProps<TPlugin> &
-  InjectedHandlerProps<TPlugin>
+type _WithInjectedProps<
+  T extends Record<string, Record<string, any>>,
+  TPlugin extends common.BasePlugin,
+  TMerge extends object = {},
+> = {
+  [K in keyof T]: utils.Merge<T[K], TMerge> & InjectedHandlerProps<TPlugin>
+}
 
-export type MessagePayloads<TPlugin extends common.BasePlugin> = {
-  [TMessageName in utils.StringKeys<IncomingMessages<TPlugin>>]: ExtendedHandlerProps<TPlugin> & {
+type _WithInjectedPropsFn<
+  T extends Record<string, (args: any) => any>,
+  TPlugin extends common.BasePlugin,
+  TMerge extends object = {},
+> = {
+  [K in keyof T]: (args: utils.Merge<Parameters<T[K]>[0], TMerge> & InjectedHandlerProps<TPlugin>) => ReturnType<T[K]>
+}
+
+export type MessagePayloadsWithoutInjectedProps<TPlugin extends common.BasePlugin> = {
+  [TMessageName in utils.StringKeys<IncomingMessages<TPlugin>>]: CommonHandlerProps<TPlugin> & {
     message: IncomingMessages<TPlugin>[TMessageName]
     user: client.User
     conversation: client.Conversation
@@ -152,64 +165,123 @@ export type MessagePayloads<TPlugin extends common.BasePlugin> = {
   }
 }
 
-export type MessageHandlers<TPlugin extends common.BasePlugin> = {
+export type MessageHandlersWithoutInjectedProps<TPlugin extends common.BasePlugin> = {
   [TMessageName in utils.StringKeys<IncomingMessages<TPlugin>>]: (
-    args: MessagePayloads<TPlugin>[TMessageName]
+    args: MessagePayloadsWithoutInjectedProps<TPlugin>[TMessageName]
   ) => Promise<void>
 }
 
-export type EventPayloads<TPlugin extends common.BasePlugin> = {
-  [TEventName in utils.StringKeys<IncomingEvents<TPlugin>>]: ExtendedHandlerProps<TPlugin> & {
+export type MessageHandlers<TPlugin extends common.BasePlugin> = _WithInjectedPropsFn<
+  MessageHandlersWithoutInjectedProps<TPlugin>,
+  TPlugin
+>
+
+export type EventPayloadsWithoutInjectedProps<TPlugin extends common.BasePlugin> = {
+  [TEventName in utils.StringKeys<IncomingEvents<TPlugin>>]: CommonHandlerProps<TPlugin> & {
     event: IncomingEvents<TPlugin>[TEventName]
   }
 }
 
-export type EventHandlers<TPlugin extends common.BasePlugin> = {
-  [TEventName in utils.StringKeys<IncomingEvents<TPlugin>>]: (args: EventPayloads<TPlugin>[TEventName]) => Promise<void>
+export type EventPayloads<TPlugin extends common.BasePlugin> = _WithInjectedProps<
+  EventPayloadsWithoutInjectedProps<TPlugin>,
+  TPlugin
+>
+
+export type EventHandlersWithoutInjectedProps<TPlugin extends common.BasePlugin> = {
+  [TEventName in utils.StringKeys<IncomingEvents<TPlugin>>]: (
+    args: EventPayloadsWithoutInjectedProps<TPlugin>[TEventName]
+  ) => Promise<void>
 }
 
-export type StateExpiredPayloads<TPlugin extends common.BasePlugin> = {
-  [TSateName in utils.StringKeys<IncomingStates<TPlugin>>]: ExtendedHandlerProps<TPlugin> & {
+export type EventHandlers<TPlugin extends common.BasePlugin> = _WithInjectedPropsFn<
+  EventHandlersWithoutInjectedProps<TPlugin>,
+  TPlugin
+>
+
+export type StateExpiredPayloadsWithoutInjectedProps<TPlugin extends common.BasePlugin> = {
+  [TSateName in utils.StringKeys<IncomingStates<TPlugin>>]: CommonHandlerProps<TPlugin> & {
     state: IncomingStates<TPlugin>[TSateName]
   }
 }
 
-export type StateExpiredHandlers<TPlugin extends common.BasePlugin> = {
+export type StateExpiredPayloads<TPlugin extends common.BasePlugin> = _WithInjectedProps<
+  StateExpiredPayloadsWithoutInjectedProps<TPlugin>,
+  TPlugin
+>
+
+export type StateExpiredHandlersWithoutInjectedProps<TPlugin extends common.BasePlugin> = {
   [TSateName in utils.StringKeys<IncomingStates<TPlugin>>]: (
-    args: StateExpiredPayloads<TPlugin>[TSateName]
+    args: StateExpiredPayloadsWithoutInjectedProps<TPlugin>[TSateName]
   ) => Promise<void>
 }
 
-export type ActionHandlerPayloads<TPlugin extends common.BasePlugin> = {
-  [TActionName in utils.StringKeys<TPlugin['actions']>]: ExtendedHandlerProps<TPlugin> & {
+export type StateExpiredHandlers<TPlugin extends common.BasePlugin> = _WithInjectedPropsFn<
+  StateExpiredHandlersWithoutInjectedProps<TPlugin>,
+  TPlugin
+>
+
+export type ActionHandlerPayloadsWithoutInjectedProps<TPlugin extends common.BasePlugin> = {
+  [TActionName in utils.StringKeys<TPlugin['actions']>]: CommonHandlerProps<TPlugin> & {
     type?: TActionName
     input: TPlugin['actions'][TActionName]['input']
   }
 }
 
-export type ActionHandlers<TPlugin extends common.BasePlugin> = {
+export type ActionHandlerPayloads<TPlugin extends common.BasePlugin> = _WithInjectedProps<
+  ActionHandlerPayloadsWithoutInjectedProps<TPlugin>,
+  TPlugin
+>
+
+export type ActionHandlersWithoutInjectedProps<TPlugin extends common.BasePlugin> = {
   [TActionName in utils.StringKeys<TPlugin['actions']>]: (
-    props: ActionHandlerPayloads<TPlugin>[TActionName]
+    props: ActionHandlerPayloadsWithoutInjectedProps<TPlugin>[TActionName]
   ) => Promise<TPlugin['actions'][TActionName]['output']>
 }
 
-export type WorkflowPayloads<TPlugin extends common.BasePlugin> = {
-  [TWorkflowName in utils.StringKeys<TPlugin['workflows']>]: ExtendedHandlerProps<TPlugin> & {
+export type ActionHandlers<TPlugin extends common.BasePlugin> = _WithInjectedPropsFn<
+  ActionHandlersWithoutInjectedProps<TPlugin>,
+  TPlugin
+>
+
+export type WorkflowPayloadsWithoutInjectedProps<TPlugin extends common.BasePlugin> = {
+  [TWorkflowName in utils.StringKeys<TPlugin['workflows']>]: CommonHandlerProps<TPlugin> & {
     conversation?: client.Conversation
     user?: client.User
     event: bot.WorkflowUpdateEvent
-
-    /**
-     * # EXPERIMENTAL
-     * This API is experimental and may change in the future.
-     */
-    workflow: workflowProxy.WorkflowWithUtilities<TPlugin, TWorkflowName>
+    workflow: client.Workflow
   }
+}
+
+export type WorkflowPayloads<TPlugin extends common.BasePlugin> = _WithInjectedProps<
+  {
+    [TWorkflowName in keyof WorkflowPayloadsWithoutInjectedProps<TPlugin>]: utils.Merge<
+      WorkflowPayloadsWithoutInjectedProps<TPlugin>[TWorkflowName],
+      {
+        /**
+         * # EXPERIMENTAL
+         * This API is experimental and may change in the future.
+         */
+        workflow: workflowProxy.WorkflowWithUtilities<TPlugin, TWorkflowName>
+      }
+    >
+  },
+  TPlugin
+>
+
+export type WorkflowHandlersWithoutInjectedProps<TPlugin extends common.BasePlugin> = {
+  [TWorkflowName in utils.StringKeys<TPlugin['workflows']>]: (
+    props: WorkflowPayloadsWithoutInjectedProps<TPlugin>[TWorkflowName]
+  ) => Promise<void>
 }
 
 export type WorkflowHandlers<TPlugin extends common.BasePlugin> = {
   [TWorkflowName in utils.StringKeys<TPlugin['workflows']>]: (
-    props: WorkflowPayloads<TPlugin>[TWorkflowName]
+    props: utils.Merge<
+      WorkflowPayloads<TPlugin>[TWorkflowName],
+      {
+        workflow: workflowProxy.WorkflowWithUtilities<TPlugin, TWorkflowName>
+      }
+    >
   ) => Promise<void>
 }
 
@@ -279,12 +351,19 @@ export type HookData<TPlugin extends common.BasePlugin> = {
   }
 }
 
-export type HookInputs<TPlugin extends common.BasePlugin> = {
+export type HookInputsWithoutInjectedProps<TPlugin extends common.BasePlugin> = {
   [THookType in utils.StringKeys<HookData<TPlugin>>]: {
-    [THookDataName in utils.StringKeys<HookData<TPlugin>[THookType]>]: ExtendedHandlerProps<TPlugin> & {
+    [THookDataName in utils.StringKeys<HookData<TPlugin>[THookType]>]: CommonHandlerProps<TPlugin> & {
       data: HookData<TPlugin>[THookType][THookDataName]
     }
   }
+}
+
+export type HookInputs<TPlugin extends common.BasePlugin> = {
+  [THookType in utils.StringKeys<HookData<TPlugin>>]: _WithInjectedProps<
+    HookInputsWithoutInjectedProps<TPlugin>[THookType],
+    TPlugin
+  >
 }
 
 export type HookOutputs<TPlugin extends common.BasePlugin> = {
@@ -295,43 +374,26 @@ export type HookOutputs<TPlugin extends common.BasePlugin> = {
   }
 }
 
-export type HookHandlers<TPlugin extends common.BasePlugin> = {
+export type HookHandlersWithoutInjectedProps<TPlugin extends common.BasePlugin> = {
   [THookType in utils.StringKeys<HookData<TPlugin>>]: {
     [THookDataName in utils.StringKeys<HookData<TPlugin>[THookType]>]: (
-      input: HookInputs<TPlugin>[THookType][THookDataName]
+      input: HookInputsWithoutInjectedProps<TPlugin>[THookType][THookDataName]
     ) => Promise<HookOutputs<TPlugin>[THookType][THookDataName] | undefined>
   }
 }
 
-export type ActionHandlersMap<TPlugin extends common.BasePlugin> = {
-  [TActionName in utils.StringKeys<TPlugin['actions']>]?: (
-    props: Omit<Parameters<ActionHandlers<TPlugin>[TActionName]>[0], keyof InjectedHandlerProps<TPlugin>>
-  ) => Promise<Awaited<ReturnType<ActionHandlers<TPlugin>[TActionName]>>>
-}
-
-export type MessageHandlersMap<TPlugin extends common.BasePlugin> = {
-  [TMessageName in utils.StringKeys<IncomingMessages<TPlugin>>]?: ((
-    props: Omit<Parameters<MessageHandlers<TPlugin>[TMessageName]>[0], keyof InjectedHandlerProps<TPlugin>>
-  ) => Promise<void>)[]
-}
-
-export type EventHandlersMap<TPlugin extends common.BasePlugin> = {
-  [TEventName in utils.StringKeys<IncomingEvents<TPlugin>>]?: ((
-    props: Omit<Parameters<EventHandlers<TPlugin>[TEventName]>[0], keyof InjectedHandlerProps<TPlugin>>
-  ) => Promise<void>)[]
-}
-
-export type StateExpiredHandlersMap<TPlugin extends common.BasePlugin> = {
-  [TStateName in utils.StringKeys<IncomingStates<TPlugin>>]?: ((
-    props: Omit<Parameters<StateExpiredHandlers<TPlugin>[TStateName]>[0], keyof InjectedHandlerProps<TPlugin>>
-  ) => Promise<void>)[]
+export type HookHandlers<TPlugin extends common.BasePlugin> = {
+  [THookType in utils.StringKeys<HookData<TPlugin>>]: _WithInjectedPropsFn<
+    HookHandlersWithoutInjectedProps<TPlugin>[THookType],
+    TPlugin
+  >
 }
 
 export type HookHandlersMap<TPlugin extends common.BasePlugin> = {
   [THookType in utils.StringKeys<HookData<TPlugin>>]: {
-    [THookDataName in utils.StringKeys<HookData<TPlugin>[THookType]>]?: ((
-      props: Omit<Parameters<HookHandlers<TPlugin>[THookType][THookDataName]>[0], keyof InjectedHandlerProps<TPlugin>>
-    ) => Promise<Awaited<ReturnType<HookHandlers<TPlugin>[THookType][THookDataName]>>>)[]
+    [THookDataName in utils.StringKeys<
+      HookData<TPlugin>[THookType]
+    >]?: HookHandlersWithoutInjectedProps<TPlugin>[THookType][THookDataName][]
   }
 }
 
@@ -339,10 +401,7 @@ export type WorkflowHandlersMap<TPlugin extends common.BasePlugin> = {
   [TWorkflowUpdateType in bot.WorkflowUpdateType]: {
     [TWorkflowName in utils.StringKeys<TPlugin['workflows']>]?: {
       handler: (
-        props: Omit<
-          Parameters<WorkflowHandlers<TPlugin>[TWorkflowName]>[0],
-          keyof InjectedHandlerProps<TPlugin> | 'workflow'
-        > & {
+        props: Omit<Parameters<WorkflowHandlersWithoutInjectedProps<TPlugin>[TWorkflowName]>[0], 'workflow'> & {
           workflow: client.Workflow
         }
       ) => Promise<client.Workflow>
@@ -392,12 +451,35 @@ export type OrderedWorkflowHandlersMap<TPlugin extends common.BasePlugin> = {
 
 /** Plugin handlers without InjectedHandlerProps */
 export type PluginHandlers<TPlugin extends common.BasePlugin> = {
-  actionHandlers: ActionHandlersMap<TPlugin>
-  messageHandlers: MessageHandlersMap<TPlugin>
-  eventHandlers: EventHandlersMap<TPlugin>
-  stateExpiredHandlers: StateExpiredHandlersMap<TPlugin>
-  hookHandlers: HookHandlersMap<TPlugin>
-  workflowHandlers: WorkflowHandlersMap<TPlugin>
+  actionHandlers: ActionHandlersWithoutInjectedProps<TPlugin>
+  messageHandlers: {
+    [TMessageName in utils.StringKeys<
+      IncomingMessages<TPlugin>
+    >]?: MessageHandlersWithoutInjectedProps<TPlugin>[TMessageName][]
+  }
+  eventHandlers: {
+    [TEventName in utils.StringKeys<IncomingEvents<TPlugin>>]?: EventHandlersWithoutInjectedProps<TPlugin>[TEventName][]
+  }
+  stateExpiredHandlers: {
+    [TStateName in utils.StringKeys<
+      IncomingStates<TPlugin>
+    >]?: StateExpiredHandlersWithoutInjectedProps<TPlugin>[TStateName][]
+  }
+  hookHandlers: {
+    [THookType in utils.StringKeys<HookData<TPlugin>>]: {
+      [THookDataName in utils.StringKeys<
+        HookData<TPlugin>[THookType]
+      >]?: HookHandlersWithoutInjectedProps<TPlugin>[THookType][THookDataName][]
+    }
+  }
+  workflowHandlers: {
+    [TWorkflowUpdateType in bot.WorkflowUpdateType]: {
+      [TWorkflowName in utils.StringKeys<TPlugin['workflows']>]?: {
+        handler: WorkflowHandlersWithoutInjectedProps<TPlugin>[TWorkflowName]
+        order: number
+      }[]
+    }
+  }
 }
 /** identical to PluginHandlers, but contains the injected properties */
 export type InjectedPluginHandlers<TPlugin extends common.BasePlugin> = {


### PR DESCRIPTION
Part 4 of the multi-plugin merge train.
Lays the groundwork for adding the proxies.

Contributes to SQD-3132

---

1. https://github.com/botpress/botpress/pull/14447
2. https://github.com/botpress/botpress/pull/14452
3. https://github.com/botpress/botpress/pull/14453
4. https://github.com/botpress/botpress/pull/14454 **<= this PR**
5. https://github.com/botpress/botpress/pull/14459
6. https://github.com/botpress/botpress/pull/14460
7. https://github.com/botpress/botpress/pull/14461