### PR TITLE
fix(common/posthog): remove symbol for version

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -11,7 +11,7 @@
     "dedent": "^1.6.0",
     "marked": "^15.0.1",
     "openai": "^6.9.0",
-    "posthog-node": "^5.11.2",
+    "posthog-node": "5.11.2",
     "preact": "^10.26.6",
     "preact-render-to-string": "^6.5.13",
     "remark": "^15.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2587,7 +2587,7 @@ importers:
         specifier: ^6.9.0
         version: 6.9.0(ws@8.18.2)
       posthog-node:
-        specifier: ^5.11.2
+        specifier: 5.11.2
         version: 5.11.2
       preact:
         specifier: ^10.26.6


### PR DESCRIPTION
to make sure we don't install the vulnerable version of posthog-node