### PR TITLE
chore(bots/bugbuster): simplified recently linted logic

### DIFF
--- a/bots/bugbuster/bot.definition.ts
+++ b/bots/bugbuster/bot.definition.ts
@@ -7,20 +7,6 @@ import telegram from './bp_modules/telegram'
 
 export default new sdk.BotDefinition({
   states: {
-    recentlyLinted: {
-      type: 'bot',
-      schema: sdk.z.object({
-        issues: sdk.z
-          .array(
-            sdk.z.object({
-              id: sdk.z.string(),
-              lintedAt: sdk.z.string().datetime(),
-            })
-          )
-          .title('Recently Linted Issues')
-          .describe('List of recently linted issues'),
-      }),
-    },
     watchedTeams: {
       type: 'bot',
       schema: sdk.z.object({

--- a/bots/bugbuster/src/bootstrap.ts
+++ b/bots/bugbuster/src/bootstrap.ts
@@ -10,7 +10,7 @@ export const bootstrap = (props: types.CommonHandlerProps) => {
 
   const linear = utils.linear.LinearApi.create()
   const teamsManager = new TeamsManager(linear, client, ctx.botId)
-  const recentlyLintedManager = new RecentlyLintedManager(client, ctx.botId)
+  const recentlyLintedManager = new RecentlyLintedManager(linear)
   const issueProcessor = new IssueProcessor(logger, linear, teamsManager)
 
   return {

--- a/bots/bugbuster/src/handlers/linear-issue-updated.ts
+++ b/bots/bugbuster/src/handlers/linear-issue-updated.ts
@@ -17,14 +17,9 @@ export const handleLinearIssueUpdated: bp.EventHandlers['linear:issueUpdated'] =
     return
   }
 
-  const recentlyLinted = await recentlyLintedManager
-    .getRecentlyLinted()
+  const isRecentlyLinted = await recentlyLintedManager
+    .isRecentlyLinted(issue)
     .catch(_handleError('trying to get recently linted issues'))
 
-  const isRecentlyLinted = recentlyLinted.some(({ id: issueId }) => issue.id === issueId)
-
   await issueProcessor.lintIssue(issue, isRecentlyLinted).catch(_handleError('trying to lint the updated Linear issue'))
-  await recentlyLintedManager
-    .setRecentlyLinted([...recentlyLinted, { id: issue.id, lintedAt: new Date().toISOString() }])
-    .catch(_handleError('trying to update recently linted issues'))
 }

--- a/bots/bugbuster/src/services/issue-processor/index.ts
+++ b/bots/bugbuster/src/services/issue-processor/index.ts
@@ -56,7 +56,7 @@ export class IssueProcessor {
       return { identifier: issue.identifier, result: 'ignored' }
     }
 
-    const errors = await lintIssue(issue, status)
+    const errors = lintIssue(issue, status)
 
     if (errors.length === 0) {
       this._logger.info(`Issue ${issue.identifier} passed all lint checks.`)

--- a/bots/bugbuster/src/services/issue-processor/lint-issue.ts
+++ b/bots/bugbuster/src/services/issue-processor/lint-issue.ts
@@ -5,7 +5,7 @@ export type IssueLint = {
   message: string
 }
 
-export const lintIssue = async (issue: lin.Issue, status: lin.StateKey): Promise<IssueLint[]> => {
+export const lintIssue = (issue: lin.Issue, status: lin.StateKey): IssueLint[] => {
   const lints: string[] = []
 
   if (!_hasLabelOfCategory(issue, 'type')) {
@@ -57,7 +57,7 @@ export const lintIssue = async (issue: lin.Issue, status: lin.StateKey): Promise
     )
   }
 
-  const issueProject = await issue.project
+  const issueProject = issue.project
   if (issueProject && issueProject.completedAt) {
     lints.push(
       `Issue ${issue.identifier} is associated with a completed project (${issueProject.name}). Consider removing the project association.`

--- a/bots/bugbuster/src/services/recently-linted-manager.ts
+++ b/bots/bugbuster/src/services/recently-linted-manager.ts
@@ -1,42 +1,21 @@
-import * as bp from '.botpress'
+import * as lin from '../utils/linear-utils'
 
 const RECENT_THRESHOLD: number = 1000 * 60 * 10 // 10 minutes
-type IssueLintEntry = bp.states.recentlyLinted.RecentlyLinted['payload']['issues'][number]
 
 export class RecentlyLintedManager {
-  public constructor(
-    private _client: bp.Client,
-    private _botId: string
-  ) {}
+  public constructor(private _linear: lin.LinearApi) {}
 
-  public async getRecentlyLinted(): Promise<bp.states.recentlyLinted.RecentlyLinted['payload']['issues']> {
-    const {
-      state: {
-        payload: { issues },
-      },
-    } = await this._client.getOrSetState({
-      id: this._botId,
-      type: 'bot',
-      name: 'recentlyLinted',
-      payload: { issues: [] },
-    })
-    return issues.filter(this._isRecentlyLinted)
-  }
-
-  public async setRecentlyLinted(issues: bp.states.recentlyLinted.RecentlyLinted['payload']['issues']): Promise<void> {
-    await this._client.setState({
-      id: this._botId,
-      type: 'bot',
-      name: 'recentlyLinted',
-      payload: {
-        issues: issues.filter(this._isRecentlyLinted),
-      },
-    })
-  }
-
-  private _isRecentlyLinted = (issue: IssueLintEntry): boolean => {
-    const lintedAt = new Date(issue.lintedAt).getTime()
+  public async isRecentlyLinted(issue: lin.Issue): Promise<boolean> {
+    const user = await this._linear.getMe()
+    const timestamps = issue.comments.nodes
+      .filter((comment) => comment.user.id === user.id)
+      .map((comment) => new Date(comment.createdAt).getTime())
     const now = new Date().getTime()
-    return now - lintedAt < RECENT_THRESHOLD
+    for (const timestamp of timestamps) {
+      if (now - timestamp < RECENT_THRESHOLD) {
+        return true
+      }
+    }
+    return false
   }
 }

--- a/bots/bugbuster/src/services/recently-linted-manager.ts
+++ b/bots/bugbuster/src/services/recently-linted-manager.ts
@@ -6,9 +6,9 @@ export class RecentlyLintedManager {
   public constructor(private _linear: lin.LinearApi) {}
 
   public async isRecentlyLinted(issue: lin.Issue): Promise<boolean> {
-    const user = await this._linear.getMe()
+    const me = await this._linear.getMe()
     const timestamps = issue.comments.nodes
-      .filter((comment) => comment.user.id === user.id)
+      .filter((comment) => comment.user.id === me.id)
       .map((comment) => new Date(comment.createdAt).getTime())
     const now = new Date().getTime()
     for (const timestamp of timestamps) {

--- a/bots/bugbuster/src/utils/linear-utils/client.ts
+++ b/bots/bugbuster/src/utils/linear-utils/client.ts
@@ -40,6 +40,9 @@ export class LinearApi {
   }
 
   public async getMe(): Promise<lin.User> {
+    if (this._viewer) {
+      return this._viewer
+    }
     const me = await this._client.viewer
     if (!me) {
       throw new Error('Viewer not found. Please ensure you are authenticated.')

--- a/bots/bugbuster/src/utils/linear-utils/graphql-queries.ts
+++ b/bots/bugbuster/src/utils/linear-utils/graphql-queries.ts
@@ -41,6 +41,7 @@ export type Issue = {
     nodes: {
       id: string
       resolvedAt: string | null
+      createdAt: string
       user: {
         id: string
       }
@@ -95,7 +96,9 @@ export const GRAPHQL_QUERIES = {
                 user {
                   id
                 },
-                parentId
+                parentId,
+                resolvedAt,
+                createdAt
               }
             }
           }


### PR DESCRIPTION
The logic that determines whether an issue has been linted recently has been simplified. Instead of keeping the recently linted issues in a state, we just check whether our user commented the issue recently. If we find a recent comment, we assume it has been linted recently. This will hopefully fix a bug where we linted and commented the issue twice in a row when Linear sends two `issueUpdated` events at almost the same time.

Other changes:
- The `resolvedAt` field hsa been added to a graphQL query because I forgot to add it for a previous feature. This improves performance when linting an issue that has already been commented by BugBuster.
- Removed `async` from a function signature because it didn't make any async calls.
- The Linear user is now only fetched once instead of for every lint in the `lintAll` workflow. This dramatically improves performance.