### PR TITLE
feature(integrations): update google sheets integration to use new scope; filepicker

### DIFF
--- a/integrations/gsheets/definitions/secrets.ts
+++ b/integrations/gsheets/definitions/secrets.ts
@@ -5,4 +5,5 @@ export const secrets = {
   ...posthogHelper.COMMON_SECRET_NAMES,
   CLIENT_ID: { description: 'Google OAuth Client ID' },
   CLIENT_SECRET: { description: 'Google OAuth Client Secret' },
+  FILE_PICKER_API_KEY: { description: 'The API key used to access the Google Picker API' },
 } as const satisfies sdk.IntegrationDefinitionProps['secrets']

--- a/integrations/gsheets/integration.definition.ts
+++ b/integrations/gsheets/integration.definition.ts
@@ -13,7 +13,7 @@ import {
 } from './definitions'
 
 export const INTEGRATION_NAME = 'gsheets'
-export const INTEGRATION_VERSION = '2.1.5'
+export const INTEGRATION_VERSION = '2.1.6'
 
 export default new sdk.IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/gsheets/linkTemplate.vrl
+++ b/integrations/gsheets/linkTemplate.vrl
@@ -8,4 +8,4 @@ if env == "production" {
   clientId = "225318133116-rm2n5rnpj4r6s6mj48dg2rl26gjss6n6.apps.googleusercontent.com"
 }
 
-"https://accounts.google.com/o/oauth2/v2/auth?scope=https%3A//www.googleapis.com/auth/spreadsheets&access_type=offline&response_type=code&prompt=consent&state={{ webhookId }}&redirect_uri={{ webhookUrl }}/oauth&client_id={{ clientId }}"
+"https://accounts.google.com/o/oauth2/v2/auth?scope=https%3A//www.googleapis.com/auth/drive.file&access_type=offline&response_type=code&prompt=consent&state={{ webhookId }}&redirect_uri={{ webhookUrl }}/oauth&client_id={{ clientId }}"

--- a/integrations/gsheets/linkTemplate.vrl
+++ b/integrations/gsheets/linkTemplate.vrl
@@ -1,11 +1,4 @@
 webhookId = to_string!(.webhookId)
 webhookUrl = to_string!(.webhookUrl)
-env = to_string!(.env)
 
-clientId = "28217397-drlib1gf7qb0l5kkmsqmbtrfmojtghp2.apps.googleusercontent.com"
-
-if env == "production" {
-  clientId = "225318133116-rm2n5rnpj4r6s6mj48dg2rl26gjss6n6.apps.googleusercontent.com"
-}
-
-"https://accounts.google.com/o/oauth2/v2/auth?scope=https%3A//www.googleapis.com/auth/drive.file&access_type=offline&response_type=code&prompt=consent&state={{ webhookId }}&redirect_uri={{ webhookUrl }}/oauth&client_id={{ clientId }}"
+"{{ webhookUrl }}/oauth/wizard/start?state={{ webhookId }}"

--- a/integrations/gsheets/package.json
+++ b/integrations/gsheets/package.json
@@ -18,6 +18,7 @@
     "@botpress/cli": "workspace:*",
     "@botpress/common": "workspace:*",
     "@botpress/sdk": "workspace:*",
-    "@sentry/cli": "^2.39.1"
+    "@sentry/cli": "^2.39.1",
+    "preact": "^10.26.6"
   }
 }

--- a/integrations/gsheets/src/google-api/google-client.ts
+++ b/integrations/gsheets/src/google-api/google-client.ts
@@ -36,12 +36,14 @@ export class GoogleClient {
     ctx,
     client,
     authorizationCode,
+    redirectUri,
   }: {
     ctx: bp.Context
     client: bp.Client
     authorizationCode: string
+    redirectUri?: string
   }) {
-    await exchangeAuthCodeAndSaveRefreshToken({ ctx, client, authorizationCode })
+    await exchangeAuthCodeAndSaveRefreshToken({ ctx, client, authorizationCode, redirectUri })
   }
 
   @handleErrors('Failed to get values from spreadsheet range')

--- a/integrations/gsheets/src/google-api/google-client.ts
+++ b/integrations/gsheets/src/google-api/google-client.ts
@@ -41,7 +41,7 @@ export class GoogleClient {
     ctx: bp.Context
     client: bp.Client
     authorizationCode: string
-    redirectUri?: string
+    redirectUri: string
   }) {
     await exchangeAuthCodeAndSaveRefreshToken({ ctx, client, authorizationCode, redirectUri })
   }

--- a/integrations/gsheets/src/google-api/oauth-client.ts
+++ b/integrations/gsheets/src/google-api/oauth-client.ts
@@ -4,22 +4,25 @@ import * as bp from '.botpress'
 
 type GoogleOAuth2Client = InstanceType<(typeof google.auth)['OAuth2']>
 
-const OAUTH_SCOPES = ['https://www.googleapis.com/auth/spreadsheets']
+const OAUTH_SCOPES = ['https://www.googleapis.com/auth/drive.file']
 const GLOBAL_OAUTH_ENDPOINT = `${process.env.BP_WEBHOOK_URL}/oauth`
 
 export const exchangeAuthCodeAndSaveRefreshToken = async ({
   ctx,
   client,
   authorizationCode,
+  redirectUri,
 }: {
   ctx: bp.Context
   client: bp.Client
   authorizationCode: string
+  redirectUri?: string
 }) => {
   const oauth2Client = _getPlainOAuth2Client()
 
   const { tokens } = await oauth2Client.getToken({
     code: authorizationCode,
+    redirect_uri: redirectUri || GLOBAL_OAUTH_ENDPOINT,
   })
 
   if (!tokens.refresh_token) {

--- a/integrations/gsheets/src/google-api/oauth-client.ts
+++ b/integrations/gsheets/src/google-api/oauth-client.ts
@@ -5,6 +5,8 @@ import * as bp from '.botpress'
 type GoogleOAuth2Client = InstanceType<(typeof google.auth)['OAuth2']>
 
 const OAUTH_SCOPES = ['https://www.googleapis.com/auth/drive.file']
+// Note: This endpoint is used to construct the OAuth2 client but is overridden
+// when exchanging tokens. The actual redirect URI is passed explicitly.
 const GLOBAL_OAUTH_ENDPOINT = `${process.env.BP_WEBHOOK_URL}/oauth`
 
 export const exchangeAuthCodeAndSaveRefreshToken = async ({
@@ -16,13 +18,13 @@ export const exchangeAuthCodeAndSaveRefreshToken = async ({
   ctx: bp.Context
   client: bp.Client
   authorizationCode: string
-  redirectUri?: string
+  redirectUri: string
 }) => {
   const oauth2Client = _getPlainOAuth2Client()
 
   const { tokens } = await oauth2Client.getToken({
     code: authorizationCode,
-    redirect_uri: redirectUri || GLOBAL_OAUTH_ENDPOINT,
+    redirect_uri: redirectUri,
   })
 
   if (!tokens.refresh_token) {

--- a/integrations/gsheets/src/webhook-events/handler-dispatcher.ts
+++ b/integrations/gsheets/src/webhook-events/handler-dispatcher.ts
@@ -1,11 +1,15 @@
-import { oauthCallbackHandler } from './handlers/oauth-callback'
+import * as oauthWizard from '@botpress/common/src/oauth-wizard'
+import { handleOAuthWizard } from './handlers/oauth-wizard'
 import * as bp from '.botpress'
 
-export const handler: bp.IntegrationProps['handler'] = async ({ client, ctx, logger, req }) => {
-  if (req.path === '/oauth') {
-    logger.forBot().info('Handling Google Sheets OAuth callback')
-    await oauthCallbackHandler({ client, ctx, req, logger })
-  } else {
-    logger.forBot().debug('Received unsupported webhook event', { path: req.path, query: req.query })
+export const handler: bp.IntegrationProps['handler'] = async (props) => {
+  const { req, logger } = props
+
+  if (oauthWizard.isOAuthWizardUrl(req.path)) {
+    logger.forBot().info('Handling Google Sheets OAuth wizard')
+    return await handleOAuthWizard(props)
   }
+
+  logger.forBot().debug('Received unsupported webhook event', { path: req.path, query: req.query })
+  return
 }

--- a/integrations/gsheets/src/webhook-events/handlers/oauth-callback.ts
+++ b/integrations/gsheets/src/webhook-events/handlers/oauth-callback.ts
@@ -9,10 +9,15 @@ export const oauthCallbackHandler = async ({ client, ctx, req, logger }: bp.Hand
     return
   }
 
+  // Note: This handler is deprecated in favor of the OAuth wizard
+  // but kept for backward compatibility
+  const redirectUri = `${process.env.BP_WEBHOOK_URL}/oauth`
+
   await GoogleClient.authenticateWithAuthorizationCode({
     client,
     ctx,
     authorizationCode,
+    redirectUri,
   })
 
   await client.configureIntegration({ identifier: ctx.webhookId })

--- a/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
+++ b/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
@@ -5,7 +5,7 @@ import { getAuthenticatedOAuth2Client } from 'src/google-api/oauth-client'
 import * as bp from '.botpress'
 
 export const handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Response> => {
-  const { client, ctx } = props
+  const { ctx } = props
 
   const wizard = new oauthWizard.OAuthWizardBuilder(props)
 

--- a/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
+++ b/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
@@ -38,12 +38,24 @@ export const handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Res
       async handler({ query, responses, client, ctx, logger }) {
         const authorizationCode = query.get('code')
         const error = query.get('error')
+        const state = query.get('state')
 
         if (error) {
           logger.forBot().error('OAuth error:', error)
           return responses.endWizard({
             success: false,
             errorMessage: `OAuth error: ${error}`,
+          })
+        }
+
+        // Validate state parameter to prevent CSRF attacks
+        if (state !== ctx.webhookId) {
+          logger
+            .forBot()
+            .error('OAuth state mismatch — possible CSRF attack', { expected: ctx.webhookId, received: state })
+          return responses.endWizard({
+            success: false,
+            errorMessage: 'Invalid OAuth state parameter.',
           })
         }
 
@@ -127,6 +139,8 @@ export const handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Res
                       }
                     })
                     .setSize(640,790)
+                    // App ID must be the Google Cloud project number (numeric prefix of CLIENT_ID)
+                    // Format: <project-number>-<rest>.apps.googleusercontent.com
                     .setAppId('${bp.secrets.CLIENT_ID.split('-')[0]}')
                     .build().setVisible(true);
               }

--- a/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
+++ b/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
@@ -110,7 +110,11 @@ export const handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Res
                     .setCallback((data) => {
                       if (data[google.picker.Response.ACTION] == google.picker.Action.PICKED) {
                         document.location.href = '${oauthWizard.getWizardStepUrl('end', ctx).href}';
-                      }})
+                      } else if (data[google.picker.Response.ACTION] == google.picker.Action.CANCEL) {
+                        // User closed the picker without selecting files.
+                        // They can still click "Skip file selection" to continue.
+                      }
+                    })
                     .setSize(640,790)
                     .setAppId('${bp.secrets.CLIENT_ID.split('-')[0]}')
                     .build().setVisible(true);
@@ -154,7 +158,7 @@ const _getOAuthAuthorizationUri = (ctx: { webhookId: string }) =>
   'https://accounts.google.com/o/oauth2/v2/auth?scope=' +
   'https%3A//www.googleapis.com/auth/drive.file&access_type=offline' +
   '&include_granted_scopes=true&response_type=code&prompt=consent' +
-  `&state=${ctx.webhookId}&redirect_uri=${encodeURI(_getOAuthRedirectUri().href)}` +
+  `&state=${ctx.webhookId}&redirect_uri=${encodeURIComponent(_getOAuthRedirectUri().href)}` +
   `&client_id=${bp.secrets.CLIENT_ID}`
 
 const _getOAuthRedirectUri = () => oauthWizard.getWizardStepUrl('oauth-callback')

--- a/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
+++ b/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
@@ -93,8 +93,17 @@ export const handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Res
 
     .addStep({
       id: 'file-picker',
-      async handler({ responses, client, ctx }) {
-        const accessToken = await _getAccessToken({ client, ctx })
+      async handler({ responses, client, ctx, logger }) {
+        let accessToken: string
+        try {
+          accessToken = await _getAccessToken({ client, ctx })
+        } catch (err) {
+          logger.forBot().error('Failed to get access token for file picker:', err)
+          return responses.endWizard({
+            success: false,
+            errorMessage: `Failed to get access token: ${err instanceof Error ? err.message : 'Unknown error'}`,
+          })
+        }
 
         return responses.displayButtons({
           pageTitle: 'Google Sheets Integration',

--- a/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
+++ b/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
@@ -1,0 +1,171 @@
+import * as oauthWizard from '@botpress/common/src/oauth-wizard'
+import * as sdk from '@botpress/sdk'
+import { GoogleClient } from 'src/google-api'
+import { getAuthenticatedOAuth2Client } from 'src/google-api/oauth-client'
+import * as bp from '.botpress'
+
+export const handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Response> => {
+  const { client, ctx } = props
+
+  const wizard = new oauthWizard.OAuthWizardBuilder(props)
+
+    .addStep({
+      id: 'start',
+      handler({ responses }) {
+        return responses.displayButtons({
+          pageTitle: 'Google Sheets Integration',
+          htmlOrMarkdownPageContents: `
+              This wizard will set up your Google Sheets integration. This will allow
+              the integration to access your Google Sheets files.
+
+              Do you wish to continue?
+            `,
+          buttons: [
+            {
+              action: 'external',
+              label: 'Yes, continue',
+              navigateToUrl: _getOAuthAuthorizationUri(ctx),
+              buttonType: 'primary',
+            },
+            { action: 'close', label: 'No, cancel', buttonType: 'secondary' },
+          ],
+        })
+      },
+    })
+
+    .addStep({
+      id: 'oauth-callback',
+      async handler({ query, responses, client, ctx, logger }) {
+        const authorizationCode = query.get('code')
+        const error = query.get('error')
+
+        if (error) {
+          logger.forBot().error('OAuth error:', error)
+          return responses.endWizard({
+            success: false,
+            errorMessage: `OAuth error: ${error}`,
+          })
+        }
+
+        if (!authorizationCode) {
+          logger.forBot().error('Error extracting code from url in OAuth handler')
+          return responses.endWizard({
+            success: false,
+            errorMessage: 'Error extracting code from url in OAuth handler',
+          })
+        }
+
+        try {
+          await GoogleClient.authenticateWithAuthorizationCode({
+            client,
+            ctx,
+            authorizationCode,
+            redirectUri: _getOAuthRedirectUri().href,
+          })
+
+          // Done in order to correctly display the authorization status in the UI
+          await client.configureIntegration({
+            identifier: ctx.webhookId,
+          })
+
+          return responses.redirectToStep('file-picker')
+        } catch (err) {
+          logger.forBot().error('Failed to authenticate with Google:', err)
+          return responses.endWizard({
+            success: false,
+            errorMessage: `Authentication failed: ${err instanceof Error ? err.message : 'Unknown error'}`,
+          })
+        }
+      },
+    })
+
+    .addStep({
+      id: 'file-picker',
+      async handler({ responses, client, ctx }) {
+        const accessToken = await _getAccessToken({ client, ctx })
+
+        return responses.displayButtons({
+          pageTitle: 'Google Sheets Integration',
+          htmlOrMarkdownPageContents: `
+            You will now be asked to select the files and folders you wish to
+            grant access to. This is necessary for the integration to work
+            properly.
+
+            If you do not give access to any files or folders, the integration
+            will only be able to access files that are created through the
+            integration.
+
+            <script>
+              function createPicker() {
+                new google.picker.PickerBuilder()
+                    .addView(new google.picker.DocsView(google.picker.ViewId.SPREADSHEETS)
+                      .setIncludeFolders(true)
+                      .setSelectFolderEnabled(true)
+                      .setMode(google.picker.DocsViewMode.LIST))
+                    .enableFeature(google.picker.Feature.NAV_HIDDEN)
+                    .enableFeature(google.picker.Feature.MULTISELECT_ENABLED)
+                    .setTitle('Select the spreadsheets and folders you wish to share with Botpress')
+                    .setOAuthToken('${accessToken}')
+                    .setDeveloperKey('${bp.secrets.FILE_PICKER_API_KEY}')
+                    .setCallback((data) => {
+                      if (data[google.picker.Response.ACTION] == google.picker.Action.PICKED) {
+                        document.location.href = '${oauthWizard.getWizardStepUrl('end', ctx).href}';
+                      }})
+                    .setSize(640,790)
+                    .setAppId('${bp.secrets.CLIENT_ID.split('-')[0]}')
+                    .build().setVisible(true);
+              }
+            </script>
+            <script async defer src="https://apis.google.com/js/api.js" onload="gapi.load('picker')"></script>
+            `,
+          buttons: [
+            {
+              action: 'javascript',
+              label: 'Select files',
+              callFunction: 'createPicker',
+              buttonType: 'primary',
+            },
+            {
+              action: 'navigate',
+              label: 'Skip file selection',
+              navigateToStep: 'end',
+              buttonType: 'warning',
+            },
+          ],
+        })
+      },
+    })
+
+    .addStep({
+      id: 'end',
+      handler({ responses }) {
+        return responses.endWizard({
+          success: true,
+        })
+      },
+    })
+
+    .build()
+
+  return await wizard.handleRequest()
+}
+
+const _getOAuthAuthorizationUri = (ctx: { webhookId: string }) =>
+  'https://accounts.google.com/o/oauth2/v2/auth?scope=' +
+  'https%3A//www.googleapis.com/auth/drive.file&access_type=offline' +
+  '&include_granted_scopes=true&response_type=code&prompt=consent' +
+  `&state=${ctx.webhookId}&redirect_uri=${encodeURI(_getOAuthRedirectUri().href)}` +
+  `&client_id=${bp.secrets.CLIENT_ID}`
+
+const _getOAuthRedirectUri = () => oauthWizard.getWizardStepUrl('oauth-callback')
+
+const _getAccessToken = async ({ client, ctx }: { client: bp.Client; ctx: bp.Context }): Promise<string> => {
+  const oauth2Client = await getAuthenticatedOAuth2Client({ client, ctx })
+  const { token } = await oauth2Client.getAccessToken()
+
+  if (!token) {
+    throw new sdk.RuntimeError('Failed to get access token')
+  }
+
+  return token
+}

--- a/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
+++ b/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
@@ -128,11 +128,11 @@ export const handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Res
                     .enableFeature(google.picker.Feature.NAV_HIDDEN)
                     .enableFeature(google.picker.Feature.MULTISELECT_ENABLED)
                     .setTitle('Select the spreadsheets and folders you wish to share with Botpress')
-                    .setOAuthToken('${accessToken}')
-                    .setDeveloperKey('${bp.secrets.FILE_PICKER_API_KEY}')
+                    .setOAuthToken(${JSON.stringify(accessToken)})
+                    .setDeveloperKey(${JSON.stringify(bp.secrets.FILE_PICKER_API_KEY)})
                     .setCallback((data) => {
                       if (data[google.picker.Response.ACTION] == google.picker.Action.PICKED) {
-                        document.location.href = '${oauthWizard.getWizardStepUrl('end', ctx).href}';
+                        document.location.href = ${JSON.stringify(oauthWizard.getWizardStepUrl('end', ctx).href)};
                       } else if (data[google.picker.Response.ACTION] == google.picker.Action.CANCEL) {
                         // User closed the picker without selecting files.
                         // They can still click "Skip file selection" to continue.
@@ -141,7 +141,7 @@ export const handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Res
                     .setSize(640,790)
                     // App ID must be the Google Cloud project number (numeric prefix of CLIENT_ID)
                     // Format: <project-number>-<rest>.apps.googleusercontent.com
-                    .setAppId('${bp.secrets.CLIENT_ID.split('-')[0]}')
+                    .setAppId(${JSON.stringify(bp.secrets.CLIENT_ID.split('-')[0])})
                     .build().setVisible(true);
               }
             </script>
@@ -180,11 +180,15 @@ export const handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Res
 }
 
 const _getOAuthAuthorizationUri = (ctx: { webhookId: string }) =>
-  'https://accounts.google.com/o/oauth2/v2/auth?scope=' +
-  'https%3A//www.googleapis.com/auth/drive.file&access_type=offline' +
-  '&include_granted_scopes=true&response_type=code&prompt=consent' +
-  `&state=${ctx.webhookId}&redirect_uri=${encodeURIComponent(_getOAuthRedirectUri().href)}` +
-  `&client_id=${bp.secrets.CLIENT_ID}`
+  'https://accounts.google.com/o/oauth2/v2/auth?' +
+  `scope=${encodeURIComponent('https://www.googleapis.com/auth/drive.file')}` +
+  '&access_type=offline' +
+  '&include_granted_scopes=true' +
+  '&response_type=code' +
+  '&prompt=consent' +
+  `&state=${encodeURIComponent(ctx.webhookId)}` +
+  `&redirect_uri=${encodeURIComponent(_getOAuthRedirectUri().href)}` +
+  `&client_id=${encodeURIComponent(bp.secrets.CLIENT_ID)}`
 
 const _getOAuthRedirectUri = () => oauthWizard.getWizardStepUrl('oauth-callback')
 

--- a/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
+++ b/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
@@ -96,7 +96,18 @@ export const handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Res
             integration.
 
             <script>
+              let pickerApiLoaded = false;
+
+              function onPickerApiLoad() {
+                pickerApiLoaded = true;
+              }
+
               function createPicker() {
+                if (!pickerApiLoaded) {
+                  alert('The file picker is still loading. Please try again in a moment.');
+                  return;
+                }
+
                 new google.picker.PickerBuilder()
                     .addView(new google.picker.DocsView(google.picker.ViewId.SPREADSHEETS)
                       .setIncludeFolders(true)
@@ -120,7 +131,7 @@ export const handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Res
                     .build().setVisible(true);
               }
             </script>
-            <script async defer src="https://apis.google.com/js/api.js" onload="gapi.load('picker')"></script>
+            <script async defer src="https://apis.google.com/js/api.js" onload="gapi.load('picker', onPickerApiLoad)"></script>
             `,
           buttons: [
             {

--- a/integrations/gsheets/tsconfig.json
+++ b/integrations/gsheets/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "types": ["preact"],
     "baseUrl": ".",
     "outDir": "dist",
     "experimentalDecorators": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -679,7 +679,7 @@ importers:
         version: link:../../packages/sdk
       openai:
         specifier: ^5.12.1
-        version: 5.12.1(ws@8.18.2)(zod@3.24.2)
+        version: 5.12.1(ws@8.19.0)(zod@3.24.2)
     devDependencies:
       '@botpress/cli':
         specifier: workspace:*
@@ -929,7 +929,7 @@ importers:
         version: link:../../packages/sdk
       openai:
         specifier: ^5.12.1
-        version: 5.12.1(ws@8.18.2)(zod@3.24.2)
+        version: 5.12.1(ws@8.19.0)(zod@3.24.2)
     devDependencies:
       '@botpress/cli':
         specifier: workspace:*
@@ -1176,7 +1176,7 @@ importers:
         version: link:../../packages/sdk
       openai:
         specifier: ^5.12.1
-        version: 5.12.1(ws@8.18.2)(zod@3.24.2)
+        version: 5.12.1(ws@8.19.0)(zod@3.24.2)
     devDependencies:
       '@botpress/cli':
         specifier: workspace:*
@@ -1212,6 +1212,9 @@ importers:
       '@sentry/cli':
         specifier: ^2.39.1
         version: 2.39.1
+      preact:
+        specifier: ^10.26.6
+        version: 10.26.6
 
   integrations/hubspot:
     dependencies:
@@ -1586,7 +1589,7 @@ importers:
         version: link:../../packages/sdk
       openai:
         specifier: ^6.9.0
-        version: 6.9.0(ws@8.18.2)
+        version: 6.9.0(ws@8.19.0)
     devDependencies:
       '@botpress/cli':
         specifier: workspace:*
@@ -2793,7 +2796,7 @@ importers:
         version: 15.0.1
       openai:
         specifier: ^6.9.0
-        version: 6.9.0(ws@8.18.2)
+        version: 6.9.0(ws@8.19.0)
       posthog-node:
         specifier: 5.14.1
         version: 5.14.1
@@ -20532,14 +20535,14 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openai@5.12.1(ws@8.18.2)(zod@3.24.2):
+  openai@5.12.1(ws@8.19.0)(zod@3.24.2):
     optionalDependencies:
-      ws: 8.18.2
+      ws: 8.19.0
       zod: 3.24.2
 
-  openai@6.9.0(ws@8.18.2):
+  openai@6.9.0(ws@8.19.0):
     optionalDependencies:
-      ws: 8.18.2
+      ws: 8.19.0
 
   openapi-types@12.1.3: {}
 


### PR DESCRIPTION
we updated the google sheets production oauth application to have scope `auth/drive.file` instead of `auth/spreadsheets`, to get the application approved

we need to update the linkTemplate.vrl for the integration to reflect the change

this allows the integration to be used externally (not just @botpress.com accounts):

https://github.com/user-attachments/assets/34f51254-bb83-4e71-9907-11b27124146d


