### PR TITLE
feat(monday): add OAuth install confirmation step

### DIFF
--- a/integrations/monday/integration.definition.ts
+++ b/integrations/monday/integration.definition.ts
@@ -5,7 +5,7 @@ export default new IntegrationDefinition({
   name: 'monday',
   title: 'Monday',
   description: 'Manage items in Monday boards.',
-  version: '1.1.3',
+  version: '1.1.5',
   readme: 'hub.md',
   icon: 'icon.svg',
   states: {

--- a/integrations/monday/integration.definition.ts
+++ b/integrations/monday/integration.definition.ts
@@ -6,7 +6,6 @@ export default new IntegrationDefinition({
   title: 'Monday',
   description: 'Manage items in Monday boards.',
   version: '1.1.5',
-
   readme: 'hub.md',
   icon: 'icon.svg',
   states: {

--- a/integrations/monday/src/oauth-wizard/wizard.ts
+++ b/integrations/monday/src/oauth-wizard/wizard.ts
@@ -69,6 +69,12 @@ const _confirmInstallHandler: WizardHandler = ({ responses }) => {
         navigateToStep: 'oauth-redirect',
         buttonType: 'primary',
       },
+      {
+        action: 'navigate',
+        label: 'Go back',
+        navigateToStep: 'start',
+        buttonType: 'secondary',
+      },
     ],
   })
 }

--- a/integrations/monday/src/oauth-wizard/wizard.ts
+++ b/integrations/monday/src/oauth-wizard/wizard.ts
@@ -69,7 +69,6 @@ const _confirmInstallHandler: WizardHandler = ({ responses }) => {
         navigateToStep: 'oauth-redirect',
         buttonType: 'primary',
       },
-
     ],
   })
 }

--- a/integrations/monday/src/oauth-wizard/wizard.ts
+++ b/integrations/monday/src/oauth-wizard/wizard.ts
@@ -34,9 +34,9 @@ const _startHandler: WizardHandler = ({ ctx, responses }) => {
   return responses.displayButtons({
     pageTitle: 'Connect Monday.com',
     htmlOrMarkdownPageContents:
-      `1. Open the <a href="${getMondayInstallUrl()}" target="_blank" rel="noopener noreferrer">Monday.com install page</a> and install the Botpress app in your workspace.\n` +
-      '2. Come back to this page after the installation is complete.\n' +
-      '3. Click **Next step** to start the OAuth connection.' +
+      '1. Click **Next step** to open the Monday.com install page in a new tab.\n' +
+      '2. Install the Botpress app in your Monday.com workspace.\n' +
+      '3. Return to this wizard and confirm the installation to start the OAuth connection.' +
       `
       <script>
         function installMondayAppAndContinue() {

--- a/integrations/monday/src/oauth-wizard/wizard.ts
+++ b/integrations/monday/src/oauth-wizard/wizard.ts
@@ -22,6 +22,7 @@ const getMondayInstallUrl = () => {
 export const handler = async (props: bp.HandlerProps) => {
   const wizard = new oauthWizard.OAuthWizardBuilder(props)
     .addStep({ id: 'start', handler: _startHandler })
+    .addStep({ id: 'confirm-install', handler: _confirmInstallHandler })
     .addStep({ id: 'oauth-redirect', handler: _oauthRedirectHandler })
     .addStep({ id: 'oauth-callback', handler: _oauthCallbackHandler })
     .build()
@@ -29,20 +30,46 @@ export const handler = async (props: bp.HandlerProps) => {
   return await wizard.handleRequest()
 }
 
-const _startHandler: WizardHandler = ({ responses }) => {
+const _startHandler: WizardHandler = ({ ctx, responses }) => {
   return responses.displayButtons({
     pageTitle: 'Connect Monday.com',
     htmlOrMarkdownPageContents:
       `1. Open the <a href="${getMondayInstallUrl()}" target="_blank" rel="noopener noreferrer">Monday.com install page</a> and install the Botpress app in your workspace.\n` +
       '2. Come back to this page after the installation is complete.\n' +
-      '3. Click **Next step** to start the OAuth connection.',
+      '3. Click **Next step** to start the OAuth connection.' +
+      `
+      <script>
+        function installMondayAppAndContinue() {
+          window.open(${JSON.stringify(getMondayInstallUrl())}, '_blank', 'noopener,noreferrer');
+          window.location.href = ${JSON.stringify(getWizardStepUrl('confirm-install', ctx).toString())};
+        }
+      </script>
+      `,
+    buttons: [
+      {
+        action: 'javascript',
+        label: 'Next step',
+        callFunction: 'installMondayAppAndContinue',
+        buttonType: 'primary',
+      },
+    ],
+  })
+}
+
+const _confirmInstallHandler: WizardHandler = ({ responses }) => {
+  return responses.displayButtons({
+    pageTitle: 'Confirm Monday.com installation',
+    htmlOrMarkdownPageContents:
+      'Have you installed the Botpress app in your Monday.com workspace?\n\n' +
+      'Start OAuth only after the Monday app is installed in your workspace.',
     buttons: [
       {
         action: 'navigate',
-        label: 'Next step',
+        label: 'Yes, continue',
         navigateToStep: 'oauth-redirect',
         buttonType: 'primary',
       },
+
     ],
   })
 }
@@ -125,7 +152,7 @@ const _exchangeCodeForTokens = async ({ code, redirectUri }: { code: string; red
   }
 }
 
-const getWizardStepUrl = (stepId: string) => oauthWizard.getWizardStepUrl(stepId)
+const getWizardStepUrl = (stepId: string, ctx?: { webhookId: string }) => oauthWizard.getWizardStepUrl(stepId, ctx)
 
 const getOAuthRedirectUri = () => getWizardStepUrl('oauth-callback')
 


### PR DESCRIPTION
Opening a new page prompts the user to install the app. After installing it, they return and click the OAuth button to log in with OAuth.