### PR TITLE
fix: honor Retry-After header in CLI retry delay for 429 responses

### DIFF
--- a/packages/cli/src/api/retry.ts
+++ b/packages/cli/src/api/retry.ts
@@ -9,10 +9,22 @@ function getRetryAfterMs(error: Parameters<NonNullable<client.RetryConfig['retry
 
   const headerNames = ['retry-after', 'ratelimit-reset', 'x-ratelimit-reset']
   for (const name of headerNames) {
-    const value = headers[name]
-    if (!value) continue
-    const seconds = parseInt(String(value), 10)
-    if (!isNaN(seconds) && seconds > 0) {
+    const raw = headers[name]
+    if (!raw) continue
+    const value = String(raw)
+
+    // HTTP-date format (e.g. "Mon, 28 Apr 2026 12:00:00 GMT")
+    if (value.includes(' ')) {
+      const futureDate = new Date(value)
+      if (!isNaN(futureDate.getTime())) {
+        return Math.max(0, futureDate.getTime() - Date.now())
+      }
+      continue
+    }
+
+    // Seconds format (e.g. "120")
+    const seconds = parseInt(value, 10)
+    if (!isNaN(seconds) && seconds >= 0) {
       return seconds * 1000
     }
   }

--- a/packages/cli/src/api/retry.ts
+++ b/packages/cli/src/api/retry.ts
@@ -2,10 +2,35 @@ import * as client from '@botpress/client'
 
 // TODO: we probably shouldnt retry on 500 errors, but this is a temporary fix for the botpress repo CI
 const HTTP_STATUS_TO_RETRY_ON = [429, 500, 502, 503, 504]
+
+function getRetryAfterMs(error: Parameters<NonNullable<client.RetryConfig['retryDelay']>>[1]): number | undefined {
+  const headers = error?.response?.headers
+  if (!headers) return undefined
+
+  const headerNames = ['retry-after', 'ratelimit-reset', 'x-ratelimit-reset']
+  for (const name of headerNames) {
+    const value = headers[name]
+    if (!value) continue
+    const seconds = parseInt(String(value), 10)
+    if (!isNaN(seconds) && seconds > 0) {
+      return seconds * 1000
+    }
+  }
+  return undefined
+}
+
 export const config: client.RetryConfig = {
   retries: 3,
   retryCondition: (err) =>
     client.axiosRetry.isNetworkOrIdempotentRequestError(err) ||
     HTTP_STATUS_TO_RETRY_ON.includes(err.response?.status ?? 0),
-  retryDelay: (retryCount) => retryCount * 1000,
+  retryDelay: (retryCount, error) => {
+    if (error?.response?.status === 429) {
+      const retryAfterMs = getRetryAfterMs(error)
+      if (retryAfterMs !== undefined) {
+        return retryAfterMs
+      }
+    }
+    return Math.max(retryCount, 1) * 1000
+  },
 }


### PR DESCRIPTION
## Summary

`packages/cli/src/api/retry.ts` was retrying 429 responses using `retryCount * 1000` without consulting the server's `Retry-After` header. 

This meant the CLI retried immediately into the server's recovery window, burning all three attempts and failing even when the server provided a valid wait time.

The SDK retry (`packages/sdk/src/retry.ts`) already handles this correctly. This PR brings the CLI into alignment.

---

## Changes

**`packages/cli/src/api/retry.ts`**

- Added `getRetryAfterMs()` to read `retry-after`, `ratelimit-reset`, and `x-ratelimit-reset` headers
- For 429 responses: uses server-provided delay when present, falls back to existing schedule when absent
- Fixed 0ms first retry (`retryCount * 1000` → `Math.max(retryCount, 1) * 1000`)
- No changes to `retryCondition` or `retries`

---

## Scope

Single file. No new dependencies. Backwards compatible. 
Existing behavior preserved for non-429 status codes.

---

## Reference

This matches a retry/cooldown failure pattern documented across production AI/API systems — clients detect 429 correctly but retry inside the server's recovery window.

Corpus: https://github.com/SirBrenton/pitstop-truth
