### PR TITLE
fix(zui): duplicated properties in zui schemas

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",
@@ -28,7 +28,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.4",
     "@botpress/client": "1.33.0",
-    "@botpress/sdk": "5.4.0",
+    "@botpress/sdk": "5.4.1",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/verel": "^0.2.0",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.33.0",
-    "@botpress/sdk": "5.4.0"
+    "@botpress/sdk": "5.4.1"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.33.0",
-    "@botpress/sdk": "5.4.0"
+    "@botpress/sdk": "5.4.1"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "5.4.0"
+    "@botpress/sdk": "5.4.1"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.33.0",
-    "@botpress/sdk": "5.4.0"
+    "@botpress/sdk": "5.4.1"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.33.0",
-    "@botpress/sdk": "5.4.0",
+    "@botpress/sdk": "5.4.1",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/cognitive/package.json
+++ b/packages/cognitive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cognitive",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Wrapper around the Botpress Client to call LLMs",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -2,7 +2,7 @@
   "name": "llmz",
   "type": "module",
   "description": "LLMz - An LLM-native Typescript VM built on top of Zui",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -72,9 +72,9 @@
   },
   "peerDependencies": {
     "@botpress/client": "1.33.0",
-    "@botpress/cognitive": "0.3.11",
+    "@botpress/cognitive": "0.3.12",
     "@bpinternal/thicktoken": "^2.0.0",
-    "@bpinternal/zui": "^1.3.2"
+    "@bpinternal/zui": "^1.3.3"
   },
   "dependenciesMeta": {
     "@bpinternal/zui": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -31,7 +31,7 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "@bpinternal/zui": "^1.3.2",
+    "@bpinternal/zui": "^1.3.3",
     "esbuild": "^0.16.12"
   },
   "peerDependenciesMeta": {

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/vai",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Vitest AI (vai) – a vitest extension for testing with LLMs",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "@botpress/client": "1.33.0",
     "@bpinternal/thicktoken": "^1.0.1",
-    "@bpinternal/zui": "^1.3.2",
+    "@bpinternal/zui": "^1.3.3",
     "lodash": "^4.17.21",
     "vitest": "^2 || ^3 || ^4 || ^5"
   },

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "2.5.14",
+  "version": "2.5.15",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -32,7 +32,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@botpress/cognitive": "0.3.11",
+    "@botpress/cognitive": "0.3.12",
     "json5": "^2.2.3",
     "jsonrepair": "^3.10.0",
     "lodash-es": "^4.17.21",
@@ -56,7 +56,7 @@
   },
   "peerDependencies": {
     "@bpinternal/thicktoken": "^1.0.0",
-    "@bpinternal/zui": "^1.3.2"
+    "@bpinternal/zui": "^1.3.3"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/zui/package.json
+++ b/packages/zui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/zui",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A fork of Zod with additional features",
   "type": "module",
   "source": "./src/index.ts",

--- a/packages/zui/src/transforms/zui-to-typescript-schema/index.test.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-schema/index.test.ts
@@ -152,6 +152,15 @@ describe.concurrent('toTypescriptSchema', () => {
       const evaluated = generate(schema)
       expect(evaluated._def.checks).toEqual([{ kind: 'ip', message: undefined }])
     })
+    test('props with innertype only add keys once', () => {
+      const schema = z.string().describe('some desc').optional()
+      assert(schema).toGenerateItself()
+
+      const ts = toTypescript(schema)
+      const count = (ts.match(/\.describe\(/g) || []).length
+      expect(count).toBe(1)
+      expect(ts).toContain(".describe('some desc')")
+    })
 
     describe.concurrent('optional', () => {
       it('should preserve .secret modifier', () => {

--- a/packages/zui/src/transforms/zui-to-typescript-schema/index.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-schema/index.ts
@@ -1,4 +1,4 @@
-import { mapValues } from 'lodash-es'
+import { mapValues, isEqual } from 'lodash-es'
 
 import { zuiKey } from '../../ui/constants'
 import z, { util } from '../../z'
@@ -33,43 +33,43 @@ function sUnwrapZod(schema: z.Schema): string {
 
   switch (def.typeName) {
     case z.ZodFirstPartyTypeKind.ZodString:
-      return `z.string()${generateStringChecks(def)}${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.string()${generateStringChecks(def)}${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodNumber:
-      return `z.number()${generateNumberChecks(def)}${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.number()${generateNumberChecks(def)}${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodNaN:
-      return `z.nan()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.nan()${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodBigInt:
-      return `z.bigint()${generateBigIntChecks(def)}${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.bigint()${generateBigIntChecks(def)}${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodBoolean:
-      return `z.boolean()${_addZuiExtensions(def)}${_maybeDescribe(schema._def)}`.trim()
+      return `z.boolean()${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodDate:
-      return `z.date()${generateDateChecks(def)}${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.date()${generateDateChecks(def)}${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodUndefined:
-      return `z.undefined()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.undefined()${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodNull:
-      return `z.null()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.null()${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodAny:
-      return `z.any()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.any()${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodUnknown:
-      return `z.unknown()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.unknown()${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodNever:
-      return `z.never()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.never()${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodVoid:
-      return `z.void()${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.void()${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodArray:
-      return `z.array(${sUnwrapZod(def.type)})${generateArrayChecks(def)}${_addZuiExtensions(def)}${_maybeDescribe(def)}`
+      return `z.array(${sUnwrapZod(def.type)})${generateArrayChecks(def)}${_addMetadata(def, def.type)}`
 
     case z.ZodFirstPartyTypeKind.ZodObject:
       const props = mapValues(def.shape(), sUnwrapZod)
@@ -79,58 +79,58 @@ function sUnwrapZod(schema: z.Schema): string {
         //
         'z.object({',
         ...Object.entries(props).map(([key, value]) => `  ${key}: ${value},`),
-        `})${catchallString}${_addZuiExtensions(def)}${_maybeDescribe(def)}`,
+        `})${catchallString}${_addMetadata(def)}`,
       ]
         .join('\n')
         .trim()
 
     case z.ZodFirstPartyTypeKind.ZodUnion:
       const options = def.options.map(sUnwrapZod)
-      return `z.union([${options.join(', ')}])${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.union([${options.join(', ')}])${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodDiscriminatedUnion:
       const opts = (def.options as z.ZodSchema[]).map(sUnwrapZod)
       const discriminator = primitiveToTypescriptValue(def.discriminator)
-      return `z.discriminatedUnion(${discriminator}, [${opts.join(', ')}])${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.discriminatedUnion(${discriminator}, [${opts.join(', ')}])${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodIntersection:
       const left: string = sUnwrapZod(def.left)
       const right: string = sUnwrapZod(def.right)
-      return `z.intersection(${left}, ${right})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.intersection(${left}, ${right})${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodTuple:
       const items = def.items.map(sUnwrapZod)
-      return `z.tuple([${items.join(', ')}])${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.tuple([${items.join(', ')}])${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodRecord:
       const keyType = sUnwrapZod(def.keyType)
       const valueType = sUnwrapZod(def.valueType)
-      return `z.record(${keyType}, ${valueType})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.record(${keyType}, ${valueType})${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodMap:
       const mapKeyType = sUnwrapZod(def.keyType)
       const mapValueType = sUnwrapZod(def.valueType)
-      return `z.map(${mapKeyType}, ${mapValueType})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.map(${mapKeyType}, ${mapValueType})${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodSet:
-      return `z.set(${sUnwrapZod(def.valueType)})${generateSetChecks(def)}${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.set(${sUnwrapZod(def.valueType)})${generateSetChecks(def)}${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodFunction:
       const args = def.args.items.map(sUnwrapZod)
       const argsString = args.length ? `.args(${args.join(', ')})` : ''
       const returns = sUnwrapZod(def.returns)
-      return `z.function()${argsString}.returns(${returns})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.function()${argsString}.returns(${returns})${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodLazy:
-      return `z.lazy(() => ${sUnwrapZod(def.getter())})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.lazy(() => ${sUnwrapZod(def.getter())})${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodLiteral:
       const value = primitiveToTypescriptValue(def.value)
-      return `z.literal(${value})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.literal(${value})${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodEnum:
       const values = def.values.map(primitiveToTypescriptValue)
-      return `z.enum([${values.join(', ')}])${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.enum([${values.join(', ')}])${_addMetadata(def)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodEffects:
       throw new errors.UnsupportedZuiToTypescriptSchemaError(z.ZodFirstPartyTypeKind.ZodEffects)
@@ -139,21 +139,21 @@ function sUnwrapZod(schema: z.Schema): string {
       throw new errors.UnsupportedZuiToTypescriptSchemaError(z.ZodFirstPartyTypeKind.ZodNativeEnum)
 
     case z.ZodFirstPartyTypeKind.ZodOptional:
-      return `z.optional(${sUnwrapZod(def.innerType)})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.optional(${sUnwrapZod(def.innerType)})${_addMetadata(def, def.innerType)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodNullable:
-      return `z.nullable(${sUnwrapZod(def.innerType)})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.nullable(${sUnwrapZod(def.innerType)})${_addMetadata(def, def.innerType)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodDefault:
       const defaultValue = unknownToTypescriptValue(def.defaultValue())
       // TODO: use z.default() notation
-      return `z.default(${sUnwrapZod(def.innerType)}, ${defaultValue})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.default(${sUnwrapZod(def.innerType)}, ${defaultValue})${_addMetadata(def, def.innerType)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodCatch:
       throw new errors.UnsupportedZuiToTypescriptSchemaError(z.ZodFirstPartyTypeKind.ZodCatch)
 
     case z.ZodFirstPartyTypeKind.ZodPromise:
-      return `z.promise(${sUnwrapZod(def.type)})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.promise(${sUnwrapZod(def.type)})${_addMetadata(def, def.type)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodBranded:
       throw new errors.UnsupportedZuiToTypescriptSchemaError(z.ZodFirstPartyTypeKind.ZodBranded)
@@ -165,41 +165,102 @@ function sUnwrapZod(schema: z.Schema): string {
       throw new errors.UnsupportedZuiToTypescriptSchemaError(z.ZodFirstPartyTypeKind.ZodSymbol)
 
     case z.ZodFirstPartyTypeKind.ZodReadonly:
-      return `z.readonly(${sUnwrapZod(def.innerType)})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.readonly(${sUnwrapZod(def.innerType)})${_addMetadata(def, def.innerType)}`.trim()
 
     case z.ZodFirstPartyTypeKind.ZodRef:
       const uri = primitiveToTypescriptValue(def.uri)
-      return `z.ref(${uri})${_addZuiExtensions(def)}${_maybeDescribe(def)}`.trim()
+      return `z.ref(${uri})${_addMetadata(def)}`.trim()
 
     default:
       util.assertNever(def)
   }
 }
 
-const _maybeDescribe = (def: z.ZodTypeDef) =>
-  def.description ? `.describe(${primitiveToTypescriptValue(def.description)})` : ''
+const _addMetadata = (def: z.ZodTypeDef, inner?: z.ZodTypeAny) => {
+  const innerDef = inner?._def
+  return `${_addZuiExtensions(def, innerDef)}${_maybeDescribe(def, innerDef)}`
+}
 
-const _addZuiExtensions = (def: z.ZodTypeDef) =>
-  `${_maybeTitle(def)}${_maybeDisplayAs(def)}${_maybeDisabled(def)}${_maybeHidden(def)}${_maybePlaceholder(def)}${_maybeSecret(def)}${_maybeSetMetadata(def)}`
+const _maybeDescribe = (def: z.ZodTypeDef, innerDef?: z.ZodTypeDef) => {
+  if (!def.description) {
+    return ''
+  }
+  if (innerDef && innerDef.description === def.description) {
+    return ''
+  }
+  return `.describe(${primitiveToTypescriptValue(def.description)})`
+}
 
-const _maybeTitle = (def: z.ZodTypeDef) =>
-  def[zuiKey]?.title ? `.title(${primitiveToTypescriptValue(def[zuiKey].title)})` : ''
+const _addZuiExtensions = (def: z.ZodTypeDef, innerDef?: z.ZodTypeDef) =>
+  `${_maybeTitle(def, innerDef)}${_maybeDisplayAs(def, innerDef)}${_maybeDisabled(def, innerDef)}${_maybeHidden(def, innerDef)}${_maybePlaceholder(def, innerDef)}${_maybeSecret(def, innerDef)}${_maybeSetMetadata(def, innerDef)}`
 
-const _maybeDisplayAs = (def: z.ZodTypeDef) =>
-  def[zuiKey]?.displayAs
-    ? `.displayAs(${recordOfUnknownToTypescriptRecord({ id: def[zuiKey].displayAs[0], params: def[zuiKey].displayAs[1] })})`
-    : ''
+const _maybeTitle = (def: z.ZodTypeDef, innerDef?: z.ZodTypeDef) => {
+  const title = def[zuiKey]?.title
+  if (!title) {
+    return ''
+  }
+  if (innerDef && innerDef[zuiKey]?.title === title) {
+    return ''
+  }
+  return `.title(${primitiveToTypescriptValue(title)})`
+}
 
-const _maybeDisabled = (def: z.ZodTypeDef) => (def[zuiKey]?.disabled ? `.disabled(${def[zuiKey].disabled})` : '')
+const _maybeDisplayAs = (def: z.ZodTypeDef, innerDef?: z.ZodTypeDef) => {
+  const displayAs = def[zuiKey]?.displayAs
+  if (!displayAs) {
+    return ''
+  }
+  if (innerDef && isEqual(innerDef[zuiKey]?.displayAs, displayAs)) {
+    return ''
+  }
+  return `.displayAs(${recordOfUnknownToTypescriptRecord({ id: displayAs[0], params: displayAs[1] })})`
+}
 
-const _maybeHidden = (def: z.ZodTypeDef) => (def[zuiKey]?.hidden ? `.hidden(${def[zuiKey].hidden})` : '')
+const _maybeDisabled = (def: z.ZodTypeDef, innerDef?: z.ZodTypeDef) => {
+  const disabled = def[zuiKey]?.disabled
+  if (!disabled) {
+    return ''
+  }
+  if (innerDef && innerDef[zuiKey]?.disabled === disabled) {
+    return ''
+  }
+  return `.disabled(${disabled})`
+}
 
-const _maybePlaceholder = (def: z.ZodTypeDef) =>
-  def[zuiKey]?.placeholder ? `.placeholder(${primitiveToTypescriptValue(def[zuiKey].placeholder)})` : ''
+const _maybeHidden = (def: z.ZodTypeDef, innerDef?: z.ZodTypeDef) => {
+  const hidden = def[zuiKey]?.hidden
+  if (!hidden) {
+    return ''
+  }
+  if (innerDef && innerDef[zuiKey]?.hidden === hidden) {
+    return ''
+  }
+  return `.hidden(${hidden})`
+}
 
-const _maybeSecret = (def: z.ZodTypeDef) => (def[zuiKey]?.secret ? '.secret()' : '')
+const _maybePlaceholder = (def: z.ZodTypeDef, innerDef?: z.ZodTypeDef) => {
+  const placeholder = def[zuiKey]?.placeholder
+  if (!placeholder) {
+    return ''
+  }
+  if (innerDef && innerDef[zuiKey]?.placeholder === placeholder) {
+    return ''
+  }
+  return `.placeholder(${primitiveToTypescriptValue(placeholder)})`
+}
 
-const _maybeSetMetadata = (def: z.ZodTypeDef) => {
+const _maybeSecret = (def: z.ZodTypeDef, innerDef?: z.ZodTypeDef) => {
+  const secret = def[zuiKey]?.secret
+  if (!secret) {
+    return ''
+  }
+  if (innerDef && innerDef[zuiKey]?.secret === secret) {
+    return ''
+  }
+  return '.secret()'
+}
+
+const _maybeSetMetadata = (def: z.ZodTypeDef, innerDef?: z.ZodTypeDef) => {
   const reservedKeys = [
     'title',
     'tooltip',
@@ -214,5 +275,18 @@ const _maybeSetMetadata = (def: z.ZodTypeDef) => {
     ([key]) => !reservedKeys.includes(key as (typeof reservedKeys)[number])
   )
 
-  return metadata.length > 0 ? `.metadata(${recordOfUnknownToTypescriptRecord(Object.fromEntries(metadata))})` : ''
+  if (metadata.length === 0) {
+    return ''
+  }
+
+  if (innerDef) {
+    const innerMetadata = Object.entries(innerDef[zuiKey] ?? {}).filter(
+      ([key]) => !reservedKeys.includes(key as (typeof reservedKeys)[number])
+    )
+    if (isEqual(Object.fromEntries(metadata), Object.fromEntries(innerMetadata))) {
+      return ''
+    }
+  }
+
+  return `.metadata(${recordOfUnknownToTypescriptRecord(Object.fromEntries(metadata))})`
 }

--- a/plugins/conversation-insights/package.json
+++ b/plugins/conversation-insights/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/cognitive": "0.3.11",
+    "@botpress/cognitive": "0.3.12",
     "@botpress/sdk": "workspace:*",
     "browser-or-node": "^2.1.1",
     "jsonrepair": "^3.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2505,7 +2505,7 @@ importers:
         specifier: 1.33.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 5.4.0
+        specifier: 5.4.1
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2629,7 +2629,7 @@ importers:
         specifier: 1.33.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.4.0
+        specifier: 5.4.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2645,7 +2645,7 @@ importers:
         specifier: 1.33.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.4.0
+        specifier: 5.4.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2658,7 +2658,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 5.4.0
+        specifier: 5.4.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2674,7 +2674,7 @@ importers:
         specifier: 1.33.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.4.0
+        specifier: 5.4.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2690,7 +2690,7 @@ importers:
         specifier: 1.33.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.4.0
+        specifier: 5.4.1
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8
@@ -2844,13 +2844,13 @@ importers:
         specifier: 1.33.0
         version: link:../client
       '@botpress/cognitive':
-        specifier: 0.3.11
+        specifier: 0.3.12
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^2.0.0
         version: 2.0.0
       '@bpinternal/zui':
-        specifier: ^1.3.2
+        specifier: ^1.3.3
         version: link:../zui
       '@jitl/quickjs-singlefile-browser-release-sync':
         specifier: ^0.31.0
@@ -2950,7 +2950,7 @@ importers:
         specifier: 1.33.0
         version: link:../client
       '@bpinternal/zui':
-        specifier: ^1.3.2
+        specifier: ^1.3.3
         version: link:../zui
       browser-or-node:
         specifier: ^2.1.1
@@ -2990,7 +2990,7 @@ importers:
         specifier: ^1.0.1
         version: 1.0.2
       '@bpinternal/zui':
-        specifier: ^1.3.2
+        specifier: ^1.3.3
         version: link:../zui
       json5:
         specifier: ^2.2.3
@@ -3030,13 +3030,13 @@ importers:
   packages/zai:
     dependencies:
       '@botpress/cognitive':
-        specifier: 0.3.11
+        specifier: 0.3.12
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^1.0.0
         version: 1.0.2
       '@bpinternal/zui':
-        specifier: ^1.3.2
+        specifier: ^1.3.3
         version: link:../zui
       json5:
         specifier: ^2.2.3
@@ -3149,7 +3149,7 @@ importers:
   plugins/conversation-insights:
     dependencies:
       '@botpress/cognitive':
-        specifier: 0.3.11
+        specifier: 0.3.12
         version: link:../../packages/cognitive
       '@botpress/sdk':
         specifier: workspace:*


### PR DESCRIPTION
When there's a modifier (eg optional, nullable) on a zui property, keys were added twice (once on the wrapper and once on the value) when calling `transforms.toTypescriptSchema`

<img width="443" height="130" alt="image" src="https://github.com/user-attachments/assets/85c0bbeb-4a97-4ccc-b3a5-f263e8552ffb" />
