### PR TITLE
feat(cli): bp profile add, delete and dev

### DIFF
--- a/packages/cli/src/command-definitions.ts
+++ b/packages/cli/src/command-definitions.ts
@@ -60,6 +60,15 @@ export default {
         description: 'Set the current profile',
         schema: config.schemas.useProfile,
       },
+      add: {
+        description: 'Add a new profile',
+        schema: config.schemas.addProfile,
+      },
+      delete: {
+        description: 'Delete a profile',
+        schema: config.schemas.deleteProfile,
+        alias: 'rm',
+      },
     },
   },
 } satisfies DefinitionTree

--- a/packages/cli/src/command-implementations/index.ts
+++ b/packages/cli/src/command-implementations/index.ts
@@ -85,6 +85,8 @@ export default {
       list: getHandler(profiles.ListProfilesCommand),
       active: getHandler(profiles.ActiveProfileCommand),
       use: getHandler(profiles.UseProfileCommand),
+      add: getHandler(profiles.AddProfileCommand),
+      delete: getHandler(profiles.DeleteProfileCommand),
     },
   },
 } satisfies ImplementationTree<typeof commandDefinitions>

--- a/packages/cli/src/command-implementations/profile-commands.ts
+++ b/packages/cli/src/command-implementations/profile-commands.ts
@@ -1,4 +1,7 @@
+import * as client from '@botpress/client'
 import chalk from 'chalk'
+import * as fs from 'fs'
+import * as paging from '../api/paging'
 import type commandDefinitions from '../command-definitions'
 import * as consts from '../consts'
 import * as errors from '../errors'
@@ -73,6 +76,176 @@ export class UseProfileCommand extends GlobalCommand<UseProfileCommandDefinition
     await this.globalCache.set('activeProfile', selectedProfile)
     await _updateGlobalCache({ globalCache: this.globalCache, profileName: selectedProfile, profile })
     logSuccess(selectedProfile)
+  }
+}
+
+export type AddProfileCommandDefinition = typeof commandDefinitions.profiles.subcommands.add
+export class AddProfileCommand extends GlobalCommand<AddProfileCommandDefinition> {
+  public async run(): Promise<void> {
+    let profileName = this.argv.profileName
+    if (!profileName) {
+      profileName = await this.prompt.text('Enter the profile name', {})
+      if (!profileName) {
+        throw new errors.ParamRequiredError('Profile name')
+      }
+    }
+
+    let profileExists = false
+    if (fs.existsSync(this.globalPaths.abs.profilesPath)) {
+      try {
+        const profiles = await this.readProfilesFromFS()
+        profileExists = profiles[profileName] !== undefined
+      } catch {
+        profileExists = false
+      }
+    }
+
+    if (profileExists) {
+      const overwrite = await this.prompt.confirm(
+        `Profile "${profileName}" already exists. Do you want to overwrite it?`
+      )
+      if (!overwrite) {
+        throw new errors.AbortedOperationError()
+      }
+    }
+
+    let apiUrl: string
+    if (this.argv.dev) {
+      if (this.argv.apiUrl) {
+        this.logger.warn('Both --dev and --apiUrl are specified. --dev flag will override --apiUrl.')
+      }
+      apiUrl = `https://api.${consts.stagingBotpressDomain}`
+      this.logger.log(`Using dev environment: ${apiUrl}`, { prefix: '🔗' })
+    } else {
+      apiUrl = this.argv.apiUrl ?? (await this.globalCache.get('apiUrl')) ?? consts.defaultBotpressApiUrl
+      if (apiUrl !== consts.defaultBotpressApiUrl) {
+        this.logger.log(`Using custom API URL: ${apiUrl}`, { prefix: '🔗' })
+      }
+    }
+
+    const token = await this.globalCache.sync('token', this.argv.token, async (previousToken) => {
+      const prompted = await this.prompt.text('Enter your Personal Access Token', {
+        initial: previousToken,
+      })
+      if (!prompted) {
+        throw new errors.ParamRequiredError('Personal Access Token')
+      }
+      return prompted
+    })
+
+    const workspaceId = await this.globalCache.sync('workspaceId', this.argv.workspaceId, async (defaultId) => {
+      const tmpClient = new client.Client({ apiUrl, token })
+      const userWorkspaces = await paging
+        .listAllPages(tmpClient.listWorkspaces, (r) => r.workspaces)
+        .catch((thrown) => {
+          throw errors.BotpressCLIError.wrap(thrown, 'Could not list workspaces')
+        })
+
+      if (userWorkspaces.length === 0) {
+        throw new errors.NoWorkspacesFoundError()
+      }
+
+      const initial = userWorkspaces.find((ws) => ws.id === defaultId)
+
+      const prompted = await this.prompt.select('Which workspace do you want to use?', {
+        initial: initial && { title: initial.name, value: initial.id },
+        choices: userWorkspaces.map((ws) => ({ title: ws.name, value: ws.id })),
+      })
+
+      if (!prompted) {
+        throw new errors.ParamRequiredError('Workspace ID')
+      }
+
+      return prompted
+    })
+
+    // Validate credentials by testing login
+    const testClient = this.api.newClient({ apiUrl, token, workspaceId }, this.logger)
+    try {
+      await testClient.testLogin()
+    } catch (thrown) {
+      throw errors.BotpressCLIError.wrap(
+        thrown,
+        'Failed to validate credentials. Please check your token and workspace ID.'
+      )
+    }
+
+    const profile: ProfileCredentials = {
+      apiUrl,
+      token,
+      workspaceId,
+    }
+
+    await this.writeProfileToFS(profileName, profile)
+
+    this.logger.success(`Profile "${profileName}" added successfully`)
+    await this.globalCache.set('activeProfile', profileName)
+  }
+}
+
+export type DeleteProfileCommandDefinition = typeof commandDefinitions.profiles.subcommands.delete
+export class DeleteProfileCommand extends GlobalCommand<DeleteProfileCommandDefinition> {
+  public async run(): Promise<void> {
+    let profileName = this.argv.profileToDelete
+    if (!profileName) {
+      const profiles = await this.readProfilesFromFS()
+      const choices = Object.entries(profiles).map(([name, _]) => ({
+        title: name,
+        description: '',
+        value: name,
+      }))
+      const selectedProfile = await this.prompt.select('Select the profile you want to delete.', { choices })
+
+      if (!selectedProfile) {
+        this.logger.log('No profile selected, aborting.')
+        return
+      }
+
+      profileName = selectedProfile
+    }
+
+    let profiles: Record<string, ProfileCredentials>
+    try {
+      profiles = await this.readProfilesFromFS()
+    } catch (thrown) {
+      throw errors.BotpressCLIError.wrap(thrown, 'Could not read profiles')
+    }
+
+    if (!profiles[profileName]) {
+      throw new errors.BotpressCLIError(`Profile "${profileName}" not found`)
+    }
+
+    const activeProfileName = await this.globalCache.get('activeProfile')
+    const isActive = activeProfileName === profileName
+
+    if (isActive) {
+      this.logger.warn(`Profile "${profileName}" is currently active.`)
+    }
+
+    if (profileName === consts.defaultProfileName) {
+      const confirm = await this.prompt.confirm(
+        `Profile "${profileName}" is the default profile. Are you sure you want to delete it?`
+      )
+      if (!confirm) {
+        throw new errors.AbortedOperationError()
+      }
+    } else if (!this.argv.confirm) {
+      const confirm = await this.prompt.confirm(`Are you sure you want to delete profile "${profileName}"?`)
+      if (!confirm) {
+        throw new errors.AbortedOperationError()
+      }
+    }
+
+    delete profiles[profileName]
+
+    await fs.promises.writeFile(this.globalPaths.abs.profilesPath, JSON.stringify(profiles, null, 2), 'utf-8')
+
+    if (isActive) {
+      await this.globalCache.set('activeProfile', '')
+      this.logger.warn('Active profile has been cleared. Use "bp profiles use" to set a new active profile.')
+    }
+
+    this.logger.success(`Profile "${profileName}" deleted successfully`)
   }
 }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -389,6 +389,32 @@ const useProfileSchema = {
   },
 } satisfies CommandSchema
 
+const addProfileSchema = {
+  ...globalSchema,
+  ...credentialsSchema,
+  profileName: {
+    type: 'string',
+    description: 'The name of the profile to add',
+    positional: true,
+    idx: 0,
+  },
+  dev: {
+    type: 'boolean',
+    description: 'Use the dev environment (api.botpress.dev)',
+    default: false,
+  },
+} satisfies CommandSchema
+
+const deleteProfileSchema = {
+  ...globalSchema,
+  profileToDelete: {
+    type: 'string',
+    description: 'The name of the profile to delete',
+    positional: true,
+    idx: 0,
+  },
+} satisfies CommandSchema
+
 // exports
 
 export const schemas = {
@@ -425,4 +451,6 @@ export const schemas = {
   listProfiles: listProfilesSchema,
   activeProfile: activeProfileSchema,
   useProfile: useProfileSchema,
+  addProfile: addProfileSchema,
+  deleteProfile: deleteProfileSchema,
 } as const

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -52,5 +52,7 @@ export default {
     list: commandImplementations.profiles.subcommands.list,
     active: commandImplementations.profiles.subcommands.active,
     use: commandImplementations.profiles.subcommands.use,
+    add: commandImplementations.profiles.subcommands.add,
+    delete: commandImplementations.profiles.subcommands.delete,
   },
 } satisfies CommandHandlers<typeof commandDefinitions>


### PR DESCRIPTION
## Why

I'm personally having issues with writing permissions on my Mac so I couldn't set up my dev profile by editing the json file.
I quickly improved the bp profile command so I could continue testing my google calendar integration

## Content 

- `bp profile add` - Add a new profile with credentials
- `bp profile delete` (alias: `rm`) - Delete an existing profile

Also add a --dev flag to automatically use the dev API URL `api.botpress.dev`

