### PR TITLE
fix(integration/notion): Catching unhandled errors when getting oauth state

### DIFF
--- a/integrations/notion/src/notion-api/notion-oauth-client.ts
+++ b/integrations/notion/src/notion-api/notion-oauth-client.ts
@@ -16,7 +16,6 @@ export class NotionOAuthClient {
     this._notion = new NotionHQClient({})
   }
 
-  @handleErrors('Failed to get access token. Please reconfigure the integration.')
   public async getNewAccessToken() {
     const { authToken } = await this._getAuthState()
 

--- a/integrations/notion/src/setup.ts
+++ b/integrations/notion/src/setup.ts
@@ -3,11 +3,13 @@ import { NotionClient } from './notion-api'
 import * as bp from '.botpress'
 
 export const register: bp.IntegrationProps['register'] = async (props) => {
-  const notionClient = await NotionClient.create(props)
-  await notionClient.testAuthentication().catch((thrown) => {
+  try {
+    const notionClient = await NotionClient.create(props)
+    await notionClient.testAuthentication()
+  } catch (thrown) {
     const error = thrown instanceof Error ? thrown : new Error(String(thrown))
-    throw new RuntimeError(`Failed to test authentication: ${error.message}`)
-  })
+    throw new RuntimeError(`Registering Notion integration failed: ${error.message}`)
+  }
 }
 
 export const unregister: bp.IntegrationProps['unregister'] = async (props) => {

--- a/integrations/notion/src/webhook-events/handler-dispatcher.ts
+++ b/integrations/notion/src/webhook-events/handler-dispatcher.ts
@@ -25,7 +25,7 @@ export const handler: bp.IntegrationProps['handler'] = async (props) => {
   } catch (thrown) {
     const error = thrown instanceof Error ? thrown : new Error(String(thrown))
     props.logger.forBot().error(`Handling webhook event failed: ${error.message}`)
-    return { status: 200 } // We return 200 to avoid retries
+    return { status: 200 }
   }
 
   props.logger.forBot().info('Unsupported webhook event received')

--- a/integrations/notion/src/webhook-events/handler-dispatcher.ts
+++ b/integrations/notion/src/webhook-events/handler-dispatcher.ts
@@ -11,18 +11,24 @@ export const handler: bp.IntegrationProps['handler'] = async (props) => {
   }
 
   _validatePayloadSignature(props)
-
-  if (handlers.isDatabaseDeletedEvent(props)) {
-    return await handlers.handleDatabaseDeletedEvent(props)
-  } else if (handlers.isPageCreatedEvent(props)) {
-    return await handlers.handlePageCreatedEvent(props)
-  } else if (handlers.isPageDeletedEvent(props)) {
-    return await handlers.handlePageDeletedEvent(props)
-  } else if (handlers.isPageMovedEvent(props)) {
-    return await handlers.handlePageMovedEvent(props)
+  
+  try {
+    if (handlers.isDatabaseDeletedEvent(props)) {
+      return await handlers.handleDatabaseDeletedEvent(props)
+    } else if (handlers.isPageCreatedEvent(props)) {
+      return await handlers.handlePageCreatedEvent(props)
+    } else if (handlers.isPageDeletedEvent(props)) {
+      return await handlers.handlePageDeletedEvent(props)
+    } else if (handlers.isPageMovedEvent(props)) {
+      return await handlers.handlePageMovedEvent(props)
+    }
+  } catch (thrown) {
+    const error = thrown instanceof Error ? thrown : new Error(String(thrown))
+    props.logger.forBot().error(`Handling webhook event failed: ${error.message}`)
   }
 
-  throw new sdk.RuntimeError('Unsupported webhook event')
+  props.logger.forBot().error('Unsupported webhook event')
+  return { status: 200 } // We return 200 to avoid retries
 }
 
 const _validatePayloadSignature = (props: bp.HandlerProps) => {

--- a/integrations/notion/src/webhook-events/handler-dispatcher.ts
+++ b/integrations/notion/src/webhook-events/handler-dispatcher.ts
@@ -11,7 +11,7 @@ export const handler: bp.IntegrationProps['handler'] = async (props) => {
   }
 
   _validatePayloadSignature(props)
-  
+
   try {
     if (handlers.isDatabaseDeletedEvent(props)) {
       return await handlers.handleDatabaseDeletedEvent(props)

--- a/integrations/notion/src/webhook-events/handler-dispatcher.ts
+++ b/integrations/notion/src/webhook-events/handler-dispatcher.ts
@@ -25,10 +25,11 @@ export const handler: bp.IntegrationProps['handler'] = async (props) => {
   } catch (thrown) {
     const error = thrown instanceof Error ? thrown : new Error(String(thrown))
     props.logger.forBot().error(`Handling webhook event failed: ${error.message}`)
+    return { status: 200 } // We return 200 to avoid retries
   }
 
   props.logger.forBot().error('Unsupported webhook event')
-  return { status: 200 } // We return 200 to avoid retries
+  return { status: 200 }
 }
 
 const _validatePayloadSignature = (props: bp.HandlerProps) => {

--- a/integrations/notion/src/webhook-events/handler-dispatcher.ts
+++ b/integrations/notion/src/webhook-events/handler-dispatcher.ts
@@ -28,7 +28,7 @@ export const handler: bp.IntegrationProps['handler'] = async (props) => {
     return { status: 200 } // We return 200 to avoid retries
   }
 
-  props.logger.forBot().error('Unsupported webhook event')
+  props.logger.forBot().info('Unsupported webhook event received')
   return { status: 200 }
 }
 


### PR DESCRIPTION
Resolves SH-248.

Even though the error was decorated with a try/catch, it was still throwing an error using `sdk.RuntimeError` which didn't make sense. Implemented a high-level try/catch instead and log the issue since it's inside the handler.

This resolves the issue above.