### PR TITLE
feat(llmz): early return execution when cognitive service broken

### DIFF
--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -2,7 +2,7 @@
   "name": "llmz",
   "type": "module",
   "description": "LLMz - An LLM-native Typescript VM built on top of Zui",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/llmz/src/llmz.test.ts
+++ b/packages/llmz/src/llmz.test.ts
@@ -1,0 +1,41 @@
+import { Client } from '@botpress/client'
+import { Cognitive, Model } from '@botpress/cognitive'
+import { expect, test } from 'vitest'
+import { executeContext } from './llmz.js'
+import { ErrorExecutionResult } from './result.js'
+import { CognitiveError } from './errors.js'
+
+test('executeContext should early exit when cognitive service is unreachable', async () => {
+  class FailingCognitive extends Cognitive {
+    public constructor(private _err: Error) {
+      super({ client: new Client({}) })
+    }
+
+    public async getModelDetails(model: string): Promise<Model> {
+      return {
+        id: model,
+        name: 'Failing Cognitive Model',
+        integration: 'botpress',
+        description: 'A failing cognitive model that simulates errors',
+        input: { maxTokens: 8192, costPer1MTokens: 0 },
+        output: { maxTokens: 2048, costPer1MTokens: 0 },
+        ref: `failing:${model}`,
+        tags: [],
+      }
+    }
+
+    public async generateContent(): Promise<never> {
+      throw this._err
+    }
+  }
+
+  const err = new Error('Simulated connection error')
+  const cognitive = new FailingCognitive(err)
+
+  const output = await executeContext({ client: cognitive, options: { loop: 5 } })
+
+  expect(output.status).toBe('error')
+  expect(output.iterations.length).toBe(1)
+  expect((output as ErrorExecutionResult).error).toBeInstanceOf(CognitiveError)
+  expect(((output as ErrorExecutionResult).error as Error).message).toContain(err.message)
+})


### PR DESCRIPTION
fixes SQD-3475

I figure I could reuse the cognitive error that we already have for when there's no text output

I also thought about having a base error class for errors that cannot be retried with more iterations, but it felt to soon of an abstraction

<img width="1030" height="392" alt="image" src="https://github.com/user-attachments/assets/87d68c36-8b8c-439b-9af0-ed454330c82d" />

