### PR TITLE
fix(whatsapp): status updates thows errors

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -157,7 +157,7 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp'
-export const INTEGRATION_VERSION = '4.13.0'
+export const INTEGRATION_VERSION = '4.13.1'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,

--- a/integrations/whatsapp/src/misc/types.ts
+++ b/integrations/whatsapp/src/misc/types.ts
@@ -3,9 +3,11 @@ import { qualityScoreSchema } from 'definitions/events'
 
 const WhatsAppContactSchema = z.object({
   wa_id: z.string(),
-  profile: z.object({
-    name: z.string(),
-  }),
+  profile: z
+    .object({
+      name: z.string().optional(),
+    })
+    .optional(),
 })
 
 const WhatsAppBaseMessageSchema = z.object({

--- a/integrations/whatsapp/src/webhook/handlers/messages.ts
+++ b/integrations/whatsapp/src/webhook/handlers/messages.ts
@@ -78,9 +78,10 @@ export const messagesHandler = async (
   const { user } = await client.getOrCreateUser({
     tags: {
       userId: contact.wa_id,
-      name: contact?.profile.name,
+      name: contact.profile?.name,
     },
-    name: contact?.profile.name,
+    name: contact.profile?.name,
+    discriminateByTags: [ 'userId' ]
   })
 
   const replyToWhatsAppId = message.context?.id

--- a/integrations/whatsapp/src/webhook/handlers/messages.ts
+++ b/integrations/whatsapp/src/webhook/handlers/messages.ts
@@ -81,7 +81,7 @@ export const messagesHandler = async (
       name: contact.profile?.name,
     },
     name: contact.profile?.name,
-    discriminateByTags: [ 'userId' ]
+    discriminateByTags: ['userId'],
   })
 
   const replyToWhatsAppId = message.context?.id


### PR DESCRIPTION
Meta is now sending the contact alongside the message status update, but this contact doesn't have the profile, since our schema was not expecting that the handler is throwing this error

 WhatsApp handler failed with status 500: Error while handling request: [
  {
    "code": "invalid_type",
    "expected": "object",
    "received": "undefined",
    "path": [
      "entry",
      0,
      "changes",
      0,
      "value",
      "contacts",
      0,
      "profile"
    ],
    "message": "Required"
  }
]