### PR TITLE
fix(common): prevent runtime type error when user gets created

### DIFF
--- a/integrations/zendesk/integration.definition.ts
+++ b/integrations/zendesk/integration.definition.ts
@@ -6,7 +6,7 @@ import { actions, events, configuration, channels, states, user } from './src/de
 export default new sdk.IntegrationDefinition({
   name: 'zendesk',
   title: 'Zendesk',
-  version: '3.1.3',
+  version: '3.1.4',
   icon: 'icon.svg',
   description:
     'Optimize your support workflow. Trigger workflows from ticket updates as well as manage tickets, access conversations, and engage with customers.',

--- a/packages/common/src/entity-helpers/create-or-update-user.ts
+++ b/packages/common/src/entity-helpers/create-or-update-user.ts
@@ -24,21 +24,23 @@ export const createOrUpdateUser = async <
 ): Promise<Awaited<ReturnType<Client['createUser']>>> => {
   const { users: matchingUsers } = await props.client.listUsers({ tags: _getFilteredTags(props) })
 
-  if (matchingUsers.length > 1) {
+  const [firstUser, ...otherUsers] = matchingUsers
+  if (otherUsers.length > 0) {
     throw new sdk.RuntimeError('Multiple users found with the same discriminating tags')
   }
 
   type UserTags = keyof TIntegration['user']['tags']
-  const updateTags: Partial<Record<UserTags, string | null>> = { ...matchingUsers[0]!.tags, ...props.tags }
-  return (
-    matchingUsers.length === 1
-      ? await props.client.updateUser({
-          ...matchingUsers[0]!,
-          ...props,
-          tags: updateTags as Cast<typeof updateTags, Record<string, string | null>>,
-        })
-      : await props.client.createUser(props)
-  ) as Awaited<ReturnType<Client['createUser']>>
+
+  if (firstUser) {
+    const updateTags: Partial<Record<UserTags, string | null>> = { ...firstUser.tags, ...props.tags }
+    return (await props.client.updateUser({
+      ...firstUser,
+      ...props,
+      tags: updateTags as Cast<typeof updateTags, Record<string, string | null>>,
+    })) as Awaited<ReturnType<Client['createUser']>>
+  }
+
+  return (await props.client.createUser(props)) as Awaited<ReturnType<Client['createUser']>>
 }
 
 const _getFilteredTags = <TAGS extends client.User['tags']>({


### PR DESCRIPTION
I introduced this bug here: https://github.com/botpress/botpress/pull/15170/changes

I think it's best if we get rid of the need for non-null assertions 