### PR TITLE
fix(hitl): forward original message tags through conversation relay

### DIFF
--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -102,7 +102,7 @@ const PLUGIN_CONFIG_SCHEMA = sdk.z.object({
 
 export default new sdk.PluginDefinition({
   name: 'hitl',
-  version: '1.3.0',
+  version: '1.3.1',
   title: 'Human In The Loop',
   description: 'Seamlessly transfer conversations to human agents',
   icon: 'icon.svg',

--- a/plugins/hitl/src/conv-manager.ts
+++ b/plugins/hitl/src/conv-manager.ts
@@ -85,7 +85,7 @@ export class ConversationManager {
     await this.respond({ type: 'text', text })
   }
 
-  public async respond(messagePayload: types.MessagePayload): Promise<void> {
+  public async respond(messagePayload: types.MessagePayload, tags: Record<string, string> = {}): Promise<void> {
     // FIXME: in the future, we should use the provided UserId so that messages
     //        on Botpress appear to come from the agent/user instead of the
     //        bot user. For now, this is not possible because of checks in the
@@ -99,7 +99,7 @@ export class ConversationManager {
           type: messagePayload.type,
           userId: this._props.ctx.botId,
           payload: messagePayload,
-          tags: {},
+          tags,
         })
         break
       case 'image':
@@ -107,7 +107,7 @@ export class ConversationManager {
           type: messagePayload.type,
           userId: this._props.ctx.botId,
           payload: messagePayload,
-          tags: {},
+          tags,
         })
         break
       case 'audio':
@@ -115,7 +115,7 @@ export class ConversationManager {
           type: messagePayload.type,
           userId: this._props.ctx.botId,
           payload: messagePayload,
-          tags: {},
+          tags,
         })
         break
       case 'file':
@@ -123,7 +123,7 @@ export class ConversationManager {
           type: messagePayload.type,
           userId: this._props.ctx.botId,
           payload: messagePayload,
-          tags: {},
+          tags,
         })
         break
       case 'video':
@@ -131,7 +131,7 @@ export class ConversationManager {
           type: messagePayload.type,
           userId: this._props.ctx.botId,
           payload: messagePayload,
-          tags: {},
+          tags,
         })
         break
       case 'bloc':
@@ -139,7 +139,7 @@ export class ConversationManager {
           type: messagePayload.type,
           userId: this._props.ctx.botId,
           payload: messagePayload,
-          tags: {},
+          tags,
         })
         break
       default:

--- a/plugins/hitl/src/conv-manager.ts
+++ b/plugins/hitl/src/conv-manager.ts
@@ -1,3 +1,4 @@
+import * as client from '@botpress/client'
 import { NULL_MESSAGE_CODE } from 'plugin.definition'
 import * as types from './types'
 import * as bp from '.botpress'
@@ -85,7 +86,7 @@ export class ConversationManager {
     await this.respond({ type: 'text', text })
   }
 
-  public async respond(messagePayload: types.MessagePayload, tags: Record<string, string> = {}): Promise<void> {
+  public async respond(messagePayload: types.MessagePayload, tags: client.Message['tags'] = {}): Promise<void> {
     // FIXME: in the future, we should use the provided UserId so that messages
     //        on Botpress appear to come from the agent/user instead of the
     //        bot user. For now, this is not possible because of checks in the

--- a/plugins/hitl/src/hooks/before-incoming-message/all.ts
+++ b/plugins/hitl/src/hooks/before-incoming-message/all.ts
@@ -81,7 +81,7 @@ const _handleDownstreamMessage = async (
     })
   }
 
-  await upstreamCm.respond({ ...messagePayload, userId: upstreamUserId })
+  await upstreamCm.respond({ ...messagePayload, userId: upstreamUserId }, props.data.tags)
   return consts.STOP_EVENT_HANDLING
 }
 
@@ -153,7 +153,7 @@ const _handleUpstreamMessage = async (
   }
 
   props.logger.withConversationId(upstreamConversation.id).info('Sending message to downstream')
-  await downstreamCm.respond({ ...messagePayload, userId: patientDownstreamUserId })
+  await downstreamCm.respond({ ...messagePayload, userId: patientDownstreamUserId }, props.data.tags)
 
   return consts.STOP_EVENT_HANDLING
 }


### PR DESCRIPTION
When the HITL plugin pipes messages between upstream and downstream conversations, message-level tags were hardcoded to {} and discarded. This means any metadata attached to the original message (e.g. external IDs, tracking info from integrations) was lost during the relay.

This change forwards props.data.tags from the incoming message through to the createMessage call on the target conversation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where message-level tags were being discarded during message relay in the HITL plugin. Previously, when messages were piped between upstream and downstream conversations, tags were hardcoded to `{}`, losing metadata like external IDs and tracking information from integrations.

**Key changes:**
- Modified `respond()` method to accept an optional `tags` parameter with proper typing (`client.Message['tags']`)- Updated all `createMessage()` calls to use the tags parameter instead of hardcoded empty objects
- Both message relay paths (upstream→downstream and downstream→upstream) now forward `props.data.tags`- Maintains backward compatibility with default parameter value for existing call sites- Version bumped to 1.3.1

The implementation is clean and straightforward. All existing calls to `respond()` without tags will use the default empty object, maintaining backward compatibility.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-contained, properly typed, and maintain backward compatibility. The fix directly addresses the stated problem without introducing complexity or side effects. All message relay paths consistently forward tags, and non-relay system messages correctly use the default empty tags.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/hitl/src/conv-manager.ts | Added tags parameter to respond method with proper typing and default value, updated all createMessage calls to use tags instead of hardcoded empty object |
| plugins/hitl/src/hooks/before-incoming-message/all.ts | Updated both upstream and downstream message relay calls to forward props.data.tags to preserve message metadata |

</details>



<sub>Last reviewed commit: 0525800</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->