### PR TITLE
fix(integrations/messenger): Catch `typingIndicator` error + set clientSecret to undefined when not provided 

### DIFF
--- a/integrations/messenger/integration.definition.ts
+++ b/integrations/messenger/integration.definition.ts
@@ -36,7 +36,7 @@ const replyToCommentsSchema = z.object({
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '5.0.1',
+  version: '5.0.2',
   title: 'Messenger and Facebook',
   description:
     'Give your bot access to one of the world’s largest messaging platforms and manage your Facebook page content in one place.',

--- a/integrations/messenger/src/actions/typing-indicator.ts
+++ b/integrations/messenger/src/actions/typing-indicator.ts
@@ -14,7 +14,7 @@ export const stopTypingIndicator: bp.IntegrationProps['actions']['stopTypingIndi
 }
 
 const sendSenderActions = async ({
-  props: { client, ctx, input },
+  props: { client, ctx, input, logger },
   actions,
 }: {
   props: bp.ActionProps['startTypingIndicator'] | bp.ActionProps['stopTypingIndicator']
@@ -31,7 +31,10 @@ const sendSenderActions = async ({
   const messengerClient = await createAuthenticatedMessengerClient(client, ctx)
   const userMessengerId = getEndUserMessengerId(conversation)
   for (const action of actions) {
-    await messengerClient.sendSenderAction(userMessengerId, action)
+    await messengerClient.sendSenderAction(userMessengerId, action).catch((thrown) => {
+      const error = thrown instanceof Error ? thrown.message : String(thrown)
+      logger.forBot().debug(`Error sending sender action "${action}": ${error}`)
+    })
   }
   return {}
 }

--- a/integrations/messenger/src/misc/auth.ts
+++ b/integrations/messenger/src/misc/auth.ts
@@ -13,16 +13,17 @@ export async function getMessengerClientCredentials(
   ctx: bp.Context
 ): Promise<MessengerClientCredentials> {
   let credentials: MessengerClientCredentials
+  const clientSecret = getClientSecret(ctx)
   if (ctx.configurationType === 'manual') {
     credentials = {
       accessToken: ctx.configuration.accessToken,
-      clientSecret: ctx.configuration.clientSecret,
+      clientSecret,
       clientId: ctx.configuration.clientId,
     }
   } else if (ctx.configurationType === 'sandbox') {
     credentials = {
       accessToken: bp.secrets.SANDBOX_ACCESS_TOKEN,
-      clientSecret: bp.secrets.SANDBOX_CLIENT_SECRET,
+      clientSecret,
       clientId: bp.secrets.SANDBOX_CLIENT_ID,
     }
   } else {
@@ -38,7 +39,7 @@ export async function getMessengerClientCredentials(
 
     credentials = {
       accessToken: pageToken,
-      clientSecret: bp.secrets.CLIENT_SECRET,
+      clientSecret,
       clientId: bp.secrets.CLIENT_ID,
     }
   }


### PR DESCRIPTION
Resolves SH-228.

There are two errors from startTypingIndicator and stopTypingIndicator and they are:

**Messenger API - 551 OAuthException (#551) This person isn't available right now.**
This occurs when the user we are sending to has blocked the client's page or deactivated/deleted their account.

**Must provide appSecret when skipAppSecretProof is false**
This occurs when an app secret is not undefined (most likely empty string)

Decided to catch the error and log the error as well as use `getClientSecret` which converts the secret to undefined if it's an empty string.