### PR TITLE
chore(bots/bugbuster): notif channel conversation IDs are now stored in state

### DIFF
--- a/bots/bugbuster/bot.definition.ts
+++ b/bots/bugbuster/bot.definition.ts
@@ -46,6 +46,7 @@ export default new sdk.BotDefinition({
         channels: sdk.z
           .array(
             sdk.z.object({
+              conversationId: sdk.z.string().title('Conversation ID').describe('The conversation ID'),
               name: sdk.z.string().title('Name').describe('The channel name'),
               teams: sdk.z
                 .array(sdk.z.string())
@@ -77,7 +78,7 @@ export default new sdk.BotDefinition({
       payload: sdk.z.object({}),
       type: 'timeToLintAll',
       schedule: {
-        cron: '0 8 * * 1',
+        cron: '0 13 * * 1',
       },
     },
     timeToCheckIssuesState: {

--- a/bots/bugbuster/bot.definition.ts
+++ b/bots/bugbuster/bot.definition.ts
@@ -78,14 +78,14 @@ export default new sdk.BotDefinition({
       payload: sdk.z.object({}),
       type: 'timeToLintAll',
       schedule: {
-        cron: '0 13 * * 1',
+        cron: '0 13 * * 1', // runs every week on Monday at 8AM EST
       },
     },
     timeToCheckIssuesState: {
       payload: sdk.z.object({}),
       type: 'timeToCheckIssuesState',
       schedule: {
-        cron: '0 * * * *',
+        cron: '0 * * * *', // runs every hour on the hour
       },
     },
   },

--- a/bots/bugbuster/src/handlers/lint-all.ts
+++ b/bots/bugbuster/src/handlers/lint-all.ts
@@ -90,15 +90,11 @@ export const handleLintAll: bp.WorkflowHandlers['lintAll'] = async (props) => {
   })
 
   for (const channel of channels) {
-    const conversationId = await _getConversationId(client, channel.name).catch(
-      _handleError(`trying to get the conversation ID of Slack channel '${channel.name}'`)
-    )
-
     const relevantIssues = lintResults.filter((result) =>
       channel.teams.some((team) => result.identifier.includes(team))
     )
 
-    await botpress.respondText(conversationId, _buildResultMessage(relevantIssues)).catch(() => {})
+    await botpress.respondText(channel.conversationId, _buildResultMessage(relevantIssues)).catch(() => {})
   }
 
   await workflow.setCompleted()
@@ -124,14 +120,4 @@ const _buildResultMessage = (results: types.LintResult[]) => {
   }
 
   return `Linting complete. ${messageDetail}`
-}
-
-const _getConversationId = async (client: bp.Client, channelName: string) => {
-  const conversation = await client.callAction({
-    type: 'slack:startChannelConversation',
-    input: {
-      channelName,
-    },
-  })
-  return conversation.output.conversationId
 }

--- a/bots/bugbuster/src/services/command-processor.ts
+++ b/bots/bugbuster/src/services/command-processor.ts
@@ -83,7 +83,11 @@ export class CommandProcessor {
 
     const existingChannel = channels.find((channel) => channel.name === channelToAdd)
     if (!existingChannel) {
-      channels.push({ name: channelToAdd, teams })
+      const conversation = await this._client.callAction({
+        type: 'slack:startChannelConversation',
+        input: { channelName: channelToAdd },
+      })
+      channels.push({ conversationId: conversation.output.conversationId, name: channelToAdd, teams })
     } else {
       teams.forEach((team) => {
         if (!existingChannel.teams.includes(team)) {


### PR DESCRIPTION
We used to query the Slack API every time we needed to get the conversationId of a Slack channel. The Slack API is unefficient and returns only a small number or issues per page, which made the query take a couple seconds, on top of risking getting timed out if we have multiple channels to send notifications to.

We now query the Slack API only when adding a new notif channel. On top of that it validates that every channel we add actually exists.

I also fixed the cron schedule so it actually runs at 8am; I didn't realize it used UTC time.