### PR TITLE
feat(sdk): implement signature validation for self-hosted integrations

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.4",
     "@botpress/client": "1.32.0",
-    "@botpress/sdk": "5.3.3",
+    "@botpress/sdk": "5.4.0",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/verel": "^0.2.0",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.32.0",
-    "@botpress/sdk": "5.3.3"
+    "@botpress/sdk": "5.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.32.0",
-    "@botpress/sdk": "5.3.3"
+    "@botpress/sdk": "5.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "5.3.3"
+    "@botpress/sdk": "5.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.32.0",
-    "@botpress/sdk": "5.3.3"
+    "@botpress/sdk": "5.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.32.0",
-    "@botpress/sdk": "5.3.3",
+    "@botpress/sdk": "5.4.0",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@botpress/client": "1.32.0",
+    "@bpinternal/signature-verification": "^0.2.0",
     "browser-or-node": "^2.1.1",
     "semver": "^7.3.8"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "5.3.3",
+  "version": "5.4.0",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/bot/implementation.ts
+++ b/packages/sdk/src/bot/implementation.ts
@@ -452,5 +452,6 @@ export class BotImplementation<TBot extends BaseBot = BaseBot, TPlugins extends 
 
   public readonly handler = botHandler(this as unknown as BotHandlers<any>)
 
-  public readonly start = (port?: number): Promise<Server> => serve(this.handler, port)
+  public readonly start = (port?: number, signingSecrets?: string[]): Promise<Server> =>
+    serve({ handler: this.handler, port, signingSecrets })
 }

--- a/packages/sdk/src/integration/implementation.ts
+++ b/packages/sdk/src/integration/implementation.ts
@@ -56,5 +56,6 @@ export class IntegrationImplementation<TIntegration extends BaseIntegration = Ba
   }
 
   public readonly handler = integrationHandler(this as IntegrationImplementation<any>)
-  public readonly start = (port?: number): Promise<Server> => serve(this.handler, port)
+  public readonly start = (port?: number, signingSecrets?: string[]): Promise<Server> =>
+    serve({ handler: this.handler, port, signingSecrets })
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2949,6 +2949,9 @@ importers:
       '@botpress/client':
         specifier: 1.32.0
         version: link:../client
+      '@bpinternal/signature-verification':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@bpinternal/zui':
         specifier: ^1.3.2
         version: link:../zui
@@ -4027,6 +4030,10 @@ packages:
     resolution: {integrity: sha512-gXzkw2nByc/mFGlEnfi6lpBPuXU/uKBDQ1oQ0ipsDGngztfteyEwt5BUt746QlqH26k5KU36TbnEhqE089U3hg==}
     engines: {node: '>=16.0.0', pnpm: 8.6.2}
     hasBin: true
+
+  '@bpinternal/signature-verification@0.2.0':
+    resolution: {integrity: sha512-vv0djt1szcVunRpJ6AKlbdApyxQUDsx56kqYl+IBPbpiLkstYmmkGJLMTzrvRXAT68baZf8qlvRUCymDZ7w0YA==}
+    engines: {node: '>=19.0.0', pnpm: 10.28.2}
 
   '@bpinternal/slackdown@0.1.0':
     resolution: {integrity: sha512-Gz6xR/BQcfbpxiors8W94JmEl+eoNI7kRncNbduTaSD7saIqGnYokwoVqZw4FzSUSLgpiXCQCnUnoQsc+Yt63Q==}
@@ -13244,6 +13251,8 @@ snapshots:
       '@bpinternal/yargs-extra': 0.0.20
       cross-spawn: 7.0.6
       retry: 0.13.1
+
+  '@bpinternal/signature-verification@0.2.0': {}
 
   '@bpinternal/slackdown@0.1.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2505,7 +2505,7 @@ importers:
         specifier: 1.32.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 5.3.3
+        specifier: 5.4.0
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2629,7 +2629,7 @@ importers:
         specifier: 1.32.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.3.3
+        specifier: 5.4.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2645,7 +2645,7 @@ importers:
         specifier: 1.32.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.3.3
+        specifier: 5.4.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2658,7 +2658,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 5.3.3
+        specifier: 5.4.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2674,7 +2674,7 @@ importers:
         specifier: 1.32.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.3.3
+        specifier: 5.4.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2690,7 +2690,7 @@ importers:
         specifier: 1.32.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.3.3
+        specifier: 5.4.0
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
Uses `@bpinternal/signature-verification` to validate whether incoming webhook requests are properly authenticated.

When a self-hosted integration or bot provides a set of signing secrets, the bot/integration middleware starts strictly enforcing request validation.

Contributes to KKN-269. Depends on [bpinternal/signature-verification](https://github.com/botpress/botpress/commit/07408c0df855e50d6c0e2bc8354c04edb3b210c7).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces request authentication enforcement in the SDK server path and changes the `serve`/`start` APIs, which could break self-hosted setups if misconfigured or if callers rely on non-POST/empty-body behavior.
> 
> **Overview**
> Adds optional webhook signature enforcement to the SDK’s Node `serve` helper: when `signingSecrets` are provided it now requires POST requests with a body and a valid `X-BP-Signature`, otherwise returns `400`/`401` before invoking the handler.
> 
> Updates `BotImplementation.start` and `IntegrationImplementation.start` to accept `signingSecrets` and pass them through to `serve`, and bumps `@botpress/sdk` to `5.4.0` across the CLI and templates while adding the new `@bpinternal/signature-verification` dependency (plus lockfile updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1df902ba0fe675e95726fa97097863fb94e0026. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->