### PR TITLE
feat(integration/notion): `add page to db` --> `create page`

### DIFF
--- a/integrations/notion/definitions/actions.ts
+++ b/integrations/notion/definitions/actions.ts
@@ -1,16 +1,17 @@
 import * as sdk from '@botpress/sdk'
 
 export const actions = {
-  addPageToDb: {
-    title: 'Create Page in Database',
-    description: 'Add a new page to a database in Notion',
+  createPage: {
+    title: 'Create Page',
+    description: 'Create a new page in Notion',
     input: {
       schema: sdk.z.object({
-        databaseId: sdk.z
+        parentType: sdk.z.enum(['data source', 'page']).title('Parent Type').describe('The type of the parent'),
+        parentId: sdk.z
           .string()
           .min(1)
-          .title('Database ID')
-          .describe('The ID of the database to add the page to. Can be found in the URL of the database'),
+          .title('Parent ID')
+          .describe('The ID of the parent to add the page to. Can be found in the URL of the parent'),
         title: sdk.z.string().title('Page Title').describe('The title of the page'),
         propertiesJson : sdk.z
         .string()

--- a/integrations/notion/definitions/actions.ts
+++ b/integrations/notion/definitions/actions.ts
@@ -13,6 +13,12 @@ export const actions = {
           .title('Parent ID')
           .describe('The ID of the parent to add the page to. Can be found in the URL of the parent'),
         title: sdk.z.string().title('Page Title').describe('The title of the page'),
+        dataSourceTitleName: sdk.z
+          .string()
+          .title('Data Source Title Name')
+          .describe('The name of the title property in the data source. If not provided, the default is "Name".')
+          .optional()
+          .default('Name'),
       }),
     },
     output: {

--- a/integrations/notion/definitions/actions.ts
+++ b/integrations/notion/definitions/actions.ts
@@ -11,14 +11,21 @@ export const actions = {
           .min(1)
           .title('Database ID')
           .describe('The ID of the database to add the page to. Can be found in the URL of the database'),
-        pageProperties: sdk.z
-          .record(sdk.z.string(), sdk.z.object({}).passthrough())
-          .title('Page Properties')
-          .describe("The values of the page's properties. Must match the parent database's properties"),
+        title: sdk.z.string().title('Page Title').describe('The title of the page'),
+        propertiesJson : sdk.z
+        .string()
+        .min(2)
+        .title('Properties (JSON)')
+        .describe(
+          'Stringified JSON object for the Notion properties payload (same format as Notion pages.update API endpoint but without the "properties" key). Check the Notion API documentation for the correct format. https://developers.notion.com/reference/patch-page'
+        )
+        .placeholder('{"In stock": { "checkbox": true }}'),
       }),
     },
     output: {
-      schema: sdk.z.object({}),
+      schema: sdk.z.object({
+        pageId: sdk.z.string().title('Page ID').describe('The ID of the page that was created'),
+      }),
     },
   },
   updatePageProperties: {

--- a/integrations/notion/definitions/actions.ts
+++ b/integrations/notion/definitions/actions.ts
@@ -12,7 +12,7 @@ export const actions = {
           .min(1)
           .title('Parent ID')
           .describe('The ID of the parent to add the page to. Can be found in the URL of the parent'),
-        title: sdk.z.string().title('Page Title').describe('The title of the page')
+        title: sdk.z.string().title('Page Title').describe('The title of the page'),
       }),
     },
     output: {
@@ -38,7 +38,9 @@ export const actions = {
           .describe(
             'Stringified JSON object for the Notion properties payload (same format as Notion pages.update API endpoint but without the "properties" key). Check the Notion API documentation for the correct format. https://developers.notion.com/reference/patch-page'
           )
-          .placeholder('{"In stock": { "checkbox": true }}').optional().default('{}'),
+          .placeholder('{"In stock": { "checkbox": true }}')
+          .optional()
+          .default('{}'),
       }),
     },
     output: {

--- a/integrations/notion/definitions/actions.ts
+++ b/integrations/notion/definitions/actions.ts
@@ -12,15 +12,7 @@ export const actions = {
           .min(1)
           .title('Parent ID')
           .describe('The ID of the parent to add the page to. Can be found in the URL of the parent'),
-        title: sdk.z.string().title('Page Title').describe('The title of the page'),
-        propertiesJson : sdk.z
-        .string()
-        .min(2)
-        .title('Properties (JSON)')
-        .describe(
-          'Stringified JSON object for the Notion properties payload (same format as Notion pages.update API endpoint but without the "properties" key). Check the Notion API documentation for the correct format. https://developers.notion.com/reference/patch-page'
-        )
-        .placeholder('{"In stock": { "checkbox": true }}'),
+        title: sdk.z.string().title('Page Title').describe('The title of the page')
       }),
     },
     output: {
@@ -46,7 +38,7 @@ export const actions = {
           .describe(
             'Stringified JSON object for the Notion properties payload (same format as Notion pages.update API endpoint but without the "properties" key). Check the Notion API documentation for the correct format. https://developers.notion.com/reference/patch-page'
           )
-          .placeholder('{"In stock": { "checkbox": true }}'),
+          .placeholder('{"In stock": { "checkbox": true }}').optional().default('{}'),
       }),
     },
     output: {

--- a/integrations/notion/definitions/actions.ts
+++ b/integrations/notion/definitions/actions.ts
@@ -44,9 +44,7 @@ export const actions = {
           .describe(
             'Stringified JSON object for the Notion properties payload (same format as Notion pages.update API endpoint but without the "properties" key). Check the Notion API documentation for the correct format. https://developers.notion.com/reference/patch-page'
           )
-          .placeholder('{"In stock": { "checkbox": true }}')
-          .optional()
-          .default('{}'),
+          .placeholder('{"In stock": { "checkbox": true }}'),
       }),
     },
     output: {

--- a/integrations/notion/integration.definition.ts
+++ b/integrations/notion/integration.definition.ts
@@ -3,7 +3,7 @@ import filesReadonly from './bp_modules/files-readonly'
 import { actions, configuration, configurations, events, identifier, secrets, states, user } from './definitions'
 
 export const INTEGRATION_NAME = 'notion'
-export const INTEGRATION_VERSION = '2.2.8'
+export const INTEGRATION_VERSION = '3.0.0'
 
 export default new sdk.IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/notion/integration.definition.ts
+++ b/integrations/notion/integration.definition.ts
@@ -3,7 +3,7 @@ import filesReadonly from './bp_modules/files-readonly'
 import { actions, configuration, configurations, events, identifier, secrets, states, user } from './definitions'
 
 export const INTEGRATION_NAME = 'notion'
-export const INTEGRATION_VERSION = '3.0.4'
+export const INTEGRATION_VERSION = '2.2.8'
 
 export default new sdk.IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/notion/integration.definition.ts
+++ b/integrations/notion/integration.definition.ts
@@ -3,7 +3,7 @@ import filesReadonly from './bp_modules/files-readonly'
 import { actions, configuration, configurations, events, identifier, secrets, states, user } from './definitions'
 
 export const INTEGRATION_NAME = 'notion'
-export const INTEGRATION_VERSION = '3.0.0'
+export const INTEGRATION_VERSION = '3.0.4'
 
 export default new sdk.IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/notion/src/actions/add-page-to-db.ts
+++ b/integrations/notion/src/actions/add-page-to-db.ts
@@ -1,8 +1,25 @@
+import { updatePagePropertiesSchema } from 'definitions/notion-schemas'
 import { wrapAction } from '../action-wrapper'
+import { RuntimeError } from '@botpress/client'
 
 export const addPageToDb = wrapAction(
   { actionName: 'addPageToDb', errorMessage: 'Failed to add page to database' },
-  async ({ notionClient }, { databaseId, pageProperties }) => {
-    await notionClient.addPageToDb({ databaseId, properties: pageProperties as any }) // TODO: fix type and bump major
+  async ({ notionClient }, { databaseId, propertiesJson }) => {
+    let parsed: unknown
+
+    try {
+      parsed = JSON.parse(propertiesJson)
+    } catch (thrown) {
+      const error = thrown instanceof Error ? thrown : new Error(String(thrown))
+      throw new RuntimeError(`propertiesJson must be valid JSON: ${error.message}`)
+    }
+
+    const updatePagePropertiesResult = updatePagePropertiesSchema.safeParse(parsed)
+    if (!updatePagePropertiesResult.success) {
+      throw new RuntimeError(
+        `propertiesJson must be a valid Notion properties object. Check the Notion API documentation for the correct format. ${updatePagePropertiesResult.error.message}`
+      )
+    }
+    return await notionClient.addPageToDb({ databaseId, properties: updatePagePropertiesResult.data }) // TODO: fix type and bump major
   }
 )

--- a/integrations/notion/src/actions/create-page.ts
+++ b/integrations/notion/src/actions/create-page.ts
@@ -1,6 +1,6 @@
+import { RuntimeError } from '@botpress/client'
 import { updatePagePropertiesSchema } from 'definitions/notion-schemas'
 import { wrapAction } from '../action-wrapper'
-import { RuntimeError } from '@botpress/client'
 
 export const createPage = wrapAction(
   { actionName: 'createPage', errorMessage: 'Failed to create page' },

--- a/integrations/notion/src/actions/create-page.ts
+++ b/integrations/notion/src/actions/create-page.ts
@@ -2,9 +2,9 @@ import { updatePagePropertiesSchema } from 'definitions/notion-schemas'
 import { wrapAction } from '../action-wrapper'
 import { RuntimeError } from '@botpress/client'
 
-export const addPageToDb = wrapAction(
-  { actionName: 'addPageToDb', errorMessage: 'Failed to add page to database' },
-  async ({ notionClient }, { databaseId, propertiesJson }) => {
+export const createPage = wrapAction(
+  { actionName: 'createPage', errorMessage: 'Failed to create page' },
+  async ({ notionClient }, { parentType, parentId, title, propertiesJson }) => {
     let parsed: unknown
 
     try {
@@ -20,6 +20,6 @@ export const addPageToDb = wrapAction(
         `propertiesJson must be a valid Notion properties object. Check the Notion API documentation for the correct format. ${updatePagePropertiesResult.error.message}`
       )
     }
-    return await notionClient.addPageToDb({ databaseId, properties: updatePagePropertiesResult.data }) // TODO: fix type and bump major
+    return await notionClient.createPage({ parentType, parentId, title, properties: updatePagePropertiesResult.data }) // TODO: fix type and bump major
   }
 )

--- a/integrations/notion/src/actions/create-page.ts
+++ b/integrations/notion/src/actions/create-page.ts
@@ -2,7 +2,10 @@ import { wrapAction } from '../action-wrapper'
 
 export const createPage = wrapAction(
   { actionName: 'createPage', errorMessage: 'Failed to create page' },
-  async ({ notionClient }, { parentType, parentId, title }) => {
-    return await notionClient.createPage({ parentType, parentId, title })
+  async ({ notionClient }, { parentType, parentId, title, dataSourceTitleName }) => {
+    if (!dataSourceTitleName) {
+      dataSourceTitleName = 'Name' // default title property name for data sources
+    }
+    return await notionClient.createPage({ parentType, parentId, title, dataSourceTitleName })
   }
 )

--- a/integrations/notion/src/actions/create-page.ts
+++ b/integrations/notion/src/actions/create-page.ts
@@ -4,22 +4,7 @@ import { RuntimeError } from '@botpress/client'
 
 export const createPage = wrapAction(
   { actionName: 'createPage', errorMessage: 'Failed to create page' },
-  async ({ notionClient }, { parentType, parentId, title, propertiesJson }) => {
-    let parsed: unknown
-
-    try {
-      parsed = JSON.parse(propertiesJson)
-    } catch (thrown) {
-      const error = thrown instanceof Error ? thrown : new Error(String(thrown))
-      throw new RuntimeError(`propertiesJson must be valid JSON: ${error.message}`)
-    }
-
-    const updatePagePropertiesResult = updatePagePropertiesSchema.safeParse(parsed)
-    if (!updatePagePropertiesResult.success) {
-      throw new RuntimeError(
-        `propertiesJson must be a valid Notion properties object. Check the Notion API documentation for the correct format. ${updatePagePropertiesResult.error.message}`
-      )
-    }
-    return await notionClient.createPage({ parentType, parentId, title, properties: updatePagePropertiesResult.data }) // TODO: fix type and bump major
+  async ({ notionClient }, { parentType, parentId, title }) => {
+    return await notionClient.createPage({ parentType, parentId, title })
   }
 )

--- a/integrations/notion/src/actions/create-page.ts
+++ b/integrations/notion/src/actions/create-page.ts
@@ -1,5 +1,3 @@
-import { RuntimeError } from '@botpress/client'
-import { updatePagePropertiesSchema } from 'definitions/notion-schemas'
 import { wrapAction } from '../action-wrapper'
 
 export const createPage = wrapAction(

--- a/integrations/notion/src/actions/index.ts
+++ b/integrations/notion/src/actions/index.ts
@@ -1,7 +1,7 @@
 import { addCommentToDiscussion } from './add-comment-to-discussion'
 import { addCommentToPage } from './add-comment-to-page'
-import { createPage } from './create-page'
 import { appendBlocksToPage } from './append-blocks-to-page'
+import { createPage } from './create-page'
 import { deleteBlock } from './delete-block'
 import { filesReadonlyListItemsInFolder } from './files-readonly/list-items-in-folder'
 import { filesReadonlyTransferFileToBotpress } from './files-readonly/transfer-file-to-botpress'

--- a/integrations/notion/src/actions/index.ts
+++ b/integrations/notion/src/actions/index.ts
@@ -1,6 +1,6 @@
 import { addCommentToDiscussion } from './add-comment-to-discussion'
 import { addCommentToPage } from './add-comment-to-page'
-import { addPageToDb } from './add-page-to-db'
+import { createPage } from './create-page'
 import { appendBlocksToPage } from './append-blocks-to-page'
 import { deleteBlock } from './delete-block'
 import { filesReadonlyListItemsInFolder } from './files-readonly/list-items-in-folder'
@@ -15,7 +15,7 @@ import * as bp from '.botpress'
 export const actions = {
   addCommentToDiscussion,
   addCommentToPage,
-  addPageToDb,
+  createPage,
   appendBlocksToPage,
   deleteBlock,
   filesReadonlyListItemsInFolder,

--- a/integrations/notion/src/actions/update-page-properties.ts
+++ b/integrations/notion/src/actions/update-page-properties.ts
@@ -7,6 +7,10 @@ export const updatePageProperties = wrapAction(
   async ({ notionClient }, { pageId, propertiesJson }) => {
     let parsed: unknown
 
+    if (!propertiesJson) {
+      throw new RuntimeError('propertiesJson is required')
+    }
+
     try {
       parsed = JSON.parse(propertiesJson)
     } catch (thrown) {

--- a/integrations/notion/src/notion-api/notion-client.ts
+++ b/integrations/notion/src/notion-api/notion-client.ts
@@ -63,11 +63,12 @@ export class NotionClient {
   }: {
     databaseId: string
     properties: Record<types.NotionPagePropertyTypes, any>
-  }): Promise<void> {
-    void (await this._notion.pages.create({
+  }): Promise<{ pageId: string }> {
+    const response = await this._notion.pages.create({
       parent: { database_id: databaseId },
       properties,
-    }))
+    })
+    return { pageId: response.id }
   }
 
   @handleErrors('Failed to add comment to page')

--- a/integrations/notion/src/notion-api/notion-client.ts
+++ b/integrations/notion/src/notion-api/notion-client.ts
@@ -72,7 +72,7 @@ export class NotionClient {
   }
 
   @handleErrors('Failed to create page')
-  public async createPage({ parentType, parentId, title, properties }: { parentType: string; parentId: string; title: string; properties: Record<types.NotionPagePropertyTypes, any> }): Promise<{ pageId: string }> {
+  public async createPage({ parentType, parentId, title }: { parentType: string; parentId: string; title: string }): Promise<{ pageId: string }> {
     
     const pageProperties = { 
       Name: { 
@@ -83,13 +83,14 @@ export class NotionClient {
           }
         ] 
       }, 
-      ...properties 
     }
     
     const response = await this._notion.pages.create({
       parent: parentType === 'database' 
         ? { database_id: parentId } 
-        : { page_id: parentId }
+        : { page_id: parentId },
+      properties:
+       { Name: { title: [{ type: 'text', text: { content: title } }] } }
     })
     
     return { pageId: response.id }

--- a/integrations/notion/src/notion-api/notion-client.ts
+++ b/integrations/notion/src/notion-api/notion-client.ts
@@ -81,16 +81,6 @@ export class NotionClient {
     parentId: string
     title: string
   }): Promise<{ pageId: string }> {
-    const pageProperties = {
-      Name: {
-        title: [
-          {
-            type: 'text',
-            text: { content: title },
-          },
-        ],
-      },
-    }
 
     const response = await this._notion.pages.create({
       parent: parentType === 'database' ? { database_id: parentId } : { page_id: parentId },

--- a/integrations/notion/src/notion-api/notion-client.ts
+++ b/integrations/notion/src/notion-api/notion-client.ts
@@ -72,27 +72,31 @@ export class NotionClient {
   }
 
   @handleErrors('Failed to create page')
-  public async createPage({ parentType, parentId, title }: { parentType: string; parentId: string; title: string }): Promise<{ pageId: string }> {
-    
-    const pageProperties = { 
-      Name: { 
+  public async createPage({
+    parentType,
+    parentId,
+    title,
+  }: {
+    parentType: string
+    parentId: string
+    title: string
+  }): Promise<{ pageId: string }> {
+    const pageProperties = {
+      Name: {
         title: [
-          { 
-            type: 'text', 
-            text: { content: title } 
-          }
-        ] 
-      }, 
+          {
+            type: 'text',
+            text: { content: title },
+          },
+        ],
+      },
     }
-    
+
     const response = await this._notion.pages.create({
-      parent: parentType === 'database' 
-        ? { database_id: parentId } 
-        : { page_id: parentId },
-      properties:
-       { Name: { title: [{ type: 'text', text: { content: title } }] } }
+      parent: parentType === 'database' ? { database_id: parentId } : { page_id: parentId },
+      properties: { Name: { title: [{ type: 'text', text: { content: title } }] } },
     })
-    
+
     return { pageId: response.id }
   }
 

--- a/integrations/notion/src/notion-api/notion-client.ts
+++ b/integrations/notion/src/notion-api/notion-client.ts
@@ -71,6 +71,30 @@ export class NotionClient {
     return { pageId: response.id }
   }
 
+  @handleErrors('Failed to create page')
+  public async createPage({ parentType, parentId, title, properties }: { parentType: string; parentId: string; title: string; properties: Record<types.NotionPagePropertyTypes, any> }): Promise<{ pageId: string }> {
+    
+    const pageProperties = { 
+      Name: { 
+        title: [
+          { 
+            type: 'text', 
+            text: { content: title } 
+          }
+        ] 
+      }, 
+      ...properties 
+    }
+    
+    const response = await this._notion.pages.create({
+      parent: parentType === 'database' 
+        ? { database_id: parentId } 
+        : { page_id: parentId }
+    })
+    
+    return { pageId: response.id }
+  }
+
   @handleErrors('Failed to add comment to page')
   public async addCommentToPage({ pageId, commentBody }: { pageId: string; commentBody: string }): Promise<void> {
     void (await this._notion.comments.create({


### PR DESCRIPTION
Resolves SH-338

This PR contains the removal of `add page to db` and adding `create page` as a replacement. This is due to the page properties not showing in the UI previously and the Notion update (databases -> data sources)