### PR TITLE
feat(packages/cli): implement profiles get command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/command-definitions.ts
+++ b/packages/cli/src/command-definitions.ts
@@ -69,6 +69,10 @@ export default {
         description: 'Set the current profile',
         schema: config.schemas.useProfile,
       },
+      get: {
+        description: 'Get a specific profile by name',
+        schema: config.schemas.getProfile,
+      },
     },
   },
 } satisfies DefinitionTree

--- a/packages/cli/src/command-implementations/index.ts
+++ b/packages/cli/src/command-implementations/index.ts
@@ -87,6 +87,7 @@ export default {
       list: getHandler(profiles.ListProfilesCommand),
       active: getHandler(profiles.ActiveProfileCommand),
       use: getHandler(profiles.UseProfileCommand),
+      get: getHandler(profiles.GetProfileCommand),
     },
   },
 } satisfies ImplementationTree<typeof commandDefinitions>

--- a/packages/cli/src/command-implementations/profile-commands.ts
+++ b/packages/cli/src/command-implementations/profile-commands.ts
@@ -62,7 +62,7 @@ export class UseProfileCommand extends GlobalCommand<UseProfileCommandDefinition
       return
     }
     const profiles = await this.readProfilesFromFS()
-    const choices = Object.entries(profiles).map(([profileName, _]) => ({
+    const choices = Object.keys(profiles).map((profileName) => ({
       title: profileName,
       description: '',
       value: profileName,
@@ -98,7 +98,7 @@ export class GetProfileCommand extends GlobalCommand<GetProfileCommandDefinition
     }
 
     const profiles = await this.readProfilesFromFS()
-    const choices = Object.entries(profiles).map(([profileName, _]) => ({
+    const choices = Object.keys(profiles).map((profileName) => ({
       title: profileName,
       description: '',
       value: profileName,

--- a/packages/cli/src/command-implementations/profile-commands.ts
+++ b/packages/cli/src/command-implementations/profile-commands.ts
@@ -82,6 +82,40 @@ export class UseProfileCommand extends GlobalCommand<UseProfileCommandDefinition
   }
 }
 
+export type GetProfileCommandDefinition = typeof commandDefinitions.profiles.subcommands.get
+export class GetProfileCommand extends GlobalCommand<GetProfileCommandDefinition> {
+  public async run(): Promise<void> {
+    const logResult = (profileEntry: ProfileEntry) => {
+      const profile = _shouldOmitToken(this.argv) ? _stripProfileToken(profileEntry) : profileEntry
+      this.logger.log('Profile:')
+      this.logger.json(profile)
+    }
+
+    if (this.argv.profileToGet) {
+      const profile = await this.readProfileFromFS(this.argv.profileToGet)
+      logResult({ name: this.argv.profileToGet, ...profile })
+      return
+    }
+
+    const profiles = await this.readProfilesFromFS()
+    const choices = Object.entries(profiles).map(([profileName, _]) => ({
+      title: profileName,
+      description: '',
+      value: profileName,
+    }))
+    const selectedProfile = await this.prompt.select('Select the profile you want to use.', { choices })
+
+    if (!selectedProfile) {
+      this.logger.log('No profile selected, aborting.')
+      return
+    }
+
+    const profile = profiles[selectedProfile]
+    if (!profile) throw new errors.BotpressCLIError('The selected profile could not be read')
+    logResult({ name: selectedProfile, ...profile })
+  }
+}
+
 const _updateGlobalCache = async (props: {
   globalCache: utils.cache.FSKeyValueCache<GlobalCache>
   profileName: string

--- a/packages/cli/src/command-implementations/profile-commands.ts
+++ b/packages/cli/src/command-implementations/profile-commands.ts
@@ -103,7 +103,7 @@ export class GetProfileCommand extends GlobalCommand<GetProfileCommandDefinition
       description: '',
       value: profileName,
     }))
-    const selectedProfile = await this.prompt.select('Select the profile you want to use.', { choices })
+    const selectedProfile = await this.prompt.select('Select the profile you want to get.', { choices })
 
     if (!selectedProfile) {
       this.logger.log('No profile selected, aborting.')

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -399,6 +399,17 @@ const useProfileSchema = {
   },
 } satisfies CommandSchema
 
+const getProfileSchema = {
+  ...globalSchema,
+  profileToGet: {
+    type: 'string',
+    description: 'The CLI profile defined in the $BP_BOTPRESS_HOME/profiles.json',
+    positional: true,
+    idx: 0,
+  },
+  displayToken: { type: 'boolean', description: 'Display the token in the bp profile', default: false },
+} satisfies CommandSchema
+
 // exports
 
 export const schemas = {
@@ -436,4 +447,5 @@ export const schemas = {
   listProfiles: listProfilesSchema,
   activeProfile: activeProfileSchema,
   useProfile: useProfileSchema,
+  getProfile: getProfileSchema,
 } as const

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -53,5 +53,6 @@ export default {
     list: commandImplementations.profiles.subcommands.list,
     active: commandImplementations.profiles.subcommands.active,
     use: commandImplementations.profiles.subcommands.use,
+    get: commandImplementations.profiles.subcommands.get,
   },
 } satisfies CommandHandlers<typeof commandDefinitions>


### PR DESCRIPTION
The purpose of this is to have a more efficient means of getting details on a profile in CI scripts instead of using `bp profiles list` and then filtering, or where `bp profiles active` doesn't work for the given use-case.