### PR TITLE
fix(cognitive): populate botId from x-bot-id header in getExtendedClient

### DIFF
--- a/packages/cognitive/src/bp-client.ts
+++ b/packages/cognitive/src/bp-client.ts
@@ -50,6 +50,7 @@ export const getExtendedClient = (_client: unknown): ExtendedClient => {
 
   return {
     ...client,
+    botId: client.config.headers['x-bot-id'] as string,
     axios: (client as any).axiosInstance as AxiosInstance,
     clone,
     abortable: (signal: AbortSignal) => {


### PR DESCRIPTION
## Summary

- `ExtendedClient` declares `botId: string`, but `getExtendedClient` was relying on the object spread (`...client`) to provide it
- The public `@botpress/client` `Client` does **not** expose `botId` as an own instance property — it is stored only in `config.headers['x-bot-id']` after `getClientConfig()` processes the constructor props
- As a result, `extendedClient.botId` was always `undefined` at runtime despite the type saying `string`; the `as ExtendedClient` cast silenced TypeScript

**Fix:** explicitly read `botId` from `client.config.headers['x-bot-id']` in the returned object.

## Test plan

- [ ] Instantiate `new Client({ botId: 'test-bot', token: '...' })` and pass it through `getExtendedClient`
- [ ] Assert `extendedClient.botId === 'test-bot'`
- [ ] Verify `clone()` and `abortable()` also carry the correct `botId` (they call `getExtendedClient` recursively)

🤖 Generated with [Claude Code](https://claude.com/claude-code)