### PR TITLE
fix(integrations/linear): Fixed the lienar app use for Desk

### DIFF
--- a/integrations/linear/definitions/states.ts
+++ b/integrations/linear/definitions/states.ts
@@ -1,17 +1,22 @@
 import { z, IntegrationDefinitionProps } from '@botpress/sdk'
 import { userProfileSchema } from './schemas'
 
+const oauthCredentialsSchema = z.object({
+  accessToken: z.string().title('Access Token').describe('The access token for Linear'),
+  refreshToken: z.string().title('Refresh Token').describe('The refresh token needed when the access token expires'),
+  expiresAt: z.string().title('Expires At').describe('The time when the access token expires'),
+})
+
 export const states = {
   credentials: {
     type: 'integration',
-    schema: z.object({
-      accessToken: z.string().title('Access Token').describe('The access token for Linear'),
-      refreshToken: z
-        .string()
-        .title('Refresh Token')
-        .describe('The refresh token needed when the access token expires'),
-      expiresAt: z.string().title('Expires At').describe('The time when the access token expires'),
-    }),
+    schema: oauthCredentialsSchema,
+  },
+  adminCredentials: {
+    type: 'integration',
+    schema: oauthCredentialsSchema.describe(
+      'User-actor OAuth credentials used only for admin operations (webhook register/unregister)'
+    ),
   },
   environment: {
     type: 'integration',
@@ -21,6 +26,11 @@ export const states = {
         .title('Environment')
         .describe('The environment where the integration is installed'),
       source: z.string().optional().title('Source').describe('The source of the OAuth request, eg: "desk"'),
+      wizardPhase: z
+        .enum(['admin', 'app'])
+        .optional()
+        .title('Wizard Phase')
+        .describe('Which leg of the two-phase OAuth wizard is currently expected on /oauth callback'),
     }),
   },
 

--- a/integrations/linear/integration.definition.ts
+++ b/integrations/linear/integration.definition.ts
@@ -9,7 +9,7 @@ import listable from './bp_modules/listable'
 import { actions, channels, events, configuration, configurations, user, states, entities } from './definitions'
 
 export const INTEGRATION_NAME = 'linear'
-export const INTEGRATION_VERSION = '2.5.0'
+export const INTEGRATION_VERSION = '2.5.1'
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/linear/linkTemplate.vrl
+++ b/integrations/linear/linkTemplate.vrl
@@ -1,5 +1,6 @@
 webhookId = to_string!(.webhookId)
 webhookUrl = to_string!(.webhookUrl)
+env = to_string!(.env)
 source = to_string!(.source)
 
-"{{ webhookUrl }}/oauth/wizard/start?state={{ webhookId }}&source={{ source }}"
+"{{ webhookUrl }}/oauth/wizard/start?state={{ webhookId }}&source={{ source }}&env={{ env }}"

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -194,6 +194,17 @@ export class LinearOauthClient {
   }
 
   public static async create(props: { client: bp.Client; ctx: bp.Context }) {
+    return LinearOauthClient._createFromStoredCredentials(props, 'credentials')
+  }
+
+  public static async createAdmin(props: { client: bp.Client; ctx: bp.Context }) {
+    return LinearOauthClient._createFromStoredCredentials(props, 'adminCredentials')
+  }
+
+  private static async _createFromStoredCredentials(
+    props: { client: bp.Client; ctx: bp.Context },
+    stateName: 'credentials' | 'adminCredentials'
+  ) {
     const { ctx, client } = props
     if (ctx.configurationType === 'apiKey') {
       return new LinearClient({ apiKey: ctx.configuration.apiKey })
@@ -203,7 +214,7 @@ export class LinearOauthClient {
       state: { payload },
     } = await client.getState({
       type: 'integration',
-      name: 'credentials',
+      name: stateName,
       id: ctx.integrationId,
     })
 
@@ -219,7 +230,7 @@ export class LinearOauthClient {
     const credentials = await linearOauthClient.resolveValidCredentials(payload)
 
     if (credentials.accessToken !== payload.accessToken) {
-      await client.setState({ type: 'integration', name: 'credentials', id: ctx.integrationId, payload: credentials })
+      await client.setState({ type: 'integration', name: stateName, id: ctx.integrationId, payload: credentials })
     }
 
     return new LinearClient({ accessToken: credentials.accessToken })

--- a/integrations/linear/src/oauth-wizard.ts
+++ b/integrations/linear/src/oauth-wizard.ts
@@ -30,7 +30,7 @@ const _startStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async ({ ctx,
     `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
     '&response_type=code' +
     '&prompt=consent' +
-    'actor=app' +
+    '&actor=app' +
     `&state=${ctx.webhookId}` +
     `&scope=${SCOPES}`
 

--- a/integrations/linear/src/oauth-wizard.ts
+++ b/integrations/linear/src/oauth-wizard.ts
@@ -24,14 +24,13 @@ const _startStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async ({ ctx,
 
   const isDesk = useDeskOAuth(payload)
   const clientId = isDesk ? bp.secrets.DESK_CLIENT_ID : bp.secrets.CLIENT_ID
-  const actor = isDesk ? 'user' : 'application'
   const authorizeUrl =
     'https://linear.app/oauth/authorize' +
     `?client_id=${clientId}` +
     `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
     '&response_type=code' +
     '&prompt=consent' +
-    `&actor=${actor}` +
+    'actor=app' +
     `&state=${ctx.webhookId}` +
     `&scope=${SCOPES}`
 

--- a/integrations/linear/src/oauth-wizard.ts
+++ b/integrations/linear/src/oauth-wizard.ts
@@ -6,13 +6,37 @@ import { useDeskOAuth } from './misc/utils'
 import * as bp from '.botpress'
 
 const REDIRECT_URI = `${process.env.BP_WEBHOOK_URL}/oauth`
-const SCOPES = 'read,write,issues:create,comments:create,admin'
+const APP_SCOPES = 'read,write,issues:create,comments:create'
+const ADMIN_SCOPES = 'read,write,admin'
+
+const _buildAuthorizeUrl = ({
+  clientId,
+  actor,
+  scopes,
+  state,
+  promptConsent,
+}: {
+  clientId: string
+  actor: 'user' | 'application'
+  scopes: string
+  state: string
+  promptConsent: boolean
+}) =>
+  'https://linear.app/oauth/authorize' +
+  `?client_id=${clientId}` +
+  `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
+  '&response_type=code' +
+  (promptConsent ? '&prompt=consent' : '') +
+  `&actor=${actor}` +
+  `&state=${state}` +
+  `&scope=${scopes}`
 
 const _startStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async ({ ctx, client, query, responses }) => {
   const searchParams = new URLSearchParams(query)
   const payload = {
     source: searchParams.get('source') ?? undefined,
     env: z.enum(['preview', 'production']).catch('preview').parse(searchParams.get('env')),
+    wizardPhase: 'admin',
   } as bp.states.environment.Environment['payload']
 
   await client.setState({
@@ -24,17 +48,10 @@ const _startStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async ({ ctx,
 
   const isDesk = useDeskOAuth(payload)
   const clientId = isDesk ? bp.secrets.DESK_CLIENT_ID : bp.secrets.CLIENT_ID
-  const authorizeUrl =
-    'https://linear.app/oauth/authorize' +
-    `?client_id=${clientId}` +
-    `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
-    '&response_type=code' +
-    '&prompt=consent' +
-    '&actor=app' +
-    `&state=${ctx.webhookId}` +
-    `&scope=${SCOPES}`
 
-  return responses.redirectToExternalUrl(authorizeUrl)
+  return responses.redirectToExternalUrl(
+    _buildAuthorizeUrl({ clientId, actor: 'user', scopes: ADMIN_SCOPES, state: ctx.webhookId, promptConsent: true })
+  )
 }
 
 const _oauthCallbackStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async ({
@@ -66,27 +83,56 @@ const _oauthCallbackStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async
   const useDesk = useDeskOAuth(environment)
   const linearOauthClient = new LinearOauthClient(useDesk)
   const credentials = await linearOauthClient.getAccessTokenFromOAuthCode(code)
-  logger.forBot().info('Obtained credentials from OAuth flow, saving to state...')
+
+  if (environment.wizardPhase === 'app') {
+    logger.forBot().info('Received app-actor OAuth callback, saving runtime credentials...')
+    await client.setState({
+      type: 'integration',
+      name: 'credentials',
+      id: ctx.integrationId,
+      payload: credentials,
+    })
+
+    const linearClient = new LinearClient({ accessToken: credentials.accessToken })
+    const organization = await linearClient.organization
+    setIntegrationIdentifier(organization.id)
+    return responses.endWizard({ success: true })
+  }
+
+  logger.forBot().info('Received user-actor OAuth callback, saving admin credentials...')
   await client.setState({
     type: 'integration',
-    name: 'credentials',
+    name: 'adminCredentials',
     id: ctx.integrationId,
     payload: credentials,
   })
 
-  const linearClient = new LinearClient({ accessToken: credentials.accessToken })
-  const organization = await linearClient.organization
-
+  const adminClient = new LinearClient({ accessToken: credentials.accessToken })
   const webhookUrl = `${process.env.BP_WEBHOOK_URL}/${ctx.webhookId}`
   try {
-    await registerWebhook({ linearClient, logger, url: webhookUrl })
+    await registerWebhook({ linearClient: adminClient, logger, url: webhookUrl })
   } catch (thrown) {
     const errorMessage = thrown instanceof Error ? thrown.message : String(thrown)
     logger.forBot().warn('Failed to register webhook:', errorMessage)
   }
 
-  setIntegrationIdentifier(organization.id)
-  return responses.endWizard({ success: true })
+  await client.setState({
+    type: 'integration',
+    name: 'environment',
+    id: ctx.integrationId,
+    payload: { ...environment, wizardPhase: 'app' },
+  })
+
+  const clientId = useDesk ? bp.secrets.DESK_CLIENT_ID : bp.secrets.CLIENT_ID
+  return responses.redirectToExternalUrl(
+    _buildAuthorizeUrl({
+      clientId,
+      actor: 'application',
+      scopes: APP_SCOPES,
+      state: ctx.webhookId,
+      promptConsent: false,
+    })
+  )
 }
 
 export const buildOAuthWizard = (props: bp.HandlerProps) =>

--- a/integrations/linear/src/setup.ts
+++ b/integrations/linear/src/setup.ts
@@ -9,13 +9,12 @@ export const register: bp.IntegrationProps['register'] = async ({ client, ctx, l
   const manuallyRegistered = _isWebhookManuallyRegistered(ctx)
   logger.forBot().info('Registering Linear integration.')
 
-  const linearClient = await LinearOauthClient.create({ client, ctx })
-
   if (!manuallyRegistered) {
+    const adminClient = await LinearOauthClient.createAdmin({ client, ctx })
     const webhookUrl = `${process.env.BP_WEBHOOK_URL}/${ctx.webhookId}`
     logger.forBot().info('Registering Linear webhook')
     try {
-      await registerWebhook({ linearClient, logger, url: webhookUrl })
+      await registerWebhook({ linearClient: adminClient, logger, url: webhookUrl })
       logger.forBot().info('Linear webhook registered')
     } catch (thrown) {
       const errorMessage = thrown instanceof Error ? thrown.message : String(thrown)
@@ -38,10 +37,10 @@ export const unregister: bp.IntegrationProps['unregister'] = async ({ client, ct
     return
   }
   try {
-    const linearClient = await LinearOauthClient.create({ client, ctx })
+    const adminClient = await LinearOauthClient.createAdmin({ client, ctx })
     const webhookUrl = `${process.env.BP_WEBHOOK_URL}/${ctx.webhookId}`
     logger.forBot().info('Unregistering Linear webhook.')
-    await unregisterWebhook({ linearClient, logger, url: webhookUrl })
+    await unregisterWebhook({ linearClient: adminClient, logger, url: webhookUrl })
     logger.forBot().info('Linear webhook unregistration step completed.')
   } catch (thrown) {
     const errorMessage = thrown instanceof Error ? thrown.message : String(thrown)


### PR DESCRIPTION
- The `env` param was not passed to the wizard so the environment was always `preview` even in prod.
- The actor was `user` instead of `application` when installed through Desk. We always want the actor to be the application.
- The `application` actor has been deprecated in favor of `app`, so I updated that as well.