### PR TITLE
fix(integrations/github): Added log for auth error

### DIFF
--- a/integrations/github/src/misc/github-client.ts
+++ b/integrations/github/src/misc/github-client.ts
@@ -43,7 +43,13 @@ export class GitHubClient {
 
   public async getAuthenticatedEntity() {
     if (!this._authenticatedEntity) {
-      this._authenticatedEntity = await this._getGithubAuthenticatedEntity()
+      try {
+        this._authenticatedEntity = await this._getGithubAuthenticatedEntity()
+      } catch (thrown) {
+        throw new sdk.RuntimeError(
+          `An error occured while trying to authenticate to GitHub${thrown instanceof Error ? `: ${thrown.message}` : '.'}`
+        )
+      }
     }
 
     return this._authenticatedEntity

--- a/integrations/github/src/misc/github-client.ts
+++ b/integrations/github/src/misc/github-client.ts
@@ -46,9 +46,8 @@ export class GitHubClient {
       try {
         this._authenticatedEntity = await this._getGithubAuthenticatedEntity()
       } catch (thrown) {
-        throw new sdk.RuntimeError(
-          `An error occured while trying to authenticate to GitHub${thrown instanceof Error ? `: ${thrown.message}` : '.'}`
-        )
+        const message = thrown instanceof Error ? `: ${thrown.message}` : ''
+        throw new sdk.RuntimeError(`An error occured while trying to authenticate to GitHub${message}.`)
       }
     }
 


### PR DESCRIPTION
If bad credentials are present in the integration config, there was no log indicating to the bot developer that his credentials were bad.