### PR TITLE
fix(packages/cli): ghost path issue in linter

### DIFF
--- a/packages/cli/src/linter/base-linter.ts
+++ b/packages/cli/src/linter/base-linter.ts
@@ -22,7 +22,8 @@ export abstract class BaseLinter<TDefinition> {
 
   public logResults(logger: Logger) {
     for (const result of this.getSortedResults()) {
-      const message = `${result.path}: ${result.message}`
+      const resultPath = result.path.trim() || '{root}'
+      const message = `${resultPath}: ${result.message}`
 
       this._logResultMessage(logger, message, result.severity)
     }


### PR DESCRIPTION
Resolves SH-259

After investigation, I realized this wasn't an actions lint issue, but rather an issue where if the detection was at the root, the "path" would output as blank.