### PR TITLE
feat(integration/notion): Consolidate comment actions into a single `addComment` action

### DIFF
--- a/integrations/notion/definitions/actions.ts
+++ b/integrations/notion/definitions/actions.ts
@@ -53,22 +53,28 @@ export const actions = {
       }),
     },
   },
-  addCommentToPage: {
-    title: 'Add Comment to Page',
-    description: 'Add a comment to a page in Notion',
+  addComment: {
+    title: 'Add Comment',
+    description: 'Add a comment to a page, block, or discussion in Notion',
     input: {
       schema: sdk.z.object({
-        pageId: sdk.z
+        parentType: sdk.z.enum(['page', 'block', 'discussion']).title('Parent Type').describe('The type of the parent'),
+        parentId: sdk.z
           .string()
           .min(1)
-          .title('Page ID')
-          .describe('The ID of the page to add the comment to. Can be found in the URL of the page'),
+          .title('Parent ID')
+          .describe('The ID of the parent to add the comment to. Can be found in the URL of the parent'),
         commentBody: sdk.z.string().min(1).title('Comment Body').describe('Must be plain text'),
       }),
     },
     output: {
       schema: sdk.z.object({
         commentId: sdk.z.string().title('Comment ID').describe('The ID of the comment that was created'),
+        discussionId: sdk.z
+          .string()
+          .optional()
+          .title('Discussion ID')
+          .describe('The ID of the discussion that was created'),
       }),
     },
   },
@@ -184,25 +190,6 @@ export const actions = {
           .optional()
           .title('Page Properties')
           .describe('Schema of properties for the page as they appear in Notion'),
-      }),
-    },
-  },
-  addCommentToDiscussion: {
-    title: 'Add Comment to Discussion',
-    description: 'Add a comment to a discussion in Notion',
-    input: {
-      schema: sdk.z.object({
-        discussionId: sdk.z
-          .string()
-          .min(1)
-          .title('Discussion ID')
-          .describe('The ID of the discussion to add the comment to. Can be found in the URL of the discussion'),
-        commentBody: sdk.z.string().min(1).title('Comment Body').describe('Must be plain text'),
-      }),
-    },
-    output: {
-      schema: sdk.z.object({
-        commentId: sdk.z.string().title('Comment ID').describe('The ID of the comment that was created'),
       }),
     },
   },

--- a/integrations/notion/src/actions/add-comment-to-discussion.ts
+++ b/integrations/notion/src/actions/add-comment-to-discussion.ts
@@ -1,8 +1,0 @@
-import { wrapAction } from '../action-wrapper'
-
-export const addCommentToDiscussion = wrapAction(
-  { actionName: 'addCommentToDiscussion', errorMessage: 'Failed to add comment to discussion' },
-  async ({ notionClient }, { commentBody, discussionId }) => {
-    return await notionClient.addCommentToDiscussion({ commentBody, discussionId })
-  }
-)

--- a/integrations/notion/src/actions/add-comment-to-page.ts
+++ b/integrations/notion/src/actions/add-comment-to-page.ts
@@ -1,8 +1,0 @@
-import { wrapAction } from '../action-wrapper'
-
-export const addCommentToPage = wrapAction(
-  { actionName: 'addCommentToPage', errorMessage: 'Failed to add comment to page' },
-  async ({ notionClient }, { commentBody, pageId }) => {
-    return await notionClient.addCommentToPage({ commentBody, pageId })
-  }
-)

--- a/integrations/notion/src/actions/add-comment.ts
+++ b/integrations/notion/src/actions/add-comment.ts
@@ -1,0 +1,11 @@
+import { wrapAction } from '../action-wrapper'
+
+export const addComment = wrapAction(
+  { actionName: 'addComment', errorMessage: 'Failed to add comment' },
+  async (
+    { notionClient },
+    { parentType, parentId, commentBody }: { parentType: string; parentId: string; commentBody: string }
+  ) => {
+    return await notionClient.addComment({ parentType, parentId, commentBody })
+  }
+)

--- a/integrations/notion/src/actions/index.ts
+++ b/integrations/notion/src/actions/index.ts
@@ -1,5 +1,4 @@
-import { addCommentToDiscussion } from './add-comment-to-discussion'
-import { addCommentToPage } from './add-comment-to-page'
+import { addComment } from './add-comment'
 import { appendBlocksToPage } from './append-blocks-to-page'
 import { createPage } from './create-page'
 import { deleteBlock } from './delete-block'
@@ -14,8 +13,7 @@ import { updatePageProperties } from './update-page-properties'
 import * as bp from '.botpress'
 
 export const actions = {
-  addCommentToDiscussion,
-  addCommentToPage,
+  addComment,
   createPage,
   appendBlocksToPage,
   deleteBlock,


### PR DESCRIPTION
This PR contains the removal of seperate comment actions and combining them into one action.

- Added `addComment` with the ability to add comments to pages, blocks, or discussions.
- Removed the separate `addCommentToDiscussion` and `addCommentToPage` actions.
- Updated the Notion client to handle comments for different parent types and adjusted the input/output schema accordingly.