### PR TITLE
feat(slack): add files:read scope to slack manifest config

### DIFF
--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -17,7 +17,7 @@ export default new IntegrationDefinition({
   name: 'slack',
   title: 'Slack',
   description: 'Automate interactions with your team.',
-  version: '4.0.3',
+  version: '4.0.4',
   icon: 'icon.svg',
   readme: 'hub.md',
   configuration,

--- a/integrations/slack/src/setup.ts
+++ b/integrations/slack/src/setup.ts
@@ -8,6 +8,7 @@ export const REQUIRED_SLACK_SCOPES = [
   'channels:manage',
   'channels:read',
   'chat:write',
+  'files:read',
   'groups:history',
   'groups:read',
   'groups:write',


### PR DESCRIPTION
when we are creating a slack app using the manifest config option, 
we should add the 'files:read' scope to the app