### PR TITLE
fix(cli,sdk): fix exported bot typings

### DIFF
--- a/packages/cli/src/code-generation/bot-implementation/bot-implementation.ts
+++ b/packages/cli/src/code-generation/bot-implementation/bot-implementation.ts
@@ -62,7 +62,7 @@ export class BotImplementationModule extends Module {
       '',
       'type AsyncFunction = (...args: any[]) => Promise<any>',
       '',
-      'export type BotHandlers = sdk.BotHandlers<TBot>',
+      'export type BotHandlers = sdk.InjectedBotHandlers<TBot>',
       '',
       'export type EventHandlers = Required<{',
       "  [K in keyof BotHandlers['eventHandlers']]: NonNullable<BotHandlers['eventHandlers'][K]>[number]",

--- a/packages/cli/src/code-generation/plugin-implementation/plugin-implementation.ts
+++ b/packages/cli/src/code-generation/plugin-implementation/plugin-implementation.ts
@@ -38,7 +38,7 @@ export class PluginImplementationModule extends Module {
       'type ValueOf<T> = T[keyof T]',
       'type AsyncFunction = (...args: any[]) => Promise<any>',
       '',
-      'export type PluginHandlers = sdk.PluginHandlers<TPlugin>',
+      'export type PluginHandlers = sdk.InjectedPluginHandlers<TPlugin>',
       '',
       'export type EventHandlers = Required<{',
       "  [K in keyof PluginHandlers['eventHandlers']]: NonNullable<PluginHandlers['eventHandlers'][K]>[number]",

--- a/packages/sdk/src/bot/server/types.ts
+++ b/packages/sdk/src/bot/server/types.ts
@@ -431,10 +431,7 @@ export type InjectedBotHandlers<TBot extends common.BaseBot> = {
   }
   workflowHandlers: {
     [TWorkflowUpdateType in WorkflowUpdateType]: {
-      [TWorkflowName in utils.StringKeys<TBot['workflows']>]?: {
-        handler: WorkflowHandlers<TBot>[TWorkflowName]
-        order: number
-      }[]
+      [TWorkflowName in utils.StringKeys<TBot['workflows']>]?: WorkflowHandlers<TBot>[TWorkflowName][]
     }
   }
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -44,7 +44,10 @@ export {
   BotImplementation as Bot,
   BotImplementationProps as BotProps,
   BotSpecificClient,
-  InjectedBotHandlers as BotHandlers,
+  // NOTE: BotHandlers is needed by the Studio, and InjectedBotHandlers is
+  //       needed for the code generation in the CLI
+  BotHandlers,
+  InjectedBotHandlers,
   TagDefinition as BotTagDefinition,
   StateType as BotStateType,
   StateDefinition as BotStateDefinition,
@@ -74,7 +77,8 @@ export {
   PluginImplementation as Plugin,
   PluginImplementationProps as PluginProps,
   PluginRuntimeProps,
-  InjectedPluginHandlers as PluginHandlers,
+  PluginHandlers,
+  InjectedPluginHandlers,
 } from './plugin'
 
 export * as version from './version-utils'


### PR DESCRIPTION
The CLI and Studio need different types: the CLI needs types as they will be consumed by developers (with injected props), and the Studio needs types without the injected props (the SDK does the injection itself)