### PR TITLE
now checking if channel is threads

### DIFF
--- a/bots/bugbuster/src/handlers/message-created.ts
+++ b/bots/bugbuster/src/handlers/message-created.ts
@@ -18,7 +18,10 @@ export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
     props.logger.info(`Ignoring message from ${conversation.integration}`)
     return
   }
-  if (conversation.integration === 'slack' && conversation.channel === 'channel') {
+  if (
+    conversation.integration === 'slack' &&
+    (conversation.channel === 'channel' || conversation.channel === 'thread')
+  ) {
     return
   }
 


### PR DESCRIPTION
BugBuster was replying in reply threads because I didn't notice reply threads were a separate channel from Slack channels.