### PR TITLE
feat(integration/notion): Added `searchByTitle` Action Card

### DIFF
--- a/integrations/notion/definitions/actions.ts
+++ b/integrations/notion/definitions/actions.ts
@@ -99,14 +99,17 @@ export const actions = {
   },
   queryByTitle: {
     title: 'Query by Title',
-    description: 'Search for pages and databases in Notion. Optionally filter by title. Only returns items that have been shared with the integration.',
+    description:
+      'Search for pages and databases in Notion. Optionally filter by title. Only returns items that have been shared with the integration.',
     input: {
       schema: sdk.z.object({
         title: sdk.z
           .string()
           .optional()
           .title('Title')
-          .describe('Optional search query to match against page and database titles. If not provided, returns all accessible pages and databases.'),
+          .describe(
+            'Optional search query to match against page and database titles. If not provided, returns all accessible pages and databases.'
+          ),
       }),
     },
     output: {

--- a/integrations/notion/definitions/actions.ts
+++ b/integrations/notion/definitions/actions.ts
@@ -97,4 +97,32 @@ export const actions = {
       schema: sdk.z.object({}),
     },
   },
+  queryByTitle: {
+    title: 'Query by Title',
+    description: 'Search for pages and databases in Notion. Optionally filter by title. Only returns items that have been shared with the integration.',
+    input: {
+      schema: sdk.z.object({
+        title: sdk.z
+          .string()
+          .optional()
+          .title('Title')
+          .describe('Optional search query to match against page and database titles. If not provided, returns all accessible pages and databases.'),
+      }),
+    },
+    output: {
+      schema: sdk.z.object({
+        results: sdk.z
+          .array(
+            sdk.z.object({
+              id: sdk.z.string().title('ID').describe('The ID of the page or database'),
+              title: sdk.z.string().title('Title').describe('The title of the page or database'),
+              type: sdk.z.string().title('Type').describe('The type of the result (page or database)'),
+              url: sdk.z.string().title('URL').describe('The URL to the page or database'),
+            })
+          )
+          .title('Results')
+          .describe('Array of pages and databases matching the search query'),
+      }),
+    },
+  },
 } as const satisfies sdk.IntegrationDefinitionProps['actions']

--- a/integrations/notion/definitions/actions.ts
+++ b/integrations/notion/definitions/actions.ts
@@ -120,8 +120,8 @@ export const actions = {
       schema: sdk.z.object({}),
     },
   },
-  queryByTitle: {
-    title: 'Query by Title',
+  searchByTitle: {
+    title: 'Search by Title',
     description:
       'Search for pages and databases in Notion. Optionally filter by title. Only returns items that have been shared with the integration.',
     input: {

--- a/integrations/notion/src/actions/index.ts
+++ b/integrations/notion/src/actions/index.ts
@@ -5,8 +5,8 @@ import { deleteBlock } from './delete-block'
 import { filesReadonlyListItemsInFolder } from './files-readonly/list-items-in-folder'
 import { filesReadonlyTransferFileToBotpress } from './files-readonly/transfer-file-to-botpress'
 import { getDb } from './get-db'
-import { queryByTitle } from './query-by-title'
 import { getPage } from './get-page'
+import { queryByTitle } from './query-by-title'
 import * as bp from '.botpress'
 
 export const actions = {

--- a/integrations/notion/src/actions/index.ts
+++ b/integrations/notion/src/actions/index.ts
@@ -5,6 +5,7 @@ import { deleteBlock } from './delete-block'
 import { filesReadonlyListItemsInFolder } from './files-readonly/list-items-in-folder'
 import { filesReadonlyTransferFileToBotpress } from './files-readonly/transfer-file-to-botpress'
 import { getDb } from './get-db'
+import { queryByTitle } from './query-by-title'
 import * as bp from '.botpress'
 
 export const actions = {
@@ -15,4 +16,5 @@ export const actions = {
   filesReadonlyListItemsInFolder,
   filesReadonlyTransferFileToBotpress,
   getDb,
+  queryByTitle,
 } as const satisfies bp.IntegrationProps['actions']

--- a/integrations/notion/src/actions/index.ts
+++ b/integrations/notion/src/actions/index.ts
@@ -6,7 +6,7 @@ import { filesReadonlyListItemsInFolder } from './files-readonly/list-items-in-f
 import { filesReadonlyTransferFileToBotpress } from './files-readonly/transfer-file-to-botpress'
 import { getDb } from './get-db'
 import { getPage } from './get-page'
-import { queryByTitle } from './query-by-title'
+import { searchByTitle } from './search-by-title'
 import * as bp from '.botpress'
 
 export const actions = {
@@ -17,6 +17,6 @@ export const actions = {
   filesReadonlyListItemsInFolder,
   filesReadonlyTransferFileToBotpress,
   getDb,
-  queryByTitle,
+  searchByTitle,
   getPage,
 } as const satisfies bp.IntegrationProps['actions']

--- a/integrations/notion/src/actions/query-by-title.ts
+++ b/integrations/notion/src/actions/query-by-title.ts
@@ -1,0 +1,9 @@
+import { wrapAction } from '../action-wrapper'
+
+export const queryByTitle = wrapAction(
+  { actionName: 'queryByTitle', errorMessage: 'Failed to query by title' },
+  async ({ notionClient }, { title }) => {
+    return await notionClient.searchByTitle({ title })
+  }
+)
+

--- a/integrations/notion/src/actions/query-by-title.ts
+++ b/integrations/notion/src/actions/query-by-title.ts
@@ -6,4 +6,3 @@ export const queryByTitle = wrapAction(
     return await notionClient.searchByTitle({ title })
   }
 )
-

--- a/integrations/notion/src/actions/search-by-title.ts
+++ b/integrations/notion/src/actions/search-by-title.ts
@@ -1,7 +1,7 @@
 import { wrapAction } from '../action-wrapper'
 
-export const queryByTitle = wrapAction(
-  { actionName: 'queryByTitle', errorMessage: 'Failed to query by title' },
+export const searchByTitle = wrapAction(
+  { actionName: 'searchByTitle', errorMessage: 'Failed to search by title' },
   async ({ notionClient }, { title }) => {
     return await notionClient.searchByTitle({ title })
   }

--- a/integrations/notion/src/notion-api/notion-client.ts
+++ b/integrations/notion/src/notion-api/notion-client.ts
@@ -1,11 +1,15 @@
 import * as notionhq from '@notionhq/client'
+import {
+  PartialDatabaseObjectResponse,
+  PartialPageObjectResponse,
+  RichTextItemResponse,
+} from '@notionhq/client/build/src/api-endpoints'
 import { getDbStructure } from './db-structure'
 import { handleErrorsDecorator as handleErrors } from './error-handling'
 import { NotionOAuthClient } from './notion-oauth-client'
 import { NotionToMdxClient } from './notion-to-mdx-client'
 import type * as types from './types'
 import * as bp from '.botpress'
-import { PartialDatabaseObjectResponse, PartialPageObjectResponse, RichTextItemResponse } from '@notionhq/client/build/src/api-endpoints'
 
 export class NotionClient {
   private readonly _notion: notionhq.Client
@@ -105,18 +109,18 @@ export class NotionClient {
 
   @handleErrors('Failed to search by title')
   public async searchByTitle({ title }: { title?: string }) {
-    const [response, databaseResponse] = await Promise.all([  
-      this._notion.search({  
-        query: title,  
-        filter: { property: "object", value: "page" },  
-      }),  
-      this._notion.search({  
-        query: title,  
-        filter: { property: "object", value: "database" },  
-      }),  
-    ]);  
-    
-    const allResults = [...response.results, ...databaseResponse.results];  
+    const [response, databaseResponse] = await Promise.all([
+      this._notion.search({
+        query: title,
+        filter: { property: 'object', value: 'page' },
+      }),
+      this._notion.search({
+        query: title,
+        filter: { property: 'object', value: 'database' },
+      }),
+    ])
+
+    const allResults = [...response.results, ...databaseResponse.results]
 
     const formattedResults = this._formatSearchResults(allResults)
 
@@ -207,10 +211,10 @@ export class NotionClient {
       )
       .map((result) => {
         let resultTitle = ''
-  
+
         if (result.object === 'page' && 'properties' in result) {
           const titleProp = Object.values(result.properties).find(
-            (prop): prop is { type: 'title'; title: RichTextItemResponse[]; id: string } => 
+            (prop): prop is { type: 'title'; title: RichTextItemResponse[]; id: string } =>
               typeof prop === 'object' && prop !== null && 'type' in prop && prop.type === 'title'
           )
           if (titleProp) {
@@ -219,7 +223,7 @@ export class NotionClient {
         } else if (result.object === 'database' && 'title' in result && Array.isArray(result.title)) {
           resultTitle = result.title.map((t) => t.plain_text).join('')
         }
-  
+
         return {
           id: result.id,
           title: resultTitle,

--- a/integrations/notion/src/notion-api/notion-client.ts
+++ b/integrations/notion/src/notion-api/notion-client.ts
@@ -124,12 +124,16 @@ export class NotionClient {
     const allResults = [...response.results, ...databaseResponse.results]
 
     const formattedResults = allResults
-      .filter((result): result is types.NotionTopLevelItem => 'parent' in result && !('in_trash' in result && result.in_trash))
+      .filter(
+        (result): result is types.NotionTopLevelItem => 'parent' in result && !('in_trash' in result && result.in_trash)
+      )
       .map((result) => {
         let resultTitle = ''
-        
+
         if (result.object === 'page' && 'properties' in result) {
-          const titleProp = Object.values(result.properties as Record<string, any>).find((prop: any) => prop.type === 'title')
+          const titleProp = Object.values(result.properties as Record<string, any>).find(
+            (prop: any) => prop.type === 'title'
+          )
           if (titleProp && 'title' in titleProp && Array.isArray(titleProp.title)) {
             resultTitle = titleProp.title.map((t: any) => t.plain_text).join('')
           }


### PR DESCRIPTION
Resolves SH-246.

This PR gives dev-bots the ability to search through the shared files which wasn't possible before. There was no direct way of getting id's of their pages which this action card resolves.

This PR contains:
- `searchByTitle` action definition and action function
- Notion client query function

**Note:** This has been tested in the Studio
<img width="479" height="839" alt="image" src="https://github.com/user-attachments/assets/85202b04-9601-4319-832b-d1374e68ba38" />
