### PR TITLE
fix(integration/googlecalendar): update logic to retrieve free and busy slots

### DIFF
--- a/integrations/googlecalendar/integration.definition.ts
+++ b/integrations/googlecalendar/integration.definition.ts
@@ -3,7 +3,7 @@ import { actions, entities, configuration, configurations, identifier, events, s
 
 export default new sdk.IntegrationDefinition({
   name: 'googlecalendar',
-  version: '2.0.0',
+  version: '2.0.1',
   description: 'Sync with your calendar to manage events, appointments, and schedules directly within the chatbot.',
   title: 'Google Calendar',
   readme: 'hub.md',

--- a/integrations/googlecalendar/src/google-api/google-client.ts
+++ b/integrations/googlecalendar/src/google-api/google-client.ts
@@ -115,6 +115,7 @@ export class GoogleClient {
       requestBody: {
         timeMin,
         timeMax,
+        items: [{ id: this._calendarId }],
       },
     })
 


### PR DESCRIPTION
Precising the items property allows for more detailed filtering to check availability

<img width="254" height="485" alt="Capture d’écran, le 2025-11-21 à 09 57 09" src="https://github.com/user-attachments/assets/aa4d70a1-fc74-42f2-859b-aaaf010de05f" />

<img width="662" height="248" alt="Capture d’écran, le 2025-11-21 à 09 57 40" src="https://github.com/user-attachments/assets/85522e2d-c00a-4d59-abea-f97880287d0f" />


