### PR TITLE
chore(llmz, zai): bump llmz version, refine ZaiContextProps.modelId type

### DIFF
--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -2,7 +2,7 @@
   "name": "llmz",
   "type": "module",
   "description": "LLMz - An LLM-native Typescript VM built on top of Zui",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "2.6.20",
+  "version": "2.6.21",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/zai/src/context.ts
+++ b/packages/zai/src/context.ts
@@ -15,7 +15,7 @@ export type ZaiContextProps = {
   client: Cognitive
   taskType: string
   taskId: string
-  modelId: GenerateContentInput['model']
+  modelId: string | string[]
   adapter?: Adapter
   source?: GenerateContentInput['meta']
   memoizer?: Memoizer


### PR DESCRIPTION
## Summary
- Bump `llmz` version from `0.0.76` to `0.0.77`.
- Tighten the `modelId` types in `@botpress/zai`'s `ZaiContext` from `GenerateContentInput['model']` (which resolved to `any` due to the auto-generated schema) to `string | string[]`. Type-only change.