### PR TITLE
feat(integrations/github): find target org

### DIFF
--- a/integrations/github/src/actions/index.ts
+++ b/integrations/github/src/actions/index.ts
@@ -1,5 +1,6 @@
-import { findTarget } from './find-target'
+import { findTarget, findIssuesOrPullRequests } from './find-target'
 
 export default {
   findTarget,
+  findIssuesOrPullRequests,
 }

--- a/integrations/github/src/definitions/actions.ts
+++ b/integrations/github/src/definitions/actions.ts
@@ -1,19 +1,19 @@
 import * as sdk from '@botpress/sdk'
 import { z } from '@botpress/sdk'
 
-const Channels = ['pullRequest', 'issue'] as const
+const channels = ['pullRequest', 'issue'] as const
 
 export type Target = {
   displayName: string
   tags: { [key: string]: string }
-  channel: (typeof Channels)[number]
+  channel: (typeof channels)[number]
 }
 
 const findTarget = {
   input: {
     schema: z.object({
       query: z.string().title('Query').describe('The search query'),
-      channel: z.enum(Channels).title('Channel').describe('The channel in which to execute the query'),
+      channel: z.enum(channels).title('Channel').describe('The channel in which to execute the query'),
       repo: z.string().title('Repository').describe('The repository name'),
       organization: z
         .string()
@@ -30,7 +30,7 @@ const findTarget = {
         z.object({
           displayName: z.string().title('Display Name').describe('The display name'),
           tags: z.record(z.string()).title('Tags').describe('The tags'),
-          channel: z.enum(Channels).title('Channel').describe('The channel'),
+          channel: z.enum(channels).title('Channel').describe('The channel'),
         })
       ),
     }),

--- a/integrations/github/src/definitions/actions.ts
+++ b/integrations/github/src/definitions/actions.ts
@@ -15,6 +15,13 @@ const findTarget = {
       query: z.string().title('Query').describe('The search query'),
       channel: z.enum(Channels).title('Channel').describe('The channel in which to execute the query'),
       repo: z.string().title('Repository').describe('The repository name'),
+      organization: z
+        .string()
+        .optional()
+        .title('Organization')
+        .describe(
+          'The organization that owns the repository. Leave empty if the repository is owned by the current user.'
+        ),
     }),
   },
   output: {

--- a/integrations/github/src/definitions/actions.ts
+++ b/integrations/github/src/definitions/actions.ts
@@ -37,6 +37,11 @@ const findTarget = {
   },
 }
 
+const findIssuesOrPullRequests = {
+  ...findTarget,
+}
+
 export const actions = {
-  findTarget,
+  findTarget: { ...findTarget, attributes: { ...sdk.WELL_KNOWN_ATTRIBUTES.HIDDEN_IN_STUDIO } },
+  findIssuesOrPullRequests,
 } satisfies sdk.IntegrationDefinitionProps['actions']

--- a/integrations/github/src/misc/action-wrapper.ts
+++ b/integrations/github/src/misc/action-wrapper.ts
@@ -19,14 +19,12 @@ const _wrapActionAndInjectTools = createActionWrapper<bp.IntegrationProps>()({
   toolFactories: {
     octokit: ({ ctx, client }) => GitHubClient.create({ ctx, client }),
     owner: async ({ ctx, client, input }) => {
-      console.log(input.organization)
       if (input.organization) {
         return input.organization
       }
       const user = await client.getUser({
         id: ctx.botUserId,
       })
-      console.log(user.user.name)
       if (!user.user.name) {
         throw new RuntimeError('No user or organization was provided. Cannot query the repository.')
       }

--- a/integrations/github/src/misc/action-wrapper.ts
+++ b/integrations/github/src/misc/action-wrapper.ts
@@ -1,7 +1,7 @@
+import { RuntimeError } from '@botpress/client'
 import { createActionWrapper } from '@botpress/common'
 import { wrapAsyncFnWithTryCatch } from './error-handling'
 import { GitHubClient } from './github-client'
-import { GithubSettings } from './github-settings'
 import * as bp from '.botpress'
 
 export const wrapActionAndInjectOctokit: typeof _wrapActionAndInjectTools = (meta, actionImpl) =>
@@ -18,7 +18,20 @@ export const wrapActionAndInjectOctokit: typeof _wrapActionAndInjectTools = (met
 const _wrapActionAndInjectTools = createActionWrapper<bp.IntegrationProps>()({
   toolFactories: {
     octokit: ({ ctx, client }) => GitHubClient.create({ ctx, client }),
-    owner: ({ ctx, client }) => GithubSettings.getOrganizationHandle({ ctx, client }),
+    owner: async ({ ctx, client, input }) => {
+      console.log(input.organization)
+      if (input.organization) {
+        return input.organization
+      }
+      const user = await client.getUser({
+        id: ctx.botUserId,
+      })
+      console.log(user.user.name)
+      if (!user.user.name) {
+        throw new RuntimeError('No user or organization was provided. Cannot query the repository.')
+      }
+      return user.user.name
+    },
   },
   extraMetadata: {} as {
     errorMessage: string


### PR DESCRIPTION
Resolves SQD-233
When calling the `findTarget` action, it is now possible to provide an organization parameter to specify in which organization the repo is. If omitted, it is assumed that the repo is directly on the user's profile.