### PR TITLE
refactor(integration/teams): remove bloc channel override

### DIFF
--- a/integrations/teams/definitions/channels.ts
+++ b/integrations/teams/definitions/channels.ts
@@ -1,30 +1,10 @@
-import { IntegrationDefinitionProps, messages, z } from '@botpress/sdk'
-
-// Remove the override once we remove the "markdown" message type from bloc items default in the sdk
-const _blocSchema = z.union([
-  z.object({ type: z.literal('text'), payload: messages.defaults.text.schema }),
-  z.object({ type: z.literal('image'), payload: messages.defaults.image.schema }),
-  z.object({ type: z.literal('audio'), payload: messages.defaults.audio.schema }),
-  z.object({ type: z.literal('video'), payload: messages.defaults.video.schema }),
-  z.object({ type: z.literal('file'), payload: messages.defaults.file.schema }),
-  z.object({ type: z.literal('location'), payload: messages.defaults.location.schema }),
-])
-
-const _blocMessageDefinition = {
-  ...messages.defaults.bloc,
-  schema: z.object({
-    items: z.array(_blocSchema),
-  }),
-}
+import { IntegrationDefinitionProps, messages } from '@botpress/sdk'
 
 export const channels = {
   channel: {
     title: 'Channel',
     description: 'Teams conversation channel',
-    messages: {
-      ...messages.defaults,
-      bloc: _blocMessageDefinition,
-    },
+    messages: messages.defaults,
     message: {
       tags: {
         id: {


### PR DESCRIPTION
removed bloc channel override since "markdown" was removed from the sdk default bloc items