### PR TITLE
fix(integrations/linkedin): small fixes

### DIFF
--- a/integrations/linkedin/src/linkedin-api/apis/posts-api.ts
+++ b/integrations/linkedin/src/linkedin-api/apis/posts-api.ts
@@ -1,7 +1,7 @@
 import * as sdk from '@botpress/sdk'
 import { LinkedInBaseApi } from '../base-api'
 import { extractLinkedInHeaders } from '../linkedin-oauth-client'
-import { InitializeUploadResponse } from '../schemas'
+import { initializeUploadResponseSchema } from '../schemas'
 import { getImageBufferFromResponse } from './get-image-buffer-from-response'
 
 export type CreatePostParams = {
@@ -120,7 +120,7 @@ export class PostsApi extends LinkedInBaseApi {
       'Failed to initialize image upload with LinkedIn'
     )
 
-    const data = (await response.json()) as InitializeUploadResponse
+    const data = initializeUploadResponseSchema.parse(await response.json())
 
     return {
       uploadUrl: data.value.uploadUrl,

--- a/integrations/linkedin/src/linkedin-api/linkedin-oauth-client.ts
+++ b/integrations/linkedin/src/linkedin-api/linkedin-oauth-client.ts
@@ -236,7 +236,7 @@ export class LinkedInOAuthClient {
     const now = new Date().getTime()
 
     if (!this._credentials.refreshToken) {
-      if (this._credentials.accessToken.expiresAt > now + REFRESH_TOKEN_BUFFER_MS) {
+      if (this._credentials.accessToken.expiresAt <= now + REFRESH_TOKEN_BUFFER_MS) {
         this._logger.issue({
           type: 'issue',
           title: ACCESS_TOKEN_EXPIRED_ISSUE_TITLE,
@@ -340,7 +340,7 @@ export class LinkedInOAuthClient {
     }
 
     const tokenData = linkedInTokenResponseSchema.parse(await response.json())
-    LinkedInOAuthClient._generateCredentials(
+    this._credentials = LinkedInOAuthClient._generateCredentials(
       tokenData,
       this._credentials.linkedInUserId,
       this._credentials.grantedScopes

--- a/integrations/linkedin/src/linkedin-api/schemas.ts
+++ b/integrations/linkedin/src/linkedin-api/schemas.ts
@@ -46,5 +46,3 @@ export const initializeUploadResponseSchema = z
       .passthrough(),
   })
   .passthrough()
-
-export type InitializeUploadResponse = z.infer<typeof initializeUploadResponseSchema>


### PR DESCRIPTION
These are all fixes from bugs found by the cursor bot's review.

- Now using `initializeUploadResponseSchema.parse()` instead of `as InitializeUploadResponse`.
- The condition for creating an issue when a token is expired was reversed.
- The credentials obtained when refreshing the token weren't being saved.