### PR TITLE
feat(whatsapp): add referral metadata to tags

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -93,7 +93,7 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp'
-export const INTEGRATION_VERSION = '4.5.20'
+export const INTEGRATION_VERSION = '4.7.0'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,
@@ -265,6 +265,14 @@ export default new IntegrationDefinition({
           replyTo: {
             title: 'Reply To',
             description: 'The ID of the message that this message is a reply to',
+          },
+          referralSourceUrl: {
+            title: 'Referral Source URL',
+            description: 'The URL of the ad or content that led to the conversation',
+          },
+          referralSourceId: {
+            title: 'Referral Source ID',
+            description: 'The ID of the ad or content that led to the conversation',
           },
         },
       },

--- a/integrations/whatsapp/src/auth.ts
+++ b/integrations/whatsapp/src/auth.ts
@@ -13,7 +13,7 @@ const getWabaIdsFromTokenResponseSchema = z
       granular_scopes: z.array(
         z.object({
           scope: z.string(),
-          target_ids: z.array(z.string()),
+          target_ids: z.array(z.string()).optional(),
         })
       ),
     }),

--- a/integrations/whatsapp/src/misc/types.ts
+++ b/integrations/whatsapp/src/misc/types.ts
@@ -21,6 +21,13 @@ const WhatsAppBaseMessageSchema = z.object({
       id: z.string().optional(),
     })
     .optional(),
+  // there are other fields in the referral object, but we don't need them
+  referral: z
+    .object({
+      source_url: z.string().optional(),
+      source_id: z.string().optional(),
+    })
+    .optional(),
   errors: z
     .array(
       z.object({

--- a/integrations/whatsapp/src/webhook/handlers/messages.ts
+++ b/integrations/whatsapp/src/webhook/handlers/messages.ts
@@ -88,8 +88,15 @@ async function _handleIncomingMessage(
     replyTo,
   }: ValueOf<IncomingMessages> & { incomingMessageType?: string; replyTo?: string }) => {
     logger.forBot().debug(`Received ${incomingMessageType ?? type} message from WhatsApp:`, payload)
+    const { referral } = message
     return client.getOrCreateMessage({
-      tags: { id: message.id, replyTo },
+      tags: {
+        id: message.id,
+        replyTo,
+        // Urls can go up to 2048 characters, but we limit to 500 to avoid tags limit error
+        ...(referral?.source_url && { referralSourceUrl: referral.source_url.slice(0, 500) }),
+        ...(referral?.source_id && { referralSourceId: referral.source_id }),
+      },
       type,
       payload,
       userId: user.id,


### PR DESCRIPTION
Resolves SH-217, I choose only to add the essential tags

PS: I just simulated the referral object in a webhook and didn't use a production ad, but I made sure that the code is safe in case something changes for a production referral object, looking at the docs, we should be good