### PR TITLE
feat(integrations/sunco): Added webhook secret validation

### DIFF
--- a/integrations/sunco/src/channels.ts
+++ b/integrations/sunco/src/channels.ts
@@ -1,14 +1,6 @@
 import { RuntimeError } from '@botpress/client'
 import axios from 'axios'
-import {
-  Action,
-  ApiClient,
-  CarouselItem,
-  CombinedApiClient,
-  createClient,
-  MessageContent,
-  PostMessageRequest,
-} from './api/sunshine-api'
+import { Action, CarouselItem, createClient, MessageContent, PostMessageRequest } from './api/sunshine-api'
 import { getStoredCredentials } from './get-stored-credentials'
 import { Carousel, Choice, Conversation, StoredCredentials } from './types'
 import { getSuncoConversationId } from './util'

--- a/integrations/sunco/src/get-stored-credentials.ts
+++ b/integrations/sunco/src/get-stored-credentials.ts
@@ -29,3 +29,23 @@ export const getStoredCredentials = async (
 
   return { configType, token, appId, subdomain }
 }
+
+export const getWebhookSecret = async (client: bp.Client, ctx: bp.HandlerProps['ctx']) => {
+  if (ctx.configurationType === 'manual') {
+    return ctx.configuration.webhookSecret
+  }
+  const {
+    state: {
+      payload: { secret },
+    },
+  } = await client.getOrSetState({
+    name: 'webhook',
+    type: 'integration',
+    id: ctx.integrationId,
+    payload: { id: '', secret: '' },
+  })
+  if (!secret) {
+    throw new sdk.RuntimeError('Error: the webhook secret was not found in the bot state.')
+  }
+  return secret
+}

--- a/integrations/sunco/src/handler.ts
+++ b/integrations/sunco/src/handler.ts
@@ -15,6 +15,11 @@ export const handler: bp.IntegrationProps['handler'] = async (props) => {
     return await _handleOAuthCallback(props)
   }
 
+  if (!isWebhookSignatureValid(req.headers, await getWebhookSecret(client, ctx))) {
+    logger.forBot().warn('Received a request with an invalid webhook secret')
+    return
+  }
+
   if (!req.body) {
     console.warn('Handler received an empty body')
     return
@@ -23,11 +28,6 @@ export const handler: bp.IntegrationProps['handler'] = async (props) => {
   const data = JSON.parse(req.body)
 
   if (!isSuncoWebhookPayload(data)) {
-    logger.forBot().warn('Received an invalid payload from Sunco')
-    return
-  }
-
-  if (!isWebhookSignatureValid(req.headers, await getWebhookSecret(client, ctx))) {
     logger.forBot().warn('Received an invalid payload from Sunco')
     return
   }

--- a/integrations/sunco/src/handler.ts
+++ b/integrations/sunco/src/handler.ts
@@ -4,7 +4,7 @@ import { RuntimeError } from '@botpress/sdk'
 import { getCredentials } from './api/get-credentials'
 import { executeConversationCreated, handleConversationMessage } from './events'
 import { getWebhookSecret } from './get-stored-credentials'
-import { isSuncoWebhookPayload, isWebhookSignatureValid as isSignatureValid } from './messaging-events'
+import { isSuncoWebhookPayload, isWebhookSignatureValid } from './messaging-events'
 import * as wizard from './wizard'
 import * as bp from '.botpress'
 
@@ -27,7 +27,7 @@ export const handler: bp.IntegrationProps['handler'] = async (props) => {
     return
   }
 
-  if (!isSignatureValid(req.headers, await getWebhookSecret(client, ctx))) {
+  if (!isWebhookSignatureValid(req.headers, await getWebhookSecret(client, ctx))) {
     logger.forBot().warn('Received an invalid payload from Sunco')
     return
   }

--- a/integrations/sunco/src/messaging-events.ts
+++ b/integrations/sunco/src/messaging-events.ts
@@ -188,3 +188,16 @@ export function isSuncoWebhookPayload(data: unknown): data is SuncoWebhookPayloa
     })
     .safeParse(data).success
 }
+
+export function isWebhookSignatureValid(
+  headers: {
+    [key: string]: string | undefined
+  },
+  webhookSecret: string
+) {
+  const actualSecret = headers['x-api-key']
+  if (!actualSecret || actualSecret !== webhookSecret) {
+    return false
+  }
+  return true
+}

--- a/integrations/sunco/tsconfig.json
+++ b/integrations/sunco/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "baseUrl": ".",
     "outDir": "dist"
   },


### PR DESCRIPTION
Contributes to SH-307

Despite having a field for the webhook secret in the manual configuration, it was never actually validated. We now validate it for every request we receive, for both the manual and OAuth config.

This is unrelated, but I also removed some unused imports instead of doing a separate PR for it.