### PR TITLE
feat(integrations/teams): refactor integration - part 2

### DIFF
--- a/integrations/teams/definitions/channels.ts
+++ b/integrations/teams/definitions/channels.ts
@@ -1,0 +1,25 @@
+import { IntegrationDefinitionProps, messages } from '@botpress/sdk'
+
+export const channels = {
+  channel: {
+    title: 'Channel',
+    description: 'Teams conversation channel',
+    messages: { ...messages.defaults, markdown: messages.markdown },
+    message: {
+      tags: {
+        id: {
+          title: 'ID',
+          description: 'Teams activity ID',
+        },
+      },
+    },
+    conversation: {
+      tags: {
+        id: {
+          title: 'ID',
+          description: 'Teams conversation ID',
+        },
+      },
+    },
+  },
+} satisfies IntegrationDefinitionProps['channels']

--- a/integrations/teams/definitions/index.ts
+++ b/integrations/teams/definitions/index.ts
@@ -1,41 +1,4 @@
-import { IntegrationDefinitionProps, messages } from '@botpress/sdk'
-
 export { states } from './states'
 export { actions } from './actions'
-
-export const channels = {
-  channel: {
-    title: 'Channel',
-    description: 'Teams conversation channel',
-    messages: { ...messages.defaults, markdown: messages.markdown },
-    message: {
-      tags: {
-        id: {
-          title: 'ID',
-          description: 'Teams activity ID',
-        },
-      },
-    },
-    conversation: {
-      tags: {
-        id: {
-          title: 'ID',
-          description: 'Teams conversation ID',
-        },
-      },
-    },
-  },
-} satisfies IntegrationDefinitionProps['channels']
-
-export const user = {
-  tags: {
-    id: {
-      title: 'ID',
-      description: 'Teams user ID',
-    },
-    email: {
-      title: 'Email',
-      description: 'Email address',
-    },
-  },
-} satisfies IntegrationDefinitionProps['user']
+export { channels } from './channels'
+export { user } from './user'

--- a/integrations/teams/definitions/index.ts
+++ b/integrations/teams/definitions/index.ts
@@ -1,15 +1,7 @@
-import { z, IntegrationDefinitionProps, messages } from '@botpress/sdk'
+import { IntegrationDefinitionProps, messages } from '@botpress/sdk'
 
 export { states } from './states'
 export { actions } from './actions'
-
-export const configuration = {
-  schema: z.object({
-    appId: z.string().min(1).title('App ID').describe('Teams application ID'),
-    appPassword: z.string().min(1).title('App Password').describe('Teams application password'),
-    tenantId: z.string().optional().title('Tenant ID').describe('Teams tenant ID'),
-  }),
-} satisfies IntegrationDefinitionProps['configuration']
 
 export const channels = {
   channel: {

--- a/integrations/teams/definitions/states.ts
+++ b/integrations/teams/definitions/states.ts
@@ -5,16 +5,16 @@ import type { ConversationReference } from 'botbuilder'
 type Is<A, B> = A extends B ? (B extends A ? true : false) : false
 type Expect<_T extends true> = void
 
-const channelAccount = z.object({
+export const channelAccountSchema = z.object({
   id: z.string(),
   name: z.string(),
 })
 
-const convReference = z.object({
+const _convReferenceSchema = z.object({
   activityId: z.string().optional().title('Activity ID').describe('The activity ID'),
-  user: channelAccount.optional().title('User').describe('User account of the user conversing with the bot'),
+  user: channelAccountSchema.optional().title('User').describe('User account of the user conversing with the bot'),
   locale: z.string().optional().title('Locale').describe('The locale of the conversation'),
-  bot: channelAccount.title('Bot').describe('Bot account of the bot'),
+  bot: channelAccountSchema.title('Bot').describe('Bot account of the bot'),
   conversation: z.any().title('Conversation').describe('Conversation reference'), // botbuilder typings are deceiving
   channelId: z.string().title('Channel ID').describe('The channel ID of the conversation'),
   serviceUrl: z
@@ -22,18 +22,15 @@ const convReference = z.object({
     .title('Service URL')
     .describe('Service endpoint where the operations concerning the conversation are performed'),
 })
-
-const _convStateSchema = convReference.partial()
-type ConvStateSchema = z.infer<typeof _convStateSchema>
+const _convReferenceStateSchema = _convReferenceSchema.partial()
+type ConvReferenceState = z.infer<typeof _convReferenceStateSchema>
 
 // this builds only if the state schema is the same type as ConversationReference from 'botbuilder'
-type A = ConvStateSchema
-type B = Partial<ConversationReference>
-type _Test = Expect<Is<A, B>>
+type _Test = Expect<Is<ConvReferenceState, Partial<ConversationReference>>>
 
 export const states = {
   conversation: {
     type: 'conversation',
-    schema: convReference.partial(),
+    schema: _convReferenceStateSchema,
   },
 } satisfies IntegrationDefinitionProps['states']

--- a/integrations/teams/definitions/user.ts
+++ b/integrations/teams/definitions/user.ts
@@ -1,0 +1,14 @@
+import { IntegrationDefinitionProps } from '@botpress/sdk'
+
+export const user = {
+  tags: {
+    id: {
+      title: 'ID',
+      description: 'Teams user ID',
+    },
+    email: {
+      title: 'Email',
+      description: 'Email address',
+    },
+  },
+} satisfies IntegrationDefinitionProps['user']

--- a/integrations/teams/integration.definition.ts
+++ b/integrations/teams/integration.definition.ts
@@ -1,7 +1,7 @@
-import { IntegrationDefinition } from '@botpress/sdk'
+import { IntegrationDefinition, z } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import typingIndicator from 'bp_modules/typing-indicator'
-import { actions, configuration, channels, user, states } from 'definitions'
+import { actions, channels, user, states } from 'definitions'
 
 export default new IntegrationDefinition({
   name: 'teams',
@@ -10,7 +10,13 @@ export default new IntegrationDefinition({
   description: 'Interact with users, deliver notifications, and perform actions within Microsoft Teams.',
   icon: 'icon.svg',
   readme: 'hub.md',
-  configuration,
+  configuration: {
+    schema: z.object({
+      appId: z.string().min(1).title('App ID').describe('Teams application ID'),
+      appPassword: z.string().min(1).title('App Password').describe('Teams application password'),
+      tenantId: z.string().optional().title('Tenant ID').describe('Teams tenant ID'),
+    }),
+  },
   channels,
   user,
   actions,

--- a/integrations/teams/src/actions/start-dm.ts
+++ b/integrations/teams/src/actions/start-dm.ts
@@ -1,6 +1,6 @@
 import { RuntimeError } from '@botpress/client'
 import { ConversationParameters, ConversationReference, TeamsChannelAccount, TeamsInfo, TurnContext } from 'botbuilder'
-import { getUserByEmail } from '../microsoft-api'
+import { MicrosoftClient } from '../microsoft-api'
 import { getAdapter, getError } from '../utils'
 import * as bp from '.botpress'
 
@@ -43,7 +43,7 @@ export const startDmConversation: bp.IntegrationProps['actions']['startDmConvers
   // ── If we only have an email, call TeamsInfo.getMember to fetch the account ──
   if (!teamsUserId?.length && teamsUserEmail?.length) {
     try {
-      const teamsUser = await getUserByEmail(ctx, teamsUserEmail)
+      const teamsUser = await MicrosoftClient.create(ctx).getUserByEmail(teamsUserEmail)
       teamsUserId = teamsUser?.id
     } catch (thrown) {
       const err = getError(thrown)

--- a/integrations/teams/src/channels/inbound.ts
+++ b/integrations/teams/src/channels/inbound.ts
@@ -1,0 +1,60 @@
+import { Activity, ConversationReference, TurnContext, TeamsInfo, TeamsChannelAccount } from 'botbuilder'
+import { getAdapter, sleep } from '../utils'
+import * as bp from '.botpress'
+
+export const processInboundChannelMessage = async ({ client, ctx, logger }: bp.HandlerProps, activity: Activity) => {
+  const convRef: Partial<ConversationReference> = TurnContext.getConversationReference(activity)
+
+  const senderChannelAccount = activity.from!
+  const adapter = getAdapter(ctx.configuration)
+
+  const getUserPromise = new Promise<TeamsChannelAccount | undefined>((resolve, reject) => {
+    void adapter
+      .continueConversation(convRef, async (tc) => {
+        const user = await TeamsInfo.getMember(tc, senderChannelAccount.id)
+        resolve(user)
+      })
+      .then(() => resolve(undefined))
+      .catch(reject)
+  })
+
+  const sender = await Promise.race([getUserPromise, sleep(2000)])
+  if (sender?.email) {
+    logger.forBot().info(`Received request from user: ${sender.email}`)
+  }
+
+  switch (activity.type) {
+    case 'message':
+      const { conversation } = await client.getOrCreateConversation({
+        channel: 'channel',
+        tags: {
+          id: activity.conversation.id,
+        },
+      })
+
+      await client.setState({
+        id: conversation.id,
+        name: 'conversation',
+        type: 'conversation',
+        payload: convRef,
+      })
+
+      const { user } = await client.getOrCreateUser({
+        tags: {
+          id: activity.from.id,
+          email: sender?.email,
+        },
+      })
+
+      await client.getOrCreateMessage({
+        tags: { id: activity.id },
+        type: 'text',
+        userId: user.id,
+        conversationId: conversation.id,
+        payload: { text: activity.text },
+      })
+      break
+    default:
+      return
+  }
+}

--- a/integrations/teams/src/channels/outbound.ts
+++ b/integrations/teams/src/channels/outbound.ts
@@ -18,7 +18,10 @@ type Card = bp.channels.channel.card.Card
 type Action = Card['actions'][number]
 type ActionType = Action['action']
 
-const renderTeams = async ({ ctx, ack, conversation, client }: bp.AnyMessageProps, activity: Partial<Activity>) => {
+const renderTeams = async (
+  { ctx, ack, conversation, client, logger }: bp.AnyMessageProps,
+  activity: Partial<Activity>
+) => {
   const { configuration } = ctx
   const adapter = getAdapter(configuration)
 
@@ -32,7 +35,7 @@ const renderTeams = async ({ ctx, ack, conversation, client }: bp.AnyMessageProp
 
   await adapter.continueConversation(convRef, async (turnContext) => {
     if (!turnContext.activity.id) {
-      console.warn('No activity id found')
+      logger.forBot().warn('No activity id found')
       return
     }
 

--- a/integrations/teams/src/channels/outbound.ts
+++ b/integrations/teams/src/channels/outbound.ts
@@ -8,7 +8,7 @@ import {
   Attachment,
   MessageFactory,
 } from 'botbuilder'
-import { getAdapter } from './utils'
+import { getAdapter } from '../utils'
 import * as bp from '.botpress'
 
 type Choice = bp.channels.channel.choice.Choice

--- a/integrations/teams/src/index.ts
+++ b/integrations/teams/src/index.ts
@@ -1,6 +1,6 @@
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import actions from './actions'
-import { channels } from './channels'
+import { channels } from './channels/outbound'
 import { register, unregister } from './setup'
 import { handler } from './webhooks/handler'
 import * as bp from '.botpress'

--- a/integrations/teams/src/microsoft-api/index.ts
+++ b/integrations/teams/src/microsoft-api/index.ts
@@ -2,29 +2,36 @@ import { ClientSecretCredential } from '@azure/identity'
 import { Client } from '@microsoft/microsoft-graph-client'
 import * as bp from '.botpress'
 
-function getGraphClient({ ctx }: { ctx: bp.Context }) {
-  const { tenantId, appId, appPassword } = ctx.configuration
+export class MicrosoftClient {
+  private _graphClient: Client
 
-  const credential = new ClientSecretCredential(tenantId as string, appId, appPassword)
+  private constructor(ctx: bp.Context) {
+    const { tenantId, appId, appPassword } = ctx.configuration
 
-  return Client.initWithMiddleware({
-    authProvider: {
-      getAccessToken: async () => {
-        const token = await credential.getToken('https://graph.microsoft.com/.default')
-        return token?.token!
+    const credential = new ClientSecretCredential(tenantId as string, appId, appPassword)
+
+    this._graphClient = Client.initWithMiddleware({
+      authProvider: {
+        getAccessToken: async () => {
+          const token = await credential.getToken('https://graph.microsoft.com/.default')
+          return token?.token!
+        },
       },
-    },
-  })
-}
+    })
+  }
 
-export async function getUserByEmail(ctx: bp.Context, email: string) {
-  try {
-    const graphClient = getGraphClient({ ctx })
-    return await graphClient.api(`/users/${email}`).get()
-  } catch (err: any) {
-    if (err.statusCode === 404) {
-      throw new Error(`No user found with email: ${email}`)
+  public async getUserByEmail(email: string) {
+    try {
+      return await this._graphClient.api(`/users/${email}`).get()
+    } catch (err: any) {
+      if (err.statusCode === 404) {
+        throw new Error(`No user found with email: ${email}`)
+      }
+      throw err
     }
-    throw err
+  }
+
+  public static create(ctx: bp.Context) {
+    return new MicrosoftClient(ctx)
   }
 }

--- a/integrations/teams/src/schemas.ts
+++ b/integrations/teams/src/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from '@botpress/sdk'
-import { channelAccountSchema } from '../definitions/states'
+import { channelAccountSchema } from 'definitions/states'
 
 export const teamsActivitySchema = z
   .object({

--- a/integrations/teams/src/schemas.ts
+++ b/integrations/teams/src/schemas.ts
@@ -1,0 +1,16 @@
+import { z } from '@botpress/sdk'
+import { channelAccountSchema } from '../definitions/states'
+
+export const teamsActivitySchema = z
+  .object({
+    id: z.string().trim().min(1),
+    type: z.string(),
+    from: channelAccountSchema.passthrough(),
+    conversation: z
+      .object({
+        id: z.string().trim().min(1),
+      })
+      .passthrough(),
+    text: z.string(),
+  })
+  .passthrough()

--- a/integrations/teams/src/schemas.ts
+++ b/integrations/teams/src/schemas.ts
@@ -5,12 +5,12 @@ export const teamsActivitySchema = z
   .object({
     id: z.string().trim().min(1),
     type: z.string(),
-    from: channelAccountSchema.passthrough(),
+    from: channelAccountSchema.passthrough().partial().optional(),
     conversation: z
       .object({
         id: z.string().trim().min(1),
       })
       .passthrough(),
-    text: z.string(),
+    text: z.string().optional(),
   })
   .passthrough()

--- a/integrations/teams/src/webhooks/handler.ts
+++ b/integrations/teams/src/webhooks/handler.ts
@@ -1,9 +1,10 @@
-import { Activity, ConversationReference, TurnContext, TeamsInfo, TeamsChannelAccount } from 'botbuilder'
-import { getAdapter, sleep } from '../utils'
+import { Activity } from 'botbuilder'
+import { processInboundChannelMessage } from '../channels/inbound'
 import { authorizeRequest } from './signature'
 import * as bp from '.botpress'
 
-export const handler: bp.IntegrationProps['handler'] = async ({ req, client, ctx, logger }) => {
+export const handler: bp.IntegrationProps['handler'] = async (props) => {
+  const { req } = props
   await authorizeRequest(req)
 
   if (!req.body) {
@@ -18,58 +19,5 @@ export const handler: bp.IntegrationProps['handler'] = async ({ req, client, ctx
     return
   }
 
-  const convRef: Partial<ConversationReference> = TurnContext.getConversationReference(activity)
-
-  const senderChannelAccount = activity.from!
-  const adapter = getAdapter(ctx.configuration)
-
-  const getUserPromise = new Promise<TeamsChannelAccount | undefined>((resolve, reject) => {
-    void adapter
-      .continueConversation(convRef, async (tc) => {
-        const user = await TeamsInfo.getMember(tc, senderChannelAccount.id)
-        resolve(user)
-      })
-      .then(() => resolve(undefined))
-      .catch(reject)
-  })
-
-  const sender = await Promise.race([getUserPromise, sleep(2000)])
-  if (sender?.email) {
-    logger.forBot().info(`Received request from user: ${sender.email}`)
-  }
-
-  switch (activity.type) {
-    case 'message':
-      const { conversation } = await client.getOrCreateConversation({
-        channel: 'channel',
-        tags: {
-          id: activity.conversation.id,
-        },
-      })
-
-      await client.setState({
-        id: conversation.id,
-        name: 'conversation',
-        type: 'conversation',
-        payload: convRef,
-      })
-
-      const { user } = await client.getOrCreateUser({
-        tags: {
-          id: activity.from.id,
-          email: sender?.email,
-        },
-      })
-
-      await client.getOrCreateMessage({
-        tags: { id: activity.id },
-        type: 'text',
-        userId: user.id,
-        conversationId: conversation.id,
-        payload: { text: activity.text },
-      })
-      break
-    default:
-      return
-  }
+  await processInboundChannelMessage(props, activity)
 }

--- a/integrations/teams/src/webhooks/handler.ts
+++ b/integrations/teams/src/webhooks/handler.ts
@@ -1,5 +1,6 @@
 import { Activity } from 'botbuilder'
 import { processInboundChannelMessage } from '../channels/inbound'
+import { teamsActivitySchema } from '../schemas'
 import { authorizeRequest } from './signature'
 import * as bp from '.botpress'
 
@@ -12,12 +13,14 @@ export const handler: bp.IntegrationProps['handler'] = async (props) => {
     return
   }
 
-  const activity: Activity = JSON.parse(req.body)
-  console.info(`Handler received event of type ${activity.type}`)
-
-  if (!activity.id) {
+  const parsedBody: Object = JSON.parse(req.body)
+  const result = teamsActivitySchema.safeParse(parsedBody)
+  if (!result.success) {
+    console.error('Invalid activity payload received:', result.error.format())
     return
   }
 
+  const activity = result.data as unknown as Activity
+  console.info(`Handler received event of type ${activity.type}`)
   await processInboundChannelMessage(props, activity)
 }

--- a/integrations/teams/src/webhooks/handler.ts
+++ b/integrations/teams/src/webhooks/handler.ts
@@ -9,18 +9,18 @@ export const handler: bp.IntegrationProps['handler'] = async (props) => {
   await authorizeRequest(req)
 
   if (!req.body) {
-    console.warn('Handler received an empty body')
+    props.logger.forBot().warn('Handler received an empty body')
     return
   }
 
   const parsedBody: Object = JSON.parse(req.body)
   const result = teamsActivitySchema.safeParse(parsedBody)
   if (!result.success) {
-    console.error('Invalid activity payload received:', result.error.format())
+    props.logger.forBot().error('Invalid activity payload received:', result.error.format())
     return
   }
 
   const activity = result.data as unknown as Activity
-  console.info(`Handler received event of type ${activity.type}`)
+  props.logger.forBot().info(`Handler received event of type ${activity.type}`)
   await processInboundChannelMessage(props, activity)
 }


### PR DESCRIPTION
This PR restructures the integration a bit more by moving logic around (e.g. configuration definition, channels logic), eliminating some tech debt (replace "console" with "logger"), renaming some variables to align with other integrations (e.g. state definitions), and refactor api calls into the "Microsoft Client"