### PR TITLE
fix(integrations/whatsapp): allows message of more than 4096 chars by splitting the bot response sent through WhatsApp

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -201,7 +201,7 @@ export default new IntegrationDefinition({
                   }),
                 }),
                 z.object({
-                  type: z.literal('markdown'), // TODO Remove for 4.0.0
+                  type: z.literal('markdown'), // TODO Remove for 5.0.0
                   payload: z.object({
                     markdown: z.string(),
                   }),

--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -95,7 +95,7 @@ const defaultBotPhoneNumberId = {
 export const INTEGRATION_NAME = 'whatsapp'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '4.5.17',
+  version: '4.5.18',
   title: 'WhatsApp',
   description: 'Send and receive messages through WhatsApp.',
   icon: 'icon.svg',

--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -95,7 +95,7 @@ const defaultBotPhoneNumberId = {
 export const INTEGRATION_NAME = 'whatsapp'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '4.5.16',
+  version: '4.5.17',
   title: 'WhatsApp',
   description: 'Send and receive messages through WhatsApp.',
   icon: 'icon.svg',

--- a/integrations/whatsapp/src/channels/channel.ts
+++ b/integrations/whatsapp/src/channels/channel.ts
@@ -14,6 +14,7 @@ import {
 import { getAuthenticatedWhatsappClient } from '../auth'
 import { WHATSAPP } from '../misc/constants'
 import { convertMarkdownToWhatsApp } from '../misc/markdown-to-whatsapp-rtf'
+import { splitTextMessageIfNeeded } from '../misc/split-text-message'
 import { sleep } from '../misc/util'
 import { repeat } from '../repeat'
 import * as card from './message-types/card'
@@ -255,24 +256,6 @@ function backoffDelayMs(attempt: number) {
 }
 
 const MAX_ATTEMPT = 3
-const WHATSAPP_MAX_TEXT_LENGTH = 4096
-
-export function splitTextMessageIfNeeded(message: string): OutgoingMessage[] {
-  const textLength = message.length
-  if (textLength <= WHATSAPP_MAX_TEXT_LENGTH) {
-    return [new Text(message)]
-  }
-
-  const numChunks = Math.ceil(textLength / WHATSAPP_MAX_TEXT_LENGTH)
-  const chunks = Array.from({ length: numChunks }, (_, i) => {
-    const start = i * WHATSAPP_MAX_TEXT_LENGTH
-    const end = (i + 1) * WHATSAPP_MAX_TEXT_LENGTH
-    const chunk = new Text(message.slice(start, end))
-    return chunk
-  })
-
-  return chunks
-}
 
 async function _send({ client, ctx, conversation, logger, message, ack }: SendMessageProps) {
   if (!message) {

--- a/integrations/whatsapp/src/misc/split-text-message-if-needed.test.ts
+++ b/integrations/whatsapp/src/misc/split-text-message-if-needed.test.ts
@@ -1,38 +1,32 @@
 import { describe, it, expect } from 'vitest'
-import { Text } from 'whatsapp-api-js/messages'
 import { splitTextMessageIfNeeded } from './split-text-message'
 
 const WHATSAPP_MAX_TEXT_LENGTH = 4096
 
-function getTextContent(message: Text): string {
-  return (message as any).text || (message as any).body || ''
-}
-
 describe('splitTextMessageIfNeeded', () => {
   describe('Messages within limit', () => {
-    it('should return a single Text message for empty string', () => {
+    it('should return a single string for empty string', () => {
       const result = splitTextMessageIfNeeded('')
       expect(result).toHaveLength(1)
-      expect(result[0]).toBeInstanceOf(Text)
-      expect(getTextContent(result[0] as Text)).toBe('')
+      expect(result[0]).toBe('')
+      expect(typeof result[0]).toBe('string')
     })
 
-    it('should return a single Text message for short message', () => {
+    it('should return a single string for short message', () => {
       const message = 'Hello, world!'
       const result = splitTextMessageIfNeeded(message)
       expect(result).toHaveLength(1)
-      expect(result[0]).toBeInstanceOf(Text)
-      expect(getTextContent(result[0] as Text)).toBe(message)
+      expect(typeof result[0]).toBe('string')
+      expect(result[0]).toBe(message)
     })
 
-    it('should return a single Text message for message at exact limit', () => {
+    it('should return a single string for message at exact limit', () => {
       const message = 'a'.repeat(WHATSAPP_MAX_TEXT_LENGTH)
       const result = splitTextMessageIfNeeded(message)
       expect(result).toHaveLength(1)
-      expect(result[0]).toBeInstanceOf(Text)
-      const textContent = getTextContent(result[0] as Text)
-      expect(textContent).toBe(message)
-      expect(textContent.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(typeof result[0]).toBe('string')
+      expect(result[0]).toBe(message)
+      expect(result[0]!.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
     })
   })
 
@@ -41,40 +35,36 @@ describe('splitTextMessageIfNeeded', () => {
       const message = 'a'.repeat(WHATSAPP_MAX_TEXT_LENGTH + 1)
       const result = splitTextMessageIfNeeded(message)
       expect(result).toHaveLength(2)
-      expect(result[0]).toBeInstanceOf(Text)
-      expect(result[1]).toBeInstanceOf(Text)
-      const text0 = getTextContent(result[0] as Text)
-      const text1 = getTextContent(result[1] as Text)
-      expect(text0.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
-      expect(text1.length).toBe(1)
-      expect(text0 + text1).toBe(message)
+      expect(typeof result[0]).toBe('string')
+      expect(typeof result[1]).toBe('string')
+      expect(result[0]!.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(result[1]!.length).toBe(1)
+      expect(result[0]! + result[1]!).toBe(message)
     })
 
     it('should split message that is exactly double the limit', () => {
       const message = 'a'.repeat(WHATSAPP_MAX_TEXT_LENGTH * 2)
       const result = splitTextMessageIfNeeded(message)
       expect(result).toHaveLength(2)
-      expect(result[0]).toBeInstanceOf(Text)
-      expect(result[1]).toBeInstanceOf(Text)
-      const text0 = getTextContent(result[0] as Text)
-      const text1 = getTextContent(result[1] as Text)
-      expect(text0.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
-      expect(text1.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
-      expect(text0 + text1).toBe(message)
+      expect(typeof result[0]).toBe('string')
+      expect(typeof result[1]).toBe('string')
+      expect(result[0]!.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(result[1]!.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(result[0]! + result[1]!).toBe(message)
     })
 
     it('should split message that requires multiple chunks', () => {
       const message = 'a'.repeat(WHATSAPP_MAX_TEXT_LENGTH * 3 + 100)
       const result = splitTextMessageIfNeeded(message)
       expect(result).toHaveLength(4)
-      result.forEach((chunk) => {
-        expect(chunk).toBeInstanceOf(Text)
-      })
-      expect(getTextContent(result[0] as Text).length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
-      expect(getTextContent(result[1] as Text).length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
-      expect(getTextContent(result[2] as Text).length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
-      expect(getTextContent(result[3] as Text).length).toBe(100)
-      expect(result.map((chunk) => getTextContent(chunk as Text)).join('')).toBe(message)
+      for (const chunk of result) {
+        expect(typeof chunk).toBe('string')
+      }
+      expect(result[0]!.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(result[1]!.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(result[2]!.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(result[3]!.length).toBe(100)
+      expect(result.join('')).toBe(message)
     })
 
     it('should split large message correctly', () => {
@@ -82,11 +72,11 @@ describe('splitTextMessageIfNeeded', () => {
       const result = splitTextMessageIfNeeded(message)
       const expectedChunks = Math.ceil(10000 / WHATSAPP_MAX_TEXT_LENGTH)
       expect(result).toHaveLength(expectedChunks)
-      result.forEach((chunk) => {
-        expect(chunk).toBeInstanceOf(Text)
-        expect(getTextContent(chunk as Text).length).toBeLessThanOrEqual(WHATSAPP_MAX_TEXT_LENGTH)
-      })
-      expect(result.map((chunk) => getTextContent(chunk as Text)).join('')).toBe(message)
+      for (const chunk of result) {
+        expect(typeof chunk).toBe('string')
+        expect(chunk.length).toBeLessThanOrEqual(WHATSAPP_MAX_TEXT_LENGTH)
+      }
+      expect(result.join('')).toBe(message)
     })
   })
 
@@ -94,14 +84,14 @@ describe('splitTextMessageIfNeeded', () => {
     it('should preserve message content exactly when splitting', () => {
       const message = 'Hello, this is a test message! ' + 'x'.repeat(WHATSAPP_MAX_TEXT_LENGTH)
       const result = splitTextMessageIfNeeded(message)
-      const reconstructed = result.map((chunk) => getTextContent(chunk as Text)).join('')
+      const reconstructed = result.join('')
       expect(reconstructed).toBe(message)
     })
 
     it('should handle unicode characters correctly', () => {
       const message = 'Hello 世界 🌍 ' + 'é'.repeat(WHATSAPP_MAX_TEXT_LENGTH)
       const result = splitTextMessageIfNeeded(message)
-      const reconstructed = result.map((chunk) => getTextContent(chunk as Text)).join('')
+      const reconstructed = result.join('')
       expect(reconstructed).toBe(message)
     })
 
@@ -109,7 +99,7 @@ describe('splitTextMessageIfNeeded', () => {
       const baseMessage = 'Line 1\nLine 2\nLine 3\n' + 'Special: !@#$%^&*()'
       const message = baseMessage + 'x'.repeat(WHATSAPP_MAX_TEXT_LENGTH)
       const result = splitTextMessageIfNeeded(message)
-      const reconstructed = result.map((chunk) => getTextContent(chunk as Text)).join('')
+      const reconstructed = result.join('')
       expect(reconstructed).toBe(message)
     })
   })
@@ -119,36 +109,36 @@ describe('splitTextMessageIfNeeded', () => {
       const message = 'a'.repeat(WHATSAPP_MAX_TEXT_LENGTH - 1)
       const result = splitTextMessageIfNeeded(message)
       expect(result).toHaveLength(1)
-      expect(getTextContent(result[0] as Text).length).toBe(WHATSAPP_MAX_TEXT_LENGTH - 1)
+      expect(result[0]!.length).toBe(WHATSAPP_MAX_TEXT_LENGTH - 1)
     })
 
     it('should handle message that is exactly limit plus one', () => {
       const message = 'a'.repeat(WHATSAPP_MAX_TEXT_LENGTH + 1)
       const result = splitTextMessageIfNeeded(message)
       expect(result).toHaveLength(2)
-      expect(getTextContent(result[0] as Text).length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
-      expect(getTextContent(result[1] as Text).length).toBe(1)
+      expect(result[0]!.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(result[1]!.length).toBe(1)
     })
 
     it('should handle very large message (10x limit)', () => {
       const message = 'c'.repeat(WHATSAPP_MAX_TEXT_LENGTH * 10)
       const result = splitTextMessageIfNeeded(message)
       expect(result).toHaveLength(10)
-      result.forEach((chunk) => {
-        expect(chunk).toBeInstanceOf(Text)
-        expect(getTextContent(chunk as Text).length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
-      })
-      expect(result.map((chunk) => getTextContent(chunk as Text)).join('')).toBe(message)
+      for (const chunk of result) {
+        expect(typeof chunk).toBe('string')
+        expect(chunk.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      }
+      expect(result.join('')).toBe(message)
     })
 
     it('should handle message with exactly 2x limit plus one', () => {
       const message = 'd'.repeat(WHATSAPP_MAX_TEXT_LENGTH * 2 + 1)
       const result = splitTextMessageIfNeeded(message)
       expect(result).toHaveLength(3)
-      expect(getTextContent(result[0] as Text).length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
-      expect(getTextContent(result[1] as Text).length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
-      expect(getTextContent(result[2] as Text).length).toBe(1)
-      expect(result.map((chunk) => getTextContent(chunk as Text)).join('')).toBe(message)
+      expect(result[0]!.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(result[1]!.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(result[2]!.length).toBe(1)
+      expect(result.join('')).toBe(message)
     })
   })
 })

--- a/integrations/whatsapp/src/misc/split-text-message.ts
+++ b/integrations/whatsapp/src/misc/split-text-message.ts
@@ -1,0 +1,22 @@
+import { Text } from 'whatsapp-api-js/messages'
+
+const WHATSAPP_MAX_TEXT_LENGTH = 4096
+
+export type OutgoingTextMessage = Text
+
+export function splitTextMessageIfNeeded(message: string): OutgoingTextMessage[] {
+  const textLength = message.length
+  if (textLength <= WHATSAPP_MAX_TEXT_LENGTH) {
+    return [new Text(message)]
+  }
+
+  const numChunks = Math.ceil(textLength / WHATSAPP_MAX_TEXT_LENGTH)
+  const chunks = Array.from({ length: numChunks }, (_, i) => {
+    const start = i * WHATSAPP_MAX_TEXT_LENGTH
+    const end = (i + 1) * WHATSAPP_MAX_TEXT_LENGTH
+    const chunk = new Text(message.slice(start, end))
+    return chunk
+  })
+
+  return chunks
+}

--- a/integrations/whatsapp/src/misc/split-text-message.ts
+++ b/integrations/whatsapp/src/misc/split-text-message.ts
@@ -1,21 +1,16 @@
-import { Text } from 'whatsapp-api-js/messages'
-
 const WHATSAPP_MAX_TEXT_LENGTH = 4096
 
-export type OutgoingTextMessage = Text
-
-export function splitTextMessageIfNeeded(message: string): OutgoingTextMessage[] {
+export function splitTextMessageIfNeeded(message: string): string[] {
   const textLength = message.length
   if (textLength <= WHATSAPP_MAX_TEXT_LENGTH) {
-    return [new Text(message)]
+    return [message]
   }
 
   const numChunks = Math.ceil(textLength / WHATSAPP_MAX_TEXT_LENGTH)
   const chunks = Array.from({ length: numChunks }, (_, i) => {
     const start = i * WHATSAPP_MAX_TEXT_LENGTH
     const end = (i + 1) * WHATSAPP_MAX_TEXT_LENGTH
-    const chunk = new Text(message.slice(start, end))
-    return chunk
+    return message.slice(start, end)
   })
 
   return chunks

--- a/integrations/whatsapp/src/misc/splitTextMessageIfNeeded.test.ts
+++ b/integrations/whatsapp/src/misc/splitTextMessageIfNeeded.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest'
+import { Text } from 'whatsapp-api-js/messages'
+import { splitTextMessageIfNeeded } from '../channels/channel'
+
+const WHATSAPP_MAX_TEXT_LENGTH = 4096
+
+function getTextContent(message: Text): string {
+  return (message as any).text || (message as any).body || ''
+}
+
+describe('splitTextMessageIfNeeded', () => {
+  describe('Messages within limit', () => {
+    it('should return a single Text message for empty string', () => {
+      const result = splitTextMessageIfNeeded('')
+      expect(result).toHaveLength(1)
+      expect(result[0]).toBeInstanceOf(Text)
+      expect(getTextContent(result[0] as Text)).toBe('')
+    })
+
+    it('should return a single Text message for short message', () => {
+      const message = 'Hello, world!'
+      const result = splitTextMessageIfNeeded(message)
+      expect(result).toHaveLength(1)
+      expect(result[0]).toBeInstanceOf(Text)
+      expect(getTextContent(result[0] as Text)).toBe(message)
+    })
+
+    it('should return a single Text message for message at exact limit', () => {
+      const message = 'a'.repeat(WHATSAPP_MAX_TEXT_LENGTH)
+      const result = splitTextMessageIfNeeded(message)
+      expect(result).toHaveLength(1)
+      expect(result[0]).toBeInstanceOf(Text)
+      const textContent = getTextContent(result[0] as Text)
+      expect(textContent).toBe(message)
+      expect(textContent.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+    })
+  })
+
+  describe('Messages exceeding limit', () => {
+    it('should split message that is one character over limit', () => {
+      const message = 'a'.repeat(WHATSAPP_MAX_TEXT_LENGTH + 1)
+      const result = splitTextMessageIfNeeded(message)
+      expect(result).toHaveLength(2)
+      expect(result[0]).toBeInstanceOf(Text)
+      expect(result[1]).toBeInstanceOf(Text)
+      const text0 = getTextContent(result[0] as Text)
+      const text1 = getTextContent(result[1] as Text)
+      expect(text0.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(text1.length).toBe(1)
+      expect(text0 + text1).toBe(message)
+    })
+
+    it('should split message that is exactly double the limit', () => {
+      const message = 'a'.repeat(WHATSAPP_MAX_TEXT_LENGTH * 2)
+      const result = splitTextMessageIfNeeded(message)
+      expect(result).toHaveLength(2)
+      expect(result[0]).toBeInstanceOf(Text)
+      expect(result[1]).toBeInstanceOf(Text)
+      const text0 = getTextContent(result[0] as Text)
+      const text1 = getTextContent(result[1] as Text)
+      expect(text0.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(text1.length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(text0 + text1).toBe(message)
+    })
+
+    it('should split message that requires multiple chunks', () => {
+      const message = 'a'.repeat(WHATSAPP_MAX_TEXT_LENGTH * 3 + 100)
+      const result = splitTextMessageIfNeeded(message)
+      expect(result).toHaveLength(4)
+      result.forEach((chunk) => {
+        expect(chunk).toBeInstanceOf(Text)
+      })
+      expect(getTextContent(result[0] as Text).length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(getTextContent(result[1] as Text).length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(getTextContent(result[2] as Text).length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(getTextContent(result[3] as Text).length).toBe(100)
+      expect(result.map((chunk) => getTextContent(chunk as Text)).join('')).toBe(message)
+    })
+
+    it('should split large message correctly', () => {
+      const message = 'b'.repeat(10000)
+      const result = splitTextMessageIfNeeded(message)
+      const expectedChunks = Math.ceil(10000 / WHATSAPP_MAX_TEXT_LENGTH)
+      expect(result).toHaveLength(expectedChunks)
+      result.forEach((chunk) => {
+        expect(chunk).toBeInstanceOf(Text)
+        expect(getTextContent(chunk as Text).length).toBeLessThanOrEqual(WHATSAPP_MAX_TEXT_LENGTH)
+      })
+      expect(result.map((chunk) => getTextContent(chunk as Text)).join('')).toBe(message)
+    })
+  })
+
+  describe('Message content preservation', () => {
+    it('should preserve message content exactly when splitting', () => {
+      const message = 'Hello, this is a test message! ' + 'x'.repeat(WHATSAPP_MAX_TEXT_LENGTH)
+      const result = splitTextMessageIfNeeded(message)
+      const reconstructed = result.map((chunk) => getTextContent(chunk as Text)).join('')
+      expect(reconstructed).toBe(message)
+    })
+
+    it('should handle unicode characters correctly', () => {
+      const message = 'Hello 世界 🌍 ' + 'é'.repeat(WHATSAPP_MAX_TEXT_LENGTH)
+      const result = splitTextMessageIfNeeded(message)
+      const reconstructed = result.map((chunk) => getTextContent(chunk as Text)).join('')
+      expect(reconstructed).toBe(message)
+    })
+
+    it('should handle newlines and special characters', () => {
+      const baseMessage = 'Line 1\nLine 2\nLine 3\n' + 'Special: !@#$%^&*()'
+      const message = baseMessage + 'x'.repeat(WHATSAPP_MAX_TEXT_LENGTH)
+      const result = splitTextMessageIfNeeded(message)
+      const reconstructed = result.map((chunk) => getTextContent(chunk as Text)).join('')
+      expect(reconstructed).toBe(message)
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('should handle message that is exactly limit minus one', () => {
+      const message = 'a'.repeat(WHATSAPP_MAX_TEXT_LENGTH - 1)
+      const result = splitTextMessageIfNeeded(message)
+      expect(result).toHaveLength(1)
+      expect(getTextContent(result[0] as Text).length).toBe(WHATSAPP_MAX_TEXT_LENGTH - 1)
+    })
+
+    it('should handle message that is exactly limit plus one', () => {
+      const message = 'a'.repeat(WHATSAPP_MAX_TEXT_LENGTH + 1)
+      const result = splitTextMessageIfNeeded(message)
+      expect(result).toHaveLength(2)
+      expect(getTextContent(result[0] as Text).length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(getTextContent(result[1] as Text).length).toBe(1)
+    })
+
+    it('should handle very large message (10x limit)', () => {
+      const message = 'c'.repeat(WHATSAPP_MAX_TEXT_LENGTH * 10)
+      const result = splitTextMessageIfNeeded(message)
+      expect(result).toHaveLength(10)
+      result.forEach((chunk) => {
+        expect(chunk).toBeInstanceOf(Text)
+        expect(getTextContent(chunk as Text).length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      })
+      expect(result.map((chunk) => getTextContent(chunk as Text)).join('')).toBe(message)
+    })
+
+    it('should handle message with exactly 2x limit plus one', () => {
+      const message = 'd'.repeat(WHATSAPP_MAX_TEXT_LENGTH * 2 + 1)
+      const result = splitTextMessageIfNeeded(message)
+      expect(result).toHaveLength(3)
+      expect(getTextContent(result[0] as Text).length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(getTextContent(result[1] as Text).length).toBe(WHATSAPP_MAX_TEXT_LENGTH)
+      expect(getTextContent(result[2] as Text).length).toBe(1)
+      expect(result.map((chunk) => getTextContent(chunk as Text)).join('')).toBe(message)
+    })
+  })
+})

--- a/integrations/whatsapp/src/misc/splitTextMessageIfNeeded.test.ts
+++ b/integrations/whatsapp/src/misc/splitTextMessageIfNeeded.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { Text } from 'whatsapp-api-js/messages'
-import { splitTextMessageIfNeeded } from '../channels/channel'
+import { splitTextMessageIfNeeded } from './split-text-message'
 
 const WHATSAPP_MAX_TEXT_LENGTH = 4096
 


### PR DESCRIPTION
Resolves SH-194

Tested long bot replies in sandbox mode (>4096 chars) to verify splitting behavior.
Messages are split sequentially with no loss of content or coherence.

Root cause of the original failure was the new Text() constructor’s default validation rejecting payloads over 4096 chars handled this so long responses can pass through and be split correctly.