### PR TITLE
feat(cli): `bp remove` command

### DIFF
--- a/packages/cli/e2e/index.ts
+++ b/packages/cli/e2e/index.ts
@@ -8,7 +8,8 @@ import { devBot } from './tests/dev-bot'
 import { installAllInterfaces } from './tests/install-interfaces'
 import { addIntegration, addPlugin } from './tests/install-package'
 import { requiredSecrets } from './tests/integration-secrets'
-import { prependWorkspaceHandle, enforceWorkspaceHandle } from './tests/manage-workspace-handle'
+import { enforceWorkspaceHandle, prependWorkspaceHandle } from './tests/manage-workspace-handle'
+import { removePackage } from './tests/remove-package'
 import { Test } from './typings'
 import { sleep, TmpDirectory } from './utils'
 
@@ -23,6 +24,7 @@ const tests: Test[] = [
   addIntegration,
   addPlugin,
   installAllInterfaces,
+  removePackage,
 ]
 
 const timeout = (ms: number) =>

--- a/packages/cli/e2e/tests/create-deploy-bot-with-dependencies.ts
+++ b/packages/cli/e2e/tests/create-deploy-bot-with-dependencies.ts
@@ -22,7 +22,7 @@ type ARGV = typeof defaults & {
 }
 
 export const createDeployBotWithDependencies: Test = {
-  name: 'cli should allow creating, building, deploying and mannaging a bot that has nested dependencies',
+  name: 'cli should allow creating, building, deploying and managing a bot that has nested dependencies',
   handler: async ({ tmpDir, dependencies, logger, ...creds }) => {
     if (!_isBotpressWorkspace(creds.workspaceHandle, creds.workspaceId)) {
       // Unfortunately, only the botpress workspace can deploy interfaces

--- a/packages/cli/e2e/tests/create-deploy-bot.ts
+++ b/packages/cli/e2e/tests/create-deploy-bot.ts
@@ -14,7 +14,7 @@ const fetchBot = async (client: Client, botName: string): Promise<ApiBot | undef
 }
 
 export const createDeployBot: Test = {
-  name: 'cli should allow creating, building, deploying and mannaging a bot',
+  name: 'cli should allow creating, building, deploying and managing a bot',
   handler: async ({ tmpDir, dependencies, ...creds }) => {
     const botpressHomeDir = pathlib.join(tmpDir, '.botpresshome')
     const baseDir = pathlib.join(tmpDir, 'bots')

--- a/packages/cli/e2e/tests/create-deploy-integration.ts
+++ b/packages/cli/e2e/tests/create-deploy-integration.ts
@@ -14,7 +14,7 @@ const fetchIntegration = async (client: Client, integrationName: string): Promis
 }
 
 export const createDeployIntegration: Test = {
-  name: 'cli should allow creating, building, deploying and mannaging an integration',
+  name: 'cli should allow creating, building, deploying and managing an integration',
   handler: async ({ tmpDir, dependencies, workspaceHandle, logger, ...creds }) => {
     const botpressHomeDir = pathlib.join(tmpDir, '.botpresshome')
     const baseDir = pathlib.join(tmpDir, 'integrations')

--- a/packages/cli/e2e/tests/remove-package.ts
+++ b/packages/cli/e2e/tests/remove-package.ts
@@ -59,7 +59,6 @@ export const removePackage: Test = {
         .add({
           ...argv,
           packageRef: plugin,
-          packageType: 'plugin',
           installPath: botDir,
           useDev: false,
           alias: ALIAS,

--- a/packages/cli/e2e/tests/remove-package.ts
+++ b/packages/cli/e2e/tests/remove-package.ts
@@ -1,0 +1,88 @@
+import * as fslib from 'fs'
+import * as pathlib from 'path'
+import * as uuid from 'uuid'
+import impl from '../../src'
+import defaults from '../defaults'
+import { Test, TestProps } from '../typings'
+import * as utils from '../utils'
+
+const getHomeDir = (props: { tmpDir: string }) => pathlib.join(props.tmpDir, '.botpresshome')
+const initBot = async (props: TestProps, definitionFile: string) => {
+  const { tmpDir, dependencies, ...creds } = props
+  const argv = {
+    ...defaults,
+    botpressHome: getHomeDir(props),
+    confirm: true,
+    ...creds,
+  }
+  const botName = uuid.v4().replace(/-/g, '')
+  const botDir = pathlib.join(tmpDir, botName)
+  await impl
+    .init({ ...argv, workDir: tmpDir, name: botName, type: 'bot', template: 'empty' })
+    .then(utils.handleExitCode)
+  await utils.fixBotpressDependencies({ workDir: botDir, target: dependencies })
+  await utils.npmInstall({ workDir: botDir }).then(utils.handleExitCode)
+  fslib.writeFileSync(pathlib.join(botDir, 'bot.definition.ts'), definitionFile)
+  return { botDir }
+}
+
+const ALIAS = 'alias'
+export const removePackage: Test = {
+  name: 'cli should allow removing a plugin',
+  handler: async (props) => {
+    const botpressHomeDir = pathlib.join(props.tmpDir, '.botpresshome')
+
+    const botDir = await initBot(
+      props,
+      ['import * as sdk from "@botpress/sdk"', 'export default new sdk.BotDefinition({})'].join('\n')
+    ).then((bot) => bot.botDir)
+
+    const argv = {
+      ...defaults,
+      botpressHome: botpressHomeDir,
+      confirm: true,
+      ...props,
+    }
+
+    await impl
+      .login({
+        ...argv,
+      })
+      .then(utils.handleExitCode)
+
+    const plugin: string = 'hitl'
+
+    props.logger.info(`Installing plugin: ${plugin}`)
+    await impl
+      .add({
+        ...argv,
+        packageRef: plugin,
+        packageType: 'plugin',
+        installPath: botDir,
+        useDev: false,
+        alias: ALIAS,
+      })
+      .then(utils.handleExitCode)
+
+    await impl.remove({
+      ...argv,
+      alias: ALIAS,
+      workDir: botDir,
+    })
+
+    const aliasPath = pathlib.join(botDir, 'bp_modules', ALIAS)
+    const exists = await fslib.promises
+      .access(aliasPath)
+      .then(() => true)
+      .catch(() => false)
+    if (exists) {
+      throw new Error(`Expected ${aliasPath} to not exist`)
+    }
+
+    const pkgJsonPath = pathlib.join(botDir, 'package.json')
+    const pkgJson = JSON.parse(fslib.readFileSync(pkgJsonPath, 'utf-8'))
+    if (pkgJson.bpDependencies && Object.keys(pkgJson.bpDependencies).length !== 0) {
+      throw new Error('Expected bpDependencies to be empty')
+    }
+  },
+}

--- a/packages/cli/src/command-definitions.ts
+++ b/packages/cli/src/command-definitions.ts
@@ -45,6 +45,11 @@ export default {
   serve: { description: 'Serve your project locally', schema: config.schemas.serve },
   deploy: { description: 'Deploy your project to the cloud', schema: config.schemas.deploy },
   add: { description: 'Install a package; could be an integration or an interface', schema: config.schemas.add },
+  remove: {
+    description: "Remove a package from your project's dependencies",
+    schema: config.schemas.remove,
+    alias: 'rm',
+  },
   dev: { description: 'Run your project in dev mode', schema: config.schemas.dev },
   lint: { description: 'EXPERIMENTAL: Lint an integration definition', schema: config.schemas.lint },
   chat: { description: 'EXPERIMENTAL: Chat with a bot directly from the CLI', schema: config.schemas.chat },

--- a/packages/cli/src/command-implementations/index.ts
+++ b/packages/cli/src/command-implementations/index.ts
@@ -23,6 +23,7 @@ import { LogoutCommand } from './logout-command'
 import * as plugins from './plugin-commands'
 import * as profiles from './profile-commands'
 import { ReadCommand } from './read-command'
+import { RemoveCommand } from './remove-command'
 import { ServeCommand } from './serve-command'
 
 type GlobalCtor<C extends GlobalCommandDefinition> = new (
@@ -77,6 +78,7 @@ export default {
   serve: getHandler(ServeCommand),
   deploy: getHandler(DeployCommand),
   add: getHandler(AddCommand),
+  remove: getHandler(RemoveCommand),
   dev: getHandler(DevCommand),
   lint: getHandler(LintCommand),
   chat: getHandler(ChatCommand),

--- a/packages/cli/src/command-implementations/remove-command.ts
+++ b/packages/cli/src/command-implementations/remove-command.ts
@@ -68,6 +68,7 @@ export class RemoveCommand extends ProjectCommand<RemoveCommandDefinition> {
   ) {
     const { [correspondingPackageAlias]: _, ...newBpDependencies } = validatedBpDeps
     pkgJson[BP_DEPENDENCIES_KEY] = newBpDependencies
+
     await utils.pkgJson.writePackageJson(workDir, pkgJson)
     this.logger.log(`Package with alias "${alias}" was removed from ${PKGJSON_FILE_NAME}`)
   }

--- a/packages/cli/src/command-implementations/remove-command.ts
+++ b/packages/cli/src/command-implementations/remove-command.ts
@@ -1,0 +1,30 @@
+import * as sdk from '@botpress/sdk'
+import * as fslib from 'fs'
+import * as pathlib from 'path'
+import semver from 'semver'
+import * as apiUtils from '../api'
+import * as codegen from '../code-generation'
+import type commandDefinitions from '../command-definitions'
+import * as consts from '../consts'
+import * as errors from '../errors'
+import * as pkgRef from '../package-ref'
+import * as utils from '../utils'
+import { ProjectCommand } from './project-command'
+
+type RemovablePackage =
+  | {
+      type: 'integration'
+    }
+  | {
+      type: 'interface'
+    }
+  | {
+      type: 'plugin'
+    }
+
+export type RemoveCommandDefinition = typeof commandDefinitions.remove
+export class RemoveCommand extends ProjectCommand<RemoveCommandDefinition> {
+  protected run(): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+}

--- a/packages/cli/src/command-implementations/remove-command.ts
+++ b/packages/cli/src/command-implementations/remove-command.ts
@@ -1,30 +1,60 @@
 import * as sdk from '@botpress/sdk'
 import * as fslib from 'fs'
-import * as pathlib from 'path'
-import semver from 'semver'
-import * as apiUtils from '../api'
-import * as codegen from '../code-generation'
 import type commandDefinitions from '../command-definitions'
 import * as consts from '../consts'
 import * as errors from '../errors'
-import * as pkgRef from '../package-ref'
 import * as utils from '../utils'
 import { ProjectCommand } from './project-command'
 
-type RemovablePackage =
-  | {
-      type: 'integration'
-    }
-  | {
-      type: 'interface'
-    }
-  | {
-      type: 'plugin'
-    }
-
 export type RemoveCommandDefinition = typeof commandDefinitions.remove
 export class RemoveCommand extends ProjectCommand<RemoveCommandDefinition> {
-  protected run(): Promise<void> {
-    throw new Error('Method not implemented.')
+  protected async run(): Promise<void> {
+    const ref = this.argv.packageRef
+    if (!ref) {
+      throw new errors.BotpressCLIError('You have to provide a packageRef')
+    }
+
+    const baseInstallPath = utils.path.absoluteFrom(utils.path.cwd(), this.argv.workDir)
+    //remove from package.json
+    const pkgJson = await utils.pkgJson.readPackageJson(baseInstallPath)
+    if (!pkgJson) {
+      throw new errors.BotpressCLIError(`No package.json found in path ${baseInstallPath}`)
+    }
+
+    const { bpDependencies } = pkgJson
+    if (!bpDependencies) {
+      throw new errors.BotpressCLIError('package')
+    }
+
+    const bpDependenciesSchema = sdk.z.record(sdk.z.string())
+    const parseResult = bpDependenciesSchema.safeParse(bpDependencies)
+    if (!parseResult.success) {
+      throw new errors.BotpressCLIError('Invalid bpDependencies found in package.json')
+    }
+
+    const { data: validatedBpDeps } = parseResult
+
+    const correspondingPackageAlias = this._findCorrespondingPackage(ref, validatedBpDeps)
+
+    //remove from bp_modules
+    const packageDirName = utils.casing.to.kebabCase(correspondingPackageAlias)
+    const installPath = utils.path.join(baseInstallPath, consts.installDirName, packageDirName)
+    fslib.rmSync(installPath, { force: true, recursive: true })
+
+    //rewrite package.json
+    const { [correspondingPackageAlias]: _, ...newBpDependencies } = validatedBpDeps
+    pkgJson.bpDependencies = newBpDependencies
+
+    await utils.pkgJson.writePackageJson(baseInstallPath, pkgJson)
+  }
+
+  private _findCorrespondingPackage(alias: string, bpDependencies: Record<string, string>): string {
+    const correspondingPackage: string | undefined = Object.keys(bpDependencies).find((key) => key === alias)
+
+    if (!correspondingPackage) {
+      throw new errors.BotpressCLIError(`No corresponding package for alias ${alias} was found`)
+    }
+
+    return correspondingPackage
   }
 }

--- a/packages/cli/src/command-implementations/remove-command.ts
+++ b/packages/cli/src/command-implementations/remove-command.ts
@@ -45,6 +45,7 @@ export class RemoveCommand extends ProjectCommand<RemoveCommandDefinition> {
     if (!parseResult.success) {
       throw new errors.BotpressCLIError(`Invalid ${BP_DEPENDENCIES_KEY} found in ${PKGJSON_FILE_NAME}`)
     }
+
     return { validatedBpDeps: parseResult.data, pkgJson }
   }
 
@@ -55,6 +56,7 @@ export class RemoveCommand extends ProjectCommand<RemoveCommandDefinition> {
   ) {
     const packageDirName = utils.casing.to.kebabCase(correspondingPackageAlias)
     const installPath = utils.path.join(workDir, consts.installDirName, packageDirName)
+
     await fslib.promises.rm(installPath, { force: true, recursive: true })
     this.logger.log(`Package "${alias}" was removed from bp_modules`)
   }

--- a/packages/cli/src/command-implementations/remove-command.ts
+++ b/packages/cli/src/command-implementations/remove-command.ts
@@ -9,9 +9,9 @@ import { ProjectCommand } from './project-command'
 export type RemoveCommandDefinition = typeof commandDefinitions.remove
 export class RemoveCommand extends ProjectCommand<RemoveCommandDefinition> {
   protected async run(): Promise<void> {
-    const ref = this.argv.packageRef
+    const ref = this.argv.alias
     if (!ref) {
-      throw new errors.BotpressCLIError('You have to provide a packageRef')
+      throw new errors.BotpressCLIError('You have to provide the alias of the package to remove')
     }
 
     const baseInstallPath = utils.path.absoluteFrom(utils.path.cwd(), this.argv.workDir)

--- a/packages/cli/src/command-implementations/remove-command.ts
+++ b/packages/cli/src/command-implementations/remove-command.ts
@@ -1,10 +1,10 @@
 import * as sdk from '@botpress/sdk'
 import * as fslib from 'fs'
-import { BP_DEPENDENCIES_KEY, PKGJSON_FILE_NAME } from 'src/utils/pkgjson-utils'
 import type commandDefinitions from '../command-definitions'
 import * as consts from '../consts'
 import * as errors from '../errors'
 import * as utils from '../utils'
+import { BP_DEPENDENCIES_KEY, PKGJSON_FILE_NAME } from '../utils/pkgjson-utils'
 import { ProjectCommand } from './project-command'
 
 export type RemoveCommandDefinition = typeof commandDefinitions.remove

--- a/packages/cli/src/command-implementations/remove-command.ts
+++ b/packages/cli/src/command-implementations/remove-command.ts
@@ -1,5 +1,6 @@
 import * as sdk from '@botpress/sdk'
 import * as fslib from 'fs'
+import { BP_DEPENDENCIES_KEY, PKGJSON_FILE_NAME } from 'src/utils/pkgjson-utils'
 import type commandDefinitions from '../command-definitions'
 import * as consts from '../consts'
 import * as errors from '../errors'
@@ -9,19 +10,32 @@ import { ProjectCommand } from './project-command'
 export type RemoveCommandDefinition = typeof commandDefinitions.remove
 export class RemoveCommand extends ProjectCommand<RemoveCommandDefinition> {
   protected async run(): Promise<void> {
-    const ref = this.argv.alias
-    if (!ref) {
+    const alias = this.argv.alias
+    if (!alias) {
       throw new errors.BotpressCLIError('You have to provide the alias of the package to remove')
     }
 
-    const baseInstallPath = utils.path.absoluteFrom(utils.path.cwd(), this.argv.workDir)
-    //remove from package.json
-    const pkgJson = await utils.pkgJson.readPackageJson(baseInstallPath)
+    const { validatedBpDeps, workDir, pkgJson } = await this._validatePkgJson()
+
+    const correspondingPackageAlias = this._findCorrespondingPackage(alias, validatedBpDeps)
+
+    this._removeDepFromBpModules(correspondingPackageAlias, workDir, alias)
+
+    await this._removeDepFromPkgJson(correspondingPackageAlias, validatedBpDeps, pkgJson, workDir, alias)
+  }
+
+  private async _validatePkgJson(): Promise<{
+    validatedBpDeps: Record<string, string>
+    workDir: utils.path.AbsolutePath
+    pkgJson: utils.pkgJson.PackageJson
+  }> {
+    const workDir = utils.path.absoluteFrom(utils.path.cwd(), this.argv.workDir)
+    const pkgJson = await utils.pkgJson.readPackageJson(workDir)
     if (!pkgJson) {
-      throw new errors.BotpressCLIError(`No package.json found in path ${baseInstallPath}`)
+      throw new errors.BotpressCLIError(`No ${PKGJSON_FILE_NAME} found in path ${workDir}`)
     }
 
-    const { bpDependencies } = pkgJson
+    const bpDependencies = pkgJson[BP_DEPENDENCIES_KEY]
     if (!bpDependencies) {
       throw new errors.BotpressCLIError('package')
     }
@@ -29,32 +43,42 @@ export class RemoveCommand extends ProjectCommand<RemoveCommandDefinition> {
     const bpDependenciesSchema = sdk.z.record(sdk.z.string())
     const parseResult = bpDependenciesSchema.safeParse(bpDependencies)
     if (!parseResult.success) {
-      throw new errors.BotpressCLIError('Invalid bpDependencies found in package.json')
+      throw new errors.BotpressCLIError(`Invalid ${BP_DEPENDENCIES_KEY} found in ${PKGJSON_FILE_NAME}`)
     }
+    return { validatedBpDeps: parseResult.data, workDir, pkgJson }
+  }
 
-    const { data: validatedBpDeps } = parseResult
-
-    const correspondingPackageAlias = this._findCorrespondingPackage(ref, validatedBpDeps)
-
-    //remove from bp_modules
+  private _removeDepFromBpModules(correspondingPackageAlias: string, workDir: utils.path.AbsolutePath, alias: string) {
     const packageDirName = utils.casing.to.kebabCase(correspondingPackageAlias)
-    const installPath = utils.path.join(baseInstallPath, consts.installDirName, packageDirName)
+    const installPath = utils.path.join(workDir, consts.installDirName, packageDirName)
     fslib.rmSync(installPath, { force: true, recursive: true })
+    this.logger.log(`Package "${alias}" was removed from bp_modules`)
+  }
 
-    //rewrite package.json
+  private async _removeDepFromPkgJson(
+    correspondingPackageAlias: string,
+    validatedBpDeps: Record<string, string>,
+    pkgJson: utils.pkgJson.PackageJson,
+    workDir: string,
+    alias: string
+  ) {
     const { [correspondingPackageAlias]: _, ...newBpDependencies } = validatedBpDeps
-    pkgJson.bpDependencies = newBpDependencies
-
-    await utils.pkgJson.writePackageJson(baseInstallPath, pkgJson)
+    pkgJson[BP_DEPENDENCIES_KEY] = newBpDependencies
+    await utils.pkgJson.writePackageJson(workDir, pkgJson)
+    this.logger.log(`Package with alias "${alias}" was removed from ${PKGJSON_FILE_NAME}`)
   }
 
   private _findCorrespondingPackage(alias: string, bpDependencies: Record<string, string>): string {
     const correspondingPackage: string | undefined = Object.keys(bpDependencies).find((key) => key === alias)
 
     if (!correspondingPackage) {
-      throw new errors.BotpressCLIError(`No corresponding package for alias ${alias} was found`)
+      throw new errors.BotpressCLIError(
+        `No corresponding package for alias "${alias}" was found in ${BP_DEPENDENCIES_KEY}`
+      )
     }
 
     return correspondingPackage
   }
 }
+
+//TODO add e2e tests

--- a/packages/cli/src/command-implementations/remove-command.ts
+++ b/packages/cli/src/command-implementations/remove-command.ts
@@ -80,5 +80,3 @@ export class RemoveCommand extends ProjectCommand<RemoveCommandDefinition> {
     return correspondingPackage
   }
 }
-
-//TODO add e2e tests

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -244,6 +244,14 @@ const addSchema = {
   },
 } satisfies CommandSchema
 
+const removeSchema = {
+  ...globalSchema,
+  ...credentialsSchema,
+  packageRef,
+  packageType,
+  workDir,
+} satisfies CommandSchema
+
 const loginSchema = {
   ...globalSchema,
   token,
@@ -419,6 +427,7 @@ export const schemas = {
   serve: serveSchema,
   deploy: deploySchema,
   add: addSchema,
+  remove: removeSchema,
   dev: devSchema,
   lint: lintSchema,
   chat: chatSchema,

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -248,7 +248,7 @@ const removeSchema = {
   ...globalSchema,
   ...credentialsSchema,
   workDir,
-  alias: { idx: 0, type: 'string', description: 'The alias of the package to uninstall' },
+  alias: { idx: 0, positional: true, type: 'string', description: 'The alias of the package to uninstall' },
 } satisfies CommandSchema
 
 const loginSchema = {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -248,7 +248,6 @@ const removeSchema = {
   ...globalSchema,
   ...credentialsSchema,
   packageRef,
-  packageType,
   workDir,
 } satisfies CommandSchema
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -240,15 +240,15 @@ const addSchema = {
   },
   alias: {
     type: 'string',
-    description: 'The alias of the dependency you want to install',
+    description: 'The alias to install the package with',
   },
 } satisfies CommandSchema
 
 const removeSchema = {
   ...globalSchema,
   ...credentialsSchema,
-  packageRef,
   workDir,
+  alias: { idx: 0, type: 'string', description: 'The alias of the package to uninstall' },
 } satisfies CommandSchema
 
 const loginSchema = {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -45,6 +45,7 @@ export default {
   serve: commandImplementations.serve,
   deploy: commandImplementations.deploy,
   add: commandImplementations.add,
+  remove: commandImplementations.remove,
   dev: commandImplementations.dev,
   lint: commandImplementations.lint,
   chat: commandImplementations.chat,

--- a/packages/cli/src/utils/pkgjson-utils.ts
+++ b/packages/cli/src/utils/pkgjson-utils.ts
@@ -15,7 +15,8 @@ export type PackageJson = {
   [key: string]: JSON
 }
 
-const FILE_NAME = 'package.json'
+export const PKGJSON_FILE_NAME = 'package.json'
+export const BP_DEPENDENCIES_KEY = 'bpDependencies'
 
 export const readPackageJson = async (path: string): Promise<PackageJson | undefined> => {
   const filePath = _resolveFilePath(path)
@@ -40,5 +41,5 @@ export const writePackageJson = async (path: string, pkgJson: PackageJson) => {
 }
 
 function _resolveFilePath(path: string) {
-  return pathlib.basename(path) === FILE_NAME ? path : pathlib.join(path, FILE_NAME)
+  return pathlib.basename(path) === PKGJSON_FILE_NAME ? path : pathlib.join(path, PKGJSON_FILE_NAME)
 }


### PR DESCRIPTION
How the command works:
Given a package.json and a bp_modules, it will remove the dependency with alias (based on the key) passed in positional argument.
Ex: `bp rm hitl` will remove the `hitl` dependency from `package.json.bpDependencies` and delete the `bp_modules/hitl` folder.