### PR TITLE
feat(packages/cli): implement token masking for profile commands

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "5.5.6",
+  "version": "5.6.0",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/command-implementations/profile-commands.ts
+++ b/packages/cli/src/command-implementations/profile-commands.ts
@@ -9,20 +9,6 @@ type ProfileEntry = ProfileCredentials & {
   name: string
 }
 
-const _maskProfileToken = ({ token, ...restProfile }: ProfileEntry): ProfileEntry => {
-  // Using both "floor" & "ceil" to handle cases where the token has an odd number length
-  const maxHalfTokenLength = Math.ceil(token.length / 2)
-  const minHalfTokenLength = Math.floor(token.length / 2)
-  const firstHalf = token.slice(0, maxHalfTokenLength)
-
-  const maskedToken = firstHalf + '*'.repeat(minHalfTokenLength)
-
-  return {
-    ...restProfile,
-    token: maskedToken,
-  }
-}
-
 export type ActiveProfileCommandDefinition = typeof commandDefinitions.profiles.subcommands.active
 export class ActiveProfileCommand extends GlobalCommand<ActiveProfileCommandDefinition> {
   public async run(): Promise<void> {
@@ -103,4 +89,18 @@ const _updateGlobalCache = async (props: {
   await props.globalCache.set('apiUrl', props.profile.apiUrl)
   await props.globalCache.set('token', props.profile.token)
   await props.globalCache.set('workspaceId', props.profile.workspaceId)
+}
+
+const _maskProfileToken = ({ token, ...restProfile }: ProfileEntry): ProfileEntry => {
+  // Using both "floor" & "ceil" to handle cases where the token has an odd number length
+  const maxHalfTokenLength = Math.ceil(token.length / 2)
+  const minHalfTokenLength = Math.floor(token.length / 2)
+  const firstHalf = token.slice(0, maxHalfTokenLength)
+
+  const maskedToken = firstHalf + '*'.repeat(minHalfTokenLength)
+
+  return {
+    ...restProfile,
+    token: maskedToken,
+  }
 }

--- a/packages/cli/src/command-implementations/profile-commands.ts
+++ b/packages/cli/src/command-implementations/profile-commands.ts
@@ -22,7 +22,7 @@ export class ActiveProfileCommand extends GlobalCommand<ActiveProfileCommandDefi
 
     const profile = await this.readProfileFromFS(activeProfileName)
     let profileEntry: ProfileEntry = { name: activeProfileName, ...profile }
-    if (!this.argv.json) profileEntry = _maskProfileToken(profileEntry)
+    if (_shouldMaskToken(this.argv)) profileEntry = _maskProfileToken(profileEntry)
 
     this.logger.log('Active profile:')
     this.logger.json(profileEntry)
@@ -42,7 +42,7 @@ export class ListProfilesCommand extends GlobalCommand<ListProfilesCommandDefini
     const activeProfileMsg = `Active profile: '${chalk.bold(chalk.cyanBright(activeProfileName))}'`
 
     this.logger.log(activeProfileMsg)
-    this.logger.json(this.argv.json ? profileEntries : profileEntries.map(_maskProfileToken))
+    this.logger.json(!_shouldMaskToken(this.argv) ? profileEntries : profileEntries.map(_maskProfileToken))
     this.logger.log(activeProfileMsg)
   }
 }
@@ -104,3 +104,5 @@ const _maskProfileToken = ({ token, ...restProfile }: ProfileEntry): ProfileEntr
     token: maskedToken,
   }
 }
+
+const _shouldMaskToken = (argv: { unmaskToken: boolean; json: boolean }) => !argv.json && !argv.unmaskToken

--- a/packages/cli/src/command-implementations/profile-commands.ts
+++ b/packages/cli/src/command-implementations/profile-commands.ts
@@ -53,7 +53,7 @@ export class ListProfilesCommand extends GlobalCommand<ListProfilesCommandDefini
       return
     }
     const activeProfileName = await this.globalCache.get('activeProfile')
-    this.logger.log(`Active profile: '${chalk.bold(activeProfileName)}'`)
+    this.logger.log(`Active profile: '${chalk.bold(chalk.cyanBright(activeProfileName))}'`)
     this.logger.json(this.argv.json ? profileEntries : profileEntries.map(_maskProfileToken))
   }
 }

--- a/packages/cli/src/command-implementations/profile-commands.ts
+++ b/packages/cli/src/command-implementations/profile-commands.ts
@@ -53,8 +53,11 @@ export class ListProfilesCommand extends GlobalCommand<ListProfilesCommandDefini
       return
     }
     const activeProfileName = await this.globalCache.get('activeProfile')
-    this.logger.log(`Active profile: '${chalk.bold(chalk.cyanBright(activeProfileName))}'`)
+    const activeProfileMsg = `Active profile: '${chalk.bold(chalk.cyanBright(activeProfileName))}'`
+
+    this.logger.log(activeProfileMsg)
     this.logger.json(this.argv.json ? profileEntries : profileEntries.map(_maskProfileToken))
+    this.logger.log(activeProfileMsg)
   }
 }
 

--- a/packages/cli/src/command-implementations/profile-commands.ts
+++ b/packages/cli/src/command-implementations/profile-commands.ts
@@ -99,4 +99,4 @@ const _stripProfileToken = (profile: ProfileEntry | ProfileEntryWithoutToken): P
   workspaceId: profile.workspaceId,
 })
 
-const _shouldOmitToken = (argv: { displayToken: boolean; json: boolean }) => !argv.json && !argv.displayToken
+const _shouldOmitToken = (argv: { displayToken: boolean }) => !argv.displayToken

--- a/packages/cli/src/command-implementations/profile-commands.ts
+++ b/packages/cli/src/command-implementations/profile-commands.ts
@@ -9,6 +9,8 @@ type ProfileEntry = ProfileCredentials & {
   name: string
 }
 
+type ProfileEntryWithoutToken = Omit<ProfileEntry, 'token'>
+
 export type ActiveProfileCommandDefinition = typeof commandDefinitions.profiles.subcommands.active
 export class ActiveProfileCommand extends GlobalCommand<ActiveProfileCommandDefinition> {
   public async run(): Promise<void> {
@@ -21,8 +23,8 @@ export class ActiveProfileCommand extends GlobalCommand<ActiveProfileCommandDefi
     }
 
     const profile = await this.readProfileFromFS(activeProfileName)
-    let profileEntry: ProfileEntry = { name: activeProfileName, ...profile }
-    if (_shouldMaskToken(this.argv)) profileEntry = _maskProfileToken(profileEntry)
+    let profileEntry: ProfileEntry | ProfileEntryWithoutToken = { name: activeProfileName, ...profile }
+    if (_shouldMaskToken(this.argv)) profileEntry = _stripProfileToken(profileEntry)
 
     this.logger.log('Active profile:')
     this.logger.json(profileEntry)
@@ -42,7 +44,7 @@ export class ListProfilesCommand extends GlobalCommand<ListProfilesCommandDefini
     const activeProfileMsg = `Active profile: '${chalk.bold(chalk.cyanBright(activeProfileName))}'`
 
     this.logger.log(activeProfileMsg)
-    this.logger.json(!_shouldMaskToken(this.argv) ? profileEntries : profileEntries.map(_maskProfileToken))
+    this.logger.json(!_shouldMaskToken(this.argv) ? profileEntries : profileEntries.map(_stripProfileToken))
     this.logger.log(activeProfileMsg)
   }
 }
@@ -91,18 +93,10 @@ const _updateGlobalCache = async (props: {
   await props.globalCache.set('workspaceId', props.profile.workspaceId)
 }
 
-const _maskProfileToken = ({ token, ...restProfile }: ProfileEntry): ProfileEntry => {
-  // Using both "floor" & "ceil" to handle cases where the token has an odd number length
-  const maxHalfTokenLength = Math.ceil(token.length / 2)
-  const minHalfTokenLength = Math.floor(token.length / 2)
-  const firstHalf = token.slice(0, maxHalfTokenLength)
+const _stripProfileToken = (profile: ProfileEntry | ProfileEntryWithoutToken): ProfileEntryWithoutToken => ({
+  name: profile.name,
+  apiUrl: profile.apiUrl,
+  workspaceId: profile.workspaceId,
+})
 
-  const maskedToken = firstHalf + '*'.repeat(minHalfTokenLength)
-
-  return {
-    ...restProfile,
-    token: maskedToken,
-  }
-}
-
-const _shouldMaskToken = (argv: { unmaskToken: boolean; json: boolean }) => !argv.json && !argv.unmaskToken
+const _shouldMaskToken = (argv: { displayToken: boolean; json: boolean }) => !argv.json && !argv.displayToken

--- a/packages/cli/src/command-implementations/profile-commands.ts
+++ b/packages/cli/src/command-implementations/profile-commands.ts
@@ -24,7 +24,7 @@ export class ActiveProfileCommand extends GlobalCommand<ActiveProfileCommandDefi
 
     const profile = await this.readProfileFromFS(activeProfileName)
     let profileEntry: ProfileEntry | ProfileEntryWithoutToken = { name: activeProfileName, ...profile }
-    if (_shouldMaskToken(this.argv)) profileEntry = _stripProfileToken(profileEntry)
+    if (_shouldOmitToken(this.argv)) profileEntry = _stripProfileToken(profileEntry)
 
     this.logger.log('Active profile:')
     this.logger.json(profileEntry)
@@ -44,7 +44,7 @@ export class ListProfilesCommand extends GlobalCommand<ListProfilesCommandDefini
     const activeProfileMsg = `Active profile: '${chalk.bold(chalk.cyanBright(activeProfileName))}'`
 
     this.logger.log(activeProfileMsg)
-    this.logger.json(!_shouldMaskToken(this.argv) ? profileEntries : profileEntries.map(_stripProfileToken))
+    this.logger.json(!_shouldOmitToken(this.argv) ? profileEntries : profileEntries.map(_stripProfileToken))
     this.logger.log(activeProfileMsg)
   }
 }
@@ -99,4 +99,4 @@ const _stripProfileToken = (profile: ProfileEntry | ProfileEntryWithoutToken): P
   workspaceId: profile.workspaceId,
 })
 
-const _shouldMaskToken = (argv: { displayToken: boolean; json: boolean }) => !argv.json && !argv.displayToken
+const _shouldOmitToken = (argv: { displayToken: boolean; json: boolean }) => !argv.json && !argv.displayToken

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -381,10 +381,12 @@ const chatSchema = {
 
 const listProfilesSchema = {
   ...globalSchema,
+  unmaskToken: { type: 'boolean', description: 'Remove the mask from the bp tokens', default: false },
 } satisfies CommandSchema
 
 const activeProfileSchema = {
   ...globalSchema,
+  unmaskToken: { type: 'boolean', description: 'Remove the mask from the bp tokens', default: false },
 } satisfies CommandSchema
 
 const useProfileSchema = {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -381,12 +381,12 @@ const chatSchema = {
 
 const listProfilesSchema = {
   ...globalSchema,
-  unmaskToken: { type: 'boolean', description: 'Remove the mask from the bp tokens', default: false },
+  displayToken: { type: 'boolean', description: 'Display the token in each of the bp profiles', default: false },
 } satisfies CommandSchema
 
 const activeProfileSchema = {
   ...globalSchema,
-  unmaskToken: { type: 'boolean', description: 'Remove the mask from the bp tokens', default: false },
+  displayToken: { type: 'boolean', description: 'Display the token in the bp profile', default: false },
 } satisfies CommandSchema
 
 const useProfileSchema = {

--- a/scripts/upload-sandbox-scripts.ts
+++ b/scripts/upload-sandbox-scripts.ts
@@ -24,7 +24,7 @@ const _fallbackProfileArgs = () => ({
   token: undefined,
 })
 function getProfileArgs(): any {
-  const activeProfileCmdResult = spawnSync('pnpm', ['exec', 'bp', 'profiles', 'active', '--json'])
+  const activeProfileCmdResult = spawnSync('pnpm', ['exec', 'bp', 'profiles', 'active', '--json', '--displayToken'])
   if (activeProfileCmdResult.status !== 0) {
     console.debug(
       `Failed to get active profile: ${activeProfileCmdResult.error?.message || activeProfileCmdResult.stderr.toString() || 'Unknown error'}`


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces token masking for the `profiles active` and `profiles list` CLI commands. Tokens are now hidden by default, and users must pass an explicit `--displayToken` flag to reveal them, improving the security posture of the CLI. The automation script `upload-sandbox-scripts.ts` is correctly updated to pass `--displayToken` so it can continue to retrieve tokens programmatically. The version is bumped to `5.6.0` as appropriate for this new feature.

**Key changes:**
- New `--displayToken` boolean flag (default: `false`) added to both `activeProfileSchema` and `listProfilesSchema` in `config.ts`.
- `_stripProfileToken` helper strips the `token` field before display when `--displayToken` is not set.
- `_shouldOmitToken` helper encapsulates the flag inversion logic.
- `scripts/upload-sandbox-scripts.ts` updated to pass `--displayToken` to preserve existing automation behavior.
- `ListProfilesCommand` now renders the active profile name in `cyanBright` and repeats the active profile message after the profile list (confirmed intentional).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it improves security by masking tokens by default and correctly updates all automated consumers.
- The logic is correct, the default-off behavior is appropriately secure, and the automation script is properly updated to avoid breakage. The implementation cleanly handles token masking across both profile commands while maintaining backward compatibility for automation scripts.
- No files require special attention

<sub>Last reviewed commit: b70b30f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->