### PR TITLE
fix(packages/cli): implement mapping for configurations in base-linter test setup helper

### DIFF
--- a/packages/cli/src/api/integration-body.ts
+++ b/packages/cli/src/api/integration-body.ts
@@ -11,6 +11,22 @@ export const prepareCreateIntegrationBody = async (
   title: 'title' in integration ? integration.title : undefined,
   description: 'description' in integration ? integration.description : undefined,
   user: integration.user,
+  configuration: integration.configuration
+    ? {
+        ...integration.configuration,
+        schema: await utils.schema.mapZodToJsonSchema(integration.configuration, {
+          useLegacyZuiTransformer: integration.__advanced?.useLegacyZuiTransformer,
+        }),
+      }
+    : undefined,
+  configurations: integration.configurations
+    ? await utils.records.mapValuesAsync(integration.configurations, async (configuration) => ({
+        ...configuration,
+        schema: await utils.schema.mapZodToJsonSchema(configuration, {
+          useLegacyZuiTransformer: integration.__advanced?.useLegacyZuiTransformer,
+        }),
+      }))
+    : undefined,
   events: integration.events
     ? await utils.records.mapValuesAsync(integration.events, async (event) => ({
         ...event,

--- a/packages/cli/src/api/integration-body.ts
+++ b/packages/cli/src/api/integration-body.ts
@@ -11,22 +11,6 @@ export const prepareCreateIntegrationBody = async (
   title: 'title' in integration ? integration.title : undefined,
   description: 'description' in integration ? integration.description : undefined,
   user: integration.user,
-  configuration: integration.configuration
-    ? {
-        ...integration.configuration,
-        schema: await utils.schema.mapZodToJsonSchema(integration.configuration, {
-          useLegacyZuiTransformer: integration.__advanced?.useLegacyZuiTransformer,
-        }),
-      }
-    : undefined,
-  configurations: integration.configurations
-    ? await utils.records.mapValuesAsync(integration.configurations, async (configuration) => ({
-        ...configuration,
-        schema: await utils.schema.mapZodToJsonSchema(configuration, {
-          useLegacyZuiTransformer: integration.__advanced?.useLegacyZuiTransformer,
-        }),
-      }))
-    : undefined,
   events: integration.events
     ? await utils.records.mapValuesAsync(integration.events, async (event) => ({
         ...event,

--- a/packages/cli/src/linter/base-linter.test.ts
+++ b/packages/cli/src/linter/base-linter.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, describe, vi } from 'vitest'
 import { prepareCreateIntegrationBody } from '../api/integration-body'
+import * as utils from '../utils'
 import { IntegrationLinter } from './integration-linter'
 import { IntegrationDefinition, type IntegrationDefinitionProps, z } from '@botpress/sdk'
 
@@ -146,6 +147,22 @@ const lintDefinition = async (definition: IntegrationDefinitionProps) => {
   const integrationBody = await prepareCreateIntegrationBody(integrationDefinition)
   const linter = new IntegrationLinter({
     ...integrationBody,
+    configuration: integrationDefinition.configuration
+      ? {
+          ...integrationDefinition.configuration,
+          schema: await utils.schema.mapZodToJsonSchema(integrationDefinition.configuration, {
+            useLegacyZuiTransformer: integrationDefinition.__advanced?.useLegacyZuiTransformer,
+          }),
+        }
+      : undefined,
+    configurations: integrationDefinition.configurations
+      ? await utils.records.mapValuesAsync(integrationDefinition.configurations, async (configuration) => ({
+          ...configuration,
+          schema: await utils.schema.mapZodToJsonSchema(configuration, {
+            useLegacyZuiTransformer: integrationDefinition.__advanced?.useLegacyZuiTransformer,
+          }),
+        }))
+      : undefined,
     readme: integrationDefinition.readme,
     icon: integrationDefinition.icon,
     secrets: integrationDefinition.secrets,


### PR DESCRIPTION
While working on a different fix, I noticed that the linter wasn't checking for invalid "configuration" & "configurations" in the mock integration definition. This PR addresses the issue by implementing the mapping for these fields.