### PR TITLE
feat(sdk): prevent conflicting aliases in plugins

### DIFF
--- a/packages/sdk/src/plugin/definition.ts
+++ b/packages/sdk/src/plugin/definition.ts
@@ -250,6 +250,18 @@ export class PluginDefinition<
     this.attributes = props.attributes
     this.__advanced = props.__advanced
 
+    const aliases = new Set<string>()
+
+    for (const alias of [...Object.keys(props.integrations ?? {}), ...Object.keys(props.interfaces ?? {})]) {
+      if (aliases.has(alias)) {
+        throw new Error(
+          `Duplicate interface or integration alias detected in plugin definition: '${alias}'. ` +
+            'Please use unique aliases for each interface and integration.'
+        )
+      }
+      aliases.add(alias)
+    }
+
     this.configuration = props.configuration
       ? {
           ...props.configuration,


### PR DESCRIPTION
Part 7 of the multi-plugin merge train.

Contributes to SQD-3132

---

1. https://github.com/botpress/botpress/pull/14447
2. https://github.com/botpress/botpress/pull/14452
3. https://github.com/botpress/botpress/pull/14453
4. https://github.com/botpress/botpress/pull/14454
5. https://github.com/botpress/botpress/pull/14459
6. https://github.com/botpress/botpress/pull/14460
7. https://github.com/botpress/botpress/pull/14461 **<= this PR**
8. TODO: rename client to `__client` in plugins and add a tsdoc comment to discourage usage