### PR TITLE
chore(integrations/google-ai): override Gemini 3 model IDs

### DIFF
--- a/integrations/google-ai/src/actions/generate-content.ts
+++ b/integrations/google-ai/src/actions/generate-content.ts
@@ -17,7 +17,7 @@ import {
   FunctionDeclaration,
 } from '@google/genai'
 import crypto from 'crypto'
-import { DefaultModelId, DiscontinuedModelIds, ModelId } from 'src/schemas'
+import { DefaultModelId, DiscontinuedModelIds, ModelId, OverrideModelIds } from 'src/schemas'
 
 type ReasoningEffort = NonNullable<llm.GenerateContentInput['reasoningEffort']>
 
@@ -127,13 +127,17 @@ async function buildGenerateContentRequest(
   }
 
   let defaultReasoningEffort: ReasoningEffort = 'none'
-  if (modelId === 'gemini-3-pro-preview') {
+  if (modelId === 'gemini-3-pro') {
     // Gemini 3 Pro doesn't support disabling reasoning, so we use the lowest reasoning effort by default.
     defaultReasoningEffort = 'low'
   }
 
   const thinkingBudget = ThinkingModeBudgetTokens[input.reasoningEffort ?? defaultReasoningEffort]
   const modelSupportsThinking = modelId !== 'models/gemini-2.0-flash' // Gemini 2.0 doesn't support thinking mode
+
+  if (OverrideModelIds[modelId]) {
+    modelId = OverrideModelIds[modelId] as ModelId
+  }
 
   return {
     model: modelId,

--- a/integrations/google-ai/src/index.ts
+++ b/integrations/google-ai/src/index.ts
@@ -1,15 +1,13 @@
 import { llm } from '@botpress/common'
 import { GoogleGenAI } from '@google/genai'
 import { generateContent } from './actions/generate-content'
-import { ModelId } from './schemas'
+import { DefaultModelId, ModelId } from './schemas'
 import * as bp from '.botpress'
 
 const googleAIClient = new GoogleGenAI({ apiKey: bp.secrets.GOOGLE_AI_API_KEY })
 
-const DEFAULT_LANGUAGE_MODEL_ID: ModelId = 'models/gemini-2.0-flash'
-
 const languageModels: Record<ModelId, llm.ModelDetails> = {
-  'gemini-3-pro-preview': {
+  'gemini-3-pro': {
     name: 'Gemini 3 Pro (Preview)',
     description:
       "One of the best models for multimodal understanding, and Google's most powerful agentic and vibe-coding model yet, delivering richer visuals and deeper interactivity, built on a foundation of state-of-the-art reasoning.",
@@ -25,7 +23,7 @@ const languageModels: Record<ModelId, llm.ModelDetails> = {
       maxTokens: 65_536,
     },
   },
-  'gemini-3-flash-preview': {
+  'gemini-3-flash': {
     name: 'Gemini 3 Flash (Preview)',
     description: "Google's most balanced model built for speed, scale, and frontier intelligence.",
     tags: ['preview', 'reasoning', 'agents', 'general-purpose', 'vision'],
@@ -96,7 +94,7 @@ export default new bp.Integration({
     generateContent: async ({ input, logger, metadata }) => {
       const output = await generateContent(<llm.GenerateContentInput>input, googleAIClient, logger, {
         models: languageModels,
-        defaultModel: DEFAULT_LANGUAGE_MODEL_ID,
+        defaultModel: DefaultModelId,
       })
       metadata.setCost(output.botpress.cost)
       return output

--- a/integrations/google-ai/src/schemas.ts
+++ b/integrations/google-ai/src/schemas.ts
@@ -3,16 +3,15 @@ import { z } from '@botpress/sdk'
 export const DefaultModelId: ModelId = 'gemini-2.5-flash'
 
 export const ModelId = z
-  .enum([
-    'gemini-3-pro-preview',
-    'gemini-3-flash-preview',
-    'gemini-2.5-flash',
-    'gemini-2.5-pro',
-    'models/gemini-2.0-flash',
-  ])
+  .enum(['gemini-3-pro', 'gemini-3-flash', 'gemini-2.5-flash', 'gemini-2.5-pro', 'models/gemini-2.0-flash'])
   .describe('Model to use for content generation')
   .placeholder(DefaultModelId)
 export type ModelId = z.infer<typeof ModelId>
+
+export const OverrideModelIds: Partial<Record<ModelId, string>> = {
+  'gemini-3-pro': 'gemini-3-pro-preview',
+  'gemini-3-flash': 'gemini-3-flash-preview',
+}
 
 export const DiscontinuedModelIds = [
   'models/gemini-1.5-flash-8b-001',


### PR DESCRIPTION
This will allow a seamless change to the production model when Google releases Gemini 3 out of preview.