### PR TITLE
fix: return distinct response when plugin hook stops propagation

### DIFF
--- a/packages/sdk/src/bot/server/index.ts
+++ b/packages/sdk/src/bot/server/index.ts
@@ -6,7 +6,7 @@ import { BotLogger } from '../bot-logger'
 import { BotSpecificClient } from '../client'
 import * as common from '../common'
 import { extractContext } from './context'
-import { SUCCESS_RESPONSE } from './responses'
+import { SUCCESS_RESPONSE, SUCCESS_STOPPED_RESPONSE } from './responses'
 import * as types from './types'
 import { handleWorkflowUpdateEvent } from './workflows/update-handler'
 
@@ -186,7 +186,7 @@ const onEventReceived = async (serverProps: types.ServerProps): Promise<Response
       })
       message = hookOutput?.data ?? message
       if (hookOutput?.stop) {
-        return SUCCESS_RESPONSE
+        return SUCCESS_STOPPED_RESPONSE
       }
     }
 
@@ -210,7 +210,7 @@ const onEventReceived = async (serverProps: types.ServerProps): Promise<Response
       })
       message = hookOutput?.data ?? message
       if (hookOutput?.stop) {
-        return SUCCESS_RESPONSE
+        return SUCCESS_STOPPED_RESPONSE
       }
     }
 
@@ -242,7 +242,7 @@ const onEventReceived = async (serverProps: types.ServerProps): Promise<Response
     })
     event = hookOutput?.data ?? event
     if (hookOutput?.stop) {
-      return SUCCESS_RESPONSE
+      return SUCCESS_STOPPED_RESPONSE
     }
   }
 
@@ -260,7 +260,7 @@ const onEventReceived = async (serverProps: types.ServerProps): Promise<Response
     })
     event = hookOutput?.data ?? event
     if (hookOutput?.stop) {
-      return SUCCESS_RESPONSE
+      return SUCCESS_STOPPED_RESPONSE
     }
   }
 

--- a/packages/sdk/src/bot/server/responses.ts
+++ b/packages/sdk/src/bot/server/responses.ts
@@ -1,2 +1,2 @@
 export const SUCCESS_RESPONSE = { status: 200 } as const
-export const SUCCESS_STOPPED_RESPONSE = { status: 200, stopped: true } as const
+export const SUCCESS_STOPPED_RESPONSE = { status: 200, body: JSON.stringify({ stopped: true }) } as const

--- a/packages/sdk/src/bot/server/responses.ts
+++ b/packages/sdk/src/bot/server/responses.ts
@@ -1,1 +1,2 @@
 export const SUCCESS_RESPONSE = { status: 200 } as const
+export const SUCCESS_STOPPED_RESPONSE = { status: 200, stopped: true } as const


### PR DESCRIPTION
## Problem

When a plugin hook returns `{ stop: true }`, `bot.handler` returns the same `SUCCESS_RESPONSE` (`{ status: 200 }`) as when the handler completes normally. Callers of `bot.handler` have no way to know whether the bot handler actually ran or a plugin stopped propagation.

The ADK wraps `bot.handler` (as `original()`) and needs to run cleanup — specifically calling `stopTypingIndicator` — when a plugin like HITL stops propagation and the bot's conversation handler is skipped. Without a signal from the SDK, the ADK either has to call `stopTypingIndicator` unconditionally on every message (wasteful, causes duplicate SSE events), or use fragile context flags to guess what happened inside `original()`.

## Fix

When a plugin hook returns `{ stop: true }`, return `SUCCESS_STOPPED_RESPONSE` (`{ status: 200, body: '{"stopped":true}' }`) instead of `SUCCESS_RESPONSE`. The `stopped` flag is in the response body so the `Response` type doesn't need to change — it's already typed as `body?: string`.

Four hook stop points updated:
- `before_incoming_message` (line 189)
- `after_incoming_message` (line 213)
- `before_incoming_event` (line 245)
- `after_incoming_event` (line 263)

## Consumer

botpress/agent-lack#356 — ADK handler wrapper checks `JSON.parse(result.body)?.stopped` to decide whether to call `stopTypingIndicator`.