### PR TITLE
fix(sdk, integrations/whatsapp): add optional description to dropdown/choice options

### DIFF
--- a/integrations/whatsapp/src/channels/message-types/dropdown.ts
+++ b/integrations/whatsapp/src/channels/message-types/dropdown.ts
@@ -31,7 +31,7 @@ export function* generateOutgoingMessages({
 
     for (const chunk of chunks) {
       const rows: Row[] = chunk.map(
-        (o) => new Row(o.value.substring(0, 200), truncate(o.label, ACTION_LABEL_MAX_LENGTH), ' ')
+        (o) => new Row(o.value.substring(0, 200), truncate(o.label, ACTION_LABEL_MAX_LENGTH), o.description || ' ')
       )
       if (!hasAtleastOne(rows)) {
         logger.debug('No rows in chunk, skipping')

--- a/packages/sdk/src/message.ts
+++ b/packages/sdk/src/message.ts
@@ -59,6 +59,7 @@ const choiceSchema = z.object({
     z.object({
       label: NonEmptyString,
       value: NonEmptyString,
+      description: z.string().optional(),
     })
   ),
 })


### PR DESCRIPTION
## Summary

Fixes #14180

The SDK choice/dropdown schema only exposes `label` and `value` for options, with no way to pass a description. The WhatsApp integration hardcodes a space character (`' '`) as the description for every interactive list row, so users have no way to provide meaningful row descriptions.

This PR:
- Adds an optional `description` field (`z.string().optional()`) to the choice option schema in `packages/sdk/src/message.ts`
- Updates the WhatsApp dropdown implementation in `integrations/whatsapp/src/channels/message-types/dropdown.ts` to use `o.description || ' '`, so descriptions are used when provided and fall back to a space to work around WhatsApp's API bug that requires a non-empty description string

## Changes

**`packages/sdk/src/message.ts`**
- Added `description: z.string().optional()` to the `choiceSchema` options array

**`integrations/whatsapp/src/channels/message-types/dropdown.ts`**
- Changed hardcoded `' '` to `o.description || ' '` in the `Row` constructor

## Notes

- Fully backward compatible: the new field is optional, so existing bots sending dropdown/choice messages without a description continue to work exactly as before
- The SDK-level change benefits all integrations, not just WhatsApp
- The WhatsApp-specific workaround (fallback to `' '`) is preserved in the integration layer, not leaked into the SDK
- Both `@botpress/sdk` and `@botpresshub/whatsapp` build successfully with these changes