### PR TITLE
fix(integrations/linear): Fixed the OAuth app used in desk and the actor type for webhook registration

### DIFF
--- a/integrations/linear/definitions/states.ts
+++ b/integrations/linear/definitions/states.ts
@@ -1,17 +1,22 @@
 import { z, IntegrationDefinitionProps } from '@botpress/sdk'
 import { userProfileSchema } from './schemas'
 
+const oauthCredentialsSchema = z.object({
+  accessToken: z.string().title('Access Token').describe('The access token for Linear'),
+  refreshToken: z.string().title('Refresh Token').describe('The refresh token needed when the access token expires'),
+  expiresAt: z.string().title('Expires At').describe('The time when the access token expires'),
+})
+
 export const states = {
   credentials: {
     type: 'integration',
-    schema: z.object({
-      accessToken: z.string().title('Access Token').describe('The access token for Linear'),
-      refreshToken: z
-        .string()
-        .title('Refresh Token')
-        .describe('The refresh token needed when the access token expires'),
-      expiresAt: z.string().title('Expires At').describe('The time when the access token expires'),
-    }),
+    schema: oauthCredentialsSchema,
+  },
+  adminCredentials: {
+    type: 'integration',
+    schema: oauthCredentialsSchema.describe(
+      'User-actor OAuth credentials used only for admin operations (webhook register/unregister)'
+    ),
   },
   environment: {
     type: 'integration',
@@ -21,6 +26,11 @@ export const states = {
         .title('Environment')
         .describe('The environment where the integration is installed'),
       source: z.string().optional().title('Source').describe('The source of the OAuth request, eg: "desk"'),
+      wizardPhase: z
+        .enum(['admin', 'app'])
+        .optional()
+        .title('Wizard Phase')
+        .describe('Which leg of the two-phase OAuth wizard is currently expected on /oauth callback'),
     }),
   },
 

--- a/integrations/linear/integration.definition.ts
+++ b/integrations/linear/integration.definition.ts
@@ -9,7 +9,7 @@ import listable from './bp_modules/listable'
 import { actions, channels, events, configuration, configurations, user, states, entities } from './definitions'
 
 export const INTEGRATION_NAME = 'linear'
-export const INTEGRATION_VERSION = '2.5.0'
+export const INTEGRATION_VERSION = '2.5.1'
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/linear/linkTemplate.vrl
+++ b/integrations/linear/linkTemplate.vrl
@@ -1,5 +1,6 @@
 webhookId = to_string!(.webhookId)
 webhookUrl = to_string!(.webhookUrl)
+env = to_string!(.env)
 source = to_string!(.source)
 
-"{{ webhookUrl }}/oauth/wizard/start?state={{ webhookId }}&source={{ source }}"
+"{{ webhookUrl }}/oauth/wizard/start?state={{ webhookId }}&source={{ source }}&env={{ env }}"

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -194,6 +194,17 @@ export class LinearOauthClient {
   }
 
   public static async create(props: { client: bp.Client; ctx: bp.Context }) {
+    return LinearOauthClient._createFromStoredCredentials(props, 'credentials')
+  }
+
+  public static async createAdmin(props: { client: bp.Client; ctx: bp.Context }) {
+    return LinearOauthClient._createFromStoredCredentials(props, 'adminCredentials')
+  }
+
+  private static async _createFromStoredCredentials(
+    props: { client: bp.Client; ctx: bp.Context },
+    stateName: 'credentials' | 'adminCredentials'
+  ) {
     const { ctx, client } = props
     if (ctx.configurationType === 'apiKey') {
       return new LinearClient({ apiKey: ctx.configuration.apiKey })
@@ -203,7 +214,7 @@ export class LinearOauthClient {
       state: { payload },
     } = await client.getState({
       type: 'integration',
-      name: 'credentials',
+      name: stateName,
       id: ctx.integrationId,
     })
 
@@ -219,7 +230,7 @@ export class LinearOauthClient {
     const credentials = await linearOauthClient.resolveValidCredentials(payload)
 
     if (credentials.accessToken !== payload.accessToken) {
-      await client.setState({ type: 'integration', name: 'credentials', id: ctx.integrationId, payload: credentials })
+      await client.setState({ type: 'integration', name: stateName, id: ctx.integrationId, payload: credentials })
     }
 
     return new LinearClient({ accessToken: credentials.accessToken })

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -220,6 +220,20 @@ export class LinearOauthClient {
       id: ctx.integrationId,
     })
 
+    let effectiveStateName = stateName
+    let effectivePayload = payload
+    if (stateName === 'adminCredentials' && !payload.accessToken) {
+      const {
+        state: { payload: fallbackPayload },
+      } = await client.getState({
+        type: 'integration',
+        name: 'credentials',
+        id: ctx.integrationId,
+      })
+      effectiveStateName = 'credentials'
+      effectivePayload = fallbackPayload
+    }
+
     const {
       state: { payload: environment },
     } = await client.getState({
@@ -229,11 +243,16 @@ export class LinearOauthClient {
     })
     const useDesk = useDeskOAuth(environment)
     const linearOauthClient = new LinearOauthClient(useDesk)
-    const actor: Actor = stateName === 'adminCredentials' ? 'user' : 'app'
-    const credentials = await linearOauthClient.resolveValidCredentials(payload, actor)
+    const actor: Actor = effectiveStateName === 'adminCredentials' ? 'user' : 'app'
+    const credentials = await linearOauthClient.resolveValidCredentials(effectivePayload, actor)
 
-    if (credentials.accessToken !== payload.accessToken) {
-      await client.setState({ type: 'integration', name: stateName, id: ctx.integrationId, payload: credentials })
+    if (credentials.accessToken !== effectivePayload.accessToken) {
+      await client.setState({
+        type: 'integration',
+        name: effectiveStateName,
+        id: ctx.integrationId,
+        payload: credentials,
+      })
     }
 
     return new LinearClient({ accessToken: credentials.accessToken })

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -83,8 +83,10 @@ const oauthSchema = z.object({
 
 type OAuthResponse = z.infer<typeof oauthSchema>
 
+export type Actor = 'user' | 'app'
+
 const tokenRequestSchema = z.object({
-  actor: z.literal('application'),
+  actor: z.enum(['user', 'app']),
   redirect_uri: z.string(),
 })
 
@@ -159,21 +161,21 @@ export class LinearOauthClient {
     return this._parseCredentials(data)
   }
 
-  public async getAccessTokenFromRefreshToken(oldRefreshToken: string): Promise<Credentials> {
+  public async getAccessTokenFromRefreshToken(oldRefreshToken: string, actor: Actor): Promise<Credentials> {
     const data = await this._handleOAuthRequest<typeof refreshTokenRequestSchema>(`${linearEndpoint}/oauth/token`, {
       grant_type: 'refresh_token',
       refresh_token: oldRefreshToken,
-      actor: 'application',
+      actor,
       redirect_uri: this._redirectUri,
     })
     return this._parseCredentials(data)
   }
 
-  public async getAccessTokenFromOAuthCode(code: string) {
+  public async getAccessTokenFromOAuthCode(code: string, actor: Actor) {
     const data = await this._handleOAuthRequest<typeof getAccessTokenRequestSchema>(`${linearEndpoint}/oauth/token`, {
       grant_type: 'authorization_code',
       code,
-      actor: 'application',
+      actor,
       redirect_uri: this._redirectUri,
     })
     if (!data.refresh_token) {
@@ -182,12 +184,12 @@ export class LinearOauthClient {
     return this._parseCredentials(data)
   }
 
-  public async resolveValidCredentials(current: Credentials): Promise<Credentials> {
+  public async resolveValidCredentials(current: Credentials, actor: Actor): Promise<Credentials> {
     const FIVE_MINUTES_MS = 5 * 60 * 1000
     const isExpired = new Date(current.expiresAt).getTime() <= Date.now() + FIVE_MINUTES_MS
 
     if (isExpired) {
-      return this.getAccessTokenFromRefreshToken(current.refreshToken)
+      return this.getAccessTokenFromRefreshToken(current.refreshToken, actor)
     }
 
     return current
@@ -227,7 +229,8 @@ export class LinearOauthClient {
     })
     const useDesk = useDeskOAuth(environment)
     const linearOauthClient = new LinearOauthClient(useDesk)
-    const credentials = await linearOauthClient.resolveValidCredentials(payload)
+    const actor: Actor = stateName === 'adminCredentials' ? 'user' : 'app'
+    const credentials = await linearOauthClient.resolveValidCredentials(payload, actor)
 
     if (credentials.accessToken !== payload.accessToken) {
       await client.setState({ type: 'integration', name: stateName, id: ctx.integrationId, payload: credentials })

--- a/integrations/linear/src/oauth-wizard.ts
+++ b/integrations/linear/src/oauth-wizard.ts
@@ -107,10 +107,10 @@ const _oauthCallbackStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async
     payload: credentials,
   })
 
-  const adminClient = new LinearClient({ accessToken: credentials.accessToken })
+  const linearClient = new LinearClient({ accessToken: credentials.accessToken })
   const webhookUrl = `${process.env.BP_WEBHOOK_URL}/${ctx.webhookId}`
   try {
-    await registerWebhook({ linearClient: adminClient, logger, url: webhookUrl })
+    await registerWebhook({ linearClient, logger, url: webhookUrl })
   } catch (thrown) {
     const errorMessage = thrown instanceof Error ? thrown.message : String(thrown)
     logger.forBot().warn('Failed to register webhook:', errorMessage)

--- a/integrations/linear/src/oauth-wizard.ts
+++ b/integrations/linear/src/oauth-wizard.ts
@@ -30,7 +30,7 @@ const _startStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async ({ ctx,
     `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
     '&response_type=code' +
     '&prompt=consent' +
-    'actor=app' +
+    '&actor=app' +
     `&state=${ctx.webhookId}` +
     `&scope=${SCOPES}`
 

--- a/integrations/linear/src/oauth-wizard.ts
+++ b/integrations/linear/src/oauth-wizard.ts
@@ -24,14 +24,13 @@ const _startStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async ({ ctx,
 
   const isDesk = useDeskOAuth(payload)
   const clientId = isDesk ? bp.secrets.DESK_CLIENT_ID : bp.secrets.CLIENT_ID
-  const actor = isDesk ? 'user' : 'application'
   const authorizeUrl =
     'https://linear.app/oauth/authorize' +
     `?client_id=${clientId}` +
     `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
     '&response_type=code' +
     '&prompt=consent' +
-    `&actor=${actor}` +
+    'actor=app' +
     `&state=${ctx.webhookId}` +
     `&scope=${SCOPES}`
 

--- a/integrations/linear/src/oauth-wizard.ts
+++ b/integrations/linear/src/oauth-wizard.ts
@@ -17,7 +17,7 @@ const _buildAuthorizeUrl = ({
   promptConsent,
 }: {
   clientId: string
-  actor: 'user' | 'application'
+  actor: 'user' | 'app'
   scopes: string
   state: string
   promptConsent: boolean
@@ -127,7 +127,7 @@ const _oauthCallbackStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async
   return responses.redirectToExternalUrl(
     _buildAuthorizeUrl({
       clientId,
-      actor: 'application',
+      actor: 'app',
       scopes: APP_SCOPES,
       state: ctx.webhookId,
       promptConsent: false,

--- a/integrations/linear/src/oauth-wizard.ts
+++ b/integrations/linear/src/oauth-wizard.ts
@@ -6,13 +6,37 @@ import { useDeskOAuth } from './misc/utils'
 import * as bp from '.botpress'
 
 const REDIRECT_URI = `${process.env.BP_WEBHOOK_URL}/oauth`
-const SCOPES = 'read,write,issues:create,comments:create,admin'
+const APP_SCOPES = 'read,write,issues:create,comments:create'
+const ADMIN_SCOPES = 'read,write,admin'
+
+const _buildAuthorizeUrl = ({
+  clientId,
+  actor,
+  scopes,
+  state,
+  promptConsent,
+}: {
+  clientId: string
+  actor: 'user' | 'application'
+  scopes: string
+  state: string
+  promptConsent: boolean
+}) =>
+  'https://linear.app/oauth/authorize' +
+  `?client_id=${clientId}` +
+  `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
+  '&response_type=code' +
+  (promptConsent ? '&prompt=consent' : '') +
+  `&actor=${actor}` +
+  `&state=${state}` +
+  `&scope=${scopes}`
 
 const _startStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async ({ ctx, client, query, responses }) => {
   const searchParams = new URLSearchParams(query)
   const payload = {
     source: searchParams.get('source') ?? undefined,
     env: z.enum(['preview', 'production']).catch('preview').parse(searchParams.get('env')),
+    wizardPhase: 'admin',
   } as bp.states.environment.Environment['payload']
 
   await client.setState({
@@ -24,17 +48,10 @@ const _startStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async ({ ctx,
 
   const isDesk = useDeskOAuth(payload)
   const clientId = isDesk ? bp.secrets.DESK_CLIENT_ID : bp.secrets.CLIENT_ID
-  const authorizeUrl =
-    'https://linear.app/oauth/authorize' +
-    `?client_id=${clientId}` +
-    `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
-    '&response_type=code' +
-    '&prompt=consent' +
-    '&actor=app' +
-    `&state=${ctx.webhookId}` +
-    `&scope=${SCOPES}`
 
-  return responses.redirectToExternalUrl(authorizeUrl)
+  return responses.redirectToExternalUrl(
+    _buildAuthorizeUrl({ clientId, actor: 'user', scopes: ADMIN_SCOPES, state: ctx.webhookId, promptConsent: true })
+  )
 }
 
 const _oauthCallbackStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async ({
@@ -66,27 +83,56 @@ const _oauthCallbackStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async
   const useDesk = useDeskOAuth(environment)
   const linearOauthClient = new LinearOauthClient(useDesk)
   const credentials = await linearOauthClient.getAccessTokenFromOAuthCode(code)
-  logger.forBot().info('Obtained credentials from OAuth flow, saving to state...')
+
+  if (environment.wizardPhase === 'app') {
+    logger.forBot().info('Received app-actor OAuth callback, saving runtime credentials...')
+    await client.setState({
+      type: 'integration',
+      name: 'credentials',
+      id: ctx.integrationId,
+      payload: credentials,
+    })
+
+    const linearClient = new LinearClient({ accessToken: credentials.accessToken })
+    const organization = await linearClient.organization
+    setIntegrationIdentifier(organization.id)
+    return responses.endWizard({ success: true })
+  }
+
+  logger.forBot().info('Received user-actor OAuth callback, saving admin credentials...')
   await client.setState({
     type: 'integration',
-    name: 'credentials',
+    name: 'adminCredentials',
     id: ctx.integrationId,
     payload: credentials,
   })
 
-  const linearClient = new LinearClient({ accessToken: credentials.accessToken })
-  const organization = await linearClient.organization
-
+  const adminClient = new LinearClient({ accessToken: credentials.accessToken })
   const webhookUrl = `${process.env.BP_WEBHOOK_URL}/${ctx.webhookId}`
   try {
-    await registerWebhook({ linearClient, logger, url: webhookUrl })
+    await registerWebhook({ linearClient: adminClient, logger, url: webhookUrl })
   } catch (thrown) {
     const errorMessage = thrown instanceof Error ? thrown.message : String(thrown)
     logger.forBot().warn('Failed to register webhook:', errorMessage)
   }
 
-  setIntegrationIdentifier(organization.id)
-  return responses.endWizard({ success: true })
+  await client.setState({
+    type: 'integration',
+    name: 'environment',
+    id: ctx.integrationId,
+    payload: { ...environment, wizardPhase: 'app' },
+  })
+
+  const clientId = useDesk ? bp.secrets.DESK_CLIENT_ID : bp.secrets.CLIENT_ID
+  return responses.redirectToExternalUrl(
+    _buildAuthorizeUrl({
+      clientId,
+      actor: 'application',
+      scopes: APP_SCOPES,
+      state: ctx.webhookId,
+      promptConsent: false,
+    })
+  )
 }
 
 export const buildOAuthWizard = (props: bp.HandlerProps) =>

--- a/integrations/linear/src/oauth-wizard.ts
+++ b/integrations/linear/src/oauth-wizard.ts
@@ -82,7 +82,8 @@ const _oauthCallbackStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async
   })
   const useDesk = useDeskOAuth(environment)
   const linearOauthClient = new LinearOauthClient(useDesk)
-  const credentials = await linearOauthClient.getAccessTokenFromOAuthCode(code)
+  const tokenActor = environment.wizardPhase === 'app' ? 'app' : 'user'
+  const credentials = await linearOauthClient.getAccessTokenFromOAuthCode(code, tokenActor)
 
   if (environment.wizardPhase === 'app') {
     logger.forBot().info('Received app-actor OAuth callback, saving runtime credentials...')

--- a/integrations/linear/src/setup.ts
+++ b/integrations/linear/src/setup.ts
@@ -10,11 +10,11 @@ export const register: bp.IntegrationProps['register'] = async ({ client, ctx, l
   logger.forBot().info('Registering Linear integration.')
 
   if (!manuallyRegistered) {
-    const adminClient = await LinearOauthClient.createAdmin({ client, ctx })
+    const linearClient = await LinearOauthClient.createAdmin({ client, ctx })
     const webhookUrl = `${process.env.BP_WEBHOOK_URL}/${ctx.webhookId}`
     logger.forBot().info('Registering Linear webhook')
     try {
-      await registerWebhook({ linearClient: adminClient, logger, url: webhookUrl })
+      await registerWebhook({ linearClient, logger, url: webhookUrl })
       logger.forBot().info('Linear webhook registered')
     } catch (thrown) {
       const errorMessage = thrown instanceof Error ? thrown.message : String(thrown)
@@ -37,10 +37,10 @@ export const unregister: bp.IntegrationProps['unregister'] = async ({ client, ct
     return
   }
   try {
-    const adminClient = await LinearOauthClient.createAdmin({ client, ctx })
+    const linearClient = await LinearOauthClient.createAdmin({ client, ctx })
     const webhookUrl = `${process.env.BP_WEBHOOK_URL}/${ctx.webhookId}`
     logger.forBot().info('Unregistering Linear webhook.')
-    await unregisterWebhook({ linearClient: adminClient, logger, url: webhookUrl })
+    await unregisterWebhook({ linearClient, logger, url: webhookUrl })
     logger.forBot().info('Linear webhook unregistration step completed.')
   } catch (thrown) {
     const errorMessage = thrown instanceof Error ? thrown.message : String(thrown)

--- a/integrations/linear/src/setup.ts
+++ b/integrations/linear/src/setup.ts
@@ -9,13 +9,12 @@ export const register: bp.IntegrationProps['register'] = async ({ client, ctx, l
   const manuallyRegistered = _isWebhookManuallyRegistered(ctx)
   logger.forBot().info('Registering Linear integration.')
 
-  const linearClient = await LinearOauthClient.create({ client, ctx })
-
   if (!manuallyRegistered) {
+    const adminClient = await LinearOauthClient.createAdmin({ client, ctx })
     const webhookUrl = `${process.env.BP_WEBHOOK_URL}/${ctx.webhookId}`
     logger.forBot().info('Registering Linear webhook')
     try {
-      await registerWebhook({ linearClient, logger, url: webhookUrl })
+      await registerWebhook({ linearClient: adminClient, logger, url: webhookUrl })
       logger.forBot().info('Linear webhook registered')
     } catch (thrown) {
       const errorMessage = thrown instanceof Error ? thrown.message : String(thrown)
@@ -38,10 +37,10 @@ export const unregister: bp.IntegrationProps['unregister'] = async ({ client, ct
     return
   }
   try {
-    const linearClient = await LinearOauthClient.create({ client, ctx })
+    const adminClient = await LinearOauthClient.createAdmin({ client, ctx })
     const webhookUrl = `${process.env.BP_WEBHOOK_URL}/${ctx.webhookId}`
     logger.forBot().info('Unregistering Linear webhook.')
-    await unregisterWebhook({ linearClient, logger, url: webhookUrl })
+    await unregisterWebhook({ linearClient: adminClient, logger, url: webhookUrl })
     logger.forBot().info('Linear webhook unregistration step completed.')
   } catch (thrown) {
     const errorMessage = thrown instanceof Error ? thrown.message : String(thrown)


### PR DESCRIPTION
Two issues:
1. The `env` parameter always fell back to preview because it was not being passed to the OAuth handler, which made it so the Desk app was never being used.
2. The Desk app has been created more recently than the staging and prod Botpress apps, so it can't use the deprecated `application` actor type. The new `app` actor type cannot register webhooks, so we now have to do the OAuth flow twice; once for each token type. Slightly worse UX but necessary if we want to use the app as the comment author and we want to keep registering webhooks automatically.