### PR TITLE
feat(whatsapp): add message status events

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -93,7 +93,7 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp'
-export const INTEGRATION_VERSION = '4.8.3'
+export const INTEGRATION_VERSION = '4.9.0'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,
@@ -323,6 +323,23 @@ export default new IntegrationDefinition({
     },
   },
   events: {
+    messageSent: {
+      title: 'Message Sent',
+      description: 'Triggered when a message is sent',
+      schema: z.object({}),
+    },
+    messageDelivered: {
+      title: 'Message Delivered',
+      description: 'Triggered when a message is delivered to a user',
+      schema: z.object({}),
+    },
+    messageFailed: {
+      title: 'Message Failed',
+      description: 'Triggered when a message fails to be delivered',
+      schema: z.object({
+        error: z.string().describe('Error details describing why the message failed'),
+      }),
+    },
     messageRead: {
       title: 'Message Read',
       description: 'Triggered when a user reads a message',

--- a/integrations/whatsapp/src/webhook/handlers/status.ts
+++ b/integrations/whatsapp/src/webhook/handlers/status.ts
@@ -5,6 +5,38 @@ import * as bp from '.botpress'
 export const statusHandler = async (value: WhatsAppStatusValue, props: bp.HandlerProps) => {
   const { client, logger } = props
 
+  if (value.status === 'sent') {
+    const message = await getMessageFromWhatsappMessageId(value.id, client)
+    if (!message) {
+      logger.forBot().error(`No message found for WhatsApp message ID ${value.id}, cannot create messageSent event`)
+      return
+    }
+
+    await client.createEvent({
+      type: 'messageSent',
+      conversationId: message.conversationId,
+      messageId: message.id,
+      payload: {},
+    })
+  }
+
+  if (value.status === 'delivered') {
+    const message = await getMessageFromWhatsappMessageId(value.id, client)
+    if (!message) {
+      logger
+        .forBot()
+        .error(`No message found for WhatsApp message ID ${value.id}, cannot create messageDelivered event`)
+      return
+    }
+
+    await client.createEvent({
+      type: 'messageDelivered',
+      conversationId: message.conversationId,
+      messageId: message.id,
+      payload: {},
+    })
+  }
+
   if (value.status === 'read') {
     const message = await getMessageFromWhatsappMessageId(value.id, client)
     if (!message) {
@@ -34,5 +66,20 @@ export const statusHandler = async (value: WhatsAppStatusValue, props: bp.Handle
       .error(
         `WhatsApp message delivery failed. Message ID: ${value.id}, Recipient: ${value.recipient_id}, Errors: ${errorDetails}`
       )
+
+    const message = await getMessageFromWhatsappMessageId(value.id, client)
+    if (!message) {
+      logger.forBot().error(`No message found for WhatsApp message ID ${value.id}, cannot create messageFailed event`)
+      return
+    }
+
+    await client.createEvent({
+      type: 'messageFailed',
+      conversationId: message.conversationId,
+      messageId: message.id,
+      payload: {
+        error: errorDetails,
+      },
+    })
   }
 }


### PR DESCRIPTION
## Summary

Add three new integration events to track outbound message delivery lifecycle in WhatsApp:
- **messageSent**: fires when message is confirmed sent by WhatsApp
- **messageDelivered**: fires when message reaches recipient's device
- **messageFailed**: fires on delivery failure with error details

Extends the webhook status handler following the existing pattern for messageRead events. Version bumped to 4.9.0.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>