### PR TITLE
feat(cli): support --no-watch in bp dev

### DIFF
--- a/packages/cli/e2e/defaults.ts
+++ b/packages/cli/e2e/defaults.ts
@@ -2,6 +2,7 @@ const noBuild = false
 const dryRun = false
 const secrets = [] satisfies string[]
 const sourceMap = false
+const watch = true
 const verbose = false
 const confirm = true
 const json = false
@@ -18,6 +19,7 @@ export default {
   dryRun,
   secrets,
   sourceMap,
+  watch,
   verbose,
   confirm,
   json,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "6.8.5",
+  "version": "6.8.6",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/command-implementations/bundle-command.ts
+++ b/packages/cli/src/command-implementations/bundle-command.ts
@@ -42,18 +42,22 @@ export class BundleCommand extends ProjectCommand<BundleCommandDefinition> {
     props: Partial<utils.esbuild.BuildOptions> = {}
   ) {
     const abs = this.projectPaths.abs
-    const context = buildContext ?? new utils.esbuild.BuildCodeContext()
-    await context.rebuild(
-      {
-        outfile,
-        absWorkingDir: abs.workDir,
-        code: this._code,
-      },
-      {
-        ...this._buildOptions,
-        ...props,
-      }
-    )
+    const buildProps = {
+      outfile,
+      absWorkingDir: abs.workDir,
+      code: this._code,
+    }
+    const buildOptions = {
+      ...this._buildOptions,
+      ...props,
+    }
+
+    if (buildContext) {
+      await buildContext.rebuild(buildProps, buildOptions)
+      return
+    }
+
+    await utils.esbuild.buildCode(buildProps, buildOptions)
   }
 
   private get _code() {

--- a/packages/cli/src/command-implementations/dev-command.ts
+++ b/packages/cli/src/command-implementations/dev-command.ts
@@ -330,9 +330,16 @@ export class DevCommand extends ProjectCommand<DevCommandDefinition> {
   }
 
   private async _disposeBuildResources({ stopEsbuild = false } = {}) {
-    await Promise.all([this._buildContext.dispose(), this.projectContext.dispose()])
-    if (stopEsbuild) {
-      await utils.esbuild.stop()
+    // Best-effort teardown: this runs from the `finally` of `run()`, so it must never throw —
+    // a failure here would mask the original error being propagated by the dev server.
+    try {
+      await Promise.all([this._buildContext.dispose(), this.projectContext.dispose()])
+      if (stopEsbuild) {
+        await utils.esbuild.stop()
+      }
+    } catch (thrown: unknown) {
+      const err = errors.BotpressCLIError.map(thrown)
+      this.logger.debug(`Failed to dispose build resources: ${err.message}`)
     }
   }
 

--- a/packages/cli/src/command-implementations/dev-command.ts
+++ b/packages/cli/src/command-implementations/dev-command.ts
@@ -36,6 +36,7 @@ export class DevCommand extends ProjectCommand<DevCommandDefinition> {
   public async run(): Promise<void> {
     this.logger.warn('This command is experimental and subject to breaking changes without notice.')
 
+    const watchEnabled = this.argv.watch !== false
     let api = await this.ensureLoginAndCreateClient(this.argv)
 
     const { projectType, resolveProjectDefinition } = this.readProjectDefinitionFromFS()
@@ -156,7 +157,7 @@ export class DevCommand extends ProjectCommand<DevCommandDefinition> {
 
     await supervisor.start()
 
-    await this._runBuild()
+    await this._runBuild(watchEnabled)
     worker = await this._spawnWorker(env, port)
 
     try {
@@ -169,43 +170,49 @@ export class DevCommand extends ProjectCommand<DevCommandDefinition> {
     }
 
     try {
-      const watcher = await utils.filewatcher.FileWatcher.watch(
-        this.argv.workDir,
-        async (events) => {
-          if (!worker) {
-            this.logger.debug('Worker not ready yet, ignoring file change event')
-            return
+      let watcher: Awaited<ReturnType<typeof utils.filewatcher.FileWatcher.watch>> | undefined
+      if (!watchEnabled) {
+        await this._disposeBuildResources({ stopEsbuild: true })
+        await Promise.race([worker.wait(), supervisor.wait()])
+      } else {
+        watcher = await utils.filewatcher.FileWatcher.watch(
+          this.argv.workDir,
+          async (events) => {
+            if (!worker) {
+              this.logger.debug('Worker not ready yet, ignoring file change event')
+              return
+            }
+
+            const typescriptEvents = events
+              .filter((e) => !e.path.startsWith(this.projectPaths.abs.outDir))
+              .filter((e) => pathlib.extname(e.path) === '.ts')
+
+            const packageJsonEvents = events
+              .filter((e) => !e.path.startsWith(this.projectPaths.abs.outDir))
+              .filter((e) => pathlib.basename(e.path) === 'package.json')
+
+            const distEvents = events.filter((e) => e.path.startsWith(this.projectPaths.abs.distDir))
+
+            if (typescriptEvents.length > 0 || packageJsonEvents.length > 0) {
+              this.logger.log('Changes detected, rebuilding')
+              await this._restart(api, worker, httpTunnelUrl)
+            } else if (distEvents.length > 0) {
+              this.logger.log('Changes detected in output directory, reloading worker')
+              await worker.reload()
+            }
+          },
+          {
+            debounceMs: FILEWATCHER_DEBOUNCE_MS,
           }
+        )
 
-          const typescriptEvents = events
-            .filter((e) => !e.path.startsWith(this.projectPaths.abs.outDir))
-            .filter((e) => pathlib.extname(e.path) === '.ts')
-
-          const packageJsonEvents = events
-            .filter((e) => !e.path.startsWith(this.projectPaths.abs.outDir))
-            .filter((e) => pathlib.basename(e.path) === 'package.json')
-
-          const distEvents = events.filter((e) => e.path.startsWith(this.projectPaths.abs.distDir))
-
-          if (typescriptEvents.length > 0 || packageJsonEvents.length > 0) {
-            this.logger.log('Changes detected, rebuilding')
-            await this._restart(api, worker, httpTunnelUrl)
-          } else if (distEvents.length > 0) {
-            this.logger.log('Changes detected in output directory, reloading worker')
-            await worker.reload()
-          }
-        },
-        {
-          debounceMs: FILEWATCHER_DEBOUNCE_MS,
-        }
-      )
-
-      await Promise.race([worker.wait(), watcher.wait(), supervisor.wait()])
+        await Promise.race([worker.wait(), watcher.wait(), supervisor.wait()])
+      }
 
       if (worker.running) {
         await worker.kill()
       }
-      await watcher.close()
+      await watcher?.close()
       supervisor.close()
     } catch (thrown) {
       throw errors.BotpressCLIError.wrap(thrown, 'An error occurred while running the dev server')
@@ -213,6 +220,7 @@ export class DevCommand extends ProjectCommand<DevCommandDefinition> {
       if (worker.running) {
         await worker.kill()
       }
+      await this._disposeBuildResources()
     }
   }
 
@@ -315,10 +323,17 @@ export class DevCommand extends ProjectCommand<DevCommandDefinition> {
     return worker
   }
 
-  private _runBuild() {
+  private _runBuild(watchEnabled = true) {
     return new BuildCommand(this.api, this.prompt, this.logger, this.argv)
       .setProjectContext(this.projectContext)
-      .run(this._buildContext)
+      .run(watchEnabled ? this._buildContext : undefined)
+  }
+
+  private async _disposeBuildResources({ stopEsbuild = false } = {}) {
+    await Promise.all([this._buildContext.dispose(), this.projectContext.dispose()])
+    if (stopEsbuild) {
+      await utils.esbuild.stop()
+    }
   }
 
   private async _deployDevIntegration(

--- a/packages/cli/src/command-implementations/project-command.ts
+++ b/packages/cli/src/command-implementations/project-command.ts
@@ -97,8 +97,13 @@ export class ProjectDefinitionContext {
   }
 
   public async dispose() {
+    // Drop the resolved-definition cache up front so a failed esbuild teardown can't leave stale state behind.
     this._codeCache.clear()
-    await this._buildContext.dispose()
+    try {
+      await this._buildContext.dispose()
+    } catch (thrown: unknown) {
+      throw errors.BotpressCLIError.map(thrown)
+    }
   }
 }
 

--- a/packages/cli/src/command-implementations/project-command.ts
+++ b/packages/cli/src/command-implementations/project-command.ts
@@ -95,6 +95,11 @@ export class ProjectDefinitionContext {
   public rebuildEntrypoint(...args: Parameters<utils.esbuild.BuildEntrypointContext['rebuild']>) {
     return this._buildContext.rebuild(...args)
   }
+
+  public async dispose() {
+    this._codeCache.clear()
+    await this._buildContext.dispose()
+  }
 }
 
 type ResolvedDependency = { id: string }

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import yargs, { cleanupConfig } from '@bpinternal/yargs-extra'
+import { schemas } from './config'
+
+const watchSchema = { watch: schemas.dev.watch }
+
+const parseWatch = (args: string[]) => {
+  const argv = yargs(args).option('watch', schemas.dev.watch).parseSync()
+  return cleanupConfig(watchSchema, argv)
+}
+
+describe('config schemas', () => {
+  it('enables dev file watching by default', () => {
+    expect(parseWatch([])).toEqual({ watch: true })
+  })
+
+  it('parses --no-watch as disabled dev file watching', () => {
+    expect(parseWatch(['--no-watch'])).toEqual({ watch: false })
+  })
+})

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -102,6 +102,12 @@ const dev = {
   default: false,
 } satisfies CommandOption
 
+const watch = {
+  type: 'boolean',
+  description: 'Watch project files and hot reload on changes',
+  default: true,
+} satisfies CommandOption
+
 // base schemas
 
 const globalSchema = {
@@ -220,6 +226,7 @@ const devSchema = {
   ...secretsSchema,
   sourceMap,
   minify,
+  watch,
   port,
   tunnelUrl: {
     type: 'string',

--- a/packages/cli/src/utils/esbuild-utils.test.ts
+++ b/packages/cli/src/utils/esbuild-utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+import { BuildContext } from './esbuild-utils'
+
+class TestBuildContext extends BuildContext<{ value: string }> {
+  public contexts: Array<{
+    dispose: ReturnType<typeof vi.fn>
+    rebuild: ReturnType<typeof vi.fn>
+  }> = []
+
+  protected async _createContext() {
+    const context = {
+      dispose: vi.fn().mockResolvedValue(undefined),
+      rebuild: vi.fn().mockResolvedValue({ errors: [], warnings: [] }),
+    }
+    this.contexts.push(context)
+    return context as never
+  }
+}
+
+describe('BuildContext', () => {
+  it('recreates the underlying esbuild context after disposal', async () => {
+    const context = new TestBuildContext()
+
+    await context.rebuild({ value: 'first' })
+    await context.rebuild({ value: 'first' })
+
+    expect(context.contexts).toHaveLength(1)
+
+    await context.dispose()
+
+    expect(context.contexts[0]?.dispose).toHaveBeenCalledTimes(1)
+
+    await context.rebuild({ value: 'first' })
+
+    expect(context.contexts).toHaveLength(2)
+  })
+})

--- a/packages/cli/src/utils/esbuild-utils.ts
+++ b/packages/cli/src/utils/esbuild-utils.ts
@@ -52,10 +52,17 @@ export abstract class BuildContext<T> {
       return
     }
 
-    await this._context.dispose()
-    this._context = undefined
-    this._previousProps = undefined
-    this._previousOpts = {}
+    // Clear our handle in `finally` so a failed teardown can't leave a stale context behind
+    // that a later dispose would try to tear down a second time.
+    try {
+      await this._context.dispose()
+    } catch (thrown: unknown) {
+      throw thrown instanceof Error ? thrown : new Error(String(thrown))
+    } finally {
+      this._context = undefined
+      this._previousProps = undefined
+      this._previousOpts = {}
+    }
   }
 }
 

--- a/packages/cli/src/utils/esbuild-utils.ts
+++ b/packages/cli/src/utils/esbuild-utils.ts
@@ -46,6 +46,17 @@ export abstract class BuildContext<T> {
     }
     return await this._context?.rebuild()
   }
+
+  public async dispose() {
+    if (!this._context) {
+      return
+    }
+
+    await this._context.dispose()
+    this._context = undefined
+    this._previousProps = undefined
+    this._previousOpts = {}
+  }
 }
 
 export class BuildCodeContext extends BuildContext<BuildCodeProps> {


### PR DESCRIPTION
## What

Adds a `--watch` flag to `bp dev` (default `true`, so nothing changes for normal use). Lets headless/agent-driven runs opt out of hot-reload with `--no-watch`.

When `--no-watch` is passed, it:
- bundles once with a one-shot esbuild `build()` instead of keeping a warm incremental `context()`,
- skips the file watcher, and
- stops the esbuild service after deploy.

## Why
The goal is to run the ADK's Agent(0) benchmark autonomously in CI/Docker, where hot-reload buys nothing as the agent writes files and is graded over HTTP (and the produced bot is graded separately), so the dev bot never needs to live-reflect edits mid-run. But hot-reload isn't free in that setting: `bp dev` runs in a memory-constrained container where the warm esbuild context sits resident at ~1.5 GB for the whole session, and the output watcher reloads the dev bot mid-run (dropping the connection → `driver_error`). `--no-watch` drops that esbuild footprint and removes the mid-run reloads, so autonomous benchmark runs are lighter and stable. This enables more parallel tests to be run as each requires less resources.

**Paired with the ADK side (botpress/agent-lack#651)**, which skips its own watcher and passes `--no-watch` down to `bp dev`. This PR is a no-op until that flag is passed, so they should land together.

## Testing
`pnpm test` (incl. new tests for `--no-watch` parsing and `BuildContext.dispose()`), `pnpm run check:type` clean, and `bp dev --help` shows the flag.

I also did a test with this updated Botpress CLI on the benchmark, and saved around 1.3 GB. 