### PR TITLE
feat(slack): use bot user id as identifier; register integration webhook

### DIFF
--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -17,7 +17,7 @@ export default new IntegrationDefinition({
   name: 'slack',
   title: 'Slack',
   description: 'Automate interactions with your team.',
-  version: '4.0.2',
+  version: '4.0.3',
   icon: 'icon.svg',
   readme: 'hub.md',
   configuration,

--- a/integrations/slack/src/oauth-wizard/wizard.ts
+++ b/integrations/slack/src/oauth-wizard/wizard.ts
@@ -125,7 +125,7 @@ const _createAppHandler: WizardHandler = async (props) => {
   }
   const appName = manifestState.appName || 'Botpress Bot'
 
-  const webhookUrl = `https://webhook.botpress.cloud/${props.ctx.webhookId}`
+  const webhookUrl = `${process.env.BP_WEBHOOK_URL!}/${props.ctx.webhookId}`
   const redirectUri = `${process.env.BP_WEBHOOK_URL!}/oauth`
   const manifest = buildSlackAppManifest(webhookUrl, redirectUri, appName)
   const manifestClient = await SlackManifestClient.create({

--- a/integrations/slack/src/oauth-wizard/wizard.ts
+++ b/integrations/slack/src/oauth-wizard/wizard.ts
@@ -125,8 +125,8 @@ const _createAppHandler: WizardHandler = async (props) => {
   }
   const appName = manifestState.appName || 'Botpress Bot'
 
-  const webhookUrl = process.env.BP_WEBHOOK_URL!
-  const redirectUri = `${webhookUrl}/oauth`
+  const webhookUrl = `https://webhook.botpress.cloud/${props.ctx.webhookId}`
+  const redirectUri = `${process.env.BP_WEBHOOK_URL!}/oauth`
   const manifest = buildSlackAppManifest(webhookUrl, redirectUri, appName)
   const manifestClient = await SlackManifestClient.create({
     client,

--- a/integrations/slack/src/webhook-events/handlers/oauth-callback.ts
+++ b/integrations/slack/src/webhook-events/handlers/oauth-callback.ts
@@ -13,6 +13,8 @@ export const handleOAuthCallback = async ({ req, client, ctx, logger }: bp.Handl
   }
 
   const slackClient = await SlackClient.createFromAuthorizationCode({ client, ctx, logger, authorizationCode: code })
+  const identifier =
+    ctx.configurationType === 'manifestAppCredentials' ? slackClient.getBotUserId() : slackClient.getTeamId()
 
-  await client.configureIntegration({ identifier: slackClient.getBotUserId() })
+  await client.configureIntegration({ identifier })
 }

--- a/integrations/slack/src/webhook-events/handlers/oauth-callback.ts
+++ b/integrations/slack/src/webhook-events/handlers/oauth-callback.ts
@@ -14,5 +14,5 @@ export const handleOAuthCallback = async ({ req, client, ctx, logger }: bp.Handl
 
   const slackClient = await SlackClient.createFromAuthorizationCode({ client, ctx, logger, authorizationCode: code })
 
-  await client.configureIntegration({ identifier: slackClient.getTeamId() })
+  await client.configureIntegration({ identifier: slackClient.getBotUserId() })
 }


### PR DESCRIPTION
two minor updates to the slack integration: 
- use the slack bot user id in the case that the manifest app credentials configuration is used, so that the manifest app configuration can be used on multiple bots with the same slack team/workspace
- on the manifest app credentials integration config, register the correct webhook id (ctx.webhookId) rather than a generic webhook ID, so that slack can send webhook events to the correct bot

<img width="434" height="125" alt="Screenshot 2026-03-19 at 9 56 52 AM" src="https://github.com/user-attachments/assets/66cc4d70-5319-4850-bf59-7c0a667392e8" />

<img width="512" height="120" alt="Screenshot 2026-03-19 at 9 56 48 AM" src="https://github.com/user-attachments/assets/17b40f06-0c76-40a1-bec7-721e61b404c8" />

