### PR TITLE
fix(common): prevent createOrUpdateUser crash when no matching user exists

### DIFF
--- a/packages/common/src/entity-helpers/create-or-update-user.ts
+++ b/packages/common/src/entity-helpers/create-or-update-user.ts
@@ -29,7 +29,7 @@ export const createOrUpdateUser = async <
   }
 
   type UserTags = keyof TIntegration['user']['tags']
-  const updateTags: Partial<Record<UserTags, string | null>> = { ...matchingUsers[0]!.tags, ...props.tags }
+  const updateTags: Partial<Record<UserTags, string | null>> = { ...matchingUsers[0]?.tags, ...props.tags }
   return (
     matchingUsers.length === 1
       ? await props.client.updateUser({


### PR DESCRIPTION
Fixes: [ENG-3921](https://linear.app/botpress/issue/ENG-3921/common-createorupdateuser-crashes-with-typeerror-when-no-matching-user)