### PR TITLE
Fix #15049: [Integrations/WhatsApp] order messages are not triggering...

### DIFF
--- a/integrations/whatsapp/src/misc/types.ts
+++ b/integrations/whatsapp/src/misc/types.ts
@@ -145,8 +145,22 @@ const WhatsAppMessageSchema = z.union([
     }),
   }),
   WhatsAppBaseMessageSchema.extend({
+    type: z.literal('order'),
+    order: z.object({
+      catalog_id: z.string(),
+      text: z.string().optional(),
+      product_items: z.array(
+        z.object({
+          product_retailer_id: z.string(),
+          quantity: z.number(),
+          item_price: z.number(),
+          currency: z.string(),
+        })
+      ),
+    }),
+  }),
+  WhatsAppBaseMessageSchema.extend({
     type: z.union([
-      z.literal('order'),
       z.literal('system'),
       z.literal('unknown'),
       z.literal('unsupported'), // not documented but can be received

--- a/integrations/whatsapp/src/webhook/handlers/messages.ts
+++ b/integrations/whatsapp/src/webhook/handlers/messages.ts
@@ -188,6 +188,12 @@ export async function _handleMessage(args: HandleMessageArgs) {
         incomingMessageType: type,
       })
     }
+  } else if (message.type === 'order') {
+    return _createMessage({
+      type: 'text',
+      payload: { text: JSON.stringify(message.order) },
+      incomingMessageType: 'order',
+    })
   } else if (message.type === 'unsupported' || message.type === 'unknown') {
     const errors = message.errors?.map((err) => `${err.message} (${err.error_data.details})`).join('\n')
     logger.forBot().warn(`Received message type ${message.type} by WhatsApp, errors: ${errors ?? 'none'}`)


### PR DESCRIPTION
Closes #15049

## Before

WhatsApp `order` messages (sent when a user completes a catalog/cart checkout) were silently dropped. In `integrations/whatsapp/src/misc/types.ts`, the `order` literal was grouped into the catch-all union of unhandled types (`system`, `unknown`, `unsupported`), so the message was parsed as an unrecognized type with no associated payload schema. In `integrations/whatsapp/src/webhook/handlers/messages.ts`, the handler's `_handleMessage` function had no branch for `order`, meaning the message fell through without creating any Botpress event, triggering no workflow and activating no "Wait for user input" card.

## After

`order` messages are now parsed and forwarded into Botpress as text messages containing the serialized order payload.

In `types.ts`, `order` is extracted from the catch-all union and given its own `WhatsAppBaseMessageSchema` extension with a typed `order` object: `catalog_id`, optional `text`, and a `product_items` array (each item carrying `product_retailer_id`, `quantity`, `item_price`, and `currency`).

In `messages.ts`, a new `else if (message.type === 'order')` branch calls `_createMessage` with `type: 'text'` and `payload: { text: JSON.stringify(message.order) }`, passing `incomingMessageType: 'order'` for observability. This creates a visible Botpress event that reaches workflows, where the order details can be parsed from `event.payload.text`.

## Changes

- **`integrations/whatsapp/src/misc/types.ts`**: Added a dedicated `WhatsAppBaseMessageSchema` variant for `type: 'order'` with a structured `order` field schema. Removed `z.literal('order')` from the fallback union type.
- **`integrations/whatsapp/src/webhook/handlers/messages.ts`**: Added an `else if (message.type === 'order')` branch in `_handleMessage` that serializes `message.order` to JSON and emits it as a `text` message event.

## Testing

1. Connect a WhatsApp integration to a Botpress cloud workspace.
2. Send a product order via WhatsApp catalog (cart checkout) to the connected number.
3. Verify a Botpress event is received with `payload.text` containing a JSON string matching the order structure (e.g., `{"catalog_id":"...","product_items":[{"product_retailer_id":"...","quantity":1,"item_price":9.99,"currency":"USD"}]}`).
4. Confirm a workflow with a `Start` trigger or "Wait for user input" card is activated by the event.
5. Confirm text, button, and other existing message types are unaffected.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*