### PR TITLE
feat(integrations/linkedin): Creating issues when tokens expire

### DIFF
--- a/integrations/linkedin/src/linkedin-api/linkedin-oauth-client.ts
+++ b/integrations/linkedin/src/linkedin-api/linkedin-oauth-client.ts
@@ -9,6 +9,13 @@ const OAUTH_REDIRECT_URI = `${process.env.BP_WEBHOOK_URL}/oauth`
 const ACCESS_TOKEN_BUFFER_MS = 5 * 60 * 1000 // 5 minutes
 const REFRESH_TOKEN_BUFFER_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
 
+const ACCESS_TOKEN_EXPIRED_ISSUE_TITLE = 'Access token expired'
+const ACCESS_TOKEN_EXPIRED_ISSUE_DESC =
+  'The LinkedIn api access token is expired or expiring within 7 days and no refresh token is available. Please re-authorize the integration through the OAuth flow.'
+const REFRESH_TOKEN_EXPIRED_ISSUE_TITLE = 'Refresh token expired'
+const REFRESH_TOKEN_EXPIRED_ISSUE_DESC =
+  'The LinkedIn api refresh token is expired or expiring within 7 days. Please re-authorize the integration through the OAuth flow.'
+
 type OAuthCredentialsPayload = bp.states.oauthCredentials.OauthCredentials['payload']
 
 type ClientCredentials = {
@@ -232,13 +239,20 @@ export class LinkedInOAuthClient {
       if (this._credentials.accessToken.expiresAt > now + REFRESH_TOKEN_BUFFER_MS) {
         this._logger.issue({
           type: 'issue',
-          title: 'Access token expired',
-          description:
-            'The LinkedIn api token is expired or expiring within 7 days and no refresh token is available. Please re-authorize the integration through the OAuth flow.',
+          title: ACCESS_TOKEN_EXPIRED_ISSUE_TITLE,
+          description: ACCESS_TOKEN_EXPIRED_ISSUE_DESC,
           category: 'configuration',
           groupBy: ['access_token_expired'],
           code: 'code',
-          data: {},
+          data: {
+            details: {
+              raw: ACCESS_TOKEN_EXPIRED_ISSUE_TITLE,
+              pretty: ACCESS_TOKEN_EXPIRED_ISSUE_DESC,
+            },
+            expiryDate: {
+              raw: new Date(this._credentials.accessToken.expiresAt).toISOString(),
+            },
+          },
         })
       }
       return
@@ -254,13 +268,20 @@ export class LinkedInOAuthClient {
       if (this._credentials.refreshToken.expiresAt <= now + REFRESH_TOKEN_BUFFER_MS) {
         this._logger.issue({
           type: 'issue',
-          title: 'Refresh token expired',
-          description:
-            'The LinkedIn api refresh token is expired or expiring within 7 days. Please re-authorize the integration through the OAuth flow.',
+          title: REFRESH_TOKEN_EXPIRED_ISSUE_TITLE,
+          description: REFRESH_TOKEN_EXPIRED_ISSUE_DESC,
           category: 'configuration',
           groupBy: ['refresh_token_expired'],
           code: 'code',
-          data: {},
+          data: {
+            details: {
+              raw: REFRESH_TOKEN_EXPIRED_ISSUE_TITLE,
+              pretty: REFRESH_TOKEN_EXPIRED_ISSUE_DESC,
+            },
+            expiryDate: {
+              raw: new Date(this._credentials.refreshToken.expiresAt).toISOString(),
+            },
+          },
         })
       }
     }

--- a/integrations/linkedin/src/linkedin-api/linkedin-oauth-client.ts
+++ b/integrations/linkedin/src/linkedin-api/linkedin-oauth-client.ts
@@ -243,7 +243,7 @@ export class LinkedInOAuthClient {
           description: ACCESS_TOKEN_EXPIRED_ISSUE_DESC,
           category: 'configuration',
           groupBy: ['access_token_expired'],
-          code: 'code',
+          code: 'access_token_expired',
           data: {
             details: {
               raw: ACCESS_TOKEN_EXPIRED_ISSUE_TITLE,
@@ -272,7 +272,7 @@ export class LinkedInOAuthClient {
           description: REFRESH_TOKEN_EXPIRED_ISSUE_DESC,
           category: 'configuration',
           groupBy: ['refresh_token_expired'],
-          code: 'code',
+          code: 'refresh_token_expired',
           data: {
             details: {
               raw: REFRESH_TOKEN_EXPIRED_ISSUE_TITLE,

--- a/integrations/linkedin/src/linkedin-api/linkedin-oauth-client.ts
+++ b/integrations/linkedin/src/linkedin-api/linkedin-oauth-client.ts
@@ -258,11 +258,10 @@ export class LinkedInOAuthClient {
           description:
             'The LinkedIn api refresh token is expired or expiring within 7 days. Please re-authorize the integration through the OAuth flow.',
           category: 'configuration',
-          groupBy: ['access_token_expired'],
+          groupBy: ['refresh_token_expired'],
           code: 'code',
           data: {},
         })
-        this._logger.forBot().error('LinkedIn refresh token expired or expiring within 7 days')
       }
     }
 


### PR DESCRIPTION
Contributes to SH-346

When a token has expired or is about to, we now create an issue instead of a log.

- The errors that were thrown when a token is about to expire have been removed. We don't want to voluntarily throw an exception if the token might be valid for a short amount of time still.
- Issues are raised when the refresh token is within 7 days of expiring, or when there is no refresh token and the access token is within 7 days of expiring.

<img width="1605" height="413" alt="image" src="https://github.com/user-attachments/assets/a0fbb426-cecb-4fae-a65d-ae76d5d9e936" />
