### PR TITLE
fix(bots/bugbuster): Having no watched teams shouldn't throw an error

### DIFF
--- a/bots/bugbuster/src/services/command-processor.ts
+++ b/bots/bugbuster/src/services/command-processor.ts
@@ -13,7 +13,8 @@ export class CommandProcessor {
 
   private _listTeams: types.CommandImplementation = async () => {
     const teams = await this._teamsManager.listWatchedTeams()
-    return { success: true, message: teams.join(', ') }
+    const message = teams.length > 0 ? teams.join(', ') : 'You have no watched teams.'
+    return { success: true, message }
   }
 
   private _addTeam: types.CommandImplementation = async ([team]: string[]) => {

--- a/bots/bugbuster/src/services/issue-processor/index.ts
+++ b/bots/bugbuster/src/services/issue-processor/index.ts
@@ -40,6 +40,9 @@ export class IssueProcessor {
 
   public async listRelevantIssues(endCursor?: string): Promise<{ issues: lin.Issue[]; pagination?: lin.Pagination }> {
     const watchedTeams = await this._teamsManager.listWatchedTeams()
+    if (watchedTeams.length === 0) {
+      throw new Error('You have no watched teams.')
+    }
 
     return await this._linear.listIssues(
       {

--- a/bots/bugbuster/src/services/teams-manager.ts
+++ b/bots/bugbuster/src/services/teams-manager.ts
@@ -30,9 +30,6 @@ export class TeamsManager {
 
   public async listWatchedTeams(): Promise<string[]> {
     const teamKeys = await this._getWatchedTeams()
-    if (teamKeys.length === 0) {
-      throw new Error('You have no watched teams.')
-    }
     return teamKeys
   }
 


### PR DESCRIPTION
The error thrown when there are no watched teams was not in the right place. It shouldn't be an error when simply listing the watched teams, but it should be when trying to list issues of watched teams.