### PR TITLE
feat(plugins/hitl): assign agent from first message if unassigned

### DIFF
--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -102,7 +102,7 @@ const PLUGIN_CONFIG_SCHEMA = sdk.z.object({
 
 export default new sdk.PluginDefinition({
   name: 'hitl',
-  version: '1.2.0',
+  version: '1.2.2',
   title: 'Human In The Loop',
   description: 'Seamlessly transfer conversations to human agents',
   icon: 'icon.svg',

--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -102,7 +102,7 @@ const PLUGIN_CONFIG_SCHEMA = sdk.z.object({
 
 export default new sdk.PluginDefinition({
   name: 'hitl',
-  version: '1.2.2',
+  version: '1.3.0',
   title: 'Human In The Loop',
   description: 'Seamlessly transfer conversations to human agents',
   icon: 'icon.svg',

--- a/plugins/hitl/src/hooks/before-incoming-event/hitl-assigned.ts
+++ b/plugins/hitl/src/hooks/before-incoming-event/hitl-assigned.ts
@@ -1,8 +1,6 @@
-import { DEFAULT_HUMAN_AGENT_ASSIGNED_MESSAGE } from '../../../plugin.definition'
-import * as configuration from '../../configuration'
 import * as conv from '../../conv-manager'
-import { tryLinkWebchatUser } from '../../webchat'
 import * as consts from '../consts'
+import { assignAgent } from '../operations'
 import * as bp from '.botpress'
 
 export const handleEvent: bp.HookHandlers['before_incoming_event']['hitl:hitlAssigned'] = async (props) => {
@@ -16,30 +14,11 @@ export const handleEvent: bp.HookHandlers['before_incoming_event']['hitl:hitlAss
     return consts.STOP_EVENT_HANDLING
   }
 
-  const upstreamConversationId = downstreamConversation.tags.upstream
-  if (!upstreamConversationId) {
-    props.logger
-      .withConversationId(downstreamConversationId)
-      .error('Downstream conversation was not binded to upstream conversation')
-    return consts.STOP_EVENT_HANDLING
-  }
-
-  const upstreamConversation = await props.conversations.hitl.hitl.getById({ id: upstreamConversationId })
-  const upstreamCm = conv.ConversationManager.from(props, upstreamConversation)
-
-  const sessionConfig = await configuration.retrieveSessionConfig({
-    ...props,
-    upstreamConversationId,
+  await assignAgent({
+    props,
+    downstreamConversation,
+    humanAgentUserId,
   })
 
-  const humanAgentUser = await props.users.getById({ id: humanAgentUserId })
-  const humanAgentName = humanAgentUser?.name?.length ? humanAgentUser.name : 'A Human Agent'
-
-  await Promise.all([
-    upstreamCm.maybeRespondText(sessionConfig.onHumanAgentAssignedMessage, DEFAULT_HUMAN_AGENT_ASSIGNED_MESSAGE),
-    downstreamCm.setHumanAgent(humanAgentUserId, humanAgentName),
-    upstreamCm.setHumanAgent(humanAgentUserId, humanAgentName),
-    tryLinkWebchatUser(props, { downstreamUser: humanAgentUser, upstreamConversation, forceLink: true }),
-  ])
   return consts.STOP_EVENT_HANDLING
 }

--- a/plugins/hitl/src/hooks/before-incoming-message/all.ts
+++ b/plugins/hitl/src/hooks/before-incoming-message/all.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_USER_HITL_CLOSE_COMMAND,
   DEFAULT_USER_HITL_COMMAND_MESSAGE,
 } from 'plugin.definition'
+import { assignAgent } from 'src/hooks/operations'
 import { tryLinkWebchatUser } from 'src/webchat'
 import * as configuration from '../../configuration'
 import * as conv from '../../conv-manager'
@@ -70,6 +71,16 @@ const _handleDownstreamMessage = async (
   props.logger.withConversationId(downstreamConversation.id).info('Sending message to upstream')
 
   const upstreamUserId = await tryLinkWebchatUser(props, { downstreamUser, upstreamConversation })
+
+  if (!downstreamConversation.tags.humanAgentId?.length) {
+    // Try to assing here, if there is no human agent assigned to the downstream conversation
+    await assignAgent({
+      props,
+      downstreamConversation,
+      humanAgentUserId: downstreamUser.id,
+    })
+  }
+
   await upstreamCm.respond({ ...messagePayload, userId: upstreamUserId })
   return consts.STOP_EVENT_HANDLING
 }

--- a/plugins/hitl/src/hooks/operations.ts
+++ b/plugins/hitl/src/hooks/operations.ts
@@ -1,0 +1,58 @@
+import { DEFAULT_HUMAN_AGENT_ASSIGNED_MESSAGE } from '../../plugin.definition'
+import * as configuration from '../configuration'
+import * as conv from '../conv-manager'
+import * as types from '../types'
+import { tryLinkWebchatUser } from '../webchat'
+import * as bp from '.botpress'
+
+type AssignAgentProps = bp.HookHandlerProps['before_incoming_message'] | bp.HookHandlerProps['before_incoming_event']
+
+export type AssignAgentOptions = {
+  props: AssignAgentProps
+  downstreamConversation: types.ActionableConversation
+  humanAgentUserId: string
+  forceLinkWebchatUser?: boolean
+}
+
+/**
+ * Assigns a human agent to both downstream and upstream conversations.
+ * Also links the webchat user if applicable and sends the agent assigned message.
+ */
+export const assignAgent = async (options: AssignAgentOptions): Promise<boolean> => {
+  const { props, downstreamConversation, humanAgentUserId, forceLinkWebchatUser = false } = options
+
+  const upstreamConversationId = downstreamConversation.tags.upstream
+  if (!upstreamConversationId?.length) {
+    props.logger
+      .withConversationId(downstreamConversation.id)
+      .error('Downstream conversation was not binded to upstream conversation')
+    return false
+  }
+
+  const upstreamConversation = await props.conversations.hitl.hitl.getById({
+    id: upstreamConversationId,
+  })
+
+  const upstreamCm = conv.ConversationManager.from(props, upstreamConversation)
+  const downstreamCm = conv.ConversationManager.from(props, downstreamConversation)
+  const humanAgentUser = await props.users.getById({ id: humanAgentUserId })
+  const humanAgentName = humanAgentUser?.name?.length ? humanAgentUser.name : 'A Human Agent'
+
+  const sessionConfig = await configuration.retrieveSessionConfig({
+    ...props,
+    upstreamConversationId: upstreamConversation.id,
+  })
+
+  await Promise.all([
+    downstreamCm.setHumanAgent(humanAgentUserId, humanAgentName),
+    upstreamCm.setHumanAgent(humanAgentUserId, humanAgentName),
+    upstreamCm.maybeRespondText(sessionConfig.onHumanAgentAssignedMessage, DEFAULT_HUMAN_AGENT_ASSIGNED_MESSAGE),
+    tryLinkWebchatUser(props, {
+      downstreamUser: humanAgentUser,
+      upstreamConversation,
+      forceLink: forceLinkWebchatUser,
+    }),
+  ])
+
+  return true
+}

--- a/plugins/hitl/src/hooks/operations.ts
+++ b/plugins/hitl/src/hooks/operations.ts
@@ -19,7 +19,7 @@ export type AssignAgentOptions = {
  * Also links the webchat user if applicable and sends the agent assigned message.
  */
 export const assignAgent = async (options: AssignAgentOptions): Promise<boolean> => {
-  const { props, downstreamConversation, humanAgentUserId, forceLinkWebchatUser = false } = options
+  const { props, downstreamConversation, humanAgentUserId, forceLinkWebchatUser = true } = options
 
   const upstreamConversationId = downstreamConversation.tags.upstream
   if (!upstreamConversationId?.length) {


### PR DESCRIPTION
Depending on the Third Party platform there will be no agent assigned event, we want to handle those cases and auto assign the agent that sends the first message

Tested with the Integrations Zendesk Messaging HITL (Doesn't have assigned event) and Salesforce (Has assigned event)