### PR TITLE
chore(client): bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.564.0",
-    "@botpress/api": "1.73.0",
+    "@botpress/api": "1.73.4",
     "@botpress/cli": "workspace:*",
     "@botpress/client": "workspace:*",
     "@botpress/sdk": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.5",
-    "@botpress/client": "1.35.1",
+    "@botpress/client": "1.36.0",
     "@botpress/sdk": "5.4.4",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "5.5.6",
+  "version": "5.5.7",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",
@@ -27,8 +27,8 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.5",
-    "@botpress/client": "1.35.0",
-    "@botpress/sdk": "5.4.3",
+    "@botpress/client": "1.35.1",
+    "@botpress/sdk": "5.4.4",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/verel": "^0.2.0",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -5,7 +5,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.35.1",
+    "@botpress/client": "1.36.0",
     "@botpress/sdk": "5.4.4"
   },
   "devDependencies": {

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -5,8 +5,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.35.0",
-    "@botpress/sdk": "5.4.3"
+    "@botpress/client": "1.35.1",
+    "@botpress/sdk": "5.4.4"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.35.1",
+    "@botpress/client": "1.36.0",
     "@botpress/sdk": "5.4.4"
   },
   "devDependencies": {

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.35.0",
-    "@botpress/sdk": "5.4.3"
+    "@botpress/client": "1.35.1",
+    "@botpress/sdk": "5.4.4"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "5.4.3"
+    "@botpress/sdk": "5.4.4"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.35.1",
+    "@botpress/client": "1.36.0",
     "@botpress/sdk": "5.4.4"
   },
   "devDependencies": {

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.35.0",
-    "@botpress/sdk": "5.4.3"
+    "@botpress/client": "1.35.1",
+    "@botpress/sdk": "5.4.4"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.35.0",
-    "@botpress/sdk": "5.4.3",
+    "@botpress/client": "1.35.1",
+    "@botpress/sdk": "5.4.4",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.35.1",
+    "@botpress/client": "1.36.0",
     "@botpress/sdk": "5.4.4",
     "axios": "^1.6.8"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "1.35.0",
+  "version": "1.35.1",
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "1.35.1",
+  "version": "1.36.0",
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/client/src/public/index.ts
+++ b/packages/client/src/public/index.ts
@@ -62,10 +62,6 @@ export class Client extends gen.Client implements IClient {
         new common.listing.AsyncCollection(({ nextToken }) =>
           this.listUsers({ nextToken, ...props }).then((r) => ({ ...r, items: r.users }))
         ),
-      tasks: (props: ListInputs['listTasks']) =>
-        new common.listing.AsyncCollection(({ nextToken }) =>
-          this.listTasks({ nextToken, ...props }).then((r) => ({ ...r, items: r.tasks }))
-        ),
       publicIntegrations: (props: ListInputs['listPublicIntegrations']) =>
         new common.listing.AsyncCollection(({ nextToken }) =>
           this.listPublicIntegrations({ nextToken, ...props }).then((r) => ({ ...r, items: r.integrations }))

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -56,10 +56,6 @@ export class Client extends gen.Client {
         new common.listing.AsyncCollection(({ nextToken }) =>
           this.listUsers({ nextToken, ...props }).then((r) => ({ ...r, items: r.users }))
         ),
-      tasks: (props: ListInputs['listTasks']) =>
-        new common.listing.AsyncCollection(({ nextToken }) =>
-          this.listTasks({ nextToken, ...props }).then((r) => ({ ...r, items: r.tasks }))
-        ),
     }
   }
 }

--- a/packages/cognitive/package.json
+++ b/packages/cognitive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cognitive",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "Wrapper around the Botpress Client to call LLMs",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -71,8 +71,8 @@
     "tsx": "^4.19.2"
   },
   "peerDependencies": {
-    "@botpress/client": "1.35.0",
-    "@botpress/cognitive": "0.3.14",
+    "@botpress/client": "1.35.1",
+    "@botpress/cognitive": "0.3.15",
     "@bpinternal/thicktoken": "^2.0.0",
     "@bpinternal/zui": "^1.3.3"
   },

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -71,7 +71,7 @@
     "tsx": "^4.19.2"
   },
   "peerDependencies": {
-    "@botpress/client": "1.35.1",
+    "@botpress/client": "1.36.0",
     "@botpress/cognitive": "0.3.15",
     "@bpinternal/thicktoken": "^2.0.0",
     "@bpinternal/zui": "^1.3.3"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -20,7 +20,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "1.35.0",
+    "@botpress/client": "1.35.1",
     "browser-or-node": "^2.1.1",
     "semver": "^7.3.8"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "1.35.1",
+    "@botpress/client": "1.36.0",
     "browser-or-node": "^2.1.1",
     "semver": "^7.3.8"
   },

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -40,7 +40,7 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "@botpress/client": "1.35.1",
+    "@botpress/client": "1.36.0",
     "@bpinternal/thicktoken": "^1.0.1",
     "@bpinternal/zui": "^1.3.3",
     "lodash": "^4.17.21",

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -40,7 +40,7 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "@botpress/client": "1.35.0",
+    "@botpress/client": "1.35.1",
     "@bpinternal/thicktoken": "^1.0.1",
     "@bpinternal/zui": "^1.3.3",
     "lodash": "^4.17.21",

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -32,7 +32,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@botpress/cognitive": "0.3.14",
+    "@botpress/cognitive": "0.3.15",
     "json5": "^2.2.3",
     "jsonrepair": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/plugins/conversation-insights/package.json
+++ b/plugins/conversation-insights/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/cognitive": "0.3.14",
+    "@botpress/cognitive": "0.3.15",
     "@botpress/sdk": "workspace:*",
     "browser-or-node": "^2.1.1",
     "jsonrepair": "^3.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2502,7 +2502,7 @@ importers:
         specifier: 0.5.5
         version: link:../chat-client
       '@botpress/client':
-        specifier: 1.35.1
+        specifier: 1.36.0
         version: link:../client
       '@botpress/sdk':
         specifier: 5.4.4
@@ -2626,7 +2626,7 @@ importers:
   packages/cli/templates/empty-bot:
     dependencies:
       '@botpress/client':
-        specifier: 1.35.1
+        specifier: 1.36.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 5.4.4
@@ -2642,7 +2642,7 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 1.35.1
+        specifier: 1.36.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 5.4.4
@@ -2671,7 +2671,7 @@ importers:
   packages/cli/templates/hello-world:
     dependencies:
       '@botpress/client':
-        specifier: 1.35.1
+        specifier: 1.36.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 5.4.4
@@ -2687,7 +2687,7 @@ importers:
   packages/cli/templates/webhook-message:
     dependencies:
       '@botpress/client':
-        specifier: 1.35.1
+        specifier: 1.36.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 5.4.4
@@ -2841,7 +2841,7 @@ importers:
         specifier: ^7.26.3
         version: 7.26.9
       '@botpress/client':
-        specifier: 1.35.1
+        specifier: 1.36.0
         version: link:../client
       '@botpress/cognitive':
         specifier: 0.3.15
@@ -2947,7 +2947,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 1.35.1
+        specifier: 1.36.0
         version: link:../client
       '@bpinternal/zui':
         specifier: ^1.3.3
@@ -2984,7 +2984,7 @@ importers:
   packages/vai:
     dependencies:
       '@botpress/client':
-        specifier: 1.35.1
+        specifier: 1.36.0
         version: link:../client
       '@bpinternal/thicktoken':
         specifier: ^1.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^3.564.0
         version: 3.709.0
       '@botpress/api':
-        specifier: 1.73.0
-        version: 1.73.0
+        specifier: 1.73.4
+        version: 1.73.4
       '@botpress/cli':
         specifier: workspace:*
         version: link:packages/cli
@@ -2502,10 +2502,10 @@ importers:
         specifier: 0.5.5
         version: link:../chat-client
       '@botpress/client':
-        specifier: 1.35.0
+        specifier: 1.35.1
         version: link:../client
       '@botpress/sdk':
-        specifier: 5.4.3
+        specifier: 5.4.4
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2626,10 +2626,10 @@ importers:
   packages/cli/templates/empty-bot:
     dependencies:
       '@botpress/client':
-        specifier: 1.35.0
+        specifier: 1.35.1
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.4.3
+        specifier: 5.4.4
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2642,10 +2642,10 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 1.35.0
+        specifier: 1.35.1
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.4.3
+        specifier: 5.4.4
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2658,7 +2658,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 5.4.3
+        specifier: 5.4.4
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2671,10 +2671,10 @@ importers:
   packages/cli/templates/hello-world:
     dependencies:
       '@botpress/client':
-        specifier: 1.35.0
+        specifier: 1.35.1
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.4.3
+        specifier: 5.4.4
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2687,10 +2687,10 @@ importers:
   packages/cli/templates/webhook-message:
     dependencies:
       '@botpress/client':
-        specifier: 1.35.0
+        specifier: 1.35.1
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 5.4.3
+        specifier: 5.4.4
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8
@@ -2841,10 +2841,10 @@ importers:
         specifier: ^7.26.3
         version: 7.26.9
       '@botpress/client':
-        specifier: 1.35.0
+        specifier: 1.35.1
         version: link:../client
       '@botpress/cognitive':
-        specifier: 0.3.14
+        specifier: 0.3.15
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^2.0.0
@@ -2947,7 +2947,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 1.35.0
+        specifier: 1.35.1
         version: link:../client
       '@bpinternal/zui':
         specifier: ^1.3.3
@@ -2984,7 +2984,7 @@ importers:
   packages/vai:
     dependencies:
       '@botpress/client':
-        specifier: 1.35.0
+        specifier: 1.35.1
         version: link:../client
       '@bpinternal/thicktoken':
         specifier: ^1.0.1
@@ -3030,7 +3030,7 @@ importers:
   packages/zai:
     dependencies:
       '@botpress/cognitive':
-        specifier: 0.3.14
+        specifier: 0.3.15
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^1.0.0
@@ -3149,7 +3149,7 @@ importers:
   plugins/conversation-insights:
     dependencies:
       '@botpress/cognitive':
-        specifier: 0.3.14
+        specifier: 0.3.15
         version: link:../../packages/cognitive
       '@botpress/sdk':
         specifier: workspace:*
@@ -3991,8 +3991,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@botpress/api@1.73.0':
-    resolution: {integrity: sha512-7Z3WGx8hVhc5JcN9DwdWA6lLsA4b/qcBoEHM0RWuqVQacEcFbdFgedaR4FDh7qdGxVQxEhHpwPjJv0CNbndpGA==}
+  '@botpress/api@1.73.4':
+    resolution: {integrity: sha512-pMXnEVyNfqwPBibccS/8t8s6Orzq/FSYEdYe9ukRrJLl7hWo60hClpvb0cAldh6RnAO+y/3l6JCQyHk0F9wjpg==}
 
   '@bpinternal/const@0.1.0':
     resolution: {integrity: sha512-iIQg9oYYXOt+LSK34oNhJVQTcgRdtLmLZirEUaE+R9hnmbKONA5reR2kTewxZmekGyxej+5RtDK9xrC/0hmeAw==}
@@ -13167,7 +13167,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@botpress/api@1.73.0':
+  '@botpress/api@1.73.4':
     dependencies:
       '@bpinternal/opapi': 1.0.0(openapi-types@12.1.3)
     transitivePeerDependencies:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumped `@botpress/client` from 1.35.0 to 1.36.0 and removed the `tasks` listing method from both public and runtime client implementations. 

- Removed `client.list.tasks()` convenience method that wrapped `listTasks()` API call
- Updated `@botpress/api` dependency from 1.73.0 to 1.73.4
- Cascaded version bumps across dependent packages: SDK (5.4.3→5.4.4), CLI (5.5.6→5.5.7), cognitive (0.3.14→0.3.15), zai (2.6.0→2.6.1)
- Updated all CLI templates to use new package versions
- No references to the removed `tasks` method found in the codebase

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All version bumps are consistent across packages, the removed `tasks` method has no references in the codebase, and the minor version bump (1.35.0→1.36.0) appropriately signals the breaking change. Lock file properly updated.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/client/src/public/index.ts | Removed `tasks` listing method from public client API |
| packages/client/src/runtime/index.ts | Removed `tasks` listing method from runtime client API |
| packages/client/package.json | Version bumped from 1.35.0 to 1.36.0 (minor bump for feature removal) |
| packages/sdk/package.json | Version bumped to 5.4.4, updated `@botpress/client` dependency to 1.36.0 |
| packages/cli/package.json | Version bumped to 5.5.7, updated client and sdk dependencies |
| package.json | Updated `@botpress/api` dependency from 1.73.0 to 1.73.4 |

</details>



<sub>Last reviewed commit: 5513481</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->