### PR TITLE
chore(GitHub): re-enable deployment of asana

### DIFF
--- a/.github/actions/deploy-integrations/action.yml
+++ b/.github/actions/deploy-integrations/action.yml
@@ -76,7 +76,7 @@ runs:
         redeploy=${{ inputs.force == 'true' && 1 || 0 }}
         dryrun="${{ inputs.dry_run == 'true' && '--dryRun' || '' }}"
         is_dry_run=${{ inputs.dry_run == 'true' && 1 || 0 }}
-        all_filters="-F '{integrations/*}' -F '!asana' ${{ inputs.extra_filter }}"
+        all_filters="-F '{integrations/*}' ${{ inputs.extra_filter }}"
         list_integrations_cmd="pnpm list $all_filters --json"
         integration_paths=$(eval $list_integrations_cmd | jq -r "map(".path") | .[]")
 


### PR DESCRIPTION
It’s unclear how long the Asana deployment has been disabled. During a refactor, the PR became obfuscated and the deployment was turned off. This PR re-enables the deployment since my test with the version on master is working fine.

<img width="1159" height="123" alt="image" src="https://github.com/user-attachments/assets/e1117dbd-a071-43ad-a02b-51ab2c7db92b" />
<img width="1204" height="913" alt="image" src="https://github.com/user-attachments/assets/2b41c33f-5772-4854-a83e-598aa1e77f6c" />
