### PR TITLE
Mb/bugbuster resolve own comments

### DIFF
--- a/bots/bugbuster/src/handlers/issue-processor.ts
+++ b/bots/bugbuster/src/handlers/issue-processor.ts
@@ -73,7 +73,6 @@ export async function runLint(linear: LinearApi, issue: Issue, logger: BotLogger
   if (errors.length === 0) {
     logger.info(`Issue ${issue.identifier} passed all lint checks.`)
     await linear.resolveComments(issue)
-    logger.info(`Resolved lint comments on issue ${issue.identifier}`)
     return
   }
 

--- a/bots/bugbuster/src/handlers/issue-processor.ts
+++ b/bots/bugbuster/src/handlers/issue-processor.ts
@@ -72,7 +72,7 @@ export async function runLint(linear: LinearApi, issue: Issue, logger: BotLogger
 
   if (errors.length === 0) {
     logger.info(`Issue ${issue.identifier} passed all lint checks.`)
-    await linear.resolveComments(issue.id)
+    await linear.resolveComments(issue)
     logger.info(`Resolved lint comments on issue ${issue.identifier}`)
     return
   }

--- a/bots/bugbuster/src/handlers/issue-processor.ts
+++ b/bots/bugbuster/src/handlers/issue-processor.ts
@@ -72,6 +72,8 @@ export async function runLint(linear: LinearApi, issue: Issue, logger: BotLogger
 
   if (errors.length === 0) {
     logger.info(`Issue ${issue.identifier} passed all lint checks.`)
+    await linear.resolveComments(issue.id)
+    logger.info(`Resolved lint comments on issue ${issue.identifier}`)
     return
   }
 

--- a/bots/bugbuster/src/linear-lint-issue.ts
+++ b/bots/bugbuster/src/linear-lint-issue.ts
@@ -34,7 +34,7 @@ export const lintIssue = async (issue: Issue, status: string): Promise<IssueLint
     lints.push(`Issue ${issue.identifier} is missing a priority.`)
   }
 
-  if (issue.estimate === undefined && status !== 'BLOCKED') {
+  if (issue.estimate === null && status !== 'BLOCKED') {
     // blocked issues can be unestimated
     lints.push(`Issue ${issue.identifier} is missing an estimate.`)
   }

--- a/bots/bugbuster/src/utils/graphql-queries.ts
+++ b/bots/bugbuster/src/utils/graphql-queries.ts
@@ -37,6 +37,15 @@ export type Issue = {
     name: string | null
     completedAt: string | null
   } | null
+  comments: {
+    nodes: {
+      id: string
+      resolvedAt: string | null
+      user: {
+        id: string
+      }
+    }[]
+  }
 }
 
 export type Pagination = {
@@ -78,6 +87,14 @@ export const GRAPHQL_QUERIES = {
               id,
               name,
               completedAt
+            }
+            comments {
+              nodes {
+                id,
+                user {
+                  id
+                }
+              }
             }
           }
         }

--- a/bots/bugbuster/src/utils/linear-utils.ts
+++ b/bots/bugbuster/src/utils/linear-utils.ts
@@ -120,25 +120,16 @@ export class LinearApi {
     return utils.string.toScreamingSnakeCase(state.name) as StateKey
   }
 
-  public async resolveComments(issueId?: string): Promise<void> {
-    const { nodes: comments } = await this._client.comments({
-      filter: {
-        issue: {
-          id: { eq: issueId },
-        },
-        user: {
-          id: {
-            eq: this.me.id,
-          },
-        },
-      },
-    })
+  public async resolveComments(issue: Issue): Promise<void> {
+    const comments = issue.comments.nodes
 
+    const promises: Promise<lin.CommentPayload>[] = []
     for (const comment of comments) {
-      if (!comment.resolvedAt) {
-        await this._client.commentResolve(comment.id)
+      if (comment.user.id === this.me.id && !comment.resolvedAt) {
+        promises.push(this._client.commentResolve(comment.id))
       }
     }
+    await Promise.all(promises)
   }
 
   public get teams(): Record<TeamKey, lin.Team> {

--- a/bots/bugbuster/src/utils/linear-utils.ts
+++ b/bots/bugbuster/src/utils/linear-utils.ts
@@ -26,8 +26,7 @@ export class LinearApi {
     private _client: lin.LinearClient,
     private _viewer: lin.User,
     private _teams: lin.Team[],
-    private _states: lin.WorkflowState[],
-    private _userId: string
+    private _states: lin.WorkflowState[]
   ) {}
 
   public static async create(): Promise<LinearApi> {
@@ -39,9 +38,8 @@ export class LinearApi {
 
     const states = await this._listAllStates(client)
     const teams = await this._listAllTeams(client)
-    const userId = (await client.viewer).id
 
-    return new LinearApi(client, me, teams, states, userId)
+    return new LinearApi(client, me, teams, states)
   }
 
   public get client(): lin.LinearClient {
@@ -122,16 +120,6 @@ export class LinearApi {
     return utils.string.toScreamingSnakeCase(state.name) as StateKey
   }
 
-  public async isBlockedByOtherIssues(issueA: lin.Issue): Promise<boolean> {
-    const { nodes: issues } = await this._client.issues({
-      filter: {
-        hasBlockedByRelations: { eq: true },
-        id: { eq: issueA.id },
-      },
-    })
-    return issues.length > 0
-  }
-
   public async resolveComments(issueId?: string): Promise<void> {
     const { nodes: comments } = await this._client.comments({
       filter: {
@@ -140,7 +128,7 @@ export class LinearApi {
         },
         user: {
           id: {
-            eq: this._userId,
+            eq: this.me.id,
           },
         },
       },


### PR DESCRIPTION
Contributes to SQD-3388

When an issue passes all lint checks, Bugbuster now resolves every comment he made on that issue.

Also, because we're now using raw GraphQL queries, `issue.estimate` cannot be `undefined` anymore but it can be `null` instead. As a result, issues with no estimate were allowed. I included the fix in this PR.