### PR TITLE
chore(bots/bugbuster): Added new lint constraints

### DIFF
--- a/bots/bugbuster/src/issue-title-format-validator.test.ts
+++ b/bots/bugbuster/src/issue-title-format-validator.test.ts
@@ -1,0 +1,194 @@
+import { test, assert } from 'vitest'
+import { isIssueTitleFormatValid } from './issue-title-format-validator'
+
+test('assert that a title containing only words is valid', async () => {
+  const title = 'any string'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isTrue(actual)
+})
+
+test('assert that a title with square brackets not on the first or second word is valid', async () => {
+  const title = 'any string [abc]'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isTrue(actual)
+})
+
+test('assert that a title with one opening square bracket on the first word is valid', async () => {
+  const title = '[abc'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isTrue(actual)
+})
+
+test('assert that a title with one closing square bracket on the first word is valid', async () => {
+  const title = 'abc]'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isTrue(actual)
+})
+
+test('assert that a title with and one opening square bracket on the second word is valid', async () => {
+  const title = 'abc[def'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isTrue(actual)
+})
+
+test('assert that a title with one closing square bracket on the second word is valid', async () => {
+  const title = 'abc def]'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isTrue(actual)
+})
+
+test('assert that a title with parenthesiss not on the first or second word is valid', async () => {
+  const title = 'any string (abc)'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isTrue(actual)
+})
+
+test('assert that a title with one opening parenthesis on the first word is valid', async () => {
+  const title = '(abc'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isTrue(actual)
+})
+
+test('assert that a title with one closing parenthesis on the first word is valid', async () => {
+  const title = 'abc)'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isTrue(actual)
+})
+
+test('assert that a title with one opening parenthesis on the second word is valid', async () => {
+  const title = 'abc(def'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isTrue(actual)
+})
+
+test('assert that a title with one closing parenthesis on the second word is valid', async () => {
+  const title = 'abc def)'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isTrue(actual)
+})
+
+test('assert that a title with one closing parenthesis on the second word is valid', async () => {
+  const title = 'abc def)'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isTrue(actual)
+})
+
+test('assert that a title with square brackets on the first word is invalid', async () => {
+  const title = '[abc] def'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isFalse(actual)
+})
+
+test('assert that a title with square brackets on the second word is invalid', async () => {
+  const title = 'abc [def]'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isFalse(actual)
+})
+
+test('assert that a title with square brackets on the second word with no space between the first and second word is invalid', async () => {
+  const title = 'abc[def]'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isFalse(actual)
+})
+
+test('assert that a title with square brackets on the second word with multiple spaces between the first and second word is invalid', async () => {
+  const title = 'abc    [def]'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isFalse(actual)
+})
+
+test('assert that a title with square brackets on the second word with multiple spaces between the first and second word is invalid', async () => {
+  const title = 'abc    [def]'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isFalse(actual)
+})
+
+test('assert that a title with square brackets on the first and second words is invalid', async () => {
+  const title = '[abc def]'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isFalse(actual)
+})
+
+test('assert that a title with parenthesis on the first word is invalid', async () => {
+  const title = '(abc) def'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isFalse(actual)
+})
+
+test('assert that a title with parenthesis on the second word is invalid', async () => {
+  const title = 'abc (def)'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isFalse(actual)
+})
+
+test('assert that a title with parenthesis on the second word with no space between the first and second word is invalid', async () => {
+  const title = 'abc(def)'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isFalse(actual)
+})
+
+test('assert that a title with parenthesis on the second word with multiple spaces between the first and second word is invalid', async () => {
+  const title = 'abc    (def)'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isFalse(actual)
+})
+
+test('assert that a title with parenthesis on the second word with multiple spaces between the first and second word is invalid', async () => {
+  const title = 'abc    (def)'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isFalse(actual)
+})
+
+test('assert that a title with parenthesis on the first and second words is invalid', async () => {
+  const title = '(abc def)'
+
+  const actual = isIssueTitleFormatValid(title)
+
+  assert.isFalse(actual)
+})

--- a/bots/bugbuster/src/issue-title-format-validator.ts
+++ b/bots/bugbuster/src/issue-title-format-validator.ts
@@ -1,0 +1,5 @@
+const PATTERN = /^\w{0,} {0,}((\[.{1,}\])|(\(.{1,}\)))/
+
+export function isIssueTitleFormatValid(title: string) {
+  return !title.match(PATTERN)
+}

--- a/bots/bugbuster/src/linear-lint-issue.ts
+++ b/bots/bugbuster/src/linear-lint-issue.ts
@@ -48,7 +48,7 @@ export const lintIssue = async (client: utils.linear.LinearApi, issue: lin.Issue
     lints.push(`Issue ${issue.identifier} is missing a priority.`)
   }
 
-  if (!issue.estimate && status !== 'BLOCKED') {
+  if ((issue.estimate === undefined || issue.estimate === null) && status !== 'BLOCKED') {
     // blocked issues can be unestimated
     lints.push(`Issue ${issue.identifier} is missing an estimate.`)
   }

--- a/bots/bugbuster/src/linear-lint-issue.ts
+++ b/bots/bugbuster/src/linear-lint-issue.ts
@@ -49,7 +49,7 @@ export const lintIssue = async (client: utils.linear.LinearApi, issue: lin.Issue
     lints.push(`Issue ${issue.identifier} is missing a priority.`)
   }
 
-  if ((issue.estimate === undefined || issue.estimate === null) && status !== 'BLOCKED') {
+  if (issue.estimate === undefined && status !== 'BLOCKED') {
     // blocked issues can be unestimated
     lints.push(`Issue ${issue.identifier} is missing an estimate.`)
   }

--- a/bots/bugbuster/src/linear-lint-issue.ts
+++ b/bots/bugbuster/src/linear-lint-issue.ts
@@ -37,7 +37,8 @@ export const lintIssue = async (client: utils.linear.LinearApi, issue: lin.Issue
   }
   if (status === 'BLOCKED' && !hasBlockedLabel && !hasBlockedRelation) {
     lints.push(`Issue ${issue.identifier} is blocked but missing a "blocked" label or a blocking issue.`)
-  } else if (status === 'BACKLOG' && issue.assignee) {
+  }
+  if (status === 'BACKLOG' && issue.assignee) {
     lints.push(`Issue ${issue.identifier} has an assignee but is still in the backlog.`)
   }
 

--- a/bots/bugbuster/src/linear-lint-issue.ts
+++ b/bots/bugbuster/src/linear-lint-issue.ts
@@ -30,8 +30,13 @@ export const lintIssue = async (client: utils.linear.LinearApi, issue: lin.Issue
   })
 
   const hasBlockedRelation = await client.isBlockedByOtherIssues(issue)
-  if (status === 'BLOCKED' && !hasBlockedLabel && !hasBlockedRelation) {
-    lints.push(`Issue ${issue.identifier} is blocked but missing a "blocked" label or a blocking issue.`)
+  if (status === 'BLOCKED') {
+    if (!issue.assignee) {
+      lints.push(`Issue ${issue.identifier} is blocked but has no assignee.`)
+    }
+    if (!hasBlockedLabel && !hasBlockedRelation) {
+      lints.push(`Issue ${issue.identifier} is blocked but missing a "blocked" label or a blocking issue.`)
+    }
   }
 
   const hasArea = labels.some((label) => label.name.startsWith('area/'))

--- a/bots/bugbuster/src/linear-lint-issue.ts
+++ b/bots/bugbuster/src/linear-lint-issue.ts
@@ -30,13 +30,12 @@ export const lintIssue = async (client: utils.linear.LinearApi, issue: lin.Issue
   })
 
   const hasBlockedRelation = await client.isBlockedByOtherIssues(issue)
-  if (status === 'BLOCKED') {
-    if (!issue.assignee) {
-      lints.push(`Issue ${issue.identifier} is blocked but has no assignee.`)
-    }
-    if (!hasBlockedLabel && !hasBlockedRelation) {
-      lints.push(`Issue ${issue.identifier} is blocked but missing a "blocked" label or a blocking issue.`)
-    }
+
+  if (status === 'BLOCKED' && !issue.assignee) {
+    lints.push(`Issue ${issue.identifier} is blocked but has no assignee.`)
+  }
+  if (status === 'BLOCKED' && !hasBlockedLabel && !hasBlockedRelation) {
+    lints.push(`Issue ${issue.identifier} is blocked but missing a "blocked" label or a blocking issue.`)
   } else if (status === 'BACKLOG' && issue.assignee) {
     lints.push(`Issue ${issue.identifier} has an assignee but is still in the backlog.`)
   }

--- a/bots/bugbuster/src/linear-lint-issue.ts
+++ b/bots/bugbuster/src/linear-lint-issue.ts
@@ -37,6 +37,8 @@ export const lintIssue = async (client: utils.linear.LinearApi, issue: lin.Issue
     if (!hasBlockedLabel && !hasBlockedRelation) {
       lints.push(`Issue ${issue.identifier} is blocked but missing a "blocked" label or a blocking issue.`)
     }
+  } else if (status === 'BACKLOG' && issue.assignee) {
+    lints.push(`Issue ${issue.identifier} has an assignee but is still in the backlog.`)
   }
 
   const hasArea = labels.some((label) => label.name.startsWith('area/'))

--- a/bots/bugbuster/src/linear-lint-issue.ts
+++ b/bots/bugbuster/src/linear-lint-issue.ts
@@ -1,4 +1,5 @@
 import * as lin from '@linear/sdk'
+import { isIssueTitleFormatValid } from './issue-title-format-validator'
 import * as utils from './utils'
 
 export type IssueLint = {
@@ -69,7 +70,7 @@ export const lintIssue = async (client: utils.linear.LinearApi, issue: lin.Issue
     lints.push(`Issue ${issue.identifier} is missing both a project and a goal label.`)
   }
 
-  if (issue.title.match(/^\w{0,}\[.{1,}\]/)) {
+  if (!isIssueTitleFormatValid(issue.title)) {
     lints.push(
       `Issue ${issue.identifier} has unconventional commit syntax in the title. Issue title should not attempt to follow a formal syntax.`
     )

--- a/bots/bugbuster/src/linear-lint-issue.ts
+++ b/bots/bugbuster/src/linear-lint-issue.ts
@@ -70,8 +70,7 @@ export const lintIssue = async (client: utils.linear.LinearApi, issue: lin.Issue
     lints.push(`Issue ${issue.identifier} is missing both a project and a goal label.`)
   }
 
-  const hasFormalTitle = issue.title.includes('[') && issue.title.includes(']')
-  if (hasFormalTitle) {
+  if (issue.title.match(/^\w{0,}\[.{1,}\]/)) {
     lints.push(
       `Issue ${issue.identifier} has unconventional commit syntax in the title. Issue title should not attempt to follow a formal syntax.`
     )


### PR DESCRIPTION
Contributes to SQD-3388

Small additions to Bugbuster's lint:
- A blocked issue must have an assignee.
- An issue can have an estimate of 0 points.
- An issue in the backlog should not have an assignee.
- An issue's title must not start with `feat[abc] ...` or `[integrations->abc] ...`. Here's [the regex](https://regex101.com/r/h1BisS/1) I used.

I opened a PR just for these four small changes because the next change will involve a lot of refactoring, which would have made the whole thing more difficult to review.