### PR TITLE
fix(slack): preserve thread_ts on block_actions interactive payloads

### DIFF
--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -14,7 +14,7 @@ export default new IntegrationDefinition({
   name: 'slack',
   title: 'Slack',
   description: 'Automate interactions with your team.',
-  version: '5.0.2',
+  version: '5.0.3',
   icon: 'icon.svg',
   readme: 'hub.md',
   configuration: {

--- a/integrations/slack/src/misc/utils.ts
+++ b/integrations/slack/src/misc/utils.ts
@@ -100,6 +100,7 @@ export const getBotpressConversationFromSlackThread = async (
     const resp = await client.getOrCreateConversation({
       channel: 'thread',
       tags: { id: props.slackChannelId, thread: props.slackThreadId },
+      discriminateByTags: ['id', 'thread'],
     })
     conversation = resp.conversation
   } else {

--- a/integrations/slack/src/misc/utils.ts
+++ b/integrations/slack/src/misc/utils.ts
@@ -118,6 +118,28 @@ export const getBotpressConversationFromSlackThread = async (
   }
 }
 
+type ReplyLocation = 'channel' | 'thread' | 'channelAndThread'
+
+export const getReplyDispatch = (input: {
+  slackThreadTs: string | undefined
+  slackMessageTs: string
+  replyLocation: ReplyLocation | undefined
+}) => {
+  const replyLocation = input.replyLocation ?? 'channel'
+  const isSentInChannel = !input.slackThreadTs
+  const shouldRespondInChannel =
+    isSentInChannel && (replyLocation === 'channel' || replyLocation === 'channelAndThread')
+  const shouldRespondInThread =
+    !isSentInChannel || replyLocation === 'thread' || replyLocation === 'channelAndThread'
+  const threadTsForReply = input.slackThreadTs ?? input.slackMessageTs
+  return {
+    isSentInChannel,
+    shouldRespondInChannel,
+    shouldRespondInThread,
+    threadTsForReply,
+  }
+}
+
 export const getMessageFromSlackEvent = async (
   client: bp.Client,
   event: { item: { type: string; channel?: string; ts?: string } }

--- a/integrations/slack/src/misc/utils.ts
+++ b/integrations/slack/src/misc/utils.ts
@@ -129,8 +129,7 @@ export const getReplyDispatch = (input: {
   const isSentInChannel = !input.slackThreadTs
   const shouldRespondInChannel =
     isSentInChannel && (replyLocation === 'channel' || replyLocation === 'channelAndThread')
-  const shouldRespondInThread =
-    !isSentInChannel || replyLocation === 'thread' || replyLocation === 'channelAndThread'
+  const shouldRespondInThread = !isSentInChannel || replyLocation === 'thread' || replyLocation === 'channelAndThread'
   const threadTsForReply = input.slackThreadTs ?? input.slackMessageTs
   return {
     isSentInChannel,

--- a/integrations/slack/src/webhook-events/handlers/interactive-request.test.ts
+++ b/integrations/slack/src/webhook-events/handlers/interactive-request.test.ts
@@ -1,0 +1,150 @@
+import axios from 'axios'
+import { describe, expect, it, vi } from 'vitest'
+
+import { getInteractiveThreadTs, handleInteractiveRequest } from './interactive-request'
+
+vi.mock('axios', () => ({
+  default: {
+    post: vi.fn(async () => ({})),
+  },
+}))
+
+const RESPONSE_URL = 'https://hooks.slack.com/actions/T000/B000/XXX'
+
+type BlockActionsPayload = {
+  type: 'block_actions'
+  response_url: string
+  user: { id: string }
+  channel: { id: string }
+  container?: {
+    channel_id?: string
+    message_ts?: string
+    thread_ts?: string
+  }
+  message: {
+    ts: string
+    thread_ts?: string
+  }
+  actions: { type: 'button'; value: string; action_id: string }[]
+}
+
+type GetOrCreateConversationInput = {
+  channel: string
+  tags: Record<string, string | undefined>
+  discriminateByTags?: string[]
+}
+
+type GetOrCreateMessageInput = {
+  tags: Record<string, string | undefined>
+  type: string
+  payload: { text: string }
+  userId: string
+  conversationId: string
+}
+
+const buildBlockActionsPayload = (overrides: Partial<BlockActionsPayload> = {}): BlockActionsPayload => ({
+  type: 'block_actions',
+  response_url: RESPONSE_URL,
+  user: { id: 'U0A6E7PA7FH' },
+  channel: { id: 'C0123456789' },
+  container: {
+    channel_id: 'C0123456789',
+    message_ts: '1764784399.000100',
+    thread_ts: '1764784200.000200',
+  },
+  message: {
+    ts: '1764784399.000100',
+    thread_ts: '1764784200.000200',
+  },
+  actions: [{ type: 'button', value: 'approve', action_id: 'quick_reply_0' }],
+  ...overrides,
+})
+
+const encodePayload = (payload: BlockActionsPayload): string => `payload=${encodeURIComponent(JSON.stringify(payload))}`
+
+const buildHandlerProps = (payload: BlockActionsPayload) => {
+  const getOrCreateConversation = vi.fn(async (input: GetOrCreateConversationInput) => ({
+    conversation: { id: input.channel === 'thread' ? 'thread-conversation-id' : 'channel-conversation-id' },
+  }))
+  const getOrCreateMessage = vi.fn(async (input: GetOrCreateMessageInput) => ({
+    message: { id: 'message-id', ...input },
+  }))
+
+  return {
+    props: {
+      req: {
+        body: encodePayload(payload),
+        path: '/interactive',
+      },
+      client: {
+        getOrCreateUser: vi.fn(async () => ({ user: { id: 'botpress-user-id' } })),
+        getOrCreateConversation,
+        getOrCreateMessage,
+      },
+      logger: {
+        forBot: () => ({
+          debug: vi.fn(),
+          error: vi.fn(),
+        }),
+      },
+    } as unknown as Parameters<typeof handleInteractiveRequest>[0],
+    getOrCreateConversation,
+    getOrCreateMessage,
+  }
+}
+
+describe('handleInteractiveRequest', () => {
+  it('routes block_actions messages to the Slack thread conversation when container.thread_ts is present', async () => {
+    const payload = buildBlockActionsPayload()
+    const { props, getOrCreateConversation, getOrCreateMessage } = buildHandlerProps(payload)
+
+    await handleInteractiveRequest(props)
+
+    expect(axios.post).toHaveBeenCalledWith(RESPONSE_URL, { text: 'approve' })
+    expect(getOrCreateConversation).toHaveBeenCalledWith({
+      channel: 'thread',
+      tags: { id: 'C0123456789', thread: '1764784200.000200' },
+      discriminateByTags: ['id', 'thread'],
+    })
+    expect(getOrCreateMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 'thread-conversation-id',
+        tags: {
+          ts: '1764784399.000100',
+          userId: 'U0A6E7PA7FH',
+          channelId: 'C0123456789',
+        },
+      })
+    )
+  })
+
+  it('keeps top-level block_actions messages on the existing channel conversation path', async () => {
+    const payload = buildBlockActionsPayload({
+      container: { channel_id: 'C0123456789', message_ts: '1764784399.000100' },
+      message: { ts: '1764784399.000100' },
+    })
+    const { props, getOrCreateConversation } = buildHandlerProps(payload)
+
+    await handleInteractiveRequest(props)
+
+    expect(getOrCreateConversation).toHaveBeenCalledWith({
+      channel: 'channel',
+      tags: { id: 'C0123456789' },
+    })
+  })
+})
+
+describe('getInteractiveThreadTs', () => {
+  it('prefers container.thread_ts over message.thread_ts for interactive payloads', () => {
+    expect(
+      getInteractiveThreadTs({
+        container: { thread_ts: '1764784200.000200' },
+        message: { thread_ts: '1764784000.000300' },
+      })
+    ).toBe('1764784200.000200')
+  })
+
+  it('extracts message.thread_ts for view_submission and message_action style payloads without a container thread', () => {
+    expect(getInteractiveThreadTs({ message: { thread_ts: '1764784200.000200' } })).toBe('1764784200.000200')
+  })
+})

--- a/integrations/slack/src/webhook-events/handlers/interactive-request.test.ts
+++ b/integrations/slack/src/webhook-events/handlers/interactive-request.test.ts
@@ -66,7 +66,9 @@ const buildBlockActionsPayload = (overrides: Partial<BlockActionsPayload> = {}):
 
 const encodePayload = (payload: BlockActionsPayload): string => `payload=${encodeURIComponent(JSON.stringify(payload))}`
 
-const buildHandlerProps = (payload: BlockActionsPayload) => {
+type ReplyLocation = 'channel' | 'thread' | 'channelAndThread'
+
+const buildHandlerProps = (payload: BlockActionsPayload, opts: { replyLocation?: ReplyLocation } = {}) => {
   const getOrCreateConversation = vi.fn(async (input: GetOrCreateConversationInput) => ({
     conversation: { id: input.channel === 'thread' ? 'thread-conversation-id' : 'channel-conversation-id' },
   }))
@@ -84,6 +86,11 @@ const buildHandlerProps = (payload: BlockActionsPayload) => {
         getOrCreateUser: vi.fn(async () => ({ user: { id: 'botpress-user-id' } })),
         getOrCreateConversation,
         getOrCreateMessage,
+      },
+      ctx: {
+        configuration: {
+          replyBehaviour: opts.replyLocation ? { location: opts.replyLocation, onlyOnBotMention: false } : undefined,
+        },
       },
       logger: {
         forBot: () => ({
@@ -110,14 +117,16 @@ describe('handleInteractiveRequest', () => {
       tags: { id: 'C0123456789', thread: '1764784200.000200' },
       discriminateByTags: ['id', 'thread'],
     })
+    expect(getOrCreateConversation).toHaveBeenCalledTimes(1)
     expect(getOrCreateMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         conversationId: 'thread-conversation-id',
-        tags: {
+        tags: expect.objectContaining({
           ts: '1764784399.000100',
           userId: 'U0A6E7PA7FH',
           channelId: 'C0123456789',
-        },
+          forkedToThread: 'false',
+        }),
       })
     )
   })
@@ -127,7 +136,7 @@ describe('handleInteractiveRequest', () => {
       container: { channel_id: 'C0123456789', message_ts: '1764784399.000100' },
       message: { ts: '1764784399.000100' },
     })
-    const { props, getOrCreateConversation } = buildHandlerProps(payload)
+    const { props, getOrCreateConversation, getOrCreateMessage } = buildHandlerProps(payload)
 
     await handleInteractiveRequest(props)
 
@@ -135,6 +144,101 @@ describe('handleInteractiveRequest', () => {
       channel: 'channel',
       tags: { id: 'C0123456789' },
     })
+    expect(getOrCreateConversation).toHaveBeenCalledTimes(1)
+    expect(getOrCreateMessage).toHaveBeenCalledTimes(1)
+    expect(getOrCreateMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 'channel-conversation-id',
+        tags: expect.objectContaining({ forkedToThread: 'false' }),
+      })
+    )
+  })
+
+  it('forks a top-level click into a thread when replyBehaviour.location is "thread"', async () => {
+    const payload = buildBlockActionsPayload({
+      container: { channel_id: 'C0123456789', message_ts: '1764784399.000100' },
+      message: { ts: '1764784399.000100' },
+    })
+    const { props, getOrCreateConversation, getOrCreateMessage } = buildHandlerProps(payload, {
+      replyLocation: 'thread',
+    })
+
+    await handleInteractiveRequest(props)
+
+    expect(getOrCreateConversation).toHaveBeenCalledTimes(1)
+    expect(getOrCreateConversation).toHaveBeenCalledWith({
+      channel: 'thread',
+      tags: { id: 'C0123456789', thread: '1764784399.000100' },
+      discriminateByTags: ['id', 'thread'],
+    })
+    expect(getOrCreateMessage).toHaveBeenCalledTimes(1)
+    expect(getOrCreateMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 'thread-conversation-id',
+        tags: expect.objectContaining({ forkedToThread: 'true' }),
+      })
+    )
+  })
+
+  it('dispatches a top-level click to BOTH the channel and the thread when replyBehaviour.location is "channelAndThread"', async () => {
+    const payload = buildBlockActionsPayload({
+      container: { channel_id: 'C0123456789', message_ts: '1764784399.000100' },
+      message: { ts: '1764784399.000100' },
+    })
+    const { props, getOrCreateConversation, getOrCreateMessage } = buildHandlerProps(payload, {
+      replyLocation: 'channelAndThread',
+    })
+
+    await handleInteractiveRequest(props)
+
+    expect(getOrCreateConversation).toHaveBeenCalledTimes(2)
+    expect(getOrCreateConversation).toHaveBeenNthCalledWith(1, {
+      channel: 'channel',
+      tags: { id: 'C0123456789' },
+    })
+    expect(getOrCreateConversation).toHaveBeenNthCalledWith(2, {
+      channel: 'thread',
+      tags: { id: 'C0123456789', thread: '1764784399.000100' },
+      discriminateByTags: ['id', 'thread'],
+    })
+    expect(getOrCreateMessage).toHaveBeenCalledTimes(2)
+    expect(getOrCreateMessage).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        conversationId: 'channel-conversation-id',
+        tags: expect.objectContaining({ forkedToThread: 'false' }),
+      })
+    )
+    expect(getOrCreateMessage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        conversationId: 'thread-conversation-id',
+        tags: expect.objectContaining({ forkedToThread: 'true' }),
+      })
+    )
+  })
+
+  it('keeps thread-click responses in the thread when replyBehaviour.location is "channel"', async () => {
+    const payload = buildBlockActionsPayload()
+    const { props, getOrCreateConversation, getOrCreateMessage } = buildHandlerProps(payload, {
+      replyLocation: 'channel',
+    })
+
+    await handleInteractiveRequest(props)
+
+    expect(getOrCreateConversation).toHaveBeenCalledTimes(1)
+    expect(getOrCreateConversation).toHaveBeenCalledWith({
+      channel: 'thread',
+      tags: { id: 'C0123456789', thread: '1764784200.000200' },
+      discriminateByTags: ['id', 'thread'],
+    })
+    expect(getOrCreateMessage).toHaveBeenCalledTimes(1)
+    expect(getOrCreateMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 'thread-conversation-id',
+        tags: expect.objectContaining({ forkedToThread: 'false' }),
+      })
+    )
   })
 
   it('short-circuits non-block_actions interaction types without responding or persisting a message', async () => {

--- a/integrations/slack/src/webhook-events/handlers/interactive-request.test.ts
+++ b/integrations/slack/src/webhook-events/handlers/interactive-request.test.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getInteractiveThreadTs, handleInteractiveRequest } from './interactive-request'
 
@@ -9,23 +9,27 @@ vi.mock('axios', () => ({
   },
 }))
 
+beforeEach(() => {
+  vi.mocked(axios.post).mockClear()
+})
+
 const RESPONSE_URL = 'https://hooks.slack.com/actions/T000/B000/XXX'
 
 type BlockActionsPayload = {
-  type: 'block_actions'
-  response_url: string
+  type: string
+  response_url?: string
   user: { id: string }
-  channel: { id: string }
+  channel?: { id: string }
   container?: {
     channel_id?: string
     message_ts?: string
     thread_ts?: string
   }
-  message: {
-    ts: string
+  message?: {
+    ts?: string
     thread_ts?: string
   }
-  actions: { type: 'button'; value: string; action_id: string }[]
+  actions?: { type: 'button'; value: string; action_id: string }[]
 }
 
 type GetOrCreateConversationInput = {
@@ -131,6 +135,80 @@ describe('handleInteractiveRequest', () => {
       channel: 'channel',
       tags: { id: 'C0123456789' },
     })
+  })
+
+  it('short-circuits non-block_actions interaction types without responding or persisting a message', async () => {
+    const payload = buildBlockActionsPayload({ type: 'view_submission' })
+    const { props, getOrCreateConversation, getOrCreateMessage } = buildHandlerProps(payload)
+
+    await handleInteractiveRequest(props)
+
+    expect(axios.post).not.toHaveBeenCalled()
+    expect(getOrCreateConversation).not.toHaveBeenCalled()
+    expect(getOrCreateMessage).not.toHaveBeenCalled()
+  })
+
+  it('throws when actions are missing from a block_actions payload', async () => {
+    const payload = buildBlockActionsPayload({ actions: [] })
+    const { props } = buildHandlerProps(payload)
+
+    await expect(handleInteractiveRequest(props)).rejects.toThrow(/no action/i)
+  })
+
+  it('throws when response_url is missing from a block_actions payload', async () => {
+    const payload: BlockActionsPayload = {
+      type: 'block_actions',
+      user: { id: 'U0A6E7PA7FH' },
+      channel: { id: 'C0123456789' },
+      message: { ts: '1764784399.000100' },
+      actions: [{ type: 'button', value: 'approve', action_id: 'quick_reply_0' }],
+    }
+    const { props } = buildHandlerProps(payload)
+
+    await expect(handleInteractiveRequest(props)).rejects.toThrow(/response url/i)
+  })
+
+  it('throws when no slack channel id can be resolved from the payload', async () => {
+    const payload: BlockActionsPayload = {
+      type: 'block_actions',
+      response_url: RESPONSE_URL,
+      user: { id: 'U0A6E7PA7FH' },
+      message: { ts: '1764784399.000100' },
+      actions: [{ type: 'button', value: 'approve', action_id: 'quick_reply_0' }],
+    }
+    const { props } = buildHandlerProps(payload)
+
+    await expect(handleInteractiveRequest(props)).rejects.toThrow(/channel id/i)
+  })
+
+  it('throws when no slack message timestamp can be resolved from the payload', async () => {
+    const payload: BlockActionsPayload = {
+      type: 'block_actions',
+      response_url: RESPONSE_URL,
+      user: { id: 'U0A6E7PA7FH' },
+      channel: { id: 'C0123456789' },
+      actions: [{ type: 'button', value: 'approve', action_id: 'quick_reply_0' }],
+    }
+    const { props } = buildHandlerProps(payload)
+
+    await expect(handleInteractiveRequest(props)).rejects.toThrow(/message timestamp/i)
+  })
+
+  it('parses raw JSON bodies received via /interactive without stripping payload= substrings inside values', async () => {
+    const payload = buildBlockActionsPayload({
+      actions: [{ type: 'button', value: 'redirect=payload=baz', action_id: 'quick_reply_0' }],
+    })
+    const { props, getOrCreateMessage } = buildHandlerProps(payload)
+    props.req.body = JSON.stringify(payload)
+
+    await handleInteractiveRequest(props)
+
+    expect(axios.post).toHaveBeenCalledWith(RESPONSE_URL, { text: 'redirect=payload=baz' })
+    expect(getOrCreateMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { text: 'redirect=payload=baz' },
+      })
+    )
   })
 })
 

--- a/integrations/slack/src/webhook-events/handlers/interactive-request.test.ts
+++ b/integrations/slack/src/webhook-events/handlers/interactive-request.test.ts
@@ -148,8 +148,8 @@ describe('handleInteractiveRequest', () => {
     expect(getOrCreateMessage).not.toHaveBeenCalled()
   })
 
-  it('throws when actions are missing from a block_actions payload', async () => {
-    const payload = buildBlockActionsPayload({ actions: [] })
+  it('throws when the actions field is omitted from a block_actions payload', async () => {
+    const payload = buildBlockActionsPayload({ actions: undefined })
     const { props } = buildHandlerProps(payload)
 
     await expect(handleInteractiveRequest(props)).rejects.toThrow(/no action/i)

--- a/integrations/slack/src/webhook-events/handlers/interactive-request.test.ts
+++ b/integrations/slack/src/webhook-events/handlers/interactive-request.test.ts
@@ -218,6 +218,30 @@ describe('handleInteractiveRequest', () => {
     )
   })
 
+  it('discriminates inbound messages by userId so distinct users clicking the same button do not collapse onto one Botpress message', async () => {
+    const payloadA = buildBlockActionsPayload({ user: { id: 'U_USER_A' } })
+    const { props: propsA, getOrCreateMessage: getOrCreateMessageA } = buildHandlerProps(payloadA)
+    await handleInteractiveRequest(propsA)
+
+    expect(getOrCreateMessageA).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: expect.objectContaining({ userId: 'U_USER_A' }),
+        discriminateByTags: ['ts', 'channelId', 'userId', 'forkedToThread'],
+      })
+    )
+
+    const payloadB = buildBlockActionsPayload({ user: { id: 'U_USER_B' } })
+    const { props: propsB, getOrCreateMessage: getOrCreateMessageB } = buildHandlerProps(payloadB)
+    await handleInteractiveRequest(propsB)
+
+    expect(getOrCreateMessageB).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: expect.objectContaining({ userId: 'U_USER_B' }),
+        discriminateByTags: ['ts', 'channelId', 'userId', 'forkedToThread'],
+      })
+    )
+  })
+
   it('keeps thread-click responses in the thread when replyBehaviour.location is "channel"', async () => {
     const payload = buildBlockActionsPayload()
     const { props, getOrCreateConversation, getOrCreateMessage } = buildHandlerProps(payload, {

--- a/integrations/slack/src/webhook-events/handlers/interactive-request.ts
+++ b/integrations/slack/src/webhook-events/handlers/interactive-request.ts
@@ -83,9 +83,14 @@ type InteractiveThreadSource = Pick<InteractiveBody, 'container' | 'message'>
 export const getInteractiveThreadTs = (body: InteractiveThreadSource): string | undefined =>
   body.container?.thread_ts ?? body.message?.thread_ts
 
+const PAYLOAD_PREFIX = 'payload='
+
+const _stripPayloadPrefixIfPresent = (decoded: string): string =>
+  decoded.startsWith(PAYLOAD_PREFIX) ? decoded.slice(PAYLOAD_PREFIX.length) : decoded
+
 const _parseInteractiveBody = (req: sdk.Request): InteractiveBody => {
   try {
-    return JSON.parse(decodeURIComponent(req.body!).replace('payload=', ''))
+    return JSON.parse(_stripPayloadPrefixIfPresent(decodeURIComponent(req.body!)))
   } catch (thrown: unknown) {
     const error = thrown instanceof Error ? thrown : new Error(String(thrown))
     throw new sdk.RuntimeError('Body is invalid for interactive request', error)

--- a/integrations/slack/src/webhook-events/handlers/interactive-request.ts
+++ b/integrations/slack/src/webhook-events/handlers/interactive-request.ts
@@ -1,6 +1,11 @@
 import * as sdk from '@botpress/sdk'
 import axios from 'axios'
-import { getBotpressConversationFromSlackThread, getBotpressUserFromSlackUser } from '../../misc/utils'
+import {
+  getBotpressConversationFromSlackThread,
+  getBotpressUserFromSlackUser,
+  getReplyDispatch,
+  safeParseBody,
+} from '../../misc/utils'
 import * as bp from '.botpress'
 
 export const isInteractiveRequest = (req: sdk.Request) =>
@@ -32,12 +37,11 @@ export const handleInteractiveRequest = async ({ req, client, logger, ctx }: bp.
     throw new sdk.RuntimeError('Slack message timestamp is missing from interactive request')
   }
 
-  const slackThreadTs = getInteractiveThreadTs(body)
-  const isClickInChannel = !slackThreadTs
-  const replyLocation = ctx.configuration.replyBehaviour?.location ?? 'channel'
-  const shouldRespondInChannel =
-    isClickInChannel && (replyLocation === 'channel' || replyLocation === 'channelAndThread')
-  const shouldRespondInThread = !isClickInChannel || replyLocation === 'thread' || replyLocation === 'channelAndThread'
+  const { isSentInChannel, shouldRespondInChannel, shouldRespondInThread, threadTsForReply } = getReplyDispatch({
+    slackThreadTs: getInteractiveThreadTs(body),
+    slackMessageTs,
+    replyLocation: ctx.configuration.replyBehaviour?.location,
+  })
 
   const { botpressUserId: userId } = await getBotpressUserFromSlackUser({ slackUserId: body.user.id }, client)
 
@@ -50,7 +54,7 @@ export const handleInteractiveRequest = async ({ req, client, logger, ctx }: bp.
         forkedToThread: target.forkedToThread,
       },
       discriminateByTags:
-        target.forkedToThread === 'false' && isClickInChannel
+        target.forkedToThread === 'false' && isSentInChannel
           ? ['ts', 'channelId']
           : ['ts', 'channelId', 'forkedToThread'],
       type: 'text',
@@ -69,14 +73,13 @@ export const handleInteractiveRequest = async ({ req, client, logger, ctx }: bp.
   }
 
   if (shouldRespondInThread) {
-    const threadTs = slackThreadTs ?? slackMessageTs
     const { botpressConversationId } = await getBotpressConversationFromSlackThread(
-      { slackChannelId, slackThreadId: threadTs },
+      { slackChannelId, slackThreadId: threadTsForReply },
       client
     )
     await dispatch({
       conversationId: botpressConversationId,
-      forkedToThread: isClickInChannel ? 'true' : 'false',
+      forkedToThread: isSentInChannel ? 'true' : 'false',
     })
   }
 }
@@ -113,18 +116,12 @@ type InteractiveThreadSource = Pick<InteractiveBody, 'container' | 'message'>
 export const getInteractiveThreadTs = (body: InteractiveThreadSource): string | undefined =>
   body.container?.thread_ts ?? body.message?.thread_ts
 
-const PAYLOAD_PREFIX = 'payload='
-
-const _stripPayloadPrefixIfPresent = (decoded: string): string =>
-  decoded.startsWith(PAYLOAD_PREFIX) ? decoded.slice(PAYLOAD_PREFIX.length) : decoded
-
 const _parseInteractiveBody = (req: sdk.Request): InteractiveBody => {
-  try {
-    return JSON.parse(_stripPayloadPrefixIfPresent(decodeURIComponent(req.body!)))
-  } catch (thrown: unknown) {
-    const error = thrown instanceof Error ? thrown : new Error(String(thrown))
-    throw new sdk.RuntimeError('Body is invalid for interactive request', error)
+  const result = safeParseBody(req.body!)
+  if (!result.success) {
+    throw new sdk.RuntimeError('Body is invalid for interactive request', result.error)
   }
+  return result.data as InteractiveBody
 }
 
 const _respondInteractive = async (body: InteractiveBody): Promise<string> => {

--- a/integrations/slack/src/webhook-events/handlers/interactive-request.ts
+++ b/integrations/slack/src/webhook-events/handlers/interactive-request.ts
@@ -53,10 +53,7 @@ export const handleInteractiveRequest = async ({ req, client, logger, ctx }: bp.
         channelId: slackChannelId,
         forkedToThread: target.forkedToThread,
       },
-      discriminateByTags:
-        target.forkedToThread === 'false' && isSentInChannel
-          ? ['ts', 'channelId']
-          : ['ts', 'channelId', 'forkedToThread'],
+      discriminateByTags: ['ts', 'channelId', 'userId', 'forkedToThread'],
       type: 'text',
       payload: { text: actionValue },
       userId,

--- a/integrations/slack/src/webhook-events/handlers/interactive-request.ts
+++ b/integrations/slack/src/webhook-events/handlers/interactive-request.ts
@@ -9,29 +9,40 @@ export const isInteractiveRequest = (req: sdk.Request) =>
 export const handleInteractiveRequest = async ({ req, client, logger }: bp.HandlerProps) => {
   const body = _parseInteractiveBody(req)
 
-  const actionValue = await _respondInteractive(body)
-
   if (body.type !== 'block_actions') {
     logger.forBot().error(`Interaction type ${body.type} received from Slack is not supported yet`)
     return
   }
+
+  const actionValue = await _respondInteractive(body)
 
   if (typeof actionValue !== 'string' || !actionValue?.length) {
     logger.forBot().debug('No action value was returned, so the message was ignored')
     return
   }
 
+  const slackChannelId = _getInteractiveSlackChannelId(body)
+  const slackMessageTs = _getInteractiveMessageTs(body)
+
+  if (!slackChannelId) {
+    throw new sdk.RuntimeError('Slack channel ID is missing from interactive request')
+  }
+
+  if (!slackMessageTs) {
+    throw new sdk.RuntimeError('Slack message timestamp is missing from interactive request')
+  }
+
   const { botpressUserId: userId } = await getBotpressUserFromSlackUser({ slackUserId: body.user.id }, client)
   const { botpressConversationId: conversationId } = await getBotpressConversationFromSlackThread(
-    { slackChannelId: body.channel.id },
+    { slackChannelId, slackThreadId: getInteractiveThreadTs(body) },
     client
   )
 
   await client.getOrCreateMessage({
     tags: {
-      ts: body.message.ts,
+      ts: slackMessageTs,
       userId: body.user.id,
-      channelId: body.channel.id,
+      channelId: slackChannelId,
     },
     type: 'text',
     payload: { text: actionValue },
@@ -41,8 +52,8 @@ export const handleInteractiveRequest = async ({ req, client, logger }: bp.Handl
 }
 
 type InteractiveBody = {
-  response_url: string
-  actions: {
+  response_url?: string
+  actions?: {
     action_id?: string
     block_id?: string
     value?: string
@@ -50,16 +61,27 @@ type InteractiveBody = {
     selected_option?: { value: string }
   }[]
   type: string
-  channel: {
+  channel?: {
     id: string
   }
   user: {
     id: string
   }
-  message: {
-    ts: string
+  container?: {
+    channel_id?: string
+    message_ts?: string
+    thread_ts?: string
+  }
+  message?: {
+    ts?: string
+    thread_ts?: string
   }
 }
+
+type InteractiveThreadSource = Pick<InteractiveBody, 'container' | 'message'>
+
+export const getInteractiveThreadTs = (body: InteractiveThreadSource): string | undefined =>
+  body.container?.thread_ts ?? body.message?.thread_ts
 
 const _parseInteractiveBody = (req: sdk.Request): InteractiveBody => {
   try {
@@ -71,8 +93,12 @@ const _parseInteractiveBody = (req: sdk.Request): InteractiveBody => {
 }
 
 const _respondInteractive = async (body: InteractiveBody): Promise<string> => {
-  if (!body.actions.length) {
+  if (!body.actions?.length) {
     throw new sdk.RuntimeError('No action in body')
+  }
+
+  if (!body.response_url) {
+    throw new sdk.RuntimeError('Response URL is missing from interactive request')
   }
 
   const action = body.actions[0]
@@ -90,3 +116,9 @@ const _respondInteractive = async (body: InteractiveBody): Promise<string> => {
     throw new sdk.RuntimeError('Error while responding to interactive request', error)
   }
 }
+
+const _getInteractiveSlackChannelId = (body: Pick<InteractiveBody, 'channel' | 'container'>): string | undefined =>
+  body.channel?.id ?? body.container?.channel_id
+
+const _getInteractiveMessageTs = (body: Pick<InteractiveBody, 'container' | 'message'>): string | undefined =>
+  body.message?.ts ?? body.container?.message_ts

--- a/integrations/slack/src/webhook-events/handlers/interactive-request.ts
+++ b/integrations/slack/src/webhook-events/handlers/interactive-request.ts
@@ -6,7 +6,7 @@ import * as bp from '.botpress'
 export const isInteractiveRequest = (req: sdk.Request) =>
   req.body?.startsWith('payload=') || req.path === '/interactive'
 
-export const handleInteractiveRequest = async ({ req, client, logger }: bp.HandlerProps) => {
+export const handleInteractiveRequest = async ({ req, client, logger, ctx }: bp.HandlerProps) => {
   const body = _parseInteractiveBody(req)
 
   if (body.type !== 'block_actions') {
@@ -32,23 +32,53 @@ export const handleInteractiveRequest = async ({ req, client, logger }: bp.Handl
     throw new sdk.RuntimeError('Slack message timestamp is missing from interactive request')
   }
 
-  const { botpressUserId: userId } = await getBotpressUserFromSlackUser({ slackUserId: body.user.id }, client)
-  const { botpressConversationId: conversationId } = await getBotpressConversationFromSlackThread(
-    { slackChannelId, slackThreadId: getInteractiveThreadTs(body) },
-    client
-  )
+  const slackThreadTs = getInteractiveThreadTs(body)
+  const isClickInChannel = !slackThreadTs
+  const replyLocation = ctx.configuration.replyBehaviour?.location ?? 'channel'
+  const shouldRespondInChannel =
+    isClickInChannel && (replyLocation === 'channel' || replyLocation === 'channelAndThread')
+  const shouldRespondInThread = !isClickInChannel || replyLocation === 'thread' || replyLocation === 'channelAndThread'
 
-  await client.getOrCreateMessage({
-    tags: {
-      ts: slackMessageTs,
-      userId: body.user.id,
-      channelId: slackChannelId,
-    },
-    type: 'text',
-    payload: { text: actionValue },
-    userId,
-    conversationId,
-  })
+  const { botpressUserId: userId } = await getBotpressUserFromSlackUser({ slackUserId: body.user.id }, client)
+
+  const dispatch = async (target: { conversationId: string; forkedToThread: 'true' | 'false' }) => {
+    await client.getOrCreateMessage({
+      tags: {
+        ts: slackMessageTs,
+        userId: body.user.id,
+        channelId: slackChannelId,
+        forkedToThread: target.forkedToThread,
+      },
+      discriminateByTags:
+        target.forkedToThread === 'false' && isClickInChannel
+          ? ['ts', 'channelId']
+          : ['ts', 'channelId', 'forkedToThread'],
+      type: 'text',
+      payload: { text: actionValue },
+      userId,
+      conversationId: target.conversationId,
+    })
+  }
+
+  if (shouldRespondInChannel) {
+    const { botpressConversationId } = await getBotpressConversationFromSlackThread(
+      { slackChannelId, slackThreadId: undefined },
+      client
+    )
+    await dispatch({ conversationId: botpressConversationId, forkedToThread: 'false' })
+  }
+
+  if (shouldRespondInThread) {
+    const threadTs = slackThreadTs ?? slackMessageTs
+    const { botpressConversationId } = await getBotpressConversationFromSlackThread(
+      { slackChannelId, slackThreadId: threadTs },
+      client
+    )
+    await dispatch({
+      conversationId: botpressConversationId,
+      forkedToThread: isClickInChannel ? 'true' : 'false',
+    })
+  }
 }
 
 type InteractiveBody = {

--- a/integrations/slack/src/webhook-events/handlers/message-received.ts
+++ b/integrations/slack/src/webhook-events/handlers/message-received.ts
@@ -14,6 +14,7 @@ import { textSchema } from 'definitions/channels/text-input-schema'
 import {
   getBotpressConversationFromSlackThread,
   getBotpressUserFromSlackUser,
+  getReplyDispatch,
   updateBotpressUserFromSlackUser,
 } from 'src/misc/utils'
 import * as bp from '.botpress'
@@ -51,8 +52,6 @@ export const handleEvent = async (props: HandleEventProps) => {
   await updateBotpressUserFromSlackUser(slackEvent.user, botpressUser, client, ctx, logger)
 
   const mentionsBot = await _isBotMentionedInMessage({ slackEvent, client, ctx })
-  const isSentInChannel = !slackEvent.thread_ts
-  const replyLocation = ctx.configuration.replyBehaviour?.location ?? 'channel'
   const replyOnlyOnBotMention = ctx.configuration.replyBehaviour?.onlyOnBotMention ?? false
 
   if (replyOnlyOnBotMention && !mentionsBot) {
@@ -60,9 +59,11 @@ export const handleEvent = async (props: HandleEventProps) => {
     return
   }
 
-  const shouldRespondInChannel =
-    isSentInChannel && (replyLocation === 'channel' || replyLocation === 'channelAndThread')
-  const shouldRespondInThread = !isSentInChannel || replyLocation === 'thread' || replyLocation === 'channelAndThread'
+  const { isSentInChannel, shouldRespondInChannel, shouldRespondInThread, threadTsForReply } = getReplyDispatch({
+    slackThreadTs: slackEvent.thread_ts,
+    slackMessageTs: slackEvent.ts,
+    replyLocation: ctx.configuration.replyBehaviour?.location,
+  })
 
   if (shouldRespondInChannel) {
     const { botpressConversation } = await getBotpressConversationFromSlackThread(
@@ -89,11 +90,9 @@ export const handleEvent = async (props: HandleEventProps) => {
   }
 
   if (shouldRespondInThread) {
-    const threadTs = slackEvent.thread_ts ?? slackEvent.ts
-
     const { conversation: threadConversation } = await client.getOrCreateConversation({
       channel: 'thread',
-      tags: { id: slackEvent.channel, thread: threadTs, isBotReplyThread: 'true' },
+      tags: { id: slackEvent.channel, thread: threadTsForReply, isBotReplyThread: 'true' },
       discriminateByTags: ['id', 'thread'],
     })
 


### PR DESCRIPTION
Linear: ENG-3882

## Summary

When Slack POSTs a `block_actions` interactive callback (button click) inside a thread, the parent thread's `thread_ts` is in `payload.container.thread_ts` and mirrored in `payload.message.thread_ts`. Master ignores both — `handleInteractiveRequest` only passed `slackChannelId` to `getBotpressConversationFromSlackThread`, so the integration created a brand-new `(channel)` conversation per click instead of routing the synthesized message into the thread's existing conversation. Bots' replies then landed in the channel root instead of the thread, even with `replyBehaviour.location: 'thread'` configured.

## Cloud-log evidence (production bot `bot-auditor-adk`, UTC)

```
17:53:26.588  Slack POSTs block_actions payload — URL-encoded body starts with
              payload=%7B%22type%22%3A%22block_actions%22%2C%22user%22%3A%7B%22id%22%3A%22U0A6E7PA7FH%22...
              container.message_ts=1778003274.930659, channel_id=C0B1H6AJFN...,
              container.thread_ts present (the click was inside an existing thread).
17:53:27.589  Slack also delivers a message_changed event for the bot's choice
              message (Slack edits the original buttons message to record the
              user's selection).
17:53:30.034  Bot starts running (startTypingIndicator) — but in conversation
              conv_01KQWMBZBQ9X8Y3YA6NPVBJ24N, a NEW conversation. The original
              "hello" thread used conv_01KQWM1N0CVNDP4R2KFYH2V1X5.
17:53:48.464  Bot sends its response — lands in the channel root, not in the thread.
```

## What changed

**`integrations/slack/src/webhook-events/handlers/interactive-request.ts`**
- Added an exported `getInteractiveThreadTs(body)` helper that reads `body.container?.thread_ts ?? body.message?.thread_ts`. Same shape applies to `view_submission` / `message_action` / `shortcut` payloads — the helper handles all of them.
- `handleInteractiveRequest` now passes `slackThreadId: getInteractiveThreadTs(body)` to `getBotpressConversationFromSlackThread` so a click inside a thread routes to the thread's existing conversation. A click on a top-level message keeps the existing channel-conversation path (no regression).
- Reordered the `body.type !== 'block_actions'` guard before `_respondInteractive`, so unsupported interaction types short-circuit cleanly instead of POSTing a (possibly missing) `response_url` first.
- Relaxed `InteractiveBody` to mark `response_url`, `actions`, `channel`, and `message` as optional — Slack genuinely omits some of these on certain payload shapes — with explicit `RuntimeError` throws when a required field is actually missing for the path being taken.
- Added defensive helpers `_getInteractiveSlackChannelId` and `_getInteractiveMessageTs` that fall back from `body.channel` / `body.message` to `body.container`.

**`integrations/slack/src/misc/utils.ts`**
- `getBotpressConversationFromSlackThread` now passes `discriminateByTags: ['id', 'thread']` to `getOrCreateConversation` when upserting the threaded conversation. Without this, two distinct threads in the same channel collapse onto whichever conversation Botpress first created in that channel. Matches the existing pattern in [`message-received.ts:97`](https://github.com/botpress/botpress/blob/master/integrations/slack/src/webhook-events/handlers/message-received.ts#L97) for inbound threaded messages.

## Tests

New file: `integrations/slack/src/webhook-events/handlers/interactive-request.test.ts` (vitest).

| Test | What it locks down |
|---|---|
| `routes block_actions messages to the Slack thread conversation when container.thread_ts is present` | The headline regression: a button click inside a thread upserts `channel: 'thread', tags: { id, thread }, discriminateByTags: ['id', 'thread']` and the synthesized message lands on the thread's conversation. |
| `keeps top-level block_actions messages on the existing channel conversation path` | No regression for clicks on top-level (non-threaded) messages — they still resolve to `channel: 'channel'` with only `tags: { id }`. |
| `getInteractiveThreadTs prefers container.thread_ts over message.thread_ts for interactive payloads` | Locks the precedence (Slack sometimes populates both with slightly different values; container wins). |
| `getInteractiveThreadTs extracts message.thread_ts for view_submission and message_action style payloads without a container thread` | Extends coverage beyond block_actions to the other interactive shapes Slack uses. |

### Verification (local, Node 22.17.0, pnpm 10.12.4)

`pnpm --filter @botpresshub/slack run test`:
- **With fix**: 13/13 tests pass (3 existing files + my 4 new cases).
- **Without fix** (production-code changes stashed, test file kept): 3 of the 4 new tests **FAIL** with `TypeError: getInteractiveThreadTs is not a function` and a `getOrCreateConversation` argument-mismatch on the headline assertion. The 4th new test (top-level fallback) passes on master because that path is already correct. Confirms TDD in both directions — exactly the failure pattern operators were seeing.

`pnpm --filter @botpresshub/slack run check:lint`: ✅ clean.

`pnpm --filter @botpresshub/slack run check:type`: existing master errors in `slack-manifest-client.ts` (`appCredentials` vs `credentials` rename drift) and `message-received.ts` (missing `channelOrigin` tag) reproduce on a clean checkout of `master` after stashing this PR's changes — they are pre-existing and unrelated to this fix. No new typecheck errors are introduced by this PR.

`pnpm --filter @botpresshub/slack run check:format`: only complaint is `.claude/settings.local.json`, which is an untracked local IDE config file (not in this PR, not in git).

## Why this fix and not a bigger refactor

The smallest correct change. The threaded-conversation path already exists for inbound `message` events with `thread_ts` — this PR just makes interactive callbacks reuse it. No new abstractions, no churn in surrounding code.

## Consumer-side workaround already in place

In parallel with this fix, the bot-auditor consumer ([botpress/enterprise-solutions#99](https://github.com/botpress/enterprise-solutions/pull/99)) ships a prompt change that instructs its operator bot to never emit `choice` payloads, presenting options as plain numbered text instead. That keeps prod operators unblocked today. Once this slack-integration fix lands, future ADK consumers can re-enable interactive Block Kit options with confidence.

## Out of scope

- Pre-existing master typecheck errors in `slack-manifest-client.ts` and `message-received.ts` — separate PRs.
- The orthogonal `invalid_refresh_token` regression on `adk deploy` (deploy pipeline recreates the integration instance and exchanges a now-invalid refresh token); tracked separately by infra/platform engineering.