### PR TITLE
feat(zui): export zui guard to discriminate between different zod types

### DIFF
--- a/packages/zui/src/transforms/common/eval-zui-string.ts
+++ b/packages/zui/src/transforms/common/eval-zui-string.ts
@@ -20,7 +20,7 @@ export const evalZuiString = (zuiString: string): EvalZuiStringResult => {
     return { sucess: false, error: `Failed to evaluate schema: ${err.message}` }
   }
 
-  if (!z.isZuiType(result)) {
+  if (!z.is.zuiType(result)) {
     return { sucess: false, error: `String "${zuiString}" does not evaluate to a Zod schema` }
   }
 

--- a/packages/zui/src/transforms/zui-from-json-schema-legacy/json-schema-to-zui.test.ts
+++ b/packages/zui/src/transforms/zui-from-json-schema-legacy/json-schema-to-zui.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, test, it } from 'vitest'
-import { ZodNativeType, z, zuiKey } from '../../z'
+import { z, ZodType, zuiKey } from '../../z'
 import { jsonSchemaToZodStr, fromJSONSchemaLegacy, traverseZodDefinitions } from '.'
 import { toJSONSchemaLegacy } from '../zui-to-json-schema-legacy/zui-extension'
 import { JSONSchema7 } from 'json-schema'
 import { assert } from '../../assertions.utils.test'
-import { JsonSchema7Type } from '../zui-to-json-schema-legacy/parseDef'
 
-const testZuiConversion = (zuiObject: ZodNativeType) => {
+const testZuiConversion = (zuiObject: ZodType) => {
   const jsonSchema = toJSONSchemaLegacy(zuiObject)
   const asZui = fromJSONSchemaLegacy(jsonSchema)
   const convertedJsonSchema = toJSONSchemaLegacy(asZui)

--- a/packages/zui/src/transforms/zui-from-json-schema/index.ts
+++ b/packages/zui/src/transforms/zui-from-json-schema/index.ts
@@ -102,7 +102,7 @@ function _fromJSONSchema(schema: JSONSchema7Definition | undefined): z.ZodType {
   }
 
   if (schema.type === 'integer') {
-    const zSchema = toZuiPrimitive('number', schema) as z.ZodNativeType
+    const zSchema = toZuiPrimitive('number', schema)
     if (zSchema.typeName === 'ZodNumber') {
       return zSchema.int()
     }

--- a/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/object.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema-legacy/parsers/object.ts
@@ -11,7 +11,7 @@ export type JsonSchema7ObjectType = {
 }
 
 const getAdditionalProperties = (def: ZodObjectDef, refs: Refs): boolean | JsonSchema7Type => {
-  if (z.isZuiType(def.unknownKeys)) {
+  if (z.is.zuiType(def.unknownKeys)) {
     return (
       parseDef((def.unknownKeys as ZodTypeAny)._def, {
         ...refs,

--- a/packages/zui/src/transforms/zui-to-json-schema/index.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema/index.ts
@@ -285,7 +285,7 @@ const additionalPropertiesSchema = (def: z.ZodObjectDef): NonNullable<json.Objec
     return false
   }
 
-  if (!z.isZuiType(def.unknownKeys)) {
+  if (!z.is.zuiType(def.unknownKeys)) {
     return false
   }
 

--- a/packages/zui/src/transforms/zui-to-typescript-schema/index.test.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-schema/index.test.ts
@@ -5,7 +5,7 @@ import * as errors from '../common/errors'
 import z, { ZodLiteral } from '../../z'
 import { UIComponentDefinitions } from '../../z/typings'
 
-const evalZui = (source: string): z.ZodNativeType => {
+const evalZui = (source: string): z.ZodType => {
   const evalResult = evalZuiString(source)
   if (!evalResult.sucess) {
     throw new Error(`${evalResult.error}: ${source}`)

--- a/packages/zui/src/transforms/zui-to-typescript-type/index.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-type/index.ts
@@ -126,16 +126,15 @@ function sUnwrapZod(schema: z.ZodType | KeyValue | FnParameters | Declaration | 
   if (schema instanceof KeyValue) {
     let optionalValue: z.ZodOptional | undefined = undefined
 
-    const schemaValue = schema.value as z.ZodNativeType
-    if (schemaValue.typeName === 'ZodOptional') {
-      optionalValue = schemaValue
-    } else if (schemaValue.typeName === 'ZodDefault' && config.treatDefaultAsOptional) {
-      optionalValue = schemaValue._def.innerType.optional()
+    if (z.is.zuiOptional(schema.value)) {
+      optionalValue = schema.value
+    } else if (z.is.zuiDefault(schema.value) && config.treatDefaultAsOptional) {
+      optionalValue = schema.value._def.innerType.optional()
     }
 
     if (optionalValue) {
       let innerType = optionalValue._def.innerType
-      if (z.isZuiType(innerType) && !innerType.description && optionalValue.description) {
+      if (z.is.zuiType(innerType) && !innerType.description && optionalValue.description) {
         innerType = innerType?.describe(optionalValue.description)
       }
 
@@ -146,27 +145,26 @@ function sUnwrapZod(schema: z.ZodType | KeyValue | FnParameters | Declaration | 
     const delimiter = description?.trim().length > 0 ? '\n' : ''
     const withoutDesc = schema.value.describe('')
 
-    const isOptional = (schema.value as z.ZodNativeType).typeName === 'ZodAny' // any is treated as optional for backwards compatibility
+    const isOptional = z.is.zuiAny(schema.value) // any is treated as optional for backwards compatibility
     const key = isOptional ? _optionalKey(schema.key) : schema.key
     return `${delimiter}${description}${delimiter}${key}: ${sUnwrapZod(withoutDesc, newConfig)}${delimiter}`
   }
 
   if (schema instanceof FnParameters) {
-    const schemaSchema = schema.schema as z.ZodNativeType
-    if (schemaSchema.typeName === 'ZodTuple') {
+    if (z.is.zuiTuple(schema.schema)) {
       let args = ''
-      for (let i = 0; i < schemaSchema.items.length; i++) {
-        const argName = (schemaSchema.items[i]?.ui?.title as string) ?? `arg${i}`
-        const item = schemaSchema.items[i]!
+      for (let i = 0; i < schema.schema.items.length; i++) {
+        const argName = (schema.schema.items[i]?.ui?.title as string) ?? `arg${i}`
+        const item = schema.schema.items[i]!
         args += `${sUnwrapZod(new KeyValue(toPropertyKey(argName), item), newConfig)}${
-          i < schemaSchema.items.length - 1 ? ', ' : ''
+          i < schema.schema.items.length - 1 ? ', ' : ''
         } `
       }
 
       return args
     }
 
-    const isLiteral = (schema.schema.naked() as z.ZodNativeType).typeName === 'ZodLiteral'
+    const isLiteral = z.is.zuiLiteral(schema.schema.naked())
 
     const typings = sUnwrapZod(schema.schema, newConfig).trim()
     const startsWithPairs =
@@ -185,12 +183,11 @@ function sUnwrapZod(schema: z.ZodType | KeyValue | FnParameters | Declaration | 
   }
 
   if (schema instanceof FnReturn) {
-    const schemaSchema = schema.schema as z.ZodNativeType
-    if (schemaSchema.typeName === 'ZodOptional') {
-      return `${sUnwrapZod(schemaSchema.unwrap(), newConfig)} | undefined`
+    if (z.is.zuiOptional(schema.schema)) {
+      return `${sUnwrapZod(schema.schema.unwrap(), newConfig)} | undefined`
     }
 
-    return sUnwrapZod(schemaSchema, newConfig)
+    return sUnwrapZod(schema.schema, newConfig)
   }
 
   const s = schema as z.ZodFirstPartySchemaTypes
@@ -239,7 +236,7 @@ function sUnwrapZod(schema: z.ZodType | KeyValue | FnParameters | Declaration | 
 
     case 'ZodObject':
       const props = Object.entries(s._def.shape()).map(([key, value]) => {
-        if (z.isZuiType(value)) {
+        if (z.is.zuiType(value)) {
           return sUnwrapZod(new KeyValue(toPropertyKey(key), value), newConfig)
         }
         return `${key}: unknown`

--- a/packages/zui/src/z/__tests__/deref.test.ts
+++ b/packages/zui/src/z/__tests__/deref.test.ts
@@ -11,7 +11,7 @@ const deref = {
   baz: z.boolean(),
 }
 
-const intersect = (...schemas: z.ZodNativeType[]) => {
+const intersect = (...schemas: z.ZodType[]) => {
   if (schemas.length === 0) {
     throw new Error('Intersection expects at least one schema')
   }

--- a/packages/zui/src/z/__tests__/mandatory.test.ts
+++ b/packages/zui/src/z/__tests__/mandatory.test.ts
@@ -8,9 +8,7 @@ const expectZui = (actual: z.ZodType) => ({
       const result = actual.isEqual(expected)
       let msg: string | undefined = undefined
       try {
-        msg = `Expected ${transforms.toTypescriptSchema(
-          actual as z.ZodNativeType
-        )} not to equal ${transforms.toTypescriptSchema(expected as z.ZodNativeType)}`
+        msg = `Expected ${transforms.toTypescriptSchema(actual)} not to equal ${transforms.toTypescriptSchema(expected)}`
       } catch {}
       expect(result, msg).toBe(true)
     },
@@ -19,9 +17,7 @@ const expectZui = (actual: z.ZodType) => ({
     const result = actual.isEqual(expected)
     let msg: string | undefined = undefined
     try {
-      msg = `Expected ${transforms.toTypescriptSchema(actual as z.ZodNativeType)} to equal ${transforms.toTypescriptSchema(
-        expected as z.ZodNativeType
-      )}`
+      msg = `Expected ${transforms.toTypescriptSchema(actual)} to equal ${transforms.toTypescriptSchema(expected)}`
     } catch {}
     expect(result, msg).toBe(true)
   },

--- a/packages/zui/src/z/__tests__/zui.test.ts
+++ b/packages/zui/src/z/__tests__/zui.test.ts
@@ -94,7 +94,7 @@ test('Discriminated Unions', () => {
 })
 
 test('ZuiTypeAny', () => {
-  const func = (type: zui.ZodNativeType) => {
+  const func = (type: zui.ZodType) => {
     return type
   }
 

--- a/packages/zui/src/z/guards.ts
+++ b/packages/zui/src/z/guards.ts
@@ -1,12 +1,106 @@
 import { ZodError } from './error'
 import { ZodBaseTypeImpl } from './types'
-import { IZodError, ZodNativeType } from './typings'
+import type {
+  IZodError,
+  IZodType,
+  ZodNativeType,
+  ZodNativeTypeName,
+  IZodAny,
+  IZodArray,
+  IZodBigInt,
+  IZodBoolean,
+  IZodBranded,
+  IZodCatch,
+  IZodDate,
+  IZodDefault,
+  IZodDiscriminatedUnion,
+  IZodEnum,
+  IZodFunction,
+  IZodIntersection,
+  IZodLazy,
+  IZodLiteral,
+  IZodMap,
+  IZodNaN,
+  IZodNativeEnum,
+  IZodNever,
+  IZodNull,
+  IZodNullable,
+  IZodNumber,
+  IZodObject,
+  IZodOptional,
+  IZodPipeline,
+  IZodPromise,
+  IZodReadonly,
+  IZodRecord,
+  IZodRef,
+  IZodSet,
+  IZodString,
+  IZodSymbol,
+  IZodEffects,
+  IZodTuple,
+  IZodUndefined,
+  IZodUnion,
+  IZodUnknown,
+  IZodVoid,
+} from './typings'
 
 const _isError = (value: unknown): value is Error => value instanceof Error
 const _isObject = (value: unknown): value is object => typeof value === 'object' && value !== null
 
-export const isZuiError = (thrown: unknown): thrown is IZodError =>
-  thrown instanceof ZodError || (_isError(thrown) && '__type__' in thrown && thrown.__type__ === 'ZuiError')
+type _GuardName<S extends ZodNativeTypeName> = S extends `Zod${infer R}` ? `zui${R}` : never
+type _Guards = {
+  [G in ZodNativeTypeName as _GuardName<G>]: (value: IZodType) => value is Extract<ZodNativeType, { typeName: G }>
+} & {
+  zuiError: (thrown: unknown) => thrown is IZodError
+  zuiType: (value: unknown) => value is ZodNativeType
+}
 
-export const isZuiType = (value: unknown): value is ZodNativeType =>
-  value instanceof ZodBaseTypeImpl || (_isObject(value) && '__type__' in value && value.__type__ === 'ZuiType')
+export const is: _Guards = {
+  zuiError: (thrown: unknown): thrown is IZodError =>
+    thrown instanceof ZodError || (_isError(thrown) && '__type__' in thrown && thrown.__type__ === 'ZuiError'),
+  zuiType: (value: unknown): value is ZodNativeType =>
+    value instanceof ZodBaseTypeImpl || (_isObject(value) && '__type__' in value && value.__type__ === 'ZuiType'),
+
+  zuiAny: (s: IZodType): s is IZodAny => s.typeName === 'ZodAny',
+  zuiArray: (s: IZodType): s is IZodArray => s.typeName === 'ZodArray',
+  zuiBigInt: (s: IZodType): s is IZodBigInt => s.typeName === 'ZodBigInt',
+  zuiBoolean: (s: IZodType): s is IZodBoolean => s.typeName === 'ZodBoolean',
+  zuiBranded: (s: IZodType): s is IZodBranded => s.typeName === 'ZodBranded',
+  zuiCatch: (s: IZodType): s is IZodCatch => s.typeName === 'ZodCatch',
+  zuiDate: (s: IZodType): s is IZodDate => s.typeName === 'ZodDate',
+  zuiDefault: (s: IZodType): s is IZodDefault => s.typeName === 'ZodDefault',
+  zuiDiscriminatedUnion: (s: IZodType): s is IZodDiscriminatedUnion => s.typeName === 'ZodDiscriminatedUnion',
+  zuiEnum: (s: IZodType): s is IZodEnum => s.typeName === 'ZodEnum',
+  zuiFunction: (s: IZodType): s is IZodFunction => s.typeName === 'ZodFunction',
+  zuiIntersection: (s: IZodType): s is IZodIntersection => s.typeName === 'ZodIntersection',
+  zuiLazy: (s: IZodType): s is IZodLazy => s.typeName === 'ZodLazy',
+  zuiLiteral: (s: IZodType): s is IZodLiteral => s.typeName === 'ZodLiteral',
+  zuiMap: (s: IZodType): s is IZodMap => s.typeName === 'ZodMap',
+  zuiNaN: (s: IZodType): s is IZodNaN => s.typeName === 'ZodNaN',
+  zuiNativeEnum: (s: IZodType): s is IZodNativeEnum => s.typeName === 'ZodNativeEnum',
+  zuiNever: (s: IZodType): s is IZodNever => s.typeName === 'ZodNever',
+  zuiNull: (s: IZodType): s is IZodNull => s.typeName === 'ZodNull',
+  zuiNullable: (s: IZodType): s is IZodNullable => s.typeName === 'ZodNullable',
+  zuiNumber: (s: IZodType): s is IZodNumber => s.typeName === 'ZodNumber',
+  zuiObject: (s: IZodType): s is IZodObject => s.typeName === 'ZodObject',
+  zuiOptional: (s: IZodType): s is IZodOptional => s.typeName === 'ZodOptional',
+  zuiPipeline: (s: IZodType): s is IZodPipeline => s.typeName === 'ZodPipeline',
+  zuiPromise: (s: IZodType): s is IZodPromise => s.typeName === 'ZodPromise',
+  zuiReadonly: (s: IZodType): s is IZodReadonly => s.typeName === 'ZodReadonly',
+  zuiRecord: (s: IZodType): s is IZodRecord => s.typeName === 'ZodRecord',
+  zuiRef: (s: IZodType): s is IZodRef => s.typeName === 'ZodRef',
+  zuiSet: (s: IZodType): s is IZodSet => s.typeName === 'ZodSet',
+  zuiString: (s: IZodType): s is IZodString => s.typeName === 'ZodString',
+  zuiSymbol: (s: IZodType): s is IZodSymbol => s.typeName === 'ZodSymbol',
+  zuiEffects: (s: IZodType): s is IZodEffects => s.typeName === 'ZodEffects',
+  zuiTuple: (s: IZodType): s is IZodTuple => s.typeName === 'ZodTuple',
+  zuiUndefined: (s: IZodType): s is IZodUndefined => s.typeName === 'ZodUndefined',
+  zuiUnion: (s: IZodType): s is IZodUnion => s.typeName === 'ZodUnion',
+  zuiUnknown: (s: IZodType): s is IZodUnknown => s.typeName === 'ZodUnknown',
+  zuiVoid: (s: IZodType): s is IZodVoid => s.typeName === 'ZodVoid',
+} satisfies {
+  [G in ZodNativeTypeName as _GuardName<G>]: (value: IZodType) => value is Extract<ZodNativeType, { typeName: G }>
+} & {
+  zuiError: (thrown: unknown) => thrown is IZodError
+  zuiType: (value: unknown) => value is ZodNativeType
+}

--- a/packages/zui/src/z/types/function/index.ts
+++ b/packages/zui/src/z/types/function/index.ts
@@ -1,4 +1,5 @@
 import { defaultErrorMap, getErrorMap, ZodError } from '../../error'
+import { is } from '../../guards'
 import { builders } from '../../internal-builders'
 import type {
   IZodType,
@@ -11,7 +12,6 @@ import type {
   InnerTypeOfFunction,
   IZodUnknown,
   IZodPromise,
-  ZodNativeType,
 } from '../../typings'
 
 import * as utils from '../../utils'
@@ -90,8 +90,7 @@ export class ZodFunctionImpl<Args extends IZodTuple<any, any> = IZodTuple, Retur
     const params = { errorMap: ctx.common.contextualErrorMap }
     const fn = ctx.data
 
-    const returns = this._def.returns as ZodNativeType
-    if (returns.typeName === 'ZodPromise') {
+    if (is.zuiPromise(this._def.returns)) {
       // Would love a way to avoid disabling this rule, but we need
       // an alias (using an arrow function was what caused 2651).
 

--- a/packages/zui/src/z/types/object/index.ts
+++ b/packages/zui/src/z/types/object/index.ts
@@ -1,3 +1,4 @@
+import { is } from '../../guards'
 import { builders } from '../../internal-builders'
 import type {
   IZodObject,
@@ -12,7 +13,6 @@ import type {
   KeyOfObject,
   IZodOptional,
   IZodEnum,
-  ZodNativeType,
 } from '../../typings'
 import * as utils from '../../utils'
 import {
@@ -507,10 +507,10 @@ export class ZodObjectImpl<
         newShape[key] = this.shape[key]
       } else {
         const fieldSchema = this.shape[key]
-        let newField = fieldSchema as ZodNativeType
 
-        while (newField.typeName === 'ZodOptional') {
-          newField = (newField as IZodOptional<any>)._def.innerType
+        let newField = fieldSchema!
+        while (is.zuiOptional(newField)) {
+          newField = newField._def.innerType
         }
 
         newShape[key] = newField

--- a/packages/zui/src/z/types/union/index.ts
+++ b/packages/zui/src/z/types/union/index.ts
@@ -1,14 +1,7 @@
 import { ZodError } from '../../error'
+import { is } from '../../guards'
 import { builders } from '../../internal-builders'
-import type {
-  DefaultZodUnionOptions,
-  IZodUnion,
-  IZodType,
-  ZodUnionDef,
-  ZodUnionOptions,
-  ZodIssue,
-  ZodNativeType,
-} from '../../typings'
+import type { DefaultZodUnionOptions, IZodUnion, IZodType, ZodUnionDef, ZodUnionOptions, ZodIssue } from '../../typings'
 import * as utils from '../../utils'
 import {
   ZodBaseTypeImpl,
@@ -159,9 +152,7 @@ export class ZodUnionImpl<T extends ZodUnionOptions = DefaultZodUnionOptions>
   }
 
   mandatory(): IZodType {
-    const options = this._def.options
-      .filter((o) => !((o as ZodNativeType).typeName === 'ZodUndefined'))
-      .map((option) => option.mandatory())
+    const options = this._def.options.filter((o) => !is.zuiUndefined(o)).map((option) => option.mandatory())
 
     const [first, second, ...others] = options
     if (!first) {

--- a/packages/zui/src/z/z.ts
+++ b/packages/zui/src/z/z.ts
@@ -1,5 +1,5 @@
 export { zuiKey } from './consts'
-export { isZuiError, isZuiType } from './guards'
+export { is } from './guards'
 
 export type {
   // ui


### PR DESCRIPTION
My original plan was to only expose `ZodNativeType` as `ZodType` to allow consumers to discriminate using `typeName`, but unfortunately, I was not able to make it build, and I'm running out of time to ship. 

So this is my best attempt at allowing consumers to traverse a Zod schema.