### PR TITLE
chore(integrations/linear): now using the new zod transformer

### DIFF
--- a/integrations/linear/definitions/actions.ts
+++ b/integrations/linear/definitions/actions.ts
@@ -81,7 +81,7 @@ const userSchema = z.object({
     .title('Description')
     .describe("The user's description, such as their title or bio"),
   lastSeen: z.string().optional().title('Last Seen').describe('The last time the user was seen'),
-  updatedAt: z.date().title('Updated At').describe('The last time the user was updated'),
+  updatedAt: z.string().datetime().title('Updated At').describe('The last time the user was updated'),
 })
 
 const listUsers = {

--- a/integrations/linear/integration.definition.ts
+++ b/integrations/linear/integration.definition.ts
@@ -36,9 +36,6 @@ export default new IntegrationDefinition({
     },
     ...sentryHelpers.COMMON_SECRET_NAMES,
   },
-  __advanced: {
-    useLegacyZuiTransformer: true,
-  },
 })
   .extend(listable, ({ entities }) => ({
     entities: { item: entities.issue },

--- a/integrations/linear/src/actions/list-users.ts
+++ b/integrations/linear/src/actions/list-users.ts
@@ -19,7 +19,7 @@ export const listUsers: bp.IntegrationProps['actions']['listUsers'] = async (arg
   const users: bp.actions.listUsers.output.Output['users'] = query.nodes.map((user) => ({
     ...user,
     lastSeen: user.lastSeen?.toISOString(),
-    updatedAt: user.updatedAt,
+    updatedAt: user.updatedAt.toISOString(),
   }))
 
   return {


### PR DESCRIPTION
The only change is because we can't use the ZodDate type with the new transformer. The output used to be a string of the same format as when we use `toISOString()`, which means this change is non-breaking.