### PR TITLE
fix(llmz): made sure tool names were unique

### DIFF
--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -2,7 +2,7 @@
   "name": "llmz",
   "type": "module",
   "description": "LLMz - An LLM-native Typescript VM built on top of Zui",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/llmz/src/tool.test.ts
+++ b/packages/llmz/src/tool.test.ts
@@ -132,7 +132,7 @@ describe('tools with unique names', () => {
     expect(tools.map((t) => t.name)).toMatchInlineSnapshot(`
       [
         "add1",
-        "add1",
+        "add2",
         "sub1",
         "add",
         "sub",

--- a/packages/llmz/src/tool.ts
+++ b/packages/llmz/src/tool.ts
@@ -808,6 +808,8 @@ export class Tool<I extends ZuiType = ZuiType, O extends ZuiType = ZuiType> impl
         toolName = `${tool.name}${++counter}`
       }
 
+      names.add(toolName)
+
       return tool.rename(toolName)
     })
   }


### PR DESCRIPTION
When using the same tool more that 3 times, only the first 2 and the last one were recognized by LLMZ

See [this issue](https://linear.app/botpress/issue/STU-1377/autonomous-node-does-not-recognize-more-than-2-search-kb-cards) for more details