### PR TITLE
fix(chat): remove update url step from chat deployment worklflows

### DIFF
--- a/.github/workflows/deploy-chat-production.yml
+++ b/.github/workflows/deploy-chat-production.yml
@@ -48,37 +48,14 @@ jobs:
           ref: ${{ inputs.branchOrCommit || github.sha }}
           environment: production
 
-  update-integration-url:
-    needs: deploy-chat-production
-    if: ${{ !inputs.skipDeploy }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branchOrCommit || github.sha }}
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Deploy integration with ECS URL
-        run: |
-          pnpm bp login -y \
-            --api-url "https://api.botpress.cloud" \
-            --workspaceId "${{ secrets.PRODUCTION_CLOUD_OPS_WORKSPACE_ID }}" \
-            --token "${{ secrets.PRODUCTION_TOKEN_CLOUD_OPS_ACCOUNT }}"
-
-          pnpm -F @botpresshub/chat -c exec -- \
-            bp deploy -v -y --noBuild --visibility public --allowDeprecated \
-            --url "http://chat.private:9271"
-
   ping-success:
-    needs: [deploy-chat-production, update-integration-url]
+    needs: [deploy-chat-production]
     runs-on: ubuntu-latest
     steps:
       - run: curl -m 10 --retry 5 ${{ secrets.CHAT_DEPLOY_PRODUCTION_PING_URL }}
 
   ping-failure:
-    needs: [deploy-chat-production, update-integration-url]
+    needs: [deploy-chat-production]
     if: ${{ failure() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-chat-staging.yml
+++ b/.github/workflows/deploy-chat-staging.yml
@@ -1,6 +1,11 @@
 name: Deploy Chat Staging
 
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'integrations/chat/**'
   workflow_dispatch:
     inputs:
       branchOrCommit:
@@ -47,37 +52,14 @@ jobs:
           ref: ${{ inputs.branchOrCommit || github.sha }}
           environment: staging
 
-  update-integration-url:
-    needs: deploy-chat-staging
-    if: ${{ !inputs.skipDeploy }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branchOrCommit || github.sha }}
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - name: Deploy integration with ECS URL
-        run: |
-          pnpm bp login -y \
-            --api-url "https://api.botpress.dev" \
-            --workspaceId "${{ secrets.STAGING_CLOUD_OPS_WORKSPACE_ID }}" \
-            --token "${{ secrets.STAGING_TOKEN_CLOUD_OPS_ACCOUNT }}"
-
-          pnpm -F @botpresshub/chat -c exec -- \
-            bp deploy -v -y --noBuild --visibility public --allowDeprecated \
-            --url "http://chat.private:9271"
-
   ping-success:
-    needs: [deploy-chat-staging, update-integration-url]
+    needs: [deploy-chat-staging]
     runs-on: ubuntu-latest
     steps:
       - run: curl -m 10 --retry 5 ${{ secrets.CHAT_DEPLOY_STAGING_PING_URL }}
 
   ping-failure:
-    needs: [deploy-chat-staging, update-integration-url]
+    needs: [deploy-chat-staging]
     if: ${{ failure() }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Remove the `update-integration-url` from the chat deployment workflows since we will now update chat in place.

Also trigger the staging workflow on push to `master` to stay consistent with our other ECS services