### PR TITLE
fix(packages/cli): fix linter ruleset messages to have correct call to action words

### DIFF
--- a/packages/cli/src/linter/rulesets/bot.ruleset.ts
+++ b/packages/cli/src/linter/rulesets/bot.ruleset.ts
@@ -23,8 +23,7 @@ export const BOT_RULESET = {
     },
     'event-outputparams-must-have-description': {
       description: 'All event output parameters MUST have a description',
-      message:
-        '{{description}}: {{error}} SHOULD provide a non-empty description by using .describe() in its Zod schema',
+      message: '{{description}}: {{error}} MUST provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
       given: '$.events[*]..schema.properties[*]',
       then: [
@@ -142,7 +141,7 @@ export const BOT_RULESET = {
     },
     'legacy-zui-title-should-be-removed': {
       description:
-        'Legacy ZUI title fields (ui.title) SHOULD be removed. Please use .title() in your Zod schemas instead',
+        'Legacy ZUI title fields (ui.title) MUST be removed. Please use .title() in your Zod schemas instead',
       severity: 'error',
       given: '$..ui[*].title',
       then: [{ function: falsy }],
@@ -170,8 +169,7 @@ export const BOT_RULESET = {
     },
     'state-fields-must-have-description': {
       description: 'All state fields MUST have a description',
-      message:
-        '{{description}}: {{error}} SHOULD provide a non-empty description by using .describe() in its Zod schema',
+      message: '{{description}}: {{error}} MUST provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
       given: '$.states[*]..schema.properties[*]',
       then: [

--- a/packages/cli/src/linter/rulesets/integration.ruleset.ts
+++ b/packages/cli/src/linter/rulesets/integration.ruleset.ts
@@ -125,8 +125,7 @@ export const INTEGRATION_RULESET = {
     },
     'event-outputparams-must-have-description': {
       description: 'All event output parameters MUST have a description',
-      message:
-        '[{{path}} | {{property}}] {{description}}: {{error}} MUST provide a non-empty description by using .describe() in its Zod schema',
+      message: '{{description}}: {{error}} MUST provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
       given: '$.events[*]..schema.properties[*]',
       then: [

--- a/packages/cli/src/linter/rulesets/integration.ruleset.ts
+++ b/packages/cli/src/linter/rulesets/integration.ruleset.ts
@@ -126,7 +126,7 @@ export const INTEGRATION_RULESET = {
     'event-outputparams-must-have-description': {
       description: 'All event output parameters MUST have a description',
       message:
-        '{{description}}: {{error}} SHOULD provide a non-empty description by using .describe() in its Zod schema',
+        '[{{path}} | {{property}}] {{description}}: {{error}} MUST provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
       given: '$.events[*]..schema.properties[*]',
       then: [
@@ -366,8 +366,7 @@ export const INTEGRATION_RULESET = {
     },
     'state-fields-must-have-description': {
       description: 'All state fields MUST have a description',
-      message:
-        '{{description}}: {{error}} SHOULD provide a non-empty description by using .describe() in its Zod schema',
+      message: '{{description}}: {{error}} MUST provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
       given: '$.states[*]..schema.properties[*]',
       then: [

--- a/packages/cli/src/linter/rulesets/interface.ruleset.ts
+++ b/packages/cli/src/linter/rulesets/interface.ruleset.ts
@@ -87,8 +87,7 @@ export const INTERFACE_RULESET = {
     },
     'event-outputparams-must-have-description': {
       description: 'All event output parameters MUST have a description',
-      message:
-        '{{description}}: {{error}} SHOULD provide a non-empty description by using .describe() in its Zod schema',
+      message: '{{description}}: {{error}} MUST provide a non-empty description by using .describe() in its Zod schema',
       severity: 'error',
       given: '$.events[*]..schema.properties[*]',
       then: [


### PR DESCRIPTION
This fixes the issue where some rules with an "error" severity used "SHOULD" instead of "MUST" and vice versa for some rules with a "warn" severity.

This PR hardcodes the fixed call to action words. However, I also created a PR where the call to action words are substituted dynamically based on the severity of the rule, which can be found here: https://github.com/botpress/botpress/pull/14897
