### PR TITLE
feat(integrations/gsheets): add handy actions

### DIFF
--- a/integrations/gsheets/integration.definition.ts
+++ b/integrations/gsheets/integration.definition.ts
@@ -13,7 +13,7 @@ import {
 } from './definitions'
 
 export const INTEGRATION_NAME = 'gsheets'
-export const INTEGRATION_VERSION = '2.0.1'
+export const INTEGRATION_VERSION = '2.0.2'
 
 export default new sdk.IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/gsheets/src/actions/implementations/delete-rows.ts
+++ b/integrations/gsheets/src/actions/implementations/delete-rows.ts
@@ -1,0 +1,21 @@
+import { wrapAction } from '../action-wrapper'
+
+export const deleteRows = wrapAction(
+  { actionName: 'deleteRows', errorMessageWhenFailed: 'Failed to delete rows' },
+  async ({ googleClient }, { sheetName, rowIndexes }) => {
+    if (rowIndexes.length === 0) {
+      return { deletedCount: 0 }
+    }
+
+    const { sheetId } = await googleClient.getSheetIdByName(sheetName)
+
+    await googleClient.deleteRowsFromSheet({
+      sheetId,
+      rowIndexes,
+    })
+
+    return {
+      deletedCount: rowIndexes.length,
+    }
+  }
+)

--- a/integrations/gsheets/src/actions/implementations/find-row.ts
+++ b/integrations/gsheets/src/actions/implementations/find-row.ts
@@ -1,0 +1,43 @@
+import { wrapAction } from '../action-wrapper'
+import { buildSheetPrefix, columnLetterToIndex } from './row-utils'
+
+export const findRow = wrapAction(
+  { actionName: 'findRow', errorMessageWhenFailed: 'Failed to find row' },
+  async ({ googleClient }, { sheetName, searchColumn, searchValue, dataRange }) => {
+    const { sheetTitle } = await googleClient.getSheetIdByName(sheetName)
+    const prefix = buildSheetPrefix(sheetTitle)
+
+    const rangeA1 = dataRange ? `${prefix}${dataRange.split('!').pop()}` : `${prefix}A:ZZ`
+
+    let values: string[][] = []
+    try {
+      const result = await googleClient.getValuesFromSpreadsheetRange({ rangeA1, majorDimension: 'ROWS' })
+      values = result.values ?? []
+    } catch {
+      return { found: false, row: null }
+    }
+
+    if (values.length === 0) {
+      return { found: false, row: null }
+    }
+
+    const searchColumnIndex = columnLetterToIndex(searchColumn)
+
+    for (let i = 0; i < values.length; i++) {
+      const row = values[i] ?? []
+      const cellValue = row[searchColumnIndex] ?? ''
+
+      if (cellValue === searchValue) {
+        return {
+          found: true,
+          row: {
+            rowIndex: i + 1,
+            values: row.map(String),
+          },
+        }
+      }
+    }
+
+    return { found: false, row: null }
+  }
+)

--- a/integrations/gsheets/src/actions/implementations/find-rows.ts
+++ b/integrations/gsheets/src/actions/implementations/find-rows.ts
@@ -1,0 +1,44 @@
+import { wrapAction } from '../action-wrapper'
+import { buildSheetPrefix, columnLetterToIndex } from './row-utils'
+
+export const findRows = wrapAction(
+  { actionName: 'findRows', errorMessageWhenFailed: 'Failed to find rows' },
+  async ({ googleClient }, { sheetName, searchColumn, searchValue, dataRange }) => {
+    const { sheetTitle } = await googleClient.getSheetIdByName(sheetName)
+    const prefix = buildSheetPrefix(sheetTitle)
+
+    const rangeA1 = dataRange ? `${prefix}${dataRange.split('!').pop()}` : `${prefix}A:ZZ`
+
+    let values: string[][] = []
+    try {
+      const result = await googleClient.getValuesFromSpreadsheetRange({ rangeA1, majorDimension: 'ROWS' })
+      values = result.values ?? []
+    } catch {
+      return { rows: [], totalMatches: 0 }
+    }
+
+    if (values.length === 0) {
+      return { rows: [], totalMatches: 0 }
+    }
+
+    const searchColumnIndex = columnLetterToIndex(searchColumn)
+    const rows: Array<{ rowIndex: number; values: string[] }> = []
+
+    for (let i = 0; i < values.length; i++) {
+      const row = values[i] ?? []
+      const cellValue = row[searchColumnIndex] ?? ''
+
+      if (cellValue === searchValue) {
+        rows.push({
+          rowIndex: i + 1,
+          values: row.map(String),
+        })
+      }
+    }
+
+    return {
+      rows,
+      totalMatches: rows.length,
+    }
+  }
+)

--- a/integrations/gsheets/src/actions/implementations/get-row.ts
+++ b/integrations/gsheets/src/actions/implementations/get-row.ts
@@ -1,0 +1,36 @@
+import { wrapAction } from '../action-wrapper'
+import { buildRowRange } from './row-utils'
+
+export const getRow = wrapAction(
+  { actionName: 'getRow', errorMessageWhenFailed: 'Failed to get row' },
+  async ({ googleClient }, { sheetName, rowIndex, startColumn, endColumn }) => {
+    const { sheetTitle } = await googleClient.getSheetIdByName(sheetName)
+
+    const rangeA1 = buildRowRange({
+      sheetTitle,
+      rowIndex,
+      startColumn: startColumn ?? 'A',
+      endColumn,
+    })
+
+    let values: string[][] = []
+    try {
+      const result = await googleClient.getValuesFromSpreadsheetRange({ rangeA1, majorDimension: 'ROWS' })
+      values = result.values ?? []
+    } catch {
+      return { found: false, row: null }
+    }
+
+    if (values.length === 0 || !values[0] || values[0].length === 0) {
+      return { found: false, row: null }
+    }
+
+    return {
+      found: true,
+      row: {
+        rowIndex,
+        values: values[0].map(String),
+      },
+    }
+  }
+)

--- a/integrations/gsheets/src/actions/implementations/insert-row-at-index.ts
+++ b/integrations/gsheets/src/actions/implementations/insert-row-at-index.ts
@@ -1,0 +1,39 @@
+import { wrapAction } from '../action-wrapper'
+import { buildRowRange, indexToColumnLetter, columnLetterToIndex } from './row-utils'
+
+export const insertRowAtIndex = wrapAction(
+  { actionName: 'insertRowAtIndex', errorMessageWhenFailed: 'Failed to insert row at index' },
+  async ({ googleClient }, { sheetName, rowIndex, values, startColumn }) => {
+    const { sheetId, sheetTitle } = await googleClient.getSheetIdByName(sheetName)
+
+    await googleClient.insertRows({
+      sheetId,
+      startIndex: rowIndex - 1,
+      numberOfRows: 1,
+    })
+
+    if (values && values.length > 0) {
+      const start = startColumn ?? 'A'
+      const startColIndex = columnLetterToIndex(start)
+      const endColIndex = startColIndex + values.length - 1
+      const endColumn = indexToColumnLetter(endColIndex)
+
+      const rangeA1 = buildRowRange({
+        sheetTitle,
+        rowIndex,
+        startColumn: start,
+        endColumn,
+      })
+
+      await googleClient.updateValuesInSpreadsheetRange({
+        rangeA1,
+        values: [values],
+        majorDimension: 'ROWS',
+      })
+    }
+
+    return {
+      insertedRowIndex: rowIndex,
+    }
+  }
+)

--- a/integrations/gsheets/src/actions/implementations/row-utils.test.ts
+++ b/integrations/gsheets/src/actions/implementations/row-utils.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import {
+  columnLetterToIndex,
+  indexToColumnLetter,
+  buildSheetPrefix,
+  buildRowRange,
+  buildColumnRange,
+} from './row-utils'
+
+describe.concurrent('columnLetterToIndex', () => {
+  it('converts single letters A-Z to indices 0-25', () => {
+    expect(columnLetterToIndex('A')).toBe(0)
+    expect(columnLetterToIndex('B')).toBe(1)
+    expect(columnLetterToIndex('Z')).toBe(25)
+  })
+
+  it('converts double letters starting with AA', () => {
+    expect(columnLetterToIndex('AA')).toBe(26)
+    expect(columnLetterToIndex('AB')).toBe(27)
+    expect(columnLetterToIndex('AZ')).toBe(51)
+  })
+
+  it('converts BA and beyond', () => {
+    expect(columnLetterToIndex('BA')).toBe(52)
+    expect(columnLetterToIndex('ZZ')).toBe(701)
+  })
+
+  it('is case-insensitive', () => {
+    expect(columnLetterToIndex('a')).toBe(0)
+    expect(columnLetterToIndex('aa')).toBe(26)
+    expect(columnLetterToIndex('Aa')).toBe(26)
+  })
+})
+
+describe.concurrent('indexToColumnLetter', () => {
+  it('converts indices 0-25 to single letters A-Z', () => {
+    expect(indexToColumnLetter(0)).toBe('A')
+    expect(indexToColumnLetter(1)).toBe('B')
+    expect(indexToColumnLetter(25)).toBe('Z')
+  })
+
+  it('converts index 26+ to double letters', () => {
+    expect(indexToColumnLetter(26)).toBe('AA')
+    expect(indexToColumnLetter(27)).toBe('AB')
+    expect(indexToColumnLetter(51)).toBe('AZ')
+  })
+
+  it('converts higher indices correctly', () => {
+    expect(indexToColumnLetter(52)).toBe('BA')
+    expect(indexToColumnLetter(701)).toBe('ZZ')
+  })
+})
+
+describe.concurrent('columnLetterToIndex and indexToColumnLetter roundtrip', () => {
+  it('indexToColumnLetter inverts columnLetterToIndex', () => {
+    const letters = ['A', 'Z', 'AA', 'AZ', 'BA', 'ZZ']
+    for (const letter of letters) {
+      expect(indexToColumnLetter(columnLetterToIndex(letter))).toBe(letter)
+    }
+  })
+
+  it('columnLetterToIndex inverts indexToColumnLetter', () => {
+    const indices = [0, 25, 26, 51, 52, 701]
+    for (const index of indices) {
+      expect(columnLetterToIndex(indexToColumnLetter(index))).toBe(index)
+    }
+  })
+})
+
+describe.concurrent('buildSheetPrefix', () => {
+  it('returns empty string when no sheet title', () => {
+    expect(buildSheetPrefix()).toBe('')
+    expect(buildSheetPrefix(undefined)).toBe('')
+  })
+
+  it('returns simple prefix for alphanumeric titles', () => {
+    expect(buildSheetPrefix('Sheet1')).toBe('Sheet1!')
+    expect(buildSheetPrefix('Data')).toBe('Data!')
+  })
+
+  it('quotes titles containing spaces', () => {
+    expect(buildSheetPrefix('My Sheet')).toBe("'My Sheet'!")
+  })
+
+  it('quotes and escapes titles containing apostrophes', () => {
+    expect(buildSheetPrefix("It's")).toBe("'It''s'!")
+    expect(buildSheetPrefix("Don't stop")).toBe("'Don''t stop'!")
+  })
+})
+
+describe.concurrent('buildRowRange', () => {
+  it('builds simple row range with defaults', () => {
+    expect(buildRowRange({ rowIndex: 1 })).toBe('A1:1')
+  })
+
+  it('builds row range with explicit start and end columns', () => {
+    expect(buildRowRange({ rowIndex: 5, startColumn: 'B', endColumn: 'D' })).toBe('B5:D5')
+  })
+
+  it('includes sheet prefix when provided', () => {
+    expect(buildRowRange({ sheetTitle: 'Data', rowIndex: 3, startColumn: 'A', endColumn: 'C' })).toBe('Data!A3:C3')
+  })
+
+  it('handles sheet titles requiring quotes', () => {
+    expect(buildRowRange({ sheetTitle: 'My Data', rowIndex: 1, endColumn: 'B' })).toBe("'My Data'!A1:B1")
+  })
+})
+
+describe.concurrent('buildColumnRange', () => {
+  it('builds single column range with defaults', () => {
+    expect(buildColumnRange({})).toBe('A1:A100000')
+  })
+
+  it('builds range for specified columns', () => {
+    expect(buildColumnRange({ startColumn: 'B', endColumn: 'D' })).toBe('B1:D100000')
+  })
+
+  it('uses startColumn as endColumn when endColumn not specified', () => {
+    expect(buildColumnRange({ startColumn: 'C' })).toBe('C1:C100000')
+  })
+
+  it('respects custom maxRow', () => {
+    expect(buildColumnRange({ startColumn: 'A', endColumn: 'B', maxRow: 500 })).toBe('A1:B500')
+  })
+
+  it('includes sheet prefix when provided', () => {
+    expect(buildColumnRange({ sheetTitle: 'Sales', startColumn: 'A', endColumn: 'C' })).toBe('Sales!A1:C100000')
+  })
+})

--- a/integrations/gsheets/src/actions/implementations/row-utils.ts
+++ b/integrations/gsheets/src/actions/implementations/row-utils.ts
@@ -1,0 +1,58 @@
+const ASCII_UPPERCASE_A = 65
+const BASE_26 = 26
+
+export const columnLetterToIndex = (col: string): number =>
+  col
+    .toUpperCase()
+    .split('')
+    .reduce((acc, char) => acc * BASE_26 + char.charCodeAt(0) - ASCII_UPPERCASE_A + 1, 0) - 1
+
+export const indexToColumnLetter = (index: number): string => {
+  let letter = ''
+  let i = index
+  while (i >= 0) {
+    letter = String.fromCharCode((i % BASE_26) + ASCII_UPPERCASE_A) + letter
+    i = Math.floor(i / BASE_26) - 1
+  }
+  return letter
+}
+
+export const buildSheetPrefix = (sheetTitle?: string): string => {
+  if (!sheetTitle) {
+    return ''
+  }
+  const needsQuotes = sheetTitle.includes(' ') || sheetTitle.includes("'")
+  return needsQuotes ? `'${sheetTitle.replace(/'/g, "''")}'!` : `${sheetTitle}!`
+}
+
+export const buildRowRange = ({
+  sheetTitle,
+  rowIndex,
+  startColumn = 'A',
+  endColumn,
+}: {
+  sheetTitle?: string
+  rowIndex: number
+  startColumn?: string
+  endColumn?: string
+}): string => {
+  const prefix = buildSheetPrefix(sheetTitle)
+  const end = endColumn ? `${endColumn}${rowIndex}` : `${rowIndex}`
+  return `${prefix}${startColumn}${rowIndex}:${end}`
+}
+
+export const buildColumnRange = ({
+  sheetTitle,
+  startColumn = 'A',
+  endColumn,
+  maxRow = 100000,
+}: {
+  sheetTitle?: string
+  startColumn?: string
+  endColumn?: string
+  maxRow?: number
+}): string => {
+  const prefix = buildSheetPrefix(sheetTitle)
+  const end = endColumn ?? startColumn
+  return `${prefix}${startColumn}1:${end}${maxRow}`
+}

--- a/integrations/gsheets/src/actions/implementations/update-row.ts
+++ b/integrations/gsheets/src/actions/implementations/update-row.ts
@@ -1,0 +1,32 @@
+import { wrapAction } from '../action-wrapper'
+import { buildRowRange, indexToColumnLetter, columnLetterToIndex } from './row-utils'
+
+export const updateRow = wrapAction(
+  { actionName: 'updateRow', errorMessageWhenFailed: 'Failed to update row' },
+  async ({ googleClient }, { sheetName, rowIndex, values, startColumn }) => {
+    const { sheetTitle } = await googleClient.getSheetIdByName(sheetName)
+
+    const start = startColumn ?? 'A'
+    const startColIndex = columnLetterToIndex(start)
+    const endColIndex = startColIndex + values.length - 1
+    const endColumn = indexToColumnLetter(endColIndex)
+
+    const rangeA1 = buildRowRange({
+      sheetTitle,
+      rowIndex,
+      startColumn: start,
+      endColumn,
+    })
+
+    const result = await googleClient.updateValuesInSpreadsheetRange({
+      rangeA1,
+      values: [values],
+      majorDimension: 'ROWS',
+    })
+
+    return {
+      updatedRange: result.updatedRange,
+      updatedCells: result.updatedCells,
+    }
+  }
+)

--- a/integrations/gsheets/src/actions/implementations/upsert-row.ts
+++ b/integrations/gsheets/src/actions/implementations/upsert-row.ts
@@ -1,0 +1,75 @@
+import { wrapAction } from '../action-wrapper'
+import { buildSheetPrefix, buildRowRange, columnLetterToIndex, indexToColumnLetter } from './row-utils'
+
+export const upsertRow = wrapAction(
+  { actionName: 'upsertRow', errorMessageWhenFailed: 'Failed to upsert row' },
+  async ({ googleClient }, { sheetName, keyColumn, keyValue, values, startColumn }) => {
+    const { sheetTitle } = await googleClient.getSheetIdByName(sheetName)
+    const prefix = buildSheetPrefix(sheetTitle)
+
+    const rangeA1 = `${prefix}A:ZZ`
+
+    let existingValues: string[][] = []
+    try {
+      const result = await googleClient.getValuesFromSpreadsheetRange({ rangeA1, majorDimension: 'ROWS' })
+      existingValues = result.values ?? []
+    } catch {
+      existingValues = []
+    }
+
+    const keyColumnIndex = columnLetterToIndex(keyColumn)
+    let matchingRowIndex: number | null = null
+
+    for (let i = 0; i < existingValues.length; i++) {
+      const row = existingValues[i] ?? []
+      const cellValue = row[keyColumnIndex] ?? ''
+
+      if (cellValue === keyValue) {
+        matchingRowIndex = i + 1
+        break
+      }
+    }
+
+    const start = startColumn ?? 'A'
+    const startColIndex = columnLetterToIndex(start)
+    const endColIndex = startColIndex + values.length - 1
+    const endColumn = indexToColumnLetter(endColIndex)
+
+    if (matchingRowIndex !== null) {
+      const updateRangeA1 = buildRowRange({
+        sheetTitle,
+        rowIndex: matchingRowIndex,
+        startColumn: start,
+        endColumn,
+      })
+
+      await googleClient.updateValuesInSpreadsheetRange({
+        rangeA1: updateRangeA1,
+        values: [values],
+        majorDimension: 'ROWS',
+      })
+
+      return {
+        action: 'updated' as const,
+        rowIndex: matchingRowIndex,
+      }
+    }
+
+    const appendRangeA1 = `${prefix}${start}:${endColumn}`
+
+    const appendResult = await googleClient.appendValuesToSpreadsheetRange({
+      rangeA1: appendRangeA1,
+      values: [values],
+      majorDimension: 'ROWS',
+    })
+
+    const updatedRange = appendResult.updates.updatedRange
+    const rowMatch = updatedRange.match(/:?[A-Z]+(\d+)$/)
+    const insertedRowIndex = rowMatch ? parseInt(rowMatch[1], 10) : existingValues.length + 1
+
+    return {
+      action: 'inserted' as const,
+      rowIndex: insertedRowIndex,
+    }
+  }
+)

--- a/integrations/gsheets/src/actions/index.ts
+++ b/integrations/gsheets/src/actions/index.ts
@@ -2,18 +2,25 @@ import { addSheet } from './implementations/add-sheet'
 import { appendValues } from './implementations/append-values'
 import { clearValues } from './implementations/clear-values'
 import { createNamedRangeInSheet } from './implementations/create-named-range-in-sheet'
+import { deleteRows } from './implementations/delete-rows'
 import { deleteSheet } from './implementations/delete-sheet'
+import { findRow } from './implementations/find-row'
+import { findRows } from './implementations/find-rows'
 import { getAllSheetsInSpreadsheet } from './implementations/get-all-sheets-in-spreadsheet'
 import { getInfoSpreadsheet } from './implementations/get-info-spread-sheet'
 import { getNamedRanges } from './implementations/get-named-ranges'
 import { getProtectedRanges } from './implementations/get-protected-ranges'
+import { getRow } from './implementations/get-row'
 import { getValues } from './implementations/get-values'
+import { insertRowAtIndex } from './implementations/insert-row-at-index'
 import { moveSheetHorizontally } from './implementations/move-sheet-horizontally'
 import { protectNamedRange } from './implementations/protect-named-range'
 import { renameSheet } from './implementations/rename-sheet'
 import { setSheetVisibility } from './implementations/set-sheet-visibility'
 import { setValues } from './implementations/set-values'
 import { unprotectRange } from './implementations/unprotect-range'
+import { updateRow } from './implementations/update-row'
+import { upsertRow } from './implementations/upsert-row'
 import * as bp from '.botpress'
 
 export default {
@@ -21,16 +28,23 @@ export default {
   appendValues,
   clearValues,
   createNamedRangeInSheet,
+  deleteRows,
   deleteSheet,
+  findRow,
+  findRows,
   getAllSheetsInSpreadsheet,
   getInfoSpreadsheet,
   getNamedRanges,
   getProtectedRanges,
+  getRow,
   getValues,
+  insertRowAtIndex,
   moveSheetHorizontally,
   protectNamedRange,
   renameSheet,
   setSheetVisibility,
-  unprotectRange,
   setValues,
+  unprotectRange,
+  updateRow,
+  upsertRow,
 } as const satisfies bp.IntegrationProps['actions']


### PR DESCRIPTION
Resolves SH-272

## Summary

This PR adds seven new core actions to the Google Sheets integration, providing developers with powerful and intuitive row-level operations without requiring complex A1 notation calculations. These actions handle edge cases gracefully (empty sheets, no matches) and offer convenient wrappers for common use cases.

## New Actions

### 1. Find Rows

**Action:** `findRows`

Search for rows where a specific column matches a value. Returns all matching rows with their indexes.

---

### 2. Find Row (First Match)

**Action:** `findRow`

Convenience wrapper over Find Rows that returns a single row and its index, or null if no match is found.

---

### 3. Get Row

**Action:** `getRow`

Fetch a specific row by its 1-based index. Provides direct row access without A1 notation math.

---

### 4. Update Row

**Action:** `updateRow`

Update a specific row by its 1-based index with a partial or complete set of values. Only the provided values are updated.

---

### 5. Insert Row at Index

**Action:** `insertRowAtIndex`

Insert a new row at a specific 1-based index. Existing rows at and below the index are shifted down.

---

### 6. Delete Row(s)

**Action:** `deleteRows`

Delete one or more rows by their 1-based indexes. Rows are deleted in reverse order to preserve indexes during deletion.

---

### 7. Upsert Row

**Action:** `upsertRow`

Update a row if it exists (based on a key column match), or append a new row if no match is found. Useful for maintaining unique records.
