### PR TITLE
fix(integrations/messenger & instagram): handle unsupported event payloads gracefully

### DIFF
--- a/integrations/instagram/integration.definition.ts
+++ b/integrations/instagram/integration.definition.ts
@@ -5,7 +5,7 @@ import proactiveUser from 'bp_modules/proactive-user'
 import { dmChannelMessages } from './definitions/channel'
 
 export const INTEGRATION_NAME = 'instagram'
-export const INTEGRATION_VERSION = '4.1.5'
+export const INTEGRATION_VERSION = '4.1.6'
 
 const commonConfigSchema = z.object({
   replyToComments: z

--- a/integrations/instagram/src/webhook/handler.ts
+++ b/integrations/instagram/src/webhook/handler.ts
@@ -55,7 +55,7 @@ const _handler: bp.IntegrationProps['handler'] = async (props: bp.HandlerProps) 
 
   const payloadResult = instagramPayloadSchema.safeParse(data)
   if (!payloadResult.success) {
-    logger.forBot().warn('Unsupported Event Payload')
+    logger.forBot().warn('Unsupported Event Payload: ' + payloadResult.error.message)
     return { status: 200 }
   }
 

--- a/integrations/instagram/src/webhook/handler.ts
+++ b/integrations/instagram/src/webhook/handler.ts
@@ -55,7 +55,7 @@ const _handler: bp.IntegrationProps['handler'] = async (props: bp.HandlerProps) 
 
   const payloadResult = instagramPayloadSchema.safeParse(data)
   if (!payloadResult.success) {
-    logger.forBot().warn(`Unsupported Event Payload`)
+    logger.forBot().warn('Unsupported Event Payload')
     return { status: 200 }
   }
 

--- a/integrations/instagram/src/webhook/handler.ts
+++ b/integrations/instagram/src/webhook/handler.ts
@@ -46,18 +46,17 @@ const _handler: bp.IntegrationProps['handler'] = async (props: bp.HandlerProps) 
   if (validationResult.error) {
     return { status: 401, body: validationResult.message }
   }
+
   const { data, success } = safeJsonParse(req.body)
   if (!success) {
     const errorMsg = 'Unable to parse request payload as JSON'
     return { status: 400, body: errorMsg }
   }
 
-  // Parse payload once with entry-level union schema
   const payloadResult = instagramPayloadSchema.safeParse(data)
   if (!payloadResult.success) {
-    const errorMsg = `Received invalid Instagram payload: ${payloadResult.error.message}`
-    props.logger.warn(errorMsg)
-    return { status: 400, body: 'Invalid payload' }
+    logger.forBot().warn(`Unsupported Event Payload`)
+    return { status: 200 }
   }
 
   const payload = payloadResult.data

--- a/integrations/messenger/integration.definition.ts
+++ b/integrations/messenger/integration.definition.ts
@@ -7,7 +7,7 @@ import typingIndicator from 'bp_modules/typing-indicator'
 import { messages } from './definitions/channels/channel/messages'
 
 export const INTEGRATION_NAME = 'messenger'
-export const INTEGRATION_VERSION = '5.0.5'
+export const INTEGRATION_VERSION = '5.1.1'
 
 const commonConfigSchema = z.object({
   downloadMedia: z

--- a/integrations/messenger/src/webhook/handler.ts
+++ b/integrations/messenger/src/webhook/handler.ts
@@ -61,7 +61,8 @@ const _handlerWrapper: typeof _handler = async (props: bp.HandlerProps) => {
     const response = await _handler(props)
 
     if (response?.status && response.status >= 400) {
-      throw new Error(`${response.status}: ${response.body}`)
+      const errorMessage = `Messenger handler failed with status ${response.status}: ${response.body}`
+      props.logger.error(errorMessage)
     }
 
     return response

--- a/integrations/messenger/src/webhook/handler.ts
+++ b/integrations/messenger/src/webhook/handler.ts
@@ -41,7 +41,7 @@ const _handler: bp.IntegrationProps['handler'] = async (props) => {
 
   const parseResult = eventPayloadSchema.safeParse(jsonParseResult.data)
   if (!parseResult.success) {
-    logger.forBot().warn('Unsupported Event Payload')
+    logger.forBot().warn('Unsupported Event Payload: ' + parseResult.error.message)
     return
   }
 

--- a/integrations/messenger/src/webhook/handler.ts
+++ b/integrations/messenger/src/webhook/handler.ts
@@ -41,10 +41,10 @@ const _handler: bp.IntegrationProps['handler'] = async (props) => {
 
   const parseResult = eventPayloadSchema.safeParse(jsonParseResult.data)
   if (!parseResult.success) {
-    const errorMessage = `Error while parsing body as Messenger payload: ${parseResult.error.message}`
-    logger.forBot().warn(errorMessage)
-    return { status: 400, body: errorMessage }
+    logger.forBot().warn(`Unsupported Event Payload`)
+    return
   }
+  
   const data = parseResult.data
   for (const entry of data.entry) {
     if ('messaging' in entry) {

--- a/integrations/messenger/src/webhook/handler.ts
+++ b/integrations/messenger/src/webhook/handler.ts
@@ -41,10 +41,10 @@ const _handler: bp.IntegrationProps['handler'] = async (props) => {
 
   const parseResult = eventPayloadSchema.safeParse(jsonParseResult.data)
   if (!parseResult.success) {
-    logger.forBot().warn(`Unsupported Event Payload`)
+    logger.forBot().warn('Unsupported Event Payload')
     return
   }
-  
+
   const data = parseResult.data
   for (const entry of data.entry) {
     if ('messaging' in entry) {


### PR DESCRIPTION
This PR changes how we handled unsupported event payloads.
- Uses `logger.forBot().warn` instead of error.
- No longer return 400. 