### PR TITLE
feat(zai): allow blank lines in multi-line edit

### DIFF
--- a/packages/zai/e2e/micropatch.test.ts
+++ b/packages/zai/e2e/micropatch.test.ts
@@ -422,13 +422,27 @@ line2
       const source = 'line1\nline2\nline3\n'
       const ops = '\n\n◼︎=2|REPLACED\n\n'
       const result = Micropatch.applyText(source, ops)
-      console.log(result)
       expect(result).toMatchInlineSnapshot(`
 "line1
 REPLACED
 
 
 line3
+"
+`)
+    })
+
+    test('two subsequent replace ops', () => {
+      const source = 'line1\nline2\nline3\nline4\nline5\n'
+      const ops = '◼︎=2|REPLACED\n\n◼︎=5|REPLACED2'
+      const result = Micropatch.applyText(source, ops)
+      expect(result).toMatchInlineSnapshot(`
+"line1
+REPLACED
+
+line3
+line4
+REPLACED2
 "
 `)
     })

--- a/packages/zai/e2e/micropatch.test.ts
+++ b/packages/zai/e2e/micropatch.test.ts
@@ -422,9 +422,12 @@ line2
       const source = 'line1\nline2\nline3\n'
       const ops = '\n\n◼︎=2|REPLACED\n\n'
       const result = Micropatch.applyText(source, ops)
+      console.log(result)
       expect(result).toMatchInlineSnapshot(`
 "line1
 REPLACED
+
+
 line3
 "
 `)

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "2.6.24",
+  "version": "2.6.25",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "2.6.25",
+  "version": "2.7.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/zai/src/micropatch.ts
+++ b/packages/zai/src/micropatch.ts
@@ -194,7 +194,8 @@ export class Micropatch {
         let j = i + 1
         while (j < lines.length) {
           const nextLine = lines[j]
-          if (!nextLine || nextLine.startsWith('◼︎')) break
+          // check if the nextLine really doesn't exixt or is just empty (!"" == true)
+          if ((!nextLine && nextLine != "") || nextLine.startsWith('◼︎')) break
           payload.push(Micropatch._unescapeMarker(nextLine))
           j++
         }

--- a/packages/zai/src/micropatch.ts
+++ b/packages/zai/src/micropatch.ts
@@ -194,8 +194,7 @@ export class Micropatch {
         let j = i + 1
         while (j < lines.length) {
           const nextLine = lines[j]
-          // check if the nextLine really doesn't exixt or is just empty (!"" == true)
-          if ((!nextLine && nextLine != "") || nextLine.startsWith('◼︎')) break
+          if (nextLine.startsWith('◼︎')) break
           payload.push(Micropatch._unescapeMarker(nextLine))
           j++
         }


### PR DESCRIPTION
When using the zai patch feature, a multi-line edit doesn't allow empty lines. This is a problem when a bot wants to edit Markdown, for example, because it needs to be able to enter empty lines. This one-line change allows empty newlines.

The `micropatch.test.ts` test `handles blank lines in ops` is also updated to conform with this change.