### PR TITLE
feat(packages/sdk): expose BaseBot type

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "5.5.6",
+  "version": "5.5.7",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",
@@ -28,7 +28,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.4",
     "@botpress/client": "1.35.0",
-    "@botpress/sdk": "5.4.3",
+    "@botpress/sdk": "5.4.4",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/verel": "^0.2.0",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.35.0",
-    "@botpress/sdk": "5.4.3"
+    "@botpress/sdk": "5.4.4"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.35.0",
-    "@botpress/sdk": "5.4.3"
+    "@botpress/sdk": "5.4.4"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "5.4.3"
+    "@botpress/sdk": "5.4.4"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.35.0",
-    "@botpress/sdk": "5.4.3"
+    "@botpress/sdk": "5.4.4"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.35.0",
-    "@botpress/sdk": "5.4.3",
+    "@botpress/sdk": "5.4.4",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -38,6 +38,7 @@ export {
 } from './integration/server'
 
 export {
+  BaseBot,
   DefaultBot,
   BotDefinition,
   BotDefinitionProps,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2505,7 +2505,7 @@ importers:
         specifier: 1.35.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 5.4.3
+        specifier: 5.4.4
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2629,7 +2629,7 @@ importers:
         specifier: 1.35.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.4.3
+        specifier: 5.4.4
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2645,7 +2645,7 @@ importers:
         specifier: 1.35.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.4.3
+        specifier: 5.4.4
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2658,7 +2658,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 5.4.3
+        specifier: 5.4.4
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2674,7 +2674,7 @@ importers:
         specifier: 1.35.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.4.3
+        specifier: 5.4.4
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2690,7 +2690,7 @@ importers:
         specifier: 1.35.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.4.3
+        specifier: 5.4.4
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
The reason for this is to enable me to improve type-safety in a helper function I'm writing in a bot-as-code project. Specifically, to create generic functions/types that will only allow the `bp.TBot` to be passed in.