### PR TITLE
fix(integrations/anthropic): validation for temperature and top_p takes into account a zero value

### DIFF
--- a/integrations/anthropic/src/actions/generate-content.ts
+++ b/integrations/anthropic/src/actions/generate-content.ts
@@ -101,8 +101,8 @@ export async function generateContent(
 
   if (
     (modelId === 'claude-sonnet-4-5-20250929' || modelId === 'claude-haiku-4-5-20251001') &&
-    request.temperature &&
-    request.top_p
+    request.temperature !== undefined &&
+    request.top_p !== undefined
   ) {
     // This model fails when setting both parameters with the error "`temperature` and `top_p` cannot both be specified for this model. Please use only one.", so we remove the top_p parameter if temperature is also set.
     request.top_p = undefined


### PR DESCRIPTION
The validation for simultaneous use of `temperature` and `top_p` parameters when using Claude 4.5 (Sonnet or Haiku) can fail to kick-in if one or both of these parameters has a value of `0` (which can be used for strictly deterministic output), so this PR fixes it.

This will be pushed as a hotfix on the existing integration version so all users can have this bug fix right away without having to upgrade the integration.