### PR TITLE
chore: bump llm interface by a major

### DIFF
--- a/integrations/anthropic/integration.definition.ts
+++ b/integrations/anthropic/integration.definition.ts
@@ -6,7 +6,7 @@ export default new IntegrationDefinition({
   name: 'anthropic',
   title: 'Anthropic',
   description: 'Access a curated list of Claude models to set as your chosen LLM.',
-  version: '15.0.1',
+  version: '16.0.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/cerebras/integration.definition.ts
+++ b/integrations/cerebras/integration.definition.ts
@@ -7,7 +7,7 @@ export default new IntegrationDefinition({
   title: 'Cerebras',
   description:
     'Get access to a curated list of Cerebras models for content generation and chat completions within your bot.',
-  version: '8.0.3',
+  version: '9.0.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/fireworks-ai/integration.definition.ts
+++ b/integrations/fireworks-ai/integration.definition.ts
@@ -8,7 +8,7 @@ export default new IntegrationDefinition({
   title: 'Fireworks AI',
   description:
     'Choose from curated Fireworks AI models for content generation, chat completions, and audio transcription.',
-  version: '10.0.3',
+  version: '11.0.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/google-ai/integration.definition.ts
+++ b/integrations/google-ai/integration.definition.ts
@@ -6,7 +6,7 @@ export default new IntegrationDefinition({
   name: 'google-ai',
   title: 'Google AI',
   description: 'Gain access to Gemini models for content generation, chat responses, and advanced language tasks.',
-  version: '7.0.5',
+  version: '8.0.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/groq/integration.definition.ts
+++ b/integrations/groq/integration.definition.ts
@@ -7,7 +7,7 @@ export default new IntegrationDefinition({
   name: 'groq',
   title: 'Groq',
   description: 'Gain access to Groq models for content generation, chat responses, and audio transcription.',
-  version: '15.0.3',
+  version: '16.0.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/mistral-ai/integration.definition.ts
+++ b/integrations/mistral-ai/integration.definition.ts
@@ -6,7 +6,7 @@ export default new IntegrationDefinition({
   name: 'mistral-ai',
   title: 'Mistral AI',
   description: 'Access a curated list of Mistral AI models to set as your chosen LLM.',
-  version: '0.1.2',
+  version: '1.0.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/integrations/openai/integration.definition.ts
+++ b/integrations/openai/integration.definition.ts
@@ -17,7 +17,7 @@ export default new IntegrationDefinition({
   title: 'OpenAI',
   description:
     'Gain access to OpenAI models for text generation, speech synthesis, audio transcription, and image generation.',
-  version: '19.0.1',
+  version: '20.0.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   entities: {

--- a/interfaces/llm/interface.definition.ts
+++ b/interfaces/llm/interface.definition.ts
@@ -3,7 +3,7 @@ import { z, InterfaceDefinition } from '@botpress/sdk'
 
 export default new InterfaceDefinition({
   name: 'llm',
-  version: '9.0.1',
+  version: '10.0.0',
   entities: {
     modelRef: {
       schema: common.llm.schemas.ModelRefSchema,


### PR DESCRIPTION
The breaking change was:
- discovered because of: https://github.com/botpress/botpress/actions/runs/24151382514/job/70479065035
- introduced here: https://github.com/botpress/botpress/pull/15091
- because of: https://github.com/botpress/botpress/pull/15086

Because of the model tag `speech-to-text`