### PR TITLE
ci: check integration versions for vrl changes

### DIFF
--- a/.github/workflows/check-integration-versions.yml
+++ b/.github/workflows/check-integration-versions.yml
@@ -23,7 +23,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v46
         with:
-          files: 'integrations/**/*.{ts,md,svg}'
+          files: 'integrations/**/*.{ts,md,svg,vrl}'
           separator: '\n'
       - name: Check integration versions
         env:


### PR DESCRIPTION
Previously, updates to files like linkTemplate.vrl could bypass the version bump check, meaning CI would pass even though the integration deployment would later be skipped because the published version already existed. Including .vrl files ensures those changes require an integration version bump before merge.