### PR TITLE
fix(bots/bugbuster): command list didn't show args

### DIFF
--- a/bots/bugbuster/src/handlers/message-created.ts
+++ b/bots/bugbuster/src/handlers/message-created.ts
@@ -67,7 +67,7 @@ const _buildListCommandsMessage = (definitions: CommandDefinition[]) => {
 }
 
 const _buildCommandMessage = (definition: CommandDefinition) => {
-  const requiredArgs = definition.requiredArgs?.map((arg) => `<${arg}>`).join(' ')
+  const requiredArgs = definition.requiredArgs?.map((arg) => `&lt;${arg}&gt;`).join(' ')
   const optionalArgs = definition.optionalArgs?.map((arg) => `[${arg}]`).join(' ')
 
   return `${definition.name} ${requiredArgs ?? ''} ${optionalArgs ?? ''}`


### PR DESCRIPTION
Command arguments were missing because of the way we downrender markdown. They are now displayed again the way they used to be.
<img width="461" height="210" alt="image" src="https://github.com/user-attachments/assets/6a198702-a029-439b-8c9c-5a63e0ef7a8d" />
