### PR TITLE
chore(integrations/linear): Add Posthog to Linear

### DIFF
--- a/integrations/linear/.sentryclirc
+++ b/integrations/linear/.sentryclirc
@@ -1,5 +1,0 @@
-[defaults]
-project=integration-linear
-
-[auth]
-dsn=https://166dae5f279f4f21a84a22bb4f073fa5@o363631.ingest.sentry.io/4505274818428928

--- a/integrations/linear/integration.definition.ts
+++ b/integrations/linear/integration.definition.ts
@@ -1,13 +1,17 @@
+import { posthogHelper } from '@botpress/common'
 import { IntegrationDefinition } from '@botpress/sdk'
-import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import proactiveConversation from 'bp_modules/proactive-conversation'
 import deletable from './bp_modules/deletable'
 import listable from './bp_modules/listable'
+
 import { actions, channels, events, configuration, configurations, user, states, entities } from './definitions'
 
+export const INTEGRATION_NAME = 'linear'
+export const INTEGRATION_VERSION = '1.3.0'
+
 export default new IntegrationDefinition({
-  name: 'linear',
-  version: '1.3.0',
+  name: INTEGRATION_NAME,
+  version: INTEGRATION_VERSION,
   title: 'Linear',
   description:
     'Manage your projects autonomously. Have your bot participate in discussions, manage issues and teams, and track progress.',
@@ -34,7 +38,7 @@ export default new IntegrationDefinition({
     WEBHOOK_SIGNING_SECRET: {
       description: 'The signing secret of your Linear webhook.',
     },
-    ...sentryHelpers.COMMON_SECRET_NAMES,
+    ...posthogHelper.COMMON_SECRET_NAMES,
   },
 })
   .extend(listable, ({ entities }) => ({

--- a/integrations/linear/package.json
+++ b/integrations/linear/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "@botpress/client": "workspace:*",
     "@botpress/sdk": "workspace:*",
-    "@botpress/sdk-addons": "workspace:*",
     "@linear/sdk": "^65.2.0",
     "axios": "^1.4.0",
     "query-string": "^6.14.1",
@@ -21,8 +20,7 @@
     "@botpress/sdk": "workspace:*",
     "@botpresshub/deletable": "workspace:*",
     "@botpresshub/listable": "workspace:*",
-    "@botpresshub/proactive-conversation": "workspace:*",
-    "@sentry/cli": "^2.39.1"
+    "@botpresshub/proactive-conversation": "workspace:*"
   },
   "bpDependencies": {
     "listable": "../../interfaces/listable",

--- a/integrations/linear/src/actions/index.ts
+++ b/integrations/linear/src/actions/index.ts
@@ -3,6 +3,8 @@ import { deleteIssue } from './delete-issue'
 import { findTarget } from './find-target'
 import { getIssue } from './get-issue'
 import { getUser } from './get-user'
+import { issueDelete } from './issue-delete'
+import { issueList } from './issue-list'
 import { listIssues } from './list-issues'
 import { listStates } from './list-states'
 import { listTeams } from './list-teams'
@@ -29,4 +31,6 @@ export default {
   sendRawGraphqlQuery,
   resolveComment,
   getOrCreateIssueConversation,
+  issueDelete,
+  issueList,
 } satisfies Partial<bp.IntegrationProps['actions']>

--- a/integrations/linear/src/actions/issue-delete.ts
+++ b/integrations/linear/src/actions/issue-delete.ts
@@ -1,0 +1,10 @@
+import { deleteIssue } from './delete-issue'
+import * as bp from '.botpress'
+
+export const issueDelete: bp.IntegrationProps['actions']['issueDelete'] = async (args) => {
+  return deleteIssue({
+    ...args,
+    type: 'deleteIssue',
+    input: { id: args.input.id },
+  })
+}

--- a/integrations/linear/src/actions/issue-list.ts
+++ b/integrations/linear/src/actions/issue-list.ts
@@ -1,0 +1,19 @@
+import { listIssues } from './list-issues'
+import * as bp from '.botpress'
+
+export const issueList: bp.IntegrationProps['actions']['issueList'] = async (args) => {
+  const count = 20
+  const startCursor = args.input.nextToken
+  const res = await listIssues({
+    ...args,
+    type: 'listIssues',
+    input: {
+      count,
+      startCursor,
+    },
+  })
+  return {
+    items: res.issues.map(({ linearIds: _, ...item }) => item),
+    meta: { nextToken: res.nextCursor },
+  }
+}

--- a/integrations/linear/src/index.ts
+++ b/integrations/linear/src/index.ts
@@ -1,46 +1,23 @@
-import { sentry as sentryHelpers } from '@botpress/sdk-addons'
-
+import { posthogHelper } from '@botpress/common'
+import { INTEGRATION_NAME, INTEGRATION_VERSION } from 'integration.definition'
 import actions from './actions'
 import channels from './channels'
 import { handler } from './handler'
 import { register, unregister } from './setup'
 import * as bp from '.botpress'
 
-const integration = new bp.Integration({
+const posthogConfig: posthogHelper.PostHogConfig = {
+  integrationName: INTEGRATION_NAME,
+  integrationVersion: INTEGRATION_VERSION,
+  key: bp.secrets.POSTHOG_KEY,
+}
+
+const integrationConfig: bp.IntegrationProps = {
   register,
   unregister,
-  handler,
+  actions,
   channels,
-  actions: {
-    ...actions,
-    issueList: async (props) => {
-      const count = 20
-      const startCursor = props.input.nextToken
-      const res = await actions.listIssues({
-        ...props,
-        type: 'listIssues',
-        input: {
-          count,
-          startCursor,
-        },
-      })
-      return {
-        items: res.issues.map(({ linearIds: _, ...item }) => item),
-        meta: { nextToken: res.nextCursor },
-      }
-    },
-    issueDelete: async (props) => {
-      return actions.deleteIssue({
-        ...props,
-        type: 'deleteIssue',
-        input: { id: props.input.id },
-      })
-    },
-  },
-})
+  handler,
+}
 
-export default sentryHelpers.wrapIntegration(integration, {
-  dsn: bp.secrets.SENTRY_DSN,
-  environment: bp.secrets.SENTRY_ENVIRONMENT,
-  release: bp.secrets.SENTRY_RELEASE,
-})
+export default posthogHelper.wrapIntegration(posthogConfig, integrationConfig)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1352,9 +1352,6 @@ importers:
       '@botpress/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
-      '@botpress/sdk-addons':
-        specifier: workspace:*
-        version: link:../../packages/sdk-addons
       '@linear/sdk':
         specifier: ^65.2.0
         version: 65.2.0
@@ -1383,9 +1380,6 @@ importers:
       '@botpresshub/proactive-conversation':
         specifier: workspace:*
         version: link:../../interfaces/proactive-conversation
-      '@sentry/cli':
-        specifier: ^2.39.1
-        version: 2.39.1
 
   integrations/loops:
     dependencies:


### PR DESCRIPTION
Resolves SH-261

Unhandled errors now get sent to Posthog.

I also moved the actions `issueList` and `issueDelete` to their own separate files. Their implementation is the exact same, the code has simply been moved.