### PR TITLE
feat(zui): zui schema can be easily discriminated by type

### DIFF
--- a/packages/zui/src/transforms/common/errors.ts
+++ b/packages/zui/src/transforms/common/errors.ts
@@ -1,5 +1,5 @@
 import { JSONSchema7 } from 'json-schema'
-import { ZodFirstPartyTypeKind } from '../../z'
+import { ZodFirstPartyTypeKind, ZodNativeSchemaType } from '../../z'
 
 type Transform =
   | 'json-schema-to-zui'
@@ -38,7 +38,7 @@ export class ZuiToJSONSchemaError extends ZuiTransformError {
   }
 }
 export class UnsupportedZuiToJSONSchemaError extends ZuiToJSONSchemaError {
-  public constructor(type: ZodFirstPartyTypeKind, { suggestedAlternative }: { suggestedAlternative?: string } = {}) {
+  public constructor(type: ZodNativeSchemaType, { suggestedAlternative }: { suggestedAlternative?: string } = {}) {
     super(
       `Zod type ${type} cannot be transformed to JSON Schema.` +
         (suggestedAlternative ? ` Suggested alternative: ${suggestedAlternative}` : '')
@@ -46,7 +46,7 @@ export class UnsupportedZuiToJSONSchemaError extends ZuiToJSONSchemaError {
   }
 }
 export class UnsupportedZuiCheckToJSONSchemaError extends ZuiToJSONSchemaError {
-  public constructor({ zodType, checkKind }: { zodType: ZodFirstPartyTypeKind; checkKind: string }) {
+  public constructor({ zodType, checkKind }: { zodType: ZodNativeSchemaType; checkKind: string }) {
     super(`Zod check .${checkKind}() of type ${zodType} cannot be transformed to JSON Schema.`)
   }
 }
@@ -64,7 +64,7 @@ export class ZuiToTypescriptSchemaError extends ZuiTransformError {
   }
 }
 export class UnsupportedZuiToTypescriptSchemaError extends ZuiToTypescriptSchemaError {
-  public constructor(type: ZodFirstPartyTypeKind) {
+  public constructor(type: ZodNativeSchemaType) {
     super(`Zod type ${type} cannot be transformed to TypeScript schema.`)
   }
 }
@@ -76,7 +76,7 @@ export class ZuiToTypescriptTypeError extends ZuiTransformError {
   }
 }
 export class UnsupportedZuiToTypescriptTypeError extends ZuiToTypescriptTypeError {
-  public constructor(type: ZodFirstPartyTypeKind) {
+  public constructor(type: ZodNativeSchemaType) {
     super(`Zod type ${type} cannot be transformed to TypeScript type.`)
   }
 }

--- a/packages/zui/src/transforms/common/json-schema.ts
+++ b/packages/zui/src/transforms/common/json-schema.ts
@@ -9,12 +9,12 @@ import { util } from '../../z/types/utils'
  * Mutiple zui schemas map to the same JSON schema; undefined/never, any/unknown, union/discriminated-union
  * Adding some ZodDef to the ZuiExtension allows us to differentiate between them
  */
-type NullableDef = util.Satisfies<{ typeName: z.ZodFirstPartyTypeKind.ZodNullable }, Partial<z.ZodNullableDef>>
-type OptionalDef = util.Satisfies<{ typeName: z.ZodFirstPartyTypeKind.ZodOptional }, Partial<z.ZodOptionalDef>>
-type UndefinedDef = util.Satisfies<{ typeName: z.ZodFirstPartyTypeKind.ZodUndefined }, Partial<z.ZodUndefinedDef>>
-type UnknownDef = util.Satisfies<{ typeName: z.ZodFirstPartyTypeKind.ZodUnknown }, Partial<z.ZodUnknownDef>>
+type NullableDef = util.Satisfies<{ typeName: 'ZodNullable' }, Partial<z.ZodNullableDef>>
+type OptionalDef = util.Satisfies<{ typeName: 'ZodOptional' }, Partial<z.ZodOptionalDef>>
+type UndefinedDef = util.Satisfies<{ typeName: 'ZodUndefined' }, Partial<z.ZodUndefinedDef>>
+type UnknownDef = util.Satisfies<{ typeName: 'ZodUnknown' }, Partial<z.ZodUnknownDef>>
 type DiscriminatedUnionDef = util.Satisfies<
-  { typeName: z.ZodFirstPartyTypeKind.ZodDiscriminatedUnion; discriminator?: string },
+  { typeName: 'ZodDiscriminatedUnion'; discriminator?: string },
   Partial<z.ZodDiscriminatedUnionDef>
 >
 
@@ -24,9 +24,9 @@ type DiscriminatedUnionDef = util.Satisfies<
  * A ZUI flavored subset of JSONSchema7
  */
 
-type ZuiExtension<Def extends Partial<z.ZodDef> = {}> = { def?: Def } & ZuiExtensionObject
+type ZuiExtension<Def extends Partial<z.ZodNativeSchemaDef> = {}> = { def?: Def } & ZuiExtensionObject
 type JsonData = string | number | boolean | null | JsonData[] | { [key: string]: JsonData }
-type BaseZuiJSONSchema<Def extends Partial<z.ZodDef> = {}> = util.Satisfies<
+type BaseZuiJSONSchema<Def extends Partial<z.ZodNativeSchemaDef> = {}> = util.Satisfies<
   {
     description?: string
     readOnly?: boolean

--- a/packages/zui/src/transforms/zui-from-json-schema-legacy/index.ts
+++ b/packages/zui/src/transforms/zui-from-json-schema-legacy/index.ts
@@ -20,6 +20,7 @@ import {
   ZodEnumDef,
   ZodDefaultDef,
   z,
+  ZodNativeSchemaType,
 } from '../../z/index'
 import * as errors from '../common/errors'
 import { evalZuiString } from '../common/eval-zui-string'
@@ -78,7 +79,7 @@ const applyZuiPropsRecursively = (zodField: ZodTypeAny, jsonSchemaField: any) =>
       }
     } else if (Array.isArray(items)) {
       items.forEach((item, index) => {
-        const def: z.ZodDef = zodField._def
+        const def: z.ZodNativeSchemaDef = zodField._def
 
         if (def.typeName === z.ZodFirstPartyTypeKind.ZodTuple) {
           applyZuiPropsRecursively(def.items[index]!, item)
@@ -106,9 +107,7 @@ export type ZodAllDefs =
   | ZodStringDef
   | ZodDefaultDef
 
-export type ZodTypeKind = `${ZodFirstPartyTypeKind}`
-
-export type ZodDef<Type extends ZodTypeKind> = Type extends 'ZodObject'
+export type ZodDef<Type extends ZodNativeSchemaType = ZodNativeSchemaType> = Type extends 'ZodObject'
   ? ZodObjectDef
   : Type extends 'ZodArray'
     ? ZodArrayDef
@@ -143,8 +142,12 @@ export type ZodDef<Type extends ZodTypeKind> = Type extends 'ZodObject'
                                 : never
 
 export const traverseZodDefinitions = (
-  def: ZodDef<ZodFirstPartyTypeKind>,
-  cb: <T extends ZodTypeKind>(type: T, def: ZodDef<T> & { [zuiKey]?: ZuiExtensionObject }, path: string[]) => void,
+  def: ZodDef,
+  cb: <T extends ZodNativeSchemaType>(
+    type: T,
+    def: ZodDef<T> & { [zuiKey]?: ZuiExtensionObject },
+    path: string[]
+  ) => void,
   path: string[] = []
 ) => {
   switch (def.typeName) {

--- a/packages/zui/src/transforms/zui-to-json-schema-legacy/parseDef.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema-legacy/parseDef.ts
@@ -1,5 +1,5 @@
 import { zuiKey } from '../../ui/constants'
-import { ZodFirstPartyTypeKind, ZodTypeDef } from '../../z/index'
+import { ZodFirstPartyTypeKind, ZodNativeSchemaDef, ZodNativeSchemaType, ZodTypeDef } from '../../z/index'
 import { JsonSchema7AnyType, parseAnyDef } from './parsers/any'
 import { JsonSchema7ArrayType, parseArrayDef } from './parsers/array'
 import { JsonSchema7BigintType, parseBigintDef } from './parsers/bigint'
@@ -68,7 +68,7 @@ export type JsonSchema7TypeUnion =
 export type JsonSchema7Type = JsonSchema7TypeUnion & JsonSchema7Meta
 
 export function parseDef(
-  def: ZodTypeDef,
+  def: ZodNativeSchemaDef,
   refs: Refs,
   forceResolution = false // Forces a new schema to be instantiated even though its def has been seen. Used for improving refs in definitions. See https://github.com/StefanTerdell/zod-to-json-schema/pull/61.
 ): JsonSchema7Type | undefined {
@@ -135,7 +135,7 @@ const getRelativePath = (pathA: string[], pathB: string[]) => {
   return [(pathA.length - i).toString(), ...pathB.slice(i)].join('/')
 }
 
-const selectParser = (def: any, typeName: ZodFirstPartyTypeKind, refs: Refs): JsonSchema7Type | undefined => {
+const selectParser = (def: any, typeName: ZodNativeSchemaType, refs: Refs): JsonSchema7Type | undefined => {
   switch (typeName) {
     case ZodFirstPartyTypeKind.ZodString:
       return parseStringDef(def, refs)

--- a/packages/zui/src/transforms/zui-to-json-schema-legacy/zodToJsonSchema.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema-legacy/zodToJsonSchema.ts
@@ -1,4 +1,4 @@
-import type { ZodSchema } from '../../z/index'
+import type { ZodNativeSchema, ZodSchema } from '../../z/index'
 import { Options, Targets } from './Options'
 import { JsonSchema7Type, parseDef } from './parseDef'
 import { getRefs } from './Refs'
@@ -25,7 +25,7 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
             ...acc,
             [name]:
               parseDef(
-                schema._def,
+                (schema as ZodNativeSchema)._def,
                 {
                   ...refs,
                   currentPath: [...refs.basePath, refs.definitionPath, name],
@@ -41,7 +41,7 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
 
   const main =
     parseDef(
-      schema._def,
+      (schema as ZodNativeSchema)._def,
       name === undefined
         ? refs
         : {

--- a/packages/zui/src/transforms/zui-to-json-schema/index.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema/index.ts
@@ -13,69 +13,68 @@ import { zodTupleToJsonTuple } from './type-processors/tuple'
  * @returns ZUI flavored JSON schema
  */
 export function toJSONSchema(schema: z.Schema): json.Schema {
-  const schemaTyped = schema as z.ZodFirstPartySchemaTypes
-  const def = schemaTyped._def
+  const s = schema as z.ZodNativeSchema
 
-  switch (def.typeName) {
-    case z.ZodFirstPartyTypeKind.ZodString:
-      return zodStringToJsonString(schemaTyped as z.ZodString) satisfies json.StringSchema
+  switch (s.typeName) {
+    case 'ZodString':
+      return zodStringToJsonString(s) satisfies json.StringSchema
 
-    case z.ZodFirstPartyTypeKind.ZodNumber:
-      return zodNumberToJsonNumber(schemaTyped as z.ZodNumber) satisfies json.NumberSchema
+    case 'ZodNumber':
+      return zodNumberToJsonNumber(s) satisfies json.NumberSchema
 
-    case z.ZodFirstPartyTypeKind.ZodNaN:
-      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodNaN)
+    case 'ZodNaN':
+      throw new err.UnsupportedZuiToJSONSchemaError('ZodNaN')
 
-    case z.ZodFirstPartyTypeKind.ZodBigInt:
-      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodBigInt, {
+    case 'ZodBigInt':
+      throw new err.UnsupportedZuiToJSONSchemaError('ZodBigInt', {
         suggestedAlternative: 'serialize bigint to string',
       })
 
-    case z.ZodFirstPartyTypeKind.ZodBoolean:
+    case 'ZodBoolean':
       return {
         type: 'boolean',
-        description: def.description,
-        'x-zui': def['x-zui'],
+        description: s._def.description,
+        'x-zui': s._def['x-zui'],
       } satisfies json.BooleanSchema
 
-    case z.ZodFirstPartyTypeKind.ZodDate:
-      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodDate, {
+    case 'ZodDate':
+      throw new err.UnsupportedZuiToJSONSchemaError('ZodDate', {
         suggestedAlternative: 'use z.string().datetime() instead',
       })
 
-    case z.ZodFirstPartyTypeKind.ZodUndefined:
-      return undefinedSchema(def)
+    case 'ZodUndefined':
+      return undefinedSchema(s._def)
 
-    case z.ZodFirstPartyTypeKind.ZodNull:
-      return nullSchema(def)
+    case 'ZodNull':
+      return nullSchema(s._def)
 
-    case z.ZodFirstPartyTypeKind.ZodAny:
+    case 'ZodAny':
       return {
-        description: def.description,
-        'x-zui': def['x-zui'],
+        description: s._def.description,
+        'x-zui': s._def['x-zui'],
       } satisfies json.AnySchema
 
-    case z.ZodFirstPartyTypeKind.ZodUnknown:
+    case 'ZodUnknown':
       return {
-        description: def.description,
-        'x-zui': { ...def['x-zui'], def: { typeName: z.ZodFirstPartyTypeKind.ZodUnknown } },
+        description: s._def.description,
+        'x-zui': { ...s._def['x-zui'], def: { typeName: 'ZodUnknown' } },
       }
 
-    case z.ZodFirstPartyTypeKind.ZodNever:
+    case 'ZodNever':
       return {
         not: true,
-        description: def.description,
-        'x-zui': def['x-zui'],
+        description: s._def.description,
+        'x-zui': s._def['x-zui'],
       } satisfies json.NeverSchema
 
-    case z.ZodFirstPartyTypeKind.ZodVoid:
-      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodVoid)
+    case 'ZodVoid':
+      throw new err.UnsupportedZuiToJSONSchemaError('ZodVoid')
 
-    case z.ZodFirstPartyTypeKind.ZodArray:
-      return zodArrayToJsonArray(schemaTyped as z.ZodArray, toJSONSchema) satisfies json.ArraySchema
+    case 'ZodArray':
+      return zodArrayToJsonArray(s, toJSONSchema) satisfies json.ArraySchema
 
-    case z.ZodFirstPartyTypeKind.ZodObject:
-      const shape = Object.entries(def.shape())
+    case 'ZodObject':
+      const shape = Object.entries(s.shape)
       const requiredProperties = shape.filter(([_, value]) => !value.isOptional())
       const required = requiredProperties.length ? requiredProperties.map(([key]) => key) : undefined
       const properties = shape
@@ -83,41 +82,41 @@ export function toJSONSchema(schema: z.Schema): json.Schema {
         .map(([key, value]) => [key, toJSONSchema(value)] satisfies [string, json.Schema])
 
       let additionalProperties: json.ObjectSchema['additionalProperties'] = false
-      if (def.unknownKeys instanceof z.ZodType) {
-        additionalProperties = toJSONSchema(def.unknownKeys)
-      } else if (def.unknownKeys === 'passthrough') {
+      if (s._def.unknownKeys instanceof z.ZodType) {
+        additionalProperties = toJSONSchema(s._def.unknownKeys)
+      } else if (s._def.unknownKeys === 'passthrough') {
         additionalProperties = true
       }
 
       return {
         type: 'object',
-        description: def.description,
+        description: s._def.description,
         properties: Object.fromEntries(properties),
         required,
         additionalProperties,
-        'x-zui': def['x-zui'],
+        'x-zui': s._def['x-zui'],
       } satisfies json.ObjectSchema
 
-    case z.ZodFirstPartyTypeKind.ZodUnion:
+    case 'ZodUnion':
       return {
-        description: def.description,
-        anyOf: def.options.map((option) => toJSONSchema(option)),
-        'x-zui': def['x-zui'],
+        description: s._def.description,
+        anyOf: s._def.options.map((option) => toJSONSchema(option)),
+        'x-zui': s._def['x-zui'],
       } satisfies json.UnionSchema
 
-    case z.ZodFirstPartyTypeKind.ZodDiscriminatedUnion:
+    case 'ZodDiscriminatedUnion':
       return {
-        description: def.description,
-        anyOf: def.options.map((option) => toJSONSchema(option)),
+        description: s._def.description,
+        anyOf: s._def.options.map((option) => toJSONSchema(option)),
         'x-zui': {
-          ...def['x-zui'],
-          def: { typeName: z.ZodFirstPartyTypeKind.ZodDiscriminatedUnion, discriminator: def.discriminator },
+          ...s._def['x-zui'],
+          def: { typeName: 'ZodDiscriminatedUnion', discriminator: s._def.discriminator },
         },
       } satisfies json.DiscriminatedUnionSchema
 
-    case z.ZodFirstPartyTypeKind.ZodIntersection:
-      const left = toJSONSchema(def.left)
-      const right = toJSONSchema(def.right)
+    case 'ZodIntersection':
+      const left = toJSONSchema(s._def.left)
+      const right = toJSONSchema(s._def.right)
 
       /**
        * TODO: Potential conflict between `additionalProperties` in the left and right schemas.
@@ -136,145 +135,145 @@ export function toJSONSchema(schema: z.Schema): json.Schema {
       }
 
       return {
-        description: def.description,
+        description: s._def.description,
         allOf: [left, right],
-        'x-zui': def['x-zui'],
+        'x-zui': s._def['x-zui'],
       } satisfies json.IntersectionSchema
 
-    case z.ZodFirstPartyTypeKind.ZodTuple:
-      return zodTupleToJsonTuple(schemaTyped as z.ZodTuple, toJSONSchema) satisfies json.TupleSchema
+    case 'ZodTuple':
+      return zodTupleToJsonTuple(s, toJSONSchema) satisfies json.TupleSchema
 
-    case z.ZodFirstPartyTypeKind.ZodRecord:
+    case 'ZodRecord':
       return {
         type: 'object',
-        description: def.description,
-        additionalProperties: toJSONSchema(def.valueType),
-        'x-zui': def['x-zui'],
+        description: s._def.description,
+        additionalProperties: toJSONSchema(s._def.valueType),
+        'x-zui': s._def['x-zui'],
       } satisfies json.RecordSchema
 
-    case z.ZodFirstPartyTypeKind.ZodMap:
-      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodMap)
+    case 'ZodMap':
+      throw new err.UnsupportedZuiToJSONSchemaError('ZodMap')
 
-    case z.ZodFirstPartyTypeKind.ZodSet:
-      return zodSetToJsonSet(schemaTyped as z.ZodSet, toJSONSchema) satisfies json.SetSchema
+    case 'ZodSet':
+      return zodSetToJsonSet(s, toJSONSchema) satisfies json.SetSchema
 
-    case z.ZodFirstPartyTypeKind.ZodFunction:
-      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodFunction)
+    case 'ZodFunction':
+      throw new err.UnsupportedZuiToJSONSchemaError('ZodFunction')
 
-    case z.ZodFirstPartyTypeKind.ZodLazy:
-      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodLazy)
+    case 'ZodLazy':
+      throw new err.UnsupportedZuiToJSONSchemaError('ZodLazy')
 
-    case z.ZodFirstPartyTypeKind.ZodLiteral:
-      if (typeof def.value === 'string') {
+    case 'ZodLiteral':
+      if (typeof s._def.value === 'string') {
         return {
           type: 'string',
-          description: def.description,
-          const: def.value,
-          'x-zui': def['x-zui'],
+          description: s._def.description,
+          const: s._def.value,
+          'x-zui': s._def['x-zui'],
         } satisfies json.LiteralStringSchema
-      } else if (typeof def.value === 'number') {
+      } else if (typeof s._def.value === 'number') {
         return {
           type: 'number',
-          description: def.description,
-          const: def.value,
-          'x-zui': def['x-zui'],
+          description: s._def.description,
+          const: s._def.value,
+          'x-zui': s._def['x-zui'],
         } satisfies json.LiteralNumberSchema
-      } else if (typeof def.value === 'boolean') {
+      } else if (typeof s._def.value === 'boolean') {
         return {
           type: 'boolean',
-          description: def.description,
-          const: def.value,
-          'x-zui': def['x-zui'],
+          description: s._def.description,
+          const: s._def.value,
+          'x-zui': s._def['x-zui'],
         } satisfies json.LiteralBooleanSchema
-      } else if (def.value === null) {
-        return nullSchema(def)
-      } else if (def.value === undefined) {
-        return undefinedSchema(def)
+      } else if (s._def.value === null) {
+        return nullSchema(s._def)
+      } else if (s._def.value === undefined) {
+        return undefinedSchema(s._def)
       } else {
-        z.util.assertEqual<bigint | symbol, typeof def.value>(true)
-        const unsupportedLiteral = typeof def.value
+        z.util.assertEqual<bigint | symbol, typeof s._def.value>(true)
+        const unsupportedLiteral = typeof s._def.value
         throw new err.ZuiToJSONSchemaError(`Unsupported literal type: "${unsupportedLiteral}"`)
       }
 
-    case z.ZodFirstPartyTypeKind.ZodEnum:
+    case 'ZodEnum':
       return {
         type: 'string',
-        description: def.description,
-        enum: def.values,
-        'x-zui': def['x-zui'],
+        description: s._def.description,
+        enum: s._def.values,
+        'x-zui': s._def['x-zui'],
       } satisfies json.EnumSchema
 
-    case z.ZodFirstPartyTypeKind.ZodEffects:
-      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodEffects)
+    case 'ZodEffects':
+      throw new err.UnsupportedZuiToJSONSchemaError('ZodEffects')
 
-    case z.ZodFirstPartyTypeKind.ZodNativeEnum:
-      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodNativeEnum)
+    case 'ZodNativeEnum':
+      throw new err.UnsupportedZuiToJSONSchemaError('ZodNativeEnum')
 
-    case z.ZodFirstPartyTypeKind.ZodOptional:
+    case 'ZodOptional':
       return {
-        description: def.description,
-        anyOf: [toJSONSchema(def.innerType), undefinedSchema()],
+        description: s._def.description,
+        anyOf: [toJSONSchema(s._def.innerType), undefinedSchema()],
         'x-zui': {
-          ...def['x-zui'],
-          def: { typeName: z.ZodFirstPartyTypeKind.ZodOptional },
+          ...s._def['x-zui'],
+          def: { typeName: 'ZodOptional' },
         },
       } satisfies json.OptionalSchema
 
-    case z.ZodFirstPartyTypeKind.ZodNullable:
+    case 'ZodNullable':
       return {
-        anyOf: [toJSONSchema(def.innerType), nullSchema()],
+        anyOf: [toJSONSchema(s._def.innerType), nullSchema()],
         'x-zui': {
-          ...def['x-zui'],
-          def: { typeName: z.ZodFirstPartyTypeKind.ZodNullable },
+          ...s._def['x-zui'],
+          def: { typeName: 'ZodNullable' },
         },
       } satisfies json.NullableSchema
 
-    case z.ZodFirstPartyTypeKind.ZodDefault:
+    case 'ZodDefault':
       // ZodDefault is not treated as a metadata root so we don't need to preserve x-zui
       return {
-        ...toJSONSchema(def.innerType),
-        default: def.defaultValue(),
+        ...toJSONSchema(s._def.innerType),
+        default: s._def.defaultValue(),
       }
 
-    case z.ZodFirstPartyTypeKind.ZodCatch:
+    case 'ZodCatch':
       // TODO: could be supported using if-else json schema
-      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodCatch)
+      throw new err.UnsupportedZuiToJSONSchemaError('ZodCatch')
 
-    case z.ZodFirstPartyTypeKind.ZodPromise:
-      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodPromise)
+    case 'ZodPromise':
+      throw new err.UnsupportedZuiToJSONSchemaError('ZodPromise')
 
-    case z.ZodFirstPartyTypeKind.ZodBranded:
-      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodBranded)
+    case 'ZodBranded':
+      throw new err.UnsupportedZuiToJSONSchemaError('ZodBranded')
 
-    case z.ZodFirstPartyTypeKind.ZodPipeline:
-      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodPipeline)
+    case 'ZodPipeline':
+      throw new err.UnsupportedZuiToJSONSchemaError('ZodPipeline')
 
-    case z.ZodFirstPartyTypeKind.ZodSymbol:
-      throw new err.UnsupportedZuiToJSONSchemaError(z.ZodFirstPartyTypeKind.ZodPipeline)
+    case 'ZodSymbol':
+      throw new err.UnsupportedZuiToJSONSchemaError('ZodPipeline')
 
-    case z.ZodFirstPartyTypeKind.ZodReadonly:
+    case 'ZodReadonly':
       // ZodReadonly is not treated as a metadata root so we don't need to preserve x-zui
       return {
-        ...toJSONSchema(def.innerType),
+        ...toJSONSchema(s._def.innerType),
         readOnly: true,
       }
 
-    case z.ZodFirstPartyTypeKind.ZodRef:
+    case 'ZodRef':
       return {
-        $ref: def.uri,
-        description: def.description,
-        'x-zui': def['x-zui'],
+        $ref: s._def.uri,
+        description: s._def.description,
+        'x-zui': s._def['x-zui'],
       }
 
     default:
-      z.util.assertNever(def)
+      z.util.assertNever(s)
   }
 }
 
 const undefinedSchema = (def?: z.ZodTypeDef): json.UndefinedSchema => ({
   not: true,
   description: def?.description,
-  'x-zui': { ...def?.['x-zui'], def: { typeName: z.ZodFirstPartyTypeKind.ZodUndefined } },
+  'x-zui': { ...def?.['x-zui'], def: { typeName: 'ZodUndefined' } },
 })
 
 const nullSchema = (def?: z.ZodTypeDef): json.NullSchema => ({

--- a/packages/zui/src/transforms/zui-to-typescript-schema/index.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-schema/index.ts
@@ -28,151 +28,150 @@ export function toTypescriptSchema(schema: z.Schema): string {
 }
 
 function sUnwrapZod(schema: z.Schema): string {
-  const schemaTyped = schema as z.ZodFirstPartySchemaTypes
-  const def = schemaTyped._def
+  const s = schema as z.ZodNativeSchema
 
-  switch (def.typeName) {
-    case z.ZodFirstPartyTypeKind.ZodString:
-      return `z.string()${generateStringChecks(def)}${_addMetadata(def)}`.trim()
+  switch (s.typeName) {
+    case 'ZodString':
+      return `z.string()${generateStringChecks(s._def)}${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodNumber:
-      return `z.number()${generateNumberChecks(def)}${_addMetadata(def)}`.trim()
+    case 'ZodNumber':
+      return `z.number()${generateNumberChecks(s._def)}${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodNaN:
-      return `z.nan()${_addMetadata(def)}`.trim()
+    case 'ZodNaN':
+      return `z.nan()${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodBigInt:
-      return `z.bigint()${generateBigIntChecks(def)}${_addMetadata(def)}`.trim()
+    case 'ZodBigInt':
+      return `z.bigint()${generateBigIntChecks(s._def)}${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodBoolean:
-      return `z.boolean()${_addMetadata(def)}`.trim()
+    case 'ZodBoolean':
+      return `z.boolean()${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodDate:
-      return `z.date()${generateDateChecks(def)}${_addMetadata(def)}`.trim()
+    case 'ZodDate':
+      return `z.date()${generateDateChecks(s._def)}${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodUndefined:
-      return `z.undefined()${_addMetadata(def)}`.trim()
+    case 'ZodUndefined':
+      return `z.undefined()${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodNull:
-      return `z.null()${_addMetadata(def)}`.trim()
+    case 'ZodNull':
+      return `z.null()${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodAny:
-      return `z.any()${_addMetadata(def)}`.trim()
+    case 'ZodAny':
+      return `z.any()${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodUnknown:
-      return `z.unknown()${_addMetadata(def)}`.trim()
+    case 'ZodUnknown':
+      return `z.unknown()${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodNever:
-      return `z.never()${_addMetadata(def)}`.trim()
+    case 'ZodNever':
+      return `z.never()${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodVoid:
-      return `z.void()${_addMetadata(def)}`.trim()
+    case 'ZodVoid':
+      return `z.void()${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodArray:
-      return `z.array(${sUnwrapZod(def.type)})${generateArrayChecks(def)}${_addMetadata(def, def.type)}`
+    case 'ZodArray':
+      return `z.array(${sUnwrapZod(s._def.type)})${generateArrayChecks(s._def)}${_addMetadata(s._def, s._def.type)}`
 
-    case z.ZodFirstPartyTypeKind.ZodObject:
-      const props = mapValues(def.shape(), sUnwrapZod)
+    case 'ZodObject':
+      const props = mapValues(s._def.shape(), sUnwrapZod)
       const catchall = (schema as z.ZodObject).additionalProperties()
       const catchallString = catchall ? `.catchall(${sUnwrapZod(catchall)})` : ''
       return [
         //
         'z.object({',
         ...Object.entries(props).map(([key, value]) => `  ${key}: ${value},`),
-        `})${catchallString}${_addMetadata(def)}`,
+        `})${catchallString}${_addMetadata(s._def)}`,
       ]
         .join('\n')
         .trim()
 
-    case z.ZodFirstPartyTypeKind.ZodUnion:
-      const options = def.options.map(sUnwrapZod)
-      return `z.union([${options.join(', ')}])${_addMetadata(def)}`.trim()
+    case 'ZodUnion':
+      const options = s._def.options.map(sUnwrapZod)
+      return `z.union([${options.join(', ')}])${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodDiscriminatedUnion:
-      const opts = (def.options as z.ZodSchema[]).map(sUnwrapZod)
-      const discriminator = primitiveToTypescriptValue(def.discriminator)
-      return `z.discriminatedUnion(${discriminator}, [${opts.join(', ')}])${_addMetadata(def)}`.trim()
+    case 'ZodDiscriminatedUnion':
+      const opts = (s._def.options as z.ZodSchema[]).map(sUnwrapZod)
+      const discriminator = primitiveToTypescriptValue(s._def.discriminator)
+      return `z.discriminatedUnion(${discriminator}, [${opts.join(', ')}])${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodIntersection:
-      const left: string = sUnwrapZod(def.left)
-      const right: string = sUnwrapZod(def.right)
-      return `z.intersection(${left}, ${right})${_addMetadata(def)}`.trim()
+    case 'ZodIntersection':
+      const left: string = sUnwrapZod(s._def.left)
+      const right: string = sUnwrapZod(s._def.right)
+      return `z.intersection(${left}, ${right})${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodTuple:
-      const items = def.items.map(sUnwrapZod)
-      return `z.tuple([${items.join(', ')}])${_addMetadata(def)}`.trim()
+    case 'ZodTuple':
+      const items = s._def.items.map(sUnwrapZod)
+      return `z.tuple([${items.join(', ')}])${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodRecord:
-      const keyType = sUnwrapZod(def.keyType)
-      const valueType = sUnwrapZod(def.valueType)
-      return `z.record(${keyType}, ${valueType})${_addMetadata(def)}`.trim()
+    case 'ZodRecord':
+      const keyType = sUnwrapZod(s._def.keyType)
+      const valueType = sUnwrapZod(s._def.valueType)
+      return `z.record(${keyType}, ${valueType})${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodMap:
-      const mapKeyType = sUnwrapZod(def.keyType)
-      const mapValueType = sUnwrapZod(def.valueType)
-      return `z.map(${mapKeyType}, ${mapValueType})${_addMetadata(def)}`.trim()
+    case 'ZodMap':
+      const mapKeyType = sUnwrapZod(s._def.keyType)
+      const mapValueType = sUnwrapZod(s._def.valueType)
+      return `z.map(${mapKeyType}, ${mapValueType})${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodSet:
-      return `z.set(${sUnwrapZod(def.valueType)})${generateSetChecks(def)}${_addMetadata(def)}`.trim()
+    case 'ZodSet':
+      return `z.set(${sUnwrapZod(s._def.valueType)})${generateSetChecks(s._def)}${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodFunction:
-      const args = def.args.items.map(sUnwrapZod)
+    case 'ZodFunction':
+      const args = s._def.args.items.map(sUnwrapZod)
       const argsString = args.length ? `.args(${args.join(', ')})` : ''
-      const returns = sUnwrapZod(def.returns)
-      return `z.function()${argsString}.returns(${returns})${_addMetadata(def)}`.trim()
+      const returns = sUnwrapZod(s._def.returns)
+      return `z.function()${argsString}.returns(${returns})${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodLazy:
-      return `z.lazy(() => ${sUnwrapZod(def.getter())})${_addMetadata(def)}`.trim()
+    case 'ZodLazy':
+      return `z.lazy(() => ${sUnwrapZod(s._def.getter())})${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodLiteral:
-      const value = primitiveToTypescriptValue(def.value)
-      return `z.literal(${value})${_addMetadata(def)}`.trim()
+    case 'ZodLiteral':
+      const value = primitiveToTypescriptValue(s._def.value)
+      return `z.literal(${value})${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodEnum:
-      const values = def.values.map(primitiveToTypescriptValue)
-      return `z.enum([${values.join(', ')}])${_addMetadata(def)}`.trim()
+    case 'ZodEnum':
+      const values = s._def.values.map(primitiveToTypescriptValue)
+      return `z.enum([${values.join(', ')}])${_addMetadata(s._def)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodEffects:
-      throw new errors.UnsupportedZuiToTypescriptSchemaError(z.ZodFirstPartyTypeKind.ZodEffects)
+    case 'ZodEffects':
+      throw new errors.UnsupportedZuiToTypescriptSchemaError('ZodEffects')
 
-    case z.ZodFirstPartyTypeKind.ZodNativeEnum:
-      throw new errors.UnsupportedZuiToTypescriptSchemaError(z.ZodFirstPartyTypeKind.ZodNativeEnum)
+    case 'ZodNativeEnum':
+      throw new errors.UnsupportedZuiToTypescriptSchemaError('ZodNativeEnum')
 
-    case z.ZodFirstPartyTypeKind.ZodOptional:
-      return `z.optional(${sUnwrapZod(def.innerType)})${_addMetadata(def, def.innerType)}`.trim()
+    case 'ZodOptional':
+      return `z.optional(${sUnwrapZod(s._def.innerType)})${_addMetadata(s._def, s._def.innerType)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodNullable:
-      return `z.nullable(${sUnwrapZod(def.innerType)})${_addMetadata(def, def.innerType)}`.trim()
+    case 'ZodNullable':
+      return `z.nullable(${sUnwrapZod(s._def.innerType)})${_addMetadata(s._def, s._def.innerType)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodDefault:
-      const defaultValue = unknownToTypescriptValue(def.defaultValue())
+    case 'ZodDefault':
+      const defaultValue = unknownToTypescriptValue(s._def.defaultValue())
       // TODO: use z.default() notation
-      return `z.default(${sUnwrapZod(def.innerType)}, ${defaultValue})${_addMetadata(def, def.innerType)}`.trim()
+      return `z.default(${sUnwrapZod(s._def.innerType)}, ${defaultValue})${_addMetadata(s._def, s._def.innerType)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodCatch:
-      throw new errors.UnsupportedZuiToTypescriptSchemaError(z.ZodFirstPartyTypeKind.ZodCatch)
+    case 'ZodCatch':
+      throw new errors.UnsupportedZuiToTypescriptSchemaError('ZodCatch')
 
-    case z.ZodFirstPartyTypeKind.ZodPromise:
-      return `z.promise(${sUnwrapZod(def.type)})${_addMetadata(def, def.type)}`.trim()
+    case 'ZodPromise':
+      return `z.promise(${sUnwrapZod(s._def.type)})${_addMetadata(s._def, s._def.type)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodBranded:
-      throw new errors.UnsupportedZuiToTypescriptSchemaError(z.ZodFirstPartyTypeKind.ZodBranded)
+    case 'ZodBranded':
+      throw new errors.UnsupportedZuiToTypescriptSchemaError('ZodBranded')
 
-    case z.ZodFirstPartyTypeKind.ZodPipeline:
-      throw new errors.UnsupportedZuiToTypescriptSchemaError(z.ZodFirstPartyTypeKind.ZodPipeline)
+    case 'ZodPipeline':
+      throw new errors.UnsupportedZuiToTypescriptSchemaError('ZodPipeline')
 
-    case z.ZodFirstPartyTypeKind.ZodSymbol:
-      throw new errors.UnsupportedZuiToTypescriptSchemaError(z.ZodFirstPartyTypeKind.ZodSymbol)
+    case 'ZodSymbol':
+      throw new errors.UnsupportedZuiToTypescriptSchemaError('ZodSymbol')
 
-    case z.ZodFirstPartyTypeKind.ZodReadonly:
-      return `z.readonly(${sUnwrapZod(def.innerType)})${_addMetadata(def, def.innerType)}`.trim()
+    case 'ZodReadonly':
+      return `z.readonly(${sUnwrapZod(s._def.innerType)})${_addMetadata(s._def, s._def.innerType)}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodRef:
-      const uri = primitiveToTypescriptValue(def.uri)
-      return `z.ref(${uri})${_addMetadata(def)}`.trim()
+    case 'ZodRef':
+      const uri = primitiveToTypescriptValue(s._def.uri)
+      return `z.ref(${uri})${_addMetadata(s._def)}`.trim()
 
     default:
-      util.assertNever(def)
+      util.assertNever(s)
   }
 }
 

--- a/packages/zui/src/transforms/zui-to-typescript-type/index.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-type/index.ts
@@ -186,44 +186,43 @@ function sUnwrapZod(schema: z.Schema | KeyValue | FnParameters | Declaration | n
     return sUnwrapZod(schema.schema, newConfig)
   }
 
-  const schemaTyped = schema as z.ZodFirstPartySchemaTypes
-  const def = schemaTyped._def
+  const s = schema as z.ZodNativeSchema
 
-  switch (def.typeName) {
-    case z.ZodFirstPartyTypeKind.ZodString:
-      return `${getMultilineComment(schemaTyped.description)} string`.trim()
+  switch (s.typeName) {
+    case 'ZodString':
+      return `${getMultilineComment(s.description)} string`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodNumber:
-    case z.ZodFirstPartyTypeKind.ZodNaN:
-    case z.ZodFirstPartyTypeKind.ZodBigInt:
-      return `${getMultilineComment(schemaTyped.description)} number`.trim()
+    case 'ZodNumber':
+    case 'ZodNaN':
+    case 'ZodBigInt':
+      return `${getMultilineComment(s.description)} number`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodBoolean:
-      return `${getMultilineComment(schemaTyped.description)} boolean`.trim()
+    case 'ZodBoolean':
+      return `${getMultilineComment(s.description)} boolean`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodDate:
-      return `${getMultilineComment(schemaTyped.description)} Date`.trim()
+    case 'ZodDate':
+      return `${getMultilineComment(s.description)} Date`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodUndefined:
-      return `${getMultilineComment(schemaTyped.description)} undefined`.trim()
+    case 'ZodUndefined':
+      return `${getMultilineComment(s.description)} undefined`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodNull:
-      return `${getMultilineComment(schemaTyped.description)} null`.trim()
+    case 'ZodNull':
+      return `${getMultilineComment(s.description)} null`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodAny:
-      return `${getMultilineComment(schemaTyped.description)} any`.trim()
+    case 'ZodAny':
+      return `${getMultilineComment(s.description)} any`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodUnknown:
-      return `${getMultilineComment(schemaTyped.description)} unknown`.trim()
+    case 'ZodUnknown':
+      return `${getMultilineComment(s.description)} unknown`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodNever:
-      return `${getMultilineComment(schemaTyped.description)} never`.trim()
+    case 'ZodNever':
+      return `${getMultilineComment(s.description)} never`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodVoid:
-      return `${getMultilineComment(schemaTyped.description)} void`.trim()
+    case 'ZodVoid':
+      return `${getMultilineComment(s.description)} void`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodArray:
-      const item = sUnwrapZod(def.type, newConfig)
+    case 'ZodArray':
+      const item = sUnwrapZod(s._def.type, newConfig)
 
       if (isPrimitive(item)) {
         return `${item}[]`
@@ -231,8 +230,8 @@ function sUnwrapZod(schema: z.Schema | KeyValue | FnParameters | Declaration | n
 
       return `Array<${item}>`
 
-    case z.ZodFirstPartyTypeKind.ZodObject:
-      const props = Object.entries(def.shape()).map(([key, value]) => {
+    case 'ZodObject':
+      const props = Object.entries(s._def.shape()).map(([key, value]) => {
         if (value instanceof z.Schema) {
           return sUnwrapZod(new KeyValue(toPropertyKey(key), value), newConfig)
         }
@@ -241,106 +240,106 @@ function sUnwrapZod(schema: z.Schema | KeyValue | FnParameters | Declaration | n
 
       return `{ ${props.join('; ')} }`
 
-    case z.ZodFirstPartyTypeKind.ZodUnion:
-      const options = def.options.map((option) => {
+    case 'ZodUnion':
+      const options = s._def.options.map((option) => {
         return sUnwrapZod(option, newConfig)
       })
-      return `${getMultilineComment(schemaTyped.description)}
+      return `${getMultilineComment(s.description)}
 ${options.join(' | ')}`
 
-    case z.ZodFirstPartyTypeKind.ZodDiscriminatedUnion:
-      const opts = def.options.map((option) => {
+    case 'ZodDiscriminatedUnion':
+      const opts = s._def.options.map((option) => {
         return sUnwrapZod(option, newConfig)
       })
-      return `${getMultilineComment(schemaTyped.description)}
+      return `${getMultilineComment(s.description)}
 ${opts.join(' | ')}`
 
-    case z.ZodFirstPartyTypeKind.ZodIntersection:
-      return `${sUnwrapZod(def.left, newConfig)} & ${sUnwrapZod(def.right, newConfig)}`
+    case 'ZodIntersection':
+      return `${sUnwrapZod(s._def.left, newConfig)} & ${sUnwrapZod(s._def.right, newConfig)}`
 
-    case z.ZodFirstPartyTypeKind.ZodTuple:
-      if (def.items.length === 0) {
+    case 'ZodTuple':
+      if (s._def.items.length === 0) {
         return '[]'
       }
 
-      const items = def.items.map((i: any) => sUnwrapZod(i, newConfig))
+      const items = s._def.items.map((i: any) => sUnwrapZod(i, newConfig))
       return `[${items.join(', ')}]`
 
-    case z.ZodFirstPartyTypeKind.ZodRecord:
-      const keyType = sUnwrapZod(def.keyType, newConfig)
-      const valueType = sUnwrapZod(def.valueType, newConfig)
-      return `${getMultilineComment(schemaTyped.description)} { [key: ${keyType}]: ${valueType} }`
+    case 'ZodRecord':
+      const keyType = sUnwrapZod(s._def.keyType, newConfig)
+      const valueType = sUnwrapZod(s._def.valueType, newConfig)
+      return `${getMultilineComment(s.description)} { [key: ${keyType}]: ${valueType} }`
 
-    case z.ZodFirstPartyTypeKind.ZodMap:
-      return `Map<${sUnwrapZod(def.keyType, newConfig)}, ${sUnwrapZod(def.valueType, newConfig)}>`
+    case 'ZodMap':
+      return `Map<${sUnwrapZod(s._def.keyType, newConfig)}, ${sUnwrapZod(s._def.valueType, newConfig)}>`
 
-    case z.ZodFirstPartyTypeKind.ZodSet:
-      return `Set<${sUnwrapZod(def.valueType, newConfig)}>`
+    case 'ZodSet':
+      return `Set<${sUnwrapZod(s._def.valueType, newConfig)}>`
 
-    case z.ZodFirstPartyTypeKind.ZodFunction:
-      const input = sUnwrapZod(new FnParameters(def.args), newConfig)
-      const output = sUnwrapZod(new FnReturn(def.returns), newConfig)
+    case 'ZodFunction':
+      const input = sUnwrapZod(new FnParameters(s._def.args), newConfig)
+      const output = sUnwrapZod(new FnReturn(s._def.returns), newConfig)
       const parentIsType = config?.parent instanceof Declaration && config?.parent.props.type === 'type'
 
       if (config?.declaration && !parentIsType) {
-        return `${getMultilineComment(schemaTyped.description)}
+        return `${getMultilineComment(s.description)}
 (${input}): ${output}`
       }
 
-      return `${getMultilineComment(schemaTyped.description)}
+      return `${getMultilineComment(s.description)}
 (${input}) => ${output}`
 
-    case z.ZodFirstPartyTypeKind.ZodLazy:
-      return sUnwrapZod(def.getter(), newConfig)
+    case 'ZodLazy':
+      return sUnwrapZod(s._def.getter(), newConfig)
 
-    case z.ZodFirstPartyTypeKind.ZodLiteral:
-      const value: string = primitiveToTypscriptLiteralType(def.value)
-      return `${getMultilineComment(schemaTyped.description)}
+    case 'ZodLiteral':
+      const value: string = primitiveToTypscriptLiteralType(s._def.value)
+      return `${getMultilineComment(s.description)}
 ${value}`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodEnum:
-      const values = def.values.map(primitiveToTypescriptValue)
+    case 'ZodEnum':
+      const values = s._def.values.map(primitiveToTypescriptValue)
       return values.join(' | ')
 
-    case z.ZodFirstPartyTypeKind.ZodEffects:
-      return sUnwrapZod(def.schema, newConfig)
+    case 'ZodEffects':
+      return sUnwrapZod(s._def.schema, newConfig)
 
-    case z.ZodFirstPartyTypeKind.ZodNativeEnum:
-      throw new errors.UnsupportedZuiToTypescriptTypeError(z.ZodFirstPartyTypeKind.ZodNativeEnum)
+    case 'ZodNativeEnum':
+      throw new errors.UnsupportedZuiToTypescriptTypeError('ZodNativeEnum')
 
-    case z.ZodFirstPartyTypeKind.ZodOptional:
-      return `${sUnwrapZod(def.innerType, newConfig)} | undefined`
+    case 'ZodOptional':
+      return `${sUnwrapZod(s._def.innerType, newConfig)} | undefined`
 
-    case z.ZodFirstPartyTypeKind.ZodNullable:
-      return `${sUnwrapZod(def.innerType, newConfig)} | null`
+    case 'ZodNullable':
+      return `${sUnwrapZod(s._def.innerType, newConfig)} | null`
 
-    case z.ZodFirstPartyTypeKind.ZodDefault:
-      const defaultInnerType = config.treatDefaultAsOptional ? def.innerType.optional() : def.innerType
+    case 'ZodDefault':
+      const defaultInnerType = config.treatDefaultAsOptional ? s._def.innerType.optional() : s._def.innerType
       return sUnwrapZod(defaultInnerType, newConfig)
 
-    case z.ZodFirstPartyTypeKind.ZodCatch:
-      return sUnwrapZod(def.innerType, newConfig)
+    case 'ZodCatch':
+      return sUnwrapZod(s._def.innerType, newConfig)
 
-    case z.ZodFirstPartyTypeKind.ZodPromise:
-      return `Promise<${sUnwrapZod(def.type, newConfig)}>`
+    case 'ZodPromise':
+      return `Promise<${sUnwrapZod(s._def.type, newConfig)}>`
 
-    case z.ZodFirstPartyTypeKind.ZodBranded:
-      return sUnwrapZod(def.type, newConfig)
+    case 'ZodBranded':
+      return sUnwrapZod(s._def.type, newConfig)
 
-    case z.ZodFirstPartyTypeKind.ZodPipeline:
-      return sUnwrapZod(def.in, newConfig)
+    case 'ZodPipeline':
+      return sUnwrapZod(s._def.in, newConfig)
 
-    case z.ZodFirstPartyTypeKind.ZodSymbol:
-      return `${getMultilineComment(schemaTyped.description)} symbol`.trim()
+    case 'ZodSymbol':
+      return `${getMultilineComment(s.description)} symbol`.trim()
 
-    case z.ZodFirstPartyTypeKind.ZodReadonly:
-      return `Readonly<${sUnwrapZod(def.innerType, newConfig)}>`
+    case 'ZodReadonly':
+      return `Readonly<${sUnwrapZod(s._def.innerType, newConfig)}>`
 
-    case z.ZodFirstPartyTypeKind.ZodRef:
-      return toTypeArgumentName(def.uri)
+    case 'ZodRef':
+      return toTypeArgumentName(s._def.uri)
 
     default:
-      util.assertNever(def)
+      util.assertNever(s)
   }
 }
 

--- a/packages/zui/src/ui/types.ts
+++ b/packages/zui/src/ui/types.ts
@@ -28,29 +28,29 @@ export type UIComponentDefinitions = {
   }
 }
 
-export type ZodKindToBaseType<T extends z.ZodTypeDef> = T extends infer U
-  ? U extends { typeName: z.ZodFirstPartyTypeKind.ZodString }
+export type ZodKindToBaseType<T extends z.ZodNativeSchemaDef> = T extends infer U
+  ? U extends { typeName: 'ZodString' }
     ? 'string'
-    : U extends { typeName: z.ZodFirstPartyTypeKind.ZodNumber }
+    : U extends { typeName: 'ZodNumber' }
       ? 'number'
-      : U extends { typeName: z.ZodFirstPartyTypeKind.ZodBoolean }
+      : U extends { typeName: 'ZodBoolean' }
         ? 'boolean'
-        : U extends { typeName: z.ZodFirstPartyTypeKind.ZodArray }
+        : U extends { typeName: 'ZodArray' }
           ? 'array'
-          : U extends { typeName: z.ZodFirstPartyTypeKind.ZodObject }
+          : U extends { typeName: 'ZodObject' }
             ? 'object'
-            : U extends { typeName: z.ZodFirstPartyTypeKind.ZodTuple }
+            : U extends { typeName: 'ZodTuple' }
               ? never
               : U extends ZodEnumDef
                 ? 'string'
-                : U extends { typeName: z.ZodFirstPartyTypeKind.ZodDefault; innerType: z.ZodTypeAny }
+                : U extends { typeName: 'ZodDefault'; innerType: z.ZodTypeAny }
                   ? ZodKindToBaseType<U['innerType']['_def']>
-                  : U extends { typeName: z.ZodFirstPartyTypeKind.ZodOptional; innerType: z.ZodTypeAny }
+                  : U extends { typeName: 'ZodOptional'; innerType: z.ZodTypeAny }
                     ? ZodKindToBaseType<U['innerType']['_def']>
-                    : U extends { typeName: z.ZodFirstPartyTypeKind.ZodNullable; innerType: z.ZodTypeAny }
+                    : U extends { typeName: 'ZodNullable'; innerType: z.ZodTypeAny }
                       ? ZodKindToBaseType<U['innerType']['_def']>
                       : U extends {
-                            typeName: z.ZodFirstPartyTypeKind.ZodDiscriminatedUnion
+                            typeName: 'ZodDiscriminatedUnion'
                             options: z.ZodDiscriminatedUnionOption<any>[]
                           }
                         ? 'discriminatedUnion'

--- a/packages/zui/src/z/types/any/index.ts
+++ b/packages/zui/src/z/types/any/index.ts
@@ -1,16 +1,7 @@
-import {
-  RawCreateParams,
-  ZodFirstPartyTypeKind,
-  ZodType,
-  ZodTypeDef,
-  OK,
-  ParseInput,
-  ParseReturnType,
-  processCreateParams,
-} from '../index'
+import { RawCreateParams, ZodType, ZodTypeDef, OK, ParseInput, ParseReturnType, processCreateParams } from '../index'
 
 export type ZodAnyDef = {
-  typeName: ZodFirstPartyTypeKind.ZodAny
+  typeName: 'ZodAny'
 } & ZodTypeDef
 
 export class ZodAny extends ZodType<any, ZodAnyDef> {
@@ -21,7 +12,7 @@ export class ZodAny extends ZodType<any, ZodAnyDef> {
   }
   static create = (params?: RawCreateParams): ZodAny => {
     return new ZodAny({
-      typeName: ZodFirstPartyTypeKind.ZodAny,
+      typeName: 'ZodAny',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/array/index.ts
+++ b/packages/zui/src/z/types/array/index.ts
@@ -3,7 +3,6 @@ import {
   ZodIssueCode,
   ParseInputLazyPath,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeAny,
   ZodTypeDef,
@@ -19,7 +18,7 @@ import {
 
 export type ZodArrayDef<T extends ZodTypeAny = ZodTypeAny> = {
   type: T
-  typeName: ZodFirstPartyTypeKind.ZodArray
+  typeName: 'ZodArray'
   exactLength: { value: number; message?: string } | null
   minLength: { value: number; message?: string } | null
   maxLength: { value: number; message?: string } | null
@@ -178,7 +177,7 @@ export class ZodArray<T extends ZodTypeAny = ZodTypeAny, Cardinality extends Arr
       minLength: null,
       maxLength: null,
       exactLength: null,
-      typeName: ZodFirstPartyTypeKind.ZodArray,
+      typeName: 'ZodArray',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/bigint/index.ts
+++ b/packages/zui/src/z/types/bigint/index.ts
@@ -7,7 +7,6 @@ import {
   ParseStatus,
   ZodIssueCode,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeDef,
   processCreateParams,
@@ -24,7 +23,7 @@ export type ZodBigIntCheck =
 
 export type ZodBigIntDef = {
   checks: ZodBigIntCheck[]
-  typeName: ZodFirstPartyTypeKind.ZodBigInt
+  typeName: 'ZodBigInt'
   coerce: boolean
 } & ZodTypeDef
 
@@ -95,7 +94,7 @@ export class ZodBigInt extends ZodType<bigint, ZodBigIntDef> {
   static create = (params?: RawCreateParams & { coerce?: boolean }): ZodBigInt => {
     return new ZodBigInt({
       checks: [],
-      typeName: ZodFirstPartyTypeKind.ZodBigInt,
+      typeName: 'ZodBigInt',
       coerce: params?.coerce ?? false,
       ...processCreateParams(params),
     })

--- a/packages/zui/src/z/types/boolean/index.ts
+++ b/packages/zui/src/z/types/boolean/index.ts
@@ -1,7 +1,6 @@
 import {
   ZodIssueCode,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeDef,
   processCreateParams,
@@ -14,7 +13,7 @@ import {
 } from '../index'
 
 export type ZodBooleanDef = {
-  typeName: ZodFirstPartyTypeKind.ZodBoolean
+  typeName: 'ZodBoolean'
   coerce: boolean
 } & ZodTypeDef
 
@@ -39,7 +38,7 @@ export class ZodBoolean extends ZodType<boolean, ZodBooleanDef> {
 
   static create = (params?: RawCreateParams & { coerce?: boolean }): ZodBoolean => {
     return new ZodBoolean({
-      typeName: ZodFirstPartyTypeKind.ZodBoolean,
+      typeName: 'ZodBoolean',
       coerce: params?.coerce || false,
       ...processCreateParams(params),
     })

--- a/packages/zui/src/z/types/branded/index.ts
+++ b/packages/zui/src/z/types/branded/index.ts
@@ -1,10 +1,10 @@
-import { ZodFirstPartyTypeKind, ZodType, ZodTypeAny, ZodTypeDef, ParseInput, ParseReturnType } from '../index'
+import { ZodType, ZodTypeAny, ZodTypeDef, ParseInput, ParseReturnType } from '../index'
 
 type Key = string | number | symbol
 
 export type ZodBrandedDef<T extends ZodTypeAny = ZodTypeAny> = {
   type: T
-  typeName: ZodFirstPartyTypeKind.ZodBranded
+  typeName: 'ZodBranded'
 } & ZodTypeDef
 
 export const BRAND: unique symbol = Symbol('zod_brand')

--- a/packages/zui/src/z/types/catch/index.ts
+++ b/packages/zui/src/z/types/catch/index.ts
@@ -1,7 +1,6 @@
 import {
   ZodError,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeAny,
   ZodTypeDef,
@@ -17,7 +16,7 @@ export type CatchFn<Y> = (ctx: { error: ZodError; input: unknown }) => Y
 export type ZodCatchDef<T extends ZodTypeAny = ZodTypeAny> = {
   innerType: T
   catchValue: CatchFn<T['_output']>
-  typeName: ZodFirstPartyTypeKind.ZodCatch
+  typeName: 'ZodCatch'
 } & ZodTypeDef
 
 export class ZodCatch<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
@@ -88,7 +87,7 @@ export class ZodCatch<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
   ): ZodCatch<T> => {
     return new ZodCatch({
       innerType: type,
-      typeName: ZodFirstPartyTypeKind.ZodCatch,
+      typeName: 'ZodCatch',
       catchValue: typeof params.catch === 'function' ? params.catch : () => params.catch,
       ...processCreateParams(params),
     })

--- a/packages/zui/src/z/types/date/index.ts
+++ b/packages/zui/src/z/types/date/index.ts
@@ -4,7 +4,6 @@ import {
   util,
   ZodParsedType,
   errorUtil,
-  ZodFirstPartyTypeKind,
   ZodTypeDef,
   addIssueToContext,
   INVALID,
@@ -23,7 +22,7 @@ export type ZodDateCheck =
 export type ZodDateDef = {
   checks: ZodDateCheck[]
   coerce: boolean
-  typeName: ZodFirstPartyTypeKind.ZodDate
+  typeName: 'ZodDate'
 } & ZodTypeDef
 
 export class ZodDate extends ZodType<Date, ZodDateDef> {
@@ -141,7 +140,7 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
     return new ZodDate({
       checks: [],
       coerce: params?.coerce || false,
-      typeName: ZodFirstPartyTypeKind.ZodDate,
+      typeName: 'ZodDate',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/default/index.ts
+++ b/packages/zui/src/z/types/default/index.ts
@@ -2,7 +2,6 @@ import { isEqual } from 'lodash-es'
 
 import {
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeAny,
   ZodTypeDef,
@@ -16,7 +15,7 @@ import {
 export type ZodDefaultDef<T extends ZodTypeAny = ZodTypeAny> = {
   innerType: T
   defaultValue: () => util.noUndefined<T['_input']>
-  typeName: ZodFirstPartyTypeKind.ZodDefault
+  typeName: 'ZodDefault'
 } & ZodTypeDef
 
 export class ZodDefault<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
@@ -66,7 +65,7 @@ export class ZodDefault<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
   ): ZodDefault<T> => {
     return new ZodDefault({
       innerType: type,
-      typeName: ZodFirstPartyTypeKind.ZodDefault,
+      typeName: 'ZodDefault',
       defaultValue: typeof value === 'function' ? value : () => value,
       ...processCreateParams(params),
     })

--- a/packages/zui/src/z/types/defs.test.ts
+++ b/packages/zui/src/z/types/defs.test.ts
@@ -1,100 +1,97 @@
 import { test } from 'vitest'
-import { ZodFirstPartySchemaTypes, ZodFirstPartyTypeKind } from '..'
+import { ZodNativeSchema } from '..'
 import * as z from '../index'
 import { util } from './utils'
 
-test('first party switch', () => {
-  const myType = z.string() as z.ZodFirstPartySchemaTypes
-  const def = myType._def
-
-  switch (def.typeName) {
-    case z.ZodFirstPartyTypeKind.ZodString:
-      break
-    case z.ZodFirstPartyTypeKind.ZodNumber:
-      break
-    case z.ZodFirstPartyTypeKind.ZodNaN:
-      break
-    case z.ZodFirstPartyTypeKind.ZodBigInt:
-      break
-    case z.ZodFirstPartyTypeKind.ZodBoolean:
-      break
-    case z.ZodFirstPartyTypeKind.ZodDate:
-      break
-    case z.ZodFirstPartyTypeKind.ZodUndefined:
-      break
-    case z.ZodFirstPartyTypeKind.ZodNull:
-      break
-    case z.ZodFirstPartyTypeKind.ZodAny:
-      break
-    case z.ZodFirstPartyTypeKind.ZodUnknown:
-      break
-    case z.ZodFirstPartyTypeKind.ZodNever:
-      break
-    case z.ZodFirstPartyTypeKind.ZodVoid:
-      break
-    case z.ZodFirstPartyTypeKind.ZodArray:
-      break
-    case z.ZodFirstPartyTypeKind.ZodObject:
-      break
-    case z.ZodFirstPartyTypeKind.ZodUnion:
-      break
-    case z.ZodFirstPartyTypeKind.ZodDiscriminatedUnion:
-      break
-    case z.ZodFirstPartyTypeKind.ZodIntersection:
-      break
-    case z.ZodFirstPartyTypeKind.ZodTuple:
-      break
-    case z.ZodFirstPartyTypeKind.ZodRecord:
-      break
-    case z.ZodFirstPartyTypeKind.ZodRef:
-      break
-    case z.ZodFirstPartyTypeKind.ZodMap:
-      break
-    case z.ZodFirstPartyTypeKind.ZodSet:
-      break
-    case z.ZodFirstPartyTypeKind.ZodFunction:
-      break
-    case z.ZodFirstPartyTypeKind.ZodLazy:
-      break
-    case z.ZodFirstPartyTypeKind.ZodLiteral:
-      break
-    case z.ZodFirstPartyTypeKind.ZodEnum:
-      break
-    case z.ZodFirstPartyTypeKind.ZodEffects:
-      break
-    case z.ZodFirstPartyTypeKind.ZodNativeEnum:
-      break
-    case z.ZodFirstPartyTypeKind.ZodOptional:
-      break
-    case z.ZodFirstPartyTypeKind.ZodNullable:
-      break
-    case z.ZodFirstPartyTypeKind.ZodDefault:
-      break
-    case z.ZodFirstPartyTypeKind.ZodCatch:
-      break
-    case z.ZodFirstPartyTypeKind.ZodPromise:
-      break
-    case z.ZodFirstPartyTypeKind.ZodBranded:
-      break
-    case z.ZodFirstPartyTypeKind.ZodPipeline:
-      break
-    case z.ZodFirstPartyTypeKind.ZodSymbol:
-      break
-    case z.ZodFirstPartyTypeKind.ZodReadonly:
-      break
-    default:
-      util.assertNever(def)
+test('ZodNativeSchema can be discriminated by typeName', () => {
+  const s = z.string() as ZodNativeSchema
+  if (s.typeName === 'ZodString') {
+    s satisfies z.ZodString
+  } else if (s.typeName === 'ZodNumber') {
+    s satisfies z.ZodNumber
+  } else if (s.typeName === 'ZodNaN') {
+    s satisfies z.ZodNaN
+  } else if (s.typeName === 'ZodBigInt') {
+    s satisfies z.ZodBigInt
+  } else if (s.typeName === 'ZodBoolean') {
+    s satisfies z.ZodBoolean
+  } else if (s.typeName === 'ZodDate') {
+    s satisfies z.ZodDate
+  } else if (s.typeName === 'ZodUndefined') {
+    s satisfies z.ZodUndefined
+  } else if (s.typeName === 'ZodNull') {
+    s satisfies z.ZodNull
+  } else if (s.typeName === 'ZodAny') {
+    s satisfies z.ZodAny
+  } else if (s.typeName === 'ZodUnknown') {
+    s satisfies z.ZodUnknown
+  } else if (s.typeName === 'ZodNever') {
+    s satisfies z.ZodNever
+  } else if (s.typeName === 'ZodVoid') {
+    s satisfies z.ZodVoid
+  } else if (s.typeName === 'ZodArray') {
+    s satisfies z.ZodArray
+  } else if (s.typeName === 'ZodObject') {
+    s satisfies z.ZodObject
+  } else if (s.typeName === 'ZodUnion') {
+    s satisfies z.ZodUnion
+  } else if (s.typeName === 'ZodDiscriminatedUnion') {
+    s satisfies z.ZodDiscriminatedUnion
+  } else if (s.typeName === 'ZodIntersection') {
+    s satisfies z.ZodIntersection
+  } else if (s.typeName === 'ZodTuple') {
+    s satisfies z.ZodTuple
+  } else if (s.typeName === 'ZodRecord') {
+    s satisfies z.ZodRecord
+  } else if (s.typeName === 'ZodMap') {
+    s satisfies z.ZodMap
+  } else if (s.typeName === 'ZodSet') {
+    s satisfies z.ZodSet
+  } else if (s.typeName === 'ZodFunction') {
+    s satisfies z.ZodFunction
+  } else if (s.typeName === 'ZodLazy') {
+    s satisfies z.ZodLazy
+  } else if (s.typeName === 'ZodLiteral') {
+    s satisfies z.ZodLiteral
+  } else if (s.typeName === 'ZodEnum') {
+    s satisfies z.ZodEnum
+  } else if (s.typeName === 'ZodEffects') {
+    s satisfies z.ZodEffects
+  } else if (s.typeName === 'ZodNativeEnum') {
+    s satisfies z.ZodNativeEnum
+  } else if (s.typeName === 'ZodOptional') {
+    s satisfies z.ZodOptional
+  } else if (s.typeName === 'ZodNullable') {
+    s satisfies z.ZodNullable
+  } else if (s.typeName === 'ZodDefault') {
+    s satisfies z.ZodDefault
+  } else if (s.typeName === 'ZodCatch') {
+    s satisfies z.ZodCatch
+  } else if (s.typeName === 'ZodPromise') {
+    s satisfies z.ZodPromise
+  } else if (s.typeName === 'ZodBranded') {
+    s satisfies z.ZodBranded
+  } else if (s.typeName === 'ZodPipeline') {
+    s satisfies z.ZodPipeline
+  } else if (s.typeName === 'ZodReadonly') {
+    s satisfies z.ZodReadonly
+  } else if (s.typeName === 'ZodSymbol') {
+    s satisfies z.ZodSymbol
+  } else if (s.typeName === 'ZodRef') {
+    s satisfies z.ZodRef
+  } else {
+    util.assertNever(s)
   }
 })
 
 test('Identify missing [ZodFirstPartySchemaTypes]', () => {
-  type ZodFirstPartySchemaForType<T extends ZodFirstPartyTypeKind> = ZodFirstPartySchemaTypes extends infer Schema
+  type ZodFirstPartySchemaForType<T extends z.ZodNativeSchemaType> = ZodNativeSchema extends infer Schema
     ? Schema extends { _def: { typeName: T } }
       ? Schema
       : never
     : never
   type ZodMappedTypes = {
-    [key in ZodFirstPartyTypeKind]: ZodFirstPartySchemaForType<key>
+    [key in z.ZodNativeSchemaType]: ZodFirstPartySchemaForType<key>
   }
   type ZodFirstPartySchemaTypesMissingFromUnion = keyof {
     [key in keyof ZodMappedTypes as ZodMappedTypes[key] extends { _def: never } ? key : never]: unknown

--- a/packages/zui/src/z/types/defs.ts
+++ b/packages/zui/src/z/types/defs.ts
@@ -1,182 +1,82 @@
-import type {
-  ZodAnyDef,
-  ZodArrayDef,
-  ZodBigIntDef,
-  ZodBooleanDef,
-  ZodBrandedDef,
-  ZodCatchDef,
-  ZodDateDef,
-  ZodDefaultDef,
-  ZodDiscriminatedUnionDef,
-  ZodEnumDef,
-  ZodFunctionDef,
-  ZodIntersectionDef,
-  ZodLazyDef,
-  ZodLiteralDef,
-  ZodMapDef,
-  ZodNativeEnumDef,
-  ZodNeverDef,
-  ZodNullDef,
-  ZodNullableDef,
-  ZodNumberDef,
-  ZodObjectDef,
-  ZodOptionalDef,
-  ZodPipelineDef,
-  ZodPromiseDef,
-  ZodReadonlyDef,
-  ZodRecordDef,
-  ZodStringDef,
-  ZodEffectsDef,
-  ZodTupleDef,
-  ZodUndefinedDef,
-  ZodUnionDef,
-  ZodUnknownDef,
-  ZodVoidDef,
-  ZodRefDef,
-  ZodSetDef,
-} from './index'
+import {
+  ZodAny,
+  ZodArray,
+  ZodBigInt,
+  ZodBoolean,
+  ZodBranded,
+  ZodCatch,
+  ZodDate,
+  ZodDefault,
+  ZodDiscriminatedUnion,
+  ZodEffects,
+  ZodEnum,
+  ZodFunction,
+  ZodIntersection,
+  ZodLazy,
+  ZodLiteral,
+  ZodMap,
+  ZodNaN,
+  ZodNativeEnum,
+  ZodNever,
+  ZodNull,
+  ZodNullable,
+  ZodNumber,
+  ZodObject,
+  ZodOptional,
+  ZodPipeline,
+  ZodPromise,
+  ZodReadonly,
+  ZodRecord,
+  ZodRef,
+  ZodSet,
+  ZodString,
+  ZodSymbol,
+  ZodTuple,
+  ZodUndefined,
+  ZodUnion,
+  ZodUnknown,
+  ZodVoid,
+} from '../types'
 
-export type ZodDef =
-  | ZodStringDef
-  | ZodNumberDef
-  | ZodBigIntDef
-  | ZodBooleanDef
-  | ZodDateDef
-  | ZodUndefinedDef
-  | ZodNullDef
-  | ZodDefaultDef // contains functions
-  | ZodCatchDef // contains functions
-  | ZodReadonlyDef
-  | ZodDiscriminatedUnionDef
-  | ZodBrandedDef
-  | ZodPipelineDef
-  | ZodAnyDef
-  | ZodUnknownDef
-  | ZodNeverDef
-  | ZodVoidDef
-  | ZodArrayDef
-  | ZodObjectDef // contains functions
-  | ZodUnionDef
-  | ZodIntersectionDef
-  | ZodTupleDef
-  | ZodRecordDef
-  | ZodMapDef
-  | ZodFunctionDef
-  | ZodLazyDef // contains functions
-  | ZodLiteralDef
-  | ZodEnumDef
-  | ZodEffectsDef // contains functions
-  | ZodNativeEnumDef
-  | ZodOptionalDef
-  | ZodNullableDef
-  | ZodPromiseDef
-  | ZodRefDef
-  | ZodSetDef
+export type ZodNativeSchema =
+  | ZodString
+  | ZodNumber
+  | ZodNaN
+  | ZodBigInt
+  | ZodBoolean
+  | ZodDate
+  | ZodUndefined
+  | ZodNull
+  | ZodAny
+  | ZodUnknown
+  | ZodNever
+  | ZodVoid
+  | ZodArray
+  | ZodObject
+  | ZodUnion
+  | ZodDiscriminatedUnion
+  | ZodIntersection
+  | ZodTuple
+  | ZodRecord
+  | ZodMap
+  | ZodSet
+  | ZodFunction
+  | ZodLazy
+  | ZodLiteral
+  | ZodEnum
+  | ZodEffects
+  | ZodNativeEnum
+  | ZodOptional
+  | ZodNullable
+  | ZodDefault
+  | ZodCatch
+  | ZodPromise
+  | ZodBranded
+  | ZodPipeline
+  | ZodReadonly
+  | ZodSymbol
+  | ZodRef
 
-export enum ZodFirstPartyTypeKind {
-  ZodString = 'ZodString',
-  ZodNumber = 'ZodNumber',
-  ZodNaN = 'ZodNaN',
-  ZodBigInt = 'ZodBigInt',
-  ZodBoolean = 'ZodBoolean',
-  ZodDate = 'ZodDate',
-  ZodSymbol = 'ZodSymbol',
-  ZodUndefined = 'ZodUndefined',
-  ZodNull = 'ZodNull',
-  ZodAny = 'ZodAny',
-  ZodUnknown = 'ZodUnknown',
-  ZodNever = 'ZodNever',
-  ZodVoid = 'ZodVoid',
-  ZodArray = 'ZodArray',
-  ZodObject = 'ZodObject',
-  ZodUnion = 'ZodUnion',
-  ZodDiscriminatedUnion = 'ZodDiscriminatedUnion',
-  ZodIntersection = 'ZodIntersection',
-  ZodTuple = 'ZodTuple',
-  ZodRecord = 'ZodRecord',
-  ZodRef = 'ZodRef',
-  ZodMap = 'ZodMap',
-  ZodSet = 'ZodSet',
-  ZodFunction = 'ZodFunction',
-  ZodLazy = 'ZodLazy',
-  ZodLiteral = 'ZodLiteral',
-  ZodEnum = 'ZodEnum',
-  ZodEffects = 'ZodEffects',
-  ZodNativeEnum = 'ZodNativeEnum',
-  ZodOptional = 'ZodOptional',
-  ZodNullable = 'ZodNullable',
-  ZodDefault = 'ZodDefault',
-  ZodCatch = 'ZodCatch',
-  ZodPromise = 'ZodPromise',
-  ZodBranded = 'ZodBranded',
-  ZodPipeline = 'ZodPipeline',
-  ZodReadonly = 'ZodReadonly',
-}
+export type ZodNativeSchemaDef = ZodNativeSchema['_def']
 
-export type KindToDef<T extends ZodFirstPartyTypeKind> = T extends ZodFirstPartyTypeKind.ZodString
-  ? ZodStringDef
-  : T extends ZodFirstPartyTypeKind.ZodNumber
-    ? ZodNumberDef
-    : T extends ZodFirstPartyTypeKind.ZodBigInt
-      ? ZodBigIntDef
-      : T extends ZodFirstPartyTypeKind.ZodBoolean
-        ? ZodBooleanDef
-        : T extends ZodFirstPartyTypeKind.ZodDate
-          ? ZodDateDef
-          : T extends ZodFirstPartyTypeKind.ZodUndefined
-            ? ZodUndefinedDef
-            : T extends ZodFirstPartyTypeKind.ZodNull
-              ? ZodNullDef
-              : T extends ZodFirstPartyTypeKind.ZodAny
-                ? ZodAnyDef
-                : T extends ZodFirstPartyTypeKind.ZodUnknown
-                  ? ZodUnknownDef
-                  : T extends ZodFirstPartyTypeKind.ZodNever
-                    ? ZodNeverDef
-                    : T extends ZodFirstPartyTypeKind.ZodVoid
-                      ? ZodVoidDef
-                      : T extends ZodFirstPartyTypeKind.ZodArray
-                        ? ZodArrayDef
-                        : T extends ZodFirstPartyTypeKind.ZodObject
-                          ? ZodObjectDef
-                          : T extends ZodFirstPartyTypeKind.ZodUnion
-                            ? ZodUnionDef
-                            : T extends ZodFirstPartyTypeKind.ZodIntersection
-                              ? ZodIntersectionDef
-                              : T extends ZodFirstPartyTypeKind.ZodTuple
-                                ? ZodTupleDef
-                                : T extends ZodFirstPartyTypeKind.ZodRecord
-                                  ? ZodRecordDef
-                                  : T extends ZodFirstPartyTypeKind.ZodMap
-                                    ? ZodMapDef
-                                    : T extends ZodFirstPartyTypeKind.ZodFunction
-                                      ? ZodFunctionDef
-                                      : T extends ZodFirstPartyTypeKind.ZodLazy
-                                        ? ZodLazyDef
-                                        : T extends ZodFirstPartyTypeKind.ZodLiteral
-                                          ? ZodLiteralDef
-                                          : T extends ZodFirstPartyTypeKind.ZodEnum
-                                            ? ZodEnumDef
-                                            : T extends ZodFirstPartyTypeKind.ZodEffects
-                                              ? ZodEffectsDef
-                                              : T extends ZodFirstPartyTypeKind.ZodNativeEnum
-                                                ? ZodNativeEnumDef
-                                                : T extends ZodFirstPartyTypeKind.ZodOptional
-                                                  ? ZodOptionalDef
-                                                  : T extends ZodFirstPartyTypeKind.ZodNullable
-                                                    ? ZodNullableDef
-                                                    : T extends ZodFirstPartyTypeKind.ZodPromise
-                                                      ? ZodPromiseDef
-                                                      : T extends ZodFirstPartyTypeKind.ZodDiscriminatedUnion
-                                                        ? ZodDiscriminatedUnionDef<any>
-                                                        : T extends ZodFirstPartyTypeKind.ZodCatch
-                                                          ? ZodCatchDef
-                                                          : T extends ZodFirstPartyTypeKind.ZodDefault
-                                                            ? ZodDefaultDef
-                                                            : T extends ZodFirstPartyTypeKind.ZodBranded
-                                                              ? ZodBrandedDef<any>
-                                                              : T extends ZodFirstPartyTypeKind.ZodPipeline
-                                                                ? ZodPipelineDef<any, any>
-                                                                : T extends ZodFirstPartyTypeKind.ZodReadonly
-                                                                  ? ZodReadonlyDef
-                                                                  : never
+export type ZodNativeSchemaType = ZodNativeSchemaDef['typeName']

--- a/packages/zui/src/z/types/discriminatedUnion/index.ts
+++ b/packages/zui/src/z/types/discriminatedUnion/index.ts
@@ -8,7 +8,6 @@ import {
   input,
   output,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodRawShape,
   ZodType,
   ZodTypeAny,
@@ -81,7 +80,7 @@ export type ZodDiscriminatedUnionDef<
   discriminator: Discriminator
   options: Options
   optionsMap: Map<Primitive, ZodDiscriminatedUnionOption<any>>
-  typeName: ZodFirstPartyTypeKind.ZodDiscriminatedUnion
+  typeName: 'ZodDiscriminatedUnion'
 } & ZodTypeDef
 
 export class ZodDiscriminatedUnion<
@@ -193,7 +192,7 @@ export class ZodDiscriminatedUnion<
       // DiscriminatorValue,
       Types
     >({
-      typeName: ZodFirstPartyTypeKind.ZodDiscriminatedUnion,
+      typeName: 'ZodDiscriminatedUnion',
       discriminator,
       options,
       optionsMap,

--- a/packages/zui/src/z/types/enum/index.ts
+++ b/packages/zui/src/z/types/enum/index.ts
@@ -1,7 +1,6 @@
 import {
   ZodIssueCode,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeDef,
   processCreateParams,
@@ -25,7 +24,7 @@ export type Values<T extends EnumValues> = {
 
 export type ZodEnumDef<T extends EnumValues = EnumValues> = {
   values: T
-  typeName: ZodFirstPartyTypeKind.ZodEnum
+  typeName: 'ZodEnum'
 } & ZodTypeDef
 
 export type Writeable<T> = {
@@ -50,7 +49,7 @@ export function createZodEnum<U extends string, T extends [U, ...U[]]>(values: T
 export function createZodEnum(values: [string, ...string[]], params?: RawCreateParams) {
   return new ZodEnum({
     values,
-    typeName: ZodFirstPartyTypeKind.ZodEnum,
+    typeName: 'ZodEnum',
     ...processCreateParams(params),
   })
 }

--- a/packages/zui/src/z/types/function/index.ts
+++ b/packages/zui/src/z/types/function/index.ts
@@ -7,7 +7,6 @@ import {
   ZodIssue,
   ZodIssueCode,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeAny,
   ZodTypeDef,
@@ -28,7 +27,7 @@ import {
 export type ZodFunctionDef<Args extends ZodTuple<any, any> = ZodTuple, Returns extends ZodTypeAny = ZodTypeAny> = {
   args: Args
   returns: Returns
-  typeName: ZodFirstPartyTypeKind.ZodFunction
+  typeName: 'ZodFunction'
 } & ZodTypeDef
 
 export type OuterTypeOfFunction<Args extends ZodTuple<any, any>, Returns extends ZodTypeAny> =
@@ -201,7 +200,7 @@ export class ZodFunction<
     return new ZodFunction({
       args: args ? args : ZodTuple.create([]).rest(ZodUnknown.create()),
       returns: returns || ZodUnknown.create(),
-      typeName: ZodFirstPartyTypeKind.ZodFunction,
+      typeName: 'ZodFunction',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/intersection/index.ts
+++ b/packages/zui/src/z/types/intersection/index.ts
@@ -2,7 +2,6 @@ import { unique } from '../../utils'
 import {
   ZodIssueCode,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeAny,
   ZodTypeDef,
@@ -23,7 +22,7 @@ import { CustomSet } from '../utils/custom-set'
 export type ZodIntersectionDef<T extends ZodTypeAny = ZodTypeAny, U extends ZodTypeAny = ZodTypeAny> = {
   left: T
   right: U
-  typeName: ZodFirstPartyTypeKind.ZodIntersection
+  typeName: 'ZodIntersection'
 } & ZodTypeDef
 
 function mergeValues(a: any, b: any): { valid: true; data: any } | { valid: false } {
@@ -160,7 +159,7 @@ export class ZodIntersection<T extends ZodTypeAny = ZodTypeAny, U extends ZodTyp
     return new ZodIntersection({
       left,
       right,
-      typeName: ZodFirstPartyTypeKind.ZodIntersection,
+      typeName: 'ZodIntersection',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/lazy/index.ts
+++ b/packages/zui/src/z/types/lazy/index.ts
@@ -1,6 +1,5 @@
 import {
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeDef,
   processCreateParams,
@@ -13,7 +12,7 @@ import {
 
 export type ZodLazyDef<T extends ZodTypeAny = ZodTypeAny> = {
   getter: () => T
-  typeName: ZodFirstPartyTypeKind.ZodLazy
+  typeName: 'ZodLazy'
 } & ZodTypeDef
 
 export class ZodLazy<T extends ZodTypeAny = ZodTypeAny> extends ZodType<output<T>, ZodLazyDef<T>, input<T>> {
@@ -48,7 +47,7 @@ export class ZodLazy<T extends ZodTypeAny = ZodTypeAny> extends ZodType<output<T
   static create = <T extends ZodTypeAny>(getter: () => T, params?: RawCreateParams): ZodLazy<T> => {
     return new ZodLazy({
       getter,
-      typeName: ZodFirstPartyTypeKind.ZodLazy,
+      typeName: 'ZodLazy',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/literal/index.ts
+++ b/packages/zui/src/z/types/literal/index.ts
@@ -3,7 +3,6 @@ import { isEqual } from 'lodash-es'
 import {
   ZodIssueCode,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeDef,
   processCreateParams,
@@ -16,7 +15,7 @@ import {
 
 export type ZodLiteralDef<T extends Primitive = Primitive> = {
   value: T
-  typeName: ZodFirstPartyTypeKind.ZodLiteral
+  typeName: 'ZodLiteral'
 } & ZodTypeDef
 
 export class ZodLiteral<T extends Primitive = Primitive> extends ZodType<T, ZodLiteralDef<T>> {
@@ -40,7 +39,7 @@ export class ZodLiteral<T extends Primitive = Primitive> extends ZodType<T, ZodL
   static create = <T extends Primitive>(value: T, params?: RawCreateParams): ZodLiteral<T> => {
     return new ZodLiteral({
       value,
-      typeName: ZodFirstPartyTypeKind.ZodLiteral,
+      typeName: 'ZodLiteral',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/map/index.ts
+++ b/packages/zui/src/z/types/map/index.ts
@@ -3,7 +3,6 @@ import {
   ZodIssueCode,
   ParseInputLazyPath,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeAny,
   ZodTypeDef,
@@ -19,7 +18,7 @@ import {
 export type ZodMapDef<Key extends ZodTypeAny = ZodTypeAny, Value extends ZodTypeAny = ZodTypeAny> = {
   valueType: Value
   keyType: Key
-  typeName: ZodFirstPartyTypeKind.ZodMap
+  typeName: 'ZodMap'
 } & ZodTypeDef
 
 export class ZodMap<Key extends ZodTypeAny = ZodTypeAny, Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
@@ -119,7 +118,7 @@ export class ZodMap<Key extends ZodTypeAny = ZodTypeAny, Value extends ZodTypeAn
     return new ZodMap({
       valueType,
       keyType,
-      typeName: ZodFirstPartyTypeKind.ZodMap,
+      typeName: 'ZodMap',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/nan/index.ts
+++ b/packages/zui/src/z/types/nan/index.ts
@@ -1,7 +1,6 @@
 import {
   ZodIssueCode,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeDef,
   processCreateParams,
@@ -13,7 +12,7 @@ import {
 } from '../index'
 
 export type ZodNaNDef = {
-  typeName: ZodFirstPartyTypeKind.ZodNaN
+  typeName: 'ZodNaN'
 } & ZodTypeDef
 
 export class ZodNaN extends ZodType<number, ZodNaNDef> {
@@ -34,7 +33,7 @@ export class ZodNaN extends ZodType<number, ZodNaNDef> {
 
   static create = (params?: RawCreateParams): ZodNaN => {
     return new ZodNaN({
-      typeName: ZodFirstPartyTypeKind.ZodNaN,
+      typeName: 'ZodNaN',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/nativeEnum/index.ts
+++ b/packages/zui/src/z/types/nativeEnum/index.ts
@@ -3,7 +3,6 @@ import { isEqual } from 'lodash-es'
 import {
   ZodIssueCode,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeDef,
   processCreateParams,
@@ -18,7 +17,7 @@ import {
 
 export type ZodNativeEnumDef<T extends EnumLike = EnumLike> = {
   values: T
-  typeName: ZodFirstPartyTypeKind.ZodNativeEnum
+  typeName: 'ZodNativeEnum'
 } & ZodTypeDef
 
 export type EnumLike = { [k: string]: string | number; [nu: number]: string }
@@ -58,7 +57,7 @@ export class ZodNativeEnum<T extends EnumLike = EnumLike> extends ZodType<T[keyo
   static create = <T extends EnumLike>(values: T, params?: RawCreateParams): ZodNativeEnum<T> => {
     return new ZodNativeEnum({
       values,
-      typeName: ZodFirstPartyTypeKind.ZodNativeEnum,
+      typeName: 'ZodNativeEnum',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/never/index.ts
+++ b/packages/zui/src/z/types/never/index.ts
@@ -1,7 +1,6 @@
 import {
   ZodIssueCode,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeDef,
   processCreateParams,
@@ -13,7 +12,7 @@ import {
 } from '../index'
 
 export type ZodNeverDef = {
-  typeName: ZodFirstPartyTypeKind.ZodNever
+  typeName: 'ZodNever'
 } & ZodTypeDef
 
 export class ZodNever extends ZodType<never, ZodNeverDef> {
@@ -28,7 +27,7 @@ export class ZodNever extends ZodType<never, ZodNeverDef> {
   }
   static create = (params?: RawCreateParams): ZodNever => {
     return new ZodNever({
-      typeName: ZodFirstPartyTypeKind.ZodNever,
+      typeName: 'ZodNever',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/null/index.ts
+++ b/packages/zui/src/z/types/null/index.ts
@@ -1,7 +1,6 @@
 import {
   ZodIssueCode,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeDef,
   processCreateParams,
@@ -14,7 +13,7 @@ import {
 } from '../index'
 
 export type ZodNullDef = {
-  typeName: ZodFirstPartyTypeKind.ZodNull
+  typeName: 'ZodNull'
 } & ZodTypeDef
 
 export class ZodNull extends ZodType<null, ZodNullDef> {
@@ -33,7 +32,7 @@ export class ZodNull extends ZodType<null, ZodNullDef> {
   }
   static create = (params?: RawCreateParams): ZodNull => {
     return new ZodNull({
-      typeName: ZodFirstPartyTypeKind.ZodNull,
+      typeName: 'ZodNull',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/nullable/index.ts
+++ b/packages/zui/src/z/types/nullable/index.ts
@@ -3,7 +3,6 @@ import {
   ParseInput,
   ParseReturnType,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeAny,
   ZodTypeDef,
@@ -13,7 +12,7 @@ import {
 
 export type ZodNullableDef<T extends ZodTypeAny = ZodTypeAny> = {
   innerType: T
-  typeName: ZodFirstPartyTypeKind.ZodNullable
+  typeName: 'ZodNullable'
 } & ZodTypeDef
 
 export type ZodNullableType<T extends ZodTypeAny> = ZodNullable<T>
@@ -56,7 +55,7 @@ export class ZodNullable<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
   static create = <T extends ZodTypeAny>(type: T, params?: RawCreateParams): ZodNullable<T> => {
     return new ZodNullable({
       innerType: type,
-      typeName: ZodFirstPartyTypeKind.ZodNullable,
+      typeName: 'ZodNullable',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/number/index.ts
+++ b/packages/zui/src/z/types/number/index.ts
@@ -1,7 +1,6 @@
 import {
   ZodIssueCode,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeDef,
   processCreateParams,
@@ -35,7 +34,7 @@ function floatSafeRemainder(val: number, step: number) {
 
 export type ZodNumberDef = {
   checks: ZodNumberCheck[]
-  typeName: ZodFirstPartyTypeKind.ZodNumber
+  typeName: 'ZodNumber'
   coerce: boolean
 } & ZodTypeDef
 
@@ -128,7 +127,7 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
   static create = (params?: RawCreateParams & { coerce?: boolean }): ZodNumber => {
     return new ZodNumber({
       checks: [],
-      typeName: ZodFirstPartyTypeKind.ZodNumber,
+      typeName: 'ZodNumber',
       coerce: params?.coerce || false,
       ...processCreateParams(params),
     })

--- a/packages/zui/src/z/types/object/index.ts
+++ b/packages/zui/src/z/types/object/index.ts
@@ -16,7 +16,6 @@ import {
   ZodParsedType,
   ParseInputLazyPath,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodRawShape,
   ZodType,
   ZodTypeAny,
@@ -37,7 +36,7 @@ export type ZodObjectDef<
   T extends ZodRawShape = ZodRawShape,
   UnknownKeys extends UnknownKeysParam = UnknownKeysParam,
 > = {
-  typeName: ZodFirstPartyTypeKind.ZodObject
+  typeName: 'ZodObject'
   shape: () => T
   unknownKeys: UnknownKeys
 } & ZodTypeDef
@@ -404,7 +403,7 @@ export class ZodObject<
         ...this._def.shape(),
         ...merging._def.shape(),
       }),
-      typeName: ZodFirstPartyTypeKind.ZodObject,
+      typeName: 'ZodObject',
     })
     return merged
   }
@@ -439,7 +438,7 @@ export class ZodObject<
   //     catchall: merging._def.catchall,
   //     shape: () =>
   //       objectUtil.mergeShapes(this._def.shape(), merging._def.shape()),
-  //     typeName: ZodFirstPartyTypeKind.ZodObject,
+  //     typeName: 'ZodObject',
   //   });
   //   return merged;
   // }
@@ -476,7 +475,7 @@ export class ZodObject<
   //     catchall: merging._def.catchall,
   //     shape: () =>
   //       objectUtil.mergeShapes(this._def.shape(), merging._def.shape()),
-  //     typeName: ZodFirstPartyTypeKind.ZodObject,
+  //     typeName: 'ZodObject',
   //   });
   //   return merged;
   // }
@@ -643,7 +642,7 @@ export class ZodObject<
     return new ZodObject({
       shape: () => shape,
       unknownKeys: 'strip',
-      typeName: ZodFirstPartyTypeKind.ZodObject,
+      typeName: 'ZodObject',
       ...processCreateParams(params),
     })
   }
@@ -652,7 +651,7 @@ export class ZodObject<
     return new ZodObject({
       shape: () => shape,
       unknownKeys: 'strict',
-      typeName: ZodFirstPartyTypeKind.ZodObject,
+      typeName: 'ZodObject',
       ...processCreateParams(params),
     })
   }
@@ -661,7 +660,7 @@ export class ZodObject<
     return new ZodObject({
       shape,
       unknownKeys: 'strip',
-      typeName: ZodFirstPartyTypeKind.ZodObject,
+      typeName: 'ZodObject',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/optional/index.ts
+++ b/packages/zui/src/z/types/optional/index.ts
@@ -2,7 +2,6 @@ import {
   processCreateParams,
   ZodParsedType,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeAny,
   ZodTypeDef,
@@ -13,7 +12,7 @@ import {
 
 export type ZodOptionalDef<T extends ZodTypeAny = ZodTypeAny> = {
   innerType: T
-  typeName: ZodFirstPartyTypeKind.ZodOptional
+  typeName: 'ZodOptional'
 } & ZodTypeDef
 
 export type ZodOptionalType<T extends ZodTypeAny> = ZodOptional<T>
@@ -56,7 +55,7 @@ export class ZodOptional<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
   static create = <T extends ZodTypeAny>(type: T, params?: RawCreateParams): ZodOptional<T> => {
     return new ZodOptional({
       innerType: type,
-      typeName: ZodFirstPartyTypeKind.ZodOptional,
+      typeName: 'ZodOptional',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/pipeline/index.ts
+++ b/packages/zui/src/z/types/pipeline/index.ts
@@ -1,19 +1,10 @@
 import { unique } from '../../utils'
-import {
-  ZodFirstPartyTypeKind,
-  ZodType,
-  ZodTypeAny,
-  ZodTypeDef,
-  DIRTY,
-  INVALID,
-  ParseInput,
-  ParseReturnType,
-} from '../index'
+import { ZodType, ZodTypeAny, ZodTypeDef, DIRTY, INVALID, ParseInput, ParseReturnType } from '../index'
 
 export type ZodPipelineDef<A extends ZodTypeAny = ZodTypeAny, B extends ZodTypeAny = ZodTypeAny> = {
   in: A
   out: B
-  typeName: ZodFirstPartyTypeKind.ZodPipeline
+  typeName: 'ZodPipeline'
 } & ZodTypeDef
 
 export class ZodPipeline<A extends ZodTypeAny = ZodTypeAny, B extends ZodTypeAny = ZodTypeAny> extends ZodType<
@@ -90,7 +81,7 @@ export class ZodPipeline<A extends ZodTypeAny = ZodTypeAny, B extends ZodTypeAny
     return new ZodPipeline({
       in: a,
       out: b,
-      typeName: ZodFirstPartyTypeKind.ZodPipeline,
+      typeName: 'ZodPipeline',
     })
   }
 

--- a/packages/zui/src/z/types/promise/index.ts
+++ b/packages/zui/src/z/types/promise/index.ts
@@ -1,7 +1,6 @@
 import {
   ZodIssueCode,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeAny,
   ZodTypeDef,
@@ -16,7 +15,7 @@ import {
 
 export type ZodPromiseDef<T extends ZodTypeAny = ZodTypeAny> = {
   type: T
-  typeName: ZodFirstPartyTypeKind.ZodPromise
+  typeName: 'ZodPromise'
 } & ZodTypeDef
 
 export class ZodPromise<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
@@ -72,7 +71,7 @@ export class ZodPromise<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
   static create = <T extends ZodTypeAny>(schema: T, params?: RawCreateParams): ZodPromise<T> => {
     return new ZodPromise({
       type: schema,
-      typeName: ZodFirstPartyTypeKind.ZodPromise,
+      typeName: 'ZodPromise',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/readonly/index.ts
+++ b/packages/zui/src/z/types/readonly/index.ts
@@ -1,7 +1,6 @@
 import {
   processCreateParams,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeAny,
   ZodTypeDef,
@@ -34,7 +33,7 @@ type MakeReadonly<T> =
 
 export type ZodReadonlyDef<T extends ZodTypeAny = ZodTypeAny> = {
   innerType: T
-  typeName: ZodFirstPartyTypeKind.ZodReadonly
+  typeName: 'ZodReadonly'
 } & ZodTypeDef
 
 export class ZodReadonly<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
@@ -71,7 +70,7 @@ export class ZodReadonly<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
   static create = <T extends ZodTypeAny>(type: T, params?: RawCreateParams): ZodReadonly<T> => {
     return new ZodReadonly({
       innerType: type,
-      typeName: ZodFirstPartyTypeKind.ZodReadonly,
+      typeName: 'ZodReadonly',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/record/index.ts
+++ b/packages/zui/src/z/types/record/index.ts
@@ -4,7 +4,6 @@ import {
   ZodIssueCode,
   ParseInputLazyPath,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeAny,
   ZodTypeDef,
@@ -21,7 +20,7 @@ import {
 export type ZodRecordDef<Key extends KeySchema = ZodString, Value extends ZodTypeAny = ZodTypeAny> = {
   valueType: Value
   keyType: Key
-  typeName: ZodFirstPartyTypeKind.ZodRecord
+  typeName: 'ZodRecord'
 } & ZodTypeDef
 
 export type KeySchema = ZodType<string | number | symbol, any, any>
@@ -118,7 +117,7 @@ export class ZodRecord<Key extends KeySchema = ZodString, Value extends ZodTypeA
       return new ZodRecord({
         keyType: first,
         valueType: second,
-        typeName: ZodFirstPartyTypeKind.ZodRecord,
+        typeName: 'ZodRecord',
         ...processCreateParams(third),
       })
     }
@@ -126,7 +125,7 @@ export class ZodRecord<Key extends KeySchema = ZodString, Value extends ZodTypeA
     return new ZodRecord({
       keyType: ZodString.create(),
       valueType: first,
-      typeName: ZodFirstPartyTypeKind.ZodRecord,
+      typeName: 'ZodRecord',
       ...processCreateParams(second),
     })
   }

--- a/packages/zui/src/z/types/ref/index.ts
+++ b/packages/zui/src/z/types/ref/index.ts
@@ -1,5 +1,4 @@
 import {
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeDef,
   INVALID,
@@ -11,7 +10,7 @@ import {
 } from '../index'
 
 export type ZodRefDef = {
-  typeName: ZodFirstPartyTypeKind.ZodRef
+  typeName: 'ZodRef'
   uri: string
 } & ZodTypeDef
 
@@ -41,7 +40,7 @@ export class ZodRef extends ZodType<ZodRefOutput, ZodRefDef> {
 
   static create = (uri: string): ZodRef => {
     return new ZodRef({
-      typeName: ZodFirstPartyTypeKind.ZodRef,
+      typeName: 'ZodRef',
       uri,
     })
   }

--- a/packages/zui/src/z/types/set/index.ts
+++ b/packages/zui/src/z/types/set/index.ts
@@ -2,7 +2,6 @@ import {
   ZodIssueCode,
   ParseInputLazyPath,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeAny,
   ZodTypeDef,
@@ -18,7 +17,7 @@ import {
 
 export type ZodSetDef<Value extends ZodTypeAny = ZodTypeAny> = {
   valueType: Value
-  typeName: ZodFirstPartyTypeKind.ZodSet
+  typeName: 'ZodSet'
   minSize: { value: number; message?: string } | null
   maxSize: { value: number; message?: string } | null
 } & ZodTypeDef
@@ -140,7 +139,7 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
       valueType,
       minSize: null,
       maxSize: null,
-      typeName: ZodFirstPartyTypeKind.ZodSet,
+      typeName: 'ZodSet',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/string/index.ts
+++ b/packages/zui/src/z/types/string/index.ts
@@ -3,7 +3,6 @@ import {
   StringValidation,
   ZodIssueCode,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeDef,
   processCreateParams,
@@ -49,9 +48,10 @@ export type ZodStringCheck =
 
 export type ZodStringDef = {
   checks: ZodStringCheck[]
-  typeName: ZodFirstPartyTypeKind.ZodString
+  typeName: 'ZodString'
   coerce: boolean
 } & ZodTypeDef
+
 export const cuidRegex = /^c[^\s-]{8,}$/i
 export const cuid2Regex = /^[a-z][a-z0-9]*$/
 export const ulidRegex = /^[0-9A-HJKMNP-TV-Z]{26}$/
@@ -521,7 +521,7 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   static create = (params?: RawCreateParams & { coerce?: true }): ZodString => {
     return new ZodString({
       checks: [],
-      typeName: ZodFirstPartyTypeKind.ZodString,
+      typeName: 'ZodString',
       coerce: params?.coerce ?? false,
       ...processCreateParams({ ...params, supportsExtensions: ['secret'] }),
     })

--- a/packages/zui/src/z/types/symbol/index.ts
+++ b/packages/zui/src/z/types/symbol/index.ts
@@ -1,7 +1,6 @@
 import {
   ZodIssueCode,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeDef,
   processCreateParams,
@@ -14,7 +13,7 @@ import {
 } from '../index'
 
 export type ZodSymbolDef = {
-  typeName: ZodFirstPartyTypeKind.ZodSymbol
+  typeName: 'ZodSymbol'
 } & ZodTypeDef
 
 export class ZodSymbol extends ZodType<symbol, ZodSymbolDef, symbol> {
@@ -35,7 +34,7 @@ export class ZodSymbol extends ZodType<symbol, ZodSymbolDef, symbol> {
 
   static create = (params?: RawCreateParams): ZodSymbol => {
     return new ZodSymbol({
-      typeName: ZodFirstPartyTypeKind.ZodSymbol,
+      typeName: 'ZodSymbol',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/transformer/index.ts
+++ b/packages/zui/src/z/types/transformer/index.ts
@@ -4,7 +4,6 @@ import {
   output,
   RawCreateParams,
   RefinementCtx,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeAny,
   ZodTypeDef,
@@ -37,7 +36,7 @@ export type Effect<T> = RefinementEffect<T> | TransformEffect<T> | PreprocessEff
 
 export type ZodEffectsDef<T extends ZodTypeAny = ZodTypeAny> = {
   schema: T
-  typeName: ZodFirstPartyTypeKind.ZodEffects
+  typeName: 'ZodEffects'
   effect: Effect<any>
 } & ZodTypeDef
 
@@ -54,7 +53,7 @@ export class ZodEffects<T extends ZodTypeAny = ZodTypeAny, Output = output<T>, I
    * @deprecated use naked() instead
    */
   sourceType(): T {
-    return this._def.schema._def.typeName === ZodFirstPartyTypeKind.ZodEffects
+    return this._def.schema._def.typeName === 'ZodEffects'
       ? (this._def.schema as unknown as ZodEffects<T>).sourceType()
       : (this._def.schema as T)
   }
@@ -204,7 +203,7 @@ export class ZodEffects<T extends ZodTypeAny = ZodTypeAny, Output = output<T>, I
   ): ZodEffects<I, I['_output']> => {
     return new ZodEffects({
       schema,
-      typeName: ZodFirstPartyTypeKind.ZodEffects,
+      typeName: 'ZodEffects',
       effect,
       ...processCreateParams(params),
     })
@@ -218,7 +217,7 @@ export class ZodEffects<T extends ZodTypeAny = ZodTypeAny, Output = output<T>, I
     return new ZodEffects({
       schema,
       effect: { type: 'preprocess', transform: preprocess },
-      typeName: ZodFirstPartyTypeKind.ZodEffects,
+      typeName: 'ZodEffects',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/tuple/index.ts
+++ b/packages/zui/src/z/types/tuple/index.ts
@@ -3,7 +3,6 @@ import {
   ZodIssueCode,
   ParseInputLazyPath,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeAny,
   ZodTypeDef,
@@ -39,7 +38,7 @@ export type InputTypeOfTupleWithRest<
 export type ZodTupleDef<T extends ZodTupleItems | [] = ZodTupleItems, Rest extends ZodTypeAny | null = null> = {
   items: T
   rest: Rest
-  typeName: ZodFirstPartyTypeKind.ZodTuple
+  typeName: 'ZodTuple'
 } & ZodTypeDef
 
 export type AnyZodTuple = ZodTuple<[ZodTypeAny, ...ZodTypeAny[]] | [], ZodTypeAny | null>
@@ -147,7 +146,7 @@ export class ZodTuple<
     }
     return new ZodTuple({
       items: schemas,
-      typeName: ZodFirstPartyTypeKind.ZodTuple,
+      typeName: 'ZodTuple',
       rest: null,
       ...processCreateParams(params),
     })

--- a/packages/zui/src/z/types/undefined/index.ts
+++ b/packages/zui/src/z/types/undefined/index.ts
@@ -1,7 +1,6 @@
 import {
   ZodIssueCode,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeDef,
   processCreateParams,
@@ -15,7 +14,7 @@ import {
 } from '../index'
 
 export type ZodUndefinedDef = {
-  typeName: ZodFirstPartyTypeKind.ZodUndefined
+  typeName: 'ZodUndefined'
 } & ZodTypeDef
 
 export class ZodUndefined extends ZodType<undefined, ZodUndefinedDef> {
@@ -36,7 +35,7 @@ export class ZodUndefined extends ZodType<undefined, ZodUndefinedDef> {
 
   static create = (params?: RawCreateParams): ZodUndefined => {
     return new ZodUndefined({
-      typeName: ZodFirstPartyTypeKind.ZodUndefined,
+      typeName: 'ZodUndefined',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/union/index.ts
+++ b/packages/zui/src/z/types/union/index.ts
@@ -1,7 +1,6 @@
 import { unique } from '../../utils'
 import {
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeAny,
   ZodTypeDef,
@@ -25,7 +24,7 @@ type DefaultZodUnionOptions = Readonly<[ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]
 export type ZodUnionOptions = Readonly<[ZodTypeAny, ...ZodTypeAny[]]>
 export type ZodUnionDef<T extends ZodUnionOptions = DefaultZodUnionOptions> = {
   options: T
-  typeName: ZodFirstPartyTypeKind.ZodUnion
+  typeName: 'ZodUnion'
 } & ZodTypeDef
 
 export class ZodUnion<T extends ZodUnionOptions = DefaultZodUnionOptions> extends ZodType<
@@ -166,7 +165,7 @@ export class ZodUnion<T extends ZodUnionOptions = DefaultZodUnionOptions> extend
   ): ZodUnion<T> => {
     return new ZodUnion({
       options: types,
-      typeName: ZodFirstPartyTypeKind.ZodUnion,
+      typeName: 'ZodUnion',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/unknown/index.ts
+++ b/packages/zui/src/z/types/unknown/index.ts
@@ -1,16 +1,7 @@
-import {
-  RawCreateParams,
-  ZodFirstPartyTypeKind,
-  ZodType,
-  ZodTypeDef,
-  processCreateParams,
-  OK,
-  ParseInput,
-  ParseReturnType,
-} from '../index'
+import { RawCreateParams, ZodType, ZodTypeDef, processCreateParams, OK, ParseInput, ParseReturnType } from '../index'
 
 export type ZodUnknownDef = {
-  typeName: ZodFirstPartyTypeKind.ZodUnknown
+  typeName: 'ZodUnknown'
 } & ZodTypeDef
 
 export class ZodUnknown extends ZodType<unknown, ZodUnknownDef> {
@@ -22,7 +13,7 @@ export class ZodUnknown extends ZodType<unknown, ZodUnknownDef> {
 
   static create = (params?: RawCreateParams): ZodUnknown => {
     return new ZodUnknown({
-      typeName: ZodFirstPartyTypeKind.ZodUnknown,
+      typeName: 'ZodUnknown',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/types/void/index.ts
+++ b/packages/zui/src/z/types/void/index.ts
@@ -1,7 +1,6 @@
 import {
   ZodIssueCode,
   RawCreateParams,
-  ZodFirstPartyTypeKind,
   ZodType,
   ZodTypeDef,
   processCreateParams,
@@ -14,7 +13,7 @@ import {
 } from '../index'
 
 export type ZodVoidDef = {
-  typeName: ZodFirstPartyTypeKind.ZodVoid
+  typeName: 'ZodVoid'
 } & ZodTypeDef
 
 export class ZodVoid extends ZodType<void, ZodVoidDef> {
@@ -34,7 +33,7 @@ export class ZodVoid extends ZodType<void, ZodVoidDef> {
 
   static create = (params?: RawCreateParams): ZodVoid => {
     return new ZodVoid({
-      typeName: ZodFirstPartyTypeKind.ZodVoid,
+      typeName: 'ZodVoid',
       ...processCreateParams(params),
     })
   }

--- a/packages/zui/src/z/z.ts
+++ b/packages/zui/src/z/z.ts
@@ -6,8 +6,6 @@ import {
   ZodArray,
   ZodBigInt,
   ZodBoolean,
-  ZodBranded,
-  ZodCatch,
   ZodDate,
   ZodDefault,
   ZodDiscriminatedUnion,
@@ -20,6 +18,9 @@ import {
   ZodMap,
   ZodNaN,
   ZodNativeEnum,
+  ZodNativeSchema,
+  ZodNativeSchemaDef,
+  ZodNativeSchemaType,
   ZodNever,
   ZodNull,
   ZodNullable,
@@ -42,50 +43,17 @@ import {
   ZodVoid,
 } from './types'
 
-export { ZodType as Schema, ZodType as ZodSchema }
+export {
+  ZodType as Schema,
+  ZodType as ZodSchema,
+  type ZodNativeSchema,
+  type ZodNativeSchemaDef,
+  type ZodNativeSchemaType,
+}
 
 export const late = {
   object: ZodObject.lazycreate,
 }
-
-export type ZodFirstPartySchemaTypes =
-  | ZodString
-  | ZodNumber
-  | ZodNaN
-  | ZodBigInt
-  | ZodBoolean
-  | ZodDate
-  | ZodUndefined
-  | ZodNull
-  | ZodAny
-  | ZodUnknown
-  | ZodNever
-  | ZodVoid
-  | ZodArray
-  | ZodObject
-  | ZodUnion
-  | ZodDiscriminatedUnion
-  | ZodIntersection
-  | ZodTuple
-  | ZodRecord
-  | ZodMap
-  | ZodSet
-  | ZodFunction
-  | ZodLazy
-  | ZodLiteral
-  | ZodEnum
-  | ZodEffects
-  | ZodNativeEnum
-  | ZodOptional
-  | ZodNullable
-  | ZodDefault
-  | ZodCatch
-  | ZodPromise
-  | ZodBranded
-  | ZodPipeline
-  | ZodReadonly
-  | ZodSymbol
-  | ZodRef
 
 // requires TS 4.4+
 abstract class Class {
@@ -205,3 +173,48 @@ export * from './types/utils'
 export * from './types/utils/parseUtil'
 export * from './types/utils/typeAliases'
 export * from './extensions'
+
+/**
+ * @deprecated use ZodNativeSchemaType instead
+ */
+export const ZodFirstPartyTypeKind = {
+  ZodString: 'ZodString',
+  ZodNumber: 'ZodNumber',
+  ZodNaN: 'ZodNaN',
+  ZodBigInt: 'ZodBigInt',
+  ZodBoolean: 'ZodBoolean',
+  ZodDate: 'ZodDate',
+  ZodUndefined: 'ZodUndefined',
+  ZodNull: 'ZodNull',
+  ZodAny: 'ZodAny',
+  ZodUnknown: 'ZodUnknown',
+  ZodNever: 'ZodNever',
+  ZodVoid: 'ZodVoid',
+  ZodArray: 'ZodArray',
+  ZodObject: 'ZodObject',
+  ZodUnion: 'ZodUnion',
+  ZodDiscriminatedUnion: 'ZodDiscriminatedUnion',
+  ZodIntersection: 'ZodIntersection',
+  ZodTuple: 'ZodTuple',
+  ZodRecord: 'ZodRecord',
+  ZodMap: 'ZodMap',
+  ZodSet: 'ZodSet',
+  ZodFunction: 'ZodFunction',
+  ZodLazy: 'ZodLazy',
+  ZodLiteral: 'ZodLiteral',
+  ZodEnum: 'ZodEnum',
+  ZodEffects: 'ZodEffects',
+  ZodNativeEnum: 'ZodNativeEnum',
+  ZodOptional: 'ZodOptional',
+  ZodNullable: 'ZodNullable',
+  ZodDefault: 'ZodDefault',
+  ZodCatch: 'ZodCatch',
+  ZodPromise: 'ZodPromise',
+  ZodBranded: 'ZodBranded',
+  ZodPipeline: 'ZodPipeline',
+  ZodReadonly: 'ZodReadonly',
+  ZodSymbol: 'ZodSymbol',
+  ZodRef: 'ZodRef',
+} satisfies {
+  [K in ZodNativeSchemaType]: K
+}


### PR DESCRIPTION
**WIP**

zui schema can now be easily discriminated by type like:
```ts
const s = z.string() as z.ZodNativeSchema
if (s.typeName === 'ZodString') {
  s satisfies ZodString
  // you may use s as a ZodString here
}
```