### PR TITLE
chore(integrations/messenger): OAuth credential verification

### DIFF
--- a/integrations/messenger/src/misc/meta-client.ts
+++ b/integrations/messenger/src/misc/meta-client.ts
@@ -7,7 +7,7 @@ import * as bp from '.botpress'
 
 const ERROR_SUBSCRIBE_TO_WEBHOOKS = 'Failed to subscribe to webhooks'
 const ERROR_UNSUBSCRIBE_FROM_WEBHOOKS = 'Failed to unsubscribe from webhooks'
-export const FIELDS_TO_SUBSCRIBE = ['messages', 'messaging_postbacks', 'feed']
+const FIELDS_TO_SUBSCRIBE = ['messages', 'messaging_postbacks', 'feed']
 export class MetaClient {
   private _userToken?: string
   private _pageToken?: string

--- a/integrations/messenger/src/misc/meta-client.ts
+++ b/integrations/messenger/src/misc/meta-client.ts
@@ -7,7 +7,7 @@ import * as bp from '.botpress'
 
 const ERROR_SUBSCRIBE_TO_WEBHOOKS = 'Failed to subscribe to webhooks'
 const ERROR_UNSUBSCRIBE_FROM_WEBHOOKS = 'Failed to unsubscribe from webhooks'
-const FIELDS_TO_SUBSCRIBE = ['messages', 'messaging_postbacks', 'feed']
+export const FIELDS_TO_SUBSCRIBE = ['messages', 'messaging_postbacks', 'feed']
 export class MetaClient {
   private _userToken?: string
   private _pageToken?: string
@@ -225,7 +225,7 @@ export class MetaClient {
     }
   }
 
-  public async isSubscribedToWebhooks(inputPageId?: string) {
+  public async getSubscribedWebhooks(inputPageId?: string): Promise<string[] | null> {
     const pageId = this._getPageId(inputPageId)
     const responseData = await this._makeRequest({
       method: 'GET',
@@ -239,10 +239,19 @@ export class MetaClient {
 
     const application = applications?.find((app) => app.id === this._clientId)
     if (!application) {
+      return null
+    }
+
+    return application.subscribed_fields
+  }
+
+  public async isSubscribedToWebhooks(inputPageId?: string) {
+    const subscribedFields = await this.getSubscribedWebhooks(inputPageId)
+    
+    if (!subscribedFields) {
       return false
     }
 
-    const subscribedFields = application.subscribed_fields
     if (!FIELDS_TO_SUBSCRIBE.every((f) => subscribedFields.includes(f))) {
       return false
     }

--- a/integrations/messenger/src/misc/meta-client.ts
+++ b/integrations/messenger/src/misc/meta-client.ts
@@ -247,7 +247,7 @@ export class MetaClient {
 
   public async isSubscribedToWebhooks(inputPageId?: string) {
     const subscribedFields = await this.getSubscribedWebhooks(inputPageId)
-    
+
     if (!subscribedFields) {
       return false
     }

--- a/integrations/messenger/src/misc/meta-client.ts
+++ b/integrations/messenger/src/misc/meta-client.ts
@@ -225,7 +225,7 @@ export class MetaClient {
     }
   }
 
-  public async getSubscribedWebhooks(inputPageId?: string): Promise<string[] | null> {
+  public async getSubscribedWebhooks(inputPageId?: string): Promise<string[] | undefined> {
     const pageId = this._getPageId(inputPageId)
     const responseData = await this._makeRequest({
       method: 'GET',
@@ -239,7 +239,7 @@ export class MetaClient {
 
     const application = applications?.find((app) => app.id === this._clientId)
     if (!application) {
-      return null
+      return undefined
     }
 
     return application.subscribed_fields

--- a/integrations/messenger/src/setup.ts
+++ b/integrations/messenger/src/setup.ts
@@ -95,9 +95,7 @@ const _unsubscribeFromOAuthWebhooks = async ({ ctx, logger, client }: RegisterPr
   const { pageId } = credentials
   if (!pageId) {
     // No page ID means the OAuth flow was probably never fully completed
-    const message = 'No page ID found - OAuth flow was probably never fully completed'
-    logger.forBot().error(message)
-    throw new RuntimeError('No page ID found - OAuth flow was probably never fully completed')
+    return
   }
 
   const metaClient = await createAuthenticatedMetaClient({ configType: 'oauth', ctx, client, logger })

--- a/integrations/messenger/src/setup.ts
+++ b/integrations/messenger/src/setup.ts
@@ -72,7 +72,7 @@ const _verifyOAuthCredentials = async (props: RegisterProps) => {
 
     const pageId = credentials?.pageId
     const isSubscribedToWebhooks = await metaClient.isSubscribedToWebhooks(pageId)
-    
+
     if (!isSubscribedToWebhooks) {
       await handleAuthFailure('OAuth credentials verified. No webhooks subscribed.', 'warn')
     }
@@ -81,8 +81,6 @@ const _verifyOAuthCredentials = async (props: RegisterProps) => {
     await handleAuthFailure(`Error verifying OAuth credentials: ${errorMessage}`, 'error')
   }
 }
-
-
 
 const _unsubscribeFromOAuthWebhooks = async ({ ctx, logger, client }: RegisterProps) => {
   const credentials = await getOAuthMetaClientCredentials(client, ctx).catch(() => undefined)


### PR DESCRIPTION
Resolves SQD-3376

Added a verification step within the `register` function to ensure that the current credentials are valid. If not, will throw a `RuntimeError` and display a message asking the user to re-authorize.  