### PR TITLE
style(integration/teams): rename variables and functions to match naming convention

### DIFF
--- a/integrations/teams/src/channels/outbound.ts
+++ b/integrations/teams/src/channels/outbound.ts
@@ -18,7 +18,7 @@ type Card = bp.channels.channel.card.Card
 type Action = Card['actions'][number]
 type ActionType = Action['action']
 
-const renderTeams = async (
+const _renderTeams = async (
   { ctx, ack, conversation, client, logger }: bp.AnyMessageProps,
   activity: Partial<Activity>
 ) => {
@@ -44,7 +44,7 @@ const renderTeams = async (
   })
 }
 
-const mapActionType = (action: ActionType): ActionTypes => {
+const _mapActionType = (action: ActionType): ActionTypes => {
   if (action === 'postback') {
     return ActionTypes.MessageBack
   }
@@ -57,15 +57,15 @@ const mapActionType = (action: ActionType): ActionTypes => {
   return ActionTypes.MessageBack
 }
 
-const mapAction = (action: Action): CardAction => ({
-  type: mapActionType(action.action),
+const _mapAction = (action: Action): CardAction => ({
+  type: _mapActionType(action.action),
   title: action.label,
   value: action.value,
   text: action.label,
   displayText: action.label,
 })
 
-const mapChoice = (choice: Alternative): CardAction => ({
+const _mapChoice = (choice: Alternative): CardAction => ({
   type: ActionTypes.MessageBack,
   title: choice.label,
   displayText: choice.label,
@@ -73,9 +73,9 @@ const mapChoice = (choice: Alternative): CardAction => ({
   text: choice.label,
 })
 
-const makeCard = (card: Card): Attachment => {
+const _makeCard = (card: Card): Attachment => {
   const { actions, imageUrl, subtitle, title } = card
-  const buttons: CardAction[] = actions.map(mapAction)
+  const buttons: CardAction[] = actions.map(_mapAction)
   const images = imageUrl ? [{ url: imageUrl }] : []
   return CardFactory.heroCard(title, images, buttons, { subtitle })
 }
@@ -84,7 +84,7 @@ const channel = {
   messages: {
     text: async (props) => {
       const activity: Partial<Activity> = { type: 'message', text: props.payload.text }
-      await renderTeams(props, activity)
+      await _renderTeams(props, activity)
     },
     image: async (props) => {
       const { imageUrl } = props.payload
@@ -92,7 +92,7 @@ const channel = {
         type: 'message',
         attachments: [CardFactory.heroCard('', [{ url: imageUrl }])],
       }
-      await renderTeams(props, activity)
+      await _renderTeams(props, activity)
     },
     markdown: async (props) => {
       const { markdown } = props.payload
@@ -109,7 +109,7 @@ const channel = {
           }),
         ],
       }
-      await renderTeams(props, activity)
+      await _renderTeams(props, activity)
     },
     audio: async (props) => {
       const { audioUrl } = props.payload
@@ -117,7 +117,7 @@ const channel = {
         type: 'message',
         attachments: [CardFactory.audioCard('', [{ url: audioUrl }])],
       }
-      await renderTeams(props, activity)
+      await _renderTeams(props, activity)
     },
     video: async (props) => {
       const { videoUrl } = props.payload
@@ -125,39 +125,39 @@ const channel = {
         type: 'message',
         attachments: [CardFactory.videoCard('', [{ url: videoUrl }])],
       }
-      await renderTeams(props, activity)
+      await _renderTeams(props, activity)
     },
     file: async (props) => {
       const { fileUrl } = props.payload
       const activity: Partial<Activity> = { type: 'message', text: fileUrl }
-      await renderTeams(props, activity)
+      await _renderTeams(props, activity)
     },
     location: async (props) => {
       const { latitude, longitude } = props.payload
       const googleMapsLink = `https://www.google.com/maps/search/?api=1&query=${latitude},${longitude}`
       const activity: Partial<Activity> = { type: 'message', text: googleMapsLink }
-      await renderTeams(props, activity)
+      await _renderTeams(props, activity)
     },
     carousel: async (props) => {
       const { items } = props.payload
-      const activity = MessageFactory.carousel(items.map(makeCard))
-      await renderTeams(props, activity)
+      const activity = MessageFactory.carousel(items.map(_makeCard))
+      await _renderTeams(props, activity)
     },
     card: async (props) => {
       const activity: Partial<Activity> = {
         type: 'message',
-        attachments: [makeCard(props.payload)],
+        attachments: [_makeCard(props.payload)],
       }
-      await renderTeams(props, activity)
+      await _renderTeams(props, activity)
     },
     choice: async (props) => {
       const { options, text } = props.payload
-      const buttons: CardAction[] = options.map(mapChoice)
+      const buttons: CardAction[] = options.map(_mapChoice)
       const activity: Partial<Activity> = {
         type: 'message',
         attachments: [CardFactory.heroCard(text, [], buttons)],
       }
-      await renderTeams(props, activity)
+      await _renderTeams(props, activity)
     },
     dropdown: async (props) => {
       // TODO: actually implement a dropdown and not a choice
@@ -167,12 +167,12 @@ const channel = {
       //           - patience to mess around with adaptive cards
 
       const { options, text } = props.payload
-      const buttons: CardAction[] = options.map(mapChoice)
+      const buttons: CardAction[] = options.map(_mapChoice)
       const activity: Partial<Activity> = {
         type: 'message',
         attachments: [CardFactory.heroCard(text, [], buttons)],
       }
-      await renderTeams(props, activity)
+      await _renderTeams(props, activity)
     },
     bloc: () => {
       throw new RuntimeError('Not implemented')

--- a/integrations/teams/src/webhooks/signature.ts
+++ b/integrations/teams/src/webhooks/signature.ts
@@ -6,7 +6,7 @@ const jwksClient = new JwksClient({
   jwksUri: 'https://login.botframework.com/v1/.well-known/keys',
 })
 
-const getKey = (header: JwtHeader, callback: SigningKeyCallback) => {
+const _getKey = (header: JwtHeader, callback: SigningKeyCallback) => {
   jwksClient.getSigningKey(header.kid, function (err, key) {
     if (key) {
       callback(null, key.getPublicKey())
@@ -27,7 +27,7 @@ export const authorizeRequest = async (req: Request) => {
   }
 
   return new Promise((resolve, reject) => {
-    jwt.verify(token, getKey, (err, decoded) => {
+    jwt.verify(token, _getKey, (err, decoded) => {
       if (err) {
         reject(err)
       } else {


### PR DESCRIPTION
In other integrations the standard is to add an underscore prefix to variables and functions that are not exported as well as private class members. This PR aligns the Teams integration with that convention.