### PR TITLE
fix(integrations/zendesk): fix comment on behalf strip

### DIFF
--- a/integrations/zendesk/integration.definition.ts
+++ b/integrations/zendesk/integration.definition.ts
@@ -6,7 +6,7 @@ import { actions, events, configuration, channels, states, user } from './src/de
 export default new sdk.IntegrationDefinition({
   name: 'zendesk',
   title: 'Zendesk',
-  version: '3.0.5',
+  version: '3.0.6',
   icon: 'icon.svg',
   description:
     'Optimize your support workflow. Trigger workflows from ticket updates as well as manage tickets, access conversations, and engage with customers.',

--- a/integrations/zendesk/src/events/message-received.ts
+++ b/integrations/zendesk/src/events/message-received.ts
@@ -4,6 +4,8 @@ import type { TriggerPayload } from '../triggers'
 import { retrieveHitlConversation } from './hitl-ticket-filter'
 import * as bp from '.botpress'
 
+const COMMENT_ON_BEHALF_START = '----------------------------------------------\n\n!***'
+
 export const executeMessageReceived = async ({
   zendeskClient,
   zendeskTrigger,
@@ -65,7 +67,13 @@ export const executeMessageReceived = async ({
     })
   }
 
-  const messageWithoutAuthor = zendeskTrigger.comment.split('\n').slice(3).join('\n')
+  let messageWithoutAuthor: string
+
+  if (zendeskTrigger.comment.startsWith(COMMENT_ON_BEHALF_START)) {
+    messageWithoutAuthor = zendeskTrigger.comment.split('\n').slice(5).join('\n')
+  } else {
+    messageWithoutAuthor = zendeskTrigger.comment.split('\n').slice(3).join('\n')
+  }
 
   await client.createMessage({
     tags: { zendeskCommentId: zendeskTrigger.commentId },


### PR DESCRIPTION
This probably feels like a weird hardcoded way of doing things, We do this because zendesk transforms the message on their end and adds metadata inside of it.

We did not have the issue with metadata "on behalf of" before since it is a very specific possibility added with Desk.
Desk does an api call with a specific via to bypass the check that prevents messages to be sent from the bot.

Here is examples of payload sent by zendesk in the two case handled by the code:

### without on behalf of
```
----------------------------------------------

!*** This comment was submitted by David Ferland on behalf of the author ***!

Xavier, Jan 21, 2026, 09:28

Hello hello
```
### Without on behalf of
```
----------------------------------------------

Xavier, Jan 21, 2026, 09:27

Hello
```