### PR TITLE
fix(browser): add custom headers to Firecrawl scrape requests

### DIFF
--- a/integrations/browser/integration.definition.ts
+++ b/integrations/browser/integration.definition.ts
@@ -22,6 +22,10 @@ export default new IntegrationDefinition({
     FIRECRAWL_API_KEY: {
       description: 'FireCrawl key',
     },
+    FIRECRAWL_CUSTOM_HEADERS: {
+      description: 'Custom HTTP headers to include in Firecrawl scrape requests (JSON object)',
+      optional: true,
+    },
     LOGO_API_KEY: {
       description: 'Logo key',
     },

--- a/integrations/browser/integration.definition.ts
+++ b/integrations/browser/integration.definition.ts
@@ -3,7 +3,7 @@ import { IntegrationDefinition } from '@botpress/sdk'
 import { actionDefinitions } from 'src/definitions/actions'
 
 export const INTEGRATION_NAME = 'browser'
-export const INTEGRATION_VERSION = '0.8.6'
+export const INTEGRATION_VERSION = '0.8.7'
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/browser/src/actions/browse-pages.ts
+++ b/integrations/browser/src/actions/browse-pages.ts
@@ -22,7 +22,11 @@ const getCustomHeaders = (): Record<string, string> | undefined => {
   }
 
   try {
-    return JSON.parse(raw) as Record<string, string>
+    const parsed = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return undefined
+    }
+    return parsed as Record<string, string>
   } catch {
     return undefined
   }

--- a/integrations/browser/src/actions/browse-pages.ts
+++ b/integrations/browser/src/actions/browse-pages.ts
@@ -15,6 +15,19 @@ const fixOutput = (val: unknown): string => {
   return ''
 }
 
+const getCustomHeaders = (): Record<string, string> | undefined => {
+  const raw = bp.secrets.FIRECRAWL_CUSTOM_HEADERS
+  if (!raw) {
+    return undefined
+  }
+
+  try {
+    return JSON.parse(raw) as Record<string, string>
+  } catch {
+    return undefined
+  }
+}
+
 const getPageContent = async (props: {
   url: string
   logger: IntegrationLogger
@@ -34,6 +47,7 @@ const getPageContent = async (props: {
       waitFor: props.waitFor,
       timeout: props.timeout,
       formats: ['markdown', 'rawHtml'],
+      headers: getCustomHeaders(),
       storeInCache: true,
     })
 


### PR DESCRIPTION
## Summary
- Adds a new optional `FIRECRAWL_CUSTOM_HEADERS` secret to the browser integration
- Parses the secret as a JSON object and passes it as `headers` to `firecrawl.scrape()` calls
- Allows enterprise customers (e.g. Ambest) to whitelist Botpress crawler requests on their WAF (e.g. Radware) using a custom HTTP header

**Usage:** Set the `FIRECRAWL_CUSTOM_HEADERS` secret to a JSON string like `{"X-Botpress-Crawler": "botpress"}`. Firecrawl will include these headers when visiting target websites.

**Note:** The Firecrawl SDK's `map()` method does not support custom headers — this only applies to `scrape()` (used by Browse Pages and Web Search actions).

Resolves [STU-1568](https://linear.app/botpress/issue/STU-1568/add-custom-headers-to-botpress-crawler-firecrawl)

## Test plan
- [ ] Set `FIRECRAWL_CUSTOM_HEADERS` to `{"X-Botpress-Crawler": "botpress"}` and verify headers appear on target requests
- [ ] Verify scraping works normally when `FIRECRAWL_CUSTOM_HEADERS` is not set (backward compatible)
- [ ] Verify invalid JSON in the secret is handled gracefully (falls back to no headers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)