### PR TITLE
feat(integrations/sunco): Implemented the OAuth flow

### DIFF
--- a/integrations/sunco/integration.definition.ts
+++ b/integrations/sunco/integration.definition.ts
@@ -95,7 +95,7 @@ export default new IntegrationDefinition({
       description: 'The name of the marketplace bot',
     },
     MARKETPLACE_ORG_ID: {
-      description: 'The ID or the marketplace organization',
+      description: 'The ID of the marketplace organization',
     },
     ...sentryHelpers.COMMON_SECRET_NAMES,
   },

--- a/integrations/sunco/integration.definition.ts
+++ b/integrations/sunco/integration.definition.ts
@@ -46,6 +46,7 @@ export default new IntegrationDefinition({
   },
   configurations: {
     manual: {
+      title: 'Configure using your own app',
       schema: z.object({
         appId: z.string().min(1).title('App ID').describe('Your Sunshine Conversations App ID'),
         keyId: z.string().min(1).title('Key ID').describe('Your Sunshine Conversations Key ID'),

--- a/integrations/sunco/integration.definition.ts
+++ b/integrations/sunco/integration.definition.ts
@@ -12,13 +12,47 @@ export default new IntegrationDefinition({
   description: 'Give your bot access to a powerful omnichannel messaging platform.',
   icon: 'icon.svg',
   readme: 'hub.md',
+  states: {
+    credentials: {
+      type: 'integration',
+      schema: z.object({
+        token: z
+          .string()
+          .optional()
+          .title('Token')
+          .describe('The bearer token obtained after completing the OAuth flow'),
+        appId: z.string().optional().title('App ID').describe('The registered app ID'),
+        subdomain: z
+          .string()
+          .optional()
+          .title('Subdomain')
+          .describe('The subdomain of the authenticated app if there is one'),
+      }),
+    },
+    webhook: {
+      type: 'integration',
+      schema: z.object({
+        id: z.string().title('ID').describe('The webhook ID'),
+        secret: z.string().title('Secret').describe('The webhook secret'),
+      }),
+    },
+  },
   configuration: {
-    schema: z.object({
-      appId: z.string().min(1).title('App ID').describe('Your Sunshine Conversations App ID'),
-      keyId: z.string().min(1).title('Key ID').describe('Your Sunshine Conversations Key ID'),
-      keySecret: z.string().min(1).title('Key Secret').describe('Your Sunshine Conversations Key Secret'),
-      webhookSecret: z.string().min(1).title('Webhook Secret').describe('Your Sunshine Conversations Webhook Secret'),
-    }),
+    identifier: {
+      linkTemplateScript: 'linkTemplate.vrl',
+      required: true,
+    },
+    schema: z.object({}),
+  },
+  configurations: {
+    manual: {
+      schema: z.object({
+        appId: z.string().min(1).title('App ID').describe('Your Sunshine Conversations App ID'),
+        keyId: z.string().min(1).title('Key ID').describe('Your Sunshine Conversations Key ID'),
+        keySecret: z.string().min(1).title('Key Secret').describe('Your Sunshine Conversations Key Secret'),
+        webhookSecret: z.string().min(1).title('Webhook Secret').describe('Your Sunshine Conversations Webhook Secret'),
+      }),
+    },
   },
   channels: {
     channel: {
@@ -49,7 +83,21 @@ export default new IntegrationDefinition({
   },
   actions: {},
   events,
-  secrets: sentryHelpers.COMMON_SECRET_NAMES,
+  secrets: {
+    CLIENT_ID: {
+      description: 'Botpress SunCo OAuth Client ID',
+    },
+    CLIENT_SECRET: {
+      description: 'Botpress SunCo OAuth Client Secret',
+    },
+    MARKETPLACE_BOT_NAME: {
+      description: 'The name of the marketplace bot',
+    },
+    MARKETPLACE_ORG_ID: {
+      description: 'The ID or the marketplace organization',
+    },
+    ...sentryHelpers.COMMON_SECRET_NAMES,
+  },
   user: {
     tags: {
       id: {

--- a/integrations/sunco/integration.definition.ts
+++ b/integrations/sunco/integration.definition.ts
@@ -46,7 +46,7 @@ export default new IntegrationDefinition({
   },
   configurations: {
     manual: {
-      title: 'Configure using your own app',
+      title: 'Configure manually with your own app',
       schema: z.object({
         appId: z.string().min(1).title('App ID').describe('Your Sunshine Conversations App ID'),
         keyId: z.string().min(1).title('Key ID').describe('Your Sunshine Conversations Key ID'),

--- a/integrations/sunco/linkTemplate.vrl
+++ b/integrations/sunco/linkTemplate.vrl
@@ -1,0 +1,9 @@
+webhookId = to_string!(.webhookId)
+webhookUrl = to_string!(.webhookUrl)
+env = to_string!(.env)
+
+clientId = "botpress"
+
+redirectUri = "{{ webhookUrl }}/oauth"
+
+"https://oauth-bridge.zendesk.com/sc/oauth/authorize?response_type=code&client_id={{ clientId }}&redirect_uri={{ redirectUri }}&state={{ webhookId }}"

--- a/integrations/sunco/src/api/const.ts
+++ b/integrations/sunco/src/api/const.ts
@@ -1,0 +1,7 @@
+import * as bp from '.botpress'
+
+export const BASE_HEADERS = {
+  'Content-Type': 'application/json',
+  'X-Zendesk-Marketplace-Name': bp.secrets.MARKETPLACE_BOT_NAME,
+  'X-Zendesk-Marketplace-Organization-Id': bp.secrets.MARKETPLACE_ORG_ID,
+}

--- a/integrations/sunco/src/api/get-credentials.ts
+++ b/integrations/sunco/src/api/get-credentials.ts
@@ -6,24 +6,12 @@ const { z } = sdk
 const TOKEN_URL = 'https://oauth-bridge.zendesk.com/sc/oauth/token'
 const TOKEN_INFO_URL = 'https://oauth-bridge.zendesk.com/sc/v2/tokenInfo'
 
-type ClientCredentials = {
-  clientId: string
-  clientSecret: string
-}
+type ClientCredentials = { clientId: string; clientSecret: string }
 
-const getTokenSchema = z
-  .object({
-    access_token: z.string(),
-  })
-  .passthrough()
+const getTokenSchema = z.object({ access_token: z.string() }).passthrough()
 
 const getTokenInfoSchema = z
-  .object({
-    app: z.object({
-      id: z.string(),
-      subdomain: z.string().optional(),
-    }),
-  })
+  .object({ app: z.object({ id: z.string(), subdomain: z.string().optional() }) })
   .passthrough()
 
 export const getCredentials = async ({
@@ -32,15 +20,9 @@ export const getCredentials = async ({
 }: {
   authorizationCode: string
   logger: bp.Logger
-}): Promise<{
-  token: string
-  appId: string
-  subdomain?: string
-}> => {
+}): Promise<{ token: string; appId: string; subdomain?: string }> => {
   const token = await _getToken({ authorizationCode, clientCredentials: _getBotpressClientCredentials(), logger })
-
   const tokenInfo = await getTokenInfo({ token, logger })
-
   return { token, appId: tokenInfo.app.id, subdomain: tokenInfo.app.subdomain }
 }
 
@@ -106,8 +88,5 @@ export const getTokenInfo = async ({ token, logger }: { token: string; logger: b
 }
 
 const _getBotpressClientCredentials = (): ClientCredentials => {
-  return {
-    clientId: bp.secrets.CLIENT_ID,
-    clientSecret: bp.secrets.CLIENT_SECRET,
-  }
+  return { clientId: bp.secrets.CLIENT_ID, clientSecret: bp.secrets.CLIENT_SECRET }
 }

--- a/integrations/sunco/src/api/get-credentials.ts
+++ b/integrations/sunco/src/api/get-credentials.ts
@@ -72,7 +72,7 @@ const _getToken = async ({
   })
 
   if (!response.ok) {
-    console.log('error: ', response.json())
+    console.log('error: ', await response.json())
     logger.forBot().error('Failed to exchange authorization code for SunCo token', {
       status: response.status,
     })

--- a/integrations/sunco/src/api/get-credentials.ts
+++ b/integrations/sunco/src/api/get-credentials.ts
@@ -1,4 +1,5 @@
 import * as sdk from '@botpress/sdk'
+import { BASE_HEADERS } from './const'
 import * as bp from '.botpress'
 
 const { z } = sdk
@@ -63,11 +64,7 @@ const _getToken = async ({
 
   const response = await fetch(TOKEN_URL, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Zendesk-Marketplace-Name': bp.secrets.MARKETPLACE_BOT_NAME,
-      'X-Zendesk-Marketplace-Organization-Id': bp.secrets.MARKETPLACE_ORG_ID,
-    },
+    headers: BASE_HEADERS,
     body: JSON.stringify(params),
   })
 
@@ -91,10 +88,8 @@ export const getTokenInfo = async ({ token, logger }: { token: string; logger: b
   const response = await fetch(TOKEN_INFO_URL, {
     method: 'GET',
     headers: {
-      'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
-      'X-Zendesk-Marketplace-Name': bp.secrets.MARKETPLACE_BOT_NAME,
-      'X-Zendesk-Marketplace-Organization-Id': bp.secrets.MARKETPLACE_ORG_ID,
+      ...BASE_HEADERS,
     },
   })
 

--- a/integrations/sunco/src/api/get-credentials.ts
+++ b/integrations/sunco/src/api/get-credentials.ts
@@ -50,15 +50,14 @@ const _getToken = async ({
     body: JSON.stringify(params),
   })
 
+  const payload = await response.json()
+
   if (!response.ok) {
-    console.log('error: ', await response.json())
-    logger.forBot().error('Failed to exchange authorization code for SunCo token', {
-      status: response.status,
-    })
+    logger.forBot().error('Failed to exchange authorization code for SunCo token', { status: response.status, payload })
     throw new sdk.RuntimeError('failed to get token')
   }
 
-  const token = getTokenSchema.parse(await response.json())
+  const token = getTokenSchema.parse(payload)
   logger.forBot().debug('Successfully obtained SunCo token')
 
   return token.access_token
@@ -75,14 +74,13 @@ export const getTokenInfo = async ({ token, logger }: { token: string; logger: b
     },
   })
 
+  const payload = await response.json()
   if (!response.ok) {
-    logger.forBot().error('Failed to fetch token info', {
-      status: response.status,
-    })
+    logger.forBot().error('Failed to fetch token info', { status: response.status, payload })
     throw new sdk.RuntimeError('failed to get token')
   }
 
-  const tokenInfo = getTokenInfoSchema.parse(await response.json())
+  const tokenInfo = getTokenInfoSchema.parse(payload)
   logger.forBot().debug('Successfully obtained SunCo token info')
   return tokenInfo
 }

--- a/integrations/sunco/src/api/get-credentials.ts
+++ b/integrations/sunco/src/api/get-credentials.ts
@@ -1,0 +1,119 @@
+import * as sdk from '@botpress/sdk'
+import * as bp from '.botpress'
+
+const { z } = sdk
+const TOKEN_URL = 'https://oauth-bridge.zendesk.com/sc/oauth/token'
+const TOKEN_INFO_URL = 'https://oauth-bridge.zendesk.com/sc/v2/tokenInfo'
+
+type ClientCredentials = {
+  clientId: string
+  clientSecret: string
+}
+
+const getTokenSchema = z
+  .object({
+    access_token: z.string(),
+  })
+  .passthrough()
+
+const getTokenInfoSchema = z
+  .object({
+    app: z.object({
+      id: z.string(),
+      subdomain: z.string().optional(),
+    }),
+  })
+  .passthrough()
+
+export const getCredentials = async ({
+  authorizationCode,
+  logger,
+}: {
+  authorizationCode: string
+  logger: bp.Logger
+}): Promise<{
+  token: string
+  expiryTimestamp: number
+  appId: string
+  subdomain?: string
+}> => {
+  const token = await _getToken({ authorizationCode, clientCredentials: _getBotpressClientCredentials(), logger })
+
+  const tokenInfo = await getTokenInfo({ token, logger })
+
+  return { token, expiryTimestamp: 123456, appId: tokenInfo.app.id, subdomain: tokenInfo.app.subdomain }
+}
+
+const _getToken = async ({
+  authorizationCode,
+  clientCredentials,
+  logger,
+}: {
+  authorizationCode: string
+  clientCredentials: ClientCredentials
+  logger: bp.Logger
+}): Promise<string> => {
+  logger.forBot().debug('Exchanging authorization code for Sunco token')
+
+  const params = {
+    grant_type: 'authorization_code',
+    code: authorizationCode,
+    client_id: clientCredentials.clientId,
+    client_secret: clientCredentials.clientSecret,
+  }
+
+  const response = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Zendesk-Marketplace-Name': bp.secrets.MARKETPLACE_BOT_NAME,
+      'X-Zendesk-Marketplace-Organization-Id': bp.secrets.MARKETPLACE_ORG_ID,
+    },
+    body: JSON.stringify(params),
+  })
+
+  if (!response.ok) {
+    console.log('error: ', response.json())
+    logger.forBot().error('Failed to exchange authorization code for SunCo token', {
+      status: response.status,
+    })
+    throw new sdk.RuntimeError('failed to get token')
+  }
+
+  const token = getTokenSchema.parse(await response.json())
+  logger.forBot().debug('Successfully obtained SunCo token')
+
+  return token.access_token
+}
+
+export const getTokenInfo = async ({ token, logger }: { token: string; logger: bp.Logger }) => {
+  logger.forBot().debug('Fetching SunCo token info')
+
+  const response = await fetch(TOKEN_INFO_URL, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      'X-Zendesk-Marketplace-Name': bp.secrets.MARKETPLACE_BOT_NAME,
+      'X-Zendesk-Marketplace-Organization-Id': bp.secrets.MARKETPLACE_ORG_ID,
+    },
+  })
+
+  if (!response.ok) {
+    logger.forBot().error('Failed to fetch token info', {
+      status: response.status,
+    })
+    throw new sdk.RuntimeError('failed to get token')
+  }
+
+  const tokenInfo = getTokenInfoSchema.parse(await response.json())
+  logger.forBot().debug('Successfully obtained SunCo token info')
+  return tokenInfo
+}
+
+const _getBotpressClientCredentials = (): ClientCredentials => {
+  return {
+    clientId: bp.secrets.CLIENT_ID,
+    clientSecret: bp.secrets.CLIENT_SECRET,
+  }
+}

--- a/integrations/sunco/src/api/get-credentials.ts
+++ b/integrations/sunco/src/api/get-credentials.ts
@@ -33,7 +33,6 @@ export const getCredentials = async ({
   logger: bp.Logger
 }): Promise<{
   token: string
-  expiryTimestamp: number
   appId: string
   subdomain?: string
 }> => {
@@ -41,7 +40,7 @@ export const getCredentials = async ({
 
   const tokenInfo = await getTokenInfo({ token, logger })
 
-  return { token, expiryTimestamp: 123456, appId: tokenInfo.app.id, subdomain: tokenInfo.app.subdomain }
+  return { token, appId: tokenInfo.app.id, subdomain: tokenInfo.app.subdomain }
 }
 
 const _getToken = async ({

--- a/integrations/sunco/src/api/sunshine-api.ts
+++ b/integrations/sunco/src/api/sunshine-api.ts
@@ -16,12 +16,10 @@ export type CombinedApiClient = {
 }
 
 export function createClient(creds: StoredCredentials): CombinedApiClient {
-  let client: ApiClient | undefined
-  if (creds.configType === 'manual') {
-    client = createClientFromBasicAuth(creds.keyId, creds.keySecret)
-  } else {
-    client = createClientFromToken(creds.token)
-  }
+  const client =
+    creds.configType === 'manual'
+      ? createClientFromBasicAuth(creds.keyId, creds.keySecret)
+      : createClientFromToken(creds.token)
   return createApis(client)
 }
 

--- a/integrations/sunco/src/api/sunshine-api.ts
+++ b/integrations/sunco/src/api/sunshine-api.ts
@@ -1,12 +1,46 @@
+import { StoredCredentials } from 'src/types'
 // @ts-expect-error No types for sunshine-conversations-client
 import * as SunshineConversationsClientModule from 'sunshine-conversations-client'
 
-export function createClient(keyId: string, keySecret: string) {
+export type CombinedApiClient = {
+  activities: ActivitiesApi
+  apps: AppsApi
+  users: UsersApi
+  conversations: ConversationsApi
+  messages: MessagesApi
+  webhooks: WebhooksApi
+  integrations: IntegrationsApi
+  switchboard: SwitchboardsApi
+  switchboardActions: SwitchboardActionsApi
+  switchboardIntegrations: SwitchboardIntegrationsApi
+}
+
+export function createClient(creds: StoredCredentials): CombinedApiClient {
+  let client: ApiClient | undefined
+  if (creds.configType === 'manual') {
+    client = createClientFromBasicAuth(creds.keyId, creds.keySecret)
+  } else {
+    client = createClientFromToken(creds.token)
+  }
+  return createApis(client)
+}
+
+function createClientFromBasicAuth(keyId: string, keySecret: string): ApiClient {
   const apiClient = new SunshineConversationsApi.ApiClient()
   const auth = apiClient.authentications['basicAuth']
   auth.username = keyId
   auth.password = keySecret
+  return apiClient
+}
 
+function createClientFromToken(token: string) {
+  const apiClient = new SunshineConversationsApi.ApiClient()
+  const auth = apiClient.authentications['bearerAuth']
+  auth.accessToken = token
+  return apiClient
+}
+
+function createApis(apiClient: ApiClient): CombinedApiClient {
   return {
     activities: new SunshineConversationsApi.ActivitiesApi(apiClient),
     apps: new SunshineConversationsApi.AppsApi(apiClient),

--- a/integrations/sunco/src/api/webhooks.ts
+++ b/integrations/sunco/src/api/webhooks.ts
@@ -58,7 +58,7 @@ export const deleteApp = async ({ credentials, logger }: { credentials: OAuthCre
     throw new sdk.RuntimeError('Failed to delete app: no subdomain is associated with this bot installation')
   }
 
-  await deleteAllWebhooks({ credentials, logger })
+  await _deleteAllWebhooks({ credentials, logger })
 
   const response = await fetch(`https://${credentials.subdomain}.zendesk.com/sc/oauth/authorization`, {
     method: 'DELETE',
@@ -73,14 +73,14 @@ export const deleteApp = async ({ credentials, logger }: { credentials: OAuthCre
   logger.forBot().debug('Successfully deleted SunCo app')
 }
 
-const deleteAllWebhooks = async ({ credentials, logger }: { credentials: OAuthCredentials; logger: bp.Logger }) => {
-  const webhooks = await listWebhooks({ credentials, logger })
+const _deleteAllWebhooks = async ({ credentials, logger }: { credentials: OAuthCredentials; logger: bp.Logger }) => {
+  const webhooks = await _listWebhooks({ credentials, logger })
   for (const { id } of webhooks) {
-    await deleteWebhook({ credentials, logger, webhookId: id })
+    await _deleteWebhook({ credentials, logger, webhookId: id })
   }
 }
 
-const deleteWebhook = async ({
+const _deleteWebhook = async ({
   credentials,
   logger,
   webhookId,
@@ -109,7 +109,7 @@ const deleteWebhook = async ({
   }
 }
 
-const listWebhooks = async ({ credentials, logger }: { credentials: OAuthCredentials; logger: bp.Logger }) => {
+const _listWebhooks = async ({ credentials, logger }: { credentials: OAuthCredentials; logger: bp.Logger }) => {
   logger.forBot().debug('Listing webhooks')
 
   if (!credentials.subdomain) {

--- a/integrations/sunco/src/api/webhooks.ts
+++ b/integrations/sunco/src/api/webhooks.ts
@@ -1,0 +1,90 @@
+import * as sdk from '@botpress/sdk'
+import { OAuthCredentials, StoredCredentials } from 'src/types'
+import * as bp from '.botpress'
+
+const { z } = sdk
+
+const createWebhookSchema = z
+  .object({
+    webhook: z.object({
+      secret: z.string(),
+      id: z.string(),
+    }),
+  })
+  .passthrough()
+
+export const createWebhook = async ({
+  credentials,
+  logger,
+  webhookUrl,
+}: {
+  credentials: OAuthCredentials
+  logger: bp.Logger
+  webhookUrl: string
+}): Promise<sdk.z.infer<typeof createWebhookSchema>['webhook']> => {
+  logger.forBot().debug('Creating webhook')
+
+  if (!credentials.subdomain) {
+    throw new sdk.RuntimeError('failed to register webhook: no subdomain is associated with this bot installation')
+  }
+
+  const params = {
+    target: webhookUrl,
+    triggers: ['conversation:message', 'conversation:postback', 'conversation:create'],
+  }
+
+  const response = await fetch(
+    `https://${credentials.subdomain}.zendesk.com/sc/v2/apps/${credentials.appId}/integrations/me/webhooks`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${credentials.token}`,
+        'X-Zendesk-Marketplace-Name': bp.secrets.MARKETPLACE_BOT_NAME,
+        'X-Zendesk-Marketplace-Organization-Id': bp.secrets.MARKETPLACE_ORG_ID,
+      },
+      body: JSON.stringify(params),
+    }
+  )
+
+  if (!response.ok) {
+    console.log('error: ', response.json())
+    logger.forBot().error('Failed to register webhook', {
+      status: response.status,
+    })
+    throw new sdk.RuntimeError('failed to register webhook')
+  }
+
+  const webhook = createWebhookSchema.parse(await response.json())
+
+  logger.forBot().debug('Successfully registered webhook for SunCo')
+
+  return webhook.webhook
+}
+
+export const deleteApp = async ({ credentials, logger }: { credentials: OAuthCredentials; logger: bp.Logger }) => {
+  logger.forBot().debug(`Deleting app with ID ${credentials.appId}`)
+
+  if (!credentials.subdomain) {
+    throw new sdk.RuntimeError('failed to delete app: no subdomain is associated with this bot installation')
+  }
+
+  const response = await fetch(`https://${credentials.subdomain}.zendesk.com/sc/v2/oauth/authorization`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${credentials.token}`,
+      'X-Zendesk-Marketplace-Name': bp.secrets.MARKETPLACE_BOT_NAME,
+      'X-Zendesk-Marketplace-Organization-Id': bp.secrets.MARKETPLACE_ORG_ID,
+    },
+  })
+
+  if (!response.ok) {
+    console.log('error: ', response.json())
+    logger.forBot().error('Failed to delete app', {
+      status: response.status,
+    })
+    throw new sdk.RuntimeError('Failed to delete app')
+  }
+  logger.forBot().debug('Successfully deleted SunCo app')
+}

--- a/integrations/sunco/src/api/webhooks.ts
+++ b/integrations/sunco/src/api/webhooks.ts
@@ -69,7 +69,7 @@ export const deleteApp = async ({ credentials, logger }: { credentials: OAuthCre
     throw new sdk.RuntimeError('Failed to delete app: no subdomain is associated with this bot installation')
   }
 
-  const response = await fetch(`https://${credentials.subdomain}.zendesk.com/sc/v2/oauth/authorization`, {
+  const response = await fetch(`https://${credentials.subdomain}.zendesk.com/sc/oauth/authorization`, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',

--- a/integrations/sunco/src/api/webhooks.ts
+++ b/integrations/sunco/src/api/webhooks.ts
@@ -66,7 +66,7 @@ export const deleteApp = async ({ credentials, logger }: { credentials: OAuthCre
   logger.forBot().debug(`Deleting app with ID ${credentials.appId}`)
 
   if (!credentials.subdomain) {
-    throw new sdk.RuntimeError('failed to delete app: no subdomain is associated with this bot installation')
+    throw new sdk.RuntimeError('Failed to delete app: no subdomain is associated with this bot installation')
   }
 
   const response = await fetch(`https://${credentials.subdomain}.zendesk.com/sc/v2/oauth/authorization`, {

--- a/integrations/sunco/src/api/webhooks.ts
+++ b/integrations/sunco/src/api/webhooks.ts
@@ -1,5 +1,6 @@
 import * as sdk from '@botpress/sdk'
 import { OAuthCredentials, StoredCredentials } from 'src/types'
+import { BASE_HEADERS } from './const'
 import * as bp from '.botpress'
 
 const { z } = sdk
@@ -48,10 +49,8 @@ export const createWebhook = async ({
     {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
         Authorization: `Bearer ${credentials.token}`,
-        'X-Zendesk-Marketplace-Name': bp.secrets.MARKETPLACE_BOT_NAME,
-        'X-Zendesk-Marketplace-Organization-Id': bp.secrets.MARKETPLACE_ORG_ID,
+        ...BASE_HEADERS,
       },
       body: JSON.stringify(params),
     }
@@ -84,10 +83,8 @@ export const deleteApp = async ({ credentials, logger }: { credentials: OAuthCre
   const response = await fetch(`https://${credentials.subdomain}.zendesk.com/sc/oauth/authorization`, {
     method: 'DELETE',
     headers: {
-      'Content-Type': 'application/json',
       Authorization: `Bearer ${credentials.token}`,
-      'X-Zendesk-Marketplace-Name': bp.secrets.MARKETPLACE_BOT_NAME,
-      'X-Zendesk-Marketplace-Organization-Id': bp.secrets.MARKETPLACE_ORG_ID,
+      ...BASE_HEADERS,
     },
   })
 
@@ -128,10 +125,8 @@ const deleteWebhook = async ({
     {
       method: 'DELETE',
       headers: {
-        'Content-Type': 'application/json',
         Authorization: `Bearer ${credentials.token}`,
-        'X-Zendesk-Marketplace-Name': bp.secrets.MARKETPLACE_BOT_NAME,
-        'X-Zendesk-Marketplace-Organization-Id': bp.secrets.MARKETPLACE_ORG_ID,
+        ...BASE_HEADERS,
       },
     }
   )
@@ -157,10 +152,8 @@ const listWebhooks = async ({ credentials, logger }: { credentials: OAuthCredent
     {
       method: 'GET',
       headers: {
-        'Content-Type': 'application/json',
         Authorization: `Bearer ${credentials.token}`,
-        'X-Zendesk-Marketplace-Name': bp.secrets.MARKETPLACE_BOT_NAME,
-        'X-Zendesk-Marketplace-Organization-Id': bp.secrets.MARKETPLACE_ORG_ID,
+        ...BASE_HEADERS,
       },
     }
   )

--- a/integrations/sunco/src/get-stored-credentials.ts
+++ b/integrations/sunco/src/get-stored-credentials.ts
@@ -1,0 +1,31 @@
+import * as sdk from '@botpress/sdk'
+import { StoredCredentials } from './types'
+import * as bp from '.botpress'
+
+export const getStoredCredentials = async (
+  client: bp.Client,
+  ctx: bp.HandlerProps['ctx']
+): Promise<StoredCredentials> => {
+  const { configurationType: configType } = ctx
+  if (configType === 'manual') {
+    const { appId, keyId, keySecret } = ctx.configuration
+    return { configType, appId, keyId, keySecret }
+  }
+
+  const {
+    state: { payload: credentials },
+  } = await client.getOrSetState({
+    name: 'credentials',
+    type: 'integration',
+    id: ctx.integrationId,
+    payload: {},
+  })
+
+  const { token, appId, subdomain } = credentials
+
+  if (!token || !appId) {
+    throw new sdk.RuntimeError('failed to get stored access token or app ID')
+  }
+
+  return { configType, token, appId, subdomain }
+}

--- a/integrations/sunco/src/handler.ts
+++ b/integrations/sunco/src/handler.ts
@@ -1,8 +1,19 @@
+import { generateRedirection } from '@botpress/common/src/html-dialogs'
+import { getWizardStepUrl, isOAuthWizardUrl } from '@botpress/common/src/oauth-wizard'
+import { RuntimeError } from '@botpress/sdk'
+import { getCredentials } from './api/get-credentials'
 import { executeConversationCreated, handleConversationMessage } from './events'
 import { isSuncoWebhookPayload } from './messaging-events'
+import * as wizard from './wizard'
 import * as bp from '.botpress'
 
-export const handler: bp.IntegrationProps['handler'] = async ({ req, client, logger }) => {
+export const handler: bp.IntegrationProps['handler'] = async (props) => {
+  const { req, client, logger } = props
+
+  if (req.path.startsWith('/oauth')) {
+    return await _handleOAuthCallback(props)
+  }
+
   if (!req.body) {
     console.warn('Handler received an empty body')
     return
@@ -24,4 +35,47 @@ export const handler: bp.IntegrationProps['handler'] = async ({ req, client, log
       console.warn(`Received an event of type ${event.type}, which is not supported`)
     }
   }
+  return {
+    status: 200,
+  }
+}
+
+const _handleOAuthCallback = async ({ req, client, ctx, logger }: bp.HandlerProps) => {
+  if (isOAuthWizardUrl(req.path)) {
+    return await wizard.handler({ client, ctx, logger, req })
+  }
+
+  logger.forBot().debug('Handling OAuth callback')
+
+  const searchParams = new URLSearchParams(req.query)
+  const authorizationCode = searchParams.get('code')
+
+  //TODO verify that these are the correct error params
+  const error = searchParams.get('error')
+  const errorDescription = searchParams.get('error_description')
+
+  if (error) {
+    logger.forBot().error(`SunCo OAuth error: ${error} - ${errorDescription}`)
+    throw new RuntimeError(`SunCo OAuth error: ${error} - ${errorDescription}`)
+  }
+
+  if (!authorizationCode) {
+    logger.forBot().error('Authorization code not present in OAuth callback')
+    throw new RuntimeError('Authorization code not present in OAuth callback')
+  }
+
+  const credentials = await getCredentials({
+    authorizationCode,
+    logger,
+  })
+
+  logger.forBot().info('Successfully authenticated SunCo user')
+
+  await client.configureIntegration({
+    identifier: credentials.appId,
+  })
+
+  await client.setState({ type: 'integration', name: 'credentials', id: ctx.integrationId, payload: credentials })
+
+  return generateRedirection(getWizardStepUrl('start', ctx))
 }

--- a/integrations/sunco/src/handler.ts
+++ b/integrations/sunco/src/handler.ts
@@ -49,8 +49,6 @@ const _handleOAuthCallback = async ({ req, client, ctx, logger }: bp.HandlerProp
 
   const searchParams = new URLSearchParams(req.query)
   const authorizationCode = searchParams.get('code')
-
-  //TODO verify that these are the correct error params
   const error = searchParams.get('error')
   const errorDescription = searchParams.get('error_description')
 

--- a/integrations/sunco/src/setup/register.ts
+++ b/integrations/sunco/src/setup/register.ts
@@ -1,23 +1,44 @@
 import { RuntimeError } from '@botpress/client'
 import { getNetworkErrorDetails } from 'src/util'
-import * as bp from '../../.botpress'
 import { createClient } from '../api/sunshine-api'
+import { createWebhook } from '../api/webhooks'
+import { getStoredCredentials } from '../get-stored-credentials'
+import * as bp from '.botpress'
 
-export const register: bp.IntegrationProps['register'] = async ({ ctx, logger }) => {
+export const register: bp.IntegrationProps['register'] = async ({ ctx, logger, client, webhookUrl }) => {
   logger.forBot().info('Starting Sunshine Conversations integration registration...')
 
-  const suncoClient = createClient(ctx.configuration.keyId, ctx.configuration.keySecret)
+  const credentials = await getStoredCredentials(client, ctx)
 
-  logger.forBot().info('Verifying credentials...')
-  try {
-    const app = await suncoClient.apps.getApp(ctx.configuration.appId)
-    logger.forBot().info('✅ Credentials verified successfully. App details:', JSON.stringify(app, null, 2))
-  } catch (thrown: unknown) {
-    const details = getNetworkErrorDetails(thrown)
-    if (details) {
-      throw new RuntimeError(`Invalid credentials: ${details?.message}`)
+  if (credentials.configType === 'manual') {
+    logger.forBot().info('Verifying credentials...')
+    try {
+      const suncoClient = createClient(credentials)
+      const app = await suncoClient.apps.getApp(credentials.appId)
+      logger.forBot().info('✅ Credentials verified successfully. App details:', JSON.stringify(app, null, 2))
+    } catch (thrown: unknown) {
+      const details = getNetworkErrorDetails(thrown)
+      if (details) {
+        throw new RuntimeError(`Invalid credentials: ${details?.message}`)
+      }
+      const errMsg = thrown instanceof Error ? thrown.message : String(thrown)
+      throw new RuntimeError(errMsg)
     }
-    const errMsg = thrown instanceof Error ? thrown.message : String(thrown)
-    throw new RuntimeError(errMsg)
+    return
   }
+
+  logger.forBot().info('Registering webhook...')
+  const webhook = await createWebhook({
+    credentials,
+    logger,
+    webhookUrl,
+  })
+
+  await client.setState({
+    name: 'webhook',
+    type: 'integration',
+    id: ctx.integrationId,
+    payload: webhook,
+  })
+  logger.forBot().info('Successfully registered webhook')
 }

--- a/integrations/sunco/src/setup/register.ts
+++ b/integrations/sunco/src/setup/register.ts
@@ -1,7 +1,7 @@
 import { RuntimeError } from '@botpress/client'
 import { getNetworkErrorDetails } from 'src/util'
 import { createClient } from '../api/sunshine-api'
-import { createWebhook } from '../api/webhooks'
+import { createWebhook, deleteApp } from '../api/webhooks'
 import { getStoredCredentials } from '../get-stored-credentials'
 import * as bp from '.botpress'
 
@@ -26,6 +26,10 @@ export const register: bp.IntegrationProps['register'] = async ({ ctx, logger, c
     }
     return
   }
+
+  await deleteApp({ credentials, logger }).catch((thrown) =>
+    logger.warn(thrown instanceof Error ? thrown.message : new Error(thrown).message)
+  )
 
   logger.forBot().info('Registering webhook...')
   const webhook = await createWebhook({

--- a/integrations/sunco/src/setup/unregister.ts
+++ b/integrations/sunco/src/setup/unregister.ts
@@ -1,3 +1,16 @@
-import * as bp from '../../.botpress'
+import { deleteApp } from 'src/api/webhooks'
+import { getStoredCredentials } from 'src/get-stored-credentials'
+import * as bp from '.botpress'
 
-export const unregister: bp.IntegrationProps['unregister'] = async ({}) => {}
+export const unregister: bp.IntegrationProps['unregister'] = async (props) => {
+  const { client, ctx, logger } = props
+  logger.forBot().info('Starting Sunshine Conversations integration unregistration...')
+
+  const credentials = await getStoredCredentials(client, ctx)
+  if (credentials.configType === 'manual') {
+    logger.forBot().info('Configuration type is manual, nothing to unregister.')
+    return
+  }
+
+  await deleteApp({ credentials, logger })
+}

--- a/integrations/sunco/src/types.ts
+++ b/integrations/sunco/src/types.ts
@@ -24,6 +24,21 @@ export type CreateMessageInput = Parameters<Client['createMessage']>[0]
 export type CreateMessageInputType = CreateMessageInput['type']
 export type CreateMessageInputPayload = CreateMessageInput['payload']
 
+export type ManualCredentials = {
+  configType: 'manual'
+  appId: string
+  keyId: string
+  keySecret: string
+}
+export type OAuthCredentials = {
+  configType: null
+  appId: string
+  token: string
+  subdomain?: string
+}
+
+export type StoredCredentials = ManualCredentials | OAuthCredentials
+
 // Channel message payload types
 export type Choice = bp.channels.channel.choice.Choice
 export type Carousel = bp.channels.channel.carousel.Carousel

--- a/integrations/sunco/src/wizard.ts
+++ b/integrations/sunco/src/wizard.ts
@@ -72,6 +72,7 @@ const _addToChannels: WizardHandler = async (props) => {
   })
 }
 
-const _endHandler: WizardHandler = ({ responses }) => {
+const _endHandler: WizardHandler = async ({ responses, client, ctx }) => {
+  await client.configureIntegration({ identifier: ctx.webhookId })
   return responses.endWizard({ success: true })
 }

--- a/integrations/sunco/src/wizard.ts
+++ b/integrations/sunco/src/wizard.ts
@@ -52,7 +52,7 @@ const _getSubdomain: WizardHandler = async (props) => {
   const { responses } = props
   return responses.displayInput({
     pageTitle: 'Enter your SunCo Subdomain',
-    htmlOrMarkdownPageContents: "To continue, you need to enter your SunCo's subdomain",
+    htmlOrMarkdownPageContents: 'To continue, you need to enter your SunCo subdomain',
     input: { label: 'e.g. https://{subdomain}.zendesk.com', type: 'text' },
     nextStepId: 'start',
   })

--- a/integrations/sunco/src/wizard.ts
+++ b/integrations/sunco/src/wizard.ts
@@ -1,0 +1,93 @@
+import * as oauthWizard from '@botpress/common/src/oauth-wizard'
+import { webcrypto } from 'crypto'
+import * as bp from '.botpress'
+
+type WizardHandler = oauthWizard.WizardStepHandler<bp.HandlerProps>
+
+const BOT_LIST_PATH = '/admin/ai/ai-agents/ai-agents/marketplace-bots'
+
+export const handler = async (props: bp.HandlerProps) => {
+  const wizard = new oauthWizard.OAuthWizardBuilder(props)
+    .addStep({
+      id: 'start',
+      handler: _start,
+    })
+    .addStep({
+      id: 'get-subdomain',
+      handler: _getSubdomain,
+    })
+    .addStep({
+      id: 'add-to-channels',
+      handler: _addToChannels,
+    })
+    .addStep({
+      id: 'end',
+      handler: _endHandler,
+    })
+    .build()
+
+  return await wizard.handleRequest()
+}
+
+const _start: WizardHandler = async (props) => {
+  const { client, responses, ctx, inputValue } = props
+
+  let subdomain = inputValue
+  if (!subdomain) {
+    const {
+      state: { payload },
+    } = await client.getOrSetState({
+      name: 'credentials',
+      type: 'integration',
+      id: ctx.integrationId,
+      payload: {},
+    })
+    if (!payload.subdomain) {
+      return responses.redirectToStep('get-subdomain')
+    }
+    subdomain = payload.subdomain
+  }
+
+  const url = `https://${subdomain}.zendesk.com${BOT_LIST_PATH}`
+  const htmlUrl = `<a href="${url}" target="_blank" rel="noopener noreferrer">
+  here
+</a>`
+  return responses.displayButtons({
+    pageTitle: 'Open Admin Center',
+    htmlOrMarkdownPageContents: `Please click ${htmlUrl} to open your Admin Center on the \`AI => AI agents => AI agents => Marketplace bots\` page. (Click on \`Change subdomain\` if your subdomain is not \`${subdomain}\`.)`,
+    buttons: [
+      { action: 'navigate', label: 'Change subdomain', navigateToStep: 'get-subdomain', buttonType: 'secondary' },
+      { action: 'navigate', label: 'Next step', navigateToStep: 'add-to-channels', buttonType: 'primary' },
+    ],
+  })
+}
+
+const _getSubdomain: WizardHandler = async (props) => {
+  const { responses } = props
+  return responses.displayInput({
+    pageTitle: 'Get SunCo Subdomain',
+    htmlOrMarkdownPageContents: "To continue, you need to enter your SunCo's subdomain",
+    input: { label: 'e.g. https://{subdomain}.zendesk.com', type: 'text' },
+    nextStepId: 'start',
+  })
+}
+
+const _addToChannels: WizardHandler = async (props) => {
+  const { responses } = props
+
+  return responses.displayButtons({
+    pageTitle: 'Add The Bot To Channels',
+    htmlOrMarkdownPageContents:
+      'Click on the Botpress bot. Then in the `Basics` section, select every channel for which you want Botpress to be the default responder. Click on the `Save` button.',
+    buttons: [
+      { action: 'navigate', label: 'Previous step', navigateToStep: 'start', buttonType: 'secondary' },
+      { action: 'navigate', label: 'Finish', navigateToStep: 'end', buttonType: 'primary' },
+    ],
+  })
+}
+
+const _endHandler: WizardHandler = ({ responses }) => {
+  return responses.endWizard({
+    success: true,
+  })
+}

--- a/integrations/sunco/src/wizard.ts
+++ b/integrations/sunco/src/wizard.ts
@@ -65,7 +65,7 @@ const _start: WizardHandler = async (props) => {
 const _getSubdomain: WizardHandler = async (props) => {
   const { responses } = props
   return responses.displayInput({
-    pageTitle: 'Get SunCo Subdomain',
+    pageTitle: 'Enter your SunCo Subdomain',
     htmlOrMarkdownPageContents: "To continue, you need to enter your SunCo's subdomain",
     input: { label: 'e.g. https://{subdomain}.zendesk.com', type: 'text' },
     nextStepId: 'start',

--- a/integrations/sunco/src/wizard.ts
+++ b/integrations/sunco/src/wizard.ts
@@ -1,5 +1,4 @@
 import * as oauthWizard from '@botpress/common/src/oauth-wizard'
-import { webcrypto } from 'crypto'
 import * as bp from '.botpress'
 
 type WizardHandler = oauthWizard.WizardStepHandler<bp.HandlerProps>
@@ -8,24 +7,11 @@ const BOT_LIST_PATH = '/admin/ai/ai-agents/ai-agents/marketplace-bots'
 
 export const handler = async (props: bp.HandlerProps) => {
   const wizard = new oauthWizard.OAuthWizardBuilder(props)
-    .addStep({
-      id: 'start',
-      handler: _start,
-    })
-    .addStep({
-      id: 'get-subdomain',
-      handler: _getSubdomain,
-    })
-    .addStep({
-      id: 'add-to-channels',
-      handler: _addToChannels,
-    })
-    .addStep({
-      id: 'end',
-      handler: _endHandler,
-    })
+    .addStep({ id: 'start', handler: _start })
+    .addStep({ id: 'get-subdomain', handler: _getSubdomain })
+    .addStep({ id: 'add-to-channels', handler: _addToChannels })
+    .addStep({ id: 'end', handler: _endHandler })
     .build()
-
   return await wizard.handleRequest()
 }
 
@@ -87,7 +73,5 @@ const _addToChannels: WizardHandler = async (props) => {
 }
 
 const _endHandler: WizardHandler = ({ responses }) => {
-  return responses.endWizard({
-    success: true,
-  })
+  return responses.endWizard({ success: true })
 }


### PR DESCRIPTION
Contributes to SH-307

This PR contains everything related to the setup of the integration and the OAuth flow. It's now possible to configure the integration with either the OAuth flow or the manual config.

The actual integration logic for using a token vs basic auth will be in a separate PR.

Here are some screenshots of the wizard:
<img width="649" height="870" alt="image" src="https://github.com/user-attachments/assets/555d359e-791a-4c6e-9fa7-dcf1b81b17f4" />
<img width="649" height="870" alt="image" src="https://github.com/user-attachments/assets/033bf838-e0c6-45a5-9580-fe1db3f786a3" />
<img width="649" height="870" alt="image" src="https://github.com/user-attachments/assets/ebd74738-bd81-4e0e-a003-b7518effe72f" />
