### PR TITLE
fix(integrations/slack): messages with percentage symbols in them caused an error

### DIFF
--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -17,7 +17,7 @@ export default new IntegrationDefinition({
   name: 'slack',
   title: 'Slack',
   description: 'Automate interactions with your team.',
-  version: '3.1.2',
+  version: '3.1.3',
   icon: 'icon.svg',
   readme: 'hub.md',
   configuration,

--- a/integrations/slack/src/misc/utils.ts
+++ b/integrations/slack/src/misc/utils.ts
@@ -91,11 +91,8 @@ export const getMessageFromSlackEvent = async (
 }
 
 export const safeParseBody = (body: string) => {
-  try {
-    return _safeParseJson(body)
-  } catch {
-    return _safeDecodeURIComponent(body)
-  }
+  const parseResult = _safeParseJson(body)
+  return parseResult.success ? parseResult : _safeDecodeURIComponent(body)
 }
 
 const _safeDecodeURIComponent = (component: string) => {

--- a/integrations/slack/src/misc/utils.ts
+++ b/integrations/slack/src/misc/utils.ts
@@ -90,7 +90,27 @@ export const getMessageFromSlackEvent = async (
   return messages[0]
 }
 
-export const safeParseJson = (json: string) => {
+export const safeParseBody = (body: string) => {
+  try {
+    return _safeParseJson(body)
+  } catch {
+    return _safeDecodeURIComponent(body)
+  }
+}
+
+const _safeDecodeURIComponent = (component: string) => {
+  try {
+    const decoded = decodeURIComponent(component)
+    return _safeParseJson(decoded.startsWith('payload=') ? decoded.slice('payload='.length) : decoded)
+  } catch (thrown: unknown) {
+    return {
+      success: false,
+      error: thrown instanceof Error ? thrown : new Error(String(thrown)),
+    }
+  }
+}
+
+const _safeParseJson = (json: string) => {
   try {
     return {
       success: true,

--- a/integrations/slack/src/webhook-events/handler-dispatcher.ts
+++ b/integrations/slack/src/webhook-events/handler-dispatcher.ts
@@ -1,6 +1,6 @@
 import * as sdk from '@botpress/sdk'
 import type { SlackEvent } from '@slack/types'
-import { safeParseJson } from 'src/misc/utils'
+import { safeParseBody } from 'src/misc/utils'
 import * as handlers from './handlers'
 import { handleInteractiveRequest, isInteractiveRequest } from './handlers/interactive-request'
 import { isOAuthCallback, handleOAuthCallback } from './handlers/oauth-callback'
@@ -17,8 +17,8 @@ export const handler: bp.IntegrationProps['handler'] = async ({ req, ctx, client
 
   _verifyBodyIsPresent(req)
 
-  const decoded = decodeURIComponent(req.body)
-  const parseRes = safeParseJson(decoded.startsWith('payload=') ? decoded.slice('payload='.length) : decoded)
+  const parseRes = safeParseBody(req.body)
+
   if (!parseRes.success) {
     const { error } = parseRes
     logger.forBot().error('could not parse the JSON', error)


### PR DESCRIPTION
Resolves SH-321

We now try to parse the payload's body as JSON before trying to decode it as a URI component.