### PR TITLE
chore(integrations/github): changed polluting log

### DIFF
--- a/integrations/github/src/handler.ts
+++ b/integrations/github/src/handler.ts
@@ -136,5 +136,6 @@ const _dispatchEvent = async (props: bp.HandlerProps) => {
     }
   }
 
-  console.warn('Unsupported github event', event)
+  const action = (event as any).action
+  console.debug('Unsupported github event:', action ? action : event)
 }

--- a/integrations/github/src/handler.ts
+++ b/integrations/github/src/handler.ts
@@ -137,5 +137,5 @@ const _dispatchEvent = async (props: bp.HandlerProps) => {
   }
 
   const action = (event as any).action
-  console.debug('Unsupported github event:', action ?? event)
+  props.logger.debug('Unsupported github event:', action ?? event)
 }

--- a/integrations/github/src/handler.ts
+++ b/integrations/github/src/handler.ts
@@ -136,6 +136,6 @@ const _dispatchEvent = async (props: bp.HandlerProps) => {
     }
   }
 
-  const action = (event as { action?: string }).action
+  const action = 'action' in event ? event.action : undefined
   props.logger.debug('Unsupported github event:', action ?? event)
 }

--- a/integrations/github/src/handler.ts
+++ b/integrations/github/src/handler.ts
@@ -137,5 +137,5 @@ const _dispatchEvent = async (props: bp.HandlerProps) => {
   }
 
   const action = (event as any).action
-  console.debug('Unsupported github event:', action ? action : event)
+  console.debug('Unsupported github event:', action ?? event)
 }

--- a/integrations/github/src/handler.ts
+++ b/integrations/github/src/handler.ts
@@ -136,6 +136,6 @@ const _dispatchEvent = async (props: bp.HandlerProps) => {
     }
   }
 
-  const action = (event as any).action
+  const action = (event as { action?: string }).action
   props.logger.debug('Unsupported github event:', action ?? event)
 }


### PR DESCRIPTION
Resolves SH-235

The log which contained the whole event payload now only contains the name of the event received, and the level is debug rather than warn.

The new log will look like this: `Unsupported github event: edited`