### PR TITLE
feat(integrations/linear): Allow getting the current user's profile

### DIFF
--- a/integrations/linear/definitions/actions.ts
+++ b/integrations/linear/definitions/actions.ts
@@ -145,8 +145,11 @@ const getUser = {
     schema: z.object({
       linearUserId: z
         .string()
+        .optional()
         .title('User ID')
-        .describe("The user's ID on Linear. Ex: {{event.payload.linearIds.creatorId}}"),
+        .describe(
+          "The user's ID on Linear. Ex: {{event.payload.linearIds.creatorId}}. If omitted, returns the current user."
+        ),
     }),
   },
   output: {

--- a/integrations/linear/src/actions/get-user.ts
+++ b/integrations/linear/src/actions/get-user.ts
@@ -10,7 +10,7 @@ export const getUser: bp.IntegrationProps['actions']['getUser'] = async (args) =
     input: { linearUserId },
   } = args
   const linearClient = await getLinearClient(args, ctx.integrationId)
-  const user = await linearClient.user(linearUserId)
+  const user = linearUserId ? await linearClient.user(linearUserId) : await linearClient.viewer
 
   return userProfileSchema.parse({
     linearId: user.id,


### PR DESCRIPTION
Resolves SH-303

For the `getUser` action in the Linear integration, we return the current authenticated user when the `id` input parameter is omitted.