### PR TITLE
chore(bots/bugbuster): Refactored the messageCreated event handler

### DIFF
--- a/bots/bugbuster/src/bootstrap.ts
+++ b/bots/bugbuster/src/bootstrap.ts
@@ -15,7 +15,7 @@ export const bootstrap = (props: types.CommonHandlerProps) => {
   const recentlyLintedManager = new RecentlyLintedManager(linear)
   const issueProcessor = new IssueProcessor(logger, linear, teamsManager)
   const issueStateChecker = new IssueStateChecker(linear, logger)
-  const commandProcessor = new CommandProcessor(linear, client, logger, botpress, teamsManager, ctx.botId)
+  const commandProcessor = new CommandProcessor(client, teamsManager, ctx.botId)
 
   return {
     botpress,

--- a/bots/bugbuster/src/bootstrap.ts
+++ b/bots/bugbuster/src/bootstrap.ts
@@ -1,3 +1,4 @@
+import { CommandProcessor } from './services/command-processor'
 import { IssueProcessor } from './services/issue-processor'
 import { IssueStateChecker } from './services/issue-state-checker'
 import { RecentlyLintedManager } from './services/recently-linted-manager'
@@ -14,6 +15,7 @@ export const bootstrap = (props: types.CommonHandlerProps) => {
   const recentlyLintedManager = new RecentlyLintedManager(linear)
   const issueProcessor = new IssueProcessor(logger, linear, teamsManager)
   const issueStateChecker = new IssueStateChecker(linear, logger)
+  const commandProcessor = new CommandProcessor(linear, client, logger, botpress, teamsManager, ctx.botId)
 
   return {
     botpress,
@@ -22,5 +24,6 @@ export const bootstrap = (props: types.CommonHandlerProps) => {
     recentlyLintedManager,
     issueProcessor,
     issueStateChecker,
+    commandProcessor,
   }
 }

--- a/bots/bugbuster/src/handlers/message-created.ts
+++ b/bots/bugbuster/src/handlers/message-created.ts
@@ -61,15 +61,6 @@ export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
   }
 }
 
-const _buildNotifChannelsMessage = (channels: { name: string; teams: string[] }[]) => {
-  return `The Slack notification channels are:\n${channels.map(_getMessageForChannel).join('\n')}`
-}
-
-const _getMessageForChannel = (channel: { name: string; teams: string[] }) => {
-  const { name, teams } = channel
-  return `- channel ${name} for team(s) ${teams.join(', ')}`
-}
-
 const _buildListCommandsMessage = (definitions: CommandDefinition[]) => {
   const commands = definitions.map((def) => `${def.name} ${def.argNames ?? ''}`).join('\n')
   return `Unknown command. Here's a list of possible commands:\n${commands}`

--- a/bots/bugbuster/src/handlers/message-created.ts
+++ b/bots/bugbuster/src/handlers/message-created.ts
@@ -42,10 +42,10 @@ export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
     return
   }
 
-  if (args.length < commandDefinition.requiredArgsCount) {
+  if (commandDefinition.requiredArgs && args.length < commandDefinition.requiredArgs?.length) {
     await botpress.respondText(
       conversation.id,
-      `Error: a minimum of ${commandDefinition.requiredArgsCount} argument(s) is required.`
+      `Error: a minimum of ${commandDefinition.requiredArgs.length} argument(s) is required.`
     )
     return
   }
@@ -62,6 +62,13 @@ export const handleMessageCreated: bp.MessageHandlers['*'] = async (props) => {
 }
 
 const _buildListCommandsMessage = (definitions: CommandDefinition[]) => {
-  const commands = definitions.map((def) => `${def.name} ${def.argNames ?? ''}`).join('\n')
+  const commands = definitions.map(_buildCommandMessage).join('\n')
   return `Unknown command. Here's a list of possible commands:\n${commands}`
+}
+
+const _buildCommandMessage = (definition: CommandDefinition) => {
+  const requiredArgs = definition.requiredArgs?.map((arg) => `<${arg}>`).join(' ')
+  const optionalArgs = definition.optionalArgs?.map((arg) => `[${arg}]`).join(' ')
+
+  return `${definition.name} ${requiredArgs ?? ''} ${optionalArgs ?? ''}`
 }

--- a/bots/bugbuster/src/services/command-processor.ts
+++ b/bots/bugbuster/src/services/command-processor.ts
@@ -1,0 +1,141 @@
+import * as sdk from '@botpress/sdk'
+import { BotpressApi } from 'src/utils/botpress-utils'
+import * as types from '../types'
+import * as lin from '../utils/linear-utils'
+import { TeamsManager } from './teams-manager'
+import { Client } from '.botpress'
+
+const MISSING_ARGS_ERROR = 'More arguments are required with this command.'
+
+export class CommandProcessor {
+  public constructor(
+    private _linear: lin.LinearApi,
+    private _client: Client,
+    private _logger: sdk.BotLogger,
+    private _botpress: BotpressApi,
+    private _teamsManager: TeamsManager,
+    private _botId: string
+  ) {}
+
+  public listTeams: types.CommandImplementation = async (): Promise<types.CommandResult> => {
+    const teams = await this._teamsManager.listWatchedTeams()
+    return { success: true, message: teams.join(', ') }
+  }
+
+  public addTeam: types.CommandImplementation = async (args: string[]): Promise<types.CommandResult> => {
+    if (!args[0]) {
+      return { success: false, message: MISSING_ARGS_ERROR }
+    }
+
+    await this._teamsManager.addWatchedTeam(args[0])
+
+    return {
+      success: true,
+      message: `Success: the team with the key '${args[0]}' has been added to the watched team list.`,
+    }
+  }
+
+  public removeTeam: types.CommandImplementation = async (args: string[]): Promise<types.CommandResult> => {
+    if (!args[0]) {
+      return { success: false, message: MISSING_ARGS_ERROR }
+    }
+
+    await this._teamsManager.removeWatchedTeam(args[0])
+
+    return {
+      success: true,
+      message: `Success: the team with the key '${args[0]}' has been removed from the watched team list.`,
+    }
+  }
+
+  public lintAll: types.CommandImplementation = async (
+    _: string[],
+    conversationId: string
+  ): Promise<types.CommandResult> => {
+    await this._client.getOrCreateWorkflow({
+      name: 'lintAll',
+      input: {},
+      discriminateByStatusGroup: 'active',
+      conversationId,
+      status: 'pending',
+    })
+
+    return {
+      success: true,
+      message: "Launched 'lintAll' workflow.",
+    }
+  }
+
+  public setNotifChannel: types.CommandImplementation = async (args: string[]): Promise<types.CommandResult> => {
+    if (!args[0]) {
+      return { success: false, message: MISSING_ARGS_ERROR }
+    }
+    await this._client.setState({
+      id: this._botId,
+      name: 'notificationChannelName',
+      type: 'bot',
+      payload: { name: args[0] },
+    })
+
+    return {
+      success: true,
+      message: `Success. Notification channel is now set to ${args[0]}.`,
+    }
+  }
+
+  public getNotifChannel: types.CommandImplementation = async (): Promise<types.CommandResult> => {
+    const {
+      state: {
+        payload: { name },
+      },
+    } = await this._client.getOrSetState({
+      id: this._botId,
+      name: 'notificationChannelName',
+      type: 'bot',
+      payload: {},
+    })
+
+    let message = 'There is no set Slack notification channel.'
+    if (name) {
+      message = `The Slack notification channel is ${name}.`
+    }
+
+    return {
+      success: true,
+      message,
+    }
+  }
+
+  public commandDefinitions: types.CommandDefinition[] = [
+    {
+      name: '#listTeams',
+      implementation: this.listTeams,
+      requiredArgsCount: 0,
+    },
+    {
+      name: '#addTeam',
+      implementation: this.addTeam,
+      requiredArgsCount: 1,
+    },
+    {
+      name: '#removeTeam',
+      implementation: this.removeTeam,
+      requiredArgsCount: 1,
+    },
+    {
+      name: '#lintAll',
+      implementation: this.lintAll,
+      requiredArgsCount: 0,
+    },
+    {
+      name: '#setNotifChannel',
+      implementation: this.setNotifChannel,
+      requiredArgsCount: 1,
+    },
+    {
+      name: '#getNotifChannel',
+      implementation: this.getNotifChannel,
+      requiredArgsCount: 0,
+    },
+  ]
+}

--- a/bots/bugbuster/src/services/command-processor.ts
+++ b/bots/bugbuster/src/services/command-processor.ts
@@ -11,12 +11,12 @@ export class CommandProcessor {
     private _botId: string
   ) {}
 
-  public listTeams: types.CommandImplementation = async (): Promise<types.CommandResult> => {
+  public listTeams: types.CommandImplementation = async () => {
     const teams = await this._teamsManager.listWatchedTeams()
     return { success: true, message: teams.join(', ') }
   }
 
-  public addTeam: types.CommandImplementation = async (args: string[]): Promise<types.CommandResult> => {
+  public addTeam: types.CommandImplementation = async (args: string[]) => {
     if (!args[0]) {
       return { success: false, message: MISSING_ARGS_ERROR }
     }
@@ -29,7 +29,7 @@ export class CommandProcessor {
     }
   }
 
-  public removeTeam: types.CommandImplementation = async (args: string[]): Promise<types.CommandResult> => {
+  public removeTeam: types.CommandImplementation = async (args: string[]) => {
     if (!args[0]) {
       return { success: false, message: MISSING_ARGS_ERROR }
     }
@@ -42,10 +42,7 @@ export class CommandProcessor {
     }
   }
 
-  public lintAll: types.CommandImplementation = async (
-    _: string[],
-    conversationId: string
-  ): Promise<types.CommandResult> => {
+  public lintAll: types.CommandImplementation = async (_: string[], conversationId: string) => {
     await this._client.getOrCreateWorkflow({
       name: 'lintAll',
       input: {},
@@ -60,7 +57,7 @@ export class CommandProcessor {
     }
   }
 
-  public setNotifChannel: types.CommandImplementation = async (args: string[]): Promise<types.CommandResult> => {
+  public setNotifChannel: types.CommandImplementation = async (args: string[]) => {
     if (!args[0]) {
       return { success: false, message: MISSING_ARGS_ERROR }
     }
@@ -77,7 +74,7 @@ export class CommandProcessor {
     }
   }
 
-  public getNotifChannel: types.CommandImplementation = async (): Promise<types.CommandResult> => {
+  public getNotifChannel: types.CommandImplementation = async () => {
     const {
       state: {
         payload: { name },

--- a/bots/bugbuster/src/services/command-processor.ts
+++ b/bots/bugbuster/src/services/command-processor.ts
@@ -107,11 +107,13 @@ export class CommandProcessor {
       name: '#addTeam',
       implementation: this.addTeam,
       requiredArgsCount: 1,
+      argNames: '<teamName>',
     },
     {
       name: '#removeTeam',
       implementation: this.removeTeam,
       requiredArgsCount: 1,
+      argNames: '<teamName>',
     },
     {
       name: '#lintAll',
@@ -122,6 +124,7 @@ export class CommandProcessor {
       name: '#setNotifChannel',
       implementation: this.setNotifChannel,
       requiredArgsCount: 1,
+      argNames: '<channelName>',
     },
     {
       name: '#getNotifChannel',

--- a/bots/bugbuster/src/services/command-processor.ts
+++ b/bots/bugbuster/src/services/command-processor.ts
@@ -16,29 +16,29 @@ export class CommandProcessor {
     return { success: true, message: teams.join(', ') }
   }
 
-  private _addTeam: types.CommandImplementation = async (args: string[]) => {
-    if (!args[0]) {
+  private _addTeam: types.CommandImplementation = async ([team]: string[]) => {
+    if (!team) {
       return { success: false, message: MISSING_ARGS_ERROR }
     }
 
-    await this._teamsManager.addWatchedTeam(args[0])
+    await this._teamsManager.addWatchedTeam(team)
 
     return {
       success: true,
-      message: `Success: the team with the key '${args[0]}' has been added to the watched team list.`,
+      message: `Success: the team with the key '${team}' has been added to the watched team list.`,
     }
   }
 
-  private _removeTeam: types.CommandImplementation = async (args: string[]) => {
-    if (!args[0]) {
+  private _removeTeam: types.CommandImplementation = async ([team]: string[]) => {
+    if (!team) {
       return { success: false, message: MISSING_ARGS_ERROR }
     }
 
-    await this._teamsManager.removeWatchedTeam(args[0])
+    await this._teamsManager.removeWatchedTeam(team)
 
     return {
       success: true,
-      message: `Success: the team with the key '${args[0]}' has been removed from the watched team list.`,
+      message: `Success: the team with the key '${team}' has been removed from the watched team list.`,
     }
   }
 
@@ -57,20 +57,20 @@ export class CommandProcessor {
     }
   }
 
-  private _setNotifChannel: types.CommandImplementation = async (args: string[]) => {
-    if (!args[0]) {
+  private _setNotifChannel: types.CommandImplementation = async ([channel]: string[]) => {
+    if (!channel) {
       return { success: false, message: MISSING_ARGS_ERROR }
     }
     await this._client.setState({
       id: this._botId,
       name: 'notificationChannelName',
       type: 'bot',
-      payload: { name: args[0] },
+      payload: { name: channel },
     })
 
     return {
       success: true,
-      message: `Success. Notification channel is now set to ${args[0]}.`,
+      message: `Success. Notification channel is now set to ${channel}.`,
     }
   }
 

--- a/bots/bugbuster/src/services/command-processor.ts
+++ b/bots/bugbuster/src/services/command-processor.ts
@@ -1,7 +1,4 @@
-import * as sdk from '@botpress/sdk'
-import { BotpressApi } from 'src/utils/botpress-utils'
 import * as types from '../types'
-import * as lin from '../utils/linear-utils'
 import { TeamsManager } from './teams-manager'
 import { Client } from '.botpress'
 
@@ -9,10 +6,7 @@ const MISSING_ARGS_ERROR = 'More arguments are required with this command.'
 
 export class CommandProcessor {
   public constructor(
-    private _linear: lin.LinearApi,
     private _client: Client,
-    private _logger: sdk.BotLogger,
-    private _botpress: BotpressApi,
     private _teamsManager: TeamsManager,
     private _botId: string
   ) {}

--- a/bots/bugbuster/src/services/command-processor.ts
+++ b/bots/bugbuster/src/services/command-processor.ts
@@ -11,12 +11,12 @@ export class CommandProcessor {
     private _botId: string
   ) {}
 
-  public listTeams: types.CommandImplementation = async () => {
+  private _listTeams: types.CommandImplementation = async () => {
     const teams = await this._teamsManager.listWatchedTeams()
     return { success: true, message: teams.join(', ') }
   }
 
-  public addTeam: types.CommandImplementation = async (args: string[]) => {
+  private _addTeam: types.CommandImplementation = async (args: string[]) => {
     if (!args[0]) {
       return { success: false, message: MISSING_ARGS_ERROR }
     }
@@ -29,7 +29,7 @@ export class CommandProcessor {
     }
   }
 
-  public removeTeam: types.CommandImplementation = async (args: string[]) => {
+  private _removeTeam: types.CommandImplementation = async (args: string[]) => {
     if (!args[0]) {
       return { success: false, message: MISSING_ARGS_ERROR }
     }
@@ -42,7 +42,7 @@ export class CommandProcessor {
     }
   }
 
-  public lintAll: types.CommandImplementation = async (_: string[], conversationId: string) => {
+  private _lintAll: types.CommandImplementation = async (_: string[], conversationId: string) => {
     await this._client.getOrCreateWorkflow({
       name: 'lintAll',
       input: {},
@@ -57,7 +57,7 @@ export class CommandProcessor {
     }
   }
 
-  public setNotifChannel: types.CommandImplementation = async (args: string[]) => {
+  private _setNotifChannel: types.CommandImplementation = async (args: string[]) => {
     if (!args[0]) {
       return { success: false, message: MISSING_ARGS_ERROR }
     }
@@ -74,7 +74,7 @@ export class CommandProcessor {
     }
   }
 
-  public getNotifChannel: types.CommandImplementation = async () => {
+  private _getNotifChannel: types.CommandImplementation = async () => {
     const {
       state: {
         payload: { name },
@@ -100,36 +100,30 @@ export class CommandProcessor {
   public commandDefinitions: types.CommandDefinition[] = [
     {
       name: '#listTeams',
-      implementation: this.listTeams,
-      requiredArgsCount: 0,
+      implementation: this._listTeams,
     },
     {
       name: '#addTeam',
-      implementation: this.addTeam,
-      requiredArgsCount: 1,
-      argNames: '<teamName>',
+      implementation: this._addTeam,
+      requiredArgs: ['teamName'],
     },
     {
       name: '#removeTeam',
-      implementation: this.removeTeam,
-      requiredArgsCount: 1,
-      argNames: '<teamName>',
+      implementation: this._removeTeam,
+      requiredArgs: ['teamName'],
     },
     {
       name: '#lintAll',
-      implementation: this.lintAll,
-      requiredArgsCount: 0,
+      implementation: this._lintAll,
     },
     {
       name: '#setNotifChannel',
-      implementation: this.setNotifChannel,
-      requiredArgsCount: 1,
-      argNames: '<channelName>',
+      implementation: this._setNotifChannel,
+      requiredArgs: ['channelName'],
     },
     {
       name: '#getNotifChannel',
-      implementation: this.getNotifChannel,
-      requiredArgsCount: 0,
+      implementation: this._getNotifChannel,
     },
   ]
 }

--- a/bots/bugbuster/src/types.ts
+++ b/bots/bugbuster/src/types.ts
@@ -34,3 +34,12 @@ export type StateAttributes = {
 }
 
 export type ISO8601Duration = string
+
+export type CommandResult = { success: boolean; message: string }
+export type CommandImplementation = (args: string[], conversationId: string) => CommandResult | Promise<CommandResult>
+export type CommandDefinition = {
+  name: string
+  argNames?: string
+  requiredArgsCount: number
+  implementation: CommandImplementation
+}

--- a/bots/bugbuster/src/types.ts
+++ b/bots/bugbuster/src/types.ts
@@ -39,7 +39,7 @@ type CommandResult = { success: boolean; message: string }
 export type CommandImplementation = (args: string[], conversationId: string) => CommandResult | Promise<CommandResult>
 export type CommandDefinition = {
   name: string
-  argNames?: string
-  requiredArgsCount: number
+  requiredArgs?: string[]
+  optionalArgs?: string[]
   implementation: CommandImplementation
 }

--- a/bots/bugbuster/src/types.ts
+++ b/bots/bugbuster/src/types.ts
@@ -35,7 +35,7 @@ export type StateAttributes = {
 
 export type ISO8601Duration = string
 
-export type CommandResult = { success: boolean; message: string }
+type CommandResult = { success: boolean; message: string }
 export type CommandImplementation = (args: string[], conversationId: string) => CommandResult | Promise<CommandResult>
 export type CommandDefinition = {
   name: string


### PR DESCRIPTION
Refactored the `messageCreated` event handler so that adding new commands is simpler. The command processing logic is separate from the message handler logic, which makes the code easier to read. The behavior is exactly the same. I wanted to do this refactor before my next PR in which I'll add some commands.