### PR TITLE
fix(whatsapp): prevent status events from blocking message processing

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -149,7 +149,7 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp'
-export const INTEGRATION_VERSION = '4.12.0'
+export const INTEGRATION_VERSION = '4.12.1'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,

--- a/integrations/whatsapp/src/webhook/handler.ts
+++ b/integrations/whatsapp/src/webhook/handler.ts
@@ -57,14 +57,18 @@ const _handler: bp.IntegrationProps['handler'] = async (props: bp.HandlerProps) 
 
   switch (changes.field) {
     case 'messages':
-      for (const status of changes.value.statuses ?? []) {
-        await statusHandler(status, props)
-      }
       for (const message of changes.value.messages ?? []) {
         if (message.type === 'reaction') {
           await reactionHandler(message, props)
         } else {
           await messagesHandler(message, changes.value, props)
+        }
+      }
+      for (const status of changes.value.statuses ?? []) {
+        try {
+          await statusHandler(status, props)
+        } catch (err) {
+          logger.forBot().error(`Failed to process WhatsApp status event: ${err}`)
         }
       }
       break

--- a/integrations/whatsapp/src/webhook/handler.ts
+++ b/integrations/whatsapp/src/webhook/handler.ts
@@ -67,8 +67,9 @@ const _handler: bp.IntegrationProps['handler'] = async (props: bp.HandlerProps) 
       for (const status of changes.value.statuses ?? []) {
         try {
           await statusHandler(status, props)
-        } catch (err) {
-          logger.forBot().error(`Failed to process WhatsApp status event: ${err}`)
+        } catch (thrown: unknown) {
+          const errMsg = thrown instanceof Error ? thrown.message : 'Unknown error thrown'
+          logger.forBot().error(`Failed to process WhatsApp status event: ${errMsg}`)
         }
       }
       break


### PR DESCRIPTION
## Summary

- **Swaps processing order** in the webhook handler so incoming messages are handled before status events (sent/delivered/read/failed)
- **Wraps status processing in try/catch** so a failed status DB lookup or event creation no longer kills the entire webhook payload

## Context

After the message status events feature was added in `5ececf67c` (v4.9.0, March 19), status events are processed sequentially **before** incoming messages in the same webhook payload. WhatsApp frequently batches statuses and messages together, so:

1. **Long delays**: Each status event does a sequential `listMessages` DB lookup + `createEvent` call before any user message is touched
2. **Messages silently dropped**: If any status handler throws (DB timeout, rate limit), the exception propagates and kills the webhook — messages in that payload are never processed. The user must resend (new WhatsApp message ID bypasses deduplication)

Reported by customer hugo@mipapaya.com (tkt_dxsbhzq60r) - bot down 24+ hours, losing sales.