### PR TITLE
fix(integrations/zendesk): Prevent nullable user fields

### DIFF
--- a/integrations/zendesk/integration.definition.ts
+++ b/integrations/zendesk/integration.definition.ts
@@ -6,7 +6,7 @@ import { actions, events, configuration, channels, states, user } from './src/de
 export default new sdk.IntegrationDefinition({
   name: 'zendesk',
   title: 'Zendesk',
-  version: '3.1.2',
+  version: '3.1.3',
   icon: 'icon.svg',
   description:
     'Optimize your support workflow. Trigger workflows from ticket updates as well as manage tickets, access conversations, and engage with customers.',

--- a/integrations/zendesk/src/definitions/schemas.ts
+++ b/integrations/zendesk/src/definitions/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from '@botpress/sdk'
-import { omit } from 'lodash'
+import { omit, pickBy } from 'lodash'
 
 const requesterSchema = z.object({
   name: z.string().optional().title('Name').describe('Requester name'),
@@ -70,26 +70,34 @@ export const userSchema = z.object({
   createdAt: z.string().title('Created At').describe('User creation date'),
   updatedAt: z.string().title('Updated At').describe('User last update date'),
   externalId: z.string().nullable().title('External ID').describe('External user ID'),
-  userFields: z.record(z.string().nullable()).optional().title('User Fields').describe('Custom user fields'),
+  userFields: z.record(z.string()).optional().title('User Fields').describe('Custom user fields'),
 })
 
-const _zdUserSchema = userSchema.transform((data) => ({
-  ...omit(data, ['createdAt', 'updatedAt', 'externalId', 'userFields', 'remotePhotoUrl']),
-  created_at: data.createdAt,
-  updated_at: data.updatedAt,
-  external_id: data.externalId,
-  user_fields: data.userFields,
-  remote_photo_url: data.remotePhotoUrl,
-}))
+const _zdUserSchema = userSchema
+  .omit({ userFields: true })
+  .extend({
+    userFields: z.record(z.string().nullable()).optional(),
+  })
+  .transform((data) => ({
+    ...omit(data, ['createdAt', 'updatedAt', 'externalId', 'userFields', 'remotePhotoUrl']),
+    created_at: data.createdAt,
+    updated_at: data.updatedAt,
+    external_id: data.externalId,
+    user_fields: data.userFields,
+    remote_photo_url: data.remotePhotoUrl,
+  }))
 
 export type ZendeskUser = z.output<typeof _zdUserSchema>
 export type User = z.input<typeof userSchema>
 
 export const transformUser = (ticket: ZendeskUser): User => {
+  const userFields = ticket.user_fields
+    ? (pickBy(ticket.user_fields, (value): value is string => value !== null) as Record<string, string>)
+    : undefined
   return {
     ...omit(ticket, ['external_id', 'user_fields', 'created_at', 'updated_at', 'remote_photo_url']),
     externalId: ticket.external_id,
-    userFields: ticket.user_fields,
+    userFields,
     createdAt: ticket.created_at,
     updatedAt: ticket.updated_at,
     remotePhotoUrl: ticket.remote_photo_url,

--- a/integrations/zendesk/src/definitions/schemas.ts
+++ b/integrations/zendesk/src/definitions/schemas.ts
@@ -70,7 +70,7 @@ export const userSchema = z.object({
   createdAt: z.string().title('Created At').describe('User creation date'),
   updatedAt: z.string().title('Updated At').describe('User last update date'),
   externalId: z.string().nullable().title('External ID').describe('External user ID'),
-  userFields: z.record(z.string()).optional().title('User Fields').describe('Custom user fields'),
+  userFields: z.record(z.string().nullable()).optional().title('User Fields').describe('Custom user fields'),
 })
 
 const _zdUserSchema = userSchema.transform((data) => ({


### PR DESCRIPTION
Resolves BE-1330

Zendesk custom user fields are nullable, but the type in our action's output is not. Allowing null values would've been breaking, so instead we filter out null values.