### PR TITLE
chore(bots/bugbuster): removed useless notifications

### DIFF
--- a/bots/bugbuster/src/handlers/lint-all.ts
+++ b/bots/bugbuster/src/handlers/lint-all.ts
@@ -94,7 +94,9 @@ export const handleLintAll: bp.WorkflowHandlers['lintAll'] = async (props) => {
       channel.teams.some((team) => result.identifier.includes(team))
     )
 
-    await botpress.respondText(channel.conversationId, _buildResultMessage(relevantIssues)).catch(() => {})
+    if (relevantIssues.length > 0) {
+      await botpress.respondText(channel.conversationId, _buildResultMessage(relevantIssues)).catch(() => {})
+    }
   }
 
   await workflow.setCompleted()


### PR DESCRIPTION
Removed notifications for the `lintAll` workflow when all issues pass the lint.