### PR TITLE
refactor!: change webhook state definition

### DIFF
--- a/integrations/trello/definitions/states.ts
+++ b/integrations/trello/definitions/states.ts
@@ -5,14 +5,12 @@ const _webhookIdStateSchema = trelloIdSchema
   .nullable()
   .default(null)
   .title('Trello Webhook ID')
-  .describe('Unique id of the webhook that is created upon integration registration')
+  .describe('Unique id of the webhook that is created by Trello upon integration registration')
 export type WebhookIdState = z.infer<typeof _webhookIdStateSchema>
 
 export const states = {
   webhook: {
     type: 'integration',
-    schema: z
-      .object({ trelloWebhookId: _webhookIdStateSchema })
-      .describe('State that stores the webhook id for the Trello integration'),
+    schema: z.object({ trelloWebhookId: _webhookIdStateSchema }),
   },
 } as const satisfies NonNullable<IntegrationDefinitionProps['states']>

--- a/integrations/trello/definitions/states.ts
+++ b/integrations/trello/definitions/states.ts
@@ -9,7 +9,7 @@ const _webhookIdStateSchema = trelloIdSchema
 export type WebhookIdState = z.infer<typeof _webhookIdStateSchema>
 
 export const states = {
-  webhookState: {
+  webhook: {
     type: 'integration',
     schema: z
       .object({ trelloWebhookId: _webhookIdStateSchema })

--- a/integrations/trello/src/webhook-events/handler-dispatcher.ts
+++ b/integrations/trello/src/webhook-events/handler-dispatcher.ts
@@ -44,7 +44,7 @@ const _ensureWebhookIsAuthenticated = async ({
 }) => {
   const { state } = await client.getState({
     type: 'integration',
-    name: 'webhookState',
+    name: 'webhook',
     id: ctx.integrationId,
   })
 

--- a/integrations/trello/src/webhook-lifecycle-utils.ts
+++ b/integrations/trello/src/webhook-lifecycle-utils.ts
@@ -7,7 +7,7 @@ import * as bp from '.botpress'
 const _setWebhookId = async ({ ctx, client }: bp.CommonHandlerProps, webhookId: WebhookIdState): Promise<void> => {
   await client.setState({
     type: 'integration',
-    name: 'webhookState',
+    name: 'webhook',
     id: ctx.integrationId,
     payload: {
       trelloWebhookId: webhookId,


### PR DESCRIPTION
- Changed the name/key of the webhook state from "webhookState" to "webhook"
- Removed unnecessary describe at the state schema level (only the properties matter)
- Change the description on the "trelloWebhookId" schema property