### PR TITLE
chore(zui): move test assertion utils together and make sure it's not bundled

### DIFF
--- a/packages/zui/src/assertions.utils.test.ts
+++ b/packages/zui/src/assertions.utils.test.ts
@@ -1,24 +1,28 @@
 import { expect } from 'vitest'
 import { format } from 'prettier'
+import { IsEqual } from './z/utils/type-utils'
 
-const formatTs = async (code: string): Promise<string> => {
+const _formatTs = async (code: string): Promise<string> => {
   code = code.replace(/\s+/g, ' ')
   code = await format(code, { parser: 'typescript' })
   return code
 }
 
-export const assert = (received: string) => ({
+export const assertIs = <T>(_arg: T): void => {}
+export const assertEqual = <A, B>(val: IsEqual<A, B>) => val
+
+export const expectTypescript = (received: string) => ({
   not: {
     async toMatchWithoutFormatting(expected: string) {
-      const transformedReceived = await formatTs(received)
-      const transformedExpected = await formatTs(expected)
+      const transformedReceived = await _formatTs(received)
+      const transformedExpected = await _formatTs(expected)
       expect(transformedReceived).not.toBe(transformedExpected)
     },
   },
 
   async toMatchWithoutFormatting(expected: string) {
-    const transformedReceived = await formatTs(received)
-    const transformedExpected = await formatTs(expected)
+    const transformedReceived = await _formatTs(received)
+    const transformedExpected = await _formatTs(expected)
     expect(transformedReceived).toBe(transformedExpected)
   },
 })

--- a/packages/zui/src/assertions.utils.test.ts
+++ b/packages/zui/src/assertions.utils.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'vitest'
 import { format } from 'prettier'
-import { IsEqual } from './z/utils/type-utils'
 
 const _formatTs = async (code: string): Promise<string> => {
   code = code.replace(/\s+/g, ' ')
@@ -9,6 +8,8 @@ const _formatTs = async (code: string): Promise<string> => {
 }
 
 export const assertIs = <T>(_arg: T): void => {}
+
+export type IsEqual<T, U> = (<V>() => V extends T ? 1 : 2) extends <V>() => V extends U ? 1 : 2 ? true : false
 export const assertEqual = <A, B>(val: IsEqual<A, B>) => val
 
 export const expectTypescript = (received: string) => ({

--- a/packages/zui/src/transforms/zui-from-json-schema-legacy/json-schema-to-zui.test.ts
+++ b/packages/zui/src/transforms/zui-from-json-schema-legacy/json-schema-to-zui.test.ts
@@ -3,7 +3,7 @@ import { z, ZodType, zuiKey } from '../../z'
 import { jsonSchemaToZodStr, fromJSONSchemaLegacy, traverseZodDefinitions } from '.'
 import { toJSONSchemaLegacy } from '../zui-to-json-schema-legacy/zui-extension'
 import { JSONSchema7 } from 'json-schema'
-import { assert } from '../../assertions.utils.test'
+import * as assert from '../../assertions.utils.test'
 
 const testZuiConversion = (zuiObject: ZodType) => {
   const jsonSchema = toJSONSchemaLegacy(zuiObject)
@@ -209,7 +209,7 @@ describe('Coercion deserialization', () => {
       required: ['foo'],
     }
     const zStr = jsonSchemaToZodStr(schema)
-    await assert(zStr).toMatchWithoutFormatting(`
+    await assert.expectTypescript(zStr).toMatchWithoutFormatting(`
       z.object({ foo: z.ref("#Foo") })
     `)
   })
@@ -235,7 +235,7 @@ describe('Coercion deserialization', () => {
       required: ['foo', 'bar'],
     }
     const zStr = jsonSchemaToZodStr(schema)
-    await assert(zStr).toMatchWithoutFormatting(`
+    await assert.expectTypescript(zStr).toMatchWithoutFormatting(`
       z.object({ foo: z.literal("foo"), bar: z.literal("bar") })
     `)
   })

--- a/packages/zui/src/transforms/zui-from-json-schema/index.ts
+++ b/packages/zui/src/transforms/zui-from-json-schema/index.ts
@@ -198,7 +198,7 @@ function _fromJSONSchema(schema: JSONSchema7Definition | undefined): z.ZodType {
     return z.intersection(zLeft, zRight)
   }
 
-  type _expectUndefined = utils.assert.AssertTrue<utils.types.IsEqual<typeof schema.type, undefined>>
+  schema.type satisfies undefined
 
   if (guards.isUnknownSchema(schema)) {
     return z.unknown()

--- a/packages/zui/src/transforms/zui-from-json-schema/index.ts
+++ b/packages/zui/src/transforms/zui-from-json-schema/index.ts
@@ -1,6 +1,5 @@
 import { JSONSchema7, JSONSchema7Definition } from 'json-schema'
 import z from '../../z'
-import * as utils from '../../z/utils'
 import * as errors from '../common/errors'
 import { ArraySchema, SetSchema, TupleSchema } from '../common/json-schema'
 import * as guards from './guards'

--- a/packages/zui/src/transforms/zui-to-json-schema/index.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema/index.ts
@@ -184,7 +184,7 @@ export function toJSONSchema(schema: z.ZodType): json.Schema {
       } else if (s.value === undefined) {
         return undefinedSchema(s._def)
       } else {
-        utils.assert.assertEqual<bigint | symbol, typeof s.value>(true)
+        s.value satisfies bigint | symbol
         const unsupportedLiteral = typeof s.value
         throw new err.ZuiToJSONSchemaError(`Unsupported literal type: "${unsupportedLiteral}"`)
       }

--- a/packages/zui/src/transforms/zui-to-typescript-schema/bigint-checks.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-schema/bigint-checks.ts
@@ -1,5 +1,4 @@
 import { ZodBigIntCheck, ZodBigIntDef } from '../../z'
-import * as utils from '../../z/utils'
 import { primitiveToTypescriptValue as toTs } from '../common/utils'
 
 export const generateBigIntChecks = (def: ZodBigIntDef): string => {
@@ -19,7 +18,7 @@ const _generateBigIntCheck = (check: ZodBigIntCheck): string => {
     case 'multipleOf':
       return `.multipleOf(${toTs(check.value)}, ${toTs(check.message)})`
     default:
-      type _assertion = utils.assert.AssertNever<typeof check>
+      check satisfies never
       return ''
   }
 }

--- a/packages/zui/src/transforms/zui-to-typescript-schema/date-checks.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-schema/date-checks.ts
@@ -19,7 +19,7 @@ const _generateDateCheck = (check: ZodDateCheck): string => {
       const maxDate = dateTs(check.value)
       return `.max(${maxDate}, ${toTs(check.message)})`
     default:
-      type _assertion = utils.assert.AssertNever<typeof check>
+      check satisfies never
       return ''
   }
 }

--- a/packages/zui/src/transforms/zui-to-typescript-schema/date-checks.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-schema/date-checks.ts
@@ -1,5 +1,4 @@
 import { ZodDateCheck, ZodDateDef } from '../../z'
-import * as utils from '../../z/utils'
 import { primitiveToTypescriptValue as toTs } from '../common/utils'
 
 export const generateDateChecks = (def: ZodDateDef): string => {

--- a/packages/zui/src/transforms/zui-to-typescript-schema/number-checks.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-schema/number-checks.ts
@@ -23,7 +23,7 @@ const _generateNumberCheck = (check: ZodNumberCheck): string => {
     case 'finite':
       return `.finite(${toTs(check.message)})`
     default:
-      type _assertion = utils.assert.AssertNever<typeof check>
+      check satisfies never
       return ''
   }
 }

--- a/packages/zui/src/transforms/zui-to-typescript-schema/number-checks.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-schema/number-checks.ts
@@ -1,5 +1,4 @@
 import { ZodNumberCheck, ZodNumberDef } from '../../z/'
-import * as utils from '../../z/utils'
 import { primitiveToTypescriptValue as toTs } from '../common/utils'
 
 export const generateNumberChecks = (def: ZodNumberDef): string => {

--- a/packages/zui/src/transforms/zui-to-typescript-schema/string-checks.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-schema/string-checks.ts
@@ -60,7 +60,7 @@ const _generateStringCheck = (check: ZodStringCheck): string => {
       const ipOptions = unknownToTypescriptValue({ message: check.message, version: check.version })
       return `.ip(${ipOptions})`
     default:
-      type _assertion = utils.assert.AssertNever<typeof check>
+      check satisfies never
       return ''
   }
 }

--- a/packages/zui/src/transforms/zui-to-typescript-schema/string-checks.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-schema/string-checks.ts
@@ -1,5 +1,4 @@
 import { ZodStringCheck, ZodStringDef } from '../../z/types/string'
-import * as utils from '../../z/utils'
 import { primitiveToTypescriptValue as toTs, unknownToTypescriptValue } from '../common/utils'
 
 export const generateStringChecks = (def: ZodStringDef): string => {

--- a/packages/zui/src/transforms/zui-to-typescript-type/index.test.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-type/index.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import { toTypescriptType as toTs } from '.'
-import * as utils from '../../z/utils'
 import z, { ZodType } from '../../z'
 import * as errors from '../common/errors'
-import { assert } from '../../assertions.utils.test'
+import * as assert from '../../assertions.utils.test'
 
 const toTypescript = (schema: ZodType): string => {
   const hasTitle = 'title' in schema.ui
@@ -33,7 +32,7 @@ describe.concurrent('functions', () => {
 
     const typings = toTs(fn, { declaration: true })
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
       /**
        * Add two numbers together.
        * This is a multiline description
@@ -51,7 +50,7 @@ describe.concurrent('functions', () => {
       .describe('Add two numbers together.\nThis is a multiline description')
 
     const typings = toTs(fn, { declaration: 'type' })
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
       /**
        * Add two numbers together.
        * This is a multiline description
@@ -70,7 +69,7 @@ describe.concurrent('functions', () => {
 
     const typings = toTypescript(fn)
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
       /**
        * Add two numbers together.
        * This is a multiline description
@@ -84,7 +83,7 @@ describe.concurrent('functions', () => {
 
     const typings = toTypescript(fn)
 
-    await assert(typings).toMatchWithoutFormatting('declare function fn(): unknown;')
+    await assert.expectTypescript(typings).toMatchWithoutFormatting('declare function fn(): unknown;')
   })
 
   it('function with no args and void return', async () => {
@@ -92,7 +91,7 @@ describe.concurrent('functions', () => {
 
     const typings = toTypescript(fn)
 
-    await assert(typings).toMatchWithoutFormatting('declare function fn(): void;')
+    await assert.expectTypescript(typings).toMatchWithoutFormatting('declare function fn(): void;')
   })
 
   it('async function returning union', async () => {
@@ -103,7 +102,7 @@ describe.concurrent('functions', () => {
 
     const typings = toTypescript(fn)
 
-    await assert(typings).toMatchWithoutFormatting('declare function fn(): Promise<number | string>;')
+    await assert.expectTypescript(typings).toMatchWithoutFormatting('declare function fn(): Promise<number | string>;')
   })
 
   it('function with multiple args', async () => {
@@ -121,7 +120,7 @@ describe.concurrent('functions', () => {
 
     const typings = toTypescript(fn)
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
       declare function fn(
         arg0: {
           a?: number;
@@ -138,19 +137,23 @@ describe.concurrent('functions', () => {
   it('function with optional args', async () => {
     const fn = z.function().title('fn').args(z.string().optional())
     const typings = toTypescript(fn)
-    await assert(typings).toMatchWithoutFormatting('declare function fn(arg0?: string): unknown;')
+    await assert.expectTypescript(typings).toMatchWithoutFormatting('declare function fn(arg0?: string): unknown;')
   })
 
   it('function with readonly args', async () => {
     const fn = z.function().title('fn').args(z.string().readonly())
     const typings = toTypescript(fn)
-    await assert(typings).toMatchWithoutFormatting('declare function fn(arg0: Readonly<string>): unknown;')
+    await assert
+      .expectTypescript(typings)
+      .toMatchWithoutFormatting('declare function fn(arg0: Readonly<string>): unknown;')
   })
 
   it('function with readonly enumerable args', async () => {
     const fn = z.function().title('fn').args(z.array(z.string()).readonly())
     const typings = toTypescript(fn)
-    await assert(typings).toMatchWithoutFormatting('declare function fn(arg0: Readonly<string[]>): unknown;')
+    await assert
+      .expectTypescript(typings)
+      .toMatchWithoutFormatting('declare function fn(arg0: Readonly<string[]>): unknown;')
   })
 
   it('string literals', async () => {
@@ -160,7 +163,7 @@ describe.concurrent('functions', () => {
         .describe('yoyoyo\nmultiline')
         .title('x')
     )
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
       /**
        * yoyoyo
        * multiline
@@ -171,34 +174,34 @@ describe.concurrent('functions', () => {
 
   it('number literals', async () => {
     const code = toTypescript(z.literal(1).title('x'))
-    await assert(code).toMatchWithoutFormatting('declare const x: 1')
+    await assert.expectTypescript(code).toMatchWithoutFormatting('declare const x: 1')
   })
 
   it('boolean literals', async () => {
     const code = toTypescript(z.literal(true))
-    await assert(code).toMatchWithoutFormatting('declare const x: true')
+    await assert.expectTypescript(code).toMatchWithoutFormatting('declare const x: true')
   })
 
   it('undefined literals', async () => {
     const typings = toTypescript(z.literal(undefined))
-    await assert(typings).toMatchWithoutFormatting('declare const x: undefined')
+    await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: undefined')
   })
 
   it('null literals', async () => {
     const typings = toTypescript(z.literal(null))
-    await assert(typings).toMatchWithoutFormatting('declare const x: null')
+    await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: null')
   })
 
   it('bigint literals', async () => {
     const n = BigInt(100)
     const typings = toTypescript(z.literal(n))
-    await assert(typings).toMatchWithoutFormatting('declare const x: 100n')
+    await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: 100n')
   })
 
   it('symbol literals', async () => {
     const n = Symbol('hello')
     const typings = toTypescript(z.literal(n))
-    await assert(typings).toMatchWithoutFormatting('declare const x: symbol')
+    await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: symbol')
   })
 
   it('non explicitly discriminated union', async () => {
@@ -207,7 +210,7 @@ describe.concurrent('functions', () => {
       z.object({ enabled: z.literal(false), bar: z.number() }),
     ])
     const typings = toTypescript(schema)
-    await assert(typings).toMatchWithoutFormatting(`declare const x: {
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`declare const x: {
           enabled: true;
           foo: string
         } | {
@@ -220,7 +223,7 @@ describe.concurrent('functions', () => {
   it('function with named args', async () => {
     const fn = z.function().title('fn').args(z.string().title('firstName').optional())
     const typings = toTypescript(fn)
-    await assert(typings).toMatchWithoutFormatting('declare function fn(firstName?: string): unknown;')
+    await assert.expectTypescript(typings).toMatchWithoutFormatting('declare function fn(firstName?: string): unknown;')
   })
 
   it('mix of named and unnammed params', async () => {
@@ -229,7 +232,7 @@ describe.concurrent('functions', () => {
       .title('fn')
       .args(z.string().title('firstName').optional(), z.number(), z.object({ a: z.string() }).title('obj'))
     const typings = toTypescript(fn)
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
         declare function fn(
           firstName?: string,
           arg1: number,
@@ -246,7 +249,7 @@ describe.concurrent('functions', () => {
       .returns(z.string().nullable().optional())
 
     const typings = toTypescript(fn)
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
       declare function fn(
         arg0?: string | null,
         arg1?: number
@@ -266,7 +269,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTs(obj, { declaration: 'type' })
 
-    await assert(typings).toMatchWithoutFormatting('type MyObject = { a: number; b: string };')
+    await assert.expectTypescript(typings).toMatchWithoutFormatting('type MyObject = { a: number; b: string };')
   })
 
   it('normal object', async () => {
@@ -274,7 +277,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting('declare const MyObject: { a: number; b: string };')
+    await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const MyObject: { a: number; b: string };')
   })
 
   it('object with title and description', async () => {
@@ -285,7 +288,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
         /**
          * This is my object.
          * This is a multiline description.
@@ -317,7 +320,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTs(obj, { declaration: true, includeClosingTags: true })
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
       /**
        * This is my object.
        * This is a multiline description.
@@ -347,7 +350,9 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting('declare const MyObject: { a: number; b: string } | null;')
+    await assert
+      .expectTypescript(typings)
+      .toMatchWithoutFormatting('declare const MyObject: { a: number; b: string } | null;')
   })
 
   it('optionals with default values', async () => {
@@ -355,7 +360,9 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting('declare const MyObject: { a: number; b: string } | undefined;')
+    await assert
+      .expectTypescript(typings)
+      .toMatchWithoutFormatting('declare const MyObject: { a: number; b: string } | undefined;')
   })
 
   it('enum', async () => {
@@ -363,7 +370,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
         declare const MyObject: {
           a: 'hello' | 'world'
         };
@@ -379,7 +386,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
         declare const MyObject: {
           /** Description */
           someStr?: string
@@ -396,7 +403,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
         declare const MyObject: {
           /** Description */
           someStr?: string
@@ -413,7 +420,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting('declare const MyObject: { address: {} | null };')
+    await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const MyObject: { address: {} | null };')
   })
 
   it('object with a description & readonly', async () => {
@@ -425,7 +432,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
         declare const MyObject: {
           /** Description */ someStr: Readonly<string>
         };
@@ -441,7 +448,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
         declare const MyObject: {
           /** Description */
           someStr: Readonly<string>
@@ -466,7 +473,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
         declare const MyObject: {
           /** This is a record */
           address: { [key: number]: { street: string; number: number } }
@@ -491,7 +498,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting(
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(
       `
         declare const MyObject: {
           computed: { [key: string]: { status: string; error?: string } | undefined }
@@ -569,7 +576,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
       declare const payment:
         | {
             type: 'Credit Card';
@@ -621,7 +628,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
       declare const UserPayment: {
         value:
           | {
@@ -657,7 +664,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
         declare const MyObject: {
           /** This is a record */ address: /** This is a record */ {
             [key: number]: { street: string; number: number }
@@ -673,16 +680,16 @@ describe.concurrent('objects', () => {
       .title('MyObject')
     const typings = toTypescript(fn)
 
-    await assert(typings).toMatchWithoutFormatting(
-      'declare function MyObject(arg0: Array<{ a: number; b: string }>): unknown;'
-    )
+    await assert
+      .expectTypescript(typings)
+      .toMatchWithoutFormatting('declare function MyObject(arg0: Array<{ a: number; b: string }>): unknown;')
   })
 
   it('array of primitives as input params', async () => {
     const fn = z.function().args(z.array(z.number()).describe('This is an array of numbers')).title('MyObject')
     const typings = toTypescript(fn)
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
         declare function MyObject(
           /** This is an array of numbers */
           arg0: number[]
@@ -703,7 +710,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
         declare const MyObject: {
           /** This is A */
           a: string
@@ -722,7 +729,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
         declare const MyObject: {
           'Hello World!': string;
           'Hey?'?: string;
@@ -748,7 +755,7 @@ describe.concurrent('objects', () => {
 
     const typings = toTypescript(obj)
 
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
       declare const MyObject: {
         stringLiteral: "1";
         numberLiteral: 1;
@@ -784,11 +791,15 @@ describe.concurrent('objects', () => {
     const typings2 = toTypescript(fn2)
     const typings3 = toTypescript(fn3)
 
-    await assert(typings1).toMatchWithoutFormatting(`declare function fn1(arg0: number | string): number | string`)
-    await assert(typings2).toMatchWithoutFormatting(`declare function fn2(arg0: { id: number[] } | string): unknown`)
-    await assert(typings3).toMatchWithoutFormatting(
-      `declare function fn3(arg0: { id: number[] } | { name: string }): unknown`
-    )
+    await assert
+      .expectTypescript(typings1)
+      .toMatchWithoutFormatting(`declare function fn1(arg0: number | string): number | string`)
+    await assert
+      .expectTypescript(typings2)
+      .toMatchWithoutFormatting(`declare function fn2(arg0: { id: number[] } | string): unknown`)
+    await assert
+      .expectTypescript(typings3)
+      .toMatchWithoutFormatting(`declare function fn3(arg0: { id: number[] } | { name: string }): unknown`)
   })
 
   it('records', async () => {
@@ -800,7 +811,7 @@ describe.concurrent('objects', () => {
       .required({ Date: true })
 
     const typings = toTypescript(obj)
-    await assert(typings).toMatchWithoutFormatting(`
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
       declare const x: {
       /** Test2 */
       Date: string
@@ -816,7 +827,7 @@ describe.concurrent('objects', () => {
       .required({ Date: false } as any)
 
     const typings = toTypescript(obj)
-    await assert(typings).toMatchWithoutFormatting(`declare const x: { Date?: string }`)
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`declare const x: { Date?: string }`)
   })
 
   it('chaining optionals only make properties optional once', async () => {
@@ -832,7 +843,7 @@ describe.concurrent('objects', () => {
           foo?: string
         }
       `
-    await assert(typings).toMatchWithoutFormatting(expected)
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(expected)
   })
 
   it('chaining optional nullable should still be optional', async () => {
@@ -846,7 +857,7 @@ describe.concurrent('objects', () => {
             foo: string | undefined | null
           }
         `
-    await assert(typings).toMatchWithoutFormatting(expected)
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(expected)
   })
 
   it('should not treat default property as optional by default', async () => {
@@ -860,7 +871,7 @@ describe.concurrent('objects', () => {
           foo: string
         }
       `
-    await assert(typings).toMatchWithoutFormatting(expected)
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(expected)
   })
 
   it('should treat default property as optional when treatDefaultAsOptional is true', async () => {
@@ -876,7 +887,7 @@ describe.concurrent('objects', () => {
           foo?: string
         }
       `
-    await assert(typings).toMatchWithoutFormatting(expected)
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(expected)
   })
 
   it('should treat an any key as optional for backward compatibility', async () => {
@@ -892,10 +903,10 @@ describe.concurrent('objects', () => {
           a?: any
         }
       `
-    await assert(actual).toMatchWithoutFormatting(expected)
+    await assert.expectTypescript(actual).toMatchWithoutFormatting(expected)
 
     type S = z.infer<typeof zSchema>
-    utils.assert.assertEqual<S, { a?: any }>(true)
+    assert.assertEqual<S, { a?: any }>(true)
   })
 
   it('should treat an optional any key as optional with a single question mark', async () => {
@@ -909,7 +920,7 @@ describe.concurrent('objects', () => {
           a?: any
         }
       `
-    await assert(actual).toMatchWithoutFormatting(expected)
+    await assert.expectTypescript(actual).toMatchWithoutFormatting(expected)
   })
 })
 
@@ -926,14 +937,14 @@ describe.concurrent('generics', () => {
     const schema = z.object({ a: z.string(), b: z.ref('T') }).title('MyObject')
     const typings = toTs(schema, { declaration: 'type' })
 
-    await assert(typings).toMatchWithoutFormatting('type MyObject<T> = { a: string; b: T };')
+    await assert.expectTypescript(typings).toMatchWithoutFormatting('type MyObject<T> = { a: string; b: T };')
   })
 
   it('can generate a generic type by formating ref Uri', async () => {
     const schema = z.object({ a: z.string(), b: z.ref('#/$defs/T') }).title('MyObject')
     const typings = toTs(schema, { declaration: 'type' })
 
-    await assert(typings).toMatchWithoutFormatting('type MyObject<DefsT> = { a: string; b: DefsT };')
+    await assert.expectTypescript(typings).toMatchWithoutFormatting('type MyObject<DefsT> = { a: string; b: DefsT };')
   })
 })
 
@@ -1000,7 +1011,7 @@ describe.concurrent('optional', () => {
   it('should handle top level optional schemas as union with undefined', async () => {
     const schema = z.string().optional().title('MyString')
     const typings = toTs(schema, { declaration: true })
-    await assert(typings).toMatchWithoutFormatting('declare const MyString: string | undefined;')
+    await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const MyString: string | undefined;')
   })
 
   it('should not treat default schema as optional', async () => {
@@ -1008,7 +1019,7 @@ describe.concurrent('optional', () => {
 
     const typings = toTypescript(schema)
     const expected = `declare const x: string`
-    await assert(typings).toMatchWithoutFormatting(expected)
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(expected)
   })
 
   it('should treat default schema as optional when treatDefaultAsOptional is true', async () => {
@@ -1016,6 +1027,6 @@ describe.concurrent('optional', () => {
 
     const typings = toTs(schema, { declaration: true, treatDefaultAsOptional: true })
     const expected = `declare const MyString: string | undefined;`
-    await assert(typings).toMatchWithoutFormatting(expected)
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(expected)
   })
 })

--- a/packages/zui/src/transforms/zui-to-typescript-type/primitives.test.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-type/primitives.test.ts
@@ -1,232 +1,232 @@
 import { test } from 'vitest'
 import { toTypescriptType as toTs } from '.'
 import z from '../../z'
-import { assert } from '../../assertions.utils.test'
+import * as assert from '../../assertions.utils.test'
 
 const toTypescriptType = (schema: z.ZodType) => toTs(schema, { declaration: 'variable' })
 
 test('string', async () => {
   const schema = z.string().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: string')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: string')
 })
 test('string nullable', async () => {
   const schema = z.string().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: string | null')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: string | null')
 })
 test('string optional', async () => {
   const schema = z.string().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: string | undefined')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: string | undefined')
 })
 test('string nullable optional', async () => {
   const schema = z.string().nullable().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: string | null | undefined')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: string | null | undefined')
 })
 test('string optional nullable', async () => {
   const schema = z.string().optional().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: string | undefined | null')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: string | undefined | null')
 })
 test('number', async () => {
   const schema = z.number().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: number')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: number')
 })
 test('number nullable', async () => {
   const schema = z.number().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: number | null')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: number | null')
 })
 test('number optional', async () => {
   const schema = z.number().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: number | undefined')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: number | undefined')
 })
 test('number nullable optional', async () => {
   const schema = z.number().nullable().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: number | null | undefined')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: number | null | undefined')
 })
 test('number optional nullable', async () => {
   const schema = z.number().optional().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: number | undefined | null')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: number | undefined | null')
 })
 test('bigint', async () => {
   const schema = z.bigint().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: number') // should be bigint instead of number
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: number') // should be bigint instead of number
 })
 test('bigint nullable', async () => {
   const schema = z.bigint().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: number | null') // should be bigint instead of number
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: number | null') // should be bigint instead of number
 })
 test('bigint optional', async () => {
   const schema = z.bigint().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: number | undefined') // should be bigint instead of number
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: number | undefined') // should be bigint instead of number
 })
 test('bigint nullable optional', async () => {
   const schema = z.bigint().nullable().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: number | null | undefined') // should be bigint instead of number
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: number | null | undefined') // should be bigint instead of number
 })
 test('bigint optional nullable', async () => {
   const schema = z.bigint().optional().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: number | undefined | null') // should be bigint instead of number
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: number | undefined | null') // should be bigint instead of number
 })
 test('boolean', async () => {
   const schema = z.boolean().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: boolean')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: boolean')
 })
 test('boolean nullable', async () => {
   const schema = z.boolean().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: boolean | null')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: boolean | null')
 })
 test('boolean optional', async () => {
   const schema = z.boolean().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: boolean | undefined')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: boolean | undefined')
 })
 test('boolean nullable optional', async () => {
   const schema = z.boolean().nullable().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: boolean | null | undefined')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: boolean | null | undefined')
 })
 test('boolean optional nullable', async () => {
   const schema = z.boolean().optional().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: boolean | undefined | null')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: boolean | undefined | null')
 })
 test('date', async () => {
   const schema = z.date().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: Date')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: Date')
 })
 test('date nullable', async () => {
   const schema = z.date().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: Date | null')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: Date | null')
 })
 test('date optional', async () => {
   const schema = z.date().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: Date | undefined')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: Date | undefined')
 })
 test('date nullable optional', async () => {
   const schema = z.date().nullable().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: Date | null | undefined')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: Date | null | undefined')
 })
 test('date optional nullable', async () => {
   const schema = z.date().optional().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: Date | undefined | null')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: Date | undefined | null')
 })
 test('undefined', async () => {
   const schema = z.undefined().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: undefined')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: undefined')
 })
 test('undefined nullable', async () => {
   const schema = z.undefined().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: undefined | null')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: undefined | null')
 })
 test('undefined optional', async () => {
   const schema = z.undefined().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: undefined | undefined')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: undefined | undefined')
 })
 test('undefined nullable optional', async () => {
   const schema = z.undefined().nullable().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: undefined | null | undefined')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: undefined | null | undefined')
 })
 test('undefined optional nullable', async () => {
   const schema = z.undefined().optional().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: undefined | undefined | null')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: undefined | undefined | null')
 })
 test('null', async () => {
   const schema = z.null().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: null')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: null')
 })
 test('null nullable', async () => {
   const schema = z.null().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: null | null')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: null | null')
 })
 test('null optional', async () => {
   const schema = z.null().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: null | undefined')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: null | undefined')
 })
 test('null nullable optional', async () => {
   const schema = z.null().nullable().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: null | null | undefined')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: null | null | undefined')
 })
 test('null optional nullable', async () => {
   const schema = z.null().optional().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: null | undefined | null')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: null | undefined | null')
 })
 test('unknown', async () => {
   const schema = z.unknown().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: unknown')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: unknown')
 })
 test('unknown nullable', async () => {
   const schema = z.unknown().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: unknown | null')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: unknown | null')
 })
 test('unknown optional', async () => {
   const schema = z.unknown().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: unknown | undefined')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: unknown | undefined')
 })
 test('unknown nullable optional', async () => {
   const schema = z.unknown().nullable().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: unknown | null | undefined')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: unknown | null | undefined')
 })
 test('unknown optional nullable', async () => {
   const schema = z.unknown().optional().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: unknown | undefined | null')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: unknown | undefined | null')
 })
 test('never', async () => {
   const schema = z.never().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: never')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: never')
 })
 test('never nullable', async () => {
   const schema = z.never().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: never | null')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: never | null')
 })
 test('never optional', async () => {
   const schema = z.never().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: never | undefined')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: never | undefined')
 })
 test('never nullable optional', async () => {
   const schema = z.never().nullable().optional().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: never | null | undefined')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: never | null | undefined')
 })
 test('never optional nullable', async () => {
   const schema = z.never().optional().nullable().title('x')
   const typings: string = toTypescriptType(schema)
-  await assert(typings).toMatchWithoutFormatting('declare const x: never | undefined | null')
+  await assert.expectTypescript(typings).toMatchWithoutFormatting('declare const x: never | undefined | null')
 })

--- a/packages/zui/src/z/__tests__/base.test.ts
+++ b/packages/zui/src/z/__tests__/base.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest'
 import z from '../index'
-import * as utils from '../utils'
+import * as assert from '../../assertions.utils.test'
 
 test('type guard', () => {
   const stringToNumber = z.string().transform((arg) => arg.length)
@@ -13,7 +13,7 @@ test('type guard', () => {
   const data = { stringToNumber: 'asdf' }
   const parsed = s1.safeParse(data)
   if (parsed.success) {
-    utils.assert.assertEqual<typeof data, t1>(true)
+    assert.assertEqual<typeof data, t1>(true)
   }
 })
 

--- a/packages/zui/src/z/__tests__/generics.test.ts
+++ b/packages/zui/src/z/__tests__/generics.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import z from '../index'
-import * as utils from '../utils'
+import * as assert from '../../assertions.utils.test'
 
 test('generics', () => {
   async function stripOuter<TData extends z.ZodType>(schema: TData, data: unknown) {
@@ -15,7 +15,7 @@ test('generics', () => {
   }
 
   const result = stripOuter(z.object({ a: z.string() }), { a: 'asdf' })
-  utils.assert.assertEqual<typeof result, Promise<{ a: string }>>(true)
+  assert.assertEqual<typeof result, Promise<{ a: string }>>(true)
 })
 
 test('assignability', () => {

--- a/packages/zui/src/z/__tests__/instanceof.test.ts
+++ b/packages/zui/src/z/__tests__/instanceof.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import * as utils from '../utils'
+import * as assert from '../../assertions.utils.test'
 import z from '../index'
 
 test('instanceof', async () => {
@@ -25,7 +25,7 @@ test('instanceof', async () => {
   await expect(() => SubtestSchema.parse(new Test())).toThrow(/Input not instance of Subtest/)
   await expect(() => TestSchema.parse(12)).toThrow(/Input not instance of Test/)
 
-  utils.assert.assertEqual<Test, z.infer<typeof TestSchema>>(true)
+  assert.assertEqual<Test, z.infer<typeof TestSchema>>(true)
 })
 
 test('instanceof fatal', () => {

--- a/packages/zui/src/z/__tests__/partials.test.ts
+++ b/packages/zui/src/z/__tests__/partials.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import * as utils from '../utils'
+import * as assert from '../../assertions.utils.test'
 import z from '../index'
 
 const nested = z.object({
@@ -20,7 +20,7 @@ test('shallow inference', () => {
     outer?: { inner: string } | undefined
     array?: { asdf: string }[]
   }
-  utils.assert.assertEqual<shallow, correct>(true)
+  assert.assertEqual<shallow, correct>(true)
 })
 
 test('shallow partial parse', () => {
@@ -68,7 +68,7 @@ test('required inference', () => {
     nullableField: number | null
     nullishField: string | null
   }
-  utils.assert.assertEqual<expected, required>(true)
+  assert.assertEqual<expected, required>(true)
 })
 
 test('required with mask', () => {

--- a/packages/zui/src/z/__tests__/pickomit.test.ts
+++ b/packages/zui/src/z/__tests__/pickomit.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import * as utils from '../utils'
+import * as assert from '../../assertions.utils.test'
 import z from '../index'
 
 const fish = z.object({
@@ -11,7 +11,7 @@ const fish = z.object({
 test('pick type inference', () => {
   const nameonlyFish = fish.pick({ name: true })
   type nameonlyFish = z.infer<typeof nameonlyFish>
-  utils.assert.assertEqual<nameonlyFish, { name: string }>(true)
+  assert.assertEqual<nameonlyFish, { name: string }>(true)
 })
 
 test('pick parse - success', () => {
@@ -46,7 +46,7 @@ test('pick parse - fail', () => {
 test('omit type inference', () => {
   const nonameFish = fish.omit({ name: true })
   type nonameFish = z.infer<typeof nonameFish>
-  utils.assert.assertEqual<nonameFish, { age: number; nested: {} }>(true)
+  assert.assertEqual<nonameFish, { age: number; nested: {} }>(true)
 })
 
 test('omit parse - success', () => {
@@ -77,7 +77,7 @@ test('omit parse - fail', () => {
 test('nonstrict inference', () => {
   const laxfish = fish.pick({ name: true }).catchall(z.any())
   type laxfish = z.infer<typeof laxfish>
-  utils.assert.assertEqual<laxfish, { name: string } & { [k: string]: unknown }>(true)
+  assert.assertEqual<laxfish, { name: string } & { [k: string]: unknown }>(true)
 })
 
 test('nonstrict parsing - pass', () => {

--- a/packages/zui/src/z/__tests__/preprocess.test.ts
+++ b/packages/zui/src/z/__tests__/preprocess.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import * as utils from '../utils'
+import * as assert from '../../assertions.utils.test'
 import z from '../index'
 import { NEVER } from '../types/basetype'
 import { ZodError } from '../error'
@@ -9,7 +9,7 @@ test('preprocess', () => {
 
   const value = schema.parse('asdf')
   expect(value).toEqual(['asdf'])
-  utils.assert.assertEqual<(typeof schema)['_input'], unknown>(true)
+  assert.assertEqual<(typeof schema)['_input'], unknown>(true)
 })
 
 test('async preprocess', async () => {
@@ -135,7 +135,7 @@ test('z.NEVER in preprocess', () => {
   }, z.number())
 
   type foo = z.infer<typeof foo>
-  utils.assert.assertEqual<foo, number>(true)
+  assert.assertEqual<foo, number>(true)
   const arg = foo.safeParse(undefined)
   if (!arg.success) {
     expect(arg.error.issues[0]?.message).toEqual('bad')

--- a/packages/zui/src/z/__tests__/primitive.test.ts
+++ b/packages/zui/src/z/__tests__/primitive.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest'
 import z from '../index'
-import * as utils from '../utils'
+import * as assert from '../../assertions.utils.test'
 import { Mocker } from './Mocker'
 
 const literalStringSchema = z.literal('asdf')
@@ -135,7 +135,7 @@ test('literal bigint object', () => {
 })
 
 test('literal symbol', () => {
-  utils.assert.assertEqual<z.infer<typeof literalSymbolSchema>, typeof MySymbol>(true)
+  assert.assertEqual<z.infer<typeof literalSymbolSchema>, typeof MySymbol>(true)
   literalSymbolSchema.parse(MySymbol)
   expect(() => literalSymbolSchema.parse(Symbol('asdf'))).toThrow()
 })
@@ -371,31 +371,31 @@ test('parse nullSchema null', () => {
 })
 
 test('primitive inference', () => {
-  utils.assert.assertEqual<z.TypeOf<typeof literalStringSchema>, 'asdf'>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof literalNumberSchema>, 12>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof literalBooleanSchema>, true>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof literalBigIntSchema>, bigint>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof stringSchema>, string>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof numberSchema>, number>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof bigintSchema>, bigint>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof booleanSchema>, boolean>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof dateSchema>, Date>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof symbolSchema>, symbol>(true)
+  assert.assertEqual<z.TypeOf<typeof literalStringSchema>, 'asdf'>(true)
+  assert.assertEqual<z.TypeOf<typeof literalNumberSchema>, 12>(true)
+  assert.assertEqual<z.TypeOf<typeof literalBooleanSchema>, true>(true)
+  assert.assertEqual<z.TypeOf<typeof literalBigIntSchema>, bigint>(true)
+  assert.assertEqual<z.TypeOf<typeof stringSchema>, string>(true)
+  assert.assertEqual<z.TypeOf<typeof numberSchema>, number>(true)
+  assert.assertEqual<z.TypeOf<typeof bigintSchema>, bigint>(true)
+  assert.assertEqual<z.TypeOf<typeof booleanSchema>, boolean>(true)
+  assert.assertEqual<z.TypeOf<typeof dateSchema>, Date>(true)
+  assert.assertEqual<z.TypeOf<typeof symbolSchema>, symbol>(true)
 
-  utils.assert.assertEqual<z.TypeOf<typeof nullSchema>, null>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof undefinedSchema>, undefined>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof stringSchemaOptional>, string | undefined>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof stringSchemaNullable>, string | null>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof numberSchemaOptional>, number | undefined>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof numberSchemaNullable>, number | null>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof bigintSchemaOptional>, bigint | undefined>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof bigintSchemaNullable>, bigint | null>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof booleanSchemaOptional>, boolean | undefined>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof booleanSchemaNullable>, boolean | null>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof dateSchemaOptional>, Date | undefined>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof dateSchemaNullable>, Date | null>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof symbolSchemaOptional>, symbol | undefined>(true)
-  utils.assert.assertEqual<z.TypeOf<typeof symbolSchemaNullable>, symbol | null>(true)
+  assert.assertEqual<z.TypeOf<typeof nullSchema>, null>(true)
+  assert.assertEqual<z.TypeOf<typeof undefinedSchema>, undefined>(true)
+  assert.assertEqual<z.TypeOf<typeof stringSchemaOptional>, string | undefined>(true)
+  assert.assertEqual<z.TypeOf<typeof stringSchemaNullable>, string | null>(true)
+  assert.assertEqual<z.TypeOf<typeof numberSchemaOptional>, number | undefined>(true)
+  assert.assertEqual<z.TypeOf<typeof numberSchemaNullable>, number | null>(true)
+  assert.assertEqual<z.TypeOf<typeof bigintSchemaOptional>, bigint | undefined>(true)
+  assert.assertEqual<z.TypeOf<typeof bigintSchemaNullable>, bigint | null>(true)
+  assert.assertEqual<z.TypeOf<typeof booleanSchemaOptional>, boolean | undefined>(true)
+  assert.assertEqual<z.TypeOf<typeof booleanSchemaNullable>, boolean | null>(true)
+  assert.assertEqual<z.TypeOf<typeof dateSchemaOptional>, Date | undefined>(true)
+  assert.assertEqual<z.TypeOf<typeof dateSchemaNullable>, Date | null>(true)
+  assert.assertEqual<z.TypeOf<typeof symbolSchemaOptional>, symbol | undefined>(true)
+  assert.assertEqual<z.TypeOf<typeof symbolSchemaNullable>, symbol | null>(true)
 
   // [
   //   literalStringSchemaTest,

--- a/packages/zui/src/z/__tests__/refine.test.ts
+++ b/packages/zui/src/z/__tests__/refine.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import * as utils from '../utils'
+import * as assert from '../../assertions.utils.test'
 import z from '../index'
 
 test('refinement', () => {
@@ -47,11 +47,11 @@ test('refinement type guard', () => {
   type Input = z.input<typeof validationSchema>
   type Schema = z.infer<typeof validationSchema>
 
-  utils.assert.assertEqual<'a', Input['a']>(false)
-  utils.assert.assertEqual<string, Input['a']>(true)
+  assert.assertEqual<'a', Input['a']>(false)
+  assert.assertEqual<string, Input['a']>(true)
 
-  utils.assert.assertEqual<'a', Schema['a']>(true)
-  utils.assert.assertEqual<string, Schema['a']>(false)
+  assert.assertEqual<'a', Schema['a']>(true)
+  assert.assertEqual<string, Schema['a']>(false)
 })
 
 test('refinement Promise', async () => {
@@ -166,7 +166,7 @@ test('superRefine - type narrowing', () => {
       return true
     })
 
-  utils.assert.assertEqual<z.infer<typeof schema>, NarrowType>(true)
+  assert.assertEqual<z.infer<typeof schema>, NarrowType>(true)
 
   expect(schema.safeParse({ type: 'test', age: 0 }).success).toEqual(true)
   expect(schema.safeParse(null).success).toEqual(false)
@@ -185,7 +185,7 @@ test('chained mixed refining types', () => {
     .nullable()
     .refine((arg): arg is firstRefinement => !!arg?.third)
     .superRefine((arg, ctx): arg is secondRefinement => {
-      utils.assert.assertEqual<typeof arg, firstRefinement>(true)
+      assert.assertEqual<typeof arg, firstRefinement>(true)
       if (arg.first !== 'bob') {
         ctx.addIssue({
           code: 'custom',
@@ -196,11 +196,11 @@ test('chained mixed refining types', () => {
       return true
     })
     .refine((arg): arg is thirdRefinement => {
-      utils.assert.assertEqual<typeof arg, secondRefinement>(true)
+      assert.assertEqual<typeof arg, secondRefinement>(true)
       return arg.second === 33
     })
 
-  utils.assert.assertEqual<z.infer<typeof schema>, thirdRefinement>(true)
+  assert.assertEqual<z.infer<typeof schema>, thirdRefinement>(true)
 })
 
 test('get inner type', () => {

--- a/packages/zui/src/z/__tests__/set.test.ts
+++ b/packages/zui/src/z/__tests__/set.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import * as utils from '../utils'
+import * as assert from '../../assertions.utils.test'
 import * as z from '../index'
 
 const stringSet = z.set(z.string())
@@ -12,7 +12,7 @@ const nonEmpty = z.set(z.string()).nonempty()
 const nonEmptyMax = z.set(z.string()).nonempty().max(2)
 
 test('type inference', () => {
-  utils.assert.assertEqual<stringSet, Set<string>>(true)
+  assert.assertEqual<stringSet, Set<string>>(true)
 })
 
 test('valid parse', () => {

--- a/packages/zui/src/z/types/any/anyunknown.test.ts
+++ b/packages/zui/src/z/types/any/anyunknown.test.ts
@@ -1,13 +1,13 @@
 import { test, expect } from 'vitest'
 import * as z from '../../index'
-import * as utils from '../../utils'
+import * as assert from '../../../assertions.utils.test'
 
 test('check any inference', () => {
   const t1 = z.any()
   t1.optional()
   t1.nullable()
   type t1 = z.infer<typeof t1>
-  utils.assert.assertEqual<t1, any>(true)
+  assert.assertEqual<t1, any>(true)
 })
 
 test('check unknown inference', () => {
@@ -15,7 +15,7 @@ test('check unknown inference', () => {
   t1.optional()
   t1.nullable()
   type t1 = z.infer<typeof t1>
-  utils.assert.assertEqual<t1, unknown>(true)
+  assert.assertEqual<t1, unknown>(true)
 })
 
 test('check never inference', () => {

--- a/packages/zui/src/z/types/array/array.test.ts
+++ b/packages/zui/src/z/types/array/array.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest'
 import * as z from '../../index'
-import * as utils from '../../utils'
+import * as assert from '../../../assertions.utils.test'
 
 const minTwo = z.string().array().min(2)
 const maxTwo = z.string().array().max(2)
@@ -9,10 +9,10 @@ const intNum = z.string().array().nonempty()
 const nonEmptyMax = z.string().array().nonempty().max(2)
 
 type t1 = z.infer<typeof nonEmptyMax>
-utils.assert.assertEqual<[string, ...string[]], t1>(true)
+assert.assertEqual<[string, ...string[]], t1>(true)
 
 type t2 = z.infer<typeof minTwo>
-utils.assert.assertEqual<string[], t2>(true)
+assert.assertEqual<string[], t2>(true)
 
 test('passing validations', () => {
   minTwo.parse(['a', 'a'])

--- a/packages/zui/src/z/types/branded/branded.test.ts
+++ b/packages/zui/src/z/types/branded/branded.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import * as z from '../../index'
-import * as utils from '../../utils'
+import * as assert from '../../../assertions.utils.test'
 import { BRAND } from '../../typings'
 
 test('branded types', () => {
@@ -12,7 +12,7 @@ test('branded types', () => {
 
   // simple branding
   type MySchema = z.infer<typeof mySchema>
-  utils.assert.assertEqual<MySchema, { name: string } & { [BRAND]: { superschema: true } }>(true)
+  assert.assertEqual<MySchema, { name: string } & { [BRAND]: { superschema: true } }>(true)
 
   const doStuff = (arg: MySchema) => arg
   doStuff(mySchema.parse({ name: 'hello there' }))
@@ -20,14 +20,14 @@ test('branded types', () => {
   // inheritance
   const extendedSchema = mySchema.brand<'subschema'>()
   type ExtendedSchema = z.infer<typeof extendedSchema>
-  utils.assert.assertEqual<ExtendedSchema, { name: string } & BRAND<'superschema'> & BRAND<'subschema'>>(true)
+  assert.assertEqual<ExtendedSchema, { name: string } & BRAND<'superschema'> & BRAND<'subschema'>>(true)
 
   doStuff(extendedSchema.parse({ name: 'hello again' }))
 
   // number branding
   const numberSchema = z.number().brand<42>()
   type NumberSchema = z.infer<typeof numberSchema>
-  utils.assert.assertEqual<NumberSchema, number & { [BRAND]: { 42: true } }>(true)
+  assert.assertEqual<NumberSchema, number & { [BRAND]: { 42: true } }>(true)
 
   // symbol branding
   const MyBrand: unique symbol = Symbol('hello')
@@ -35,7 +35,7 @@ test('branded types', () => {
   const symbolBrand = z.number().brand<'sup'>().brand<typeof MyBrand>()
   type SymbolBrand = z.infer<typeof symbolBrand>
   // number & { [BRAND]: { sup: true, [MyBrand]: true } }
-  utils.assert.assertEqual<SymbolBrand, number & BRAND<'sup'> & BRAND<MyBrand>>(true)
+  assert.assertEqual<SymbolBrand, number & BRAND<'sup'> & BRAND<MyBrand>>(true)
 
   // keeping brands out of input types
   const age = z.number().brand<'age'>()
@@ -43,9 +43,9 @@ test('branded types', () => {
   type Age = z.infer<typeof age>
   type AgeInput = z.input<typeof age>
 
-  utils.assert.assertEqual<AgeInput, Age>(false)
-  utils.assert.assertEqual<number, AgeInput>(true)
-  utils.assert.assertEqual<number & BRAND<'age'>, Age>(true)
+  assert.assertEqual<AgeInput, Age>(false)
+  assert.assertEqual<number, AgeInput>(true)
+  assert.assertEqual<number & BRAND<'age'>, Age>(true)
 
   // @ts-expect-error
   doStuff({ name: 'hello there!' })

--- a/packages/zui/src/z/types/catch/catch.test.ts
+++ b/packages/zui/src/z/types/catch/catch.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest'
 import { z } from '../../../index'
-import * as utils from '../../utils'
+import * as assert from '../../../assertions.utils.test'
 import { ZodError } from '../../error'
 
 test('basic catch', () => {
@@ -44,9 +44,9 @@ test('catch with transform', () => {
   expect(stringWithDefault._def.innerType._def.schema.typeName).toBe('ZodString')
 
   type inp = z.input<typeof stringWithDefault>
-  utils.assert.assertEqual<inp, unknown>(true)
+  assert.assertEqual<inp, unknown>(true)
   type out = z.output<typeof stringWithDefault>
-  utils.assert.assertEqual<out, string>(true)
+  assert.assertEqual<out, string>(true)
 })
 
 test('catch on existing optional', () => {
@@ -58,18 +58,18 @@ test('catch on existing optional', () => {
   expect(stringWithDefault._def.innerType._def.innerType.typeName).toBe('ZodString')
 
   type inp = z.input<typeof stringWithDefault>
-  utils.assert.assertEqual<inp, unknown>(true)
+  assert.assertEqual<inp, unknown>(true)
   type out = z.output<typeof stringWithDefault>
-  utils.assert.assertEqual<out, string | undefined>(true)
+  assert.assertEqual<out, string | undefined>(true)
 })
 
 test('optional on catch', () => {
   const stringWithDefault = z.string().catch('asdf').optional()
 
   type inp = z.input<typeof stringWithDefault>
-  utils.assert.assertEqual<inp, unknown>(true)
+  assert.assertEqual<inp, unknown>(true)
   type out = z.output<typeof stringWithDefault>
-  utils.assert.assertEqual<out, string | undefined>(true)
+  assert.assertEqual<out, string | undefined>(true)
 })
 
 test('complex chain example', () => {
@@ -92,7 +92,7 @@ test('removeCatch', () => {
   const stringWithRemovedDefault = z.string().catch('asdf').removeCatch()
 
   type out = z.output<typeof stringWithRemovedDefault>
-  utils.assert.assertEqual<out, string>(true)
+  assert.assertEqual<out, string>(true)
 })
 
 test('nested', () => {
@@ -101,9 +101,9 @@ test('nested', () => {
     inner: 'asdf',
   })
   type input = z.input<typeof outer>
-  utils.assert.assertEqual<input, unknown>(true)
+  assert.assertEqual<input, unknown>(true)
   type out = z.output<typeof outer>
-  utils.assert.assertEqual<out, { inner: string }>(true)
+  assert.assertEqual<out, { inner: string }>(true)
   expect(outer.parse(undefined)).toEqual({ inner: 'asdf' })
   expect(outer.parse({})).toEqual({ inner: 'asdf' })
   expect(outer.parse({ inner: undefined })).toEqual({ inner: 'asdf' })

--- a/packages/zui/src/z/types/default/default.test.ts
+++ b/packages/zui/src/z/types/default/default.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest'
 import { z } from '../../..'
-import * as utils from '../../utils'
+import * as assert from '../../../assertions.utils.test'
 
 test('basic defaults', () => {
   expect(z.string().default('default').parse(undefined)).toBe('default')
@@ -17,9 +17,9 @@ test('default with transform', () => {
   expect(stringWithDefault._def.innerType._def.schema.typeName).toBe('ZodString')
 
   type inp = z.input<typeof stringWithDefault>
-  utils.assert.assertEqual<inp, string | undefined>(true)
+  assert.assertEqual<inp, string | undefined>(true)
   type out = z.output<typeof stringWithDefault>
-  utils.assert.assertEqual<out, string>(true)
+  assert.assertEqual<out, string>(true)
 })
 
 test('default on existing optional', () => {
@@ -30,18 +30,18 @@ test('default on existing optional', () => {
   expect(stringWithDefault._def.innerType._def.innerType.typeName).toBe('ZodString')
 
   type inp = z.input<typeof stringWithDefault>
-  utils.assert.assertEqual<inp, string | undefined>(true)
+  assert.assertEqual<inp, string | undefined>(true)
   type out = z.output<typeof stringWithDefault>
-  utils.assert.assertEqual<out, string>(true)
+  assert.assertEqual<out, string>(true)
 })
 
 test('optional on default', () => {
   const stringWithDefault = z.string().default('asdf').optional()
 
   type inp = z.input<typeof stringWithDefault>
-  utils.assert.assertEqual<inp, string | undefined>(true)
+  assert.assertEqual<inp, string | undefined>(true)
   type out = z.output<typeof stringWithDefault>
-  utils.assert.assertEqual<out, string | undefined>(true)
+  assert.assertEqual<out, string | undefined>(true)
 })
 
 test('complex chain example', () => {
@@ -61,7 +61,7 @@ test('removeDefault', () => {
   const stringWithRemovedDefault = z.string().default('asdf').removeDefault()
 
   type out = z.output<typeof stringWithRemovedDefault>
-  utils.assert.assertEqual<out, string>(true)
+  assert.assertEqual<out, string>(true)
 })
 
 test('nested', () => {
@@ -70,9 +70,9 @@ test('nested', () => {
     inner: undefined,
   })
   type input = z.input<typeof outer>
-  utils.assert.assertEqual<input, { inner?: string | undefined } | undefined>(true)
+  assert.assertEqual<input, { inner?: string | undefined } | undefined>(true)
   type out = z.output<typeof outer>
-  utils.assert.assertEqual<out, { inner: string }>(true)
+  assert.assertEqual<out, { inner: string }>(true)
   expect(outer.parse(undefined)).toEqual({ inner: 'asdf' })
   expect(outer.parse({})).toEqual({ inner: 'asdf' })
   expect(outer.parse({ inner: undefined })).toEqual({ inner: 'asdf' })

--- a/packages/zui/src/z/types/discriminatedUnion/discriminatedUnion.test.ts
+++ b/packages/zui/src/z/types/discriminatedUnion/discriminatedUnion.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest'
 import * as z from '../../index'
-import * as utils from '../../utils'
+import * as assert from '../../../assertions.utils.test'
 
 test('valid', () => {
   expect(
@@ -282,7 +282,7 @@ test('optional and nullable', () => {
   ])
 
   type schema = z.infer<typeof schema>
-  utils.assert.assertEqual<schema, { key?: 'a' | undefined; a: true } | { key: 'b' | null; b: true }>(true)
+  assert.assertEqual<schema, { key?: 'a' | undefined; a: true } | { key: 'b' | null; b: true }>(true)
 
   schema.parse({ key: 'a', a: true })
   schema.parse({ key: undefined, a: true })

--- a/packages/zui/src/z/types/enum/enum.test.ts
+++ b/packages/zui/src/z/types/enum/enum.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import * as utils from '../../utils'
+import * as assert from '../../../assertions.utils.test'
 import * as z from '../../index'
 
 test('create enum', () => {
@@ -12,7 +12,7 @@ test('create enum', () => {
 test('infer enum', () => {
   const MyEnum = z.enum(['Red', 'Green', 'Blue'])
   type MyEnum = z.infer<typeof MyEnum>
-  utils.assert.assertEqual<MyEnum, 'Red' | 'Green' | 'Blue'>(true)
+  assert.assertEqual<MyEnum, 'Red' | 'Green' | 'Blue'>(true)
 })
 
 test('get options', () => {
@@ -23,7 +23,7 @@ test('readonly enum', () => {
   const HTTP_SUCCESS = ['200', '201'] as const
   const arg = z.enum(HTTP_SUCCESS)
   type arg = z.infer<typeof arg>
-  utils.assert.assertEqual<arg, '200' | '201'>(true)
+  assert.assertEqual<arg, '200' | '201'>(true)
 
   arg.parse('201')
   expect(() => arg.parse('202')).toThrow()
@@ -44,11 +44,11 @@ test('extract/exclude', () => {
   const UnhealthyEnum = FoodEnum.exclude(['Salad'])
   const EmptyFoodEnum = FoodEnum.exclude(foods)
 
-  utils.assert.assertEqual<z.infer<typeof ItalianEnum>, 'Pasta' | 'Pizza'>(true)
-  utils.assert.assertEqual<z.infer<typeof UnhealthyEnum>, 'Pasta' | 'Pizza' | 'Tacos' | 'Burgers'>(true)
+  assert.assertEqual<z.infer<typeof ItalianEnum>, 'Pasta' | 'Pizza'>(true)
+  assert.assertEqual<z.infer<typeof UnhealthyEnum>, 'Pasta' | 'Pizza' | 'Tacos' | 'Burgers'>(true)
   // @ts-expect-error TS2344
-  utils.assert.assertEqual<typeof EmptyFoodEnum, z.ZodEnum<[]>>(true)
-  utils.assert.assertEqual<z.infer<typeof EmptyFoodEnum>, never>(true)
+  assert.assertEqual<typeof EmptyFoodEnum, z.ZodEnum<[]>>(true)
+  assert.assertEqual<z.infer<typeof EmptyFoodEnum>, never>(true)
 })
 
 test('error map in extract/exclude', () => {

--- a/packages/zui/src/z/types/function/function.test.ts
+++ b/packages/zui/src/z/types/function/function.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest'
 import * as z from '../../index'
-import * as utils from '../../utils'
+import * as assert from '../../../assertions.utils.test'
 import { ZodError } from '../../error'
 
 const args1 = z.tuple([z.string()])
@@ -24,7 +24,7 @@ test('parsed function fail 2', () => {
 
 test('function inference 1', () => {
   type func1 = z.TypeOf<typeof func1>
-  utils.assert.assertEqual<func1, (k: string) => number>(true)
+  assert.assertEqual<func1, (k: string) => number>(true)
 })
 
 test('method parsing', () => {
@@ -60,15 +60,15 @@ test('async method parsing', async () => {
 test('args method', () => {
   const t1 = z.function()
   type t1 = z.infer<typeof t1>
-  utils.assert.assertEqual<t1, (...args_1: unknown[]) => unknown>(true)
+  assert.assertEqual<t1, (...args_1: unknown[]) => unknown>(true)
 
   const t2 = t1.args(z.string())
   type t2 = z.infer<typeof t2>
-  utils.assert.assertEqual<t2, (arg: string, ...args_1: unknown[]) => unknown>(true)
+  assert.assertEqual<t2, (arg: string, ...args_1: unknown[]) => unknown>(true)
 
   const t3 = t2.returns(z.boolean())
   type t3 = z.infer<typeof t3>
-  utils.assert.assertEqual<t3, (arg: string, ...args_1: unknown[]) => boolean>(true)
+  assert.assertEqual<t3, (arg: string, ...args_1: unknown[]) => boolean>(true)
 })
 
 const args2 = z.tuple([
@@ -84,7 +84,7 @@ const func2 = z.function(args2, returns2)
 
 test('function inference 2', () => {
   type func2 = z.TypeOf<typeof func2>
-  utils.assert.assertEqual<
+  assert.assertEqual<
     func2,
     (arg: { f1: number; f2: string | null; f3?: (boolean | undefined)[] | undefined }) => string | number
   >(true)
@@ -235,7 +235,7 @@ test('inference with transforms', () => {
   })
   myFunc('asdf')
 
-  utils.assert.assertEqual<typeof myFunc, (arg: string, ...args_1: unknown[]) => { val: number; extra: string }>(true)
+  assert.assertEqual<typeof myFunc, (arg: string, ...args_1: unknown[]) => { val: number; extra: string }>(true)
 })
 
 test('fallback to OuterTypeOfFunction', () => {
@@ -248,5 +248,5 @@ test('fallback to OuterTypeOfFunction', () => {
     return { arg: val, arg2: false }
   })
 
-  utils.assert.assertEqual<typeof myFunc, (arg: string, ...args_1: unknown[]) => number>(true)
+  assert.assertEqual<typeof myFunc, (arg: string, ...args_1: unknown[]) => number>(true)
 })

--- a/packages/zui/src/z/types/map/map.test.ts
+++ b/packages/zui/src/z/types/map/map.test.ts
@@ -1,12 +1,12 @@
 import { test, expect } from 'vitest'
-import * as utils from '../../utils'
+import * as assert from '../../../assertions.utils.test'
 import * as z from '../../index'
 
 const stringMap = z.map(z.string(), z.string())
 type stringMap = z.infer<typeof stringMap>
 
 test('type inference', () => {
-  utils.assert.assertEqual<stringMap, Map<string, string>>(true)
+  assert.assertEqual<stringMap, Map<string, string>>(true)
 })
 
 test('valid parse', () => {

--- a/packages/zui/src/z/types/nativeEnum/nativeEnum.test.ts
+++ b/packages/zui/src/z/types/nativeEnum/nativeEnum.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest'
-import * as utils from '../../utils'
 import * as z from '../../index'
+import * as assert from '../../../assertions.utils.test'
 
 test('nativeEnum test with consts', () => {
   const Fruits: { Apple: 'apple'; Banana: 'banana' } = {
@@ -13,7 +13,7 @@ test('nativeEnum test with consts', () => {
   fruitEnum.parse('banana')
   fruitEnum.parse(Fruits.Apple)
   fruitEnum.parse(Fruits.Banana)
-  utils.assert.assertEqual<fruitEnum, 'apple' | 'banana'>(true)
+  assert.assertEqual<fruitEnum, 'apple' | 'banana'>(true)
 })
 
 test('nativeEnum test with real enum', () => {
@@ -28,7 +28,7 @@ test('nativeEnum test with real enum', () => {
   fruitEnum.parse('banana')
   fruitEnum.parse(Fruits.Apple)
   fruitEnum.parse(Fruits.Banana)
-  utils.assert.assertIs<fruitEnum extends Fruits ? true : false>(true)
+  assert.assertIs<fruitEnum extends Fruits ? true : false>(true)
 })
 
 test('nativeEnum test with const with numeric keys', () => {
@@ -43,7 +43,7 @@ test('nativeEnum test with const with numeric keys', () => {
   fruitEnum.parse(20)
   fruitEnum.parse(FruitValues.Apple)
   fruitEnum.parse(FruitValues.Banana)
-  utils.assert.assertEqual<fruitEnum, 10 | 20>(true)
+  assert.assertEqual<fruitEnum, 10 | 20>(true)
 })
 
 test('from enum', () => {

--- a/packages/zui/src/z/types/object/object.test.ts
+++ b/packages/zui/src/z/types/object/object.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import * as utils from '../../utils'
+import * as assert from '../../../assertions.utils.test'
 import * as z from '../../index'
 
 const Test = z.object({
@@ -18,7 +18,7 @@ test('object type inference', () => {
     f4: { t: string | boolean }[]
   }
 
-  utils.assert.assertEqual<z.TypeOf<typeof Test>, TestType>(true)
+  assert.assertEqual<z.TypeOf<typeof Test>, TestType>(true)
 })
 
 test('unknown throw', () => {
@@ -124,8 +124,8 @@ test('catchall inference', () => {
   const prop1 = d1.first
   const prop2 = d1.num
 
-  utils.assert.assertEqual<string, typeof prop1>(true)
-  utils.assert.assertEqual<unknown, typeof prop2>(true)
+  assert.assertEqual<string, typeof prop1>(true)
+  assert.assertEqual<unknown, typeof prop2>(true)
 })
 
 test('catchall overrides strict', () => {
@@ -213,7 +213,7 @@ test('test async union', async () => {
 test('test inferred merged type', async () => {
   const asdf = z.object({ a: z.string() }).merge(z.object({ a: z.number() }))
   type asdf = z.infer<typeof asdf>
-  utils.assert.assertEqual<asdf, { a: number }>(true)
+  assert.assertEqual<asdf, { a: number }>(true)
 })
 
 test('inferred merged object type with optional properties', async () => {
@@ -221,9 +221,9 @@ test('inferred merged object type with optional properties', async () => {
     .object({ a: z.string(), b: z.string().optional() })
     .merge(z.object({ a: z.string().optional(), b: z.string() }))
   type Merged = z.infer<typeof Merged>
-  utils.assert.assertEqual<Merged, { a?: string; b: string }>(true)
+  assert.assertEqual<Merged, { a?: string; b: string }>(true)
   // todo
-  // utils.assert.assertEqual<Merged, { a?: string; b: string }>(true);
+  // assert.assertEqual<Merged, { a?: string; b: string }>(true);
 })
 
 test('inferred unioned object type with optional properties', async () => {
@@ -232,7 +232,7 @@ test('inferred unioned object type with optional properties', async () => {
     z.object({ a: z.string().optional(), b: z.string() }),
   ])
   type Unioned = z.infer<typeof Unioned>
-  utils.assert.assertEqual<Unioned, { a: string; b?: string } | { a?: string; b: string }>(true)
+  assert.assertEqual<Unioned, { a: string; b?: string } | { a?: string; b: string }>(true)
 })
 
 test('inferred enum type', async () => {
@@ -248,19 +248,19 @@ test('inferred enum type', async () => {
   })
   expect(Enum._def.values).toEqual(['a', 'b'])
   type Enum = z.infer<typeof Enum>
-  utils.assert.assertEqual<Enum, 'a' | 'b'>(true)
+  assert.assertEqual<Enum, 'a' | 'b'>(true)
 })
 
 test('inferred partial object type with optional properties', async () => {
   const Partial = z.object({ a: z.string(), b: z.string().optional() }).partial()
   type Partial = z.infer<typeof Partial>
-  utils.assert.assertEqual<Partial, { a?: string; b?: string }>(true)
+  assert.assertEqual<Partial, { a?: string; b?: string }>(true)
 })
 
 test('inferred picked object type with optional properties', async () => {
   const Picked = z.object({ a: z.string(), b: z.string().optional() }).pick({ b: true })
   type Picked = z.infer<typeof Picked>
-  utils.assert.assertEqual<Picked, { b?: string }>(true)
+  assert.assertEqual<Picked, { b?: string }>(true)
 })
 
 test('inferred type for unknown/any keys', () => {
@@ -271,7 +271,7 @@ test('inferred type for unknown/any keys', () => {
     unknownRequired: z.unknown(),
   })
   type myType = z.infer<typeof myType>
-  utils.assert.assertEqual<
+  assert.assertEqual<
     myType,
     {
       anyOptional?: any
@@ -287,7 +287,7 @@ test('setKey', () => {
   const withNewKey = base.setKey('age', z.number())
 
   type withNewKey = z.infer<typeof withNewKey>
-  utils.assert.assertEqual<withNewKey, { name: string; age: number }>(true)
+  assert.assertEqual<withNewKey, { name: string; age: number }>(true)
   withNewKey.parse({ name: 'asdf', age: 1234 })
 })
 
@@ -347,7 +347,7 @@ test('constructor key', () => {
   })
 
   type Example = z.infer<typeof Example>
-  utils.assert.assertEqual<keyof Example, 'prop' | 'opt' | 'arr'>(true)
+  assert.assertEqual<keyof Example, 'prop' | 'opt' | 'arr'>(true)
 })
 
 test('unknownkeys merging', () => {
@@ -368,7 +368,7 @@ test('unknownkeys merging', () => {
   const mergedSchema = schemaA.merge(schemaB)
   type mergedSchema = typeof mergedSchema
 
-  utils.assert.assertEqual<mergedSchema['_def']['unknownKeys'], z.ZodString>(true)
+  assert.assertEqual<mergedSchema['_def']['unknownKeys'], z.ZodString>(true)
   expect(mergedSchema._def.unknownKeys.typeName).toBe('ZodString')
 })
 
@@ -385,8 +385,8 @@ test('extend() should return schema with new key', () => {
   const actual = PersonWithNickname.parse(expected)
 
   expect(actual).toEqual(expected)
-  utils.assert.assertEqual<keyof PersonWithNickname, 'firstName' | 'lastName' | 'nickName'>(true)
-  utils.assert.assertEqual<PersonWithNickname, { firstName: string; lastName: string; nickName: string }>(true)
+  assert.assertEqual<keyof PersonWithNickname, 'firstName' | 'lastName' | 'nickName'>(true)
+  assert.assertEqual<PersonWithNickname, { firstName: string; lastName: string; nickName: string }>(true)
 })
 
 test('extend() should have power to override existing key', () => {
@@ -399,16 +399,16 @@ test('extend() should have power to override existing key', () => {
   const actual = PersonWithNumberAsLastName.parse(expected)
 
   expect(actual).toEqual(expected)
-  utils.assert.assertEqual<PersonWithNumberAsLastName, { firstName: string; lastName: number }>(true)
+  assert.assertEqual<PersonWithNumberAsLastName, { firstName: string; lastName: number }>(true)
 })
 
 test('passthrough index signature', () => {
   const a = z.object({ a: z.string() })
   type a = z.infer<typeof a>
-  utils.assert.assertEqual<{ a: string }, a>(true)
+  assert.assertEqual<{ a: string }, a>(true)
   const b = a.passthrough()
   type b = z.infer<typeof b>
-  utils.assert.assertEqual<{ a: string } & { [k: string]: unknown }, b>(true)
+  assert.assertEqual<{ a: string } & { [k: string]: unknown }, b>(true)
 })
 
 test('xor', () => {

--- a/packages/zui/src/z/types/promise/promise.test.ts
+++ b/packages/zui/src/z/types/promise/promise.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import * as utils from '../../utils'
+import * as assert from '../../../assertions.utils.test'
 import * as z from '../../index'
 import { ZodError } from '../../error'
 
@@ -12,7 +12,7 @@ const promSchema = z.promise(
 
 test('promise inference', () => {
   type promSchemaType = z.infer<typeof promSchema>
-  utils.assert.assertEqual<promSchemaType, Promise<{ name: string; age: number }>>(true)
+  assert.assertEqual<promSchemaType, Promise<{ name: string; age: number }>>(true)
 })
 
 test('promise parsing success', async () => {

--- a/packages/zui/src/z/types/readonly/readonly.test.ts
+++ b/packages/zui/src/z/types/readonly/readonly.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import * as utils from '../../utils'
+import * as assert from '../../../assertions.utils.test'
 import * as z from '../../index'
 
 enum testEnum {
@@ -33,90 +33,89 @@ const schemas = [
 ] as const
 
 test('flat inference', () => {
-  utils.assert.assertEqual<z.infer<(typeof schemas)[0]>, string>(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[1]>, number>(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[2]>, number>(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[3]>, bigint>(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[4]>, boolean>(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[5]>, Date>(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[6]>, undefined>(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[7]>, null>(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[8]>, any>(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[9]>, Readonly<unknown>>(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[10]>, void>(true)
-  utils.assert.assertEqual<
-    z.infer<(typeof schemas)[11]>,
-    (args_0: string, args_1: number, ...args_2: unknown[]) => unknown
-  >(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[12]>, readonly string[]>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[0]>, string>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[1]>, number>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[2]>, number>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[3]>, bigint>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[4]>, boolean>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[5]>, Date>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[6]>, undefined>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[7]>, null>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[8]>, any>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[9]>, Readonly<unknown>>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[10]>, void>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[11]>, (args_0: string, args_1: number, ...args_2: unknown[]) => unknown>(
+    true
+  )
+  assert.assertEqual<z.infer<(typeof schemas)[12]>, readonly string[]>(true)
 
-  utils.assert.assertEqual<z.infer<(typeof schemas)[13]>, readonly [string, number]>(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[14]>, ReadonlyMap<string, Date>>(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[15]>, ReadonlySet<Promise<string>>>(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[16]>, Readonly<Record<string, string>>>(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[17]>, Readonly<Record<string, number>>>(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[18]>, { readonly a: string; readonly 1: number }>(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[19]>, Readonly<testEnum>>(true)
-  utils.assert.assertEqual<z.infer<(typeof schemas)[20]>, Promise<string>>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[13]>, readonly [string, number]>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[14]>, ReadonlyMap<string, Date>>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[15]>, ReadonlySet<Promise<string>>>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[16]>, Readonly<Record<string, string>>>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[17]>, Readonly<Record<string, number>>>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[18]>, { readonly a: string; readonly 1: number }>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[19]>, Readonly<testEnum>>(true)
+  assert.assertEqual<z.infer<(typeof schemas)[20]>, Promise<string>>(true)
 })
 
 // test("deep inference", () => {
-//   utils.assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[0]>, string>(true);
-//   utils.assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[1]>, number>(true);
-//   utils.assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[2]>, number>(true);
-//   utils.assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[3]>, bigint>(true);
-//   utils.assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[4]>, boolean>(true);
-//   utils.assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[5]>, Date>(true);
-//   utils.assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[6]>, undefined>(true);
-//   utils.assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[7]>, null>(true);
-//   utils.assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[8]>, any>(true);
-//   utils.assert.assertEqual<
+//   assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[0]>, string>(true);
+//   assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[1]>, number>(true);
+//   assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[2]>, number>(true);
+//   assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[3]>, bigint>(true);
+//   assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[4]>, boolean>(true);
+//   assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[5]>, Date>(true);
+//   assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[6]>, undefined>(true);
+//   assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[7]>, null>(true);
+//   assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[8]>, any>(true);
+//   assert.assertEqual<
 //     z.infer<(typeof deepReadonlySchemas_0)[9]>,
 //     Readonly<unknown>
 //   >(true);
-//   utils.assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[10]>, void>(true);
-//   utils.assert.assertEqual<
+//   assert.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[10]>, void>(true);
+//   assert.assertEqual<
 //     z.infer<(typeof deepReadonlySchemas_0)[11]>,
 //     (args_0: string, args_1: number, ...args_2: unknown[]) => unknown
 //   >(true);
-//   utils.assert.assertEqual<
+//   assert.assertEqual<
 //     z.infer<(typeof deepReadonlySchemas_0)[12]>,
 //     readonly string[]
 //   >(true);
-//   utils.assert.assertEqual<
+//   assert.assertEqual<
 //     z.infer<(typeof deepReadonlySchemas_0)[13]>,
 //     readonly [string, number]
 //   >(true);
-//   utils.assert.assertEqual<
+//   assert.assertEqual<
 //     z.infer<(typeof deepReadonlySchemas_0)[14]>,
 //     ReadonlyMap<string, Date>
 //   >(true);
-//   utils.assert.assertEqual<
+//   assert.assertEqual<
 //     z.infer<(typeof deepReadonlySchemas_0)[15]>,
 //     ReadonlySet<Promise<string>>
 //   >(true);
-//   utils.assert.assertEqual<
+//   assert.assertEqual<
 //     z.infer<(typeof deepReadonlySchemas_0)[16]>,
 //     Readonly<Record<string, string>>
 //   >(true);
-//   utils.assert.assertEqual<
+//   assert.assertEqual<
 //     z.infer<(typeof deepReadonlySchemas_0)[17]>,
 //     Readonly<Record<string, number>>
 //   >(true);
-//   utils.assert.assertEqual<
+//   assert.assertEqual<
 //     z.infer<(typeof deepReadonlySchemas_0)[18]>,
 //     { readonly a: string; readonly 1: number }
 //   >(true);
-//   utils.assert.assertEqual<
+//   assert.assertEqual<
 //     z.infer<(typeof deepReadonlySchemas_0)[19]>,
 //     Readonly<testEnum>
 //   >(true);
-//   utils.assert.assertEqual<
+//   assert.assertEqual<
 //     z.infer<(typeof deepReadonlySchemas_0)[20]>,
 //     Promise<string>
 //   >(true);
 
-//   utils.assert.assertEqual<
+//   assert.assertEqual<
 //     z.infer<typeof crazyDeepReadonlySchema>,
 //     ReadonlyMap<
 //       ReadonlySet<readonly [string, number]>,

--- a/packages/zui/src/z/types/record/record.test.ts
+++ b/packages/zui/src/z/types/record/record.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import * as utils from '../../utils'
+import * as assert from '../../../assertions.utils.test'
 import * as z from '../../index'
 
 const booleanRecord = z.record(z.boolean())
@@ -12,11 +12,11 @@ const recordWithLiteralKeys = z.record(z.union([z.literal('Tuna'), z.literal('Sa
 type recordWithLiteralKeys = z.infer<typeof recordWithLiteralKeys>
 
 test('type inference', () => {
-  utils.assert.assertEqual<booleanRecord, Record<string, boolean>>(true)
+  assert.assertEqual<booleanRecord, Record<string, boolean>>(true)
 
-  utils.assert.assertEqual<recordWithEnumKeys, Partial<Record<'Tuna' | 'Salmon', string>>>(true)
+  assert.assertEqual<recordWithEnumKeys, Partial<Record<'Tuna' | 'Salmon', string>>>(true)
 
-  utils.assert.assertEqual<recordWithLiteralKeys, Partial<Record<'Tuna' | 'Salmon', string>>>(true)
+  assert.assertEqual<recordWithLiteralKeys, Partial<Record<'Tuna' | 'Salmon', string>>>(true)
 })
 
 test('methods', () => {

--- a/packages/zui/src/z/types/ref/ref.test.ts
+++ b/packages/zui/src/z/types/ref/ref.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest'
 import * as z from '../../index'
-import * as utils from '../../utils'
+import * as assert from '../../../assertions.utils.test'
 
 const T = z.ref('T')
 
@@ -20,5 +20,5 @@ test('type inference', () => {
     data: NonNullable<unknown>
   }
   type Actual = z.infer<typeof schema>
-  utils.assert.assertEqual<Actual, Expected>(true)
+  assert.assertEqual<Actual, Expected>(true)
 })

--- a/packages/zui/src/z/types/transformer/index.ts
+++ b/packages/zui/src/z/types/transformer/index.ts
@@ -180,7 +180,7 @@ export class ZodEffectsImpl<T extends IZodType = IZodType, Output = output<T>, I
       return utils.others.compareFunctions(this._def.effect.transform, schema._def.effect.transform)
     }
 
-    type _assertion = utils.assert.AssertNever<typeof this._def.effect>
+    this._def.effect satisfies never
     return false
   }
 

--- a/packages/zui/src/z/types/transformer/transformer.test.ts
+++ b/packages/zui/src/z/types/transformer/transformer.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest'
-import * as utils from '../../utils'
 import * as z from '../../index'
+import * as assert from '../../../assertions.utils.test'
 import { NEVER } from '..'
 
 const stringToNumber = z.string().transform((arg) => parseFloat(arg))
@@ -85,7 +85,7 @@ test('z.NEVER in transform', () => {
       return val
     })
   type foo = z.infer<typeof foo>
-  utils.assert.assertEqual<foo, number>(true)
+  assert.assertEqual<foo, number>(true)
   const arg = foo.safeParse(undefined)
   if (!arg.success) {
     expect(arg.error.issues[0]?.message).toEqual('bad')
@@ -177,8 +177,8 @@ test('object typing', () => {
   type t1 = z.input<typeof t1>
   type t2 = z.output<typeof t1>
 
-  utils.assert.assertEqual<t1, { stringToNumber: string }>(true)
-  utils.assert.assertEqual<t2, { stringToNumber: number }>(true)
+  assert.assertEqual<t1, { stringToNumber: string }>(true)
+  assert.assertEqual<t2, { stringToNumber: number }>(true)
 })
 
 test('transform method overloads', () => {

--- a/packages/zui/src/z/types/tuple/tuple.test.ts
+++ b/packages/zui/src/z/types/tuple/tuple.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest'
-import * as utils from '../../utils'
 import * as z from '../../index'
+import * as assert from '../../../assertions.utils.test'
 import { ZodError } from '../../error'
 
 const testTuple = z.tuple([z.string(), z.object({ name: z.literal('Rudy') }), z.array(z.literal('blue'))])
@@ -12,7 +12,7 @@ test('tuple inference', () => {
   const returns1 = z.number()
   const func1 = z.function(args1, returns1)
   type func1 = z.TypeOf<typeof func1>
-  utils.assert.assertEqual<func1, (k: string) => number>(true)
+  assert.assertEqual<func1, (k: string) => number>(true)
 })
 
 test('successful validation', () => {
@@ -58,9 +58,9 @@ test('tuple with transformers', () => {
   const val = z.tuple([stringToNumber])
 
   type t1 = z.input<typeof val>
-  utils.assert.assertEqual<t1, [string]>(true)
+  assert.assertEqual<t1, [string]>(true)
   type t2 = z.output<typeof val>
-  utils.assert.assertEqual<t2, [number]>(true)
+  assert.assertEqual<t2, [number]>(true)
   expect(val.parse(['1234'])).toEqual([4])
 })
 
@@ -73,7 +73,7 @@ test('tuple with rest schema', () => {
   expect(() => myTuple.parse(['asdf', 1234, 'asdf'])).toThrow()
   type t1 = z.output<typeof myTuple>
 
-  utils.assert.assertEqual<t1, [string, number, ...boolean[]]>(true)
+  assert.assertEqual<t1, [string, number, ...boolean[]]>(true)
 })
 
 test('parse should fail given sparse array as tuple', () => {

--- a/packages/zui/src/z/types/void/void.test.ts
+++ b/packages/zui/src/z/types/void/void.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest'
 import * as z from '../../index'
-import * as utils from '../../utils'
+import * as assert from '../../../assertions.utils.test'
 
 test('void', () => {
   const v = z.void()
@@ -10,5 +10,5 @@ test('void', () => {
   expect(() => v.parse('')).toThrow()
 
   type v = z.infer<typeof v>
-  utils.assert.assertEqual<v, void>(true)
+  assert.assertEqual<v, void>(true)
 })

--- a/packages/zui/src/z/utils/assert-utils.ts
+++ b/packages/zui/src/z/utils/assert-utils.ts
@@ -1,10 +1,6 @@
-import { IsEqual } from './type-utils'
-
-export type AssertNever<_T extends never> = true
-export type AssertTrue<_T extends true> = true
-
-export const assertEqual = <A, B>(val: IsEqual<A, B>) => val
-export function assertIs<T>(_arg: T): void {}
+/**
+ * @deprecated use x satisfies never instead
+ */
 export function assertNever(_x: never): never {
   throw new Error('assertNever called')
 }

--- a/packages/zui/src/z/utils/type-utils.ts
+++ b/packages/zui/src/z/utils/type-utils.ts
@@ -1,6 +1,4 @@
 export type ValueOf<T> = T[keyof T]
-export type IsEqual<T, U> = (<V>() => V extends T ? 1 : 2) extends <V>() => V extends U ? 1 : 2 ? true : false
-export type IsAny<T> = 0 extends 1 & T ? true : false
 export type NoUndefined<T> = T extends undefined ? never : T
 export type Satisfies<X extends Y, Y> = X
 export type SafeOmit<T, K extends keyof T> = Omit<T, K>
@@ -9,21 +7,6 @@ export type Cast<A, B> = A extends B ? A : B
 export type Writeable<T> = {
   -readonly [P in keyof T]: T[P]
 }
-
-type NormalizeObject<T extends object> = T extends infer O ? { [K in keyof O]: Normalize<O[K]> } : never
-export type Normalize<T> = T extends (...args: infer A) => infer R
-  ? (...args: Normalize<A>) => Normalize<R>
-  : T extends Array<infer E>
-    ? Array<Normalize<E>>
-    : T extends ReadonlyArray<infer E>
-      ? ReadonlyArray<Normalize<E>>
-      : T extends Promise<infer R>
-        ? Promise<Normalize<R>>
-        : T extends Buffer
-          ? Buffer
-          : T extends object
-            ? NormalizeObject<T>
-            : T
 
 type _UnionToIntersectionFn<T> = (T extends unknown ? (k: () => T) => void : never) extends (
   k: infer Intersection


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Consolidated test assertion utilities (`assertIs`, `assertEqual`, `IsEqual`) from scattered utility files into a single `assertions.utils.test.ts` file, ensuring they won't be bundled in production builds.

- Moved test-only utilities from `z/utils/assert-utils.ts` and `z/utils/type-utils.ts` to `assertions.utils.test.ts`
- Updated 30+ test files to import from the new centralized location
- Replaced test utility usage in production code with native TypeScript `satisfies` keyword (in 7 non-test files)
- Renamed `assert` function to `expectTypescript` for clearer naming
- Removed unused type utilities (`IsEqual`, `IsAny`, `Normalize`) from `type-utils.ts`
- Marked remaining `assertNever` as deprecated in favor of `satisfies never`

The refactoring achieves the PR's goal of preventing test utilities from being bundled while modernizing the codebase to use native TypeScript features.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Clean refactoring that consolidates test utilities into a `.test.ts` file ensuring they won't be bundled, modernizes code with native TypeScript `satisfies` keyword, and maintains all functionality with no breaking changes
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/zui/src/assertions.utils.test.ts | Consolidated test assertion utilities (`assertIs`, `assertEqual`, `IsEqual`) and renamed `assert` to `expectTypescript` |
| packages/zui/src/z/utils/assert-utils.ts | Removed test utilities, now only contains deprecated `assertNever` function |
| packages/zui/src/z/utils/type-utils.ts | Removed unused type utilities (`IsEqual`, `IsAny`, `Normalize`) that were moved or no longer needed |
| packages/zui/src/transforms/zui-from-json-schema/index.ts | Replaced test assertion type with native TypeScript `satisfies` keyword |
| packages/zui/src/transforms/zui-to-json-schema/index.ts | Replaced `assertEqual` test utility with native TypeScript `satisfies` keyword |

</details>



<sub>Last reviewed commit: 3806db8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->