### PR TITLE
refactor!: reverse direction of move card actions

### DIFF
--- a/integrations/trello/hub.md
+++ b/integrations/trello/hub.md
@@ -67,3 +67,7 @@ The id of the board should be 24 characters long consisting of letters and numbe
 - Some Trello paid features may not be available.
 
 [Trello - API Introduction]: https://developer.atlassian.com/cloud/trello/guides/rest-api/api-introduction/
+
+## Migration from 1.x.x to 2.x.x
+
+- Replace "Move Card Up" action with "Move Card Down" actions (and vice versa) as the directions were reversed to match the visual displacement of the cards on Trello.

--- a/integrations/trello/src/actions/card-actions.ts
+++ b/integrations/trello/src/actions/card-actions.ts
@@ -96,7 +96,7 @@ export const moveCardDown: bp.Integration['actions']['moveCardDown'] = async (pr
   const { trelloClient } = getTools(props)
 
   const { cardId, moveDownByNSpaces } = props.input
-  const numOfPositions = -(moveDownByNSpaces ?? 1)
+  const numOfPositions = moveDownByNSpaces ?? 1
   await moveCardVertically({ trelloClient, cardId, numOfPositions })
 
   return { message: 'Card successfully moved down' }
@@ -107,7 +107,7 @@ export const moveCardUp: bp.Integration['actions']['moveCardUp'] = async (props)
   const { trelloClient } = getTools(props)
 
   const { cardId, moveUpByNSpaces } = props.input
-  const numOfPositions = moveUpByNSpaces ?? 1
+  const numOfPositions = -(moveUpByNSpaces ?? 1)
   await moveCardVertically({ trelloClient, cardId, numOfPositions })
 
   return { message: 'Card successfully moved up' }


### PR DESCRIPTION
This is to align the name of the action with how the cards move in a visual sense. Since before the "moveCardDown" action would visually move the card up from an end-user perspective and vice-versa.