### PR TITLE
feat(bots/bugbuster): Lint now runs on newly created issues

### DIFF
--- a/bots/bugbuster/src/handlers/index.ts
+++ b/bots/bugbuster/src/handlers/index.ts
@@ -1,3 +1,4 @@
 export * from './github-issue-opened'
 export * from './linear-issue-updated'
+export * from './linear-issue-created'
 export * from './message-created'

--- a/bots/bugbuster/src/handlers/issue-processor.ts
+++ b/bots/bugbuster/src/handlers/issue-processor.ts
@@ -1,0 +1,53 @@
+import { BotLogger } from '@botpress/sdk'
+import { Issue } from '@linear/sdk'
+import { LinearApi } from 'src/utils/linear-utils'
+import * as linlint from '../linear-lint-issue'
+
+/**
+ * @returns The corresponding issue, or `undefined` if the issue is not found or not valid.
+ */
+export async function getIssue(
+  issueNumber: number,
+  teamKey: string | undefined,
+  logger: BotLogger,
+  eventName: string,
+  linear: LinearApi
+): Promise<Issue | undefined> {
+  if (!issueNumber || !teamKey) {
+    logger.error('Missing issueNumber or teamKey in event payload')
+    return
+  }
+
+  logger.info(`Linear issue ${eventName} event received`, `${teamKey}-${issueNumber}`)
+
+  if (!linear.isTeam(teamKey) || teamKey !== 'SQD') {
+    logger.error(`Ignoring issue of team "${teamKey}"`)
+    return
+  }
+
+  const issue = await linear.findIssue({ teamKey, issueNumber })
+  if (!issue) {
+    logger.error(`Issue with number ${issueNumber} not found in team ${teamKey}`)
+    return
+  }
+  return issue
+}
+
+export async function runLint(linear: LinearApi, issue: Issue, logger: BotLogger) {
+  const errors = await linlint.lintIssue(linear, issue)
+  if (errors.length === 0) {
+    logger.info(`Issue ${issue.identifier} passed all lint checks.`)
+    return
+  }
+
+  logger.warn(`Issue ${issue.identifier} has ${errors.length} lint errors:`)
+
+  await linear.client.createComment({
+    issueId: issue.id,
+    body: [
+      `BugBuster Bot found the following problems with ${issue.identifier}:`,
+      '',
+      ...errors.map((error: any) => `- ${error.message}`),
+    ].join('\n'),
+  })
+}

--- a/bots/bugbuster/src/handlers/issue-processor.ts
+++ b/bots/bugbuster/src/handlers/issue-processor.ts
@@ -6,7 +6,7 @@ import * as linlint from '../linear-lint-issue'
 /**
  * @returns The corresponding issue, or `undefined` if the issue is not found or not valid.
  */
-export async function getIssue(
+export async function findIssue(
   issueNumber: number,
   teamKey: string | undefined,
   logger: BotLogger,

--- a/bots/bugbuster/src/handlers/linear-issue-created.ts
+++ b/bots/bugbuster/src/handlers/linear-issue-created.ts
@@ -1,11 +1,11 @@
 import * as utils from '../utils'
-import { getIssue, runLint } from './issue-processor'
+import { findIssue, runLint } from './issue-processor'
 import * as bp from '.botpress'
 
 export const handleLinearIssueCreated: bp.EventHandlers['linear:issueCreated'] = async (props) => {
   const { number: issueNumber, teamKey } = props.event.payload
   const linear = await utils.linear.LinearApi.create()
-  const issue = await getIssue(issueNumber, teamKey, props.logger, 'created', linear)
+  const issue = await findIssue(issueNumber, teamKey, props.logger, 'created', linear)
 
   if (!issue) {
     return

--- a/bots/bugbuster/src/handlers/linear-issue-created.ts
+++ b/bots/bugbuster/src/handlers/linear-issue-created.ts
@@ -1,0 +1,15 @@
+import * as utils from '../utils'
+import { getIssue, runLint } from './issue-processor'
+import * as bp from '.botpress'
+
+export const handleLinearIssueCreated: bp.EventHandlers['linear:issueCreated'] = async (props) => {
+  const { number: issueNumber, teamKey } = props.event.payload
+  const linear = await utils.linear.LinearApi.create()
+  const issue = await getIssue(issueNumber, teamKey, props.logger, 'created', linear)
+
+  if (!issue) {
+    return
+  }
+
+  await runLint(linear, issue, props.logger)
+}

--- a/bots/bugbuster/src/handlers/linear-issue-updated.ts
+++ b/bots/bugbuster/src/handlers/linear-issue-updated.ts
@@ -1,26 +1,13 @@
-import * as linlint from '../linear-lint-issue'
 import * as utils from '../utils'
+import { getIssue, runLint } from './issue-processor'
 import * as bp from '.botpress'
 
 export const handleLinearIssueUpdated: bp.EventHandlers['linear:issueUpdated'] = async (props) => {
   const { number: issueNumber, teamKey } = props.event.payload
-  if (!issueNumber || !teamKey) {
-    props.logger.error('Missing issueNumber or teamKey in event payload')
-    return
-  }
-
-  props.logger.info('Linear issue updated event received', `${teamKey}-${issueNumber}`)
-
   const linear = await utils.linear.LinearApi.create()
+  const issue = await getIssue(issueNumber, teamKey, props.logger, 'updated', linear)
 
-  if (!linear.isTeam(teamKey) || teamKey !== 'SQD') {
-    props.logger.error(`Ignoring issue of team "${teamKey}"`)
-    return
-  }
-
-  const issue = await linear.findIssue({ teamKey, issueNumber })
   if (!issue) {
-    props.logger.error(`Issue with number ${issueNumber} not found in team ${teamKey}`)
     return
   }
 
@@ -32,22 +19,6 @@ export const handleLinearIssueUpdated: bp.EventHandlers['linear:issueUpdated'] =
     return
   }
 
-  const errors = await linlint.lintIssue(linear, issue)
-  if (errors.length === 0) {
-    props.logger.info(`Issue ${issue.identifier} passed all lint checks.`)
-    return
-  }
-
-  props.logger.warn(`Issue ${issue.identifier} has ${errors.length} lint errors:`)
-
-  await linear.client.createComment({
-    issueId: issue.id,
-    body: [
-      `BugBuster Bot found the following problems with ${issue.identifier}:`,
-      '',
-      ...errors.map((error) => `- ${error.message}`),
-    ].join('\n'),
-  })
-
+  await runLint(linear, issue, props.logger)
   await botpress.setRecentlyLinted([...recentlyLinted, { id: issue.id, lintedAt: new Date().toISOString() }])
 }

--- a/bots/bugbuster/src/handlers/linear-issue-updated.ts
+++ b/bots/bugbuster/src/handlers/linear-issue-updated.ts
@@ -1,11 +1,11 @@
 import * as utils from '../utils'
-import { getIssue, runLint } from './issue-processor'
+import { findIssue, runLint } from './issue-processor'
 import * as bp from '.botpress'
 
 export const handleLinearIssueUpdated: bp.EventHandlers['linear:issueUpdated'] = async (props) => {
   const { number: issueNumber, teamKey } = props.event.payload
   const linear = await utils.linear.LinearApi.create()
-  const issue = await getIssue(issueNumber, teamKey, props.logger, 'updated', linear)
+  const issue = await findIssue(issueNumber, teamKey, props.logger, 'updated', linear)
 
   if (!issue) {
     return

--- a/bots/bugbuster/src/index.ts
+++ b/bots/bugbuster/src/index.ts
@@ -5,6 +5,7 @@ export const bot = new bp.Bot({ actions: {} })
 
 bot.on.event('github:issueOpened', handlers.handleGithubIssueOpened)
 bot.on.event('linear:issueUpdated', handlers.handleLinearIssueUpdated)
+bot.on.event('linear:issueCreated', handlers.handleLinearIssueCreated)
 bot.on.message('*', handlers.handleMessageCreated)
 
 export default bot


### PR DESCRIPTION
Contributes to SQD-3388

Lint now runs on created issues as well. I extracted shared logic from `handleLinearIssueUpdated`.

The only difference between the creation and update events is that we don't check whether the issue was recently linted on creation, and we don't add it to the recently linted issue list.