### PR TITLE
fix(whatsapp): tag synthetic template messages with wamid

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -149,7 +149,7 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp'
-export const INTEGRATION_VERSION = '4.11.0'
+export const INTEGRATION_VERSION = '4.11.1'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,

--- a/integrations/whatsapp/src/actions/start-conversation.ts
+++ b/integrations/whatsapp/src/actions/start-conversation.ts
@@ -122,12 +122,14 @@ export const startConversation: bp.IntegrationProps['actions']['startConversatio
     )
   }
 
+  const whatsappMessageId = response.messages[0]?.id
+
   await client
     .createMessage({
       origin: 'synthetic',
       conversationId: conversation.id,
       userId: ctx.botId,
-      tags: {},
+      tags: { ...(whatsappMessageId ? { id: whatsappMessageId } : {}) },
       type: 'text',
       payload: {
         text: await generateSyntheticTemplateText(

--- a/integrations/whatsapp/src/actions/start-conversation.ts
+++ b/integrations/whatsapp/src/actions/start-conversation.ts
@@ -122,7 +122,7 @@ export const startConversation: bp.IntegrationProps['actions']['startConversatio
     )
   }
 
-  const whatsappMessageId = response.messages[0]?.id
+  const whatsappMessageId = 'messages' in response ? response.messages[0]?.id : undefined
 
   await client
     .createMessage({


### PR DESCRIPTION

<img width="806" height="123" alt="image" src="https://github.com/user-attachments/assets/09400858-11db-4bf3-955d-8a8644b1bb22" />


## Summary
- Template messages sent via `sendTemplateMessage`/`startConversation` actions were creating synthetic messages with empty `tags: {}`, so the WhatsApp message ID (wamid) was never stored
- When async delivery failure webhooks arrive, the status handler tries to look up the message by wamid to create a `messageFailed` event — but can't find it, producing: `No message found for WhatsApp message ID ..., cannot create messageFailed event`
- This fix tags the synthetic message with `{ id: whatsappMessageId }`, matching the pattern the channel already uses at `channel.ts:324`

## Test plan
- [ ] Send a template message via `sendTemplateMessage` action
- [ ] Verify the synthetic message is created with the wamid in its tags
- [ ] Trigger a delivery failure (e.g. payment issue) and verify the `messageFailed` event is created and surfaces to the caller

🤖 Generated with [Claude Code](https://claude.com/claude-code)