### PR TITLE
feat(zai): add support for memoizer

### DIFF
--- a/packages/zai/e2e/memoize.test.ts
+++ b/packages/zai/e2e/memoize.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi } from 'vitest'
+import { z } from '@bpinternal/zui'
+
+import { Zai, type Memoizer } from '../src'
+
+let _responseText = ''
+
+const createMockCognitive = () => {
+  const mock: any = {
+    $$IS_COGNITIVE: true,
+    clone() {
+      return { ...mock, clone: mock.clone, on: mock.on }
+    },
+    on: vi.fn(() => () => {}),
+    generateContent: vi.fn(async () => ({
+      output: { choices: [{ content: _responseText }] },
+      meta: { cached: false, tokens: { input: 10, output: 10 }, cost: { input: 0.001, output: 0.001 } },
+    })),
+    getModelDetails: vi.fn(async () => ({
+      input: { maxTokens: 100_000 },
+      output: { maxTokens: 4096 },
+    })),
+  }
+  return mock
+}
+
+const createSequenceMock = (responses: string[]) => {
+  let callCount = 0
+  const mock = createMockCognitive()
+  mock.generateContent = vi.fn(async () => {
+    const text = responses[callCount] ?? responses[responses.length - 1]
+    callCount++
+    return {
+      output: { choices: [{ content: text }] },
+      meta: { cached: false, tokens: { input: 10, output: 10 }, cost: { input: 0.001, output: 0.001 } },
+    }
+  })
+  return mock
+}
+
+const createSpyMemoizer = () => {
+  const spy = vi.fn(async (_id: string, fn: () => Promise<any>) => fn())
+  const factory = () => ({ run: spy }) as Memoizer
+  return { factory, spy }
+}
+
+describe('memoizer integration', { timeout: 10_000 }, () => {
+  it('zai.check calls memoizer at least 1 time', async () => {
+    _responseText = 'The text is in English.\n■TRUE■\n■END■'
+    const { factory, spy } = createSpyMemoizer()
+    const zai = new Zai({ client: createMockCognitive(), memoize: factory })
+    await zai.check('Hello world', 'is english')
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0]![0]).toMatch(/^zai:memo:zai\.check:/)
+  })
+
+  it('zai.extract calls memoizer at least 1 time', async () => {
+    _responseText = '■json_start■\n{"name": "John", "age": 30}\n■json_end■\n■NO_MORE_ELEMENT■'
+    const { factory, spy } = createSpyMemoizer()
+    const zai = new Zai({ client: createMockCognitive(), memoize: factory })
+    const schema = z.object({ name: z.string(), age: z.number() })
+    await zai.extract('John is 30 years old', schema)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0]![0]).toMatch(/^zai:memo:zai\.extract:/)
+  })
+
+  it('zai.text calls memoizer at least 1 time', async () => {
+    _responseText = 'Hello, this is generated text.'
+    const { factory, spy } = createSpyMemoizer()
+    const zai = new Zai({ client: createMockCognitive(), memoize: factory })
+    await zai.text('Write a greeting')
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0]![0]).toMatch(/^zai:memo:zai\.text:/)
+  })
+
+  it('zai.check calls memoizer at least 1 time (non-factory)', async () => {
+    _responseText = 'The text is in English.\n■TRUE■\n■END■'
+    const spy = vi.fn(async (_id: string, fn: () => Promise<any>) => fn())
+    const memoizer: Memoizer = { run: spy }
+    const zai = new Zai({ client: createMockCognitive(), memoize: memoizer })
+    await zai.check('Hello world', 'is english')
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('zai.filter calls memoizer at least 1 time', async () => {
+    _responseText = '■0:true■1:false■END■'
+    const { factory, spy } = createSpyMemoizer()
+    const zai = new Zai({ client: createMockCognitive(), memoize: factory })
+    await zai.filter(['apple', 'rock'], 'is a fruit')
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0]![0]).toMatch(/^zai:memo:zai\.filter:/)
+  })
+
+  it('zai.label calls memoizer at least 1 time', async () => {
+    _responseText = '■positive:【The text sounds happy】:ABSOLUTELY_YES■\n■END■'
+    const { factory, spy } = createSpyMemoizer()
+    const zai = new Zai({ client: createMockCognitive(), memoize: factory })
+    await zai.label('I love this!', { positive: 'is positive sentiment' })
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0]![0]).toMatch(/^zai:memo:zai\.label:/)
+  })
+
+  it('zai.rate calls memoizer at least 1 time', async () => {
+    // rate has 2 phases: criteria generation (expects JSON) + scoring
+    const mock = createSequenceMock([
+      '```json\n{"quality": {"very_bad": "terrible", "bad": "poor", "average": "ok", "good": "nice", "very_good": "excellent"}}\n```',
+      '■0:quality=good■\n■END■',
+    ])
+    const { factory, spy } = createSpyMemoizer()
+    const zai = new Zai({ client: mock, memoize: factory })
+    await zai.rate(['item1'], 'quality')
+    expect(spy.mock.calls.length).toBeGreaterThanOrEqual(1)
+    expect(spy.mock.calls[0]![0]).toMatch(/^zai:memo:zai\.rate:/)
+  })
+
+  it('zai.sort calls memoizer at least 1 time', async () => {
+    // sort has 2 phases: criteria generation + scoring
+    const mock = createSequenceMock([
+      '■relevance■\nlow;medium;high\n■END■',
+      '■0:relevance=high■\n■1:relevance=low■\n■END■',
+    ])
+    const { factory, spy } = createSpyMemoizer()
+    const zai = new Zai({ client: mock, memoize: factory })
+    await zai.sort(['banana', 'apple'], 'alphabetical order')
+    expect(spy.mock.calls.length).toBeGreaterThanOrEqual(2)
+    expect(spy.mock.calls[0]![0]).toMatch(/^zai:memo:zai\.sort:/)
+  })
+
+  it('zai.answer calls memoizer at least 1 time', async () => {
+    _responseText = '■answer\nBotpress was founded in 2016 ■001.\n■end■'
+    const { factory, spy } = createSpyMemoizer()
+    const zai = new Zai({ client: createMockCognitive(), memoize: factory })
+    await zai.answer(['Botpress was founded in 2016.'], 'When was Botpress founded?')
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0]![0]).toMatch(/^zai:memo:zai\.answer:/)
+  })
+
+  it('zai.summarize calls memoizer at least 1 time', async () => {
+    _responseText = '■START■\nThis is a summary of the text.\n■END■'
+    const { factory, spy } = createSpyMemoizer()
+    const zai = new Zai({ client: createMockCognitive(), memoize: factory })
+    await zai.summarize('This is a long text that needs to be summarized.', { length: 20 })
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0]![0]).toMatch(/^zai:memo:summarize:/)
+  })
+
+  it('zai.rewrite calls memoizer at least 1 time', async () => {
+    _responseText = '■START■\nBonjour le monde\n■END■'
+    const { factory, spy } = createSpyMemoizer()
+    const zai = new Zai({ client: createMockCognitive(), memoize: factory })
+    await zai.rewrite('Hello world', 'Translate to French')
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0]![0]).toMatch(/^zai:memo:zai\.rewrite:/)
+  })
+
+  it('zai.patch calls memoizer at least 1 time', async () => {
+    _responseText = '<FILE path="hello.ts">\n◼︎=1|console.log("Hi")\n</FILE>'
+    const { factory, spy } = createSpyMemoizer()
+    const zai = new Zai({ client: createMockCognitive(), memoize: factory })
+    await zai.patch([{ name: 'hello.ts', path: 'hello.ts', content: 'console.log("Hello")' }], 'Change Hello to Hi')
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy.mock.calls[0]![0]).toMatch(/^zai:memo:zai\.patch:/)
+  })
+
+  it('zai.group calls memoizer at least 1 time', async () => {
+    _responseText = '■0:Fruits■\n■1:Vegetables■\n■END■'
+    const { factory, spy } = createSpyMemoizer()
+    const zai = new Zai({ client: createMockCognitive(), memoize: factory })
+    await zai.group(['apple', 'carrot'])
+    // group may do multiple passes (initial + merge)
+    expect(spy.mock.calls.length).toBeGreaterThanOrEqual(1)
+    expect(spy.mock.calls[0]![0]).toMatch(/^zai:memo:zai\.group:/)
+  })
+
+  it('memoizer key is deterministic for same inputs', async () => {
+    _responseText = 'The text is in English.\n■TRUE■\n■END■'
+    const { factory, spy } = createSpyMemoizer()
+    const zai = new Zai({ client: createMockCognitive(), memoize: factory })
+
+    await zai.check('Hello world', 'is english')
+    await zai.check('Hello world', 'is english')
+
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy.mock.calls[0]![0]).toBe(spy.mock.calls[1]![0])
+  })
+
+  it('memoizer key differs for different inputs', async () => {
+    _responseText = 'The text is in English.\n■TRUE■\n■END■'
+    const { factory, spy } = createSpyMemoizer()
+    const zai = new Zai({ client: createMockCognitive(), memoize: factory })
+
+    await zai.check('Hello world', 'is english')
+    await zai.check('Bonjour le monde', 'is english')
+
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy.mock.calls[0]![0]).not.toBe(spy.mock.calls[1]![0])
+  })
+
+  it('memoizer key differs for different operations', async () => {
+    const { factory, spy } = createSpyMemoizer()
+    const zai = new Zai({ client: createMockCognitive(), memoize: factory })
+
+    _responseText = 'The text is in English.\n■TRUE■\n■END■'
+    await zai.check('Hello', 'is english')
+
+    _responseText = 'Generated text.'
+    await zai.text('Hello')
+
+    expect(spy).toHaveBeenCalledTimes(2)
+    expect(spy.mock.calls[0]![0]).not.toBe(spy.mock.calls[1]![0])
+  })
+
+  it('memoizer can short-circuit and return cached result', async () => {
+    // The check transform returns { finalAnswer, explanation }, so the cached result must match
+    const cachedResult = {
+      meta: { cached: true, tokens: { input: 0, output: 0 }, cost: { input: 0, output: 0 } },
+      output: { choices: [{ content: '' }] },
+      text: '',
+      extracted: { finalAnswer: true, explanation: 'cached' },
+    }
+
+    const spy = vi.fn(async (_id: string, _fn: () => Promise<any>) => cachedResult)
+    const memoizer: Memoizer = { run: spy as any }
+    const mock = createMockCognitive()
+    const zai = new Zai({ client: mock, memoize: memoizer })
+
+    const result = await zai.check('anything', 'anything')
+    expect(result).toBe(true)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(mock.generateContent).not.toHaveBeenCalled()
+  })
+
+  it('works with .with() chaining', async () => {
+    _responseText = 'The text is in English.\n■TRUE■\n■END■'
+    const { factory, spy } = createSpyMemoizer()
+    const zai = new Zai({ client: createMockCognitive(), memoize: factory })
+    const fast = zai.with({ modelId: 'fast' })
+
+    await fast.check('Hello', 'is english')
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('no memoizer means no wrapping (noop)', async () => {
+    _responseText = 'The text is in English.\n■TRUE■\n■END■'
+    const mock = createMockCognitive()
+    const zai = new Zai({ client: mock })
+    await zai.check('Hello', 'is english')
+    expect(mock.generateContent).toHaveBeenCalled()
+  })
+})

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "2.5.18",
+  "version": "2.6.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "2.5.17",
+  "version": "2.5.18",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/zai/src/index.ts
+++ b/packages/zai/src/index.ts
@@ -1,4 +1,4 @@
-import { Zai } from './zai'
+import { Zai, type Memoizer } from './zai'
 
 import './operations/text'
 import './operations/rewrite'
@@ -14,3 +14,4 @@ import './operations/answer'
 import './operations/patch'
 
 export { Zai }
+export type { Memoizer }

--- a/packages/zai/src/operations/answer.ts
+++ b/packages/zai/src/operations/answer.ts
@@ -816,6 +816,7 @@ Zai.prototype.answer = function <T>(
     taskId: this.taskId,
     taskType: 'zai.answer',
     adapter: this.adapter,
+    memoizer: this._resolveMemoizer(),
   })
 
   return new Response<AnswerResult<T>, AnswerResult<T>>(

--- a/packages/zai/src/operations/check.ts
+++ b/packages/zai/src/operations/check.ts
@@ -354,6 +354,7 @@ Zai.prototype.check = function (
     taskId: this.taskId,
     taskType: 'zai.check',
     adapter: this.adapter,
+    memoizer: this._resolveMemoizer(),
   })
 
   return new Response<

--- a/packages/zai/src/operations/extract.ts
+++ b/packages/zai/src/operations/extract.ts
@@ -484,6 +484,7 @@ Zai.prototype.extract = function <S extends OfType<AnyObjectOrArray>>(
     taskId: this.taskId,
     taskType: 'zai.extract',
     adapter: this.adapter,
+    memoizer: this._resolveMemoizer(),
   })
 
   return new Response<S['_output']>(context, extract(input, schema, _options, context), (result) => result)

--- a/packages/zai/src/operations/filter.ts
+++ b/packages/zai/src/operations/filter.ts
@@ -363,6 +363,7 @@ Zai.prototype.filter = function <T>(
     taskId: this.taskId,
     taskType: 'zai.filter',
     adapter: this.adapter,
+    memoizer: this._resolveMemoizer(),
   })
 
   return new Response<Array<T>>(context, filter(input, condition, _options, context), (result) => result)

--- a/packages/zai/src/operations/group.ts
+++ b/packages/zai/src/operations/group.ts
@@ -955,6 +955,7 @@ Zai.prototype.group = function <T>(
     taskId: this.taskId,
     taskType: 'zai.group',
     adapter: this.adapter,
+    memoizer: this._resolveMemoizer(),
   })
 
   return new Response<Array<Group<T>>, Record<string, T[]>>(context, group(input, _options, context), (result) => {

--- a/packages/zai/src/operations/group.ts
+++ b/packages/zai/src/operations/group.ts
@@ -721,9 +721,7 @@ ${END}`.trim()
         for (let i = 1; i < sourceGroupIds.length; i++) {
           const sourceGid = sourceGroupIds[i]
           const sourceSet = groupElements.get(sourceGid)!
-          for (const elemIdx of sourceSet) {
-            targetSet.add(elemIdx)
-          }
+          sourceSet.forEach((elemIdx) => targetSet.add(elemIdx))
           sourceSet.clear()
         }
       }

--- a/packages/zai/src/operations/group.ts
+++ b/packages/zai/src/operations/group.ts
@@ -678,6 +678,7 @@ Zai.prototype.group = function <T>(
     taskId: this.taskId,
     taskType: 'zai.group',
     adapter: this.adapter,
+    memoizer: this._resolveMemoizer(),
   })
 
   return new Response<Array<Group<T>>, Record<string, T[]>>(context, group(input, _options, context), (result) => {

--- a/packages/zai/src/operations/label.ts
+++ b/packages/zai/src/operations/label.ts
@@ -542,6 +542,7 @@ Zai.prototype.label = function <T extends string>(
     taskId: this.taskId,
     taskType: 'zai.label',
     adapter: this.adapter,
+    memoizer: this._resolveMemoizer(),
   })
 
   return new Response<

--- a/packages/zai/src/operations/patch.ts
+++ b/packages/zai/src/operations/patch.ts
@@ -650,6 +650,7 @@ Zai.prototype.patch = function (
     taskId: this.taskId,
     taskType: 'zai.patch',
     adapter: this.adapter,
+    memoizer: this._resolveMemoizer(),
   })
 
   return new Response<Array<File>>(context, patch(files, instructions, _options, context), (result) => result)

--- a/packages/zai/src/operations/rate.ts
+++ b/packages/zai/src/operations/rate.ts
@@ -611,6 +611,7 @@ Zai.prototype.rate = function <T, I extends RatingInstructions>(
     taskId: this.taskId,
     taskType: 'zai.rate',
     adapter: this.adapter,
+    memoizer: this._resolveMemoizer(),
   })
 
   return new Response<Array<RatingResult<I>>, Array<SimplifiedRatingResult<I>>>(

--- a/packages/zai/src/operations/rewrite.ts
+++ b/packages/zai/src/operations/rewrite.ts
@@ -277,6 +277,7 @@ Zai.prototype.rewrite = function (this: Zai, original: string, prompt: string, _
     taskId: this.taskId,
     taskType: 'zai.rewrite',
     adapter: this.adapter,
+    memoizer: this._resolveMemoizer(),
   })
 
   return new Response<string>(context, rewrite(original, prompt, _options, context), (result) => result)

--- a/packages/zai/src/operations/sort.ts
+++ b/packages/zai/src/operations/sort.ts
@@ -800,6 +800,7 @@ Zai.prototype.sort = function <T>(
     taskId: this.taskId,
     taskType: 'zai.sort',
     adapter: this.adapter,
+    memoizer: this._resolveMemoizer(),
   })
 
   return new Response<Array<T>, Array<T>>(

--- a/packages/zai/src/operations/summarize.ts
+++ b/packages/zai/src/operations/summarize.ts
@@ -306,6 +306,7 @@ Zai.prototype.summarize = function (this: Zai, original, _options): Response<str
     taskId: this.taskId,
     taskType: 'summarize',
     adapter: this.adapter,
+    memoizer: this._resolveMemoizer(),
   })
 
   return new Response<string, string>(context, summarize(original, options, context), (value) => value)

--- a/packages/zai/src/operations/text.ts
+++ b/packages/zai/src/operations/text.ts
@@ -135,6 +135,7 @@ Zai.prototype.text = function (this: Zai, prompt: string, _options?: Options): R
     taskId: this.taskId,
     taskType: 'zai.text',
     adapter: this.adapter,
+    memoizer: this._resolveMemoizer(),
   })
 
   return new Response<string>(context, text(prompt, _options, context), (result) => result)


### PR DESCRIPTION
## Summary
- Adds a `memoize` option to `Zai` that wraps all cognitive (LLM) calls in a user-provided `Memoizer`
- The memoizer receives a deterministic key derived from the operation type, task ID, and prompt content, enabling caching/replay of results
- Accepts either a `Memoizer` instance or a factory function `() => Memoizer` (called once per operation invocation)
- When no memoizer is provided, behavior is unchanged (noop passthrough)
- Wired into all operations: `text`, `rewrite`, `summarize`, `check`, `filter`, `extract`, `label`, `rate`, `sort`, `answer`, `patch`, `group`

## Motivation
When used with the Botpress ADK workflow `step` function, this enables Zai operations to resume where they left off if a workflow is interrupted — previously completed LLM calls are replayed from cache instead of re-executed.

## Test plan
- [x] Unit tests covering every operation calls the memoizer
- [x] Deterministic key generation (same inputs → same key, different inputs → different key)
- [x] Short-circuit behavior (memoizer can return cached result, skipping LLM call)
- [x] Factory vs instance memoizer
- [x] `.with()` chaining preserves memoizer
- [x] No memoizer = no wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)