### PR TITLE
feat(integrations/hubspot): add details to error message when pipeline status cannot be found

### DIFF
--- a/integrations/hubspot/integration.definition.ts
+++ b/integrations/hubspot/integration.definition.ts
@@ -5,7 +5,7 @@ export default new IntegrationDefinition({
   name: 'hubspot',
   title: 'HubSpot',
   description: 'Manage contacts, tickets and more from your chatbot.',
-  version: '5.1.0',
+  version: '5.2.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   configuration: {

--- a/integrations/hubspot/src/hubspot-api/hubspot-client.ts
+++ b/integrations/hubspot/src/hubspot-api/hubspot-client.ts
@@ -935,7 +935,8 @@ export class HubspotClient {
   }) {
     const canonicalName = _getCanonicalName(nameOrLabel)
 
-    const matchingStage = Object.entries(stages).find(
+    const stageEntries = Object.entries(stages)
+    const matchingStage = stageEntries.find(
       ([id, { label }]) =>
         _getCanonicalName(id) === canonicalName ||
         _getCanonicalName(label) === canonicalName ||
@@ -944,7 +945,11 @@ export class HubspotClient {
     )
 
     if (!matchingStage) {
-      throw new sdk.RuntimeError(`Unable to find ticket pipeline stage with name or id "${nameOrLabel}"`)
+      const formattedStages = stageEntries.map(([id, { label }]) => `=> **${label}** (ID: "${id}")`).join('\n')
+      const allowedStagesMsg = `========================\nValid Pipeline Stages:\n${formattedStages}\n`
+      throw new sdk.RuntimeError(
+        `Unable to find ticket pipeline stage with name or id "${nameOrLabel}"\n${allowedStagesMsg}`
+      )
     }
 
     return {


### PR DESCRIPTION
This is to address the [create ticket fails when a status is newly created](https://linear.app/botpress/issue/SQD-3295/botpress-hubspot-create-ticket-fails-when-ticket-status-is-a-newly) linear issue, since after some investigation I believe this is possibly a misconfiguration in the client's HubSpot. The additional details in the error message should make it easier to debug on the client's side.