### PR TITLE
fix(google-ai): update Gemini 3 Pro display name to Gemini 3.1 Pro

### DIFF
--- a/integrations/google-ai/integration.definition.ts
+++ b/integrations/google-ai/integration.definition.ts
@@ -6,7 +6,7 @@ export default new IntegrationDefinition({
   name: 'google-ai',
   title: 'Google AI',
   description: 'Gain access to Gemini models for content generation, chat responses, and advanced language tasks.',
-  version: '7.0.3',
+  version: '7.0.4',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/google-ai/src/index.ts
+++ b/integrations/google-ai/src/index.ts
@@ -8,7 +8,7 @@ const googleAIClient = new GoogleGenAI({ apiKey: bp.secrets.GOOGLE_AI_API_KEY })
 
 const languageModels: Record<ModelId, llm.ModelDetails> = {
   'gemini-3-pro': {
-    name: 'Gemini 3 Pro (Preview)',
+    name: 'Gemini 3.1 Pro (Preview)',
     description:
       "One of the best models for multimodal understanding, and Google's most powerful agentic and vibe-coding model yet, delivering richer visuals and deeper interactivity, built on a foundation of state-of-the-art reasoning.",
     tags: ['preview', 'reasoning', 'agents', 'general-purpose', 'vision'],


### PR DESCRIPTION
Update Gemini 3 Pro display name to Gemini 3.1 Pro in Google AI integration

## Overview

This is a minor naming update to the Google AI integration. The display name of the `gemini-3-pro` model has been changed from "Gemini 3 Pro (Preview)" to "Gemini 3.1 Pro (Preview)" to accurately reflect the current model branding from Google.