### PR TITLE
feat(cognitive,llmz,zai): support ordered model fallback arrays

### DIFF
--- a/packages/cognitive/package.json
+++ b/packages/cognitive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cognitive",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Wrapper around the Botpress Client to call LLMs",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/cognitive/src/client.ts
+++ b/packages/cognitive/src/client.ts
@@ -18,7 +18,7 @@ import {
   RemoteModelProvider,
 } from './models'
 import { GenerateContentOutput } from './schemas.gen'
-import { CognitiveProps, Events, InputProps, Request, Response } from './types'
+import { CognitiveProps, Events, InputModel, InputProps, Request, Response } from './types'
 
 export class Cognitive {
   public ['$$IS_COGNITIVE'] = true
@@ -136,6 +136,10 @@ export class Cognitive {
     })
   }
 
+  private _getPrimaryModel(input: InputProps): InputModel | undefined {
+    return Array.isArray(input.model) ? input.model[0] : input.model
+  }
+
   private async _selectModel(ref: string): Promise<{ integration: string; model: string }> {
     const parseRef = (ref: string) => {
       const parts = ref.split(':')
@@ -229,7 +233,7 @@ export class Cognitive {
   }
 
   public async generateContent(input: InputProps): Promise<Response> {
-    const primaryInputModel = Array.isArray(input.model) ? input.model[0] : input.model
+    const primaryInputModel = this._getPrimaryModel(input)
 
     if (!this._useBeta || !isKnownV2Model(primaryInputModel)) {
       return this._generateContent(input)
@@ -327,7 +331,7 @@ export class Cognitive {
 
     const client = this._client.abortable(signal)
 
-    const primaryInputModel = Array.isArray(input.model) ? input.model[0] : input.model
+    const primaryInputModel = this._getPrimaryModel(input)
 
     let props: Request = { input }
     let integration: string

--- a/packages/cognitive/src/client.ts
+++ b/packages/cognitive/src/client.ts
@@ -150,7 +150,7 @@ export class Cognitive {
 
     const downtimes = [...preferences.downtimes, ...(this._downtimes ?? [])]
 
-    if (ref === 'best') {
+    if (ref === 'best' || ref === 'auto') {
       return parseRef(pickModel(preferences.best, downtimes))
     }
 
@@ -229,7 +229,9 @@ export class Cognitive {
   }
 
   public async generateContent(input: InputProps): Promise<Response> {
-    if (!this._useBeta || !isKnownV2Model(input.model)) {
+    const primaryInputModel = Array.isArray(input.model) ? input.model[0] : input.model
+
+    if (!this._useBeta || !isKnownV2Model(primaryInputModel)) {
       return this._generateContent(input)
     }
 
@@ -325,6 +327,8 @@ export class Cognitive {
 
     const client = this._client.abortable(signal)
 
+    const primaryInputModel = Array.isArray(input.model) ? input.model[0] : input.model
+
     let props: Request = { input }
     let integration: string
     let model: string
@@ -336,7 +340,7 @@ export class Cognitive {
       meta: any
     }>(
       async () => {
-        const selection = await this._selectModel(input.model ?? 'best')
+        const selection = await this._selectModel(primaryInputModel ?? 'best')
 
         integration = selection.integration
         model = selection.model

--- a/packages/cognitive/src/types.ts
+++ b/packages/cognitive/src/types.ts
@@ -20,7 +20,18 @@ export type GenerationMetadata = {
   }
 }
 
-export type InputModel = 'auto' | 'best' | 'fast' | ModelRef | (string & {})
+/**
+ * Model selector accepted by `generateContent`.
+ *
+ * - `'best'` / `'auto'`: aliases. `'best'` is the original SDK selector;
+ *   `'auto'` was added when cognitive-v2 landed (the v2 server uses that
+ *   name). Both pick the first available entry from `preferences.best` on
+ *   the legacy path, and are forwarded as-is on the v2 path.
+ * - `'fast'`: same shape — first available from `preferences.fast` on the
+ *   legacy path, forwarded on the v2 path.
+ * - `ModelRef`: any `provider:model` string.
+ */
+export type InputModel = 'auto' | 'best' | 'fast' | ModelRef
 
 export type InputProps = Omit<GenerateContentInput, 'model'> & {
   /**

--- a/packages/cognitive/src/types.ts
+++ b/packages/cognitive/src/types.ts
@@ -20,7 +20,7 @@ export type GenerationMetadata = {
   }
 }
 
-export type InputModel = 'auto' | 'best' | 'fast' | ModelRef
+export type InputModel = 'auto' | 'best' | 'fast' | ModelRef | (string & {})
 
 export type InputProps = Omit<GenerateContentInput, 'model'> & {
   /**

--- a/packages/cognitive/src/types.ts
+++ b/packages/cognitive/src/types.ts
@@ -20,8 +20,14 @@ export type GenerationMetadata = {
   }
 }
 
+export type InputModel = 'auto' | 'best' | 'fast' | ModelRef
+
 export type InputProps = Omit<GenerateContentInput, 'model'> & {
-  model?: 'best' | 'fast' | ModelRef
+  /**
+   * Model to use, or an ordered list of fallback models. Ordered fallback is honored only on the cognitive-v2 path;
+   * the legacy integration path uses the first entry and falls back to server-side preferences instead.
+   */
+  model?: InputModel | InputModel[]
   signal?: AbortSignal
 }
 

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -2,7 +2,7 @@
   "name": "llmz",
   "type": "module",
   "description": "LLMz - An LLM-native Typescript VM built on top of Zui",
-  "version": "0.0.75",
+  "version": "0.0.76",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "@botpress/client": "1.44.0",
-    "@botpress/cognitive": "0.5.3",
+    "@botpress/cognitive": "0.5.4",
     "@bpinternal/thicktoken": "^2.0.0",
     "@bpinternal/zui": "^2.1.1"
   },

--- a/packages/llmz/src/context.ts
+++ b/packages/llmz/src/context.ts
@@ -913,8 +913,12 @@ export class Context implements Serializable<Context.JSON> {
       throw new Error('Invalid temperature. Expected a number between 0 and 2.')
     }
 
-    if (typeof model !== 'string' || model.length === 0) {
-      throw new Error('Invalid model. Expected a non-empty string.')
+    if (Array.isArray(model)) {
+      if (model.length === 0 || !model.every((m) => typeof m === 'string' && m.length > 0)) {
+        throw new Error('Invalid model. Expected a non-empty array of non-empty strings.')
+      }
+    } else if (typeof model !== 'string' || model.length === 0) {
+      throw new Error('Invalid model. Expected a non-empty string or array of strings.')
     }
 
     return {

--- a/packages/llmz/src/context.ts
+++ b/packages/llmz/src/context.ts
@@ -913,12 +913,17 @@ export class Context implements Serializable<Context.JSON> {
       throw new Error('Invalid temperature. Expected a number between 0 and 2.')
     }
 
+    const isValidModel = (m: unknown): m is string =>
+      typeof m === 'string' && (m === 'best' || m === 'fast' || m === 'auto' || m.includes(':'))
+
     if (Array.isArray(model)) {
-      if (model.length === 0 || !model.every((m) => typeof m === 'string' && m.length > 0)) {
-        throw new Error('Invalid model. Expected a non-empty array of non-empty strings.')
+      if (model.length === 0 || !model.every(isValidModel)) {
+        throw new Error(
+          "Invalid model. Expected a non-empty array of model strings ('best'/'fast'/'auto' or 'provider:model')."
+        )
       }
-    } else if (typeof model !== 'string' || model.length === 0) {
-      throw new Error('Invalid model. Expected a non-empty string or array of strings.')
+    } else if (!isValidModel(model)) {
+      throw new Error("Invalid model. Expected 'best'/'fast'/'auto' or 'provider:model'.")
     }
 
     return {

--- a/packages/llmz/src/llmz.ts
+++ b/packages/llmz/src/llmz.ts
@@ -464,7 +464,7 @@ const executeIteration = async ({
     .generateContent({
       signal: controller.signal,
       systemPrompt: messages.find((x) => x.role === 'system')?.content,
-      model: iteration.model as Required<Parameters<Cognitive['generateContent']>[0]>['model'],
+      model: iteration.model,
       temperature: iteration.temperature,
       responseFormat: 'text',
       reasoningEffort: iteration.reasoningEffort,

--- a/packages/llmz/src/llmz.ts
+++ b/packages/llmz/src/llmz.ts
@@ -431,6 +431,9 @@ const executeIteration = async ({
   let startedAt = Date.now()
   const traces = iteration.traces
 
+  // When an array is provided, additional entries act as ordered fallbacks at the
+  // cognitive layer. Token budget and stop-token computation only need the primary
+  // model's details, so we resolve those off the first entry.
   const modelRef = Array.isArray(iteration.model) ? iteration.model[0]! : iteration.model
   const model = await cognitive.getModelDetails(modelRef).catch((thrown) => {
     throw new CognitiveError(`Failed to fetch model details for model "${modelRef}": ${getErrorMessage(thrown)}`)
@@ -461,7 +464,7 @@ const executeIteration = async ({
     .generateContent({
       signal: controller.signal,
       systemPrompt: messages.find((x) => x.role === 'system')?.content,
-      model: model.ref,
+      model: iteration.model as Required<Parameters<Cognitive['generateContent']>[0]>['model'],
       temperature: iteration.temperature,
       responseFormat: 'text',
       reasoningEffort: iteration.reasoningEffort,

--- a/packages/llmz/src/llmz.ts
+++ b/packages/llmz/src/llmz.ts
@@ -464,7 +464,9 @@ const executeIteration = async ({
     .generateContent({
       signal: controller.signal,
       systemPrompt: messages.find((x) => x.role === 'system')?.content,
-      model: iteration.model,
+      // Validated upstream in Context (see context.ts isValidModel). Cast narrows
+      // Models' `({} & string)` escape hatch down to cognitive's stricter InputModel.
+      model: iteration.model as Required<Parameters<Cognitive['generateContent']>[0]>['model'],
       temperature: iteration.temperature,
       responseFormat: 'text',
       reasoningEffort: iteration.reasoningEffort,

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "2.6.19",
+  "version": "2.6.20",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -32,7 +32,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@botpress/cognitive": "0.5.3",
+    "@botpress/cognitive": "0.5.4",
     "json5": "^2.2.3",
     "jsonrepair": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/packages/zai/src/context.ts
+++ b/packages/zai/src/context.ts
@@ -15,7 +15,7 @@ export type ZaiContextProps = {
   client: Cognitive
   taskType: string
   taskId: string
-  modelId: string
+  modelId: GenerateContentInput['model']
   adapter?: Adapter
   source?: GenerateContentInput['meta']
   memoizer?: Memoizer
@@ -141,7 +141,10 @@ export class ZaiContext {
   }
 
   public async getModel(): Promise<Model> {
-    return this._client.getModelDetails(this.modelId)
+    // getModelDetails resolves a single model; for a fallback array we report
+    // the primary entry's details. Fallbacks are honored at the request layer.
+    const primary = Array.isArray(this.modelId) ? this.modelId[0] : this.modelId
+    return this._client.getModelDetails(primary)
   }
 
   public on<K extends keyof ContextEvents>(type: K, listener: (event: ContextEvents[K]) => void) {

--- a/packages/zai/src/zai.ts
+++ b/packages/zai/src/zai.ts
@@ -91,8 +91,13 @@ export type ZaiConfig = {
   client: BotpressClientLike | Cognitive
   /** Optional user ID for tracking and attribution */
   userId?: string
-  /** Model to use: 'best' (default), 'fast', or specific model like 'openai:gpt-4' */
-  modelId?: Models
+  /**
+   * Model to use: 'best' (default), 'fast', or specific model like 'openai:gpt-4'.
+   * An array can be provided to specify ordered fallback models if the primary
+   * model is unavailable. Server-side fallback is honored on the cognitive-v2
+   * path; the legacy integration path uses the first entry only.
+   */
+  modelId?: Models | Models[]
   /** Active learning configuration to improve operations over time */
   activeLearning?: ActiveLearning
   /** Namespace for organizing tasks (default: 'zai') */
@@ -113,23 +118,22 @@ const _ZaiConfig = z.object({
   client: z.custom<BotpressClientLike | Cognitive>(),
   userId: z.string().describe('The ID of the user consuming the API').optional(),
   modelId: z
-    .custom<Models>(
+    .custom<Models | Models[]>(
       (value) => {
-        if (typeof value !== 'string') {
-          return false
+        const isValidSingle = (v: unknown): v is string =>
+          typeof v === 'string' && (v === 'best' || v === 'fast' || v === 'auto' || v.includes(':'))
+
+        if (Array.isArray(value)) {
+          return value.length > 0 && value.every(isValidSingle)
         }
 
-        if (value !== 'best' && value !== 'fast' && !value.includes(':')) {
-          return false
-        }
-
-        return true
+        return isValidSingle(value)
       },
       {
-        message: 'Invalid model ID',
+        message: 'At least one model ID is invalid. Expected a model string or an array of model strings.',
       }
     )
-    .describe('The ID of the model you want to use')
+    .describe('The ID of the model you want to use, or an ordered list of fallback models')
     .default('best' satisfies Models),
   activeLearning: _ActiveLearning.default({ enable: false }),
   namespace: z
@@ -211,7 +215,7 @@ export class Zai {
 
   private _userId: string | undefined
 
-  protected Model: Models
+  protected Model: Models | Models[]
   protected ModelDetails: Model
   protected namespace: string
   protected adapter: Adapter
@@ -249,7 +253,7 @@ export class Zai {
 
     this.namespace = parsed.namespace
     this._userId = parsed.userId
-    this.Model = parsed.modelId as Models
+    this.Model = parsed.modelId as Models | Models[]
     this.activeLearning = parsed.activeLearning as ActiveLearning
 
     this.adapter = parsed.activeLearning?.enable
@@ -295,7 +299,11 @@ export class Zai {
 
   protected async fetchModelDetails(): Promise<void> {
     if (!this.ModelDetails) {
-      this.ModelDetails = await this.client.getModelDetails(this.Model)
+      // getModelDetails resolves a single model. When a fallback array is
+      // configured, we describe the primary model — fallbacks are only relevant
+      // at the request layer.
+      const primaryModel = Array.isArray(this.Model) ? this.Model[0] : this.Model
+      this.ModelDetails = await this.client.getModelDetails(primaryModel)
     }
   }
 

--- a/plugins/conversation-insights/package.json
+++ b/plugins/conversation-insights/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/cognitive": "0.5.3",
+    "@botpress/cognitive": "0.5.4",
     "@botpress/sdk": "workspace:*",
     "browser-or-node": "^2.1.1",
     "jsonrepair": "^3.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3327,8 +3327,8 @@ importers:
   plugins/conversation-insights:
     dependencies:
       '@botpress/cognitive':
-        specifier: 0.5.3
-        version: 0.5.3
+        specifier: 0.5.4
+        version: link:../../packages/cognitive
       '@botpress/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
@@ -4200,10 +4200,6 @@ packages:
 
   '@botpress/api@1.105.0':
     resolution: {integrity: sha512-DnnqYlEyLCXf7cCaPSJvrQHhb+ycRbFPCyCGKTn0y7mvF32n5tgwZUbC4fEtHt/i6u9AuXPG3ObqPjPcYxocLw==}
-
-  '@botpress/cognitive@0.5.3':
-    resolution: {integrity: sha512-Rfn6Cn/Ge8YHSCD4zGF2ETLI5gBMNv/YKKP7PQc2Vz6csxz3zA7GpWZR/4lZmwYuYJ39t0IXKccB6oCB51WHdw==}
-    engines: {node: '>=18.0.0'}
 
   '@bpinternal/const@0.1.0':
     resolution: {integrity: sha512-iIQg9oYYXOt+LSK34oNhJVQTcgRdtLmLZirEUaE+R9hnmbKONA5reR2kTewxZmekGyxej+5RtDK9xrC/0hmeAw==}
@@ -14012,11 +14008,6 @@ snapshots:
       - debug
       - openapi-types
       - supports-color
-
-  '@botpress/cognitive@0.5.3':
-    dependencies:
-      exponential-backoff: 3.1.1
-      nanoevents: 9.1.0
 
   '@bpinternal/const@0.1.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3028,7 +3028,7 @@ importers:
         specifier: 1.44.0
         version: link:../client
       '@botpress/cognitive':
-        specifier: 0.5.3
+        specifier: 0.5.4
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^2.0.0
@@ -3214,7 +3214,7 @@ importers:
   packages/zai:
     dependencies:
       '@botpress/cognitive':
-        specifier: 0.5.3
+        specifier: 0.5.4
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^1.0.0
@@ -3328,7 +3328,7 @@ importers:
     dependencies:
       '@botpress/cognitive':
         specifier: 0.5.3
-        version: link:../../packages/cognitive
+        version: 0.5.3
       '@botpress/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
@@ -4200,6 +4200,10 @@ packages:
 
   '@botpress/api@1.102.0':
     resolution: {integrity: sha512-Qce4ZguplKIDAQJxkXwgHVLiHSm36nCsuLV4SbPvKPgBtGDOGINKbpimgHkfDhW7DCfMUmS2W0gWew/LHFqbpA==}
+
+  '@botpress/cognitive@0.5.3':
+    resolution: {integrity: sha512-Rfn6Cn/Ge8YHSCD4zGF2ETLI5gBMNv/YKKP7PQc2Vz6csxz3zA7GpWZR/4lZmwYuYJ39t0IXKccB6oCB51WHdw==}
+    engines: {node: '>=18.0.0'}
 
   '@bpinternal/const@0.1.0':
     resolution: {integrity: sha512-iIQg9oYYXOt+LSK34oNhJVQTcgRdtLmLZirEUaE+R9hnmbKONA5reR2kTewxZmekGyxej+5RtDK9xrC/0hmeAw==}
@@ -14008,6 +14012,11 @@ snapshots:
       - debug
       - openapi-types
       - supports-color
+
+  '@botpress/cognitive@0.5.3':
+    dependencies:
+      exponential-backoff: 3.1.1
+      nanoevents: 9.1.0
 
   '@bpinternal/const@0.1.0': {}
 


### PR DESCRIPTION
## Summary

- Allow callers to pass an ordered list of models to `cognitive.generateContent`. The cognitive-v2 path forwards the array to the server, which honors it as ordered fallback. The legacy integration path uses only the first entry and falls back via server preferences.
- Thread `Models | Models[]` through `llmz` (`Context`/`Iteration`) and `zai` (`ZaiConfig.modelId`), with primary-entry resolution where a single `Model` is needed (token budgets, `getModelDetails`).
- Treat `'auto'` as an alias for `'best'` in cognitive's V1 `_selectModel`, so it has defined semantics instead of relying on `pickModel`'s incidental fallback when V2 is disabled.

## Why

Users want to specify a preferred model with explicit fallbacks (e.g. `['anthropic:claude-opus-4-6', 'openai:gpt-5.4']`) rather than relying solely on server-side preferences. The cognitive-v2 backend already supports this; the surface types just needed to allow it end-to-end.

## Behavior

- **V2 path** (`_useBeta` + `isKnownV2Model(primary)`): full array forwarded to `betaClient.generateText`. Ordered fallback honored server-side.
- **V1 path**: only `input.model[0]` is used; subsequent entries are ignored. Server-side `preferences.best` / `preferences.fast` still provide fallback.
- **`'auto'`**: V2 already handles it, V1 now resolves it as `'best'`.