### PR TITLE
fix(integrations/gsheets): improve zod description + rework append logic

### DIFF
--- a/integrations/gsheets/definitions/actions.ts
+++ b/integrations/gsheets/definitions/actions.ts
@@ -104,7 +104,7 @@ const appendValues = {
         .string()
         .title('Start Column')
         .describe(
-          'The start column letter(s) (e.g. "A", "B", "AA"). The range will be constructed from this column row 1 to column row 100000.'
+          'The start column letter(s) (e.g. "A", "B", "AA"). Used to identify the table in the sheet — data will be appended after the last row of the detected table.'
         ),
       majorDimension: _commonFields.majorDimension
         .optional()
@@ -425,7 +425,12 @@ const createNamedRangeInSheet = {
   input: {
     schema: z.object({
       sheetId: z.number().title('Sheet ID').describe('The ID of the sheet to create the named range in.'),
-      rangeName: z.string().title('Name').describe('The name of the named range.'),
+      rangeName: z
+        .string()
+        .title('Name')
+        .describe(
+          'The name of the named range. Must follow naming rules: cannot contain spaces, cannot start with a number, and cannot conflict with standard cell references (e.g., "A1", "R1C1"). Names violating these rules will be considered invalid.'
+        ),
       rangeA1: _commonFields.range.describe(
         'The A1 notation of the range to associate with the named range. (e.g. "Sheet1!A1:B2")'
       ),

--- a/integrations/gsheets/integration.definition.ts
+++ b/integrations/gsheets/integration.definition.ts
@@ -13,7 +13,7 @@ import {
 } from './definitions'
 
 export const INTEGRATION_NAME = 'gsheets'
-export const INTEGRATION_VERSION = '2.1.3'
+export const INTEGRATION_VERSION = '2.1.4'
 
 export default new sdk.IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/gsheets/src/actions/implementations/append-values-utils.ts
+++ b/integrations/gsheets/src/actions/implementations/append-values-utils.ts
@@ -1,6 +1,15 @@
-const MAX_ROW_NUMBER = 100000
+const _quoteSheetName = (sheetName: string): string => {
+  if (sheetName.startsWith("'") && sheetName.endsWith("'")) {
+    return sheetName
+  }
+  if (/[^A-Za-z0-9_]/.test(sheetName)) {
+    const escaped = sheetName.replace(/'/g, "''")
+    return `'${escaped}'`
+  }
+  return sheetName
+}
 
 export const constructRangeFromStartColumn = (sheetName: string | undefined, startColumn: string): string => {
-  const sheetPrefix = sheetName ? `${sheetName}!` : ''
-  return `${sheetPrefix}${startColumn}:${startColumn}${MAX_ROW_NUMBER}`
+  const sheetPrefix = sheetName ? `${_quoteSheetName(sheetName)}!` : ''
+  return `${sheetPrefix}${startColumn}:${startColumn}`
 }

--- a/integrations/gsheets/src/actions/implementations/append-values.test.ts
+++ b/integrations/gsheets/src/actions/implementations/append-values.test.ts
@@ -3,35 +3,50 @@ import { constructRangeFromStartColumn } from './append-values-utils'
 
 describe.concurrent('constructRangeFromStartColumn', () => {
   it('constructs range for simple column without sheet name', () => {
-    expect(constructRangeFromStartColumn(undefined, 'A')).toBe('A:A100000')
-    expect(constructRangeFromStartColumn(undefined, 'ZZ')).toBe('ZZ:ZZ100000')
+    expect(constructRangeFromStartColumn(undefined, 'A')).toBe('A:A')
+    expect(constructRangeFromStartColumn(undefined, 'ZZ')).toBe('ZZ:ZZ')
   })
 
   it('constructs range for column with sheet name', () => {
-    expect(constructRangeFromStartColumn('Sheet1', 'A')).toBe('Sheet1!A:A100000')
-    expect(constructRangeFromStartColumn('Sheet1', 'B')).toBe('Sheet1!B:B100000')
-    expect(constructRangeFromStartColumn('My Sheet', 'C')).toBe('My Sheet!C:C100000')
-    expect(constructRangeFromStartColumn('Sheet1', 'AA')).toBe('Sheet1!AA:AA100000')
+    expect(constructRangeFromStartColumn('Sheet1', 'A')).toBe('Sheet1!A:A')
+    expect(constructRangeFromStartColumn('Sheet1', 'B')).toBe('Sheet1!B:B')
+    expect(constructRangeFromStartColumn('Sheet1', 'AA')).toBe('Sheet1!AA:AA')
   })
 
-  it('handles sheet names with special characters', () => {
-    expect(constructRangeFromStartColumn("'My Sheet'", 'A')).toBe("'My Sheet'!A:A100000")
-    expect(constructRangeFromStartColumn("'Sheet 1'", 'B')).toBe("'Sheet 1'!B:B100000")
+  it('auto-quotes sheet names with spaces', () => {
+    expect(constructRangeFromStartColumn('My Sheet', 'A')).toBe("'My Sheet'!A:A")
+    expect(constructRangeFromStartColumn('Decision Log', 'C')).toBe("'Decision Log'!C:C")
+  })
+
+  it('does not double-quote already quoted sheet names', () => {
+    expect(constructRangeFromStartColumn("'My Sheet'", 'A')).toBe("'My Sheet'!A:A")
+    expect(constructRangeFromStartColumn("'Sheet 1'", 'B')).toBe("'Sheet 1'!B:B")
+  })
+
+  it('quotes sheet names with special characters', () => {
+    expect(constructRangeFromStartColumn('Sheet-1', 'A')).toBe("'Sheet-1'!A:A")
+    expect(constructRangeFromStartColumn('Sheet.1', 'A')).toBe("'Sheet.1'!A:A")
+  })
+
+  it('escapes single quotes (apostrophes) in sheet names', () => {
+    expect(constructRangeFromStartColumn("John's Data", 'A')).toBe("'John''s Data'!A:A")
+    expect(constructRangeFromStartColumn("It's a sheet", 'B')).toBe("'It''s a sheet'!B:B")
+    expect(constructRangeFromStartColumn("A'B'C", 'A')).toBe("'A''B''C'!A:A")
+  })
+
+  it('does not quote simple alphanumeric/underscore sheet names', () => {
+    expect(constructRangeFromStartColumn('Sheet1', 'A')).toBe('Sheet1!A:A')
+    expect(constructRangeFromStartColumn('My_Sheet', 'A')).toBe('My_Sheet!A:A')
   })
 
   it('handles multi-character column names', () => {
-    expect(constructRangeFromStartColumn(undefined, 'AB')).toBe('AB:AB100000')
-    expect(constructRangeFromStartColumn(undefined, 'ABC')).toBe('ABC:ABC100000')
-    expect(constructRangeFromStartColumn('Sheet1', 'XYZ')).toBe('Sheet1!XYZ:XYZ100000')
+    expect(constructRangeFromStartColumn(undefined, 'AB')).toBe('AB:AB')
+    expect(constructRangeFromStartColumn(undefined, 'ABC')).toBe('ABC:ABC')
+    expect(constructRangeFromStartColumn('Sheet1', 'XYZ')).toBe('Sheet1!XYZ:XYZ')
   })
 
   it('handles empty string sheet name as undefined', () => {
-    expect(constructRangeFromStartColumn('', 'A')).toBe('A:A100000')
-    expect(constructRangeFromStartColumn('', 'B')).toBe('B:B100000')
-  })
-
-  it('preserves sheet name format exactly', () => {
-    expect(constructRangeFromStartColumn('Sheet1', 'A')).toBe('Sheet1!A:A100000')
-    expect(constructRangeFromStartColumn('  Sheet1  ', 'A')).toBe('  Sheet1  !A:A100000')
+    expect(constructRangeFromStartColumn('', 'A')).toBe('A:A')
+    expect(constructRangeFromStartColumn('', 'B')).toBe('B:B')
   })
 })


### PR DESCRIPTION
Resolves SH-366 , SH-463


- Remove hardcoded MAX_ROW_NUMBER (100000) limit from appendValues range, using unbounded column ranges ("A:A") instead of capped ones ("A:A100000") to let the Sheets API detect table boundaries

- Add automatic quoting for sheet names containing special characters (spaces, dashes, dots) to prevent invalid A1 notation


**Note**: The values.append Google Sheets API does not inherit cell formatting for newly appended rows. The first batch of data written "founds" the table, and subsequent appends add cells beyond the table boundary that only get raw default formatting (text = left-aligned, numbers = right-aligned). This is a known API limitation — values.append only writes data, not formatting

<img width="211" height="393" alt="Capture d’écran, le 2026-03-03 à 09 23 22" src="https://github.com/user-attachments/assets/a45f1976-0c6e-4be9-a33f-2513db7cc621" />


https://github.com/user-attachments/assets/e81afb9a-d41f-4509-89a1-b970c4a10b47

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improved the Google Sheets append operation by removing the hardcoded 100,000 row limit and implementing automatic sheet name quoting for A1 notation compliance.

**Key Changes:**
- Removed `MAX_ROW_NUMBER` constant to use unbounded column ranges (e.g., `A:A` instead of `A:A100000`), allowing the Sheets API to automatically detect table boundaries
- Added `_quoteSheetName` helper that automatically quotes sheet names containing special characters (spaces, dashes, dots) and escapes internal single quotes per Google Sheets A1 notation rules
- Updated documentation to clarify that `startColumn` identifies the table for appending, and added naming rules for `rangeName`
- Comprehensive test coverage for quoting logic including edge cases

**Issues Found:**
- One edge case where pre-quoted sheet names with unescaped internal quotes (e.g., `'John's Data'`) aren't properly handled, though this is unlikely in practice since users provide unquoted names

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor edge case that's unlikely to occur in production
- The PR correctly implements the main functionality (unbounded ranges and sheet name quoting), has comprehensive test coverage, and properly escapes single quotes in unquoted sheet names. The one identified edge case (pre-quoted names with unescaped internal quotes) is unlikely to occur since users are expected to provide unquoted sheet names as per the input schema documentation.
- integrations/gsheets/src/actions/implementations/append-values-utils.ts:2-4 needs a small fix to handle the edge case of pre-quoted sheet names with unescaped internal quotes

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| integrations/gsheets/src/actions/implementations/append-values-utils.ts | Added sheet name quoting logic to handle special characters and removed `MAX_ROW_NUMBER` limit for unbounded ranges. One edge case with pre-quoted names needs attention. |
| integrations/gsheets/src/actions/implementations/append-values.test.ts | Comprehensive test coverage added for sheet name quoting, escaping, and unbounded ranges. Tests cover most common scenarios effectively. |

</details>



<sub>Last reviewed commit: a0c5b08</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->