### PR TITLE
fix: add pnpm overrides for axios and valibot vulnerabilities 

### DIFF
--- a/integrations/vonage/package.json
+++ b/integrations/vonage/package.json
@@ -12,7 +12,7 @@
     "@botpress/client": "workspace:*",
     "@botpress/sdk": "workspace:*",
     "@botpress/sdk-addons": "workspace:*",
-    "axios": "^0.27.2"
+    "axios": "^1.14.0"
   },
   "devDependencies": {
     "@botpress/cli": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
       "source-map-js@1.2.1": "patches/source-map-js@1.2.1.patch"
     },
     "overrides": {
-      "axios": ">=1.14.0",
-      "valibot": ">=1.2.0"
+      "axios": "^1.14.0",
+      "valibot": "^1.2.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,10 @@
   "pnpm": {
     "patchedDependencies": {
       "source-map-js@1.2.1": "patches/source-map-js@1.2.1.patch"
+    },
+    "overrides": {
+      "axios": ">=1.14.0",
+      "valibot": ">=1.2.0"
     }
   }
 }


### PR DESCRIPTION
Fixes #14988 

## Problem
@botpress/webchat pulls in vulnerable versions of axios and valibot via @bpinternal/shared, which is a private package and cannot be updated directly by the community.

## Solution
Added pnpm overrides in the root package.json to enforce safe versions:
- axios >= 1.14.0 (fixes GHSA-wf5p-g6vw-rhxx, GHSA-jr5f-v2jv-69x6, GHSA-4hjh-wcwx-xvwj, GHSA-43fc-jf86-j433)
- valibot >= 1.2.0 (fixes GHSA-vqpr-j7v3-hqw9)

## Verification
After applying this change, running `npm audit` on @botpress/webchat should report 0 vulnerabilities for axios and valibot.