### PR TITLE
chore(integrations): enable bplint

### DIFF
--- a/integrations/asana/integration.definition.ts
+++ b/integrations/asana/integration.definition.ts
@@ -1,4 +1,3 @@
-/* bplint-disable */
 import { IntegrationDefinition } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 
@@ -7,7 +6,7 @@ import { configuration, states, user, channels, actions } from './src/definition
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '0.3.9',
+  version: '0.3.10',
   title: 'Asana',
   readme: 'hub.md',
   description: 'Connect your bot to your Asana inbox, create and update tasks, add comments, and locate users.',

--- a/integrations/charts/integration.definition.ts
+++ b/integrations/charts/integration.definition.ts
@@ -1,11 +1,11 @@
-/* bplint-disable */
 import { IntegrationDefinition } from '@botpress/sdk'
 import { actionDefinitions } from 'src/definitions/actions'
 
 export default new IntegrationDefinition({
   name: 'charts',
+  title: 'Charts',
   description: 'Easily generate a variety of charts, including line, bar, pie, and scatter plots, etc.',
-  version: '0.2.5',
+  version: '0.2.6',
   readme: 'hub.md',
   icon: 'icon.svg',
   actions: actionDefinitions,

--- a/integrations/make/integration.definition.ts
+++ b/integrations/make/integration.definition.ts
@@ -1,11 +1,10 @@
-/* bplint-disable */
 import { z, IntegrationDefinition } from '@botpress/sdk'
 
 const INTEGRATION_NAME = 'make'
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
-  version: '0.3.5',
+  version: '0.3.6',
   title: 'Make.com (Deprecated)',
   icon: 'icon.svg',
   description:

--- a/integrations/pdf-generator/integration.definition.ts
+++ b/integrations/pdf-generator/integration.definition.ts
@@ -1,10 +1,10 @@
-/* bplint-disable */
 import { IntegrationDefinition, z } from '@botpress/sdk'
 
 export default new IntegrationDefinition({
   name: 'pdf-generator',
-  version: '0.0.4',
+  version: '0.0.5',
   readme: 'hub.md',
+  title: 'PDF Generator',
   icon: 'icon.svg',
   description: 'Converts markdown content to PDF using PDFShift',
   configuration: {

--- a/integrations/stripe/integration.definition.ts
+++ b/integrations/stripe/integration.definition.ts
@@ -1,4 +1,3 @@
-/* bplint-disable */
 import { IntegrationDefinition, z } from '@botpress/sdk'
 import {
   createCustomerInputSchema,
@@ -43,8 +42,17 @@ export default new IntegrationDefinition({
     'Manage payments, subscriptions, and customers seamlessly. Execute workflows on charge failures and subscription updates.',
   configuration: {
     schema: z.object({
-      apiKey: z.string().min(1).describe('API Key'),
-      apiVersion: z.string().optional().default('2023-10-16').describe('API Version (optional) (default: 2023-10-16)'),
+      apiKey: z
+        .string()
+        .min(1)
+        .describe('The secret key or a restricted key from your Stripe account')
+        .title('API Key'),
+      apiVersion: z
+        .string()
+        .optional()
+        .default('2023-10-16')
+        .describe('API Version (optional) (default: 2023-10-16)')
+        .title('API Version'),
     }),
   },
   events: {

--- a/integrations/stripe/integration.definition.ts
+++ b/integrations/stripe/integration.definition.ts
@@ -34,7 +34,7 @@ import {
 
 export default new IntegrationDefinition({
   name: 'stripe',
-  version: '0.5.3',
+  version: '0.5.4',
   title: 'Stripe',
   readme: 'hub.md',
   icon: 'icon.svg',


### PR DESCRIPTION
This pr enables the bplint for every integration in the repo. We should not have any remaining `/* bplint-disable */` in the folder integrations.

Resolves SH-191