### PR TITLE
Bump patch version of @botpress/cli

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",


### PR DESCRIPTION
6.2.0 of botpress/cli doesn’t have the fix for the description of the secrets flags because the PR didn’t bump the version

https://github.com/botpress/botpress/commit/327b25709e89f85af64a83aeb9a68a9e3df73ba7