### PR TITLE
fix(bots/bugbuster): The TS type didn't match the GraphQL schema

### DIFF
--- a/bots/bugbuster/src/services/recently-linted-manager.ts
+++ b/bots/bugbuster/src/services/recently-linted-manager.ts
@@ -8,7 +8,7 @@ export class RecentlyLintedManager {
   public async isRecentlyLinted(issue: lin.Issue): Promise<boolean> {
     const me = await this._linear.getMe()
     const timestamps = issue.comments.nodes
-      .filter((comment) => comment.user.id === me.id)
+      .filter((comment) => comment.user?.id === me.id)
       .map((comment) => new Date(comment.createdAt).getTime())
     const now = new Date().getTime()
     for (const timestamp of timestamps) {

--- a/bots/bugbuster/src/utils/linear-utils/client.ts
+++ b/bots/bugbuster/src/utils/linear-utils/client.ts
@@ -126,7 +126,7 @@ export class LinearApi {
 
     const promises: Promise<lin.CommentPayload>[] = []
     for (const comment of comments) {
-      if (comment.user.id === me.id && !comment.parentId && !comment.resolvedAt) {
+      if (comment.user?.id === me.id && !comment.parentId && !comment.resolvedAt) {
         promises.push(this._client.commentResolve(comment.id))
       }
     }

--- a/bots/bugbuster/src/utils/linear-utils/graphql-queries.ts
+++ b/bots/bugbuster/src/utils/linear-utils/graphql-queries.ts
@@ -36,7 +36,7 @@ export type Issue = {
   }
   project: {
     id: string
-    name: string | null
+    name: string
     completedAt: string | null
   } | null
   comments: {
@@ -46,7 +46,7 @@ export type Issue = {
       createdAt: string
       user: {
         id: string
-      }
+      } | null
       parentId: string | null
     }[]
   }


### PR DESCRIPTION
The TS type didn't match exactly the schema returned by the API. This caused an issue when checking the user ID of a comment's creator when the user was `null`.

I took this opportunity to validate and correct the rest of the schema.