### PR TITLE
feat(integrations): add Novita AI as LLM provider

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -42,6 +42,7 @@
 /integrations/fireworks-ai @botpress/shark @botpress/leads
 /integrations/google-ai @botpress/shark @botpress/leads
 /integrations/groq @botpress/shark @botpress/leads
+/integrations/novita-ai @botpress/shark @botpress/leads
 /integrations/openai @botpress/shark @botpress/leads
 
 ## Chat

--- a/integrations/novita-ai/eslint.config.mjs
+++ b/integrations/novita-ai/eslint.config.mjs
@@ -1,0 +1,13 @@
+import rootConfig from '../../eslint.config.mjs'
+
+export default [
+  ...rootConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+]

--- a/integrations/novita-ai/hub.md
+++ b/integrations/novita-ai/hub.md
@@ -1,0 +1,5 @@
+# Novita AI Integration
+
+This integration allows your bot to choose from a curated list of models from [Novita AI](https://novita.ai/) for content generation and chat completions.
+
+Usage is charged to the AI Spend of your workspace in Botpress Cloud at the same pricing (at cost) as directly with Novita AI.

--- a/integrations/novita-ai/icon.svg
+++ b/integrations/novita-ai/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="20" fill="#6C47FF"/>
+  <text x="50" y="68" font-family="Arial, sans-serif" font-size="48" font-weight="bold" fill="white" text-anchor="middle">N</text>
+</svg>

--- a/integrations/novita-ai/integration.definition.ts
+++ b/integrations/novita-ai/integration.definition.ts
@@ -1,0 +1,30 @@
+import { IntegrationDefinition, z } from '@botpress/sdk'
+import { modelId } from 'src/schemas'
+import llm from './bp_modules/llm'
+
+export default new IntegrationDefinition({
+  name: 'novita-ai',
+  title: 'Novita AI',
+  description:
+    'Get access to a curated list of Novita AI models for content generation and chat completions within your bot.',
+  version: '1.0.0',
+  readme: 'hub.md',
+  icon: 'icon.svg',
+  entities: {
+    modelRef: {
+      schema: z.object({
+        id: modelId,
+      }),
+    },
+  },
+  secrets: {
+    NOVITA_API_KEY: {
+      description: 'Novita AI API key',
+    },
+  },
+  attributes: {
+    category: 'AI Models',
+  },
+}).extend(llm, ({ entities: { modelRef } }) => ({
+  entities: { modelRef },
+}))

--- a/integrations/novita-ai/package.json
+++ b/integrations/novita-ai/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@botpresshub/novita-ai",
+  "scripts": {
+    "build": "bp add -y && bp build",
+    "check:type": "tsc --noEmit",
+    "check:bplint": "bp lint",
+    "test": "vitest --run"
+  },
+  "private": true,
+  "dependencies": {
+    "@botpress/client": "workspace:*",
+    "@botpress/common": "workspace:*",
+    "@botpress/sdk": "workspace:*",
+    "openai": "^5.12.1"
+  },
+  "devDependencies": {
+    "@botpress/cli": "workspace:*",
+    "@botpress/sdk": "workspace:*",
+    "@botpresshub/llm": "workspace:*"
+  },
+  "bpDependencies": {
+    "llm": "../../interfaces/llm"
+  }
+}

--- a/integrations/novita-ai/src/index.ts
+++ b/integrations/novita-ai/src/index.ts
@@ -1,0 +1,87 @@
+import { llm } from '@botpress/common'
+import OpenAI from 'openai'
+import { DEFAULT_MODEL_ID, ModelId } from './schemas'
+import * as bp from '.botpress'
+
+const novitaClient = new OpenAI({
+  baseURL: 'https://api.novita.ai/openai',
+  apiKey: bp.secrets.NOVITA_API_KEY,
+})
+
+const languageModels: Record<ModelId, llm.ModelDetails> = {
+  // Reference:
+  //  https://novita.ai/llm-api
+  //  https://novita.ai/pricing
+  'moonshotai/kimi-k2.5': {
+    name: 'Kimi K2.5',
+    description:
+      'Kimi K2.5 is a mixture-of-experts model from Moonshot AI with a 262K context window. It supports function calling, structured output, reasoning, and vision (text and image input).',
+    tags: ['recommended', 'general-purpose', 'reasoning', 'vision', 'low-cost'],
+    input: {
+      costPer1MTokens: 0.6,
+      maxTokens: 262_144,
+    },
+    output: {
+      costPer1MTokens: 3,
+      maxTokens: 262_144,
+    },
+  },
+  'zai-org/glm-5': {
+    name: 'GLM-5',
+    description:
+      'GLM-5 is a mixture-of-experts model from ZhipuAI with a 202K context window. It supports function calling, structured output, and reasoning.',
+    tags: ['general-purpose', 'reasoning'],
+    input: {
+      costPer1MTokens: 1,
+      maxTokens: 202_800,
+    },
+    output: {
+      costPer1MTokens: 3.2,
+      maxTokens: 131_072,
+    },
+  },
+  'minimax/minimax-m2.5': {
+    name: 'MiniMax M2.5',
+    description:
+      'MiniMax M2.5 is a mixture-of-experts model from MiniMax with a 204K context window. It supports function calling, structured output, and reasoning.',
+    tags: ['general-purpose', 'reasoning', 'low-cost'],
+    input: {
+      costPer1MTokens: 0.3,
+      maxTokens: 204_800,
+    },
+    output: {
+      costPer1MTokens: 1.2,
+      maxTokens: 131_100,
+    },
+  },
+}
+
+const provider = 'Novita AI'
+
+export default new bp.Integration({
+  register: async () => {},
+  unregister: async () => {},
+  actions: {
+    generateContent: async ({ input, logger, metadata }) => {
+      const output = await llm.openai.generateContent<ModelId>(
+        <llm.GenerateContentInput>input,
+        novitaClient as any, // TODO: fix mismatch of openai version
+        logger,
+        {
+          provider,
+          models: languageModels,
+          defaultModel: DEFAULT_MODEL_ID,
+        }
+      )
+      metadata.setCost(output.botpress.cost)
+      return output
+    },
+    listLanguageModels: async ({}) => {
+      return {
+        models: Object.entries(languageModels).map(([id, model]) => ({ id: <ModelId>id, ...model })),
+      }
+    },
+  },
+  channels: {},
+  handler: async () => {},
+})

--- a/integrations/novita-ai/src/schemas.ts
+++ b/integrations/novita-ai/src/schemas.ts
@@ -1,0 +1,10 @@
+import { z } from '@botpress/sdk'
+
+export const DEFAULT_MODEL_ID = 'moonshotai/kimi-k2.5'
+
+export const modelId = z
+  .enum(['moonshotai/kimi-k2.5', 'zai-org/glm-5', 'minimax/minimax-m2.5'])
+  .describe('Model to use for content generation')
+  .placeholder(DEFAULT_MODEL_ID)
+
+export type ModelId = z.infer<typeof modelId>

--- a/integrations/novita-ai/tsconfig.json
+++ b/integrations/novita-ai/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist"
+  },
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+}

--- a/integrations/novita-ai/vitest.config.ts
+++ b/integrations/novita-ai/vitest.config.ts
@@ -1,0 +1,2 @@
+import config from '../../vitest.config'
+export default config

--- a/packages/cognitive/src/models.ts
+++ b/packages/cognitive/src/models.ts
@@ -6,7 +6,15 @@ import { BotpressClientLike } from './types'
 export const DOWNTIME_THRESHOLD_MINUTES = 5
 const PREFERENCES_FILE_SUFFIX = 'models.config.json'
 
-export const DEFAULT_INTEGRATIONS = ['google-ai', 'anthropic', 'openai', 'cerebras', 'fireworks-ai', 'groq']
+export const DEFAULT_INTEGRATIONS = [
+  'google-ai',
+  'anthropic',
+  'openai',
+  'cerebras',
+  'fireworks-ai',
+  'groq',
+  'novita-ai',
+]
 
 // Biases for vendors and models
 const VendorPreferences = ['google-ai', 'anthropic', 'openai']

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1567,6 +1567,28 @@ importers:
         specifier: ^2.39.1
         version: 2.39.1
 
+  integrations/novita-ai:
+    dependencies:
+      '@botpress/client':
+        specifier: workspace:*
+        version: link:../../packages/client
+      '@botpress/common':
+        specifier: workspace:*
+        version: link:../../packages/common
+      '@botpress/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      openai:
+        specifier: ^5.12.1
+        version: 5.12.1(ws@8.19.0)(zod@3.25.76)
+    devDependencies:
+      '@botpress/cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@botpresshub/llm':
+        specifier: workspace:*
+        version: link:../../interfaces/llm
+
   integrations/openai:
     dependencies:
       '@botpress/client':


### PR DESCRIPTION
## Summary

- Adds a new `novita-ai` integration under `integrations/novita-ai/`
- Uses Novita AI's OpenAI-compatible endpoint (`https://api.novita.ai/openai`) with the existing `openai` SDK — same pattern as Cerebras and Fireworks AI
- Exposes three models: `moonshotai/kimi-k2.5` (default), `zai-org/glm-5`, and `minimax/minimax-m2.5`
- Auth via `NOVITA_API_KEY` secret, declared in `integration.definition.ts`

## Integration points

- `src/schemas.ts` — model ID enum
- `integration.definition.ts` — integration metadata, secret, `llm` interface binding
- `src/index.ts` — OpenAI client, `languageModels` record, `generateContent` / `listLanguageModels` actions

No existing files were modified.