### PR TITLE
feat(integrations/zendesk): Add requester info in start HITL

### DIFF
--- a/integrations/zendesk/integration.definition.ts
+++ b/integrations/zendesk/integration.definition.ts
@@ -6,7 +6,7 @@ import { actions, events, configuration, channels, states, user } from './src/de
 export default new sdk.IntegrationDefinition({
   name: 'zendesk',
   title: 'Zendesk',
-  version: '3.0.2',
+  version: '3.0.3',
   icon: 'icon.svg',
   description:
     'Optimize your support workflow. Trigger workflows from ticket updates as well as manage tickets, access conversations, and engage with customers.',
@@ -48,6 +48,16 @@ export default new sdk.IntegrationDefinition({
           .describe(
             'Photo URL of the chatbot that will be used in the Zendesk ticket. Must be a publicly-accessible PNG image. Defaults to Botpress logo.'
           )
+          .optional(),
+        requesterName: sdk.z
+          .string()
+          .title('Requester Name')
+          .describe('The name of the requester the bot was talking to. This will be set in zendesk.')
+          .optional(),
+        requesterEmail: sdk.z
+          .string()
+          .title('Requester Email')
+          .describe('The email of the requester the bot was talking to. This will be set in zendesk.')
           .optional(),
       }),
     },

--- a/integrations/zendesk/src/actions/hitl.ts
+++ b/integrations/zendesk/src/actions/hitl.ts
@@ -38,6 +38,10 @@ export const startHitl: bp.IntegrationProps['actions']['startHitl'] = async (pro
     },
     {
       priority: input.hitlSession?.priority,
+      requester: {
+        name: input.hitlSession?.requesterName,
+        email: input.hitlSession?.requesterEmail,
+      },
     }
   )
 

--- a/integrations/zendesk/src/definitions/schemas.ts
+++ b/integrations/zendesk/src/definitions/schemas.ts
@@ -1,6 +1,11 @@
 import { z } from '@botpress/sdk'
 import { omit } from 'lodash'
 
+const requesterSchema = z.object({
+  name: z.string().optional(),
+  email: z.string().optional(),
+})
+
 export const ticketSchema = z.object({
   id: z.number(),
   subject: z.string(),
@@ -8,6 +13,7 @@ export const ticketSchema = z.object({
   status: z.enum(['new', 'open', 'pending', 'hold', 'solved', 'closed']),
   priority: z.enum(['low', 'normal', 'high', 'urgent']).nullable(),
   requesterId: z.number(),
+  requester: requesterSchema.optional(),
   assigneeId: z.number().nullable(),
   createdAt: z.string(),
   updatedAt: z.string(),


### PR DESCRIPTION
Resolves SH-319
This is what it looks like in the requester component of a zendesk ticket.
<img width="1577" height="679" alt="image" src="https://github.com/user-attachments/assets/9009e1a6-cda6-42eb-b73f-0c62cd0a2c17" />
