### PR TITLE
chore(.github): disable zendesk for seagull

### DIFF
--- a/.github/workflows/prod-master-version-verification.yml
+++ b/.github/workflows/prod-master-version-verification.yml
@@ -17,7 +17,7 @@ jobs:
         run: pnpm bp login -y --token ${{ secrets.PRODUCTION_TOKEN_CLOUD_OPS_ACCOUNT }} --workspace-id ${{ secrets.PRODUCTION_CLOUD_OPS_WORKSPACE_ID }}
       - name: Check integration versions
         run: |
-          SKIP_INTEGRATIONS=("docusign" "zendesk-messaging-hitl")
+          SKIP_INTEGRATIONS=("docusign" "zendesk" "zendesk-messaging-hitl")
 
           integrations=$(ls -d integrations/*/ | xargs -n1 basename | sort -u)
           should_fail=0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line CI workflow change that only affects which integrations are validated and alerted on; no runtime or security-sensitive logic changes.
> 
> **Overview**
> The `prod-master-version-verification` GitHub Actions workflow now **excludes `zendesk`** from its integration version checks by adding it to `SKIP_INTEGRATIONS`, alongside the existing `docusign` and `zendesk-messaging-hitl` skips.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50e7e1b5d25f83e1d5575dc0414267ca07b94706. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->