### PR TITLE
fix(sdk): remove getOrCreateMessage from bot client wrapper

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",
@@ -28,7 +28,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.5",
     "@botpress/client": "1.38.2",
-    "@botpress/sdk": "6.3.2",
+    "@botpress/sdk": "6.4.0",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/verel": "^0.2.0",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.38.2",
-    "@botpress/sdk": "6.3.2"
+    "@botpress/sdk": "6.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.38.2",
-    "@botpress/sdk": "6.3.2"
+    "@botpress/sdk": "6.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "6.3.2"
+    "@botpress/sdk": "6.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.38.2",
-    "@botpress/sdk": "6.3.2"
+    "@botpress/sdk": "6.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.38.2",
-    "@botpress/sdk": "6.3.2",
+    "@botpress/sdk": "6.4.0",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/cognitive/package.json
+++ b/packages/cognitive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cognitive",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Wrapper around the Botpress Client to call LLMs",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -2,7 +2,7 @@
   "name": "llmz",
   "type": "module",
   "description": "LLMz - An LLM-native Typescript VM built on top of Zui",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "@botpress/client": "1.38.2",
-    "@botpress/cognitive": "0.4.3",
+    "@botpress/cognitive": "0.4.4",
     "@bpinternal/thicktoken": "^2.0.0",
     "@bpinternal/zui": "^2.1.0"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "6.3.2",
+  "version": "6.4.0",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/bot/client/index.ts
+++ b/packages/sdk/src/bot/client/index.ts
@@ -42,8 +42,6 @@ export class BotSpecificClient<TBot extends common.BaseBot> implements types.Cli
   public getEvent: types.GetEvent<TBot> = ((x) => this._run('getEvent', x)) as types.GetEvent<TBot>
   public listEvents: types.ListEvents<TBot> = ((x) => this._run('listEvents', x)) as types.ListEvents<TBot>
   public createMessage: types.CreateMessage<TBot> = ((x) => this._run('createMessage', x)) as types.CreateMessage<TBot>
-  public getOrCreateMessage: types.GetOrCreateMessage<TBot> = ((x) =>
-    this._run('getOrCreateMessage', x)) as types.GetOrCreateMessage<TBot>
   public getMessage: types.GetMessage<TBot> = ((x) => this._run('getMessage', x)) as types.GetMessage<TBot>
   public updateMessage: types.UpdateMessage<TBot> = ((x) => this._run('updateMessage', x)) as types.UpdateMessage<TBot>
   public listMessages: types.ListMessages<TBot> = ((x) => this._run('listMessages', x)) as types.ListMessages<TBot>

--- a/packages/sdk/src/bot/client/types.test.ts
+++ b/packages/sdk/src/bot/client/types.test.ts
@@ -167,11 +167,6 @@ describe('ClientOperations', () => {
     type General = client.Client['createMessage']
     type _assertion = utils.AssertExtends<Specific, General>
   })
-  test('getOrCreateMessage of BotSpecificClient extends General', () => {
-    type Specific = types.ClientOperations<BaseBot>['getOrCreateMessage']
-    type General = client.Client['getOrCreateMessage']
-    type _assertion = utils.AssertExtends<Specific, General>
-  })
   test('getMessage of BotSpecificClient extends General', () => {
     type Specific = types.ClientOperations<BaseBot>['getMessage']
     type General = client.Client['getMessage']

--- a/packages/sdk/src/bot/client/types.ts
+++ b/packages/sdk/src/bot/client/types.ts
@@ -27,21 +27,6 @@ type MessageResponse<
   }>
 }
 
-type GetOrCreateMessageResponse<
-  TBot extends common.BaseBot,
-  TMessage extends keyof common.GetMessages<TBot> = keyof common.GetMessages<TBot>,
-> = utils.Merge<
-  Awaited<Res<client.Client['getOrCreateMessage']>>,
-  {
-    message: utils.ValueOf<{
-      [K in keyof common.GetMessages<TBot> as K extends TMessage ? K : never]: utils.Merge<
-        Awaited<Res<client.Client['getOrCreateMessage']>>['message'],
-        { type: K; payload: common.GetMessages<TBot>[K] }
-      >
-    }>
-  }
->
-
 type StateResponse<
   TBot extends common.BaseBot,
   TState extends keyof TBot['states'] = keyof TBot['states'],
@@ -93,17 +78,6 @@ export type CreateMessage<TBot extends common.BaseBot> = <TMessage extends keyof
     }
   >
 ) => Promise<MessageResponse<TBot, TMessage>>
-
-export type GetOrCreateMessage<TBot extends common.BaseBot> = <TMessage extends keyof common.GetMessages<TBot>>(
-  x: utils.Merge<
-    Arg<client.Client['getOrCreateMessage']>,
-    {
-      type: utils.Cast<TMessage, string>
-      payload?: utils.Cast<common.GetMessages<TBot>[TMessage], Record<string, any>>
-      // TODO: use bot definiton message property to infer allowed tags
-    }
-  >
-) => Promise<GetOrCreateMessageResponse<TBot, TMessage>>
 
 export type GetMessage<TBot extends common.BaseBot> = (
   x: Arg<client.Client['getMessage']>
@@ -452,7 +426,6 @@ export type ClientOperations<TBot extends common.BaseBot> = {
   createEvent: CreateEvent<TBot>
   listEvents: ListEvents<TBot>
   createMessage: CreateMessage<TBot>
-  getOrCreateMessage: GetOrCreateMessage<TBot>
   getMessage: GetMessage<TBot>
   updateMessage: UpdateMessage<TBot>
   listMessages: ListMessages<TBot>

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/vai",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Vitest AI (vai) – a vitest extension for testing with LLMs",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -32,7 +32,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@botpress/cognitive": "0.4.3",
+    "@botpress/cognitive": "0.4.4",
     "json5": "^2.2.3",
     "jsonrepair": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/plugins/conversation-insights/package.json
+++ b/plugins/conversation-insights/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/cognitive": "0.4.3",
+    "@botpress/cognitive": "0.4.4",
     "@botpress/sdk": "workspace:*",
     "browser-or-node": "^2.1.1",
     "jsonrepair": "^3.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2527,7 +2527,7 @@ importers:
         specifier: 1.38.2
         version: link:../client
       '@botpress/sdk':
-        specifier: 6.3.2
+        specifier: 6.4.0
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2651,7 +2651,7 @@ importers:
         specifier: 1.38.2
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.3.2
+        specifier: 6.4.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2667,7 +2667,7 @@ importers:
         specifier: 1.38.2
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.3.2
+        specifier: 6.4.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2680,7 +2680,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 6.3.2
+        specifier: 6.4.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2696,7 +2696,7 @@ importers:
         specifier: 1.38.2
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.3.2
+        specifier: 6.4.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2712,7 +2712,7 @@ importers:
         specifier: 1.38.2
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.3.2
+        specifier: 6.4.0
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8
@@ -2866,7 +2866,7 @@ importers:
         specifier: 1.38.2
         version: link:../client
       '@botpress/cognitive':
-        specifier: 0.4.3
+        specifier: 0.4.4
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^2.0.0
@@ -3052,7 +3052,7 @@ importers:
   packages/zai:
     dependencies:
       '@botpress/cognitive':
-        specifier: 0.4.3
+        specifier: 0.4.4
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^1.0.0
@@ -3165,7 +3165,7 @@ importers:
   plugins/conversation-insights:
     dependencies:
       '@botpress/cognitive':
-        specifier: 0.4.3
+        specifier: 0.4.4
         version: link:../../packages/cognitive
       '@botpress/sdk':
         specifier: workspace:*


### PR DESCRIPTION
## Summary
- Removes `getOrCreateMessage` from `BotSpecificClient` in the SDK bot client wrapper
- Removes the `GetOrCreateMessage` type and `GetOrCreateMessageResponse` type from bot client types
- Removes the related type assertion test

The bridge doesn't allow a bot to call `getOrCreateMessage`, so this change removes the function to accurately reflect that constraint.

Fixes SQD-3506

## Test plan
- [x] Verify TypeScript compilation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)