### PR TITLE
fix(ci): Fix deploy CI

### DIFF
--- a/.github/actions/deploy-integrations/action.yml
+++ b/.github/actions/deploy-integrations/action.yml
@@ -105,7 +105,7 @@ runs:
 
         all_filters="-F '{integrations/*}' $INPUT_EXTRA_FILTER"
         list_integrations_cmd="pnpm list $all_filters --json"
-        integration_paths=$(eval "$list_integrations_cmd" | jq -r 'map(".path") | .[]')
+        integration_paths=$(eval "$list_integrations_cmd" | jq -r 'map(.path) | .[]')
 
         for integration_path in $integration_paths; do
             integration=$(basename "$integration_path")

--- a/.github/actions/deploy-interfaces/action.yml
+++ b/.github/actions/deploy-interfaces/action.yml
@@ -59,7 +59,7 @@ runs:
 
         all_filters="-F '{interfaces/*}' $INPUT_EXTRA_FILTER"
         list_interfaces_cmd="pnpm list $all_filters --json"
-        interface_paths=$(eval "$list_interfaces_cmd" | jq -r 'map(".path") | .[]')
+        interface_paths=$(eval "$list_interfaces_cmd" | jq -r 'map(.path) | .[]')
 
         for interface_path in $interface_paths; do
             interface=$(basename "$interface_path")

--- a/.github/actions/deploy-interfaces/action.yml
+++ b/.github/actions/deploy-interfaces/action.yml
@@ -1,7 +1,7 @@
 name: Deploy Interfaces
 description: Deploys interfaces
 
-input:
+inputs:
   environment:
     type: choice
     description: 'Environment to deploy to'

--- a/.github/actions/deploy-plugins/action.yml
+++ b/.github/actions/deploy-plugins/action.yml
@@ -59,7 +59,7 @@ runs:
 
         all_filters="-F '{plugins/*}' $INPUT_EXTRA_FILTER"
         list_plugins_cmd="pnpm list $all_filters --json"
-        plugin_paths=$(eval "$list_plugins_cmd" | jq -r 'map(".path") | .[]')
+        plugin_paths=$(eval "$list_plugins_cmd" | jq -r 'map(.path) | .[]')
 
         for plugin_path in $plugin_paths; do
             plugin=$(basename "$plugin_path")

--- a/.github/actions/deploy-plugins/action.yml
+++ b/.github/actions/deploy-plugins/action.yml
@@ -1,7 +1,7 @@
 name: Deploy Plugins
 description: Deploys plugins
 
-input:
+inputs:
   environment:
     type: choice
     description: 'Environment to deploy to'


### PR DESCRIPTION
Fixes two recently introduced issues in our deploy CI scripts:

- typo in deploy-interfaces and deploy-plugins `input` should be `inputs` in a reusable action
- invalid quoting of jq expressions