### PR TITLE
chore(bots/bugbuster): now using a raw graphql query for linting issues

### DIFF
--- a/bots/bugbuster/src/handlers/issue-processor.ts
+++ b/bots/bugbuster/src/handlers/issue-processor.ts
@@ -1,5 +1,5 @@
 import { BotLogger } from '@botpress/sdk'
-import { Issue } from '@linear/sdk'
+import { Issue } from 'src/utils/graphql-queries'
 import { LinearApi } from 'src/utils/linear-utils'
 import * as linlint from '../linear-lint-issue'
 import { listTeams } from './teams-manager'

--- a/bots/bugbuster/src/handlers/linear-issue-updated.ts
+++ b/bots/bugbuster/src/handlers/linear-issue-updated.ts
@@ -11,14 +11,14 @@ export const handleLinearIssueUpdated: bp.EventHandlers['linear:issueUpdated'] =
     return
   }
 
-  const botpress = await utils.botpress.BotpressApi.create(props)
-  const recentlyLinted = await botpress.getRecentlyLinted()
+  // const botpress = await utils.botpress.BotpressApi.create(props)
+  // const recentlyLinted = await botpress.getRecentlyLinted()
 
-  if (recentlyLinted.some(({ id: issueId }) => issue.id === issueId)) {
-    props.logger.info(`Issue ${issue.identifier} has already been linted recently, skipping...`)
-    return
-  }
+  // if (recentlyLinted.some(({ id: issueId }) => issue.id === issueId)) {
+  //   props.logger.info(`Issue ${issue.identifier} has already been linted recently, skipping...`)
+  //   return
+  // }
 
   await runLint(linear, issue, props.logger)
-  await botpress.setRecentlyLinted([...recentlyLinted, { id: issue.id, lintedAt: new Date().toISOString() }])
+  // await botpress.setRecentlyLinted([...recentlyLinted, { id: issue.id, lintedAt: new Date().toISOString() }])
 }

--- a/bots/bugbuster/src/handlers/linear-issue-updated.ts
+++ b/bots/bugbuster/src/handlers/linear-issue-updated.ts
@@ -11,14 +11,14 @@ export const handleLinearIssueUpdated: bp.EventHandlers['linear:issueUpdated'] =
     return
   }
 
-  // const botpress = await utils.botpress.BotpressApi.create(props)
-  // const recentlyLinted = await botpress.getRecentlyLinted()
+  const botpress = await utils.botpress.BotpressApi.create(props)
+  const recentlyLinted = await botpress.getRecentlyLinted()
 
-  // if (recentlyLinted.some(({ id: issueId }) => issue.id === issueId)) {
-  //   props.logger.info(`Issue ${issue.identifier} has already been linted recently, skipping...`)
-  //   return
-  // }
+  if (recentlyLinted.some(({ id: issueId }) => issue.id === issueId)) {
+    props.logger.info(`Issue ${issue.identifier} has already been linted recently, skipping...`)
+    return
+  }
 
   await runLint(linear, issue, props.logger)
-  // await botpress.setRecentlyLinted([...recentlyLinted, { id: issue.id, lintedAt: new Date().toISOString() }])
+  await botpress.setRecentlyLinted([...recentlyLinted, { id: issue.id, lintedAt: new Date().toISOString() }])
 }

--- a/bots/bugbuster/src/linear-lint-issue.ts
+++ b/bots/bugbuster/src/linear-lint-issue.ts
@@ -1,6 +1,6 @@
-import * as lin from '@linear/sdk'
 import { isIssueTitleFormatValid } from './issue-title-format-validator'
 import * as utils from './utils'
+import { Issue } from './utils/graphql-queries'
 
 export type IssueLint = {
   message: string
@@ -8,29 +8,20 @@ export type IssueLint = {
 
 const IGNORED_STATUSES: utils.linear.StateKey[] = ['TRIAGE', 'PRODUCTION_DONE', 'CANCELED', 'STALE']
 
-export const lintIssue = async (client: utils.linear.LinearApi, issue: lin.Issue): Promise<IssueLint[]> => {
+export const lintIssue = async (client: utils.linear.LinearApi, issue: Issue): Promise<IssueLint[]> => {
   const status = client.issueStatus(issue)
   if (IGNORED_STATUSES.includes(status)) {
     return []
   }
 
   const lints: string[] = []
-  const { nodes: labels } = await issue.labels()
 
-  const hasType = await utils.promise.some(labels, async (label) => {
-    const parent = await label.parent
-    return parent?.name === 'type'
-  })
-  if (!hasType) {
+  if (!_hasLabelOfCategory(issue, 'type')) {
     lints.push(`Issue ${issue.identifier} is missing a type label.`)
   }
 
-  const hasBlockedLabel = await utils.promise.some(labels, async (label) => {
-    const parent = await label.parent
-    return parent?.name === 'blocked'
-  })
-
-  const hasBlockedRelation = await client.isBlockedByOtherIssues(issue)
+  const hasBlockedLabel = _hasLabelOfCategory(issue, 'blocked')
+  const hasBlockedRelation = issue.inverseRelations.nodes.some((relation) => relation.type === 'blocks')
 
   if (status === 'BLOCKED' && !issue.assignee) {
     lints.push(`Issue ${issue.identifier} is blocked but has no assignee.`)
@@ -42,7 +33,7 @@ export const lintIssue = async (client: utils.linear.LinearApi, issue: lin.Issue
     lints.push(`Issue ${issue.identifier} has an assignee but is still in the backlog.`)
   }
 
-  const hasArea = labels.some((label) => label.name.startsWith('area/'))
+  const hasArea = issue.labels.nodes.some((label) => label.name.startsWith('area/'))
   if (!hasArea) {
     lints.push(`Issue ${issue.identifier} is missing an "area/" label.`)
   }
@@ -62,11 +53,8 @@ export const lintIssue = async (client: utils.linear.LinearApi, issue: lin.Issue
     )
   }
 
-  const hasProject = await issue.project
-  const hasGoal = await utils.promise.some(labels, async (label) => {
-    const parent = await label.parent
-    return parent?.name === 'goal'
-  })
+  const hasProject = issue.project
+  const hasGoal = _hasLabelOfCategory(issue, 'goal')
   if (!hasProject && !hasGoal) {
     lints.push(`Issue ${issue.identifier} is missing both a project and a goal label.`)
   }
@@ -85,4 +73,8 @@ export const lintIssue = async (client: utils.linear.LinearApi, issue: lin.Issue
   }
 
   return lints.map((message) => ({ message }))
+}
+
+const _hasLabelOfCategory = (issue: Issue, category: string) => {
+  return issue.labels.nodes.some((label) => label.parent?.name === category)
 }

--- a/bots/bugbuster/src/utils/graphql-queries.ts
+++ b/bots/bugbuster/src/utils/graphql-queries.ts
@@ -1,0 +1,75 @@
+export type Issue = {
+  id: string
+  identifier: string
+  title: string
+  estimate: number | null
+  priority: number
+  assignee: {
+    id: string
+  } | null
+  state: {
+    id: string
+  }
+  labels: {
+    nodes: {
+      name: string
+      parent: {
+        name: string
+      } | null
+    }[]
+  }
+  inverseRelations: {
+    nodes: {
+      type: string
+    }[]
+  }
+  project: {
+    id: string
+    name: string | null
+    completedAt: string | null
+  } | null
+}
+
+export const FIND_ISSUE = `
+query FindIssue($filter: IssueFilter) {
+  issues(filter: $filter) {
+    nodes {
+      id,
+      identifier,
+      title,
+      estimate,
+      priority,
+      assignee {
+        id
+      },
+      state {
+        id
+      },
+      labels {
+        nodes {
+          name
+          parent {
+            name
+          }
+        }
+      },
+      inverseRelations {
+        nodes {
+          type
+        }
+      },
+      project {
+        id,
+        name,
+        completedAt
+      }
+    }
+  }
+}
+`
+
+export type FindIssueResult = {
+  issues: {
+    nodes: Issue[]
+  }
+}

--- a/bots/bugbuster/src/utils/graphql-queries.ts
+++ b/bots/bugbuster/src/utils/graphql-queries.ts
@@ -1,3 +1,12 @@
+const QUERY_INPUT = Symbol('graphqlInputType')
+const QUERY_RESPONSE = Symbol('graphqlResponseType')
+
+type GraphQLQuery<TInput, TResponse> = {
+  query: string
+  [QUERY_INPUT]: TInput
+  [QUERY_RESPONSE]: TResponse
+}
+
 export type Issue = {
   id: string
   identifier: string
@@ -30,46 +39,58 @@ export type Issue = {
   } | null
 }
 
-export const FIND_ISSUE = `
-query FindIssue($filter: IssueFilter) {
-  issues(filter: $filter) {
-    nodes {
-      id,
-      identifier,
-      title,
-      estimate,
-      priority,
-      assignee {
-        id
-      },
-      state {
-        id
-      },
-      labels {
-        nodes {
-          name
-          parent {
-            name
+export const GRAPHQL_QUERIES = {
+  findIssue: {
+    query: `
+      query FindIssue($filter: IssueFilter) {
+        issues(filter: $filter) {
+          nodes {
+            id,
+            identifier,
+            title,
+            estimate,
+            priority,
+            assignee {
+              id
+            },
+            state {
+              id
+            },
+            labels {
+              nodes {
+                name
+                parent {
+                  name
+                }
+              }
+            },
+            inverseRelations {
+              nodes {
+                type
+              }
+            },
+            project {
+              id,
+              name,
+              completedAt
+            }
           }
         }
-      },
-      inverseRelations {
-        nodes {
-          type
-        }
-      },
-      project {
-        id,
-        name,
-        completedAt
+      }`,
+    [QUERY_INPUT]: {} as {
+      filter: {
+        team: { key: { eq: string } }
+        number: { eq: number }
       }
-    }
-  }
-}
-`
+    },
+    [QUERY_RESPONSE]: {} as {
+      issues: {
+        nodes: Issue[]
+      }
+    },
+  },
+} as const satisfies Record<string, GraphQLQuery<object, object>>
 
-export type FindIssueResult = {
-  issues: {
-    nodes: Issue[]
-  }
-}
+export type GRAPHQL_QUERIES = typeof GRAPHQL_QUERIES
+export type QUERY_INPUT = typeof QUERY_INPUT
+export type QUERY_RESPONSE = typeof QUERY_RESPONSE

--- a/bots/bugbuster/src/utils/linear-utils.ts
+++ b/bots/bugbuster/src/utils/linear-utils.ts
@@ -61,8 +61,8 @@ export class LinearApi {
 
     const data = await this._executeGraphqlQuery('findIssue', {
       filter: {
-        number: { eq: issueNumber },
         team: { key: { eq: teamKey } },
+        number: { eq: issueNumber },
       },
     })
 

--- a/bots/bugbuster/src/utils/linear-utils.ts
+++ b/bots/bugbuster/src/utils/linear-utils.ts
@@ -73,6 +73,19 @@ export class LinearApi {
     return issue
   }
 
+  public async findLabel(filter: { name: string; parentName?: string }): Promise<lin.IssueLabel | undefined> {
+    const { name, parentName } = filter
+    const { nodes: labels } = await this._client.issueLabels({
+      filter: {
+        name: { eq: name },
+        parent: parentName ? { name: { eq: parentName } } : undefined,
+      },
+    })
+
+    const [label] = labels
+    return label || undefined
+  }
+
   public issueStatus(issue: Issue): StateKey {
     const state = this._states.find((s) => s.id === issue.state.id)
     if (!state) {


### PR DESCRIPTION
Contributes to SQD-3388

No change has been made to BugBuster's behavior, but we now use a raw query for finding an issue, which brings down the execution time of the `lintIssue` function from ~1200 milliseconds to ~1 millisecond. This also means we only have to query the API once to lint an issue (we used to query it several times).