### PR TITLE
chore(integrations/linear): Upgraded Linear sdk version

### DIFF
--- a/integrations/linear/integration.definition.ts
+++ b/integrations/linear/integration.definition.ts
@@ -6,7 +6,7 @@ import { actions, channels, events, configuration, configurations, user, states,
 
 export default new IntegrationDefinition({
   name: 'linear',
-  version: '1.1.5',
+  version: '1.2.0',
   title: 'Linear',
   description:
     'Manage your projects autonomously. Have your bot participate in discussions, manage issues and teams, and track progress.',

--- a/integrations/linear/package.json
+++ b/integrations/linear/package.json
@@ -10,7 +10,7 @@
     "@botpress/client": "workspace:*",
     "@botpress/sdk": "workspace:*",
     "@botpress/sdk-addons": "workspace:*",
-    "@linear/sdk": "^2.6.0",
+    "@linear/sdk": "^65.2.0",
     "axios": "^1.4.0",
     "query-string": "^6.14.1",
     "tsafe": "^1.6.4"

--- a/integrations/linear/src/handler.ts
+++ b/integrations/linear/src/handler.ts
@@ -1,5 +1,5 @@
 import { Request } from '@botpress/sdk'
-import { LinearWebhooks, LINEAR_WEBHOOK_SIGNATURE_HEADER, LINEAR_WEBHOOK_TS_FIELD } from '@linear/sdk'
+import { LinearWebhooks } from '@linear/sdk'
 
 import { fireIssueCreated } from './events/issueCreated'
 import { fireIssueDeleted } from './events/issueDeleted'
@@ -8,6 +8,9 @@ import { LinearEvent, handleOauth } from './misc/linear'
 import { Result } from './misc/types'
 import { getLinearClient, getUserAndConversation } from './misc/utils'
 import * as bp from '.botpress'
+
+const LINEAR_WEBHOOK_SIGNATURE_HEADER = 'linear-signature'
+const LINEAR_WEBHOOK_TS_FIELD = 'webhookTimestamp'
 
 export const handler: bp.IntegrationProps['handler'] = async ({ req, ctx, client, logger }) => {
   if (req.path === '/oauth') {

--- a/integrations/linear/src/misc/utils.ts
+++ b/integrations/linear/src/misc/utils.ts
@@ -1,4 +1,4 @@
-import { Comment, Issue, IssueLabel, LinearClient, Team } from '@linear/sdk'
+import { Issue, LinearClient, Team } from '@linear/sdk'
 import { LinearOauthClient } from './linear'
 import { AckFunction, MessageHandlerProps } from './types'
 import * as bp from '.botpress'
@@ -10,50 +10,6 @@ export type LinearClientProps = {
 export function getLinearClient({ client, ctx }: LinearClientProps, integrationId: string) {
   const linearOauthClient = new LinearOauthClient()
   return linearOauthClient.getLinearClient(client, ctx, integrationId)
-}
-
-export function dateToString(obj: Date | undefined) {
-  return obj ? obj.toISOString() : undefined
-}
-
-export function stringToDate(str: string | undefined) {
-  return str ? new Date(str) : undefined
-}
-
-export function toReturnedIssue(issue: Issue) {
-  return {
-    ...issue,
-    createdAt: issue.createdAt.toISOString(),
-    updatedAt: issue.updatedAt.toISOString(),
-    archivedAt: dateToString(issue.archivedAt),
-    canceledAt: dateToString(issue.canceledAt),
-    completedAt: dateToString(issue.completedAt),
-    autoArchivedAt: dateToString(issue.autoArchivedAt),
-    autoClosedAt: dateToString(issue.autoClosedAt),
-    snoozedUntilAt: dateToString(issue.snoozedUntilAt),
-    startedAt: dateToString(issue.startedAt),
-    startedTriageAt: dateToString(issue.startedTriageAt),
-    triagedAt: dateToString(issue.triagedAt),
-  }
-}
-
-export function toReturnedComment(comment: Comment) {
-  return {
-    ...comment,
-    archivedAt: dateToString(comment.archivedAt),
-    editedAt: dateToString(comment.editedAt),
-    createdAt: comment.createdAt.toISOString(),
-    updatedAt: comment.updatedAt.toISOString(),
-  }
-}
-
-export function toReturnedIssueLabel(issueLabel: IssueLabel) {
-  return {
-    ...issueLabel,
-    archivedAt: dateToString(issueLabel.archivedAt),
-    createdAt: issueLabel.createdAt.toISOString(),
-    updatedAt: issueLabel.updatedAt.toISOString(),
-  }
 }
 
 type ValueOf<T> = T[keyof T]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1331,8 +1331,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sdk-addons
       '@linear/sdk':
-        specifier: ^2.6.0
-        version: 2.6.0
+        specifier: ^65.2.0
+        version: 65.2.0
       axios:
         specifier: ^1.4.0
         version: 1.6.3
@@ -4842,10 +4842,6 @@ packages:
     resolution: {integrity: sha512-PPtul1vzoyZ5HkNqh643YD0TCFqOHI6ld4x69c/prwAxornBxPaeXoHbHcFeK8gaD2W4/666mPQe5K3CmUMepw==}
     engines: {node: '>=18'}
 
-  '@linear/sdk@2.6.0':
-    resolution: {integrity: sha512-L7Bsd5Ooa+RusZ6Y1yuzsq3NnrSOqHbhZHvdY+anNTOEtFPKonFCNeUdWXpBlyM21rzx7MWq+TfjtMo9dbxxPQ==}
-    engines: {node: '>=12.x', yarn: 1.x}
-
   '@linear/sdk@50.0.0':
     resolution: {integrity: sha512-cqOTIkayqCDTBITCieuZ3acMiJmWZB0bR9FhfrfMs2B5PotntDgcfNCBW+21LcMwcBrq0A84kwK2AQzdu+Atsg==}
     engines: {node: '>=12.x', yarn: 1.x}
@@ -4853,6 +4849,10 @@ packages:
   '@linear/sdk@55.2.1':
     resolution: {integrity: sha512-0+xjyphwdMMeGIV5O1Q7/AhS/tyTv+J0azE/WPbVXJHCDkBdgoHERvBgNXM0nRjcVt2RKUl8V0o+Fly2CJRlOA==}
     engines: {node: '>=12.x', yarn: 1.x}
+
+  '@linear/sdk@65.2.0':
+    resolution: {integrity: sha512-HnvQm31aiTLwJh0k4fB1FweXPfNFtwG8QcjUclAL/O92s+62t5izyFk7S2aTulAVj8fu4XqCmVt2k2DFf2+vSw==}
+    engines: {node: '>=18.x'}
 
   '@mailchimp/mailchimp_marketing@3.0.80':
     resolution: {integrity: sha512-Cgz0xPb+1DUjmrl5whAsmqfAChBko+Wf4/PLQE4RvwfPlcq2agfHr1QFiXEhZ8e+GQwQ3hZQn9iLGXwIXwxUCg==}
@@ -13670,14 +13670,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@linear/sdk@2.6.0':
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
-      graphql: 15.8.0
-      isomorphic-unfetch: 3.1.0
-    transitivePeerDependencies:
-      - encoding
-
   '@linear/sdk@50.0.0':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
@@ -13687,6 +13679,14 @@ snapshots:
       - encoding
 
   '@linear/sdk@55.2.1':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
+      graphql: 15.8.0
+      isomorphic-unfetch: 3.1.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@linear/sdk@65.2.0':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
       graphql: 15.8.0


### PR DESCRIPTION
The version of the Linear sdk we use in the integration has been upgraded to the latest one. I looked at all the breaking changes and made sure none of them impacted our code. The only difference that matters to us is that two constants aren't exported by Linear anymore.

I also took this opportunity to remove some dead code I found.