### PR TITLE
feat(common/posthog): add integration version

### DIFF
--- a/integrations/googlecalendar/integration.definition.ts
+++ b/integrations/googlecalendar/integration.definition.ts
@@ -2,10 +2,11 @@ import * as sdk from '@botpress/sdk'
 import { actions, entities, configuration, configurations, identifier, events, secrets, states } from './definitions'
 
 export const INTEGRATION_NAME = 'googlecalendar'
+export const INTEGRATION_VERSION = '2.0.2'
 
 export default new sdk.IntegrationDefinition({
-  name: 'googlecalendar',
-  version: '2.0.2',
+  name: INTEGRATION_NAME,
+  version: INTEGRATION_VERSION,
   description: 'Sync with your calendar to manage events, appointments, and schedules directly within the chatbot.',
   title: 'Google Calendar',
   readme: 'hub.md',

--- a/integrations/googlecalendar/integration.definition.ts
+++ b/integrations/googlecalendar/integration.definition.ts
@@ -2,7 +2,7 @@ import * as sdk from '@botpress/sdk'
 import { actions, entities, configuration, configurations, identifier, events, secrets, states } from './definitions'
 
 export const INTEGRATION_NAME = 'googlecalendar'
-export const INTEGRATION_VERSION = '2.0.2'
+export const INTEGRATION_VERSION = '2.0.3'
 
 export default new sdk.IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/googlecalendar/src/google-api/error-handling.ts
+++ b/integrations/googlecalendar/src/google-api/error-handling.ts
@@ -2,7 +2,7 @@ import { isApiError } from '@botpress/client'
 import { createAsyncFnWrapperWithErrorRedaction, createErrorHandlingDecorator, posthogHelper } from '@botpress/common'
 import * as sdk from '@botpress/sdk'
 import { Common as GoogleApisCommon } from 'googleapis'
-import { INTEGRATION_NAME } from 'integration.definition'
+import { INTEGRATION_NAME, INTEGRATION_VERSION } from 'integration.definition'
 import * as bp from '.botpress'
 
 export const wrapAsyncFnWithTryCatch = createAsyncFnWrapperWithErrorRedaction((error: Error, customMessage: string) => {
@@ -31,7 +31,11 @@ export const wrapAsyncFnWithTryCatch = createAsyncFnWrapperWithErrorRedaction((e
           errorReason: errorReason?.substring(0, 100),
         },
       },
-      { integrationName: INTEGRATION_NAME, key: (bp.secrets as any).POSTHOG_KEY as string }
+      {
+        integrationName: INTEGRATION_NAME,
+        integrationVersion: INTEGRATION_VERSION,
+        key: (bp.secrets as any).POSTHOG_KEY as string,
+      }
     )
     .catch(() => {
       // Silently fail if PostHog is unavailable

--- a/integrations/googlecalendar/src/index.ts
+++ b/integrations/googlecalendar/src/index.ts
@@ -1,6 +1,6 @@
 import { posthogHelper } from '@botpress/common'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
-import { INTEGRATION_NAME } from 'integration.definition'
+import { INTEGRATION_NAME, INTEGRATION_VERSION } from 'integration.definition'
 import { actions } from './actions'
 import { register, unregister } from './setup'
 import { handler } from './webhook-events'
@@ -8,6 +8,7 @@ import * as bp from '.botpress'
 
 @posthogHelper.wrapIntegration({
   integrationName: INTEGRATION_NAME,
+  integrationVersion: INTEGRATION_VERSION,
   key: (bp.secrets as any).POSTHOG_KEY as string,
 })
 class GoogleCalendarIntegration extends bp.Integration {

--- a/integrations/instagram/integration.definition.ts
+++ b/integrations/instagram/integration.definition.ts
@@ -5,6 +5,7 @@ import proactiveUser from 'bp_modules/proactive-user'
 import { dmChannelMessages } from './definitions/channel'
 
 export const INTEGRATION_NAME = 'instagram'
+export const INTEGRATION_VERSION = '4.1.2'
 
 const commonConfigSchema = z.object({
   replyToComments: z
@@ -16,7 +17,7 @@ const commonConfigSchema = z.object({
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '4.1.2',
+  version: INTEGRATION_VERSION,
   title: 'Instagram',
   description: 'Automate interactions, manage comments, and send/receive messages all in real-time.',
   icon: 'icon.svg',

--- a/integrations/instagram/integration.definition.ts
+++ b/integrations/instagram/integration.definition.ts
@@ -5,7 +5,7 @@ import proactiveUser from 'bp_modules/proactive-user'
 import { dmChannelMessages } from './definitions/channel'
 
 export const INTEGRATION_NAME = 'instagram'
-export const INTEGRATION_VERSION = '4.1.2'
+export const INTEGRATION_VERSION = '4.1.3'
 
 const commonConfigSchema = z.object({
   replyToComments: z

--- a/integrations/instagram/src/index.ts
+++ b/integrations/instagram/src/index.ts
@@ -1,5 +1,5 @@
 import { posthogHelper } from '@botpress/common'
-import { INTEGRATION_NAME } from 'integration.definition'
+import { INTEGRATION_NAME, INTEGRATION_VERSION } from 'integration.definition'
 import actions from './actions'
 import channels from './channels'
 import { register, unregister } from './setup'
@@ -8,6 +8,7 @@ import * as bp from '.botpress'
 
 @posthogHelper.wrapIntegration({
   integrationName: INTEGRATION_NAME,
+  integrationVersion: INTEGRATION_VERSION,
   key: bp.secrets.POSTHOG_KEY,
 })
 class InstagramIntegration extends bp.Integration {

--- a/integrations/messenger/integration.definition.ts
+++ b/integrations/messenger/integration.definition.ts
@@ -7,6 +7,7 @@ import typingIndicator from 'bp_modules/typing-indicator'
 import { messages } from './definitions/channels/channel/messages'
 
 export const INTEGRATION_NAME = 'messenger'
+export const INTEGRATION_VERSION = '5.0.2'
 
 const commonConfigSchema = z.object({
   downloadMedia: z
@@ -36,7 +37,7 @@ const replyToCommentsSchema = z.object({
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '5.0.2',
+  version: INTEGRATION_VERSION,
   title: 'Messenger and Facebook',
   description:
     'Give your bot access to one of the world’s largest messaging platforms and manage your Facebook page content in one place.',

--- a/integrations/messenger/integration.definition.ts
+++ b/integrations/messenger/integration.definition.ts
@@ -7,7 +7,7 @@ import typingIndicator from 'bp_modules/typing-indicator'
 import { messages } from './definitions/channels/channel/messages'
 
 export const INTEGRATION_NAME = 'messenger'
-export const INTEGRATION_VERSION = '5.0.2'
+export const INTEGRATION_VERSION = '5.0.3'
 
 const commonConfigSchema = z.object({
   downloadMedia: z

--- a/integrations/messenger/src/index.ts
+++ b/integrations/messenger/src/index.ts
@@ -1,5 +1,5 @@
 import { posthogHelper } from '@botpress/common'
-import { INTEGRATION_NAME } from 'integration.definition'
+import { INTEGRATION_NAME, INTEGRATION_VERSION } from 'integration.definition'
 import actions from './actions'
 import channels from './channels'
 import { register, unregister } from './setup'
@@ -8,6 +8,7 @@ import * as bp from '.botpress'
 
 @posthogHelper.wrapIntegration({
   integrationName: INTEGRATION_NAME,
+  integrationVersion: INTEGRATION_VERSION,
   key: bp.secrets.POSTHOG_KEY,
 })
 class MessengerIntegration extends bp.Integration {

--- a/integrations/twilio/integration.definition.ts
+++ b/integrations/twilio/integration.definition.ts
@@ -4,9 +4,10 @@ import proactiveConversation from 'bp_modules/proactive-conversation'
 import proactiveUser from 'bp_modules/proactive-user'
 
 export const INTEGRATION_NAME = 'twilio'
+export const INTEGRATION_VERSION = '1.0.2'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '1.0.2',
+  version: INTEGRATION_VERSION,
   title: 'Twilio',
   description: 'Send and receive messages, voice calls, emails, SMS, and more.',
   icon: 'icon.svg',

--- a/integrations/twilio/integration.definition.ts
+++ b/integrations/twilio/integration.definition.ts
@@ -4,7 +4,7 @@ import proactiveConversation from 'bp_modules/proactive-conversation'
 import proactiveUser from 'bp_modules/proactive-user'
 
 export const INTEGRATION_NAME = 'twilio'
-export const INTEGRATION_VERSION = '1.0.2'
+export const INTEGRATION_VERSION = '1.0.3'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,

--- a/integrations/twilio/src/index.ts
+++ b/integrations/twilio/src/index.ts
@@ -4,7 +4,7 @@ import * as sdk from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import axios from 'axios'
 import * as crypto from 'crypto'
-import { INTEGRATION_NAME } from 'integration.definition'
+import { INTEGRATION_NAME, INTEGRATION_VERSION } from 'integration.definition'
 import queryString from 'query-string'
 import { Twilio } from 'twilio'
 import { transformMarkdownForTwilio } from './markdown-to-twilio'
@@ -412,7 +412,7 @@ async function sendMessage({ ctx, conversation, ack, mediaUrl, text, logger }: S
           event: 'unhandled_markdown',
           properties: { errMsg },
         },
-        { integrationName: INTEGRATION_NAME, key: bp.secrets.POSTHOG_KEY }
+        { integrationName: INTEGRATION_NAME, integrationVersion: INTEGRATION_VERSION, key: bp.secrets.POSTHOG_KEY }
       )
     }
   }

--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -93,9 +93,10 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp'
+export const INTEGRATION_VERSION = '4.5.18'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '4.5.18',
+  version: INTEGRATION_VERSION,
   title: 'WhatsApp',
   description: 'Send and receive messages through WhatsApp.',
   icon: 'icon.svg',

--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -93,7 +93,7 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp'
-export const INTEGRATION_VERSION = '4.5.18'
+export const INTEGRATION_VERSION = '4.5.19'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,

--- a/integrations/whatsapp/src/actions/start-conversation.ts
+++ b/integrations/whatsapp/src/actions/start-conversation.ts
@@ -1,6 +1,6 @@
 import { isApiError } from '@botpress/client'
 import { posthogHelper } from '@botpress/common'
-import { INTEGRATION_NAME } from 'integration.definition'
+import { INTEGRATION_NAME, INTEGRATION_VERSION } from 'integration.definition'
 import { BodyComponent, BodyParameter, Language, Template } from 'whatsapp-api-js/messages'
 import { getDefaultBotPhoneNumberId, getAuthenticatedWhatsappClient } from '../auth'
 import { formatPhoneNumber } from '../misc/phone-number-to-whatsapp'
@@ -54,7 +54,7 @@ export const startConversation: bp.IntegrationProps['actions']['startConversatio
           phoneNumber: userPhone,
         },
       },
-      { integrationName: INTEGRATION_NAME, key: bp.secrets.POSTHOG_KEY }
+      { integrationName: INTEGRATION_NAME, integrationVersion: INTEGRATION_VERSION, key: bp.secrets.POSTHOG_KEY }
     )
     const errorMessage = (thrown instanceof Error ? thrown : new Error(String(thrown))).message
     logForBotAndThrow(`Failed to parse phone number "${userPhone}": ${errorMessage}`, logger)

--- a/integrations/whatsapp/src/channels/channel.ts
+++ b/integrations/whatsapp/src/channels/channel.ts
@@ -1,5 +1,5 @@
 import { posthogHelper } from '@botpress/common'
-import { INTEGRATION_NAME } from 'integration.definition'
+import { INTEGRATION_NAME, INTEGRATION_VERSION } from 'integration.definition'
 import {
   Text,
   Audio,
@@ -50,7 +50,7 @@ export const channel: bp.IntegrationProps['channels']['channel'] = {
               messageId: props.message.id,
             },
           },
-          { integrationName: INTEGRATION_NAME, key: bp.secrets.POSTHOG_KEY }
+          { integrationName: INTEGRATION_NAME, integrationVersion: INTEGRATION_VERSION, key: bp.secrets.POSTHOG_KEY }
         )
         props.logger.forBot().warn(`Message ${props.message.id} skipped: no message to send.`)
         return

--- a/integrations/whatsapp/src/index.ts
+++ b/integrations/whatsapp/src/index.ts
@@ -1,5 +1,5 @@
 import { posthogHelper } from '@botpress/common'
-import { INTEGRATION_NAME } from 'integration.definition'
+import { INTEGRATION_NAME, INTEGRATION_VERSION } from 'integration.definition'
 import actions from './actions'
 import channels from './channels'
 import { register, unregister } from './setup'
@@ -8,6 +8,7 @@ import * as bp from '.botpress'
 
 @posthogHelper.wrapIntegration({
   integrationName: INTEGRATION_NAME,
+  integrationVersion: INTEGRATION_VERSION,
   key: bp.secrets.POSTHOG_KEY,
 })
 class WhatsappIntegration extends bp.Integration {

--- a/integrations/whatsapp/src/webhook/handlers/messages.ts
+++ b/integrations/whatsapp/src/webhook/handlers/messages.ts
@@ -2,7 +2,7 @@ import { RuntimeError, isApiError } from '@botpress/client'
 import { posthogHelper } from '@botpress/common'
 import { ValueOf } from '@botpress/sdk/dist/utils/type-utils'
 import axios from 'axios'
-import { INTEGRATION_NAME } from 'integration.definition'
+import { INTEGRATION_NAME, INTEGRATION_VERSION } from 'integration.definition'
 import { getAccessToken, getAuthenticatedWhatsappClient } from '../../auth'
 import { formatPhoneNumber } from '../../misc/phone-number-to-whatsapp'
 import { WhatsAppMessage, WhatsAppMessageValue } from '../../misc/types'
@@ -53,7 +53,7 @@ async function _handleIncomingMessage(
           phoneNumber: message.from,
         },
       },
-      { integrationName: INTEGRATION_NAME, key: bp.secrets.POSTHOG_KEY }
+      { integrationName: INTEGRATION_NAME, integrationVersion: INTEGRATION_VERSION, key: bp.secrets.POSTHOG_KEY }
     )
     const errorMessage = thrown instanceof Error ? thrown.message : String(thrown)
     logger.error(`Failed to parse phone number "${message.from}": ${errorMessage}`)

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -11,7 +11,7 @@
     "dedent": "^1.6.0",
     "marked": "^15.0.1",
     "openai": "^6.9.0",
-    "posthog-node": "5.11.2",
+    "posthog-node": "5.14.1",
     "preact": "^10.26.6",
     "preact-render-to-string": "^6.5.13",
     "remark": "^15.0.1",

--- a/packages/common/src/posthog/helper.ts
+++ b/packages/common/src/posthog/helper.ts
@@ -11,10 +11,11 @@ export const COMMON_SECRET_NAMES = {
 type PostHogConfig = {
   key: string
   integrationName: string
+  integrationVersion: string
 }
 
 export const sendPosthogEvent = async (props: EventMessage, config: PostHogConfig): Promise<void> => {
-  const { key, integrationName } = config
+  const { key, integrationName, integrationVersion } = config
   const client = new PostHog(key, {
     host: 'https://us.i.posthog.com',
   })
@@ -24,6 +25,7 @@ export const sendPosthogEvent = async (props: EventMessage, config: PostHogConfi
       properties: {
         ...props.properties,
         integrationName,
+        integrationVersion,
       },
     }
     await client.captureImmediate(signedProps)
@@ -85,6 +87,7 @@ function wrapFunction(fn: Function, config: PostHogConfig) {
           properties: {
             from: fn.name,
             integrationName: config.integrationName,
+            integrationVersion: config.integrationVersion,
             errMsg,
           },
         },
@@ -109,6 +112,7 @@ function wrapHandler(fn: Function, config: PostHogConfig) {
             properties: {
               from: fn.name,
               integrationName: config.integrationName,
+              integrationVersion: config.integrationVersion,
               errMsg: 'Empty Body',
             },
           },
@@ -123,6 +127,7 @@ function wrapHandler(fn: Function, config: PostHogConfig) {
           properties: {
             from: fn.name,
             integrationName: config.integrationName,
+            integrationVersion: config.integrationVersion,
             errMsg: JSON.stringify(resp.body),
           },
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2633,8 +2633,8 @@ importers:
         specifier: ^6.9.0
         version: 6.9.0(ws@8.18.2)
       posthog-node:
-        specifier: 5.11.2
-        version: 5.11.2
+        specifier: 5.14.1
+        version: 5.14.1
       preact:
         specifier: ^10.26.6
         version: 10.26.6
@@ -4991,8 +4991,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@posthog/core@1.5.2':
-    resolution: {integrity: sha512-iedUP3EnOPPxTA2VaIrsrd29lSZnUV+ZrMnvY56timRVeZAXoYCkmjfIs3KBAsF8OUT5h1GXLSkoQdrV0r31OQ==}
+  '@posthog/core@1.6.0':
+    resolution: {integrity: sha512-Tbh8UACwbb7jFdDC7wwXHtfNzO+4wKh3VbyMHmp2UBe6w1jliJixexTJNfkqdGZm+ht3M10mcKvGGPnoZ2zLBg==}
 
   '@react-email/body@0.0.10':
     resolution: {integrity: sha512-dMJyL9aU25ieatdPtVjCyQ/WHZYHwNc+Hy/XpF8Cc18gu21cUynVEeYQzFSeigDRMeBQ3PGAyjVDPIob7YlGwA==}
@@ -9834,8 +9834,8 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
-  posthog-node@5.11.2:
-    resolution: {integrity: sha512-z+XekcBUmGePMsjPlGaEF2bJFiDHKHYPQjS4OEw4YPDQz8s7Owuim/L7xNX+6UJkyIRniBza9iC7bW8yrGTv1g==}
+  posthog-node@5.14.1:
+    resolution: {integrity: sha512-NbqZMCwHectzfeFOeLqes1fPg/V5bsKhrBfyH1qHEcDb4ZHcbDARcqLE6JDhwMDQKa4YHkInXHITYscMuPylFw==}
     engines: {node: '>=20'}
 
   preact-render-to-string@6.5.13:
@@ -14002,7 +14002,7 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@posthog/core@1.5.2':
+  '@posthog/core@1.6.0':
     dependencies:
       cross-spawn: 7.0.6
 
@@ -20161,9 +20161,9 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
-  posthog-node@5.11.2:
+  posthog-node@5.14.1:
     dependencies:
-      '@posthog/core': 1.5.2
+      '@posthog/core': 1.6.0
 
   preact-render-to-string@6.5.13(preact@10.26.6):
     dependencies:


### PR DESCRIPTION
This PR adds the integration version as a property to all PostHog events. This allows us to segment analytics by version and better understand the distribution of integration versions currently in use.

By adding the version directly to the event payload, we can:
	•	Filter events by integration version in PostHog.
	•	Create funnels and dashboards to track version adoption.
	•	Identify old or abandoned integration instances that continue emitting errors.
	•	Support future cleanup or deprecation efforts.