### PR TITLE
feat(cognitive): flip the experimental beta flag to legacy flag

### DIFF
--- a/packages/cognitive/e2e/client.test.ts
+++ b/packages/cognitive/e2e/client.test.ts
@@ -44,7 +44,7 @@ describe('constructor', () => {
   test('valid client', () => {
     // Just check that no error is thrown
     const provider = new MockProvider(getTestClient())
-    expect(() => new Cognitive({ client: getTestClient(), provider })).not.toThrow()
+    expect(() => new Cognitive({ client: getTestClient(), provider, __use_legacy: true })).not.toThrow()
   })
 })
 
@@ -57,7 +57,7 @@ describe('client', () => {
     vi.clearAllMocks()
     bp = new TestClient()
     provider = new MockProvider(bp)
-    client = new Cognitive({ client: bp, provider })
+    client = new Cognitive({ client: bp, provider, __use_legacy: true })
   })
 
   describe('predict (request)', () => {
@@ -80,7 +80,7 @@ describe('client', () => {
 
   describe('predict (fallback)', () => {
     test('when model is unavailable, registers the downtime, saves it, and selects another model', async () => {
-      client = new Cognitive({ client: bp, provider })
+      client = new Cognitive({ client: bp, provider, __use_legacy: true })
 
       bp.callAction.mockRejectedValueOnce({
         isApiError: true,
@@ -159,5 +159,7 @@ describe('client', () => {
 test('isCognitiveClient', () => {
   const client = getTestClient()
   expect(Cognitive.isCognitiveClient(client)).toBe(false)
-  expect(Cognitive.isCognitiveClient(new Cognitive({ client, provider: new MockProvider(client) }))).toBe(true)
+  expect(
+    Cognitive.isCognitiveClient(new Cognitive({ client, provider: new MockProvider(client), __use_legacy: true }))
+  ).toBe(true)
 })

--- a/packages/cognitive/src/client.ts
+++ b/packages/cognitive/src/client.ts
@@ -39,7 +39,7 @@ export class Cognitive {
   protected _preferences: ModelPreferences | null = null
   protected _provider: ModelProvider
   protected _downtimes: ModelPreferences['downtimes'] = []
-  protected _useBeta: boolean = false
+  protected _useLegacy: boolean = false
   protected _debug = false
 
   private _events = createNanoEvents<Events>()
@@ -49,7 +49,7 @@ export class Cognitive {
     this._provider = props.provider ?? new RemoteModelProvider(props.client)
     this._timeoutMs = props.timeout ?? this._timeoutMs
     this._maxRetries = props.maxRetries ?? this._maxRetries
-    this._useBeta = props.__experimental_beta ?? false
+    this._useLegacy = !!props.__use_legacy
   }
 
   public get client(): ExtendedClient {
@@ -63,7 +63,7 @@ export class Cognitive {
       timeout: this._timeoutMs,
       maxRetries: this._maxRetries,
       __debug: this._debug,
-      __experimental_beta: this._useBeta,
+      __use_legacy: this._useLegacy,
     })
 
     copy._models = [...this._models]
@@ -156,7 +156,7 @@ export class Cognitive {
   }
 
   public async getModelDetails(model: string): Promise<Model> {
-    if (this._useBeta) {
+    if (!this._useLegacy) {
       const resolvedModel = getCognitiveV2Model(model)
       if (resolvedModel) {
         return { ...resolvedModel, ref: resolvedModel.id as ModelRef, integration: 'cognitive-v2' }
@@ -174,7 +174,7 @@ export class Cognitive {
   }
 
   public async generateContent(input: InputProps): Promise<Response> {
-    if (!this._useBeta || !getCognitiveV2Model(input.model!)) {
+    if (this._useLegacy || !getCognitiveV2Model(input.model!)) {
       return this._generateContent(input)
     }
 

--- a/packages/cognitive/src/types.ts
+++ b/packages/cognitive/src/types.ts
@@ -47,8 +47,8 @@ export type CognitiveProps = {
   timeout?: number
   /** Max retry attempts */
   maxRetries?: number
-  /** Whether to use the beta client. Restricted to authorized users. */
-  __experimental_beta?: boolean
+  /** Whether to use the legacy client. Defaults to false */
+  __use_legacy?: boolean
   __debug?: boolean
 }
 

--- a/packages/llmz/src/__tests__/index.ts
+++ b/packages/llmz/src/__tests__/index.ts
@@ -153,6 +153,7 @@ export const getCachedCognitiveClient = () => {
         downtimes: [],
       }),
     },
+    __use_legacy: true,
   })
 
   return cognitive

--- a/packages/llmz/src/llmz.ts
+++ b/packages/llmz/src/llmz.ts
@@ -272,7 +272,7 @@ export const _executeContext = async (props: ExecutionProps): Promise<ExecutionR
 
   const client = props.client ?? new Client()
 
-  const cognitive = Cognitive.isCognitiveClient(client) ? client : new Cognitive({ client, __experimental_beta: true })
+  const cognitive = Cognitive.isCognitiveClient(client) ? client : new Cognitive({ client })
   const cleanups: (() => void)[] = []
 
   const ctx = new Context({

--- a/packages/zai/e2e/client.ts
+++ b/packages/zai/e2e/client.ts
@@ -109,7 +109,6 @@ export const getCognitiveClient = () => {
       botId: process.env.CLOUD_BOT_ID,
       token: process.env.CLOUD_PAT,
     }),
-    __experimental_beta: true,
   })
   return cognitive
 }
@@ -122,7 +121,6 @@ export const getCachedCognitiveClient = () => {
       botId: process.env.CLOUD_BOT_ID,
       token: process.env.CLOUD_PAT,
     }),
-    __experimental_beta: true,
   })
   return cognitive
 }

--- a/plugins/conversation-insights/src/tagsUpdater.ts
+++ b/plugins/conversation-insights/src/tagsUpdater.ts
@@ -63,7 +63,7 @@ const _generateContentWithRetries = async <T>(props: ParsePromptProps): Promise<
   let attemptCount = 0
   const maxRetries = 3
 
-  const cognitiveClient = new cognitive.Cognitive({ client: props.client, __experimental_beta: true })
+  const cognitiveClient = new cognitive.Cognitive({ client: props.client })
   let llmOutput = await cognitiveClient.generateContent(props.prompt)
   let parsed = gen.parseLLMOutput<T>({ schema: props.schema, ...llmOutput.output })
 


### PR DESCRIPTION
I would bump a minor `0.4.0` instead of a major because I'd keep `1.0.0` for a very stable release