### PR TITLE
feat(zai): add maxGroups and minElements options to zai.group

### DIFF
--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "2.5.17",
+  "version": "2.5.18",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/zai/src/operations/group.ts
+++ b/packages/zai/src/operations/group.ts
@@ -721,9 +721,7 @@ ${END}`.trim()
         for (let i = 1; i < sourceGroupIds.length; i++) {
           const sourceGid = sourceGroupIds[i]
           const sourceSet = groupElements.get(sourceGid)!
-          for (const elemIdx of sourceSet) {
-            targetSet.add(elemIdx)
-          }
+          sourceSet.forEach((elemIdx) => targetSet.add(elemIdx))
           sourceSet.clear()
         }
       }


### PR DESCRIPTION
## Summary
- Add `maxGroups` option to limit the number of groups. When exceeded, groups are merged using AI to combine semantically related categories. Minimum value is 2 (throws otherwise).
- Add `minElements` option to enforce a minimum number of elements per group. Undersized groups have their elements redistributed via `processChunk` against valid groups, with a safety fallback to merge any remaining undersized groups into the largest one.
- Both options work together: `maxGroups` runs first (Phase 4), then `minElements` (Phase 5).

## Test plan
- [x] `maxGroups`: limits groups by AI-driven merge, preserves all elements, throws on < 2, respects ALL CAPS / snake_case naming in merge labels
- [x] `minElements`: redistributes orphans via processChunk, works when all groups are undersized, preserves all elements, works combined with `maxGroups`
- [x] All 40 e2e tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)