### PR TITLE
feat(bots/bugbuster): Added error handling

### DIFF
--- a/bots/bugbuster/src/handlers/message-created.ts
+++ b/bots/bugbuster/src/handlers/message-created.ts
@@ -93,7 +93,7 @@ export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
 }
 
 const _onError = async (thrown: unknown, botpress: BotpressApi, conversationId: string) => {
-  await botpress.respondText(conversationId, 'An error occured. See logs for details.')
   const error = thrown instanceof Error ? thrown : new Error(String(thrown))
+  await botpress.respondText(conversationId, `An error occured: ${error.message}`)
   throw new RuntimeError(error.message)
 }


### PR DESCRIPTION
Contributes to SQD-3388

When an error is encountered after a command is sent, the bot will reply providing details about the error.

Example:
<img width="669" height="96" alt="image" src="https://github.com/user-attachments/assets/38c65be5-e198-46e6-b419-710059a2dc1d" />
