### PR TITLE
fix(linear): support OAuth fallback without webhooks

### DIFF
--- a/integrations/linear/definitions/states.ts
+++ b/integrations/linear/definitions/states.ts
@@ -31,6 +31,11 @@ export const states = {
         .optional()
         .title('Wizard Phase')
         .describe('Which leg of the two-phase OAuth wizard is currently expected on /oauth callback'),
+      runtimeActor: z
+        .enum(['user', 'app'])
+        .optional()
+        .title('Runtime Actor')
+        .describe('Which Linear OAuth actor type was used for the runtime credentials'),
     }),
   },
 

--- a/integrations/linear/integration.definition.ts
+++ b/integrations/linear/integration.definition.ts
@@ -9,7 +9,7 @@ import listable from './bp_modules/listable'
 import { actions, channels, events, configuration, configurations, user, states, entities } from './definitions'
 
 export const INTEGRATION_NAME = 'linear'
-export const INTEGRATION_VERSION = '2.6.2'
+export const INTEGRATION_VERSION = '2.6.0'
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/linear/integration.definition.ts
+++ b/integrations/linear/integration.definition.ts
@@ -9,7 +9,7 @@ import listable from './bp_modules/listable'
 import { actions, channels, events, configuration, configurations, user, states, entities } from './definitions'
 
 export const INTEGRATION_NAME = 'linear'
-export const INTEGRATION_VERSION = '2.5.2'
+export const INTEGRATION_VERSION = '2.6.2'
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -243,8 +243,7 @@ export class LinearOauthClient {
     })
     const useDesk = useDeskOAuth(environment)
     const linearOauthClient = new LinearOauthClient(useDesk)
-    const actor: Actor =
-      effectiveStateName === 'adminCredentials' ? 'user' : (environment.runtimeActor ?? 'app')
+    const actor: Actor = effectiveStateName === 'adminCredentials' ? 'user' : (environment.runtimeActor ?? 'app')
     const credentials = await linearOauthClient.resolveValidCredentials(effectivePayload, actor)
 
     if (credentials.accessToken !== effectivePayload.accessToken) {

--- a/integrations/linear/src/misc/linear.ts
+++ b/integrations/linear/src/misc/linear.ts
@@ -243,7 +243,8 @@ export class LinearOauthClient {
     })
     const useDesk = useDeskOAuth(environment)
     const linearOauthClient = new LinearOauthClient(useDesk)
-    const actor: Actor = effectiveStateName === 'adminCredentials' ? 'user' : 'app'
+    const actor: Actor =
+      effectiveStateName === 'adminCredentials' ? 'user' : (environment.runtimeActor ?? 'app')
     const credentials = await linearOauthClient.resolveValidCredentials(effectivePayload, actor)
 
     if (credentials.accessToken !== effectivePayload.accessToken) {
@@ -319,8 +320,8 @@ export const registerWebhook = async ({
   logger.forBot().info('Linear webhook registered successfully.')
 }
 
-export const revokeToken = async (token: string) => {
-  const form = new URLSearchParams({ token, token_type_hint: 'access_token' })
+export const revokeToken = async (token: string, tokenTypeHint: 'access_token' | 'refresh_token' = 'access_token') => {
+  const form = new URLSearchParams({ token, token_type_hint: tokenTypeHint })
   try {
     await axios.post(`${linearEndpoint}/oauth/revoke`, form.toString(), { headers: oauthHeaders })
   } catch (err: unknown) {

--- a/integrations/linear/src/oauth-wizard.ts
+++ b/integrations/linear/src/oauth-wizard.ts
@@ -125,10 +125,10 @@ const _oauthCallbackStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async
       return responses.displayButtons({
         pageTitle: 'Linear app authorization failed',
         htmlOrMarkdownPageContents:
-          'Linear did not authorize the app actor. You can still install this integration with the user actor, but Linear actions will be attributed to the authorizing user and some admin-only operations may be unavailable.',
+          'You can continue without automatic webhooks. Botpress will still be able to call Linear using your account, but Linear events will not be sent back to Botpress unless webhooks are configured by a workspace admin.',
         buttons: [
           {
-            label: 'Install with user actor',
+            label: 'Install without webhooks',
             buttonType: 'primary',
             action: 'navigate',
             navigateToStep: USER_ACTOR_FALLBACK_STEP,

--- a/integrations/linear/src/oauth-wizard.ts
+++ b/integrations/linear/src/oauth-wizard.ts
@@ -7,7 +7,8 @@ import * as bp from '.botpress'
 
 const REDIRECT_URI = `${process.env.BP_WEBHOOK_URL}/oauth`
 const APP_SCOPES = 'read,write,issues:create,comments:create'
-const ADMIN_SCOPES = 'read,write,admin'
+const ADMIN_SCOPES = 'read,write,admin,issues:create,comments:create'
+const USER_ACTOR_FALLBACK_STEP = 'use-user-actor'
 
 const _buildAuthorizeUrl = ({
   clientId,
@@ -28,6 +29,54 @@ const _buildAuthorizeUrl = ({
   `&actor=${actor}` +
   `&state=${state}` +
   `&scope=${scopes}`
+
+const _saveUserActorRuntimeCredentials = async ({
+  ctx,
+  client,
+  responses,
+  setIntegrationIdentifier,
+}: Pick<bp.HandlerProps, 'ctx' | 'client'> &
+  Pick<oauthWizard.WizardStepInputProps, 'responses' | 'setIntegrationIdentifier'>) => {
+  const {
+    state: { payload: environment },
+  } = await client.getState({
+    type: 'integration',
+    name: 'environment',
+    id: ctx.integrationId,
+  })
+  const {
+    state: { payload: adminCredentials },
+  } = await client.getState({
+    type: 'integration',
+    name: 'adminCredentials',
+    id: ctx.integrationId,
+  })
+
+  if (!adminCredentials.accessToken) {
+    return responses.endWizard({
+      success: false,
+      errorMessage: 'Cannot install with user actor because user OAuth credentials are missing.',
+    })
+  }
+
+  const linearClient = new LinearClient({ accessToken: adminCredentials.accessToken })
+  await client.setState({
+    type: 'integration',
+    name: 'credentials',
+    id: ctx.integrationId,
+    payload: adminCredentials,
+  })
+  await client.setState({
+    type: 'integration',
+    name: 'environment',
+    id: ctx.integrationId,
+    payload: { ...environment, runtimeActor: 'user' },
+  })
+
+  const organization = await linearClient.organization
+  setIntegrationIdentifier(organization.id)
+  return responses.endWizard({ success: true })
+}
 
 const _startStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async ({ ctx, client, query, responses }) => {
   const searchParams = new URLSearchParams(query)
@@ -60,9 +109,38 @@ const _oauthCallbackStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async
   responses,
   setIntegrationIdentifier,
 }) => {
+  const {
+    state: { payload: environment },
+  } = await client.getState({
+    type: 'integration',
+    name: 'environment',
+    id: ctx.integrationId,
+  })
+
   const error = query.get('error')
   if (error) {
     const description = query.get('error_description') ?? ''
+    if (environment.wizardPhase === 'app') {
+      logger.forBot().warn(`Linear app-actor OAuth failed (${error}: ${description}). Asking for user-actor fallback.`)
+      return responses.displayButtons({
+        pageTitle: 'Linear app authorization failed',
+        htmlOrMarkdownPageContents:
+          'Linear did not authorize the app actor. You can still install this integration with the user actor, but Linear actions will be attributed to the authorizing user and some admin-only operations may be unavailable.',
+        buttons: [
+          {
+            label: 'Install with user actor',
+            buttonType: 'primary',
+            action: 'navigate',
+            navigateToStep: USER_ACTOR_FALLBACK_STEP,
+          },
+          {
+            label: 'Cancel',
+            buttonType: 'secondary',
+            action: 'close',
+          },
+        ],
+      })
+    }
     return responses.endWizard({ success: false, errorMessage: `OAuth error: ${error} - ${description}` })
   }
 
@@ -71,13 +149,6 @@ const _oauthCallbackStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async
     return responses.endWizard({ success: false, errorMessage: 'Authorization code not present in OAuth callback' })
   }
 
-  const {
-    state: { payload: environment },
-  } = await client.getState({
-    type: 'integration',
-    name: 'environment',
-    id: ctx.integrationId,
-  })
   const useDesk = useDeskOAuth(environment)
   const linearOauthClient = new LinearOauthClient(useDesk)
   const tokenActor = environment.wizardPhase === 'app' ? 'app' : 'user'
@@ -90,6 +161,12 @@ const _oauthCallbackStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async
       name: 'credentials',
       id: ctx.integrationId,
       payload: credentials,
+    })
+    await client.setState({
+      type: 'integration',
+      name: 'environment',
+      id: ctx.integrationId,
+      payload: { ...environment, runtimeActor: 'app' },
     })
 
     const linearClient = new LinearClient({ accessToken: credentials.accessToken })
@@ -133,8 +210,22 @@ const _oauthCallbackStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async
   )
 }
 
+const _useUserActorStep: oauthWizard.WizardStepHandler<bp.HandlerProps> = async ({
+  ctx,
+  client,
+  responses,
+  setIntegrationIdentifier,
+}) =>
+  _saveUserActorRuntimeCredentials({
+    ctx,
+    client,
+    responses,
+    setIntegrationIdentifier,
+  })
+
 export const buildOAuthWizard = (props: bp.HandlerProps) =>
   new oauthWizard.OAuthWizardBuilder(props)
     .addStep({ id: 'start', handler: _startStep })
     .addStep({ id: 'oauth-callback', handler: _oauthCallbackStep })
+    .addStep({ id: USER_ACTOR_FALLBACK_STEP, handler: _useUserActorStep })
     .build()

--- a/integrations/linear/src/setup.ts
+++ b/integrations/linear/src/setup.ts
@@ -31,6 +31,16 @@ export const register: bp.IntegrationProps['register'] = async ({ client, ctx, l
   logger.forBot().info('Registering Linear integration.')
 
   if (!manuallyRegistered) {
+    const {
+      state: { payload: environment },
+    } = await client.getState({ type: 'integration', name: 'environment', id: ctx.integrationId })
+
+    if (environment.runtimeActor === 'user') {
+      logger.forBot().info('Skipping automatic Linear webhook registration: integration is using user-actor OAuth.')
+      logger.forBot().info(`Linear integration registered successfully (integrationId="${ctx.integrationId}").`)
+      return
+    }
+
     const linearClient = await LinearOauthClient.createAdmin({ client, ctx })
     const webhookUrl = `${process.env.BP_WEBHOOK_URL}/${ctx.webhookId}`
     logger.forBot().info('Registering Linear webhook')
@@ -69,7 +79,9 @@ export const unregister: bp.IntegrationProps['unregister'] = async ({ client, ct
       client.getState({ type: 'integration', name: 'adminCredentials', id: ctx.integrationId }),
     ])
     await _revokeCredentials(appState.payload)
-    await _revokeCredentials(adminState.payload)
+    if (adminState.payload.accessToken !== appState.payload.accessToken) {
+      await _revokeCredentials(adminState.payload)
+    }
     logger.forBot().info('Linear integration unregistration completed.')
   } catch (thrown) {
     const errorMessage = thrown instanceof Error ? thrown.message : String(thrown)

--- a/integrations/linear/src/setup.ts
+++ b/integrations/linear/src/setup.ts
@@ -5,6 +5,27 @@ import * as bp from '.botpress'
 const _isWebhookManuallyRegistered = (ctx: bp.HandlerProps['ctx']) =>
   ctx.configurationType === 'apiKey' && ctx.configuration.webhookSigningSecret
 
+const _revokeCredentials = async (credentials: { accessToken?: string; refreshToken?: string }) => {
+  if (credentials.accessToken) {
+    await revokeToken(credentials.accessToken, 'access_token')
+  }
+  if (credentials.refreshToken) {
+    await revokeToken(credentials.refreshToken, 'refresh_token')
+  }
+}
+
+const _getWebhookRegistrationErrorMessage = (errorMessage: string) => {
+  if (errorMessage.includes('Invalid role: admin required')) {
+    return (
+      'You must be an admin on the Linear workspace to automatically register webhooks. ' +
+      'You may still use the integration without webhooks, but some functionality will be limited or unavailable. ' +
+      'In order to fully configure the integration, please connect to a Linear account on which you are an admin.'
+    )
+  }
+
+  return `Failed to register webhook: ${errorMessage}`
+}
+
 export const register: bp.IntegrationProps['register'] = async ({ client, ctx, logger }) => {
   const manuallyRegistered = _isWebhookManuallyRegistered(ctx)
   logger.forBot().info('Registering Linear integration.')
@@ -18,7 +39,7 @@ export const register: bp.IntegrationProps['register'] = async ({ client, ctx, l
       logger.forBot().info('Linear webhook registered')
     } catch (thrown) {
       const errorMessage = thrown instanceof Error ? thrown.message : String(thrown)
-      throw new RuntimeError(`Failed to register webhook: ${errorMessage}`)
+      throw new RuntimeError(_getWebhookRegistrationErrorMessage(errorMessage))
     }
   } else {
     logger
@@ -47,12 +68,8 @@ export const unregister: bp.IntegrationProps['unregister'] = async ({ client, ct
       client.getState({ type: 'integration', name: 'credentials', id: ctx.integrationId }),
       client.getState({ type: 'integration', name: 'adminCredentials', id: ctx.integrationId }),
     ])
-    if (appState.payload.accessToken) {
-      await revokeToken(appState.payload.accessToken)
-    }
-    if (adminState.payload.accessToken) {
-      await revokeToken(adminState.payload.accessToken)
-    }
+    await _revokeCredentials(appState.payload)
+    await _revokeCredentials(adminState.payload)
     logger.forBot().info('Linear integration unregistration completed.')
   } catch (thrown) {
     const errorMessage = thrown instanceof Error ? thrown.message : String(thrown)

--- a/integrations/linear/src/setup.ts
+++ b/integrations/linear/src/setup.ts
@@ -2,6 +2,12 @@ import { RuntimeError } from '@botpress/client'
 import { LinearOauthClient, registerWebhook, revokeToken, unregisterWebhook } from './misc/linear'
 import * as bp from '.botpress'
 
+const INSUFFICIENT_LINEAR_ROLE_ERROR = 'Invalid role: admin required'
+const WEBHOOK_REGISTRATION_ADMIN_REQUIRED_MESSAGE =
+  'You must be an admin on the Linear workspace to automatically register webhooks. ' +
+  'You may still use the integration without webhooks, but some functionality will be limited or unavailable. ' +
+  'In order to fully configure the integration, please connect to a Linear account on which you are an admin.'
+
 const _isWebhookManuallyRegistered = (ctx: bp.HandlerProps['ctx']) =>
   ctx.configurationType === 'apiKey' && ctx.configuration.webhookSigningSecret
 
@@ -15,15 +21,32 @@ const _revokeCredentials = async (credentials: { accessToken?: string; refreshTo
 }
 
 const _getWebhookRegistrationErrorMessage = (errorMessage: string) => {
-  if (errorMessage.includes('Invalid role: admin required')) {
-    return (
-      'You must be an admin on the Linear workspace to automatically register webhooks. ' +
-      'You may still use the integration without webhooks, but some functionality will be limited or unavailable. ' +
-      'In order to fully configure the integration, please connect to a Linear account on which you are an admin.'
-    )
+  if (errorMessage.includes(INSUFFICIENT_LINEAR_ROLE_ERROR)) {
+    return WEBHOOK_REGISTRATION_ADMIN_REQUIRED_MESSAGE
   }
 
   return `Failed to register webhook: ${errorMessage}`
+}
+
+const _reportWebhookRegistrationIssue = (logger: bp.HandlerProps['logger'], errorMessage: string) => {
+  if (!errorMessage.includes(INSUFFICIENT_LINEAR_ROLE_ERROR)) {
+    return
+  }
+
+  logger.issue({
+    type: 'issue',
+    title: 'Linear webhook registration requires an admin',
+    description: WEBHOOK_REGISTRATION_ADMIN_REQUIRED_MESSAGE,
+    category: 'configuration',
+    groupBy: ['linear_webhook_admin_required'],
+    code: 'linear_webhook_admin_required',
+    data: {
+      details: {
+        raw: INSUFFICIENT_LINEAR_ROLE_ERROR,
+        pretty: WEBHOOK_REGISTRATION_ADMIN_REQUIRED_MESSAGE,
+      },
+    },
+  })
 }
 
 export const register: bp.IntegrationProps['register'] = async ({ client, ctx, logger }) => {
@@ -49,6 +72,7 @@ export const register: bp.IntegrationProps['register'] = async ({ client, ctx, l
       logger.forBot().info('Linear webhook registered')
     } catch (thrown) {
       const errorMessage = thrown instanceof Error ? thrown.message : String(thrown)
+      _reportWebhookRegistrationIssue(logger, errorMessage)
       throw new RuntimeError(_getWebhookRegistrationErrorMessage(errorMessage))
     }
   } else {


### PR DESCRIPTION
Fixes Linear OAuth setup when app-actor authorization fails, such as when the Botpress Linear app is already installed in the workspace.

The flow now lets users continue with a webhookless install using the user actor, while clearly explaining that Linear events will not be sent back to Botpress unless webhooks are configured by a workspace admin.

Also tracks the runtime OAuth actor for correct token refresh, improves the non-admin webhook registration error message, and revokes refresh tokens during unregister cleanup.