### PR TITLE
chore(llmz): extract truncator state

### DIFF
--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -2,7 +2,7 @@
   "name": "llmz",
   "type": "module",
   "description": "LLMz - An LLM-native Typescript VM built on top of Zui",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/llmz/src/truncator.ts
+++ b/packages/llmz/src/truncator.ts
@@ -282,7 +282,7 @@ class _MessageContentParser {
   private _lastIndex: number = 0
 
   public constructor() {
-    this._regex = _getRegex()
+    this._regex = _createRegex()
   }
 
   public parse(content: string): ParsedMessageContent | null {
@@ -321,9 +321,9 @@ class _MessageContentParser {
   }
 }
 
-const _getRegex = () => new RegExp(REGEXP, 'g')
+const _createRegex = () => new RegExp(REGEXP, 'g')
 
-const _renderRemainingWrappers = (content: string) => content.replace(_getRegex(), '$2')
+const _renderRemainingWrappers = (content: string) => content.replace(_createRegex(), '$2')
 
 const _countTotalTokens = (parts: Part[][]) =>
   parts.reduce((acc, x) => acc + x.reduce((acc, y) => acc + y.tokens, 0), 0)

--- a/packages/llmz/src/truncator.ts
+++ b/packages/llmz/src/truncator.ts
@@ -13,8 +13,57 @@ const DEFAULT_REMOVE_CHUNK = 250
 const WRAP_OPEN_TAG_1 = '【TRUNCATE'
 const WRAP_OPEN_TAG_2 = '】'
 const WRAP_CLOSE_TAG = '【/TRUNCATE】'
-const getRegex = () =>
-  new RegExp(`(${WRAP_OPEN_TAG_1}(?:\\s+[\\w:]+)*\\s*${WRAP_OPEN_TAG_2})([\\s\\S]*?)(${WRAP_CLOSE_TAG})`, 'g')
+const REGEXP = `(${WRAP_OPEN_TAG_1}(?:\\s+[\\w:]+)*\\s*${WRAP_OPEN_TAG_2})([\\s\\S]*?)(${WRAP_CLOSE_TAG})`
+const getRegex = () => new RegExp(REGEXP, 'g')
+
+type ParsedMessageContent = {
+  attributes: SerializedTruncateOptions
+  wrappedContent: string | undefined
+  nonTruncatableContent: string | undefined
+}
+class MessageContentParser {
+  private _regex: RegExp
+  private _lastIndex: number = 0
+
+  public constructor() {
+    this._regex = getRegex()
+  }
+
+  public parse(content: string): ParsedMessageContent | null {
+    const match = this._regex.exec(content)
+    if (!match) {
+      return null
+    }
+
+    const attributes = match[1]!
+      .split(/\s+/)
+      .slice(1)
+      .filter((x) => x !== WRAP_OPEN_TAG_2)
+      .map((x) => x.split(':'))
+      .reduce(
+        (acc, [key, value]) => ({ ...acc, [key!]: value }),
+        {} as Record<string, any>
+      ) as SerializedTruncateOptions
+
+    let nonTruncatableContent: string | undefined = undefined
+    if (match.index > this._lastIndex) {
+      nonTruncatableContent = content.slice(this._lastIndex, match.index)
+    }
+
+    const wrappedContent = match[2]
+
+    this._lastIndex = this._regex.lastIndex
+    return { attributes, nonTruncatableContent, wrappedContent }
+  }
+
+  public getRemainingContent(content: string): string | null {
+    if (this._lastIndex < content.length) {
+      const remainingContent = content.slice(this._lastIndex)
+      return remainingContent
+    }
+    return null
+  }
+}
 
 type TruncateOptions = {
   preserve: 'top' | 'bottom' | 'both'
@@ -25,6 +74,12 @@ type TruncateOptions = {
   flex: number
   /** If provided, the message will never truncate below that number */
   minTokens: number
+}
+
+type SerializedTruncateOptions = {
+  preserve: 'top' | 'bottom' | 'both'
+  flex: string
+  min: string
 }
 
 const DEFAULT_TRUNCATE_OPTIONS: TruncateOptions = {
@@ -166,21 +221,14 @@ export function truncateWrappedContent<T extends MessageLike>({
     const current: Part[] = []
 
     const content = typeof msg.content === 'string' ? msg.content : ''
-    let match
-    const regex = getRegex()
-    let lastIndex = 0
+    let match: ParsedMessageContent | null
+    const parser = new MessageContentParser()
 
-    while ((match = regex.exec(content)) !== null) {
+    while ((match = parser.parse(content)) !== null) {
       // Extract attributes from the open tag
-      const attributes = match[1]!
-        .split(/\s+/)
-        .slice(1)
-        .filter((x) => x !== WRAP_OPEN_TAG_2)
-        .map((x) => x.split(':'))
-        .reduce((acc, [key, value]) => ({ ...acc, [key!]: value }), {} as Record<string, any>)
+      const { attributes, nonTruncatableContent, wrappedContent } = match
 
-      if (match.index > lastIndex) {
-        const nonTruncatableContent = content.slice(lastIndex, match.index)
+      if (nonTruncatableContent) {
         current.push({
           content: nonTruncatableContent,
           tokens: tokenizer.count(nonTruncatableContent),
@@ -188,7 +236,6 @@ export function truncateWrappedContent<T extends MessageLike>({
         })
       }
 
-      const wrappedContent = match[2]
       current.push({
         content: wrappedContent!,
         tokens: tokenizer.count(wrappedContent!),
@@ -199,12 +246,10 @@ export function truncateWrappedContent<T extends MessageLike>({
           minTokens: Number(attributes.min) || DEFAULT_TRUNCATE_OPTIONS.minTokens,
         },
       })
-
-      lastIndex = regex.lastIndex
     }
 
-    if (lastIndex < content.length) {
-      const remainingContent = content.slice(lastIndex)
+    const remainingContent = parser.getRemainingContent(content)
+    if (remainingContent) {
       current.push({
         content: remainingContent,
         tokens: tokenizer.count(remainingContent),
@@ -222,12 +267,12 @@ export function truncateWrappedContent<T extends MessageLike>({
 
     for (const part of parts.flat()) {
       if (part.truncatable) {
-        const flex = part.attributes?.flex ?? DEFAULT_TRUNCATE_OPTIONS.flex
-        const tokens = part.tokens * flex
-
         if (part.tokens <= (part.attributes?.minTokens ?? 0)) {
           continue
         }
+
+        const flex = part.attributes?.flex ?? DEFAULT_TRUNCATE_OPTIONS.flex
+        const tokens = part.tokens * flex
 
         if (!biggest || tokens > biggest.tokens) {
           secondBiggest = biggest


### PR DESCRIPTION
No functional changes, no performance changes, just a styling refactor for my own taste:
- remove indentation 
- no nested function
- regex logic is separated from state machine