### PR TITLE
feat(sdk): zui is only exported under the z namespace

### DIFF
--- a/integrations/browser/src/actions/discover-urls.ts
+++ b/integrations/browser/src/actions/discover-urls.ts
@@ -1,5 +1,5 @@
 import { RuntimeError } from '@botpress/client'
-import { IntegrationLogger, z, ZodIssue } from '@botpress/sdk'
+import { IntegrationLogger, z } from '@botpress/sdk'
 import Firecrawl, { SdkError } from '@mendable/firecrawl-js'
 import { trackEvent } from '../tracking'
 import { isValidGlob, matchGlob } from '../utils/globs'
@@ -11,7 +11,7 @@ const COST_PER_FIRECRAWL_MAP = 0.001
 
 type StopReason = Awaited<ReturnType<bp.IntegrationProps['actions']['discoverUrls']>>['stopReason']
 
-type ZodIssueCode = ZodIssue['code']
+type ZodIssueCode = z.ZodIssue['code']
 
 export const urlSchema = z.string().transform((url, ctx) => {
   url = url.trim()

--- a/integrations/github/integration.definition.ts
+++ b/integrations/github/integration.definition.ts
@@ -7,7 +7,7 @@ import { actions, events, configuration, configurations, channels, user, secrets
 export default new sdk.IntegrationDefinition({
   name: INTEGRATION_NAME,
   title: 'GitHub',
-  version: '1.1.7',
+  version: '1.1.9',
   icon: 'icon.svg',
   readme: 'hub.md',
   description: 'Manage GitHub issues, pull requests, and repositories.',

--- a/integrations/github/src/definitions/events.ts
+++ b/integrations/github/src/definitions/events.ts
@@ -1,4 +1,4 @@
-import { z, ZodTypeAny } from '@botpress/sdk'
+import { z } from '@botpress/sdk'
 import * as sdk from '@botpress/sdk'
 import { Issue, PullRequest, User, PullRequestReview } from './entities'
 
@@ -6,7 +6,7 @@ const COMMON_EVENT_FIELDS = {
   sender: {
     eventSender: User.title('Sender').describe('The user who triggered the event'),
   },
-} as const satisfies Record<string, Record<string, ZodTypeAny>>
+} as const satisfies Record<string, Record<string, z.ZodTypeAny>>
 
 const pullRequestOpened = {
   title: 'Pull Request opened',

--- a/integrations/github/src/definitions/index.ts
+++ b/integrations/github/src/definitions/index.ts
@@ -1,4 +1,4 @@
-import { z, ZodRawShape } from '@botpress/sdk'
+import { z } from '@botpress/sdk'
 import * as sdk from '@botpress/sdk'
 
 export { actions } from './actions'
@@ -23,7 +23,7 @@ const webhookSecret = {
     .describe(
       'A high-entropy string that only you and Botpress know. Must be set to the same value as in the GitHub organization settings.'
     ),
-} as const satisfies ZodRawShape
+} as const satisfies z.ZodRawShape
 
 export const configurations = {
   manualApp: {

--- a/integrations/mailchimp/src/utils.ts
+++ b/integrations/mailchimp/src/utils.ts
@@ -1,4 +1,4 @@
-import { ZodError, RuntimeError, z } from '@botpress/sdk'
+import { RuntimeError, z } from '@botpress/sdk'
 import { MailchimpApi } from './client'
 import { Customer, MailchimpAPIError } from './misc/custom-types'
 import { Logger } from './misc/types'
@@ -27,7 +27,7 @@ export const isMailchimpError = (error: any): error is MailchimpAPIError => {
   return 'status' in error && 'response' in error && 'body' in error.response
 }
 
-export const isZodError = (error: any): error is ZodError => {
+export const isZodError = (error: any): error is z.ZodError => {
   return error && typeof error === 'object' && z.is.zuiError(error) && 'errors' in error
 }
 

--- a/integrations/todoist/integration.definition.ts
+++ b/integrations/todoist/integration.definition.ts
@@ -16,7 +16,7 @@ export default new sdk.IntegrationDefinition({
   name: 'todoist',
   title: 'Todoist',
   description: 'Create and modify tasks, post comments and more.',
-  version: '1.0.2',
+  version: '1.0.4',
   readme: 'hub.md',
   icon: 'icon.svg',
   actions,

--- a/integrations/todoist/src/todoist-api/sync-client.ts
+++ b/integrations/todoist/src/todoist-api/sync-client.ts
@@ -1,4 +1,4 @@
-import { z, ZodRawShape, ZodObject } from '@botpress/sdk'
+import { z } from '@botpress/sdk'
 
 export class TodoistSyncClient {
   private readonly _fetch: typeof fetch
@@ -28,7 +28,7 @@ export class TodoistSyncClient {
     }
   }
 
-  private async _post<T extends ZodRawShape>({
+  private async _post<T extends z.ZodRawShape>({
     endpoint,
     params,
     responseSchema,
@@ -36,7 +36,7 @@ export class TodoistSyncClient {
     endpoint: string
     responseSchema: T
     params?: Record<string, any>
-  }): Promise<z.infer<ZodObject<T, 'strip'>>> {
+  }): Promise<z.infer<z.ZodObject<T, 'strip'>>> {
     return this._sendRequest({
       endpoint,
       init: {
@@ -48,13 +48,13 @@ export class TodoistSyncClient {
     })
   }
 
-  private async _get<T extends ZodRawShape>({
+  private async _get<T extends z.ZodRawShape>({
     endpoint,
     responseSchema,
   }: {
     endpoint: string
     responseSchema: T
-  }): Promise<z.infer<ZodObject<T, 'strip'>>> {
+  }): Promise<z.infer<z.ZodObject<T, 'strip'>>> {
     return this._sendRequest({
       endpoint,
       init: {
@@ -64,7 +64,7 @@ export class TodoistSyncClient {
     })
   }
 
-  private async _sendRequest<T extends ZodRawShape>({
+  private async _sendRequest<T extends z.ZodRawShape>({
     endpoint,
     init,
     responseSchema,
@@ -72,7 +72,7 @@ export class TodoistSyncClient {
     endpoint: string
     init: RequestInit
     responseSchema: T
-  }): Promise<z.infer<ZodObject<T, 'strip'>>> {
+  }): Promise<z.infer<z.ZodObject<T, 'strip'>>> {
     const response = await this._fetch(`https://api.todoist.com/sync/v9/${endpoint}`, init)
 
     if (!response.ok) {

--- a/interfaces/hitl/interface.definition.ts
+++ b/interfaces/hitl/interface.definition.ts
@@ -18,10 +18,10 @@ const allMessages = {
   ...sdk.messages.defaults,
   markdown: sdk.messages.markdown,
   bloc: sdk.messages.markdownBloc,
-} satisfies Record<string, { schema: sdk.AnyZodObject }>
+} satisfies Record<string, { schema: sdk.z.AnyZodObject }>
 
 type Tuple<T> = [T, T, ...T[]]
-const messagePayloadSchemas: sdk.AnyZodObject[] = Object.entries(allMessages).map(([k, v]) =>
+const messagePayloadSchemas: sdk.z.AnyZodObject[] = Object.entries(allMessages).map(([k, v]) =>
   sdk.z.object({
     source: messageSourceSchema,
     type: sdk.z.literal(k),
@@ -29,7 +29,7 @@ const messagePayloadSchemas: sdk.AnyZodObject[] = Object.entries(allMessages).ma
   })
 )
 
-const messageSchema = sdk.z.union(messagePayloadSchemas as Tuple<sdk.AnyZodObject>)
+const messageSchema = sdk.z.union(messagePayloadSchemas as Tuple<sdk.z.AnyZodObject>)
 
 export default new sdk.InterfaceDefinition({
   name: 'hitl',

--- a/packages/cli/src/code-generation/generators.ts
+++ b/packages/cli/src/code-generation/generators.ts
@@ -24,7 +24,7 @@ export const jsonSchemaToTypescriptZuiSchema = async (
   extraProps: Record<string, string> = {}
 ): Promise<string> => {
   schema = await utils.schema.dereferenceSchema(schema)
-  const zuiSchema = sdk.transforms.fromJSONSchemaLegacy(schema)
+  const zuiSchema = sdk.z.transforms.fromJSONSchemaLegacy(schema)
 
   const allProps = {
     ...extraProps,

--- a/packages/cli/src/tables/tables-publisher.ts
+++ b/packages/cli/src/tables/tables-publisher.ts
@@ -114,7 +114,7 @@ export class TablesPublisher {
 
     await api.client.updateTable({
       table: existingTable.name,
-      schema: sdk.transforms.toJSONSchemaLegacy(updatedTableDef.schema),
+      schema: sdk.z.transforms.toJSONSchemaLegacy(updatedTableDef.schema),
       frozen: updatedTableDef.frozen,
       tags: updatedTableDef.tags,
       isComputeEnabled: updatedTableDef.isComputeEnabled,
@@ -130,7 +130,7 @@ export class TablesPublisher {
     tableName: string
     tableDef: sdk.BotTableDefinition
   }): Promise<Record<string, sdk.z.infer<typeof schemas.columnSchema>>> {
-    const columns = sdk.transforms.toJSONSchemaLegacy(tableDef.schema).properties!
+    const columns = sdk.z.transforms.toJSONSchemaLegacy(tableDef.schema).properties!
 
     const validColumns = await Promise.all(
       Object.entries(columns).map(async ([columnName, columnSchema]) => {
@@ -172,7 +172,7 @@ export class TablesPublisher {
   }) {
     await api.client.createTable({
       name: tableName,
-      schema: sdk.transforms.toJSONSchemaLegacy(tableDef.schema),
+      schema: sdk.z.transforms.toJSONSchemaLegacy(tableDef.schema),
       frozen: tableDef.frozen,
       tags: tableDef.tags,
       factor: tableDef.factor,

--- a/packages/cli/src/utils/schema-utils.ts
+++ b/packages/cli/src/utils/schema-utils.ts
@@ -2,7 +2,7 @@ import { dereference } from '@apidevtools/json-schema-ref-parser'
 import * as sdk from '@botpress/sdk'
 import { JSONSchema7 } from 'json-schema'
 
-type ZuiToJsonSchema = typeof sdk.transforms.toJSONSchemaLegacy
+type ZuiToJsonSchema = typeof sdk.z.transforms.toJSONSchemaLegacy
 type JsonSchema = ReturnType<ZuiToJsonSchema>
 
 type SchemaOptions = {
@@ -11,7 +11,7 @@ type SchemaOptions = {
 }
 
 type SchemaDefinition = {
-  schema: sdk.ZuiObjectOrRefSchema
+  schema: sdk.z.ZuiObjectOrRefSchema
   ui?: Record<string, SchemaOptions | undefined>
 }
 
@@ -24,12 +24,12 @@ const isObjectSchema = (schema: JsonSchema): boolean => schema.type === 'object'
 export async function mapZodToJsonSchema(
   definition: SchemaDefinition,
   options: MapSchemaOptions
-): Promise<ReturnType<typeof sdk.transforms.toJSONSchemaLegacy>> {
+): Promise<ReturnType<typeof sdk.z.transforms.toJSONSchemaLegacy>> {
   let schema: JSONSchema7
   if (options.useLegacyZuiTransformer) {
-    schema = sdk.transforms.toJSONSchemaLegacy(definition.schema, { target: 'jsonSchema7' })
+    schema = sdk.z.transforms.toJSONSchemaLegacy(definition.schema, { target: 'jsonSchema7' })
   } else {
-    schema = sdk.transforms.toJSONSchema(definition.schema)
+    schema = sdk.z.transforms.toJSONSchema(definition.schema)
   }
   schema = (await dereferenceSchema(schema)) as typeof schema
 

--- a/packages/sdk/src/bot/definition.ts
+++ b/packages/sdk/src/bot/definition.ts
@@ -6,14 +6,14 @@ import { SchemaDefinition } from '../schema'
 import * as utils from '../utils'
 import { ValueOf, Writable, Merge, StringKeys } from '../utils/type-utils'
 import { SDK_VERSION } from '../version'
-import z, { ZuiObjectSchema, ZuiObjectOrRefSchema } from '../zui'
+import { z } from '../zui'
 
-type BaseConfig = ZuiObjectSchema
-type BaseStates = Record<string, ZuiObjectOrRefSchema>
-type BaseEvents = Record<string, ZuiObjectOrRefSchema>
-type BaseActions = Record<string, ZuiObjectOrRefSchema>
-type BaseTables = Record<string, ZuiObjectOrRefSchema>
-type BaseWorkflows = Record<string, ZuiObjectSchema>
+type BaseConfig = z.ZuiObjectSchema
+type BaseStates = Record<string, z.ZuiObjectOrRefSchema>
+type BaseEvents = Record<string, z.ZuiObjectOrRefSchema>
+type BaseActions = Record<string, z.ZuiObjectOrRefSchema>
+type BaseTables = Record<string, z.ZuiObjectOrRefSchema>
+type BaseWorkflows = Record<string, z.ZuiObjectSchema>
 
 export type TagDefinition = {
   title?: string
@@ -57,7 +57,7 @@ export type ActionDefinition<TAction extends BaseActions[string] = BaseActions[s
   title?: string
   description?: string
   input: SchemaDefinition<TAction>
-  output: SchemaDefinition<ZuiObjectOrRefSchema> // cannot infer both input and output types (typescript limitation)
+  output: SchemaDefinition<z.ZuiObjectOrRefSchema> // cannot infer both input and output types (typescript limitation)
   attributes?: Record<string, string>
 }
 
@@ -65,7 +65,7 @@ export type WorkflowDefinition<TWorkflow extends BaseWorkflows[string] = BaseWor
   title?: string
   description?: string
   input: SchemaDefinition<TWorkflow>
-  output: SchemaDefinition<ZuiObjectSchema> // cannot infer both input and output types (typescript limitation)
+  output: SchemaDefinition<z.ZuiObjectSchema> // cannot infer both input and output types (typescript limitation)
   tags?: Record<string, TagDefinition>
 }
 
@@ -585,13 +585,13 @@ export class BotDefinition<
   }
 
   private _dereferenceZuiSchema(
-    schema: ZuiObjectOrRefSchema,
+    schema: z.ZuiObjectOrRefSchema,
     zuiReferenceMap: Record<string, z.ZodTypeAny>
-  ): ZuiObjectSchema {
-    return schema.dereference(zuiReferenceMap) as ZuiObjectSchema
+  ): z.ZuiObjectSchema {
+    return schema.dereference(zuiReferenceMap) as z.ZuiObjectSchema
   }
 
-  private _dereferenceDefinitionSchemas<TDefinitionRecord extends Record<string, { schema: ZuiObjectOrRefSchema }>>(
+  private _dereferenceDefinitionSchemas<TDefinitionRecord extends Record<string, { schema: z.ZuiObjectOrRefSchema }>>(
     definitions: TDefinitionRecord | undefined,
     zuiReferenceMap: Record<string, z.ZodTypeAny>
   ): TDefinitionRecord {
@@ -603,7 +603,7 @@ export class BotDefinition<
     ) as TDefinitionRecord
   }
 
-  private _dereferenceDefinitionSchema<TDefinition extends { schema: ZuiObjectOrRefSchema } | undefined>(
+  private _dereferenceDefinitionSchema<TDefinition extends { schema: z.ZuiObjectOrRefSchema } | undefined>(
     definition: TDefinition,
     zuiReferenceMap: Record<string, z.ZodTypeAny>
   ): TDefinition {
@@ -615,7 +615,7 @@ export class BotDefinition<
   private _dereferenceActionDefinitionSchemas<
     TDefinitionRecord extends Record<
       string,
-      { input: { schema: ZuiObjectOrRefSchema }; output: { schema: ZuiObjectOrRefSchema } }
+      { input: { schema: z.ZuiObjectOrRefSchema }; output: { schema: z.ZuiObjectOrRefSchema } }
     >,
   >(definitions: TDefinitionRecord | undefined, zuiReferenceMap: Record<string, z.ZodTypeAny>): TDefinitionRecord {
     return Object.fromEntries(

--- a/packages/sdk/src/integration/definition/generic.ts
+++ b/packages/sdk/src/integration/definition/generic.ts
@@ -1,10 +1,10 @@
-import { ZuiObjectSchema } from '../../zui'
+import { z } from '../../zui'
 
-export type BaseConfig = ZuiObjectSchema
+export type BaseConfig = z.ZuiObjectSchema
 export type BaseConfigs = Record<string, BaseConfig>
-export type BaseEvents = Record<string, ZuiObjectSchema>
-export type BaseActions = Record<string, ZuiObjectSchema>
-export type BaseMessages = Record<string, ZuiObjectSchema>
+export type BaseEvents = Record<string, z.ZuiObjectSchema>
+export type BaseActions = Record<string, z.ZuiObjectSchema>
+export type BaseMessages = Record<string, z.ZuiObjectSchema>
 export type BaseChannels = Record<string, BaseMessages>
-export type BaseStates = Record<string, ZuiObjectSchema>
-export type BaseEntities = Record<string, ZuiObjectSchema>
+export type BaseStates = Record<string, z.ZuiObjectSchema>
+export type BaseEntities = Record<string, z.ZuiObjectSchema>

--- a/packages/sdk/src/integration/definition/index.ts
+++ b/packages/sdk/src/integration/definition/index.ts
@@ -3,7 +3,7 @@ import { resolveInterface } from '../../interface/resolve'
 import { InterfacePackage } from '../../package'
 import * as utils from '../../utils'
 import { SDK_VERSION } from '../../version'
-import { mergeObjectSchemas, z } from '../../zui'
+import { z } from '../../zui'
 import { SchemaStore, BrandedSchema, createStore, isBranded, getName } from './branded-schema'
 import { BaseConfig, BaseEvents, BaseActions, BaseChannels, BaseStates, BaseEntities, BaseConfigs } from './generic'
 import {
@@ -337,10 +337,10 @@ export class IntegrationDefinition<
       ...a,
       ...b,
       input: {
-        schema: mergeObjectSchemas(a.input.schema, b.input.schema),
+        schema: this._mergeObjectSchemas(a.input.schema, b.input.schema),
       },
       output: {
-        schema: mergeObjectSchemas(a.output.schema, b.output.schema),
+        schema: this._mergeObjectSchemas(a.output.schema, b.output.schema),
       },
     }
   }
@@ -349,7 +349,7 @@ export class IntegrationDefinition<
     return {
       ...a,
       ...b,
-      schema: mergeObjectSchemas(a.schema, b.schema),
+      schema: this._mergeObjectSchemas(a.schema, b.schema),
     }
   }
 
@@ -387,7 +387,23 @@ export class IntegrationDefinition<
 
   private _mergeMessage = (a: MessageDefinition, b: MessageDefinition): MessageDefinition => {
     return {
-      schema: mergeObjectSchemas(a.schema, b.schema),
+      schema: this._mergeObjectSchemas(a.schema, b.schema),
     }
+  }
+
+  private _mergeObjectSchemas = (a: z.ZuiObjectSchema, b: z.ZuiObjectSchema): z.ZuiObjectSchema => {
+    const aDef = a._def
+    const bDef = b._def
+
+    if (aDef.typeName === 'ZodObject' && bDef.typeName === 'ZodObject') {
+      const aShape = aDef.shape()
+      const bShape = bDef.shape()
+      return z.object({ ...aShape, ...bShape })
+    }
+    if (aDef.typeName === 'ZodRecord' && bDef.typeName === 'ZodRecord') {
+      return z.record(z.intersection(aDef.valueType, bDef.valueType))
+    }
+    // TODO: adress this case
+    throw new Error('Cannot merge object schemas with record schemas')
   }
 }

--- a/packages/sdk/src/integration/definition/types.ts
+++ b/packages/sdk/src/integration/definition/types.ts
@@ -1,5 +1,5 @@
 import { SchemaDefinition } from '../../schema'
-import { ZuiObjectSchema } from '../../zui'
+import { z } from '../../zui'
 import {
   BaseConfig,
   BaseEvents,
@@ -62,7 +62,7 @@ export type ActionDefinition<TAction extends BaseActions[string] = BaseActions[s
   title?: string
   description?: string
   input: SchemaDefinition<TAction>
-  output: SchemaDefinition<ZuiObjectSchema> // cannot infer both input and output types (typescript limitation)
+  output: SchemaDefinition<z.ZuiObjectSchema> // cannot infer both input and output types (typescript limitation)
   billable?: boolean
   cacheable?: boolean
   attributes?: Record<string, string>

--- a/packages/sdk/src/interface/definition.ts
+++ b/packages/sdk/src/interface/definition.ts
@@ -1,20 +1,20 @@
 import { ActionDefinition, ChannelDefinition, EntityDefinition, EventDefinition } from '../integration/definition'
 import * as utils from '../utils'
 import { SDK_VERSION } from '../version'
-import z, { ZuiObjectSchema, GenericZuiSchema, ZodRef } from '../zui'
+import { z } from '../zui'
 
-type BaseEvents = Record<string, ZuiObjectSchema>
-type BaseActions = Record<string, ZuiObjectSchema>
-type BaseMessages = Record<string, ZuiObjectSchema>
+type BaseEvents = Record<string, z.ZuiObjectSchema>
+type BaseActions = Record<string, z.ZuiObjectSchema>
+type BaseMessages = Record<string, z.ZuiObjectSchema>
 type BaseChannels = Record<string, BaseMessages>
-type BaseEntities = Record<string, ZuiObjectSchema>
+type BaseEntities = Record<string, z.ZuiObjectSchema>
 
 type EntityReferences<TEntities extends BaseEntities> = {
-  [K in keyof TEntities]: ZodRef
+  [K in keyof TEntities]: z.ZodRef
 }
 
 type GenericEventDefinition<TEntities extends BaseEntities, TEvent extends BaseEvents[string] = BaseEvents[string]> = {
-  schema: GenericZuiSchema<EntityReferences<TEntities>, TEvent>
+  schema: z.GenericZuiSchema<EntityReferences<TEntities>, TEvent>
   attributes?: Record<string, string>
 }
 
@@ -24,7 +24,7 @@ type GenericChannelDefinition<
 > = {
   messages: {
     [K in keyof TChannel]: {
-      schema: GenericZuiSchema<EntityReferences<TEntities>, TChannel[K]>
+      schema: z.GenericZuiSchema<EntityReferences<TEntities>, TChannel[K]>
     }
   }
 }
@@ -37,8 +37,8 @@ type GenericActionDefinition<
   description?: string
   billable?: boolean
   cacheable?: boolean
-  input: { schema: GenericZuiSchema<EntityReferences<TEntities>, TAction> }
-  output: { schema: GenericZuiSchema<EntityReferences<TEntities>, ZuiObjectSchema> }
+  input: { schema: z.GenericZuiSchema<EntityReferences<TEntities>, TAction> }
+  output: { schema: z.GenericZuiSchema<EntityReferences<TEntities>, z.ZuiObjectSchema> }
   attributes?: Record<string, string>
 }
 
@@ -171,7 +171,7 @@ export class InterfaceDefinition<
   }
 
   private _getEntityReference = (entities: Record<string, EntityDefinition>): EntityReferences<TEntities> => {
-    const entityReferences: Record<string, ZodRef> = {} as EntityReferences<TEntities>
+    const entityReferences: Record<string, z.ZodRef> = {} as EntityReferences<TEntities>
     for (const [entityName, entityDef] of Object.entries(entities)) {
       const title = entityDef.schema._def['x-zui']?.title
       const description = entityDef.schema._def.description

--- a/packages/sdk/src/interface/resolve.ts
+++ b/packages/sdk/src/interface/resolve.ts
@@ -7,10 +7,10 @@ import {
 } from '../integration'
 import { InterfacePackage } from '../package'
 import * as utils from '../utils'
-import z, { ZuiObjectSchema } from '../zui'
+import { z } from '../zui'
 
 type ResolveInterfaceInput = InterfacePackage & {
-  entities: Record<string, { name: string; schema: ZuiObjectSchema }>
+  entities: Record<string, { name: string; schema: z.ZuiObjectSchema }>
   actions: Record<string, ActionOverrideProps>
   events: Record<string, EventOverrideProps>
   channels: Record<string, ChannelOverrideProps>

--- a/packages/sdk/src/plugin/definition.ts
+++ b/packages/sdk/src/plugin/definition.ts
@@ -12,18 +12,18 @@ import {
 import { IntegrationPackage, InterfacePackage } from '../package'
 import * as typeUtils from '../utils/type-utils'
 import { SDK_VERSION } from '../version'
-import { ZuiObjectSchema, ZuiObjectOrRefSchema, z } from '../zui'
+import { z } from '../zui'
 
 export { UserDefinition, ConversationDefinition, MessageDefinition, WorkflowDefinition } from '../bot/definition'
 
-type BaseConfig = ZuiObjectOrRefSchema
-type BaseStates = Record<string, ZuiObjectOrRefSchema>
-type BaseEvents = Record<string, ZuiObjectOrRefSchema>
-type BaseActions = Record<string, ZuiObjectOrRefSchema>
+type BaseConfig = z.ZuiObjectOrRefSchema
+type BaseStates = Record<string, z.ZuiObjectOrRefSchema>
+type BaseEvents = Record<string, z.ZuiObjectOrRefSchema>
+type BaseActions = Record<string, z.ZuiObjectOrRefSchema>
 type BaseInterfaces = Record<string, InterfacePackage>
 type BaseIntegrations = Record<string, IntegrationPackage>
-type BaseTables = Record<string, ZuiObjectOrRefSchema>
-type BaseWorkflows = Record<string, ZuiObjectSchema>
+type BaseTables = Record<string, z.ZuiObjectOrRefSchema>
+type BaseWorkflows = Record<string, z.ZuiObjectSchema>
 
 export type TableDefinition<TTable extends BaseTables[string] = BaseTables[string]> = typeUtils.Merge<
   BotTableDefinition,
@@ -57,7 +57,7 @@ export type ActionDefinition<TAction extends BaseActions[string] = BaseActions[s
   BotActionDefinition,
   {
     input: { schema: TAction }
-    output: { schema: ZuiObjectOrRefSchema }
+    output: { schema: z.ZuiObjectOrRefSchema }
   }
 >
 
@@ -73,7 +73,7 @@ export type RecurringEventDefinition<TEvents extends BaseEvents = BaseEvents> = 
 
 export type ZuiSchemaWithEntityReferences<
   TInterfaces extends BaseInterfaces,
-  TReturnType extends ZuiObjectOrRefSchema,
+  TReturnType extends z.ZuiObjectOrRefSchema,
 > =
   | ((props: {
       entities: {
@@ -86,7 +86,7 @@ export type ZuiSchemaWithEntityReferences<
 
 type GenericDefinition<
   TInterfaces extends BaseInterfaces,
-  TDefinition extends { schema: ZuiObjectOrRefSchema },
+  TDefinition extends { schema: z.ZuiObjectOrRefSchema },
 > = typeUtils.Merge<
   TDefinition,
   {
@@ -386,13 +386,13 @@ export class PluginDefinition<
   }
 
   private _dereferenceZuiSchema(
-    schema: ZuiObjectOrRefSchema,
+    schema: z.ZuiObjectOrRefSchema,
     zuiReferenceMap: Record<string, z.ZodTypeAny>
-  ): ZuiObjectSchema {
-    return schema.dereference(zuiReferenceMap) as ZuiObjectSchema
+  ): z.ZuiObjectSchema {
+    return schema.dereference(zuiReferenceMap) as z.ZuiObjectSchema
   }
 
-  private _dereferenceDefinitionSchemas<TDefinitionRecord extends Record<string, { schema: ZuiObjectOrRefSchema }>>(
+  private _dereferenceDefinitionSchemas<TDefinitionRecord extends Record<string, { schema: z.ZuiObjectOrRefSchema }>>(
     definitions: TDefinitionRecord | undefined,
     zuiReferenceMap: Record<string, z.ZodTypeAny>
   ): TDefinitionRecord {
@@ -407,7 +407,7 @@ export class PluginDefinition<
   private _dereferenceActionDefinitionSchemas<
     TDefinitionRecord extends Record<
       string,
-      { input: { schema: ZuiObjectOrRefSchema }; output: { schema: ZuiObjectOrRefSchema } }
+      { input: { schema: z.ZuiObjectOrRefSchema }; output: { schema: z.ZuiObjectOrRefSchema } }
     >,
   >(definitions: TDefinitionRecord | undefined, zuiReferenceMap: Record<string, z.ZodTypeAny>): TDefinitionRecord {
     return Object.fromEntries(

--- a/packages/sdk/src/schema.ts
+++ b/packages/sdk/src/schema.ts
@@ -1,4 +1,4 @@
-import * as z from './zui'
+import { z } from './zui'
 
 type SchemaOptions<T> = {
   title: string

--- a/packages/sdk/src/zui.ts
+++ b/packages/sdk/src/zui.ts
@@ -1,29 +1,15 @@
-import { z } from '@bpinternal/zui'
+import '@bpinternal/zui'
 
-export * from '@bpinternal/zui'
+declare module '@bpinternal/zui' {
+  export namespace z {
+    export type GenericZuiSchema<
+      A extends Record<string, z.ZodType> = Record<string, z.ZodType>,
+      R extends z.ZodType = z.ZodType,
+    > = (typeArguments: A) => R
 
-export type GenericZuiSchema<
-  A extends Record<string, z.ZodTypeAny> = Record<string, z.ZodTypeAny>,
-  R extends z.ZodTypeAny = z.ZodTypeAny,
-> = (typeArguments: A) => R
-
-export type ZuiObjectSchema = z.ZodObject | z.ZodRecord
-export type ZuiObjectOrRefSchema = ZuiObjectSchema | z.ZodRef
-
-export const mergeObjectSchemas = (a: ZuiObjectSchema, b: ZuiObjectSchema): ZuiObjectSchema => {
-  const aDef = a._def
-  const bDef = b._def
-
-  if (aDef.typeName === 'ZodObject' && bDef.typeName === 'ZodObject') {
-    const aShape = aDef.shape()
-    const bShape = bDef.shape()
-    return z.object({ ...aShape, ...bShape })
+    export type ZuiObjectSchema = z.ZodObject | z.ZodRecord
+    export type ZuiObjectOrRefSchema = ZuiObjectSchema | z.ZodRef
   }
-  if (aDef.typeName === 'ZodRecord' && bDef.typeName === 'ZodRecord') {
-    return z.record(z.intersection(aDef.valueType, bDef.valueType))
-  }
-  // TODO: adress this case
-  throw new Error('Cannot merge object schemas with record schemas')
 }
 
-export default z
+export { z } from '@bpinternal/zui'

--- a/packages/zui/src/exports.ts
+++ b/packages/zui/src/exports.ts
@@ -1,8 +1,6 @@
 import './circle'
 
 export type { JSONSchema7 } from 'json-schema'
-export * as json from './transforms/common/json-schema'
 export * as transforms from './transforms'
-
 export * from './z'
 export { default } from './z' // for the bundler not to be confused with the default export

--- a/plugins/conversation-insights/src/prompt/parse-content.ts
+++ b/plugins/conversation-insights/src/prompt/parse-content.ts
@@ -11,13 +11,13 @@ export type PredictResponse<T> = {
   json: T
 }
 
-const parseJson = <T>(expectedSchema: sdk.ZodSchema, str: string): T => {
+const parseJson = <T>(expectedSchema: sdk.z.ZodSchema, str: string): T => {
   const repaired = jsonrepair(str)
   const parsed = JSON.parse(repaired)
   return expectedSchema.parse(parsed)
 }
 
-type ParseLLMOutputProps = cognitive.GenerateContentOutput & { schema: sdk.ZodSchema }
+type ParseLLMOutputProps = cognitive.GenerateContentOutput & { schema: sdk.z.ZodSchema }
 export const parseLLMOutput = <T>(props: ParseLLMOutputProps): PredictResponse<T> => {
   const mappedChoices: LLMChoice['content'][] = props.choices.map((choice) => choice.content)
   if (!mappedChoices[0]) throw new sdk.RuntimeError('Could not parse LLM output')

--- a/plugins/conversation-insights/src/tagsUpdater.ts
+++ b/plugins/conversation-insights/src/tagsUpdater.ts
@@ -57,7 +57,7 @@ type ParsePromptProps = {
   logger: UpdateTitleAndSummaryProps['logger']
   prompt: gen.LLMInput
   client: cognitive.BotpressClientLike
-  schema: sdk.ZodSchema
+  schema: sdk.z.ZodSchema
 }
 const _generateContentWithRetries = async <T>(props: ParsePromptProps): Promise<gen.PredictResponse<T>> => {
   let attemptCount = 0

--- a/plugins/file-synchronizer/src/utils/json-lines/parser.ts
+++ b/plugins/file-synchronizer/src/utils/json-lines/parser.ts
@@ -2,7 +2,7 @@ import * as sdk from '@botpress/sdk'
 
 type _JsonParseResult<T> = { rawLine: string } & ({ value: T } | { error: Error })
 
-export function* parseJsonLines<TLineSchema extends sdk.ZodTypeAny>(
+export function* parseJsonLines<TLineSchema extends sdk.z.ZodTypeAny>(
   rawJsonLines: string,
   zodSchema: TLineSchema
 ): Generator<_JsonParseResult<sdk.z.infer<TLineSchema>>, void, undefined> {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enforces that all zui/zod types are only accessible via the `z` namespace (e.g. `z.ZodTypeAny`, `z.ZuiObjectSchema`) rather than as individual top-level named exports from `@botpress/sdk`. This is a breaking API change that touches 24 files across the monorepo — most are mechanical find-and-replace updates.

Key structural changes:
- **`packages/sdk/src/zui.ts`**: Replaced wholesale re-export of `@bpinternal/zui` with a targeted `declare module` augmentation that adds `GenericZuiSchema`, `ZuiObjectSchema`, and `ZuiObjectOrRefSchema` into the `z` namespace. Only `{ z }` is now exported.
- **`packages/sdk/src/integration/definition/index.ts`**: The previously exported `mergeObjectSchemas` utility is inlined as a private `_mergeObjectSchemas` method on `IntegrationDefinition`, removing it from the public SDK surface.
- **`packages/zui/src/exports.ts`**: The `json` namespace (`export * as json from './transforms/common/json-schema'`) is removed from `@bpinternal/zui`'s public exports — a breaking change for any external consumers of that package.
- **Integration version bumps**: GitHub (`1.1.7` → `1.1.9`) and Todoist (`1.0.2` → `1.0.4`) both skip a patch version, which may warrant verification that intermediate versions were intentionally released elsewhere.

<h3>Confidence Score: 4/5</h3>

- Safe to merge on the `zui2` feature branch; the refactor is internally consistent and all in-repo usages are updated, but two external-facing breaking changes (removed `json` export from `@bpinternal/zui`, removed `mergeObjectSchemas` from `@botpress/sdk`) and the non-sequential integration version bumps should be acknowledged before merging to a release branch.
- The in-repo changes are mechanically correct and exhaustive — no missed call sites were found. The module augmentation approach is valid TypeScript. The lower score reflects: (1) the `json` namespace removal from `@bpinternal/zui` is a semver-breaking change with no in-repo safety net, (2) the module augmentation is only active when `@botpress/sdk` is in scope which creates a subtle dependency for direct consumers of `@bpinternal/zui`, and (3) the non-sequential version jumps in GitHub and Todoist integrations are unexplained.
- `packages/sdk/src/zui.ts` (module augmentation scope caveat), `packages/zui/src/exports.ts` (breaking removal of `json` namespace), `integrations/github/integration.definition.ts` and `integrations/todoist/integration.definition.ts` (non-sequential version bumps).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/sdk/src/zui.ts | Core change: replaces re-exporting everything from `@bpinternal/zui` with a targeted module augmentation that adds `GenericZuiSchema`, `ZuiObjectSchema`, and `ZuiObjectOrRefSchema` into the `z` namespace; augmentation is only active when this file is in the compilation unit. |
| packages/zui/src/exports.ts | Removes the `json` namespace re-export (`export * as json from './transforms/common/json-schema'`), which is a breaking change for external consumers of `@bpinternal/zui`. |
| packages/sdk/src/integration/definition/index.ts | Inlines the previously exported `mergeObjectSchemas` helper as a private `_mergeObjectSchemas` method on `IntegrationDefinition`; removes the public re-export, which is a breaking change for external consumers but has no in-repo impact. |
| packages/sdk/src/schema.ts | Updates import from `import * as z from './zui'` (namespace import of module) to `import { z } from './zui'` (named `z` export), aligning with the new `z`-only export pattern. |
| integrations/github/integration.definition.ts | Version bumped from `1.1.7` to `1.1.9`, skipping `1.1.8` — this non-sequential jump is unusual and may indicate an unintended version skip. |
| integrations/todoist/integration.definition.ts | Version bumped from `1.0.2` to `1.0.4`, skipping `1.0.3` — same non-sequential version jump pattern as the GitHub integration. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["@bpinternal/zui\n(exports: z namespace + all types)"] -->|"export { z }"| B["packages/sdk/src/zui.ts\n(NEW: only re-exports z;\ndeclare module augments z namespace\nwith ZuiObjectSchema, ZuiObjectOrRefSchema,\nGenericZuiSchema)"]
    B -->|"export * from './zui'"| C["packages/sdk/src/index.ts\n(@botpress/sdk public API)"]
    C -->|"sdk.z.ZuiObjectSchema\nsdk.z.ZodTypeAny\netc."| D["Consumers\n(integrations, plugins, CLI, interfaces)"]

    E["packages/zui/src/exports.ts\n(REMOVED: export * as json)"] -.->|"json namespace no longer\navailable externally"| F["External consumers of @bpinternal/zui\n(breaking change)"]

    G["IntegrationDefinition class"] -->|"private _mergeObjectSchemas()\n(was public mergeObjectSchemas)"| H["Internal merge logic\n(no longer exported from SDK)"]
```

<sub>Last reviewed commit: 7ec5874</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->