### PR TITLE
fix(zai): reject non-zui schemas in extract and patch operations

### DIFF
--- a/packages/zai/e2e/extract.test.ts
+++ b/packages/zai/e2e/extract.test.ts
@@ -38,12 +38,11 @@ describe('zai.extract', () => {
   it('rejects non-zui schemas', async () => {
     const schema = {
       _output: undefined,
-      __type__: 'ZuiType' as const,
       safeParse: () => ({ success: true, data: { name: 'John Doe', age: 30 } }),
     }
 
     await expect(
-      zai.extract('My name is John Doe, I am 30 years old and I live in Quebec', schema).result()
+      zai.extract('My name is John Doe, I am 30 years old and I live in Quebec', schema as any).result()
     ).rejects.toThrow('@bpinternal/zui')
   })
 

--- a/packages/zai/e2e/extract.test.ts
+++ b/packages/zai/e2e/extract.test.ts
@@ -38,11 +38,12 @@ describe('zai.extract', () => {
   it('rejects non-zui schemas', async () => {
     const schema = {
       _output: undefined,
+      __type__: 'ZuiType' as const,
       safeParse: () => ({ success: true, data: { name: 'John Doe', age: 30 } }),
     }
 
     await expect(
-      zai.extract('My name is John Doe, I am 30 years old and I live in Quebec', schema as any).result()
+      zai.extract('My name is John Doe, I am 30 years old and I live in Quebec', schema).result()
     ).rejects.toThrow('@bpinternal/zui')
   })
 

--- a/packages/zai/e2e/extract.test.ts
+++ b/packages/zai/e2e/extract.test.ts
@@ -35,6 +35,17 @@ describe('zai.extract', () => {
     `)
   })
 
+  it('rejects non-zui schemas', async () => {
+    const schema = {
+      _output: undefined,
+      safeParse: () => ({ success: true, data: { name: 'John Doe', age: 30 } }),
+    }
+
+    await expect(
+      zai.extract('My name is John Doe, I am 30 years old and I live in Quebec', schema as any).result()
+    ).rejects.toThrow('@bpinternal/zui')
+  })
+
   it('extract an array of objects from paragraph', async () => {
     const people = await zai.extract(
       `

--- a/packages/zai/e2e/patch.test.ts
+++ b/packages/zai/e2e/patch.test.ts
@@ -2170,6 +2170,21 @@ describe('zai.patch — JSON file operations', { timeout: 60_000 }, () => {
     expect(parsed.version).toBe('1.0.0')
   })
 
+  it('rejects non-zui schemas', async () => {
+    const schema = {
+      _output: undefined,
+      safeParse: () => ({ success: true, data: { version: '1.0.0' } }),
+    }
+
+    await expect(
+      zai
+        .patch([configFile], 'change port to 8080 and set debug to true', {
+          schema: schema as any,
+        })
+        .result()
+    ).rejects.toThrow('@bpinternal/zui')
+  })
+
   it('validates patched JSON against a nested zui schema', async () => {
     const schema = z.object({
       database: z.object({

--- a/packages/zai/e2e/patch.test.ts
+++ b/packages/zai/e2e/patch.test.ts
@@ -2173,14 +2173,13 @@ describe('zai.patch — JSON file operations', { timeout: 60_000 }, () => {
   it('rejects non-zui schemas', async () => {
     const schema = {
       _output: undefined,
-      __type__: 'ZuiType' as const,
       safeParse: () => ({ success: true, data: { version: '1.0.0' } }),
     }
 
     await expect(
       zai
         .patch([configFile], 'change port to 8080 and set debug to true', {
-          schema: schema,
+          schema: schema as any,
         })
         .result()
     ).rejects.toThrow('@bpinternal/zui')

--- a/packages/zai/e2e/patch.test.ts
+++ b/packages/zai/e2e/patch.test.ts
@@ -2173,13 +2173,14 @@ describe('zai.patch — JSON file operations', { timeout: 60_000 }, () => {
   it('rejects non-zui schemas', async () => {
     const schema = {
       _output: undefined,
+      __type__: 'ZuiType' as const,
       safeParse: () => ({ success: true, data: { version: '1.0.0' } }),
     }
 
     await expect(
       zai
         .patch([configFile], 'change port to 8080 and set debug to true', {
-          schema: schema as any,
+          schema: schema,
         })
         .result()
     ).rejects.toThrow('@bpinternal/zui')

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "2.6.18",
+  "version": "2.6.19",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/zai/src/operations/extract.ts
+++ b/packages/zai/src/operations/extract.ts
@@ -37,6 +37,10 @@ const Options = z.object({
   strict: z.boolean().optional().default(true).describe('Whether to strictly follow the schema or not'),
 })
 
+type __Z<T> = { __type__: 'ZuiType', _output: T }
+type OfType<O, T extends __Z<any> = __Z<O>> = T extends __Z<O> ? T : never
+type AnyObjectOrArray = Record<string, unknown> | Array<unknown>
+
 declare module '@botpress/zai' {
   interface Zai {
     /**
@@ -106,7 +110,7 @@ declare module '@botpress/zai' {
      * console.log(`Extraction took ${elapsed}ms and cost $${usage.cost.total}`)
      * ```
      */
-    extract<S extends z.ZodTypeAny>(input: unknown, schema: S, options?: Options): Response<S['_output']>
+    extract<S extends OfType<any>>(input: unknown, schema: S, options?: Options): Response<S['_output']>
   }
 }
 const SPECIAL_CHAR = '■'
@@ -115,7 +119,7 @@ const END = '■json_end■'
 const NO_MORE = '■NO_MORE_ELEMENT■'
 const ZERO_ELEMENTS = '■ZERO_ELEMENTS■'
 
-const extract = async <S extends z.ZodTypeAny>(
+const extract = async <S extends OfType<AnyObjectOrArray>>(
   input: unknown,
   _schema: S,
   _options: Options | undefined,

--- a/packages/zai/src/operations/extract.ts
+++ b/packages/zai/src/operations/extract.ts
@@ -448,7 +448,7 @@ ${instructions.map((x) => `• ${x}`).join('\n')}
   return final as S['_output']
 }
 
-Zai.prototype.extract = function <S extends z.ZodTypeAny>(
+Zai.prototype.extract = function <S extends OfType<AnyObjectOrArray>>(
   this: Zai,
   input: unknown,
   schema: S,

--- a/packages/zai/src/operations/extract.ts
+++ b/packages/zai/src/operations/extract.ts
@@ -37,7 +37,7 @@ const Options = z.object({
   strict: z.boolean().optional().default(true).describe('Whether to strictly follow the schema or not'),
 })
 
-type __Z<T> = { __type__: 'ZuiType', _output: T }
+type __Z<T> = { __type__: 'ZuiType'; _output: T }
 type OfType<O, T extends __Z<any> = __Z<O>> = T extends __Z<O> ? T : never
 type AnyObjectOrArray = Record<string, unknown> | Array<unknown>
 

--- a/packages/zai/src/operations/extract.ts
+++ b/packages/zai/src/operations/extract.ts
@@ -23,6 +23,8 @@ export type Options = {
   strict?: boolean
 }
 
+const INVALID_SCHEMA_ERROR = 'zai.extract only accepts schemas created with @bpinternal/zui'
+
 const Options = z.object({
   instructions: z.string().optional().describe('Instructions to guide the user on how to extract the data'),
   chunkLength: z
@@ -34,10 +36,6 @@ const Options = z.object({
     .default(16_000),
   strict: z.boolean().optional().default(true).describe('Whether to strictly follow the schema or not'),
 })
-
-type __Z<T> = { _output: T }
-type OfType<O, T extends __Z<any> = __Z<O>> = T extends __Z<O> ? T : never
-type AnyObjectOrArray = Record<string, unknown> | Array<unknown>
 
 declare module '@botpress/zai' {
   interface Zai {
@@ -108,7 +106,7 @@ declare module '@botpress/zai' {
      * console.log(`Extraction took ${elapsed}ms and cost $${usage.cost.total}`)
      * ```
      */
-    extract<S extends OfType<any>>(input: unknown, schema: S, options?: Options): Response<S['_output']>
+    extract<S extends z.ZodTypeAny>(input: unknown, schema: S, options?: Options): Response<S['_output']>
   }
 }
 const SPECIAL_CHAR = '■'
@@ -117,7 +115,7 @@ const END = '■json_end■'
 const NO_MORE = '■NO_MORE_ELEMENT■'
 const ZERO_ELEMENTS = '■ZERO_ELEMENTS■'
 
-const extract = async <S extends OfType<AnyObjectOrArray>>(
+const extract = async <S extends z.ZodTypeAny>(
   input: unknown,
   _schema: S,
   _options: Options | undefined,
@@ -125,12 +123,16 @@ const extract = async <S extends OfType<AnyObjectOrArray>>(
 ): Promise<S['_output']> => {
   ctx.controller.signal.throwIfAborted()
 
+  if (!z.is.zuiType(_schema)) {
+    throw new Error(INVALID_SCHEMA_ERROR)
+  }
+
   let originalSchema: z.ZodType
   try {
-    originalSchema = z.transforms.fromJSONSchema(z.transforms.toJSONSchema(_schema as unknown as z.ZodType))
+    originalSchema = z.transforms.fromJSONSchema(z.transforms.toJSONSchema(_schema))
   } catch {
     // The above transformers arent the legacy ones. They are very strict and might fail on some schema types.
-    originalSchema = _schema as unknown as z.ZodType
+    originalSchema = _schema
   }
 
   const options = Options.parse(_options ?? {})
@@ -442,7 +444,7 @@ ${instructions.map((x) => `• ${x}`).join('\n')}
   return final as S['_output']
 }
 
-Zai.prototype.extract = function <S extends OfType<AnyObjectOrArray>>(
+Zai.prototype.extract = function <S extends z.ZodTypeAny>(
   this: Zai,
   input: unknown,
   schema: S,

--- a/packages/zai/src/operations/patch.ts
+++ b/packages/zai/src/operations/patch.ts
@@ -195,6 +195,10 @@ const patch = async (
     throw new Error(INVALID_SCHEMA_ERROR)
   }
 
+  if (files.length === 0) {
+    return []
+  }
+
   const tokenizer = await getTokenizer()
   const model = await ctx.getModel()
 

--- a/packages/zai/src/operations/patch.ts
+++ b/packages/zai/src/operations/patch.ts
@@ -32,9 +32,6 @@ const _File = z.object({
   content: z.string(),
 })
 
-type __Z<T> = { _output: T }
-type OfType<O, T extends __Z<any> = __Z<O>> = T extends __Z<O> ? T : never
-
 export type Options = {
   /**
    * Maximum tokens per chunk when processing large files or many files.
@@ -44,12 +41,14 @@ export type Options = {
    */
   maxTokensPerChunk?: number
   /**
-   * Optional Zui/Zod schema to validate JSON files against after patching.
+   * Optional Zui schema to validate JSON files against after patching.
    * Only applies to files detected as JSON (by .json extension).
    * If the patched JSON doesn't match the schema, the LLM is re-prompted to fix it.
    */
-  schema?: OfType<any>
+  schema?: z.ZodTypeAny
 }
+
+const INVALID_SCHEMA_ERROR = 'zai.patch only accepts schemas created with @bpinternal/zui'
 
 const Options = z.object({
   maxTokensPerChunk: z.number().optional(),
@@ -190,7 +189,12 @@ const patch = async (
     return []
   }
 
-  const options = { ...Options.parse(_options ?? {}), schema: _options?.schema } as Options
+  const options: Options = { ...Options.parse(_options ?? {}), schema: _options?.schema }
+
+  if (options.schema && !z.is.zuiType(options.schema)) {
+    throw new Error(INVALID_SCHEMA_ERROR)
+  }
+
   const tokenizer = await getTokenizer()
   const model = await ctx.getModel()
 
@@ -383,7 +387,7 @@ ${numberedView}
     // If a schema is provided, validate the JSON against it
     if (options.schema) {
       const parsed = JSON.parse(validContent)
-      const safe = (options.schema as unknown as z.ZodType).safeParse(parsed)
+      const safe = options.schema.safeParse(parsed)
       if (!safe.success) {
         return retrySchemaValidation(file, validContent, safe.error)
       }
@@ -450,7 +454,7 @@ ${numberedView}
       if (validContent !== null) {
         if (options.schema) {
           const parsed = JSON.parse(validContent)
-          const safe = (options.schema as unknown as z.ZodType).safeParse(parsed)
+          const safe = options.schema.safeParse(parsed)
           if (!safe.success) {
             return retrySchemaValidation(file, validContent, safe.error)
           }
@@ -516,7 +520,7 @@ ${numberedView}
       if (validContent !== null) {
         if (options.schema) {
           const parsed = JSON.parse(validContent)
-          const safe = (options.schema as unknown as z.ZodType).safeParse(parsed)
+          const safe = options.schema.safeParse(parsed)
           if (safe.success) {
             return { ...file, content: validContent, patch: retryPatchOps }
           }

--- a/packages/zai/src/operations/patch.ts
+++ b/packages/zai/src/operations/patch.ts
@@ -185,10 +185,6 @@ const patch = async (
 ): Promise<Array<File>> => {
   ctx.controller.signal.throwIfAborted()
 
-  if (files.length === 0) {
-    return []
-  }
-
   const options: Options = { ...Options.parse(_options ?? {}), schema: _options?.schema }
 
   if (options.schema && !z.is.zuiType(options.schema)) {

--- a/packages/zai/src/operations/patch.ts
+++ b/packages/zai/src/operations/patch.ts
@@ -32,7 +32,7 @@ const _File = z.object({
   content: z.string(),
 })
 
-type __Z<T> = { __type__: 'ZuiType', _output: T }
+type __Z<T> = { __type__: 'ZuiType'; _output: T }
 type OfType<O, T extends __Z<any> = __Z<O>> = T extends __Z<O> ? T : never
 
 export type Options = {
@@ -190,8 +190,12 @@ const patch = async (
 
   const options: Options = { ...Options.parse(_options ?? {}), schema: _options?.schema }
 
-  if (options.schema && !z.is.zuiType(options.schema)) {
-    throw new Error(INVALID_SCHEMA_ERROR)
+  let zSchema: z.ZodTypeAny | null = null
+  if (options.schema) {
+    if (!z.is.zuiType(options.schema)) {
+      throw new Error(INVALID_SCHEMA_ERROR)
+    }
+    zSchema = options.schema
   }
 
   if (files.length === 0) {
@@ -388,9 +392,9 @@ ${numberedView}
     }
 
     // If a schema is provided, validate the JSON against it
-    if (options.schema) {
+    if (zSchema) {
       const parsed = JSON.parse(validContent)
-      const safe = options.schema.safeParse(parsed)
+      const safe = zSchema.safeParse(parsed)
       if (!safe.success) {
         return retrySchemaValidation(file, validContent, safe.error)
       }
@@ -455,9 +459,9 @@ ${numberedView}
       const retryContent = Micropatch.applyText(brokenContent, retryPatchOps)
       const validContent = ensureValidJson(retryContent)
       if (validContent !== null) {
-        if (options.schema) {
+        if (zSchema) {
           const parsed = JSON.parse(validContent)
-          const safe = options.schema.safeParse(parsed)
+          const safe = zSchema.safeParse(parsed)
           if (!safe.success) {
             return retrySchemaValidation(file, validContent, safe.error)
           }
@@ -521,9 +525,9 @@ ${numberedView}
       const retryContent = Micropatch.applyText(content, retryPatchOps)
       const validContent = ensureValidJson(retryContent)
       if (validContent !== null) {
-        if (options.schema) {
+        if (zSchema) {
           const parsed = JSON.parse(validContent)
-          const safe = options.schema.safeParse(parsed)
+          const safe = zSchema.safeParse(parsed)
           if (safe.success) {
             return { ...file, content: validContent, patch: retryPatchOps }
           }

--- a/packages/zai/src/operations/patch.ts
+++ b/packages/zai/src/operations/patch.ts
@@ -32,6 +32,9 @@ const _File = z.object({
   content: z.string(),
 })
 
+type __Z<T> = { __type__: 'ZuiType', _output: T }
+type OfType<O, T extends __Z<any> = __Z<O>> = T extends __Z<O> ? T : never
+
 export type Options = {
   /**
    * Maximum tokens per chunk when processing large files or many files.
@@ -45,7 +48,7 @@ export type Options = {
    * Only applies to files detected as JSON (by .json extension).
    * If the patched JSON doesn't match the schema, the LLM is re-prompted to fix it.
    */
-  schema?: z.ZodTypeAny
+  schema?: OfType<any>
 }
 
 const INVALID_SCHEMA_ERROR = 'zai.patch only accepts schemas created with @bpinternal/zui'


### PR DESCRIPTION
Adds validation to ensure only schemas created with `@bpinternal/zui` are accepted. Includes e2e tests verifying the error is thrown for invalid schemas.

Closes ADK-443