### PR TITLE
fix(client): silence late socket errors on shared http(s) agents

### DIFF
--- a/packages/client/src/common/consts.ts
+++ b/packages/client/src/common/consts.ts
@@ -39,7 +39,5 @@ class SocketSafeHttpsAgent extends https.Agent {
   }
 }
 
-export const httpAgent =
-  isNode && http && http.Agent ? new SocketSafeHttpAgent({ keepAlive: true }) : undefined
-export const httpsAgent =
-  isNode && https && https.Agent ? new SocketSafeHttpsAgent({ keepAlive: true }) : undefined
+export const httpAgent = isNode && http && http.Agent ? new SocketSafeHttpAgent({ keepAlive: true }) : undefined
+export const httpsAgent = isNode && https && https.Agent ? new SocketSafeHttpsAgent({ keepAlive: true }) : undefined

--- a/packages/client/src/common/consts.ts
+++ b/packages/client/src/common/consts.ts
@@ -1,10 +1,45 @@
 import { isNode } from 'browser-or-node'
 import http from 'http'
 import https from 'https'
+import type { Duplex } from 'stream'
 
 const _100mb = 100 * 1024 * 1024
 
 export const maxBodyLength = _100mb
 export const maxContentLength = _100mb
-export const httpAgent = isNode && http && http.Agent ? new http.Agent({ keepAlive: true }) : undefined
-export const httpsAgent = isNode && https && https.Agent ? new https.Agent({ keepAlive: true }) : undefined
+
+// With keepAlive pooling, an aborted request (e.g. axios timeout) can leave a
+// libuv WriteWrap in flight. Its completion callback fires asynchronously
+// after axios has already settled and the caller's `.catch()` has run, emitting
+// `'error'` on the socket. With no listener on the socket itself the event has
+// no consumer and Node converts it into an `uncaughtException` — crashing the
+// process despite a correctly handled Promise rejection. Attaching a noop
+// listener at `createConnection` time provides a safety net for these late
+// secondary events; the Promise rejection still flows to callers normally.
+const silenceLateSocketErrors = (socket: Duplex): Duplex => {
+  socket.on('error', () => {})
+  return socket
+}
+
+class SocketSafeHttpAgent extends http.Agent {
+  public override createConnection(
+    options: http.ClientRequestArgs,
+    callback?: (err: Error | null, stream: Duplex) => void
+  ): Duplex {
+    return silenceLateSocketErrors(super.createConnection(options, callback))
+  }
+}
+
+class SocketSafeHttpsAgent extends https.Agent {
+  public override createConnection(
+    options: http.ClientRequestArgs,
+    callback?: (err: Error | null, stream: Duplex) => void
+  ): Duplex {
+    return silenceLateSocketErrors(super.createConnection(options, callback))
+  }
+}
+
+export const httpAgent =
+  isNode && http && http.Agent ? new SocketSafeHttpAgent({ keepAlive: true }) : undefined
+export const httpsAgent =
+  isNode && https && https.Agent ? new SocketSafeHttpsAgent({ keepAlive: true }) : undefined


### PR DESCRIPTION
## Summary

- Subclasses the shared `http.Agent` / `https.Agent` in `packages/client/src/common/consts.ts` to attach a noop `'error'` listener on every socket at `createConnection` time
- Prevents `Uncaught Exception: write ETIMEDOUT` crashes when an axios request is aborted on a keepAlive-pooled socket and a libuv `WriteWrap` fires asynchronously after the Promise has already settled
- Refs Linear [SQD-3514](https://linear.app/botpress/issue/SQD-3514)

## Why

`bp.client.captureObservation(...)` in the runtime DM is `void`-discarded with a `.catch()` attached. When the underlying axios call hits its 60s timeout:

1. axios destroys the request → Promise rejects → `.catch()` logs the warning ✅
2. A libuv `WriteWrap` was already in flight at the moment of destroy
3. Its completion callback fires asynchronously **after** the Promise has settled, emitting `'error'` on the pooled socket
4. The socket has no `'error'` listener attached → Node converts it to `uncaughtException` and the runtime lambda crashes mid-flight, silently dropping any other webhook handled by that lambda

The crash is at the socket layer, not the Promise layer — so the existing `.catch()` cannot prevent it.

## Why this is safe

By axios contract, every error that affects a request also rejects the Promise. The socket-level `'error'` event is a duplicate signal of the same information at a lower layer. Today that signal crashes the process; with this change it is silently absorbed at the layer where it was always redundant. Application-level error info still flows to callers via the Promise rejection — including in the existing `.catch()` warning log.

## Customer impact

This bug was actively dropping support tickets on an Enterprise account at peak ~3.8 lambda crashes/hour, with each crash silently dropping any in-flight webhook on the same lambda. Full investigation in SQD-3514.

## Test plan

- [x] `pnpm check:type` passes
- [x] `pnpm build:type` passes
- [x] ESLint clean
- [ ] Manual repro — induce a 60s LLMz timeout on a bot, verify the `Failed to capture LLMZ execution result observation` warning still logs but no `Uncaught Exception: write ETIMEDOUT` follows
- [ ] Confirm `httpAgent` / `httpsAgent` exports keep the same names and types (no change to public API)