### PR TITLE
chore(integrations/googledrive): new Google Picker API requirements

### DIFF
--- a/integrations/googledrive/integration.definition.ts
+++ b/integrations/googledrive/integration.definition.ts
@@ -24,7 +24,7 @@ export default new sdk.IntegrationDefinition({
   name: 'googledrive',
   title: 'Google Drive',
   description: 'Access and manage your Google Drive files from your bot.',
-  version: '0.3.5',
+  version: '0.4.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   configuration: {

--- a/integrations/googledrive/src/handler.ts
+++ b/integrations/googledrive/src/handler.ts
@@ -167,7 +167,7 @@ const _handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Response>
 const _getOAuthAuthorizationUri = (ctx: { webhookId: string }) =>
   'https://accounts.google.com/o/oauth2/v2/auth?scope=' +
   'https%3A//www.googleapis.com/auth/drive.file&access_type=offline' +
-  '&include_granted_scopes=true&response_type=code&prompt=consent' +
+  '&include_granted_scopes=true&response_type=code&prompt=consent&trigger_onepick=true' +
   `&state=${ctx.webhookId}&redirect_uri=${encodeURI(_getOAuthRedirectUri().href)}` +
   `&client_id=${bp.secrets.CLIENT_ID}`
 


### PR DESCRIPTION
Resolves SH-364

Example of actions still working: 
<img width="239" height="93" alt="Capture d’écran, le 2026-02-11 à 12 26 17" src="https://github.com/user-attachments/assets/f32c0a90-3388-4bff-91d2-c6ae3239ba6e" />

<img width="408" height="320" alt="Capture d’écran, le 2026-02-11 à 12 25 51" src="https://github.com/user-attachments/assets/bbc5f3f4-82f0-4571-b090-65b441b245c6" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to the integration metadata and OAuth authorization URL; main risk is unexpected impact on OAuth/consent behavior for some tenants.
> 
> **Overview**
> Bumps the Google Drive integration version from `0.3.5` to `0.4.0`.
> 
> Updates the OAuth authorization URL used by the integration’s setup wizard to include `trigger_onepick=true`, aligning the consent flow with newer Google Picker requirements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89e6b5d4ff389a844ebbf42177bbdfe90cbba3f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->