### PR TITLE
chore(zui): rm internal usage of ZodTypeAny

### DIFF
--- a/packages/zui/src/transforms/zui-from-json-schema-legacy/index.ts
+++ b/packages/zui/src/transforms/zui-from-json-schema-legacy/index.ts
@@ -149,7 +149,7 @@ export const traverseZodDefinitions = (
 ) => {
   switch (def.typeName) {
     case ZodFirstPartyTypeKind.ZodObject:
-      const shape = def.shape()
+      const shape = def.shape() as Record<string, ZodTypeAny>
       cb(ZodFirstPartyTypeKind.ZodObject, def, path)
       Object.entries(shape).forEach(([key, field]) => {
         traverseZodDefinitions(field._def, cb, [...path, key])
@@ -158,18 +158,18 @@ export const traverseZodDefinitions = (
 
     case ZodFirstPartyTypeKind.ZodArray:
       cb(ZodFirstPartyTypeKind.ZodArray, def, path)
-      traverseZodDefinitions(def.type._def, cb, [...path, '0'])
+      traverseZodDefinitions((def.type as ZodTypeAny)._def, cb, [...path, '0'])
       break
 
     case ZodFirstPartyTypeKind.ZodLazy:
       cb(ZodFirstPartyTypeKind.ZodLazy, def, path)
-      traverseZodDefinitions(def.getter()._def, cb, path)
+      traverseZodDefinitions((def.getter() as ZodTypeAny)._def, cb, path)
       break
 
     case ZodFirstPartyTypeKind.ZodUnion:
       cb(ZodFirstPartyTypeKind.ZodUnion, def, path)
       def.options.forEach((option) => {
-        traverseZodDefinitions(option._def, cb, path)
+        traverseZodDefinitions((option as ZodTypeAny)._def, cb, path)
       })
       break
 
@@ -212,11 +212,11 @@ export const traverseZodDefinitions = (
 
     case ZodFirstPartyTypeKind.ZodNullable:
       cb(ZodFirstPartyTypeKind.ZodNullable, def, path)
-      traverseZodDefinitions(def.innerType._def, cb, path)
+      traverseZodDefinitions((def.innerType as ZodTypeAny)._def, cb, path)
       break
     case ZodFirstPartyTypeKind.ZodOptional:
       cb(ZodFirstPartyTypeKind.ZodOptional, def, path)
-      traverseZodDefinitions(def.innerType._def, cb, path)
+      traverseZodDefinitions((def.innerType as ZodTypeAny)._def, cb, path)
       break
 
     case ZodFirstPartyTypeKind.ZodNumber:

--- a/packages/zui/src/transforms/zui-from-json-schema-legacy/json-schema-to-zui.test.ts
+++ b/packages/zui/src/transforms/zui-from-json-schema-legacy/json-schema-to-zui.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test, it } from 'vitest'
-import { ZodTypeAny, z } from '../../z/index'
+import { ZodType, z } from '../../z/index'
 import { zuiKey } from '../../ui/constants'
 import { jsonSchemaToZodStr, fromJSONSchemaLegacy, traverseZodDefinitions } from '.'
 import { toJSONSchemaLegacy } from '../zui-to-json-schema-legacy/zui-extension'
 import { JSONSchema7 } from 'json-schema'
 import { assert } from '../../assertions.utils.test'
 
-const testZuiConversion = (zuiObject: ZodTypeAny) => {
+const testZuiConversion = (zuiObject: ZodType) => {
   const jsonSchema = toJSONSchemaLegacy(zuiObject)
   const asZui = fromJSONSchemaLegacy(jsonSchema)
   const convertedJsonSchema = toJSONSchemaLegacy(asZui)

--- a/packages/zui/src/transforms/zui-from-json-schema/iterables/array.ts
+++ b/packages/zui/src/transforms/zui-from-json-schema/iterables/array.ts
@@ -4,7 +4,7 @@ import { ArraySchema, SetSchema, TupleSchema } from '../../common/json-schema'
 
 export const arrayJSONSchemaToZuiArray = (
   schema: ArraySchema | SetSchema | TupleSchema,
-  toZui: (x: JSONSchema7Definition) => z.ZodTypeAny
+  toZui: (x: JSONSchema7Definition) => z.ZodType
 ): z.ZodArray | z.ZodSet | z.ZodTuple =>
   _isTuple(schema)
     ? _handleTuple(schema, toZui)
@@ -19,7 +19,7 @@ const _isSet = (schema: ArraySchema | SetSchema | TupleSchema): schema is SetSch
 
 const _handleTuple = (
   { items, additionalItems }: TupleSchema,
-  toZui: (x: JSONSchema7Definition) => z.ZodTypeAny
+  toZui: (x: JSONSchema7Definition) => z.ZodType
 ): z.ZodTuple => {
   const itemSchemas = items.map(toZui) as [] | [z.ZodType, ...z.ZodType[]]
   let zodTuple: z.ZodTuple<any, any> = z.tuple(itemSchemas)
@@ -33,7 +33,7 @@ const _handleTuple = (
 
 const _handleSet = (
   { items, minItems, maxItems }: SetSchema,
-  toZui: (x: JSONSchema7Definition) => z.ZodTypeAny
+  toZui: (x: JSONSchema7Definition) => z.ZodType
 ): z.ZodSet => {
   let zodSet = z.set(toZui(items))
 
@@ -50,7 +50,7 @@ const _handleSet = (
 
 const _handleArray = (
   { minItems, maxItems, items }: ArraySchema,
-  toZui: (x: JSONSchema7Definition) => z.ZodTypeAny
+  toZui: (x: JSONSchema7Definition) => z.ZodType
 ): z.ZodArray | z.ZodSet | z.ZodTuple => {
   let zodArray = z.array(toZui(items))
 

--- a/packages/zui/src/transforms/zui-from-object/index.ts
+++ b/packages/zui/src/transforms/zui-from-object/index.ts
@@ -1,4 +1,4 @@
-import { z, SomeZodObject, ZodTypeAny } from '../../z/index'
+import { z, SomeZodObject, ZodType } from '../../z/index'
 import * as errors from '../common/errors'
 
 // Using a basic regex do determine if it's a date or not to avoid using another lib for that
@@ -14,7 +14,7 @@ export type ObjectToZuiOptions = { optional?: boolean; nullable?: boolean; passt
  * @param opts - Options to customize the Zod schema:
  * @returns A Zod schema representing the object.
  */
-export const fromObject = (obj: object, opts?: ObjectToZuiOptions, isRoot = true): ZodTypeAny => {
+export const fromObject = (obj: object, opts?: ObjectToZuiOptions, isRoot = true): ZodType => {
   if (typeof obj !== 'object') {
     throw new errors.ObjectToZuiError('Input must be an object')
   }

--- a/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/array.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/array.ts
@@ -1,6 +1,6 @@
 import { zuiKey } from '../../../ui/constants'
 import { ZuiExtensionObject } from '../../../ui/types'
-import { ZodArrayDef, ZodFirstPartyTypeKind } from '../../../z/index'
+import { ZodArrayDef, ZodFirstPartyTypeKind, ZodTypeAny } from '../../../z/index'
 import { ErrorMessages, setResponseValueAndErrors } from '../errorMessages'
 import { JsonSchema7Type, parseDef } from '../parseDef'
 import { Refs } from '../Refs'
@@ -20,7 +20,7 @@ export function parseArrayDef(def: ZodArrayDef, refs: Refs) {
   }
 
   if (def.type?._def?.typeName !== ZodFirstPartyTypeKind.ZodAny) {
-    res.items = parseDef(def.type._def, {
+    res.items = parseDef((def.type as ZodTypeAny)._def, {
       ...refs,
       currentPath: [...refs.currentPath, 'items'],
     })

--- a/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/default.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/default.ts
@@ -1,10 +1,10 @@
-import { ZodDefaultDef } from '../../../z/index'
+import { ZodDefaultDef, ZodTypeAny } from '../../../z/index'
 import { JsonSchema7Type, parseDef } from '../parseDef'
 import { Refs } from '../Refs'
 
 export function parseDefaultDef(_def: ZodDefaultDef, refs: Refs): JsonSchema7Type & { default: any } {
   return {
-    ...parseDef(_def.innerType._def, refs),
+    ...parseDef((_def.innerType as ZodTypeAny)._def, refs),
     default: _def.defaultValue(),
   }
 }

--- a/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/effects.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/effects.ts
@@ -1,7 +1,7 @@
-import { ZodEffectsDef } from '../../../z/index'
+import { ZodEffectsDef, ZodTypeAny } from '../../../z/index'
 import { JsonSchema7Type, parseDef } from '../parseDef'
 import { Refs } from '../Refs'
 
 export function parseEffectsDef(_def: ZodEffectsDef, refs: Refs): JsonSchema7Type | undefined {
-  return refs.effectStrategy === 'input' ? parseDef(_def.schema._def, refs) : {}
+  return refs.effectStrategy === 'input' ? parseDef((_def.schema as ZodTypeAny)._def, refs) : {}
 }

--- a/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/intersection.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/intersection.ts
@@ -1,6 +1,6 @@
 import { zuiKey } from '../../../ui/constants'
 import { ZuiExtensionObject } from '../../../ui/types'
-import { ZodIntersectionDef } from '../../../z/index'
+import { ZodIntersectionDef, ZodTypeAny } from '../../../z/index'
 import { JsonSchema7Type, parseDef } from '../parseDef'
 import { Refs } from '../Refs'
 import { JsonSchema7StringType } from './string'
@@ -21,11 +21,11 @@ export function parseIntersectionDef(
   refs: Refs
 ): JsonSchema7AllOfType | JsonSchema7Type | undefined {
   const allOf = [
-    parseDef(def.left._def, {
+    parseDef((def.left as ZodTypeAny)._def, {
       ...refs,
       currentPath: [...refs.currentPath, 'allOf', '0'],
     }),
-    parseDef(def.right._def, {
+    parseDef((def.right as ZodTypeAny)._def, {
       ...refs,
       currentPath: [...refs.currentPath, 'allOf', '1'],
     }),

--- a/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/map.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/map.ts
@@ -1,6 +1,6 @@
 import { zuiKey } from '../../../ui/constants'
 import { ZuiExtensionObject } from '../../../ui/types'
-import { ZodMapDef } from '../../../z/index'
+import { ZodMapDef, ZodTypeAny } from '../../../z/index'
 import { JsonSchema7Type, parseDef } from '../parseDef'
 import { Refs } from '../Refs'
 import { JsonSchema7RecordType, parseRecordDef } from './record'
@@ -23,12 +23,12 @@ export function parseMapDef(def: ZodMapDef, refs: Refs): JsonSchema7MapType | Js
   }
 
   const keys =
-    parseDef(def.keyType._def, {
+    parseDef((def.keyType as ZodTypeAny)._def, {
       ...refs,
       currentPath: [...refs.currentPath, 'items', 'items', '0'],
     }) || {}
   const values =
-    parseDef(def.valueType._def, {
+    parseDef((def.valueType as ZodTypeAny)._def, {
       ...refs,
       currentPath: [...refs.currentPath, 'items', 'items', '1'],
     }) || {}

--- a/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/nullable.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/nullable.ts
@@ -1,6 +1,6 @@
 import { zuiKey } from '../../../ui/constants'
 import { ZuiExtensionObject } from '../../../ui/types'
-import { ZodNullableDef } from '../../../z/index'
+import { ZodNullableDef, ZodTypeAny } from '../../../z/index'
 import { addMeta, JsonSchema7Type, parseDef } from '../parseDef'
 import { Refs } from '../Refs'
 import { JsonSchema7NullType } from './null'
@@ -17,11 +17,11 @@ export type JsonSchema7NullableType =
     }
 
 export function parseNullableDef(def: ZodNullableDef, refs: Refs): JsonSchema7NullableType | undefined {
+  const inner = def.innerType as ZodTypeAny
   if (
-    ['ZodString', 'ZodNumber', 'ZodBigInt', 'ZodBoolean', 'ZodNull'].includes(def.innerType._def.typeName) &&
-    (!def.innerType._def.checks || !def.innerType._def.checks.length)
+    ['ZodString', 'ZodNumber', 'ZodBigInt', 'ZodBoolean', 'ZodNull'].includes(inner._def.typeName) &&
+    (!inner._def.checks || !inner._def.checks.length)
   ) {
-    const inner = def.innerType
     if (refs.target === 'openApi3') {
       const schema = {
         type: primitiveMappings[inner._def.typeName as keyof typeof primitiveMappings],
@@ -37,7 +37,7 @@ export function parseNullableDef(def: ZodNullableDef, refs: Refs): JsonSchema7Nu
   }
 
   if (refs.target === 'openApi3') {
-    const base = parseDef(def.innerType._def, {
+    const base = parseDef(inner._def, {
       ...refs,
       currentPath: [...refs.currentPath],
     })
@@ -45,7 +45,7 @@ export function parseNullableDef(def: ZodNullableDef, refs: Refs): JsonSchema7Nu
     return base && ({ ...base, nullable: true } as any)
   }
 
-  const base = parseDef(def.innerType._def, {
+  const base = parseDef(inner._def, {
     ...refs,
     currentPath: [...refs.currentPath, 'anyOf', '0'],
   })

--- a/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/object.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/object.ts
@@ -1,6 +1,6 @@
 import { zuiKey } from '../../../ui/constants'
 import { ZuiExtensionObject } from '../../../ui/types'
-import { ZodObjectDef, ZodType } from '../../../z/index'
+import { ZodObjectDef, ZodType, ZodTypeAny } from '../../../z/index'
 import { JsonSchema7Type, parseDef } from '../parseDef'
 import { Refs } from '../Refs'
 
@@ -15,7 +15,7 @@ export type JsonSchema7ObjectType = {
 const getAdditionalProperties = (def: ZodObjectDef, refs: Refs): boolean | JsonSchema7Type => {
   if (def.unknownKeys instanceof ZodType) {
     return (
-      parseDef(def.unknownKeys._def, {
+      parseDef((def.unknownKeys as ZodTypeAny)._def, {
         ...refs,
         currentPath: [...refs.currentPath, 'additionalProperties'],
       }) ?? true
@@ -30,7 +30,7 @@ const getAdditionalProperties = (def: ZodObjectDef, refs: Refs): boolean | JsonS
 export function parseObjectDefX(def: ZodObjectDef, refs: Refs) {
   Object.keys(def.shape()).reduce(
     (schema: JsonSchema7ObjectType, key) => {
-      let prop = def.shape()[key]
+      let prop = def.shape()[key] as ZodTypeAny
       if (typeof prop === 'undefined' || typeof prop._def === 'undefined') {
         return schema
       }
@@ -76,7 +76,7 @@ export function parseObjectDefX(def: ZodObjectDef, refs: Refs) {
           properties: Record<string, JsonSchema7Type>
           required: string[]
         },
-        [propName, propDef]
+        [propName, propDef]: [string, ZodTypeAny]
       ) => {
         if (propDef === undefined || propDef._def === undefined) return acc
         const parsedDef = parseDef(propDef._def, {
@@ -107,7 +107,7 @@ export function parseObjectDef(def: ZodObjectDef, refs: Refs) {
           properties: Record<string, JsonSchema7Type>
           required: string[]
         },
-        [propName, propDef]
+        [propName, propDef]: [string, ZodTypeAny]
       ) => {
         if (propDef === undefined || propDef._def === undefined) return acc
         const parsedDef = parseDef(propDef._def, {

--- a/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/optional.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/optional.ts
@@ -1,13 +1,13 @@
-import { ZodOptionalDef } from '../../../z/index'
+import { ZodOptionalDef, ZodTypeAny } from '../../../z/index'
 import { JsonSchema7Type, parseDef } from '../parseDef'
 import { Refs } from '../Refs'
 
 export const parseOptionalDef = (def: ZodOptionalDef, refs: Refs): JsonSchema7Type | undefined => {
   if (refs.currentPath.toString() === refs.propertyPath?.toString()) {
-    return parseDef(def.innerType._def, refs)
+    return parseDef((def.innerType as ZodTypeAny)._def, refs)
   }
 
-  const innerSchema = parseDef(def.innerType._def, {
+  const innerSchema = parseDef((def.innerType as ZodTypeAny)._def, {
     ...refs,
     currentPath: [...refs.currentPath, 'anyOf', '1'],
   })

--- a/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/promise.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/promise.ts
@@ -1,7 +1,7 @@
-import { ZodPromiseDef } from '../../../z/index'
+import { ZodPromiseDef, ZodTypeAny } from '../../../z/index'
 import { JsonSchema7Type, parseDef } from '../parseDef'
 import { Refs } from '../Refs'
 
 export function parsePromiseDef(def: ZodPromiseDef, refs: Refs): JsonSchema7Type | undefined {
-  return parseDef(def.type._def, refs)
+  return parseDef((def.type as ZodTypeAny)._def, refs)
 }

--- a/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/set.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/set.ts
@@ -1,6 +1,6 @@
 import { zuiKey } from '../../../ui/constants'
 import { ZuiExtensionObject } from '../../../ui/types'
-import { ZodSetDef } from '../../../z/index'
+import { ZodSetDef, ZodTypeAny } from '../../../z/index'
 import { ErrorMessages, setResponseValueAndErrors } from '../errorMessages'
 import { JsonSchema7Type, parseDef } from '../parseDef'
 import { Refs } from '../Refs'
@@ -16,7 +16,7 @@ export type JsonSchema7SetType = {
 }
 
 export function parseSetDef(def: ZodSetDef, refs: Refs): JsonSchema7SetType {
-  const items = parseDef(def.valueType._def, {
+  const items = parseDef((def.valueType as ZodTypeAny)._def, {
     ...refs,
     currentPath: [...refs.currentPath, 'items'],
   })

--- a/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/tuple.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/tuple.ts
@@ -1,6 +1,6 @@
 import { zuiKey } from '../../../ui/constants'
 import { ZuiExtensionObject } from '../../../ui/types'
-import { ZodTupleDef, ZodTupleItems, ZodTypeAny } from '../../../z/index'
+import { ZodTupleDef, ZodTupleItems, ZodType, ZodTypeAny } from '../../../z/index'
 import { JsonSchema7Type, parseDef } from '../parseDef'
 import { Refs } from '../Refs'
 
@@ -18,23 +18,20 @@ export type JsonSchema7TupleType = {
     }
 )
 
-export function parseTupleDef(
-  def: ZodTupleDef<ZodTupleItems | [], ZodTypeAny | null>,
-  refs: Refs
-): JsonSchema7TupleType {
+export function parseTupleDef(def: ZodTupleDef<ZodTupleItems | [], ZodType | null>, refs: Refs): JsonSchema7TupleType {
   if (def.rest) {
     return {
       type: 'array',
       minItems: def.items.length,
       items: def.items
-        .map((x, i) =>
+        .map((x: ZodTypeAny, i) =>
           parseDef(x._def, {
             ...refs,
             currentPath: [...refs.currentPath, 'items', `${i}`],
           })
         )
         .reduce((acc: JsonSchema7Type[], x) => (x === undefined ? acc : [...acc, x]), []),
-      additionalItems: parseDef(def.rest._def, {
+      additionalItems: parseDef((def.rest as ZodTypeAny)._def, {
         ...refs,
         currentPath: [...refs.currentPath, 'additionalItems'],
       }),
@@ -45,7 +42,7 @@ export function parseTupleDef(
       minItems: def.items.length,
       maxItems: def.items.length,
       items: def.items
-        .map((x, i) =>
+        .map((x: ZodTypeAny, i) =>
           parseDef(x._def, {
             ...refs,
             currentPath: [...refs.currentPath, 'items', `${i}`],

--- a/packages/zui/src/transforms/zui-to-json-schema-legacy/zui-extension.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema-legacy/zui-extension.ts
@@ -23,7 +23,7 @@ export type ZuiSchemaOptions = {
  * @deprecated Use the new toJSONSchema function instead.
  */
 export const toJSONSchemaLegacy = (
-  zuiType: z.ZodTypeAny,
+  zuiType: z.ZodType,
   opts: ZuiSchemaOptions = { target: 'openApi3' }
 ): JSONSchema7 => {
   const jsonSchema = zodToJsonSchema(zuiType as z.ZodType, opts)

--- a/packages/zui/src/transforms/zui-to-json-schema/type-processors/array.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema/type-processors/array.ts
@@ -4,7 +4,7 @@ import * as json from '../../common/json-schema'
 
 export const zodArrayToJsonArray = (
   zodArray: z.ZodArray,
-  toSchema: (x: z.ZodTypeAny) => json.Schema
+  toSchema: (x: z.ZodType) => json.Schema
 ): json.ArraySchema => {
   const schema: json.ArraySchema = {
     type: 'array',

--- a/packages/zui/src/transforms/zui-to-json-schema/type-processors/set.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema/type-processors/set.ts
@@ -2,7 +2,7 @@ import { zuiKey } from '../../../ui/constants'
 import z from '../../../z'
 import * as json from '../../common/json-schema'
 
-export const zodSetToJsonSet = (zodSet: z.ZodSet, toSchema: (x: z.ZodTypeAny) => json.Schema): json.SetSchema => {
+export const zodSetToJsonSet = (zodSet: z.ZodSet, toSchema: (x: z.ZodType) => json.Schema): json.SetSchema => {
   const schema: json.SetSchema = {
     type: 'array',
     description: zodSet.description,

--- a/packages/zui/src/transforms/zui-to-json-schema/type-processors/tuple.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema/type-processors/tuple.ts
@@ -4,7 +4,7 @@ import * as json from '../../common/json-schema'
 
 export const zodTupleToJsonTuple = (
   zodTuple: z.ZodTuple,
-  toSchema: (x: z.ZodTypeAny) => json.Schema
+  toSchema: (x: z.ZodType) => json.Schema
 ): json.TupleSchema => {
   const schema: json.TupleSchema = {
     type: 'array',

--- a/packages/zui/src/transforms/zui-to-typescript-schema/index.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-schema/index.ts
@@ -175,7 +175,7 @@ function sUnwrapZod(schema: z.Schema): string {
   }
 }
 
-const _addMetadata = (def: z.ZodTypeDef, inner?: z.ZodTypeAny) => {
+const _addMetadata = (def: z.ZodTypeDef, inner?: z.ZodType) => {
   const innerDef = inner?._def
   return `${_addZuiExtensions(def, innerDef)}${_maybeDescribe(def, innerDef)}`
 }

--- a/packages/zui/src/ui/types.ts
+++ b/packages/zui/src/ui/types.ts
@@ -1,4 +1,5 @@
-import { ZodEnumDef, ZodNativeSchemaDef, z } from '../z'
+import { ZodTypeDef, ZodType, TypeOf } from '../z/types/basetype'
+import { ZodObject } from '../z/types/object'
 
 export type ZuiMetadata = string | number | boolean | null | undefined | ZuiMetadata[] | { [key: string]: ZuiMetadata }
 
@@ -23,12 +24,12 @@ export type UIComponentDefinitions = {
   [T in BaseType]: {
     [K: string]: {
       id: string
-      params: z.ZodObject<any>
+      params: ZodObject<any>
     }
   }
 }
 
-export type ZodKindToBaseType<T extends ZodNativeSchemaDef> = T extends infer U
+export type ZodKindToBaseType<T extends ZodTypeDef> = T extends infer U
   ? U extends { typeName: 'ZodString' }
     ? 'string'
     : U extends { typeName: 'ZodNumber' }
@@ -41,27 +42,24 @@ export type ZodKindToBaseType<T extends ZodNativeSchemaDef> = T extends infer U
             ? 'object'
             : U extends { typeName: 'ZodTuple' }
               ? never
-              : U extends ZodEnumDef
+              : U extends { typeName: 'ZodEnum' }
                 ? 'string'
-                : U extends { typeName: 'ZodDefault'; innerType: z.ZodTypeAny }
+                : U extends { typeName: 'ZodDefault'; innerType: ZodType }
                   ? ZodKindToBaseType<U['innerType']['_def']>
-                  : U extends { typeName: 'ZodOptional'; innerType: z.ZodTypeAny }
+                  : U extends { typeName: 'ZodOptional'; innerType: ZodType }
                     ? ZodKindToBaseType<U['innerType']['_def']>
-                    : U extends { typeName: 'ZodNullable'; innerType: z.ZodTypeAny }
+                    : U extends { typeName: 'ZodNullable'; innerType: ZodType }
                       ? ZodKindToBaseType<U['innerType']['_def']>
-                      : U extends {
-                            typeName: 'ZodDiscriminatedUnion'
-                            options: z.ZodDiscriminatedUnionOption<any>[]
-                          }
+                      : U extends { typeName: 'ZodDiscriminatedUnion' }
                         ? 'discriminatedUnion'
                         : never
   : never
 
 export type ParseSchema<I> = I extends infer U
-  ? U extends { id: string; params: z.AnyZodObject }
+  ? U extends { id: string; params: ZodObject }
     ? {
         id: U['id']
-        params: z.infer<U['params']>
+        params: TypeOf<U['params']>
       }
     : object
   : never

--- a/packages/zui/src/z/__tests__/generics.test.ts
+++ b/packages/zui/src/z/__tests__/generics.test.ts
@@ -3,10 +3,10 @@ import z from '../index'
 import { util } from '../types/utils'
 
 test('generics', () => {
-  async function stripOuter<TData extends z.ZodTypeAny>(schema: TData, data: unknown) {
+  async function stripOuter<TData extends z.ZodType>(schema: TData, data: unknown) {
     return z
       .object({
-        nested: schema, // as z.ZodTypeAny,
+        nested: schema,
       })
       .transform((data) => {
         return data.nested!

--- a/packages/zui/src/z/deref.test.ts
+++ b/packages/zui/src/z/deref.test.ts
@@ -11,7 +11,7 @@ const deref = {
   baz: z.boolean(),
 }
 
-const intersect = (...schemas: z.ZodTypeAny[]) => {
+const intersect = (...schemas: z.ZodType[]) => {
   if (schemas.length === 0) {
     throw new Error('Intersection expects at least one schema')
   }

--- a/packages/zui/src/z/types/array/index.ts
+++ b/packages/zui/src/z/types/array/index.ts
@@ -4,7 +4,6 @@ import {
   ParseInputLazyPath,
   RawCreateParams,
   ZodType,
-  ZodTypeAny,
   ZodTypeDef,
   processCreateParams,
   ZodParsedType,
@@ -16,7 +15,7 @@ import {
   ParseStatus,
 } from '../index'
 
-export type ZodArrayDef<T extends ZodTypeAny = ZodTypeAny> = {
+export type ZodArrayDef<T extends ZodType = ZodType> = {
   type: T
   typeName: 'ZodArray'
   exactLength: { value: number; message?: string } | null
@@ -26,16 +25,16 @@ export type ZodArrayDef<T extends ZodTypeAny = ZodTypeAny> = {
 
 export type ArrayCardinality = 'many' | 'atleastone'
 export type arrayOutputType<
-  T extends ZodTypeAny,
+  T extends ZodType,
   Cardinality extends ArrayCardinality = 'many',
 > = Cardinality extends 'atleastone' ? [T['_output'], ...T['_output'][]] : T['_output'][]
 
-export class ZodArray<T extends ZodTypeAny = ZodTypeAny, Cardinality extends ArrayCardinality = 'many'> extends ZodType<
+export class ZodArray<T extends ZodType = ZodType, Cardinality extends ArrayCardinality = 'many'> extends ZodType<
   arrayOutputType<T, Cardinality>,
   ZodArrayDef<T>,
   Cardinality extends 'atleastone' ? [T['_input'], ...T['_input'][]] : T['_input'][]
 > {
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     return new ZodArray({
       ...this._def,
       type: this._def.type.dereference(defs),
@@ -171,7 +170,7 @@ export class ZodArray<T extends ZodTypeAny = ZodTypeAny, Cardinality extends Arr
     return this.min(1, message) as ZodArray<T, 'atleastone'>
   }
 
-  static create = <T extends ZodTypeAny>(schema: T, params?: RawCreateParams): ZodArray<T> => {
+  static create = <T extends ZodType>(schema: T, params?: RawCreateParams): ZodArray<T> => {
     return new ZodArray({
       type: schema,
       minLength: null,
@@ -183,4 +182,4 @@ export class ZodArray<T extends ZodTypeAny = ZodTypeAny, Cardinality extends Arr
   }
 }
 
-export type ZodNonEmptyArray<T extends ZodTypeAny> = ZodArray<T, 'atleastone'>
+export type ZodNonEmptyArray<T extends ZodType> = ZodArray<T, 'atleastone'>

--- a/packages/zui/src/z/types/basetype/index.ts
+++ b/packages/zui/src/z/types/basetype/index.ts
@@ -38,7 +38,6 @@ import {
   ZodErrorMap,
   ZodIntersection,
   ZodIssueCode,
-  ZodNativeSchemaDef,
   ZodNullable,
   ZodOptional,
   ZodPipeline,

--- a/packages/zui/src/z/types/basetype/index.ts
+++ b/packages/zui/src/z/types/basetype/index.ts
@@ -61,14 +61,11 @@ type __ZodType<Output = any, Input = Output> = {
   readonly _input: Input
 }
 
-type Cast<A, B> = A extends B ? A : B
-
 export type RefinementCtx = {
   addIssue: (arg: IssueData) => void
   path: (string | number)[]
 }
-export type ZodRawShape = { [k: string]: ZodTypeAny }
-export type ZodTypeAny = ZodType<any, any, any>
+export type ZodRawShape = { [k: string]: ZodType }
 export type TypeOf<T extends __ZodType> = T['_output']
 export type OfType<O, T extends __ZodType> = T extends __ZodType<O> ? T : never
 export type input<T extends __ZodType> = T['_input']
@@ -177,7 +174,7 @@ export abstract class ZodType<Output = any, Def extends ZodTypeDef = ZodTypeDef,
   abstract _parse(input: ParseInput): ParseReturnType<Output>
 
   /** deeply replace all references in the schema */
-  dereference(_defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(_defs: Record<string, ZodType>): ZodType {
     return this
   }
 
@@ -448,11 +445,11 @@ export abstract class ZodType<Output = any, Def extends ZodTypeDef = ZodTypeDef,
     return this
   }
 
-  or<T extends ZodTypeAny>(option: T): ZodUnion<[this, T]> {
+  or<T extends ZodType>(option: T): ZodUnion<[this, T]> {
     return ZodUnion.create([this, option], this._def)
   }
 
-  and<T extends ZodTypeAny>(incoming: T): ZodIntersection<this, T> {
+  and<T extends ZodType>(incoming: T): ZodIntersection<this, T> {
     return ZodIntersection.create(this, incoming, this._def)
   }
 
@@ -506,7 +503,7 @@ export abstract class ZodType<Output = any, Def extends ZodTypeDef = ZodTypeDef,
     return clone
   }
 
-  pipe<T extends ZodTypeAny>(target: T): ZodPipeline<this, T> {
+  pipe<T extends ZodType>(target: T): ZodPipeline<this, T> {
     return ZodPipeline.create(this, target)
   }
 
@@ -571,7 +568,7 @@ export abstract class ZodType<Output = any, Def extends ZodTypeDef = ZodTypeDef,
    */
   displayAs<
     UI extends UIComponentDefinitions = UIComponentDefinitions,
-    Type extends BaseType = ZodKindToBaseType<Cast<this['_def'], ZodNativeSchemaDef>>,
+    Type extends BaseType = ZodKindToBaseType<this['_def']>,
   >(options: ParseSchema<UI[Type][keyof UI[Type]]>): this {
     return this.metadata({ displayAs: [options.id, options.params] })
   }
@@ -656,7 +653,7 @@ export abstract class ZodType<Output = any, Def extends ZodTypeDef = ZodTypeDef,
    * Allows removing all wrappers around the schema
    * @returns either this or the closest children schema that represents the actual data
    */
-  naked(): ZodTypeAny {
+  naked(): ZodType {
     return this
   }
 }

--- a/packages/zui/src/z/types/branded/index.ts
+++ b/packages/zui/src/z/types/branded/index.ts
@@ -1,8 +1,8 @@
-import { ZodType, ZodTypeAny, ZodTypeDef, ParseInput, ParseReturnType } from '../index'
+import { ZodType, ZodTypeDef, ParseInput, ParseReturnType } from '../index'
 
 type Key = string | number | symbol
 
-export type ZodBrandedDef<T extends ZodTypeAny = ZodTypeAny> = {
+export type ZodBrandedDef<T extends ZodType = ZodType> = {
   type: T
   typeName: 'ZodBranded'
 } & ZodTypeDef
@@ -14,12 +14,12 @@ export type BRAND<T extends Key = Key> = {
   }
 }
 
-export class ZodBranded<T extends ZodTypeAny = ZodTypeAny, B extends Key = Key> extends ZodType<
+export class ZodBranded<T extends ZodType = ZodType, B extends Key = Key> extends ZodType<
   T['_output'] & BRAND<B>,
   ZodBrandedDef<T>,
   T['_input']
 > {
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     return new ZodBranded({
       ...this._def,
       type: this._def.type.dereference(defs),
@@ -56,11 +56,11 @@ export class ZodBranded<T extends ZodTypeAny = ZodTypeAny, B extends Key = Key> 
     return this._def.type.isEqual(schema._def.type)
   }
 
-  naked(): ZodTypeAny {
+  naked(): ZodType {
     return this._def.type.naked()
   }
 
-  mandatory(): ZodBranded<ZodTypeAny, B> {
+  mandatory(): ZodBranded<ZodType, B> {
     return new ZodBranded({
       ...this._def,
       type: this._def.type.mandatory(),

--- a/packages/zui/src/z/types/catch/index.ts
+++ b/packages/zui/src/z/types/catch/index.ts
@@ -2,7 +2,6 @@ import {
   ZodError,
   RawCreateParams,
   ZodType,
-  ZodTypeAny,
   ZodTypeDef,
   processCreateParams,
   isAsync,
@@ -13,13 +12,13 @@ import {
 } from '../index'
 
 export type CatchFn<Y> = (ctx: { error: ZodError; input: unknown }) => Y
-export type ZodCatchDef<T extends ZodTypeAny = ZodTypeAny> = {
+export type ZodCatchDef<T extends ZodType = ZodType> = {
   innerType: T
   catchValue: CatchFn<T['_output']>
   typeName: 'ZodCatch'
 } & ZodTypeDef
 
-export class ZodCatch<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
+export class ZodCatch<T extends ZodType = ZodType> extends ZodType<
   T['_output'],
   ZodCatchDef<T>,
   unknown // any input will pass validation // T["_input"]
@@ -79,7 +78,7 @@ export class ZodCatch<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this._def.innerType
   }
 
-  static create = <T extends ZodTypeAny>(
+  static create = <T extends ZodType>(
     type: T,
     params: RawCreateParams & {
       catch: T['_output'] | CatchFn<T['_output']>
@@ -101,7 +100,7 @@ export class ZodCatch<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     )
   }
 
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     return new ZodCatch({
       ...this._def,
       innerType: this._def.innerType.dereference(defs),
@@ -123,7 +122,7 @@ export class ZodCatch<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this._def.innerType.naked()
   }
 
-  mandatory(): ZodCatch<ZodTypeAny> {
+  mandatory(): ZodCatch<ZodType> {
     return new ZodCatch({
       ...this._def,
       innerType: this._def.innerType.mandatory(),

--- a/packages/zui/src/z/types/default/index.ts
+++ b/packages/zui/src/z/types/default/index.ts
@@ -3,7 +3,6 @@ import { isEqual } from 'lodash-es'
 import {
   RawCreateParams,
   ZodType,
-  ZodTypeAny,
   ZodTypeDef,
   processCreateParams,
   util,
@@ -12,13 +11,13 @@ import {
   ParseReturnType,
 } from '../index'
 
-export type ZodDefaultDef<T extends ZodTypeAny = ZodTypeAny> = {
+export type ZodDefaultDef<T extends ZodType = ZodType> = {
   innerType: T
   defaultValue: () => util.noUndefined<T['_input']>
   typeName: 'ZodDefault'
 } & ZodTypeDef
 
-export class ZodDefault<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
+export class ZodDefault<T extends ZodType = ZodType> extends ZodType<
   util.noUndefined<T['_output']>,
   ZodDefaultDef<T>,
   T['_input'] | undefined
@@ -40,7 +39,7 @@ export class ZodDefault<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this._def.innerType
   }
 
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     return new ZodDefault({
       ...this._def,
       innerType: this._def.innerType.dereference(defs),
@@ -58,7 +57,7 @@ export class ZodDefault<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     }) as ZodDefault<T>
   }
 
-  static create = <T extends ZodTypeAny>(
+  static create = <T extends ZodType>(
     type: T,
     value: T['_input'] | (() => util.noUndefined<T['_input']>),
     params?: RawCreateParams
@@ -87,7 +86,7 @@ export class ZodDefault<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this._def.innerType.naked()
   }
 
-  mandatory(): ZodDefault<ZodTypeAny> {
+  mandatory(): ZodDefault<ZodType> {
     return new ZodDefault({
       ...this._def,
       innerType: this._def.innerType.mandatory(),

--- a/packages/zui/src/z/types/discriminatedUnion/index.ts
+++ b/packages/zui/src/z/types/discriminatedUnion/index.ts
@@ -10,7 +10,6 @@ import {
   RawCreateParams,
   ZodRawShape,
   ZodType,
-  ZodTypeAny,
   ZodTypeDef,
   ZodLazy,
   ZodLiteral,
@@ -34,7 +33,7 @@ import {
 } from '../index'
 import { CustomSet } from '../utils/custom-set'
 
-const getDiscriminator = <T extends ZodTypeAny>(type: T): Primitive[] => {
+const getDiscriminator = <T extends ZodType>(type: T): Primitive[] => {
   if (type instanceof ZodLazy) {
     return getDiscriminator(type.schema)
   } else if (type instanceof ZodEffects) {
@@ -68,7 +67,7 @@ const getDiscriminator = <T extends ZodTypeAny>(type: T): Primitive[] => {
 
 export type ZodDiscriminatedUnionOption<Discriminator extends string> = ZodObject<
   {
-    [key in Discriminator]: ZodTypeAny
+    [key in Discriminator]: ZodType
   } & ZodRawShape,
   UnknownKeysParam
 >
@@ -87,7 +86,7 @@ export class ZodDiscriminatedUnion<
   Discriminator extends string = string,
   Options extends ZodDiscriminatedUnionOption<Discriminator>[] = ZodDiscriminatedUnionOption<Discriminator>[],
 > extends ZodType<output<Options[number]>, ZodDiscriminatedUnionDef<Discriminator, Options>, input<Options[number]>> {
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     const options = this.options.map((option) => option.dereference(defs)) as [
       ZodDiscriminatedUnionOption<Discriminator>,
       ...ZodDiscriminatedUnionOption<Discriminator>[],

--- a/packages/zui/src/z/types/intersection/index.ts
+++ b/packages/zui/src/z/types/intersection/index.ts
@@ -3,7 +3,6 @@ import {
   ZodIssueCode,
   RawCreateParams,
   ZodType,
-  ZodTypeAny,
   ZodTypeDef,
   getParsedType,
   processCreateParams,
@@ -19,7 +18,7 @@ import {
 } from '../index'
 import { CustomSet } from '../utils/custom-set'
 
-export type ZodIntersectionDef<T extends ZodTypeAny = ZodTypeAny, U extends ZodTypeAny = ZodTypeAny> = {
+export type ZodIntersectionDef<T extends ZodType = ZodType, U extends ZodType = ZodType> = {
   left: T
   right: U
   typeName: 'ZodIntersection'
@@ -71,12 +70,12 @@ function mergeValues(a: any, b: any): { valid: true; data: any } | { valid: fals
   }
 }
 
-export class ZodIntersection<T extends ZodTypeAny = ZodTypeAny, U extends ZodTypeAny = ZodTypeAny> extends ZodType<
+export class ZodIntersection<T extends ZodType = ZodType, U extends ZodType = ZodType> extends ZodType<
   T['_output'] & U['_output'],
   ZodIntersectionDef<T, U>,
   T['_input'] & U['_input']
 > {
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     return new ZodIntersection({
       ...this._def,
       left: this._def.left.dereference(defs),
@@ -151,7 +150,7 @@ export class ZodIntersection<T extends ZodTypeAny = ZodTypeAny, U extends ZodTyp
     }
   }
 
-  static create = <T extends ZodTypeAny, U extends ZodTypeAny>(
+  static create = <T extends ZodType, U extends ZodType>(
     left: T,
     right: U,
     params?: RawCreateParams

--- a/packages/zui/src/z/types/lazy/index.ts
+++ b/packages/zui/src/z/types/lazy/index.ts
@@ -5,22 +5,21 @@ import {
   processCreateParams,
   ParseInput,
   ParseReturnType,
-  ZodTypeAny,
   output,
   input,
 } from '../index'
 
-export type ZodLazyDef<T extends ZodTypeAny = ZodTypeAny> = {
+export type ZodLazyDef<T extends ZodType = ZodType> = {
   getter: () => T
   typeName: 'ZodLazy'
 } & ZodTypeDef
 
-export class ZodLazy<T extends ZodTypeAny = ZodTypeAny> extends ZodType<output<T>, ZodLazyDef<T>, input<T>> {
+export class ZodLazy<T extends ZodType = ZodType> extends ZodType<output<T>, ZodLazyDef<T>, input<T>> {
   get schema(): T {
     return this._def.getter()
   }
 
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     return new ZodLazy({
       ...this._def,
       getter: () => this._def.getter().dereference(defs),
@@ -44,7 +43,7 @@ export class ZodLazy<T extends ZodTypeAny = ZodTypeAny> extends ZodType<output<T
     return lazySchema._parse({ data: ctx.data, path: ctx.path, parent: ctx })
   }
 
-  static create = <T extends ZodTypeAny>(getter: () => T, params?: RawCreateParams): ZodLazy<T> => {
+  static create = <T extends ZodType>(getter: () => T, params?: RawCreateParams): ZodLazy<T> => {
     return new ZodLazy({
       getter,
       typeName: 'ZodLazy',
@@ -61,7 +60,7 @@ export class ZodLazy<T extends ZodTypeAny = ZodTypeAny> extends ZodType<output<T
     return this._def.getter().naked()
   }
 
-  mandatory(): ZodLazy<ZodTypeAny> {
+  mandatory(): ZodLazy<ZodType> {
     return new ZodLazy({
       ...this._def,
       getter: () => this._def.getter().mandatory(),

--- a/packages/zui/src/z/types/map/index.ts
+++ b/packages/zui/src/z/types/map/index.ts
@@ -4,7 +4,6 @@ import {
   ParseInputLazyPath,
   RawCreateParams,
   ZodType,
-  ZodTypeAny,
   ZodTypeDef,
   processCreateParams,
   ZodParsedType,
@@ -15,13 +14,13 @@ import {
   SyncParseReturnType,
 } from '../index'
 
-export type ZodMapDef<Key extends ZodTypeAny = ZodTypeAny, Value extends ZodTypeAny = ZodTypeAny> = {
+export type ZodMapDef<Key extends ZodType = ZodType, Value extends ZodType = ZodType> = {
   valueType: Value
   keyType: Key
   typeName: 'ZodMap'
 } & ZodTypeDef
 
-export class ZodMap<Key extends ZodTypeAny = ZodTypeAny, Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
+export class ZodMap<Key extends ZodType = ZodType, Value extends ZodType = ZodType> extends ZodType<
   Map<Key['_output'], Value['_output']>,
   ZodMapDef<Key, Value>,
   Map<Key['_input'], Value['_input']>
@@ -33,7 +32,7 @@ export class ZodMap<Key extends ZodTypeAny = ZodTypeAny, Value extends ZodTypeAn
     return this._def.valueType
   }
 
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     const keyType = this._def.keyType.dereference(defs)
     const valueType = this._def.valueType.dereference(defs)
     return new ZodMap({
@@ -110,7 +109,7 @@ export class ZodMap<Key extends ZodTypeAny = ZodTypeAny, Value extends ZodTypeAn
       return { status: status.value, value: finalMap }
     }
   }
-  static create = <Key extends ZodTypeAny = ZodTypeAny, Value extends ZodTypeAny = ZodTypeAny>(
+  static create = <Key extends ZodType = ZodType, Value extends ZodType = ZodType>(
     keyType: Key,
     valueType: Value,
     params?: RawCreateParams

--- a/packages/zui/src/z/types/native.ts
+++ b/packages/zui/src/z/types/native.ts
@@ -32,7 +32,6 @@ import {
   ZodString,
   ZodSymbol,
   ZodTuple,
-  ZodType,
   ZodUndefined,
   ZodUnion,
   ZodUnknown,

--- a/packages/zui/src/z/types/native.ts
+++ b/packages/zui/src/z/types/native.ts
@@ -82,9 +82,6 @@ export type ZodNativeSchema =
   | ZodSymbol
   | ZodRef
 
-type ExtractZodDef<T extends ZodType> = T['_def']
-type ExtractedZodDef = ExtractZodDef<ZodNativeSchema>
-
 /**
  * @deprecated - use ZodNativeSchemaDef instead
  */

--- a/packages/zui/src/z/types/native.ts
+++ b/packages/zui/src/z/types/native.ts
@@ -32,6 +32,7 @@ import {
   ZodString,
   ZodSymbol,
   ZodTuple,
+  ZodType,
   ZodUndefined,
   ZodUnion,
   ZodUnknown,
@@ -80,6 +81,9 @@ export type ZodNativeSchema =
   | ZodReadonly
   | ZodSymbol
   | ZodRef
+
+type ExtractZodDef<T extends ZodType> = T['_def']
+type ExtractedZodDef = ExtractZodDef<ZodNativeSchema>
 
 /**
  * @deprecated - use ZodNativeSchemaDef instead

--- a/packages/zui/src/z/types/nullable/index.ts
+++ b/packages/zui/src/z/types/nullable/index.ts
@@ -4,25 +4,24 @@ import {
   ParseReturnType,
   RawCreateParams,
   ZodType,
-  ZodTypeAny,
   ZodTypeDef,
   processCreateParams,
   ZodParsedType,
 } from '../index'
 
-export type ZodNullableDef<T extends ZodTypeAny = ZodTypeAny> = {
+export type ZodNullableDef<T extends ZodType = ZodType> = {
   innerType: T
   typeName: 'ZodNullable'
 } & ZodTypeDef
 
-export type ZodNullableType<T extends ZodTypeAny> = ZodNullable<T>
+export type ZodNullableType<T extends ZodType> = ZodNullable<T>
 
-export class ZodNullable<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
+export class ZodNullable<T extends ZodType = ZodType> extends ZodType<
   T['_output'] | null,
   ZodNullableDef<T>,
   T['_input'] | null
 > {
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     return new ZodNullable({
       ...this._def,
       innerType: this._def.innerType.dereference(defs),
@@ -52,7 +51,7 @@ export class ZodNullable<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this._def.innerType
   }
 
-  static create = <T extends ZodTypeAny>(type: T, params?: RawCreateParams): ZodNullable<T> => {
+  static create = <T extends ZodType>(type: T, params?: RawCreateParams): ZodNullable<T> => {
     return new ZodNullable({
       innerType: type,
       typeName: 'ZodNullable',
@@ -69,7 +68,7 @@ export class ZodNullable<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this._def.innerType.naked()
   }
 
-  mandatory(): ZodNullable<ZodTypeAny> {
+  mandatory(): ZodNullable<ZodType> {
     return new ZodNullable({
       ...this._def,
       innerType: this._def.innerType.mandatory(),

--- a/packages/zui/src/z/types/nullable/nullable.test.ts
+++ b/packages/zui/src/z/types/nullable/nullable.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from 'vitest'
 import * as z from '../../index'
 
-function checkErrors(a: z.ZodTypeAny, bad: any) {
+function checkErrors(a: z.ZodType, bad: any) {
   let expected
   try {
     a.parse(bad)

--- a/packages/zui/src/z/types/object/index.ts
+++ b/packages/zui/src/z/types/object/index.ts
@@ -18,7 +18,6 @@ import {
   RawCreateParams,
   ZodRawShape,
   ZodType,
-  ZodTypeAny,
   ZodTypeDef,
   processCreateParams,
   enumUtil,
@@ -30,7 +29,7 @@ import {
 } from '../index'
 import { CustomSet } from '../utils/custom-set'
 
-export type UnknownKeysParam = 'passthrough' | 'strict' | 'strip' | ZodTypeAny
+export type UnknownKeysParam = 'passthrough' | 'strict' | 'strip' | ZodType
 
 export type ZodObjectDef<
   T extends ZodRawShape = ZodRawShape,
@@ -63,19 +62,19 @@ export type baseObjectInputType<Shape extends ZodRawShape> = objectUtil.addQuest
   [k in keyof Shape]: Shape[k]['_input']
 }>
 
-export type UnknownKeysInputType<T extends UnknownKeysParam> = T extends ZodTypeAny
+export type UnknownKeysInputType<T extends UnknownKeysParam> = T extends ZodType
   ? { [k: string]: T['_input'] | unknown } // extra properties cannot contradict the main properties
   : T extends 'passthrough'
     ? { [k: string]: unknown }
     : {}
 
-export type UnknownKeysOutputType<T extends UnknownKeysParam> = T extends ZodTypeAny
+export type UnknownKeysOutputType<T extends UnknownKeysParam> = T extends ZodType
   ? { [k: string]: T['_output'] | unknown } // extra properties cannot contradict the main properties
   : T extends 'passthrough'
     ? { [k: string]: unknown }
     : {}
 
-export type AdditionalProperties<T extends UnknownKeysParam> = T extends ZodTypeAny
+export type AdditionalProperties<T extends UnknownKeysParam> = T extends ZodType
   ? T
   : T extends 'passthrough'
     ? ZodAny
@@ -83,7 +82,7 @@ export type AdditionalProperties<T extends UnknownKeysParam> = T extends ZodType
       ? ZodNever
       : undefined
 
-export type deoptional<T extends ZodTypeAny> =
+export type deoptional<T extends ZodType> =
   T extends ZodOptional<infer U> ? deoptional<U> : T extends ZodNullable<infer U> ? ZodNullable<deoptional<U>> : T
 
 export type SomeZodObject = ZodObject<ZodRawShape, UnknownKeysParam>
@@ -91,7 +90,7 @@ export type SomeZodObject = ZodObject<ZodRawShape, UnknownKeysParam>
 export type noUnrecognized<Obj extends object, Shape extends object> = {
   [k in keyof Obj]: k extends keyof Shape ? Obj[k] : never
 }
-function deepPartialify(schema: ZodTypeAny): any {
+function deepPartialify(schema: ZodType): any {
   if (schema instanceof ZodObject) {
     const newShape: any = {}
 
@@ -134,9 +133,9 @@ export class ZodObject<
     return (this._cached = { shape, keys })
   }
 
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     const currentShape = this._def.shape()
-    const shape: Record<string, ZodTypeAny> = {}
+    const shape: Record<string, ZodType> = {}
     for (const key in currentShape) {
       shape[key] = currentShape[key]!.dereference(defs)
     }
@@ -156,7 +155,7 @@ export class ZodObject<
   }
 
   clone(): ZodObject<T, UnknownKeys, Output, Input> {
-    const newShape: Record<string, ZodTypeAny> = {}
+    const newShape: Record<string, ZodType> = {}
     const currentShape = this._def.shape()
     for (const [key, value] of Object.entries(currentShape)) {
       newShape[key] = value.clone()
@@ -442,7 +441,7 @@ export class ZodObject<
   //   });
   //   return merged;
   // }
-  setKey<Key extends string, Schema extends ZodTypeAny>(
+  setKey<Key extends string, Schema extends ZodType>(
     key: Key,
     schema: Schema
   ): ZodObject<
@@ -479,7 +478,7 @@ export class ZodObject<
   //   });
   //   return merged;
   // }
-  catchall<Index extends ZodTypeAny>(index: Index): ZodObject<T, Index> {
+  catchall<Index extends ZodType>(index: Index): ZodObject<T, Index> {
     return new ZodObject({
       ...this._def,
       unknownKeys: index,
@@ -550,7 +549,7 @@ export class ZodObject<
     UnknownKeys
   >
   partial(mask?: any) {
-    const newShape: Record<string, ZodTypeAny | undefined> = {}
+    const newShape: Record<string, ZodType | undefined> = {}
 
     util.objectKeys(this.shape).forEach((key) => {
       const fieldSchema = this.shape[key]
@@ -621,7 +620,7 @@ export class ZodObject<
     const thisShape = this._def.shape()
     const thatShape = schema._def.shape()
 
-    type Property = [string, ZodTypeAny]
+    type Property = [string, ZodType]
     const compare = (a: Property, b: Property) => a[0] === b[0] && a[1].isEqual(b[1])
     const thisProps = new CustomSet<Property>(Object.entries(thisShape), { compare })
     const thatProps = new CustomSet<Property>(Object.entries(thatShape), { compare })

--- a/packages/zui/src/z/types/optional/index.ts
+++ b/packages/zui/src/z/types/optional/index.ts
@@ -3,26 +3,25 @@ import {
   ZodParsedType,
   RawCreateParams,
   ZodType,
-  ZodTypeAny,
   ZodTypeDef,
   OK,
   ParseInput,
   ParseReturnType,
 } from '../index'
 
-export type ZodOptionalDef<T extends ZodTypeAny = ZodTypeAny> = {
+export type ZodOptionalDef<T extends ZodType = ZodType> = {
   innerType: T
   typeName: 'ZodOptional'
 } & ZodTypeDef
 
-export type ZodOptionalType<T extends ZodTypeAny> = ZodOptional<T>
+export type ZodOptionalType<T extends ZodType> = ZodOptional<T>
 
-export class ZodOptional<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
+export class ZodOptional<T extends ZodType = ZodType> extends ZodType<
   T['_output'] | undefined,
   ZodOptionalDef<T>,
   T['_input'] | undefined
 > {
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     return new ZodOptional({
       ...this._def,
       innerType: this._def.innerType.dereference(defs),
@@ -52,7 +51,7 @@ export class ZodOptional<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this._def.innerType
   }
 
-  static create = <T extends ZodTypeAny>(type: T, params?: RawCreateParams): ZodOptional<T> => {
+  static create = <T extends ZodType>(type: T, params?: RawCreateParams): ZodOptional<T> => {
     return new ZodOptional({
       innerType: type,
       typeName: 'ZodOptional',
@@ -69,7 +68,7 @@ export class ZodOptional<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this._def.innerType.naked()
   }
 
-  mandatory(): ZodTypeAny {
+  mandatory(): ZodType {
     return this._def.innerType.mandatory()
   }
 }

--- a/packages/zui/src/z/types/optional/optional.test.ts
+++ b/packages/zui/src/z/types/optional/optional.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from 'vitest'
 import * as z from '../../index'
 
-function checkErrors(a: z.ZodTypeAny, bad: any) {
+function checkErrors(a: z.ZodType, bad: any) {
   let expected
   try {
     a.parse(bad)

--- a/packages/zui/src/z/types/pipeline/index.ts
+++ b/packages/zui/src/z/types/pipeline/index.ts
@@ -1,18 +1,18 @@
 import { unique } from '../../utils'
-import { ZodType, ZodTypeAny, ZodTypeDef, DIRTY, INVALID, ParseInput, ParseReturnType } from '../index'
+import { ZodType, ZodTypeDef, DIRTY, INVALID, ParseInput, ParseReturnType } from '../index'
 
-export type ZodPipelineDef<A extends ZodTypeAny = ZodTypeAny, B extends ZodTypeAny = ZodTypeAny> = {
+export type ZodPipelineDef<A extends ZodType = ZodType, B extends ZodType = ZodType> = {
   in: A
   out: B
   typeName: 'ZodPipeline'
 } & ZodTypeDef
 
-export class ZodPipeline<A extends ZodTypeAny = ZodTypeAny, B extends ZodTypeAny = ZodTypeAny> extends ZodType<
+export class ZodPipeline<A extends ZodType = ZodType, B extends ZodType = ZodType> extends ZodType<
   B['_output'],
   ZodPipelineDef<A, B>,
   A['_input']
 > {
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     return new ZodPipeline({
       ...this._def,
       in: this._def.in.dereference(defs),
@@ -77,7 +77,7 @@ export class ZodPipeline<A extends ZodTypeAny = ZodTypeAny, B extends ZodTypeAny
     }
   }
 
-  static create<A extends ZodTypeAny, B extends ZodTypeAny>(a: A, b: B): ZodPipeline<A, B> {
+  static create<A extends ZodType, B extends ZodType>(a: A, b: B): ZodPipeline<A, B> {
     return new ZodPipeline({
       in: a,
       out: b,

--- a/packages/zui/src/z/types/promise/index.ts
+++ b/packages/zui/src/z/types/promise/index.ts
@@ -2,7 +2,6 @@ import {
   ZodIssueCode,
   RawCreateParams,
   ZodType,
-  ZodTypeAny,
   ZodTypeDef,
   processCreateParams,
   ZodParsedType,
@@ -13,12 +12,12 @@ import {
   ParseReturnType,
 } from '../index'
 
-export type ZodPromiseDef<T extends ZodTypeAny = ZodTypeAny> = {
+export type ZodPromiseDef<T extends ZodType = ZodType> = {
   type: T
   typeName: 'ZodPromise'
 } & ZodTypeDef
 
-export class ZodPromise<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
+export class ZodPromise<T extends ZodType = ZodType> extends ZodType<
   Promise<T['_output']>,
   ZodPromiseDef<T>,
   Promise<T['_input']>
@@ -27,7 +26,7 @@ export class ZodPromise<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this._def.type
   }
 
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     return new ZodPromise({
       ...this._def,
       type: this._def.type.dereference(defs),
@@ -68,7 +67,7 @@ export class ZodPromise<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     )
   }
 
-  static create = <T extends ZodTypeAny>(schema: T, params?: RawCreateParams): ZodPromise<T> => {
+  static create = <T extends ZodType>(schema: T, params?: RawCreateParams): ZodPromise<T> => {
     return new ZodPromise({
       type: schema,
       typeName: 'ZodPromise',
@@ -76,7 +75,7 @@ export class ZodPromise<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     })
   }
 
-  isEqual(schema: ZodTypeAny): boolean {
+  isEqual(schema: ZodType): boolean {
     if (!(schema instanceof ZodPromise)) return false
     return this._def.type.isEqual(schema._def.type)
   }

--- a/packages/zui/src/z/types/readonly/index.ts
+++ b/packages/zui/src/z/types/readonly/index.ts
@@ -2,7 +2,6 @@ import {
   processCreateParams,
   RawCreateParams,
   ZodType,
-  ZodTypeAny,
   ZodTypeDef,
   isValid,
   ParseInput,
@@ -31,17 +30,17 @@ type MakeReadonly<T> =
             ? T
             : Readonly<T>
 
-export type ZodReadonlyDef<T extends ZodTypeAny = ZodTypeAny> = {
+export type ZodReadonlyDef<T extends ZodType = ZodType> = {
   innerType: T
   typeName: 'ZodReadonly'
 } & ZodTypeDef
 
-export class ZodReadonly<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
+export class ZodReadonly<T extends ZodType = ZodType> extends ZodType<
   MakeReadonly<T['_output']>,
   ZodReadonlyDef<T>,
   MakeReadonly<T['_input']>
 > {
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     return new ZodReadonly({
       ...this._def,
       innerType: this._def.innerType.dereference(defs),
@@ -67,7 +66,7 @@ export class ZodReadonly<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return result
   }
 
-  static create = <T extends ZodTypeAny>(type: T, params?: RawCreateParams): ZodReadonly<T> => {
+  static create = <T extends ZodType>(type: T, params?: RawCreateParams): ZodReadonly<T> => {
     return new ZodReadonly({
       innerType: type,
       typeName: 'ZodReadonly',
@@ -88,7 +87,7 @@ export class ZodReadonly<T extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this._def.innerType.naked()
   }
 
-  mandatory(): ZodReadonly<ZodTypeAny> {
+  mandatory(): ZodReadonly<ZodType> {
     return new ZodReadonly({
       ...this._def,
       innerType: this._def.innerType.mandatory(),

--- a/packages/zui/src/z/types/record/index.ts
+++ b/packages/zui/src/z/types/record/index.ts
@@ -5,7 +5,6 @@ import {
   ParseInputLazyPath,
   RawCreateParams,
   ZodType,
-  ZodTypeAny,
   ZodTypeDef,
   ZodString,
   processCreateParams,
@@ -17,7 +16,7 @@ import {
   ParseStatus,
 } from '../index'
 
-export type ZodRecordDef<Key extends KeySchema = ZodString, Value extends ZodTypeAny = ZodTypeAny> = {
+export type ZodRecordDef<Key extends KeySchema = ZodString, Value extends ZodType = ZodType> = {
   valueType: Value
   keyType: Key
   typeName: 'ZodRecord'
@@ -35,7 +34,7 @@ export type RecordType<K extends string | number | symbol, V> = [string] extends
         ? Record<K, V>
         : Partial<Record<K, V>>
 
-export class ZodRecord<Key extends KeySchema = ZodString, Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
+export class ZodRecord<Key extends KeySchema = ZodString, Value extends ZodType = ZodType> extends ZodType<
   RecordType<Key['_output'], Value['_output']>,
   ZodRecordDef<Key, Value>,
   RecordType<Key['_input'], Value['_input']>
@@ -47,7 +46,7 @@ export class ZodRecord<Key extends KeySchema = ZodString, Value extends ZodTypeA
     return this._def.valueType
   }
 
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     const keyType = this._def.keyType.dereference(defs)
     const valueType = this._def.valueType.dereference(defs)
     return new ZodRecord({
@@ -106,8 +105,8 @@ export class ZodRecord<Key extends KeySchema = ZodString, Value extends ZodTypeA
     return this._def.valueType
   }
 
-  static create<Value extends ZodTypeAny>(valueType: Value, params?: RawCreateParams): ZodRecord<ZodString, Value>
-  static create<Keys extends KeySchema, Value extends ZodTypeAny>(
+  static create<Value extends ZodType>(valueType: Value, params?: RawCreateParams): ZodRecord<ZodString, Value>
+  static create<Keys extends KeySchema, Value extends ZodType>(
     keySchema: Keys,
     valueType: Value,
     params?: RawCreateParams

--- a/packages/zui/src/z/types/ref/index.ts
+++ b/packages/zui/src/z/types/ref/index.ts
@@ -1,13 +1,4 @@
-import {
-  ZodType,
-  ZodTypeDef,
-  INVALID,
-  ParseInput,
-  ParseReturnType,
-  ZodTypeAny,
-  addIssueToContext,
-  ZodIssueCode,
-} from '../index'
+import { ZodType, ZodTypeDef, INVALID, ParseInput, ParseReturnType, addIssueToContext, ZodIssueCode } from '../index'
 
 export type ZodRefDef = {
   typeName: 'ZodRef'
@@ -17,7 +8,7 @@ export type ZodRefDef = {
 type ZodRefOutput = NonNullable<unknown>
 
 export class ZodRef extends ZodType<ZodRefOutput, ZodRefDef> {
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     const def = defs[this._def.uri]
     if (!def) {
       return this

--- a/packages/zui/src/z/types/set/index.ts
+++ b/packages/zui/src/z/types/set/index.ts
@@ -3,7 +3,6 @@ import {
   ParseInputLazyPath,
   RawCreateParams,
   ZodType,
-  ZodTypeAny,
   ZodTypeDef,
   processCreateParams,
   ZodParsedType,
@@ -15,19 +14,19 @@ import {
   SyncParseReturnType,
 } from '../index'
 
-export type ZodSetDef<Value extends ZodTypeAny = ZodTypeAny> = {
+export type ZodSetDef<Value extends ZodType = ZodType> = {
   valueType: Value
   typeName: 'ZodSet'
   minSize: { value: number; message?: string } | null
   maxSize: { value: number; message?: string } | null
 } & ZodTypeDef
 
-export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
+export class ZodSet<Value extends ZodType = ZodType> extends ZodType<
   Set<Value['_output']>,
   ZodSetDef<Value>,
   Set<Value['_input']>
 > {
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     return new ZodSet({
       ...this._def,
       valueType: this._def.valueType.dereference(defs),
@@ -131,10 +130,7 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this.min(1, message) as this
   }
 
-  static create = <Value extends ZodTypeAny = ZodTypeAny>(
-    valueType: Value,
-    params?: RawCreateParams
-  ): ZodSet<Value> => {
+  static create = <Value extends ZodType = ZodType>(valueType: Value, params?: RawCreateParams): ZodSet<Value> => {
     return new ZodSet({
       valueType,
       minSize: null,

--- a/packages/zui/src/z/types/transformer/index.ts
+++ b/packages/zui/src/z/types/transformer/index.ts
@@ -5,7 +5,6 @@ import {
   RawCreateParams,
   RefinementCtx,
   ZodType,
-  ZodTypeAny,
   ZodTypeDef,
   processCreateParams,
   util,
@@ -34,13 +33,13 @@ export type PreprocessEffect<T> = {
 }
 export type Effect<T> = RefinementEffect<T> | TransformEffect<T> | PreprocessEffect<T>
 
-export type ZodEffectsDef<T extends ZodTypeAny = ZodTypeAny> = {
+export type ZodEffectsDef<T extends ZodType = ZodType> = {
   schema: T
   typeName: 'ZodEffects'
   effect: Effect<any>
 } & ZodTypeDef
 
-export class ZodEffects<T extends ZodTypeAny = ZodTypeAny, Output = output<T>, Input = input<T>> extends ZodType<
+export class ZodEffects<T extends ZodType = ZodType, Output = output<T>, Input = input<T>> extends ZodType<
   Output,
   ZodEffectsDef<T>,
   Input
@@ -58,7 +57,7 @@ export class ZodEffects<T extends ZodTypeAny = ZodTypeAny, Output = output<T>, I
       : (this._def.schema as T)
   }
 
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
+  dereference(defs: Record<string, ZodType>): ZodType {
     return new ZodEffects({
       ...this._def,
       schema: this._def.schema.dereference(defs),
@@ -209,7 +208,7 @@ export class ZodEffects<T extends ZodTypeAny = ZodTypeAny, Output = output<T>, I
     })
   }
 
-  static createWithPreprocess = <I extends ZodTypeAny>(
+  static createWithPreprocess = <I extends ZodType>(
     preprocess: (arg: unknown, ctx: RefinementCtx) => unknown,
     schema: I,
     params?: RawCreateParams
@@ -249,7 +248,7 @@ export class ZodEffects<T extends ZodTypeAny = ZodTypeAny, Output = output<T>, I
     return this._def.schema.naked()
   }
 
-  mandatory(): ZodEffects<ZodTypeAny> {
+  mandatory(): ZodEffects<ZodType> {
     return new ZodEffects({
       ...this._def,
       schema: this._def.schema.mandatory(),

--- a/packages/zui/src/z/types/tuple/index.ts
+++ b/packages/zui/src/z/types/tuple/index.ts
@@ -4,7 +4,6 @@ import {
   ParseInputLazyPath,
   RawCreateParams,
   ZodType,
-  ZodTypeAny,
   ZodTypeDef,
   processCreateParams,
   ZodParsedType,
@@ -17,37 +16,37 @@ import {
 } from '../index'
 import { CustomSet } from '../utils/custom-set'
 
-export type ZodTupleItems = [ZodTypeAny, ...ZodTypeAny[]]
+export type ZodTupleItems = [ZodType, ...ZodType[]]
 export type AssertArray<T> = T extends any[] ? T : never
 export type OutputTypeOfTuple<T extends ZodTupleItems | []> = AssertArray<{
   [k in keyof T]: T[k] extends ZodType<any, any> ? T[k]['_output'] : never
 }>
 export type OutputTypeOfTupleWithRest<
   T extends ZodTupleItems | [],
-  Rest extends ZodTypeAny | null = null,
-> = Rest extends ZodTypeAny ? [...OutputTypeOfTuple<T>, ...Rest['_output'][]] : OutputTypeOfTuple<T>
+  Rest extends ZodType | null = null,
+> = Rest extends ZodType ? [...OutputTypeOfTuple<T>, ...Rest['_output'][]] : OutputTypeOfTuple<T>
 
 export type InputTypeOfTuple<T extends ZodTupleItems | []> = AssertArray<{
   [k in keyof T]: T[k] extends ZodType<any, any> ? T[k]['_input'] : never
 }>
 export type InputTypeOfTupleWithRest<
   T extends ZodTupleItems | [],
-  Rest extends ZodTypeAny | null = null,
-> = Rest extends ZodTypeAny ? [...InputTypeOfTuple<T>, ...Rest['_input'][]] : InputTypeOfTuple<T>
+  Rest extends ZodType | null = null,
+> = Rest extends ZodType ? [...InputTypeOfTuple<T>, ...Rest['_input'][]] : InputTypeOfTuple<T>
 
-export type ZodTupleDef<T extends ZodTupleItems | [] = ZodTupleItems, Rest extends ZodTypeAny | null = null> = {
+export type ZodTupleDef<T extends ZodTupleItems | [] = ZodTupleItems, Rest extends ZodType | null = null> = {
   items: T
   rest: Rest
   typeName: 'ZodTuple'
 } & ZodTypeDef
 
-export type AnyZodTuple = ZodTuple<[ZodTypeAny, ...ZodTypeAny[]] | [], ZodTypeAny | null>
+export type AnyZodTuple = ZodTuple<[ZodType, ...ZodType[]] | [], ZodType | null>
 export class ZodTuple<
-  T extends [ZodTypeAny, ...ZodTypeAny[]] | [] = [ZodTypeAny, ...ZodTypeAny[]],
-  Rest extends ZodTypeAny | null = null,
+  T extends [ZodType, ...ZodType[]] | [] = [ZodType, ...ZodType[]],
+  Rest extends ZodType | null = null,
 > extends ZodType<OutputTypeOfTupleWithRest<T, Rest>, ZodTupleDef<T, Rest>, InputTypeOfTupleWithRest<T, Rest>> {
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
-    const items = this._def.items.map((item) => item.dereference(defs)) as [ZodTypeAny, ...ZodTypeAny[]]
+  dereference(defs: Record<string, ZodType>): ZodType {
+    const items = this._def.items.map((item) => item.dereference(defs)) as [ZodType, ...ZodType[]]
     const rest = this._def.rest ? this._def.rest.dereference(defs) : null
     return new ZodTuple({
       ...this._def,
@@ -64,7 +63,7 @@ export class ZodTuple<
   }
 
   clone(): ZodTuple<T, Rest> {
-    const items = this._def.items.map((item) => item.clone()) as [ZodTypeAny, ...ZodTypeAny[]]
+    const items = this._def.items.map((item) => item.clone()) as [ZodType, ...ZodType[]]
     const rest = this._def.rest ? this._def.rest.clone() : null
     return new ZodTuple({
       ...this._def,
@@ -130,17 +129,14 @@ export class ZodTuple<
     return this._def.items
   }
 
-  rest<Rest extends ZodTypeAny>(rest: Rest): ZodTuple<T, Rest> {
+  rest<Rest extends ZodType>(rest: Rest): ZodTuple<T, Rest> {
     return new ZodTuple({
       ...this._def,
       rest,
     })
   }
 
-  static create = <T extends [ZodTypeAny, ...ZodTypeAny[]] | []>(
-    schemas: T,
-    params?: RawCreateParams
-  ): ZodTuple<T, null> => {
+  static create = <T extends [ZodType, ...ZodType[]] | []>(schemas: T, params?: RawCreateParams): ZodTuple<T, null> => {
     if (!Array.isArray(schemas)) {
       throw new Error('You must pass an array of schemas to z.tuple([ ... ])')
     }

--- a/packages/zui/src/z/types/union/index.ts
+++ b/packages/zui/src/z/types/union/index.ts
@@ -2,7 +2,6 @@ import { unique } from '../../utils'
 import {
   RawCreateParams,
   ZodType,
-  ZodTypeAny,
   ZodTypeDef,
   ZodError,
   ZodIssue,
@@ -20,8 +19,8 @@ import {
 } from '../index'
 import { CustomSet } from '../utils/custom-set'
 
-type DefaultZodUnionOptions = Readonly<[ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]>
-export type ZodUnionOptions = Readonly<[ZodTypeAny, ...ZodTypeAny[]]>
+type DefaultZodUnionOptions = Readonly<[ZodType, ZodType, ...ZodType[]]>
+export type ZodUnionOptions = Readonly<[ZodType, ...ZodType[]]>
 export type ZodUnionDef<T extends ZodUnionOptions = DefaultZodUnionOptions> = {
   options: T
   typeName: 'ZodUnion'
@@ -32,12 +31,8 @@ export class ZodUnion<T extends ZodUnionOptions = DefaultZodUnionOptions> extend
   ZodUnionDef<T>,
   T[number]['_input']
 > {
-  dereference(defs: Record<string, ZodTypeAny>): ZodTypeAny {
-    const options = this._def.options.map((option) => option.dereference(defs)) as [
-      ZodTypeAny,
-      ZodTypeAny,
-      ...ZodTypeAny[],
-    ]
+  dereference(defs: Record<string, ZodType>): ZodType {
+    const options = this._def.options.map((option) => option.dereference(defs)) as [ZodType, ZodType, ...ZodType[]]
     return new ZodUnion({
       ...this._def,
       options,
@@ -53,7 +48,7 @@ export class ZodUnion<T extends ZodUnionOptions = DefaultZodUnionOptions> extend
   }
 
   clone(): ZodUnion<T> {
-    const options = this._def.options.map((option) => option.clone()) as [ZodTypeAny, ...ZodTypeAny[]]
+    const options = this._def.options.map((option) => option.clone()) as [ZodType, ...ZodType[]]
     return new ZodUnion({
       ...this._def,
       options,
@@ -159,7 +154,7 @@ export class ZodUnion<T extends ZodUnionOptions = DefaultZodUnionOptions> extend
     return this._def.options
   }
 
-  static create = <T extends Readonly<[ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]>>(
+  static create = <T extends Readonly<[ZodType, ZodType, ...ZodType[]]>>(
     types: T,
     params?: RawCreateParams
   ): ZodUnion<T> => {

--- a/packages/zui/src/z/types/utils/partialUtil.ts
+++ b/packages/zui/src/z/types/utils/partialUtil.ts
@@ -6,10 +6,10 @@ import type {
   ZodTuple,
   ZodTupleItems,
   ZodRawShape,
-  ZodTypeAny,
+  ZodType,
 } from '../index'
 export namespace partialUtil {
-  export type DeepPartial<T extends ZodTypeAny> =
+  export type DeepPartial<T extends ZodType> =
     T extends ZodObject<ZodRawShape>
       ? ZodObject<{ [k in keyof T['shape']]: ZodOptional<DeepPartial<T['shape'][k]>> }, T['_def']['unknownKeys']>
       : T extends ZodArray<infer Type, infer Card>
@@ -20,7 +20,7 @@ export namespace partialUtil {
             ? ZodNullable<DeepPartial<Type>>
             : T extends ZodTuple<infer Items>
               ? {
-                  [k in keyof Items]: Items[k] extends ZodTypeAny ? DeepPartial<Items[k]> : never
+                  [k in keyof Items]: Items[k] extends ZodType ? DeepPartial<Items[k]> : never
                 } extends infer PI
                 ? PI extends ZodTupleItems
                   ? ZodTuple<PI>

--- a/packages/zui/src/z/z.ts
+++ b/packages/zui/src/z/z.ts
@@ -164,3 +164,8 @@ export * from './types/utils'
 export * from './types/utils/parseUtil'
 export * from './types/utils/typeAliases'
 export * from './extensions'
+
+/**
+ * @deprecated - use ZodType instead
+ */
+export type ZodTypeAny = ZodType<any, any, any>

--- a/packages/zui/src/zui.test.ts
+++ b/packages/zui/src/zui.test.ts
@@ -94,7 +94,7 @@ test('Discriminated Unions', () => {
 })
 
 test('ZuiTypeAny', () => {
-  const func = (type: zui.ZodTypeAny) => {
+  const func = (type: zui.ZodType) => {
     return type
   }
 


### PR DESCRIPTION
no more usage of the type `ZodTypeAny` internally (except in the legacy transformers, because I didnt want to touch the logic)