### PR TITLE
feat(integrations): use webhookId instead of oauth-derived identifiers

### DIFF
--- a/integrations/calendly/integration.definition.ts
+++ b/integrations/calendly/integration.definition.ts
@@ -5,7 +5,7 @@ import { inviteeEventOutputSchema } from 'definitions/events'
 export default new IntegrationDefinition({
   name: 'calendly',
   title: 'Calendly',
-  version: '0.0.3',
+  version: '0.0.4',
   readme: 'hub.md',
   icon: 'icon.svg',
   description: 'Schedule meetings and manage events using the Calendly scheduling platform.',

--- a/integrations/calendly/src/calendly-api/auth.ts
+++ b/integrations/calendly/src/calendly-api/auth.ts
@@ -1,7 +1,7 @@
 import { RuntimeError } from '@botpress/sdk'
 import axios, { type AxiosInstance } from 'axios'
 import type { CommonHandlerProps, Result } from '../types'
-import { type CalendlyUri, type GetOAuthAccessTokenResp, getOAuthAccessTokenRespSchema, uuidSchema } from './schemas'
+import { type GetOAuthAccessTokenResp, getOAuthAccessTokenRespSchema } from './schemas'
 import * as bp from '.botpress'
 
 const AUTH_BASE_URL = 'https://auth.calendly.com' as const
@@ -74,21 +74,6 @@ type GetAccessTokenParams =
       refresh_token: string
     }
 
-const _extractUserUuid = (userUri: CalendlyUri): string => {
-  const match = userUri.match(/\/users\/(.+)$/)
-
-  if (!match) {
-    throw new Error('Failed to extract user UUID from URI')
-  }
-
-  const parsed = uuidSchema.safeParse(match[1])
-  if (!parsed.success) {
-    throw new Error('Failed to extract user UUID from URI')
-  }
-
-  return parsed.data
-}
-
 export const applyOAuthState = async ({ client, ctx }: CommonHandlerProps, resp: GetOAuthAccessTokenResp) => {
   const { access_token, refresh_token, created_at, expires_in, owner: userUri } = resp
   const { state } = await client.setState({
@@ -116,10 +101,9 @@ export const exchangeAuthCodeForRefreshToken = async (props: bp.HandlerProps, oA
   const resp = await authClient.getAccessTokenWithCode(oAuthCode)
   if (!resp.success) throw resp.error
 
-  const { userUri } = await applyOAuthState(props, resp.data)
+  await applyOAuthState(props, resp.data)
 
-  const userId = _extractUserUuid(userUri)
   await props.client.configureIntegration({
-    identifier: userId,
+    identifier: props.ctx.webhookId,
   })
 }

--- a/integrations/hubspot/integration.definition.ts
+++ b/integrations/hubspot/integration.definition.ts
@@ -5,7 +5,7 @@ export default new IntegrationDefinition({
   name: 'hubspot',
   title: 'HubSpot',
   description: 'Manage contacts, tickets and more from your chatbot.',
-  version: '5.3.0',
+  version: '5.3.1',
   readme: 'hub.md',
   icon: 'icon.svg',
   configuration: {

--- a/integrations/hubspot/src/webhook/handlers/oauth-callback.ts
+++ b/integrations/hubspot/src/webhook/handlers/oauth-callback.ts
@@ -1,11 +1,10 @@
 import { RuntimeError } from '@botpress/sdk'
 import { exchangeCodeForOAuthCredentials, setOAuthCredentials } from '../../auth'
-import { HubspotClient } from '../../hubspot-api'
 import * as bp from '.botpress'
 
 export const isOAuthCallback = (props: bp.HandlerProps): boolean => props.req.path.startsWith('/oauth')
 
-export const handleOAuthCallback: bp.IntegrationProps['handler'] = async ({ client, ctx, req, logger }) => {
+export const handleOAuthCallback: bp.IntegrationProps['handler'] = async ({ client, ctx, req }) => {
   const searchParams = new URLSearchParams(req.query)
   const authorizationCode = searchParams.get('code')
 
@@ -19,10 +18,7 @@ export const handleOAuthCallback: bp.IntegrationProps['handler'] = async ({ clie
     credentials,
   })
 
-  const hsClient = new HubspotClient({ accessToken: credentials.accessToken, client, ctx, logger })
-  const hubId = await hsClient.getHubId()
-
   await client.configureIntegration({
-    identifier: hubId,
+    identifier: ctx.webhookId,
   })
 }

--- a/integrations/linear/integration.definition.ts
+++ b/integrations/linear/integration.definition.ts
@@ -7,7 +7,7 @@ import listable from './bp_modules/listable'
 import { actions, channels, events, configuration, configurations, user, states, entities } from './definitions'
 
 export const INTEGRATION_NAME = 'linear'
-export const INTEGRATION_VERSION = '2.0.1'
+export const INTEGRATION_VERSION = '2.0.2'
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -226,7 +226,5 @@ export const handleOauth = async ({ req, ctx, client, logger }: bp.HandlerProps)
     payload: credentials,
   })
 
-  const linearClient = new LinearClient({ accessToken: credentials.accessToken })
-  const organization = await linearClient.organization
-  await client.configureIntegration({ identifier: organization.id, scheduleRegisterCall: 'monthly' })
+  await client.configureIntegration({ identifier: ctx.webhookId, scheduleRegisterCall: 'monthly' })
 }

--- a/integrations/linkedin/integration.definition.ts
+++ b/integrations/linkedin/integration.definition.ts
@@ -2,7 +2,7 @@ import { IntegrationDefinition } from '@botpress/sdk'
 import { configuration, configurations, identifier, states, secrets, actions } from './definitions'
 
 export const INTEGRATION_NAME = 'linkedin'
-export const INTEGRATION_VERSION = '0.1.0'
+export const INTEGRATION_VERSION = '0.1.1'
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/linkedin/src/handler.ts
+++ b/integrations/linkedin/src/handler.ts
@@ -88,14 +88,11 @@ const handleOAuthCallback = async ({ req, client, ctx, logger }: bp.HandlerProps
     logger,
   })
 
-  const linkedInUserId = oauthClient.getUserId()
-  const grantedScopes = oauthClient.getGrantedScopes()
-
-  logger.forBot().info(`Successfully authenticated LinkedIn user: ${linkedInUserId}`)
-  logger.forBot().info(`Granted scopes: ${grantedScopes.join(', ')}`)
+  logger.forBot().info(`Successfully authenticated LinkedIn user: ${oauthClient.getUserId()}`)
+  logger.forBot().info(`Granted scopes: ${oauthClient.getGrantedScopes().join(', ')}`)
 
   await client.configureIntegration({
-    identifier: linkedInUserId,
+    identifier: ctx.webhookId,
   })
 
   return { status: 200 }

--- a/integrations/linkedin/src/setup.ts
+++ b/integrations/linkedin/src/setup.ts
@@ -23,13 +23,11 @@ export const register: bp.IntegrationProps['register'] = async ({ client, ctx, l
       logger,
     })
 
-    const linkedInUserId = oauthClient.getUserId()
-
     await client.configureIntegration({
-      identifier: linkedInUserId,
+      identifier: ctx.webhookId,
     })
 
-    logger.forBot().info(`LinkedIn integration registered for user: ${linkedInUserId}`)
+    logger.forBot().info(`LinkedIn integration registered for user: ${oauthClient.getUserId()}`)
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error'
     logger.forBot().error(`Failed to exchange authorization code: ${message}`)

--- a/integrations/notion/integration.definition.ts
+++ b/integrations/notion/integration.definition.ts
@@ -3,7 +3,7 @@ import filesReadonly from './bp_modules/files-readonly'
 import { actions, configuration, configurations, events, identifier, secrets, states, user } from './definitions'
 
 export const INTEGRATION_NAME = 'notion'
-export const INTEGRATION_VERSION = '3.0.2'
+export const INTEGRATION_VERSION = '3.0.3'
 
 export default new sdk.IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/notion/src/webhook-events/handlers/oauth-callback.ts
+++ b/integrations/notion/src/webhook-events/handlers/oauth-callback.ts
@@ -12,9 +12,9 @@ export const handleOAuthCallback: bp.IntegrationProps['handler'] = async ({ clie
     return
   }
 
-  const { workspaceId } = await NotionClient.processAuthorizationCode({ client, ctx }, authorizationCode)
+  await NotionClient.processAuthorizationCode({ client, ctx }, authorizationCode)
 
   await client.configureIntegration({
-    identifier: workspaceId,
+    identifier: ctx.webhookId,
   })
 }


### PR DESCRIPTION
Standardize the configureIntegration identifier across all OAuth integrations by using ctx.webhookId instead of provider-specific IDs. This eliminates unnecessary API calls during OAuth setup and simplifies the authentication flow.

Affected integrations: Calendly, HubSpot, Linear, LinkedIn, and Notion. All receive corresponding patch version bumps.