### PR TITLE
chore(common/error-handling): improve error message in handleError method

### DIFF
--- a/packages/common/src/error-handling/try-catch-wrapper.ts
+++ b/packages/common/src/error-handling/try-catch-wrapper.ts
@@ -119,7 +119,7 @@ export const createErrorHandlingDecorator =
         } catch (thrown: unknown) {
           await asyncFnWrapperWithErrorRedaction(async () => {
             throw thrown
-          }, errorMessage)()
+          }, `${errorMessage}: ${thrown}`)()
         }
       }
       return


### PR DESCRIPTION
Resolves SH-277

After changes, we get more information on the error after the `:`
<img width="888" height="46" alt="Capture d’écran, le 2026-01-06 à 10 48 34" src="https://github.com/user-attachments/assets/57b63e0a-65bd-4cfd-9c5a-27e986033b15" />

This gives the bot developer more context on why an action might fail