### PR TITLE
fix(cli): installing a package should preserve its version

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/command-implementations/add-command.ts
+++ b/packages/cli/src/command-implementations/add-command.ts
@@ -1,7 +1,6 @@
 import * as sdk from '@botpress/sdk'
 import * as fslib from 'fs'
 import * as pathlib from 'path'
-import semver from 'semver'
 import * as apiUtils from '../api'
 import * as codegen from '../code-generation'
 import type commandDefinitions from '../command-definitions'
@@ -108,13 +107,7 @@ export class AddCommand extends GlobalCommand<AddCommandDefinition> {
       await this._uninstall(installPath)
     }
 
-    if (ref.type === 'name' && ref.version === pkgRef.LATEST_TAG) {
-      // If the semver version expression is 'latest', we assume the project
-      // is compatible with all versions of the latest major:
-      const major = semver.major(targetPackage.pkg.version)
-      targetPackage.pkg.version = `>=${major}.0.0 <${major + 1}.0.0`
-    } else if (ref.type === 'name') {
-      // Preserve the semver version expression in the generated code:
+    if (ref.type === 'name') {
       targetPackage.pkg.version = ref.version
     }
 


### PR DESCRIPTION
We've already decided that the version range must be specified in the definition file, not in the installed package. This is just a leftover from before this decision.