### PR TITLE
feat(bots/bugbuster): Added chat commands to manage BugBuster's watched teams

### DIFF
--- a/bots/bugbuster/bot.definition.ts
+++ b/bots/bugbuster/bot.definition.ts
@@ -20,7 +20,7 @@ export default new sdk.BotDefinition({
           .describe('List of recently linted issues'),
       }),
     },
-    teamsToWatch: {
+    watchedTeams: {
       type: 'bot',
       schema: sdk.z.object({
         teamKeys: sdk.z

--- a/bots/bugbuster/bot.definition.ts
+++ b/bots/bugbuster/bot.definition.ts
@@ -23,7 +23,10 @@ export default new sdk.BotDefinition({
     teamsToWatch: {
       type: 'bot',
       schema: sdk.z.object({
-        teamKeys: sdk.z.array(sdk.z.string()),
+        teamKeys: sdk.z
+          .array(sdk.z.string())
+          .title('Team Keys')
+          .describe('The keys of the teams for which BugBuster should lint issues'),
       }),
     },
   },

--- a/bots/bugbuster/bot.definition.ts
+++ b/bots/bugbuster/bot.definition.ts
@@ -20,6 +20,12 @@ export default new sdk.BotDefinition({
           .describe('List of recently linted issues'),
       }),
     },
+    teamsToWatch: {
+      type: 'bot',
+      schema: sdk.z.object({
+        teamKeys: sdk.z.array(sdk.z.string()),
+      }),
+    },
   },
   __advanced: {
     useLegacyZuiTransformer: true,

--- a/bots/bugbuster/src/handlers/issue-processor.ts
+++ b/bots/bugbuster/src/handlers/issue-processor.ts
@@ -20,7 +20,7 @@ export async function findIssue(
 
   logger.info(`Linear issue ${eventName} event received`, `${teamKey}-${issueNumber}`)
 
-  if (!linear.isTeam(teamKey) || teamKey !== 'SQD') {
+  if (!linear.isTeam(teamKey) || teamKey) {
     logger.error(`Ignoring issue of team "${teamKey}"`)
     return
   }

--- a/bots/bugbuster/src/handlers/issue-processor.ts
+++ b/bots/bugbuster/src/handlers/issue-processor.ts
@@ -20,7 +20,7 @@ export async function findIssue(
 
   logger.info(`Linear issue ${eventName} event received`, `${teamKey}-${issueNumber}`)
 
-  if (!linear.isTeam(teamKey) || teamKey) {
+  if (!linear.isTeam(teamKey)) {
     logger.error(`Ignoring issue of team "${teamKey}"`)
     return
   }

--- a/bots/bugbuster/src/handlers/issue-processor.ts
+++ b/bots/bugbuster/src/handlers/issue-processor.ts
@@ -2,6 +2,8 @@ import { BotLogger } from '@botpress/sdk'
 import { Issue } from '@linear/sdk'
 import { LinearApi } from 'src/utils/linear-utils'
 import * as linlint from '../linear-lint-issue'
+import { listWatchedTeams } from './teams-manager'
+import { Client } from '.botpress'
 
 /**
  * @returns The corresponding issue, or `undefined` if the issue is not found or not valid.
@@ -11,7 +13,9 @@ export async function findIssue(
   teamKey: string | undefined,
   logger: BotLogger,
   eventName: string,
-  linear: LinearApi
+  linear: LinearApi,
+  client: Client,
+  botId: string
 ): Promise<Issue | undefined> {
   if (!issueNumber || !teamKey) {
     logger.error('Missing issueNumber or teamKey in event payload')
@@ -20,7 +24,8 @@ export async function findIssue(
 
   logger.info(`Linear issue ${eventName} event received`, `${teamKey}-${issueNumber}`)
 
-  if (!linear.isTeam(teamKey)) {
+  const teams = await listWatchedTeams(client, botId)
+  if (!linear.isTeam(teamKey) || !teams.result?.includes(teamKey)) {
     logger.error(`Ignoring issue of team "${teamKey}"`)
     return
   }

--- a/bots/bugbuster/src/handlers/issue-processor.ts
+++ b/bots/bugbuster/src/handlers/issue-processor.ts
@@ -2,7 +2,7 @@ import { BotLogger } from '@botpress/sdk'
 import { Issue } from '@linear/sdk'
 import { LinearApi } from 'src/utils/linear-utils'
 import * as linlint from '../linear-lint-issue'
-import { listWatchedTeams } from './teams-manager'
+import { listTeams } from './teams-manager'
 import { Client } from '.botpress'
 
 /**
@@ -24,7 +24,7 @@ export async function findIssue(
 
   logger.info(`Linear issue ${eventName} event received`, `${teamKey}-${issueNumber}`)
 
-  const teams = await listWatchedTeams(client, botId)
+  const teams = await listTeams(client, botId)
   if (!linear.isTeam(teamKey) || !teams.result?.includes(teamKey)) {
     logger.error(`Ignoring issue of team "${teamKey}"`)
     return

--- a/bots/bugbuster/src/handlers/linear-issue-created.ts
+++ b/bots/bugbuster/src/handlers/linear-issue-created.ts
@@ -13,7 +13,7 @@ export const handleLinearIssueCreated: bp.EventHandlers['linear:issueCreated'] =
     return
   }
 
-  const issue = await findIssue(issueNumber, teamKey, props.logger, 'created', linear)
+  const issue = await findIssue(issueNumber, teamKey, props.logger, 'created', linear, props.client, props.ctx.botId)
   if (!issue) {
     return
   }

--- a/bots/bugbuster/src/handlers/linear-issue-created.ts
+++ b/bots/bugbuster/src/handlers/linear-issue-created.ts
@@ -1,19 +1,12 @@
 import * as utils from '../utils'
 import { findIssue, runLint } from './issue-processor'
-import { listWatchedTeams } from './teams-manager'
 import * as bp from '.botpress'
 
 export const handleLinearIssueCreated: bp.EventHandlers['linear:issueCreated'] = async (props) => {
   const { number: issueNumber, teamKey } = props.event.payload
   const linear = await utils.linear.LinearApi.create()
-
-  const teams = await listWatchedTeams(props.client, props.ctx.botId)
-  if (teamKey === undefined || !teams.result?.includes(teamKey)) {
-    props.logger.error(`Ignoring issue of team "${teamKey}"`)
-    return
-  }
-
   const issue = await findIssue(issueNumber, teamKey, props.logger, 'created', linear, props.client, props.ctx.botId)
+
   if (!issue) {
     return
   }

--- a/bots/bugbuster/src/handlers/linear-issue-created.ts
+++ b/bots/bugbuster/src/handlers/linear-issue-created.ts
@@ -1,12 +1,19 @@
 import * as utils from '../utils'
 import { findIssue, runLint } from './issue-processor'
+import { listWatchedTeams } from './teams-manager'
 import * as bp from '.botpress'
 
 export const handleLinearIssueCreated: bp.EventHandlers['linear:issueCreated'] = async (props) => {
   const { number: issueNumber, teamKey } = props.event.payload
   const linear = await utils.linear.LinearApi.create()
-  const issue = await findIssue(issueNumber, teamKey, props.logger, 'created', linear)
 
+  const teams = await listWatchedTeams(props.client, props.ctx.botId)
+  if (teamKey === undefined || !teams.result?.includes(teamKey)) {
+    props.logger.error(`Ignoring issue of team "${teamKey}"`)
+    return
+  }
+
+  const issue = await findIssue(issueNumber, teamKey, props.logger, 'created', linear)
   if (!issue) {
     return
   }

--- a/bots/bugbuster/src/handlers/linear-issue-updated.ts
+++ b/bots/bugbuster/src/handlers/linear-issue-updated.ts
@@ -1,19 +1,12 @@
 import * as utils from '../utils'
 import { findIssue, runLint } from './issue-processor'
-import { listWatchedTeams } from './teams-manager'
 import * as bp from '.botpress'
 
 export const handleLinearIssueUpdated: bp.EventHandlers['linear:issueUpdated'] = async (props) => {
   const { number: issueNumber, teamKey } = props.event.payload
   const linear = await utils.linear.LinearApi.create()
-
-  const teams = await listWatchedTeams(props.client, props.ctx.botId)
-  if (teamKey === undefined || !teams.result?.includes(teamKey)) {
-    props.logger.error(`Ignoring issue of team "${teamKey}"`)
-    return
-  }
-
   const issue = await findIssue(issueNumber, teamKey, props.logger, 'updated', linear, props.client, props.ctx.botId)
+
   if (!issue) {
     return
   }

--- a/bots/bugbuster/src/handlers/linear-issue-updated.ts
+++ b/bots/bugbuster/src/handlers/linear-issue-updated.ts
@@ -13,7 +13,7 @@ export const handleLinearIssueUpdated: bp.EventHandlers['linear:issueUpdated'] =
     return
   }
 
-  const issue = await findIssue(issueNumber, teamKey, props.logger, 'updated', linear)
+  const issue = await findIssue(issueNumber, teamKey, props.logger, 'updated', linear, props.client, props.ctx.botId)
   if (!issue) {
     return
   }

--- a/bots/bugbuster/src/handlers/linear-issue-updated.ts
+++ b/bots/bugbuster/src/handlers/linear-issue-updated.ts
@@ -5,6 +5,18 @@ import * as bp from '.botpress'
 export const handleLinearIssueUpdated: bp.EventHandlers['linear:issueUpdated'] = async (props) => {
   const { number: issueNumber, teamKey } = props.event.payload
   const linear = await utils.linear.LinearApi.create()
+
+  const teams = await props.client.getOrSetState({
+    id: props.ctx.botId,
+    name: 'teamsToWatch',
+    type: 'bot',
+    payload: {
+      teamKeys: [],
+    },
+  })
+  if (teamKey === undefined || !teams.state.payload.teamKeys.includes(teamKey)) {
+    props.logger.error(`Ignoring issue of team "${teamKey}"`)
+  }
   const issue = await findIssue(issueNumber, teamKey, props.logger, 'updated', linear)
 
   if (!issue) {

--- a/bots/bugbuster/src/handlers/message-created.ts
+++ b/bots/bugbuster/src/handlers/message-created.ts
@@ -57,7 +57,7 @@ export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
         return
       }
       linear = await utils.linear.LinearApi.create()
-      result = await listAllTeams(client, ctx.botId, linear)
+      result = await listAllTeams(linear)
       await botpress.respondText(conversation.id, result.message)
       break
     case '/list-watched-teams':

--- a/bots/bugbuster/src/handlers/message-created.ts
+++ b/bots/bugbuster/src/handlers/message-created.ts
@@ -1,14 +1,72 @@
 import * as utils from '../utils'
+import { addTeam, listAllTeams, listWatchedTeams, removeTeam, Result } from './teams-manager'
 import * as bp from '.botpress'
 
 const MESSAGING_INTEGRATIONS = ['telegram', 'slack']
+const COMMAND_LIST_MESSAGE = `Hey, I\m BugBuster. Here's a list of possible commands:
+/add-team [teamName]
+/remove-team [teamName]
+/list-all-teams
+/list-watched-teams
+`
+const ARGUMENT_REQUIRED_MESSAGE = 'Error: an argument is required with this command.'
 
 export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
-  const { conversation, message } = props
+  const { conversation, message, client, ctx } = props
   if (!MESSAGING_INTEGRATIONS.includes(conversation.integration)) {
     props.logger.info(`Ignoring message from ${conversation.integration}`)
     return
   }
+
   const botpress = await utils.botpress.BotpressApi.create(props)
-  await botpress.respondText(message.conversationId, "Hey, I'm BugBuster.")
+
+  if (message.type !== 'text') {
+    await botpress.respondText(conversation.id, COMMAND_LIST_MESSAGE)
+    return
+  }
+
+  const [command, teamKey] = message.payload.text.trim().split(' ')
+  if (!command) {
+    await botpress.respondText(conversation.id, COMMAND_LIST_MESSAGE)
+  }
+
+  let result: Result
+  let linear: utils.linear.LinearApi
+
+  switch (command) {
+    case '/add-team':
+      if (!teamKey) {
+        await botpress.respondText(conversation.id, ARGUMENT_REQUIRED_MESSAGE)
+        return
+      }
+      linear = await utils.linear.LinearApi.create()
+      result = await addTeam(client, ctx.botId, teamKey, linear)
+      await botpress.respondText(conversation.id, result.message)
+      break
+    case '/remove-team':
+      if (!teamKey) {
+        await botpress.respondText(conversation.id, ARGUMENT_REQUIRED_MESSAGE)
+        return
+      }
+      result = await removeTeam(client, ctx.botId, teamKey)
+      await botpress.respondText(conversation.id, result.message)
+      break
+    case '/list-all-teams':
+      if (!teamKey) {
+        await botpress.respondText(conversation.id, ARGUMENT_REQUIRED_MESSAGE)
+        return
+      }
+      linear = await utils.linear.LinearApi.create()
+      result = await listAllTeams(client, ctx.botId, linear)
+      await botpress.respondText(conversation.id, result.message)
+      break
+    case '/list-watched-teams':
+      linear = await utils.linear.LinearApi.create()
+      result = await listWatchedTeams(client, ctx.botId)
+      await botpress.respondText(conversation.id, result.message)
+      break
+    default:
+      await botpress.respondText(conversation.id, COMMAND_LIST_MESSAGE)
+      break
+  }
 }

--- a/bots/bugbuster/src/handlers/message-created.ts
+++ b/bots/bugbuster/src/handlers/message-created.ts
@@ -1,5 +1,5 @@
 import * as utils from '../utils'
-import { addTeam, listAllTeams, listWatchedTeams, removeTeam, Result } from './teams-manager'
+import { addTeam, listAllTeams, listWatchedTeams, removeTeam } from './teams-manager'
 import * as bp from '.botpress'
 
 const MESSAGING_INTEGRATIONS = ['telegram', 'slack']
@@ -30,39 +30,40 @@ export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
     await botpress.respondText(conversation.id, COMMAND_LIST_MESSAGE)
   }
 
-  let result: Result
-  let linear: utils.linear.LinearApi
-
   switch (command) {
-    case '/addTeam':
+    case '/addTeam': {
       if (!teamKey) {
         await botpress.respondText(conversation.id, ARGUMENT_REQUIRED_MESSAGE)
         return
       }
-      linear = await utils.linear.LinearApi.create()
-      result = await addTeam(client, ctx.botId, teamKey, linear)
+      const linear = await utils.linear.LinearApi.create()
+      const result = await addTeam(client, ctx.botId, teamKey, linear)
       await botpress.respondText(conversation.id, result.message)
       break
-    case '/removeTeam':
+    }
+    case '/removeTeam': {
       if (!teamKey) {
         await botpress.respondText(conversation.id, ARGUMENT_REQUIRED_MESSAGE)
         return
       }
-      result = await removeTeam(client, ctx.botId, teamKey)
+      const result = await removeTeam(client, ctx.botId, teamKey)
       await botpress.respondText(conversation.id, result.message)
       break
-    case '/listAllTeams':
-      linear = await utils.linear.LinearApi.create()
-      result = await listAllTeams(linear)
+    }
+    case '/listAllTeams': {
+      const linear = await utils.linear.LinearApi.create()
+      const result = await listAllTeams(linear)
       await botpress.respondText(conversation.id, result.message)
       break
-    case '/listWatchedTeams':
-      linear = await utils.linear.LinearApi.create()
-      result = await listWatchedTeams(client, ctx.botId)
+    }
+    case '/listWatchedTeams': {
+      const result = await listWatchedTeams(client, ctx.botId)
       await botpress.respondText(conversation.id, result.message)
       break
-    default:
+    }
+    default: {
       await botpress.respondText(conversation.id, COMMAND_LIST_MESSAGE)
       break
+    }
   }
 }

--- a/bots/bugbuster/src/handlers/message-created.ts
+++ b/bots/bugbuster/src/handlers/message-created.ts
@@ -1,12 +1,11 @@
 import * as utils from '../utils'
-import { addTeam, listAllTeams, listWatchedTeams, removeTeam } from './teams-manager'
+import { addTeam, listWatchedTeams, removeTeam } from './teams-manager'
 import * as bp from '.botpress'
 
 const MESSAGING_INTEGRATIONS = ['telegram', 'slack']
 const COMMAND_LIST_MESSAGE = `Unknown command. Here's a list of possible commands:
 /addTeam [teamName]
 /removeTeam [teamName]
-/listAllTeams
 /listWatchedTeams
 `
 const ARGUMENT_REQUIRED_MESSAGE = 'Error: an argument is required with this command.'
@@ -47,12 +46,6 @@ export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
         return
       }
       const result = await removeTeam(client, ctx.botId, teamKey)
-      await botpress.respondText(conversation.id, result.message)
-      break
-    }
-    case '/listAllTeams': {
-      const linear = await utils.linear.LinearApi.create()
-      const result = await listAllTeams(linear)
       await botpress.respondText(conversation.id, result.message)
       break
     }

--- a/bots/bugbuster/src/handlers/message-created.ts
+++ b/bots/bugbuster/src/handlers/message-created.ts
@@ -1,13 +1,12 @@
 import * as utils from '../utils'
-import { addTeam, listWatchedTeams, removeTeam } from './teams-manager'
+import { addTeam, listTeams, removeTeam } from './teams-manager'
 import * as bp from '.botpress'
 
 const MESSAGING_INTEGRATIONS = ['telegram', 'slack']
 const COMMAND_LIST_MESSAGE = `Unknown command. Here's a list of possible commands:
 /addTeam [teamName]
 /removeTeam [teamName]
-/listWatchedTeams
-`
+/listTeams`
 const ARGUMENT_REQUIRED_MESSAGE = 'Error: an argument is required with this command.'
 
 export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
@@ -49,8 +48,8 @@ export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
       await botpress.respondText(conversation.id, result.message)
       break
     }
-    case '/listWatchedTeams': {
-      const result = await listWatchedTeams(client, ctx.botId)
+    case '/listTeams': {
+      const result = await listTeams(client, ctx.botId)
       await botpress.respondText(conversation.id, result.message)
       break
     }

--- a/bots/bugbuster/src/handlers/message-created.ts
+++ b/bots/bugbuster/src/handlers/message-created.ts
@@ -3,11 +3,11 @@ import { addTeam, listAllTeams, listWatchedTeams, removeTeam, Result } from './t
 import * as bp from '.botpress'
 
 const MESSAGING_INTEGRATIONS = ['telegram', 'slack']
-const COMMAND_LIST_MESSAGE = `Hey, I\m BugBuster. Here's a list of possible commands:
-/add-team [teamName]
-/remove-team [teamName]
-/list-all-teams
-/list-watched-teams
+const COMMAND_LIST_MESSAGE = `Unknown command. Here's a list of possible commands:
+/addTeam [teamName]
+/removeTeam [teamName]
+/listAllTeams
+/listWatchedTeams
 `
 const ARGUMENT_REQUIRED_MESSAGE = 'Error: an argument is required with this command.'
 
@@ -34,7 +34,7 @@ export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
   let linear: utils.linear.LinearApi
 
   switch (command) {
-    case '/add-team':
+    case '/addTeam':
       if (!teamKey) {
         await botpress.respondText(conversation.id, ARGUMENT_REQUIRED_MESSAGE)
         return
@@ -43,7 +43,7 @@ export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
       result = await addTeam(client, ctx.botId, teamKey, linear)
       await botpress.respondText(conversation.id, result.message)
       break
-    case '/remove-team':
+    case '/removeTeam':
       if (!teamKey) {
         await botpress.respondText(conversation.id, ARGUMENT_REQUIRED_MESSAGE)
         return
@@ -51,16 +51,12 @@ export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
       result = await removeTeam(client, ctx.botId, teamKey)
       await botpress.respondText(conversation.id, result.message)
       break
-    case '/list-all-teams':
-      if (!teamKey) {
-        await botpress.respondText(conversation.id, ARGUMENT_REQUIRED_MESSAGE)
-        return
-      }
+    case '/listAllTeams':
       linear = await utils.linear.LinearApi.create()
       result = await listAllTeams(linear)
       await botpress.respondText(conversation.id, result.message)
       break
-    case '/list-watched-teams':
+    case '/listWatchedTeams':
       linear = await utils.linear.LinearApi.create()
       result = await listWatchedTeams(client, ctx.botId)
       await botpress.respondText(conversation.id, result.message)

--- a/bots/bugbuster/src/handlers/teams-manager.ts
+++ b/bots/bugbuster/src/handlers/teams-manager.ts
@@ -1,9 +1,10 @@
-import { LinearApi } from 'src/utils/linear-utils'
+import { LinearApi, TeamKey } from 'src/utils/linear-utils'
 import * as bp from '.botpress'
 
-export type Result = {
+export type Result<T> = {
   success: boolean
   message: string
+  result?: T
 }
 
 async function getTeamKeys(client: bp.Client, botId: string) {
@@ -30,7 +31,7 @@ async function setTeamKeys(client: bp.Client, botId: string, teamKeys: string[])
   })
 }
 
-export async function addTeam(client: bp.Client, botId: string, key: string, linear: LinearApi): Promise<Result> {
+export async function addTeam(client: bp.Client, botId: string, key: string, linear: LinearApi): Promise<Result<void>> {
   const teamKeys = await getTeamKeys(client, botId)
   if (teamKeys.includes(key)) {
     return {
@@ -52,7 +53,7 @@ export async function addTeam(client: bp.Client, botId: string, key: string, lin
   }
 }
 
-export async function removeTeam(client: bp.Client, botId: string, key: string): Promise<Result> {
+export async function removeTeam(client: bp.Client, botId: string, key: string): Promise<Result<void>> {
   const teamKeys = await getTeamKeys(client, botId)
   if (!teamKeys.includes(key)) {
     return {
@@ -72,14 +73,17 @@ export async function removeTeam(client: bp.Client, botId: string, key: string):
   }
 }
 
-export async function listAllTeams(linear: LinearApi): Promise<Result> {
+export async function listAllTeams(linear: LinearApi): Promise<Result<readonly string[]>> {
+  const teamKeys = linear.listAllTeams()
+
   return {
     success: true,
-    message: linear.listAllTeams().join(', '),
+    message: teamKeys.join(', '),
+    result: teamKeys,
   }
 }
 
-export async function listWatchedTeams(client: bp.Client, botId: string): Promise<Result> {
+export async function listWatchedTeams(client: bp.Client, botId: string): Promise<Result<readonly string[]>> {
   const teamKeys = await getTeamKeys(client, botId)
   if (teamKeys.length === 0) {
     return {
@@ -90,5 +94,6 @@ export async function listWatchedTeams(client: bp.Client, botId: string): Promis
   return {
     success: true,
     message: teamKeys.join(', '),
+    result: teamKeys,
   }
 }

--- a/bots/bugbuster/src/handlers/teams-manager.ts
+++ b/bots/bugbuster/src/handlers/teams-manager.ts
@@ -73,16 +73,6 @@ export async function removeTeam(client: bp.Client, botId: string, key: string):
   }
 }
 
-export async function listAllTeams(linear: LinearApi): Promise<Result<readonly string[]>> {
-  const teamKeys = linear.listAllTeams()
-
-  return {
-    success: true,
-    message: teamKeys.join(', '),
-    result: teamKeys,
-  }
-}
-
 export async function listWatchedTeams(client: bp.Client, botId: string): Promise<Result<readonly string[]>> {
   const teamKeys = await getTeamKeys(client, botId)
   if (teamKeys.length === 0) {

--- a/bots/bugbuster/src/handlers/teams-manager.ts
+++ b/bots/bugbuster/src/handlers/teams-manager.ts
@@ -73,7 +73,7 @@ export async function removeTeam(client: bp.Client, botId: string, key: string):
   }
 }
 
-export async function listWatchedTeams(client: bp.Client, botId: string): Promise<Result<readonly string[]>> {
+export async function listTeams(client: bp.Client, botId: string): Promise<Result<readonly string[]>> {
   const teamKeys = await getTeamKeys(client, botId)
   if (teamKeys.length === 0) {
     return {

--- a/bots/bugbuster/src/handlers/teams-manager.ts
+++ b/bots/bugbuster/src/handlers/teams-manager.ts
@@ -84,7 +84,7 @@ export async function listWatchedTeams(client: bp.Client, botId: string): Promis
   if (teamKeys.length === 0) {
     return {
       success: false,
-      message: 'There are no watched teams.',
+      message: 'You have no watched teams.',
     }
   }
   return {

--- a/bots/bugbuster/src/handlers/teams-manager.ts
+++ b/bots/bugbuster/src/handlers/teams-manager.ts
@@ -1,4 +1,4 @@
-import { LinearApi, TeamKey } from 'src/utils/linear-utils'
+import { LinearApi } from 'src/utils/linear-utils'
 import * as bp from '.botpress'
 
 export type Result<T> = {

--- a/bots/bugbuster/src/handlers/teams-manager.ts
+++ b/bots/bugbuster/src/handlers/teams-manager.ts
@@ -1,0 +1,94 @@
+import { LinearApi } from 'src/utils/linear-utils'
+import * as bp from '.botpress'
+
+export type Result = {
+  success: boolean
+  message: string
+}
+
+async function getTeamKeys(client: bp.Client, botId: string) {
+  return (
+    await client.getOrSetState({
+      id: botId,
+      name: 'teamsToWatch',
+      type: 'bot',
+      payload: {
+        teamKeys: [],
+      },
+    })
+  ).state.payload.teamKeys
+}
+
+async function setTeamKeys(client: bp.Client, botId: string, teamKeys: string[]) {
+  await client.setState({
+    id: botId,
+    name: 'teamsToWatch',
+    type: 'bot',
+    payload: {
+      teamKeys,
+    },
+  })
+}
+
+export async function addTeam(client: bp.Client, botId: string, key: string, linear: LinearApi): Promise<Result> {
+  const teamKeys = await getTeamKeys(client, botId)
+  if (teamKeys.includes(key)) {
+    return {
+      success: false,
+      message: `Error: the team with the key '${key}' is already being watched.`,
+    }
+  }
+  if (!linear.isTeam(key)) {
+    return {
+      success: false,
+      message: `Error: the team with the key '${key}' does not exist.`,
+    }
+  }
+
+  await setTeamKeys(client, botId, [...teamKeys, key])
+  return {
+    success: true,
+    message: `Success: the team with the key '${key}' has been added to the watched team list.`,
+  }
+}
+
+export async function removeTeam(client: bp.Client, botId: string, key: string): Promise<Result> {
+  const teamKeys = await getTeamKeys(client, botId)
+  if (!teamKeys.includes(key)) {
+    return {
+      message: `Error: the team with the key '${key}' is not currently being watched.`,
+      success: false,
+    }
+  }
+
+  await setTeamKeys(
+    client,
+    botId,
+    teamKeys.filter((k) => k !== key)
+  )
+  return {
+    success: false,
+    message: `Success: the team with the key '${key}' has been removed from the watched team list.`,
+  }
+}
+
+export async function listAllTeams(client: bp.Client, botId: string, linear: LinearApi): Promise<Result> {
+  return {
+    success: true,
+    message: linear.listAllTeams().join(', '),
+  }
+}
+
+export async function listWatchedTeams(client: bp.Client, botId: string): Promise<Result> {
+  const teamKeys = await getTeamKeys(client, botId)
+  if (teamKeys.length === 0) {
+    return {
+      success: false,
+      message: 'There are no watched teams.',
+    }
+  }
+  return {
+    success: true,
+    message: teamKeys.join(', '),
+  }
+}

--- a/bots/bugbuster/src/handlers/teams-manager.ts
+++ b/bots/bugbuster/src/handlers/teams-manager.ts
@@ -72,7 +72,7 @@ export async function removeTeam(client: bp.Client, botId: string, key: string):
   }
 }
 
-export async function listAllTeams(client: bp.Client, botId: string, linear: LinearApi): Promise<Result> {
+export async function listAllTeams(linear: LinearApi): Promise<Result> {
   return {
     success: true,
     message: linear.listAllTeams().join(', '),

--- a/bots/bugbuster/src/handlers/teams-manager.ts
+++ b/bots/bugbuster/src/handlers/teams-manager.ts
@@ -11,7 +11,7 @@ async function getTeamKeys(client: bp.Client, botId: string) {
   return (
     await client.getOrSetState({
       id: botId,
-      name: 'teamsToWatch',
+      name: 'watchedTeams',
       type: 'bot',
       payload: {
         teamKeys: [],
@@ -23,7 +23,7 @@ async function getTeamKeys(client: bp.Client, botId: string) {
 async function setTeamKeys(client: bp.Client, botId: string, teamKeys: string[]) {
   await client.setState({
     id: botId,
-    name: 'teamsToWatch',
+    name: 'watchedTeams',
     type: 'bot',
     payload: {
       teamKeys,

--- a/bots/bugbuster/src/handlers/teams-manager.ts
+++ b/bots/bugbuster/src/handlers/teams-manager.ts
@@ -7,7 +7,7 @@ export type Result<T> = {
   result?: T
 }
 
-async function getTeamKeys(client: bp.Client, botId: string) {
+const getWatchedTeams = async (client: bp.Client, botId: string) => {
   return (
     await client.getOrSetState({
       id: botId,
@@ -20,7 +20,7 @@ async function getTeamKeys(client: bp.Client, botId: string) {
   ).state.payload.teamKeys
 }
 
-async function setTeamKeys(client: bp.Client, botId: string, teamKeys: string[]) {
+const setWatchedTeams = async (client: bp.Client, botId: string, teamKeys: string[]) => {
   await client.setState({
     id: botId,
     name: 'watchedTeams',
@@ -32,7 +32,7 @@ async function setTeamKeys(client: bp.Client, botId: string, teamKeys: string[])
 }
 
 export async function addTeam(client: bp.Client, botId: string, key: string, linear: LinearApi): Promise<Result<void>> {
-  const teamKeys = await getTeamKeys(client, botId)
+  const teamKeys = await getWatchedTeams(client, botId)
   if (teamKeys.includes(key)) {
     return {
       success: false,
@@ -46,7 +46,7 @@ export async function addTeam(client: bp.Client, botId: string, key: string, lin
     }
   }
 
-  await setTeamKeys(client, botId, [...teamKeys, key])
+  await setWatchedTeams(client, botId, [...teamKeys, key])
   return {
     success: true,
     message: `Success: the team with the key '${key}' has been added to the watched team list.`,
@@ -54,7 +54,7 @@ export async function addTeam(client: bp.Client, botId: string, key: string, lin
 }
 
 export async function removeTeam(client: bp.Client, botId: string, key: string): Promise<Result<void>> {
-  const teamKeys = await getTeamKeys(client, botId)
+  const teamKeys = await getWatchedTeams(client, botId)
   if (!teamKeys.includes(key)) {
     return {
       message: `Error: the team with the key '${key}' is not currently being watched.`,
@@ -62,7 +62,7 @@ export async function removeTeam(client: bp.Client, botId: string, key: string):
     }
   }
 
-  await setTeamKeys(
+  await setWatchedTeams(
     client,
     botId,
     teamKeys.filter((k) => k !== key)
@@ -74,7 +74,7 @@ export async function removeTeam(client: bp.Client, botId: string, key: string):
 }
 
 export async function listTeams(client: bp.Client, botId: string): Promise<Result<readonly string[]>> {
-  const teamKeys = await getTeamKeys(client, botId)
+  const teamKeys = await getWatchedTeams(client, botId)
   if (teamKeys.length === 0) {
     return {
       success: false,

--- a/bots/bugbuster/src/handlers/teams-manager.ts
+++ b/bots/bugbuster/src/handlers/teams-manager.ts
@@ -7,7 +7,7 @@ export type Result<T> = {
   result?: T
 }
 
-const getWatchedTeams = async (client: bp.Client, botId: string) => {
+const _getWatchedTeams = async (client: bp.Client, botId: string) => {
   return (
     await client.getOrSetState({
       id: botId,
@@ -20,7 +20,7 @@ const getWatchedTeams = async (client: bp.Client, botId: string) => {
   ).state.payload.teamKeys
 }
 
-const setWatchedTeams = async (client: bp.Client, botId: string, teamKeys: string[]) => {
+const _setWatchedTeams = async (client: bp.Client, botId: string, teamKeys: string[]) => {
   await client.setState({
     id: botId,
     name: 'watchedTeams',
@@ -32,7 +32,7 @@ const setWatchedTeams = async (client: bp.Client, botId: string, teamKeys: strin
 }
 
 export async function addTeam(client: bp.Client, botId: string, key: string, linear: LinearApi): Promise<Result<void>> {
-  const teamKeys = await getWatchedTeams(client, botId)
+  const teamKeys = await _getWatchedTeams(client, botId)
   if (teamKeys.includes(key)) {
     return {
       success: false,
@@ -46,7 +46,7 @@ export async function addTeam(client: bp.Client, botId: string, key: string, lin
     }
   }
 
-  await setWatchedTeams(client, botId, [...teamKeys, key])
+  await _setWatchedTeams(client, botId, [...teamKeys, key])
   return {
     success: true,
     message: `Success: the team with the key '${key}' has been added to the watched team list.`,
@@ -54,7 +54,7 @@ export async function addTeam(client: bp.Client, botId: string, key: string, lin
 }
 
 export async function removeTeam(client: bp.Client, botId: string, key: string): Promise<Result<void>> {
-  const teamKeys = await getWatchedTeams(client, botId)
+  const teamKeys = await _getWatchedTeams(client, botId)
   if (!teamKeys.includes(key)) {
     return {
       message: `Error: the team with the key '${key}' is not currently being watched.`,
@@ -62,7 +62,7 @@ export async function removeTeam(client: bp.Client, botId: string, key: string):
     }
   }
 
-  await setWatchedTeams(
+  await _setWatchedTeams(
     client,
     botId,
     teamKeys.filter((k) => k !== key)
@@ -74,7 +74,7 @@ export async function removeTeam(client: bp.Client, botId: string, key: string):
 }
 
 export async function listTeams(client: bp.Client, botId: string): Promise<Result<readonly string[]>> {
-  const teamKeys = await getWatchedTeams(client, botId)
+  const teamKeys = await _getWatchedTeams(client, botId)
   if (teamKeys.length === 0) {
     return {
       success: false,

--- a/bots/bugbuster/src/utils/linear-utils.ts
+++ b/bots/bugbuster/src/utils/linear-utils.ts
@@ -51,6 +51,10 @@ export class LinearApi {
     return TEAM_KEYS.includes(teamKey as TeamKey)
   }
 
+  public listAllTeams() {
+    return TEAM_KEYS
+  }
+
   public isState(stateKey: string): stateKey is StateKey {
     return STATE_KEYS.includes(stateKey as StateKey)
   }

--- a/bots/bugbuster/src/utils/linear-utils.ts
+++ b/bots/bugbuster/src/utils/linear-utils.ts
@@ -51,10 +51,6 @@ export class LinearApi {
     return TEAM_KEYS.includes(teamKey as TeamKey)
   }
 
-  public listAllTeams() {
-    return TEAM_KEYS
-  }
-
   public isState(stateKey: string): stateKey is StateKey {
     return STATE_KEYS.includes(stateKey as StateKey)
   }


### PR DESCRIPTION
Contributes to SQD-3388

Sending commands to BugBuster in Telegram is now possible. The following commands are available:
- `/listTeams`
- `/addTeam [teamKey]`
- `/removeTeam [teamKey]`

The bot will lint issues associated with the watched teams.