### PR TITLE
fix(integration/linear): Add oAuth refresh token

### DIFF
--- a/integrations/linear/definitions/states.ts
+++ b/integrations/linear/definitions/states.ts
@@ -6,6 +6,10 @@ export const states = {
     type: 'integration',
     schema: z.object({
       accessToken: z.string().title('Access Token').describe('The access token for Linear'),
+      refreshToken: z
+        .string()
+        .title('Refresh Token')
+        .describe('The refresh token needed when the access token expires'),
       expiresAt: z.string().title('Expires At').describe('The time when the access token expires'),
     }),
   },

--- a/integrations/linear/definitions/states.ts
+++ b/integrations/linear/definitions/states.ts
@@ -8,6 +8,7 @@ export const states = {
       accessToken: z.string().title('Access Token').describe('The access token for Linear'),
       refreshToken: z
         .string()
+        .optional()
         .title('Refresh Token')
         .describe('The refresh token needed when the access token expires'),
       expiresAt: z.string().title('Expires At').describe('The time when the access token expires'),

--- a/integrations/linear/definitions/states.ts
+++ b/integrations/linear/definitions/states.ts
@@ -8,7 +8,6 @@ export const states = {
       accessToken: z.string().title('Access Token').describe('The access token for Linear'),
       refreshToken: z
         .string()
-        .optional()
         .title('Refresh Token')
         .describe('The refresh token needed when the access token expires'),
       expiresAt: z.string().title('Expires At').describe('The time when the access token expires'),

--- a/integrations/linear/integration.definition.ts
+++ b/integrations/linear/integration.definition.ts
@@ -7,7 +7,7 @@ import listable from './bp_modules/listable'
 import { actions, channels, events, configuration, configurations, user, states, entities } from './definitions'
 
 export const INTEGRATION_NAME = 'linear'
-export const INTEGRATION_VERSION = '1.3.1'
+export const INTEGRATION_VERSION = '1.4.0'
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/linear/integration.definition.ts
+++ b/integrations/linear/integration.definition.ts
@@ -7,7 +7,7 @@ import listable from './bp_modules/listable'
 import { actions, channels, events, configuration, configurations, user, states, entities } from './definitions'
 
 export const INTEGRATION_NAME = 'linear'
-export const INTEGRATION_VERSION = '1.3.0'
+export const INTEGRATION_VERSION = '1.3.1'
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/linear/integration.definition.ts
+++ b/integrations/linear/integration.definition.ts
@@ -7,7 +7,7 @@ import listable from './bp_modules/listable'
 import { actions, channels, events, configuration, configurations, user, states, entities } from './definitions'
 
 export const INTEGRATION_NAME = 'linear'
-export const INTEGRATION_VERSION = '1.4.0'
+export const INTEGRATION_VERSION = '2.0.0'
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/linear/src/actions/create-issue.ts
+++ b/integrations/linear/src/actions/create-issue.ts
@@ -10,7 +10,7 @@ export const createIssue: bp.IntegrationProps['actions']['createIssue'] = async 
     input: { title, description, priority, teamName, labels, project },
   } = args
 
-  const linearClient = await getLinearClient(args, ctx.integrationId)
+  const linearClient = await getLinearClient(args)
 
   const team = await getTeam(linearClient, undefined, teamName)
 

--- a/integrations/linear/src/actions/delete-issue.ts
+++ b/integrations/linear/src/actions/delete-issue.ts
@@ -4,10 +4,10 @@ import * as bp from '.botpress'
 
 export const deleteIssue: bp.IntegrationProps['actions']['deleteIssue'] = async (args) => {
   const {
-    ctx,
     input: { id: issueId },
   } = args
-  const linearClient = await getLinearClient(args, ctx.integrationId)
+
+  const linearClient = await getLinearClient(args)
 
   const existingIssue = await linearClient.issue(issueId).catch((thrown) => {
     if (thrown instanceof LinearError && thrown.type === LinearErrorType.InvalidInput) {

--- a/integrations/linear/src/actions/find-target.ts
+++ b/integrations/linear/src/actions/find-target.ts
@@ -23,8 +23,9 @@ const findIssues = async (issues: IssueConnection, targets: Target[]) => {
 export const findTarget: bp.IntegrationProps['actions']['findTarget'] = async (args) => {
   const targets: Target[] = []
 
-  const { input, ctx } = args
-  const linearClient = await getLinearClient(args, ctx.integrationId)
+  const { input } = args
+
+  const linearClient = await getLinearClient(args)
   const issues = await linearClient.issues({
     filter: {
       or: [

--- a/integrations/linear/src/actions/get-issue.ts
+++ b/integrations/linear/src/actions/get-issue.ts
@@ -20,10 +20,9 @@ export const getIssueFields = (issue: Issue): z.infer<typeof issueSchema> => ({
 
 export const getIssue: bp.IntegrationProps['actions']['getIssue'] = async (args) => {
   const {
-    ctx,
     input: { issueId },
   } = args
-  const linearClient = await getLinearClient(args, ctx.integrationId)
+  const linearClient = await getLinearClient(args)
   const issue = await linearClient.issue(issueId)
 
   return getIssueFields(issue)

--- a/integrations/linear/src/actions/get-user.ts
+++ b/integrations/linear/src/actions/get-user.ts
@@ -6,10 +6,9 @@ import * as bp from '.botpress'
 
 export const getUser: bp.IntegrationProps['actions']['getUser'] = async (args) => {
   const {
-    ctx,
     input: { linearUserId },
   } = args
-  const linearClient = await getLinearClient(args, ctx.integrationId)
+  const linearClient = await getLinearClient(args)
   const user = linearUserId ? await linearClient.user(linearUserId) : await linearClient.viewer
 
   return userProfileSchema.parse({

--- a/integrations/linear/src/actions/list-issues.ts
+++ b/integrations/linear/src/actions/list-issues.ts
@@ -6,7 +6,6 @@ import * as bp from '.botpress'
 
 export const listIssues: bp.IntegrationProps['actions']['listIssues'] = async (args) => {
   const {
-    ctx,
     input: { count, startCursor, startDate, teamId },
   } = args
   const linearClient = await getLinearClient(args)

--- a/integrations/linear/src/actions/list-issues.ts
+++ b/integrations/linear/src/actions/list-issues.ts
@@ -9,7 +9,7 @@ export const listIssues: bp.IntegrationProps['actions']['listIssues'] = async (a
     ctx,
     input: { count, startCursor, startDate, teamId },
   } = args
-  const linearClient = await getLinearClient(args, ctx.integrationId)
+  const linearClient = await getLinearClient(args)
 
   const query = await linearClient.issues({
     orderBy: LinearDocument.PaginationOrderBy.UpdatedAt,

--- a/integrations/linear/src/actions/list-states.ts
+++ b/integrations/linear/src/actions/list-states.ts
@@ -4,11 +4,10 @@ import * as bp from '.botpress'
 
 export const listStates: bp.IntegrationProps['actions']['listStates'] = async (args) => {
   const {
-    ctx,
     input: { count, startCursor },
   } = args
 
-  const linearClient = await getLinearClient(args, ctx.integrationId)
+  const linearClient = await getLinearClient(args)
 
   try {
     const states = await linearClient.workflowStates({ after: startCursor, first: count })

--- a/integrations/linear/src/actions/list-teams.ts
+++ b/integrations/linear/src/actions/list-teams.ts
@@ -6,7 +6,7 @@ export const listTeams: bp.IntegrationProps['actions']['listTeams'] = async (arg
     ctx,
     input: {},
   } = args
-  const linearClient = await getLinearClient(args, ctx.integrationId)
+  const linearClient = await getLinearClient(args)
   const teams = await linearClient.teams()
 
   return {

--- a/integrations/linear/src/actions/list-teams.ts
+++ b/integrations/linear/src/actions/list-teams.ts
@@ -3,7 +3,6 @@ import * as bp from '.botpress'
 
 export const listTeams: bp.IntegrationProps['actions']['listTeams'] = async (args) => {
   const {
-    ctx,
     input: {},
   } = args
   const linearClient = await getLinearClient(args)

--- a/integrations/linear/src/actions/list-users.ts
+++ b/integrations/linear/src/actions/list-users.ts
@@ -5,10 +5,9 @@ import * as bp from '.botpress'
 
 export const listUsers: bp.IntegrationProps['actions']['listUsers'] = async (args) => {
   const {
-    ctx,
     input: { count, startCursor },
   } = args
-  const linearClient = await getLinearClient(args, ctx.integrationId)
+  const linearClient = await getLinearClient(args)
 
   const query = await linearClient.users({
     orderBy: LinearDocument.PaginationOrderBy.UpdatedAt,

--- a/integrations/linear/src/actions/mark-as-duplicate.ts
+++ b/integrations/linear/src/actions/mark-as-duplicate.ts
@@ -4,10 +4,9 @@ import * as bp from '.botpress'
 
 export const markAsDuplicate: bp.IntegrationProps['actions']['markAsDuplicate'] = async (args) => {
   const {
-    ctx,
     input: { issueId, relatedIssueId },
   } = args
-  const linearClient = await getLinearClient(args, ctx.integrationId)
+  const linearClient = await getLinearClient(args)
   await linearClient.createIssueRelation({
     issueId,
     relatedIssueId,

--- a/integrations/linear/src/actions/proactive-conversation.ts
+++ b/integrations/linear/src/actions/proactive-conversation.ts
@@ -5,8 +5,8 @@ import * as bp from '.botpress'
 export const getOrCreateIssueConversation: bp.IntegrationProps['actions']['getOrCreateIssueConversation'] = async (
   args
 ) => {
-  const { client, input, ctx } = args
-  const linearClient = await getLinearClient(args, ctx.integrationId)
+  const { client, input } = args
+  const linearClient = await getLinearClient(args)
   const issue = await linearClient.issue(input.conversation.id).catch((thrown) => {
     const message = thrown instanceof Error ? thrown.message : new Error(thrown).message
     throw new RuntimeError(`Failed to get issue with ID ${input.conversation.id}: ${message}`)

--- a/integrations/linear/src/actions/resolve-comment.ts
+++ b/integrations/linear/src/actions/resolve-comment.ts
@@ -3,11 +3,10 @@ import * as bp from '.botpress'
 
 export const resolveComment: bp.IntegrationProps['actions']['resolveComment'] = async (args) => {
   const {
-    ctx,
     input: { id },
   } = args
 
-  const linearClient = await getLinearClient(args, ctx.integrationId)
+  const linearClient = await getLinearClient(args)
 
   try {
     const { success } = await linearClient.commentResolve(id)

--- a/integrations/linear/src/actions/send-raw-graphql-query.ts
+++ b/integrations/linear/src/actions/send-raw-graphql-query.ts
@@ -4,7 +4,6 @@ import * as bp from '.botpress'
 
 export const sendRawGraphqlQuery: bp.IntegrationProps['actions']['sendRawGraphqlQuery'] = async (args) => {
   const {
-    ctx,
     input: { query, parameters },
   } = args
 
@@ -16,7 +15,7 @@ export const sendRawGraphqlQuery: bp.IntegrationProps['actions']['sendRawGraphql
     {} as Record<string, unknown>
   )
   try {
-    const linearClient = await getLinearClient(args, ctx.integrationId)
+    const linearClient = await getLinearClient(args)
     const result = await linearClient.client.rawRequest(query, mappedParams)
     return { result: result.data }
   } catch (thrown) {

--- a/integrations/linear/src/actions/update-issue.ts
+++ b/integrations/linear/src/actions/update-issue.ts
@@ -4,10 +4,9 @@ import * as bp from '.botpress'
 
 export const updateIssue: bp.IntegrationProps['actions']['updateIssue'] = async (args) => {
   const {
-    ctx,
     input: { issueId, teamName, labels, project, priority },
   } = args
-  const linearClient = await getLinearClient(args, ctx.integrationId)
+  const linearClient = await getLinearClient(args)
 
   const existingIssue = await linearClient.issue(issueId)
   const team = await getTeam(linearClient, await existingIssue.team, teamName)

--- a/integrations/linear/src/handler.ts
+++ b/integrations/linear/src/handler.ts
@@ -14,7 +14,7 @@ const LINEAR_WEBHOOK_TS_FIELD = 'webhookTimestamp'
 
 export const handler: bp.IntegrationProps['handler'] = async ({ req, ctx, client, logger }) => {
   if (req.path === '/oauth') {
-    return handleOauth(req, client, ctx, logger).catch((err) => {
+    return handleOauth(req, client, ctx).catch((err) => {
       logger.forBot().error('Error while processing OAuth', err.response?.data || err.message)
       throw err
     })
@@ -130,7 +130,7 @@ const _getWebhookSigningSecret = ({ ctx }: { ctx: bp.Context }) =>
   ctx.configurationType === 'apiKey' ? ctx.configuration.webhookSigningSecret : bp.secrets.WEBHOOK_SIGNING_SECRET
 
 const _getLinearBotId = async ({ client, ctx }: { client: bp.Client; ctx: bp.Context }) => {
-  const linearClient = await getLinearClient({ client, ctx }, ctx.integrationId)
+  const linearClient = await getLinearClient({ client, ctx })
   const me = await linearClient.viewer
   return me.id
 }

--- a/integrations/linear/src/handler.ts
+++ b/integrations/linear/src/handler.ts
@@ -14,7 +14,7 @@ const LINEAR_WEBHOOK_TS_FIELD = 'webhookTimestamp'
 
 export const handler: bp.IntegrationProps['handler'] = async ({ req, ctx, client, logger }) => {
   if (req.path === '/oauth') {
-    return handleOauth(req, client, ctx).catch((err) => {
+    return handleOauth(req, client, ctx, logger).catch((err) => {
       logger.forBot().error('Error while processing OAuth', err.response?.data || err.message)
       throw err
     })

--- a/integrations/linear/src/handler.ts
+++ b/integrations/linear/src/handler.ts
@@ -12,9 +12,10 @@ import * as bp from '.botpress'
 const LINEAR_WEBHOOK_SIGNATURE_HEADER = 'linear-signature'
 const LINEAR_WEBHOOK_TS_FIELD = 'webhookTimestamp'
 
-export const handler: bp.IntegrationProps['handler'] = async ({ req, ctx, client, logger }) => {
+export const handler: bp.IntegrationProps['handler'] = async (props) => {
+  const { req, ctx, client, logger } = props
   if (req.path === '/oauth') {
-    return handleOauth(req, client, ctx).catch((err) => {
+    return await handleOauth(props).catch((err) => {
       logger.forBot().error('Error while processing OAuth', err.response?.data || err.message)
       throw err
     })

--- a/integrations/linear/src/handler.ts
+++ b/integrations/linear/src/handler.ts
@@ -14,7 +14,7 @@ const LINEAR_WEBHOOK_TS_FIELD = 'webhookTimestamp'
 
 export const handler: bp.IntegrationProps['handler'] = async ({ req, ctx, client, logger }) => {
   if (req.path === '/oauth') {
-    return handleOauth(req, client, ctx, logger).catch((err) => {
+    return handleOauth(req, client, ctx).catch((err) => {
       logger.forBot().error('Error while processing OAuth', err.response?.data || err.message)
       throw err
     })

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -4,6 +4,7 @@ import axios from 'axios'
 import queryString from 'query-string'
 import * as bp from '.botpress'
 import { credentials } from '.botpress/implementation/typings/states'
+import { UnauthorizedError } from '@botpress/client'
 
 type Credentials = bp.states.States['credentials']['payload']
 
@@ -110,7 +111,7 @@ export class LinearOauthClient {
 
     const { data, error } = refreshOAuthSchema.safeParse(res.data)
     if (error) {
-      throw new Error(`Failed to migrate access token: ${error}`)
+      throw new Error(`Failed to parse OAuth token response: ${error.message}`)
     }
     const { access_token, expires_in, refresh_token } = data
 
@@ -143,7 +144,7 @@ export class LinearOauthClient {
 
     const { data, error } = refreshOAuthSchema.safeParse(res.data)
     if (error) {
-      throw new Error(`Failed to refresh access token: ${error}`)
+      throw new Error(`Failed to parse OAuth token response: ${error.message}`)
     }
     const { access_token, expires_in, refresh_token } = data
     expiresAt.setSeconds(expiresAt.getSeconds() + expires_in)
@@ -175,7 +176,7 @@ export class LinearOauthClient {
 
     const { data, error } = oauthSchema.safeParse(res.data)
     if (error) {
-      throw new Error(`Failed to refresh access token: ${error}`)
+      throw new Error(`Failed to parse OAuth token response: ${error.message}`)
     }
     const { access_token, expires_in, refresh_token } = data
 

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -162,7 +162,7 @@ export class LinearOauthClient {
       {
         access_token: oldAccessToken,
       },
-      refreshOAuthSchema
+      oauthSchema
     )
     return this._toCredentials(data)
   }

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -84,12 +84,12 @@ const tokenRequestSchema = z.object({
   redirect_uri: z.string(),
 })
 
-const getAccessTokenRequestSchema = tokenResquestSchema.extend({
+const getAccessTokenRequestSchema = tokenRequestSchema.extend({
   grant_type: z.literal('authorization_code'),
   code: z.string(),
 })
 
-const refreshTokenRequestSchema = tokenResquestSchema.extend({
+const refreshTokenRequestSchema = tokenRequestSchema.extend({
   grant_type: z.literal('refresh_token'),
   refresh_token: z.string(),
 })
@@ -146,7 +146,7 @@ export class LinearOauthClient {
     return this._parseCredentials(data)
   }
 
-  public async refreshAccessToken(oldRefreshToken: string): Promise<Credentials> {
+  public async getAccessTokenFromRefreshToken(oldRefreshToken: string): Promise<Credentials> {
     const data = await this._handleOAuthRequest<typeof refreshTokenRequestSchema>(`${linearEndpoint}/oauth/token`, {
       grant_type: 'refresh_token',
       refresh_token: oldRefreshToken,
@@ -174,7 +174,7 @@ export class LinearOauthClient {
     const isExpired = new Date(current.expiresAt).getTime() <= Date.now() + FIVE_MINUTES_MS
 
     if (isExpired) {
-      return this.refreshAccessToken(current.refreshToken)
+      return this.getAccessTokenFromRefreshToken(current.refreshToken)
     }
 
     return current

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -77,12 +77,6 @@ const oauthSchema = z.object({
   expires_in: z.number(),
 })
 
-const refreshOAuthSchema = z.object({
-  access_token: z.string(),
-  refresh_token: z.string(),
-  expires_in: z.number(),
-})
-
 type TokenRequestParams = {
   actor: 'application'
   redirect_uri: string
@@ -176,7 +170,7 @@ export class LinearOauthClient {
   public async refreshAccessToken(oldRefreshToken: string): Promise<Credentials> {
     const data = await this._getAccessToken(
       { grant_type: 'refresh_token', refresh_token: oldRefreshToken },
-      refreshOAuthSchema
+      oauthSchema
     )
     return this._toCredentials(data)
   }

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -6,8 +6,6 @@ import * as bp from '.botpress'
 
 type Credentials = bp.states.States['credentials']['payload']
 
-type Credentials = bp.states.States['credentials']['payload']
-
 type BaseEvent = {
   action: 'create' | 'update' | 'remove' | 'restore'
   type: string

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -79,7 +79,7 @@ const oauthSchema = z.object({
 
 type OAuthResponse = z.infer<typeof oauthSchema>
 
-const tokenResquestSchema = z.object({
+const tokenRequestSchema = z.object({
   actor: z.literal('application'),
   redirect_uri: z.string(),
 })

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -151,7 +151,7 @@ export class LinearOauthClient {
     )
   }
 
-  private _toCredentials(data: z.infer<typeof refreshOAuthSchema>): Credentials {
+  private _toCredentials(data: z.infer<typeof oauthSchema>): Credentials {
     const expiresAt = new Date()
     expiresAt.setSeconds(expiresAt.getSeconds() + data.expires_in)
 
@@ -183,15 +183,7 @@ export class LinearOauthClient {
 
   public async getAccessToken(code: string) {
     const data = await this._getAccessToken({ grant_type: 'authorization_code', code }, oauthSchema)
-
-    const expiresAt = new Date()
-    expiresAt.setSeconds(expiresAt.getSeconds() + data.expires_in)
-
-    return {
-      accessToken: data.access_token,
-      refreshToken: data.refresh_token,
-      expiresAt: expiresAt.toISOString(),
-    }
+    return this._toCredentials(data)
   }
 
   public async resolveValidCredentials(current: Credentials): Promise<Credentials> {

--- a/integrations/linear/src/misc/utils.ts
+++ b/integrations/linear/src/misc/utils.ts
@@ -7,16 +7,15 @@ export type LinearClientProps = {
   client: bp.Client
   ctx: bp.Context
 }
-export function getLinearClient({ client, ctx }: LinearClientProps, integrationId: string) {
-  const linearOauthClient = new LinearOauthClient()
-  return linearOauthClient.getLinearClient(client, ctx, integrationId)
+export async function getLinearClient({ client, ctx }: LinearClientProps) {
+  return await LinearOauthClient.create({ client, ctx })
 }
 
 type ValueOf<T> = T[keyof T]
 type CreateCommentProps = Omit<ValueOf<bp.MessageProps['issue']>, 'payload'> & { content: string }
 export async function createComment(args: CreateCommentProps) {
   const { ctx, conversation, ack, content } = args
-  const linearClient = await getLinearClient(args, ctx.integrationId)
+  const linearClient = await getLinearClient(args)
   const issueId = getIssueId(conversation)
 
   let createAsUser: string | undefined = undefined
@@ -87,7 +86,7 @@ export const getUserAndConversation = async (props: {
     discriminateByTags: ['id'],
   })
 
-  const linearClient = await getLinearClient(props, props.integrationId)
+  const linearClient = await getLinearClient(props)
 
   // TODO: better way to know if the conversation was just created
   if (props.forceUpdate || !conversation.tags.url) {

--- a/integrations/linear/src/setup.ts
+++ b/integrations/linear/src/setup.ts
@@ -1,8 +1,10 @@
 import { LinearOauthClient } from './misc/linear'
 import * as bp from '.botpress'
 
-export const register: bp.IntegrationProps['register'] = async ({ client, ctx }) => {
+export const register: bp.IntegrationProps['register'] = async ({ client, ctx, logger }) => {
+  logger.forBot().info('Registering integration...')
   await LinearOauthClient.create({ client, ctx })
+  logger.forBot().info('Integration registered successfully.')
 }
 
 export const unregister: bp.IntegrationProps['unregister'] = async () => {

--- a/integrations/linear/src/setup.ts
+++ b/integrations/linear/src/setup.ts
@@ -1,7 +1,8 @@
+import { LinearOauthClient } from './misc/linear'
 import * as bp from '.botpress'
 
-export const register: bp.IntegrationProps['register'] = async () => {
-  // nothing to register
+export const register: bp.IntegrationProps['register'] = async ({ client, ctx }) => {
+  await LinearOauthClient.create({ client, ctx })
 }
 
 export const unregister: bp.IntegrationProps['unregister'] = async () => {


### PR DESCRIPTION
Resolves SH-445

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth token exchange/refresh and persisted credentials state; mistakes could break Linear authentication or cause unexpected token churn, but the change is localized to the integration.
> 
> **Overview**
> Improves Linear OAuth credential handling by persisting an optional `refreshToken` alongside `accessToken`/`expiresAt`, and bumping the integration version to `1.3.1`.
> 
> Refactors `LinearOauthClient` to parse OAuth responses (including `refresh_token`), migrate legacy access tokens via `/oauth/migrate_old_token`, and automatically refresh near-expired tokens via `/oauth/token` before creating a `LinearClient`; updated credentials are written back to the `credentials` integration state during both OAuth callback and normal client creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92a800461cd09e625c807f36fab20808663a059c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added OAuth refresh token support to prevent authentication failures when tokens expire. 

Major changes:
- Modified credentials state to include `refreshToken` field (breaking change, version bumped to 2.0.0)
- Implemented automatic token refresh in `LinearOauthClient.create()` when tokens are within 5 minutes of expiry
- Added migration endpoint support for legacy tokens without refresh tokens
- Refactored all actions to use simplified `getLinearClient()` signature
- Added `scheduleRegisterCall: 'monthly'` to proactively validate and refresh credentials
- Register function now validates credentials on monthly schedule to ensure continuous authentication

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor cleanup needed
- The PR successfully implements OAuth refresh token support with proper token migration and automatic refresh logic. The major version bump (2.0.0) correctly signals breaking changes in the credentials schema. The implementation follows good patterns with centralized token management. Minor style issue with commented code that should be removed.
- Pay attention to `integrations/linear/src/misc/linear.ts` which contains the core OAuth logic and has commented code to clean up

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| integrations/linear/src/misc/linear.ts | Refactored OAuth client to support refresh tokens with automatic token refresh; contains commented code and type safety concerns with unvalidated API responses |
| integrations/linear/definitions/states.ts | Added required `refreshToken` field to credentials state schema; breaking change handled by major version bump to 2.0.0 |
| integrations/linear/src/setup.ts | Register function now validates and refreshes credentials via `LinearOauthClient.create()` to ensure token validity during monthly register calls |
| integrations/linear/src/misc/utils.ts | Simplified `getLinearClient()` to use new static `LinearOauthClient.create()` method, removing `integrationId` parameter |
| integrations/linear/integration.definition.ts | Version bumped from 1.3.0 to 2.0.0 to indicate breaking changes in credentials schema |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant OAuthFlow as OAuth Flow
    participant LinearAPI as Linear API
    participant State as Credentials State
    participant Action as Linear Action
    
    User->>OAuthFlow: Initiate OAuth
    OAuthFlow->>LinearAPI: Request token with code
    LinearAPI-->>OAuthFlow: access_token + refresh_token + expires_in
    alt refresh_token missing
        OAuthFlow->>LinearAPI: POST /oauth/migrate_old_token
        LinearAPI-->>OAuthFlow: access_token + refresh_token
    end
    OAuthFlow->>State: Save credentials (accessToken, refreshToken, expiresAt)
    
    Note over Action,State: Monthly Register or Action Call
    Action->>State: Get credentials
    State-->>Action: Current credentials
    Action->>Action: Check if expired (within 5min)
    alt Token expired or expiring soon
        Action->>LinearAPI: POST /oauth/token (refresh_token grant)
        LinearAPI-->>Action: New access_token + refresh_token
        Action->>State: Update credentials
    end
    Action->>LinearAPI: Use access_token for Linear operations
```

<sub>Last reviewed commit: 329b645</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->