### PR TITLE
chore(integration/notion): Void return removal

### DIFF
--- a/integrations/notion/definitions/actions.ts
+++ b/integrations/notion/definitions/actions.ts
@@ -67,7 +67,9 @@ export const actions = {
       }),
     },
     output: {
-      schema: sdk.z.object({}),
+      schema: sdk.z.object({
+        commentId: sdk.z.string().title('Comment ID').describe('The ID of the comment that was created'),
+      }),
     },
   },
   deleteBlock: {
@@ -83,7 +85,9 @@ export const actions = {
       }),
     },
     output: {
-      schema: sdk.z.object({}),
+      schema: sdk.z.object({
+        blockId: sdk.z.string().title('Block ID').describe('The ID of the block that was deleted'),
+      }),
     },
   },
   getDb: {
@@ -196,7 +200,9 @@ export const actions = {
       }),
     },
     output: {
-      schema: sdk.z.object({}),
+      schema: sdk.z.object({
+        commentId: sdk.z.string().title('Comment ID').describe('The ID of the comment that was created'),
+      }),
     },
   },
   appendBlocksToPage: {
@@ -213,7 +219,10 @@ export const actions = {
       }),
     },
     output: {
-      schema: sdk.z.object({}),
+      schema: sdk.z.object({
+        pageId: sdk.z.string().title('Page ID').describe('The ID of the page where blocks were appended'),
+        blockIds: sdk.z.array(sdk.z.string()).title('Block IDs').describe('The IDs of the blocks that were created'),
+      }),
     },
   },
   searchByTitle: {

--- a/integrations/notion/src/actions/add-comment-to-discussion.ts
+++ b/integrations/notion/src/actions/add-comment-to-discussion.ts
@@ -3,6 +3,6 @@ import { wrapAction } from '../action-wrapper'
 export const addCommentToDiscussion = wrapAction(
   { actionName: 'addCommentToDiscussion', errorMessage: 'Failed to add comment to discussion' },
   async ({ notionClient }, { commentBody, discussionId }) => {
-    await notionClient.addCommentToDiscussion({ commentBody, discussionId })
+    return await notionClient.addCommentToDiscussion({ commentBody, discussionId })
   }
 )

--- a/integrations/notion/src/actions/add-comment-to-page.ts
+++ b/integrations/notion/src/actions/add-comment-to-page.ts
@@ -3,6 +3,6 @@ import { wrapAction } from '../action-wrapper'
 export const addCommentToPage = wrapAction(
   { actionName: 'addCommentToPage', errorMessage: 'Failed to add comment to page' },
   async ({ notionClient }, { commentBody, pageId }) => {
-    await notionClient.addCommentToPage({ commentBody, pageId })
+    return await notionClient.addCommentToPage({ commentBody, pageId })
   }
 )

--- a/integrations/notion/src/actions/append-blocks-to-page.ts
+++ b/integrations/notion/src/actions/append-blocks-to-page.ts
@@ -7,6 +7,6 @@ export const appendBlocksToPage = wrapAction(
     const { pageId, markdownText } = input
     const blocks = markdownToBlocks(markdownText)
     // @ts-expect-error - @tryfabric/martian uses notion@1.0.4 types which needs to be updated to notion@5.6.0 but it works. To find a better solution
-    await notionClient.appendBlocksToPage({ pageId, blocks })
+    return await notionClient.appendBlocksToPage({ pageId, blocks })
   }
 )

--- a/integrations/notion/src/actions/delete-block.ts
+++ b/integrations/notion/src/actions/delete-block.ts
@@ -3,6 +3,6 @@ import { wrapAction } from '../action-wrapper'
 export const deleteBlock = wrapAction(
   { actionName: 'deleteBlock', errorMessage: 'Failed to delete block' },
   async ({ notionClient }, { blockId }) => {
-    await notionClient.deleteBlock({ blockId })
+    return await notionClient.deleteBlock({ blockId })
   }
 )

--- a/integrations/notion/src/notion-api/notion-client.ts
+++ b/integrations/notion/src/notion-api/notion-client.ts
@@ -104,8 +104,8 @@ export class NotionClient {
   }
 
   @handleErrors('Failed to add comment to page')
-  public async addCommentToPage({ pageId, commentBody }: { pageId: string; commentBody: string }): Promise<void> {
-    void (await this._notion.comments.create({
+  public async addCommentToPage({ pageId, commentBody }: { pageId: string; commentBody: string }): Promise<{ commentId: string }> {
+    const response = await this._notion.comments.create({
       parent: { page_id: pageId },
       rich_text: [
         {
@@ -115,7 +115,8 @@ export class NotionClient {
           },
         },
       ],
-    }))
+    })
+    return { commentId: response.id }
   }
 
   @handleErrors('Failed to add comment to discussion')
@@ -125,8 +126,8 @@ export class NotionClient {
   }: {
     discussionId: string
     commentBody: string
-  }): Promise<void> {
-    void (await this._notion.comments.create({
+  }): Promise<{ commentId: string }> {
+    const response = await this._notion.comments.create({
       discussion_id: discussionId,
       rich_text: [
         {
@@ -136,7 +137,8 @@ export class NotionClient {
           },
         },
       ],
-    }))
+    })
+    return { commentId: response.id }
   }
 
   @handleErrors('Failed to update page properties')
@@ -154,16 +156,21 @@ export class NotionClient {
   }
 
   @handleErrors('Failed to delete block')
-  public async deleteBlock({ blockId }: { blockId: string }): Promise<void> {
-    void (await this._notion.blocks.delete({ block_id: blockId }))
+  public async deleteBlock({ blockId }: { blockId: string }): Promise<{ blockId: string }> {
+    const response = await this._notion.blocks.delete({ block_id: blockId })
+    return { blockId: response.id }
   }
 
   @handleErrors('Failed to append block to page')
-  public async appendBlocksToPage({ pageId, blocks }: { pageId: string; blocks: BlockObjectRequest[] }): Promise<void> {
-    void (await this._notion.blocks.children.append({
+  public async appendBlocksToPage({ pageId, blocks }: { pageId: string; blocks: BlockObjectRequest[] }): Promise<{ pageId: string; blockIds: string[] }> {
+    const response = await this._notion.blocks.children.append({
       block_id: pageId,
       children: blocks,
-    }))
+    })
+    return { 
+      pageId,
+      blockIds: response.results.map((block) => block.id)
+    }
   }
 
   @handleErrors('Failed to search by title')

--- a/integrations/notion/src/notion-api/notion-client.ts
+++ b/integrations/notion/src/notion-api/notion-client.ts
@@ -104,7 +104,13 @@ export class NotionClient {
   }
 
   @handleErrors('Failed to add comment to page')
-  public async addCommentToPage({ pageId, commentBody }: { pageId: string; commentBody: string }): Promise<{ commentId: string }> {
+  public async addCommentToPage({
+    pageId,
+    commentBody,
+  }: {
+    pageId: string
+    commentBody: string
+  }): Promise<{ commentId: string }> {
     const response = await this._notion.comments.create({
       parent: { page_id: pageId },
       rich_text: [
@@ -162,14 +168,20 @@ export class NotionClient {
   }
 
   @handleErrors('Failed to append block to page')
-  public async appendBlocksToPage({ pageId, blocks }: { pageId: string; blocks: BlockObjectRequest[] }): Promise<{ pageId: string; blockIds: string[] }> {
+  public async appendBlocksToPage({
+    pageId,
+    blocks,
+  }: {
+    pageId: string
+    blocks: BlockObjectRequest[]
+  }): Promise<{ pageId: string; blockIds: string[] }> {
     const response = await this._notion.blocks.children.append({
       block_id: pageId,
       children: blocks,
     })
-    return { 
+    return {
       pageId,
-      blockIds: response.results.map((block) => block.id)
+      blockIds: response.results.map((block) => block.id),
     }
   }
 


### PR DESCRIPTION
This PR contains the changes to remove all void returns. This ensures that all action cards return data which allows the bot developer
- to confidently know if the action succeeded
- to better chain actions