### PR TITLE
fix(plugins/hitl): set human agent before sending join message

### DIFF
--- a/plugins/hitl/src/hooks/operations.ts
+++ b/plugins/hitl/src/hooks/operations.ts
@@ -43,9 +43,14 @@ export const assignAgent = async (options: AssignAgentOptions): Promise<boolean>
     upstreamConversationId: upstreamConversation.id,
   })
 
+  // Set the human agent on both conversations before sending the join message,
+  // so that agent info (e.g. name) is available when the message is delivered.
   await Promise.all([
     downstreamCm.setHumanAgent(humanAgentUserId, humanAgentName),
     upstreamCm.setHumanAgent(humanAgentUserId, humanAgentName),
+  ])
+
+  await Promise.all([
     upstreamCm.maybeRespondText(sessionConfig.onHumanAgentAssignedMessage, DEFAULT_HUMAN_AGENT_ASSIGNED_MESSAGE),
     tryLinkWebchatUser(props, {
       downstreamUser: humanAgentUser,


### PR DESCRIPTION
## Summary

Fixes #13873

The `assignAgent` function in the HITL plugin runs `setHumanAgent` and `maybeRespondText` (the join message) concurrently in a single `Promise.all`. This means the join message can be sent before the human agent name is set on the conversation tags, causing the agent name to appear blank or as an unresolved template variable for the end user.

## Changes

**`plugins/hitl/src/hooks/operations.ts`**

Split the single `Promise.all` into two sequential steps:

1. First, set the human agent on both downstream and upstream conversations (these two can safely run in parallel with each other)
2. Then, send the join message and link the webchat user (these two can safely run in parallel with each other)

This ensures the agent info is available on the conversation before the join message is delivered, while still preserving parallelism where the ordering does not matter.

## Before

```typescript
await Promise.all([
  downstreamCm.setHumanAgent(humanAgentUserId, humanAgentName),
  upstreamCm.setHumanAgent(humanAgentUserId, humanAgentName),
  upstreamCm.maybeRespondText(sessionConfig.onHumanAgentAssignedMessage, DEFAULT_HUMAN_AGENT_ASSIGNED_MESSAGE),
  tryLinkWebchatUser(props, { ... }),
])
```

## After

```typescript
await Promise.all([
  downstreamCm.setHumanAgent(humanAgentUserId, humanAgentName),
  upstreamCm.setHumanAgent(humanAgentUserId, humanAgentName),
])

await Promise.all([
  upstreamCm.maybeRespondText(sessionConfig.onHumanAgentAssignedMessage, DEFAULT_HUMAN_AGENT_ASSIGNED_MESSAGE),
  tryLinkWebchatUser(props, { ... }),
])
```

## Notes

- The HITL plugin builds successfully with this change
- Backward compatible: no API or behavior changes beyond fixing the ordering
- Parallelism is preserved where safe (both `setHumanAgent` calls run together, then both post-set operations run together)