### PR TITLE
chore: bump api to 1.71.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.564.0",
-    "@botpress/api": "1.71.0",
+    "@botpress/api": "1.71.1",
     "@botpress/cli": "workspace:*",
     "@botpress/client": "workspace:*",
     "@botpress/sdk": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",
@@ -27,8 +27,8 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.4",
-    "@botpress/client": "1.32.0",
-    "@botpress/sdk": "5.3.3",
+    "@botpress/client": "1.33.0",
+    "@botpress/sdk": "5.3.4",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/verel": "^0.2.0",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -5,8 +5,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.32.0",
-    "@botpress/sdk": "5.3.3"
+    "@botpress/client": "1.33.0",
+    "@botpress/sdk": "5.3.4"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.32.0",
-    "@botpress/sdk": "5.3.3"
+    "@botpress/client": "1.33.0",
+    "@botpress/sdk": "5.3.4"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "5.3.3"
+    "@botpress/sdk": "5.3.4"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.32.0",
-    "@botpress/sdk": "5.3.3"
+    "@botpress/client": "1.33.0",
+    "@botpress/sdk": "5.3.4"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.32.0",
-    "@botpress/sdk": "5.3.3",
+    "@botpress/client": "1.33.0",
+    "@botpress/sdk": "5.3.4",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/cognitive/package.json
+++ b/packages/cognitive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cognitive",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Wrapper around the Botpress Client to call LLMs",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -2,7 +2,7 @@
   "name": "llmz",
   "type": "module",
   "description": "LLMz - An LLM-native Typescript VM built on top of Zui",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -71,8 +71,8 @@
     "tsx": "^4.19.2"
   },
   "peerDependencies": {
-    "@botpress/client": "1.32.0",
-    "@botpress/cognitive": "0.3.9",
+    "@botpress/client": "1.33.0",
+    "@botpress/cognitive": "0.3.10",
     "@bpinternal/thicktoken": "^1.0.5",
     "@bpinternal/zui": "^1.3.2"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -20,7 +20,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "1.32.0",
+    "@botpress/client": "1.33.0",
     "browser-or-node": "^2.1.1",
     "semver": "^7.3.8"
   },

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/vai",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Vitest AI (vai) – a vitest extension for testing with LLMs",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -40,7 +40,7 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "@botpress/client": "1.32.0",
+    "@botpress/client": "1.33.0",
     "@bpinternal/thicktoken": "^1.0.1",
     "@bpinternal/zui": "^1.3.2",
     "lodash": "^4.17.21",

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "2.5.12",
+  "version": "2.5.13",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -32,7 +32,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@botpress/cognitive": "0.3.9",
+    "@botpress/cognitive": "0.3.10",
     "json5": "^2.2.3",
     "jsonrepair": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/plugins/conversation-insights/package.json
+++ b/plugins/conversation-insights/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/cognitive": "0.3.9",
+    "@botpress/cognitive": "0.3.10",
     "@botpress/sdk": "workspace:*",
     "browser-or-node": "^2.1.1",
     "jsonrepair": "^3.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^3.564.0
         version: 3.709.0
       '@botpress/api':
-        specifier: 1.71.0
-        version: 1.71.0
+        specifier: 1.71.1
+        version: 1.71.1
       '@botpress/cli':
         specifier: workspace:*
         version: link:packages/cli
@@ -2502,10 +2502,10 @@ importers:
         specifier: 0.5.4
         version: link:../chat-client
       '@botpress/client':
-        specifier: 1.32.0
+        specifier: 1.33.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 5.3.3
+        specifier: 5.3.4
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2626,10 +2626,10 @@ importers:
   packages/cli/templates/empty-bot:
     dependencies:
       '@botpress/client':
-        specifier: 1.32.0
+        specifier: 1.33.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.3.3
+        specifier: 5.3.4
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2642,10 +2642,10 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 1.32.0
+        specifier: 1.33.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.3.3
+        specifier: 5.3.4
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2658,7 +2658,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 5.3.3
+        specifier: 5.3.4
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2671,10 +2671,10 @@ importers:
   packages/cli/templates/hello-world:
     dependencies:
       '@botpress/client':
-        specifier: 1.32.0
+        specifier: 1.33.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.3.3
+        specifier: 5.3.4
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2687,10 +2687,10 @@ importers:
   packages/cli/templates/webhook-message:
     dependencies:
       '@botpress/client':
-        specifier: 1.32.0
+        specifier: 1.33.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.3.3
+        specifier: 5.3.4
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8
@@ -2841,10 +2841,10 @@ importers:
         specifier: ^7.26.3
         version: 7.26.9
       '@botpress/client':
-        specifier: 1.32.0
+        specifier: 1.33.0
         version: link:../client
       '@botpress/cognitive':
-        specifier: 0.3.9
+        specifier: 0.3.10
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^1.0.5
@@ -2947,7 +2947,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 1.32.0
+        specifier: 1.33.0
         version: link:../client
       '@bpinternal/zui':
         specifier: ^1.3.2
@@ -2984,7 +2984,7 @@ importers:
   packages/vai:
     dependencies:
       '@botpress/client':
-        specifier: 1.32.0
+        specifier: 1.33.0
         version: link:../client
       '@bpinternal/thicktoken':
         specifier: ^1.0.1
@@ -3030,7 +3030,7 @@ importers:
   packages/zai:
     dependencies:
       '@botpress/cognitive':
-        specifier: 0.3.9
+        specifier: 0.3.10
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^1.0.0
@@ -3149,7 +3149,7 @@ importers:
   plugins/conversation-insights:
     dependencies:
       '@botpress/cognitive':
-        specifier: 0.3.9
+        specifier: 0.3.10
         version: link:../../packages/cognitive
       '@botpress/sdk':
         specifier: workspace:*
@@ -3991,8 +3991,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@botpress/api@1.71.0':
-    resolution: {integrity: sha512-8lK5rAzc1KKQ46HKisdzTOb6dqvc3xXI8SRT9HOl4YiR5ekrbtqhWqGri4Y/LvgoWajYdNvza4Iy9CG0st7V0w==}
+  '@botpress/api@1.71.1':
+    resolution: {integrity: sha512-vg/7/Hcy1sX9jWWiz/BlkdXPAq8+wktL9ZNqYaSvOit0nSSBtLn64BHngdzp14dIapuAVM6CJLW045rbxWojog==}
 
   '@bpinternal/const@0.1.0':
     resolution: {integrity: sha512-iIQg9oYYXOt+LSK34oNhJVQTcgRdtLmLZirEUaE+R9hnmbKONA5reR2kTewxZmekGyxej+5RtDK9xrC/0hmeAw==}
@@ -13166,7 +13166,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@botpress/api@1.71.0':
+  '@botpress/api@1.71.1':
     dependencies:
       '@bpinternal/opapi': 1.0.0(openapi-types@12.1.3)
     transitivePeerDependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only dependency bumps and lockfile updates; risk is limited to potential breaking changes in the updated Botpress packages.
> 
> **Overview**
> Updates dependency versions across the workspace: bumps `@botpress/api` to `1.71.1`, `@botpress/client` to `1.33.0`, `@botpress/sdk` to `5.3.4`, and `@botpress/cognitive` to `0.3.10`.
> 
> Propagates these bumps through the CLI package and its templates, plus related packages (`llmz`, `vai`, `zai`, and `conversation-insights`) by updating their package versions/peerDependencies, and refreshes `pnpm-lock.yaml` to match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90cbef9da90681dee885ea4c88763227e71a3ce2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->