### PR TITLE
feat(integrations/anthropic): Add opus 4.6

### DIFF
--- a/integrations/anthropic/integration.definition.ts
+++ b/integrations/anthropic/integration.definition.ts
@@ -6,7 +6,7 @@ export default new IntegrationDefinition({
   name: 'anthropic',
   title: 'Anthropic',
   description: 'Access a curated list of Claude models to set as your chosen LLM.',
-  version: '14.0.1',
+  version: '15.0.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/anthropic/src/actions/generate-content.ts
+++ b/integrations/anthropic/src/actions/generate-content.ts
@@ -102,7 +102,8 @@ export async function generateContent(
   if (
     (modelId === 'claude-sonnet-4-5-20250929' ||
       modelId === 'claude-haiku-4-5-20251001' ||
-      modelId === 'claude-sonnet-4-6') &&
+      modelId === 'claude-sonnet-4-6' ||
+      modelId === 'claude-opus-4-6') &&
     request.temperature !== undefined &&
     request.top_p !== undefined
   ) {

--- a/integrations/anthropic/src/index.ts
+++ b/integrations/anthropic/src/index.ts
@@ -34,6 +34,20 @@ const LanguageModels: Record<ModelId, llm.ModelDetails> = {
   // NOTE: We don't support returning "thinking" blocks from Claude in the integration action output as the concept of "thinking" blocks is a Claude-specific feature that other providers don't have. For now we won't support this as an official feature in the integration so it needs to be taken into account when using reasoning mode and passing a multi-turn conversation history in the generateContent action input.
   // For more information, see: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#preserving-thinking-blocks
   // NOTE: We intentionally didn't include the Opus model as it's the most expensive model in the market, it's not very popular, and no users have ever requested it so far.
+  'claude-opus-4-6': {
+    name: 'Claude Opus 4.6',
+    description:
+      'Claude Opus 4.6 is anthropic\s most capable model to date. Building on the intelligence of Opus 4.5, it brings new levels of reliability and precision to coding, agents, and enterprise workflows.',
+    tags: ['recommended', 'reasoning', 'agents', 'vision', 'general-purpose', 'coding'],
+    input: {
+      costPer1MTokens: 5,
+      maxTokens: 1_000_000,
+    },
+    output: {
+      costPer1MTokens: 15,
+      maxTokens: 128_000,
+    },
+  },
   'claude-sonnet-4-6': {
     name: 'Claude Sonnet 4.6',
     description:

--- a/integrations/anthropic/src/schemas.ts
+++ b/integrations/anthropic/src/schemas.ts
@@ -6,6 +6,7 @@ export const DefaultModel: ModelId = 'claude-sonnet-4-5-20250929'
 
 export const ModelId = z
   .enum([
+    'claude-opus-4-6',
     'claude-sonnet-4-6',
     'claude-haiku-4-5-20251001',
     'claude-haiku-4-5-reasoning-20251001',


### PR DESCRIPTION
The ADK conversation used to test:
``` typescript
import { Conversation, actions } from '@botpress/runtime'

export default new Conversation({
  channel: 'chat.channel',
  handler: async ({ message, conversation }) => {
    if (message?.type !== 'text') return

    const generateContentResult = await actions.anthropic.generateContent({
      messages: [{ role: 'user', type: 'text', content: message.payload.text }],
      model: { id: 'claude-opus-4-6' },
      temperature: 1,
      topP: 1,
    })

    console.log('generateContentResult', generateContentResult)

    const raw = generateContentResult.choices[0]?.content ?? ''
    const text = typeof raw === 'string' ? raw : ''
    await conversation.send({ type: 'text', payload: { text } })
  },
})
```

The result:
``` text
generateContentResult {
	"id":"msg_012KRK5QEG3RPXPn4AgsV6vo"
	"provider":"anthropic"
	"model":"claude-opus-4-6"
	"choices":
		[
			{
				"role":"assistant"
				"type":"multipart"
				"index":0
				"stopReason":"stop"
				"toolCalls":[]
				"content":"Hi! Sure, I'm ready. Ask me anything! 😊"
			}
		]
	"usage": {
		"inputTokens":19
		"inputCost":0.000095
		"outputTokens":18
		"outputCost":0.00027
	}
	"botpress": {
		"cost":0.000365
	}
}
```