### PR TITLE
fix(packages/cli): add try catch and default value return to FSKeyValueCache._readJSON 

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "4.23.1",
+  "version": "4.23.2",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/utils/cache-utils.ts
+++ b/packages/cli/src/utils/cache-utils.ts
@@ -74,6 +74,10 @@ export class FSKeyValueCache<T extends Object> {
 
   private _readJSON = async (filepath: string) => {
     const fileContent = await fs.promises.readFile(filepath, 'utf8')
-    return JSON.parse(fileContent)
+    try {
+      return JSON.parse(fileContent)
+    } catch {
+      return {}
+    }
   }
 }


### PR DESCRIPTION
Due to the difficulty of reproducing the issue in a controlled environment, this hotfix *should* address the intermittent CLI crashing. Since this is for value caching, any crashes should simply cause it to ignore caching for the given call.