### PR TITLE
fix(plugins/hitl): revert changes

### DIFF
--- a/plugins/hitl/src/conv-manager.ts
+++ b/plugins/hitl/src/conv-manager.ts
@@ -85,7 +85,7 @@ export class ConversationManager {
     await this.respond({ type: 'text', text })
   }
 
-  public async respond(messagePayload: types.MessagePayload, tags: types.MessageTags = {}): Promise<void> {
+  public async respond(messagePayload: types.MessagePayload, _tags: types.MessageTags = {}): Promise<void> {
     // FIXME: in the future, we should use the provided UserId so that messages
     //        on Botpress appear to come from the agent/user instead of the
     //        bot user. For now, this is not possible because of checks in the
@@ -93,6 +93,9 @@ export class ConversationManager {
 
     // FIXME: typescript has trouble narrowing the type here, so we use a switch
     //        statement as a workaround.
+
+    const tags: Record<string, string> = {} // re-enable tags, when the new hub allows updating or upgrading plugins
+
     switch (messagePayload.type) {
       case 'text':
         await this._conversation.createMessage({


### PR DESCRIPTION
Currently, if you re-publish the bot in the studio, it rebundles the plugin, but does not update the bot in the backend. So updating the plugin in place, reusing an existing version, won't define the tags properly.

I need to do this until we fix the new hub