### PR TITLE
fix(whatsapp): sandbox fails to extract identifier on statuses

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -93,7 +93,7 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp'
-export const INTEGRATION_VERSION = '4.7.0'
+export const INTEGRATION_VERSION = '4.7.1'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,

--- a/integrations/whatsapp/sandboxIdentifierExtract.vrl
+++ b/integrations/whatsapp/sandboxIdentifierExtract.vrl
@@ -4,15 +4,5 @@ if actualSignature != expectedSignature {
   null
 } else {
   body = parse_json!(.body)
-  value = body.entry[0].changes[0].value
-  identifier = if value.contacts {
-    value.contacts[0].wa_id
-  } else {
-    if value.statuses {
-      value.statuses[0].recipient_id
-    } else {
-      null
-    }
-  }
-  identifier
+  body.entry[0].changes[0].value.contacts[0].wa_id
 }

--- a/integrations/whatsapp/sandboxIdentifierExtract.vrl
+++ b/integrations/whatsapp/sandboxIdentifierExtract.vrl
@@ -5,11 +5,9 @@ if actualSignature != expectedSignature {
 } else {
   body = parse_json!(.body)
   value = body.entry[0].changes[0].value
-  if !is_nullish(value.contacts) && length!(value.contacts) > 0 {
-    value.contacts[0].wa_id
-  } else if !is_nullish(value.statuses) && length!(value.statuses) > 0 {
-      value.statuses[0].recipient_id
+  if !is_nullish(value.statuses) && length!(value.statuses) > 0 {
+    value.statuses[0].recipient_id
   } else {
-      null
+    value.contacts[0].wa_id
   }
 }

--- a/integrations/whatsapp/sandboxIdentifierExtract.vrl
+++ b/integrations/whatsapp/sandboxIdentifierExtract.vrl
@@ -4,5 +4,12 @@ if actualSignature != expectedSignature {
   null
 } else {
   body = parse_json!(.body)
-  body.entry[0].changes[0].value.contacts[0].wa_id
+  value = body.entry[0].changes[0].value
+  if !is_nullish(value.contacts) && length!(value.contacts) > 0 {
+    value.contacts[0].wa_id
+  } else if !is_nullish(value.statuses) && length!(value.statuses) > 0 {
+      value.statuses[0].recipient_id
+  } else {
+      null
+  }
 }

--- a/integrations/whatsapp/sandboxIdentifierExtract.vrl
+++ b/integrations/whatsapp/sandboxIdentifierExtract.vrl
@@ -4,5 +4,15 @@ if actualSignature != expectedSignature {
   null
 } else {
   body = parse_json!(.body)
-  body.entry[0].changes[0].value.contacts[0].wa_id
+  value = body.entry[0].changes[0].value
+  identifier = if value.contacts {
+    value.contacts[0].wa_id
+  } else {
+    if value.statuses {
+      value.statuses[0].recipient_id
+    } else {
+      null
+    }
+  }
+  identifier
 }


### PR DESCRIPTION
Statuses updates for messages are not working correctly for sandbox messages

references SH-385, tested on staging