### PR TITLE
feat(bots/bugbuster): added health command

### DIFF
--- a/bots/bugbuster/src/handlers/message-created.ts
+++ b/bots/bugbuster/src/handlers/message-created.ts
@@ -6,6 +6,7 @@ import * as bp from '.botpress'
 
 const MESSAGING_INTEGRATIONS = ['telegram', 'slack']
 const COMMAND_LIST_MESSAGE = `Unknown command. Here's a list of possible commands:
+#health
 #addTeam [teamName]
 #removeTeam [teamName]
 #listTeams
@@ -46,6 +47,18 @@ export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
   }
 
   switch (command) {
+    case '#health': {
+      let isLinearHealthy = true
+      try {
+        await utils.linear.LinearApi.create()
+      } catch {
+        isLinearHealthy = false
+      }
+
+      const healthMessages = [_generateHealthMessage('Linear', isLinearHealthy)]
+      await botpress.respondText(conversation.id, healthMessages.join('\n'))
+      break
+    }
     case '#addTeam': {
       if (!teamKey) {
         await botpress.respondText(conversation.id, ARGUMENT_REQUIRED_MESSAGE)
@@ -90,4 +103,8 @@ export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
       break
     }
   }
+}
+
+const _generateHealthMessage = (component: string, isHealthy: boolean) => {
+  return `${component}: ${isHealthy ? '' : 'un'}healthy`
 }

--- a/bots/bugbuster/src/handlers/message-created.ts
+++ b/bots/bugbuster/src/handlers/message-created.ts
@@ -55,8 +55,7 @@ export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
         isLinearHealthy = false
       }
 
-      const healthMessages = [_generateHealthMessage('Linear', isLinearHealthy)]
-      await botpress.respondText(conversation.id, healthMessages.join('\n'))
+      await botpress.respondText(conversation.id, `Linear: ${isLinearHealthy ? '' : 'un'}healthy`)
       break
     }
     case '#addTeam': {
@@ -103,8 +102,4 @@ export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
       break
     }
   }
-}
-
-const _generateHealthMessage = (component: string, isHealthy: boolean) => {
-  return `${component}: ${isHealthy ? '' : 'un'}healthy`
 }


### PR DESCRIPTION
Contributes to SQD-3388

A new command `#health` is available to verify if we're able to call the Linear API. We can add more checks in the future.
<img width="288" height="105" alt="image" src="https://github.com/user-attachments/assets/f218acc2-305e-44ea-8259-5b3b4e9b6051" />
