### PR TITLE
feat(llmz): export llmz version

### DIFF
--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "generate": "pnpm build:markdown",
-    "build": "tsup && pnpm tsc --emitDeclarationOnly",
+    "build": "tsup && pnpm tsc --emitDeclarationOnly --noCheck",
     "check:type": "tsc --noEmit",
     "watch": "tsup --watch",
     "test": "vitest --run",

--- a/packages/llmz/src/index.ts
+++ b/packages/llmz/src/index.ts
@@ -1,3 +1,6 @@
+// @ts-ignore
+export { version } from '../package.json'
+
 export { Tool } from './tool.js'
 export { Exit, ExitResult } from './exit.js'
 export { ObjectInstance } from './objects.js'


### PR DESCRIPTION
We'll be used in the studio to persist along LLMz execution results so that we can render the LLMz inspector accordingly.

I tried to `pnpm build && pnpm pack` and it seems to work fine once bundled