### PR TITLE
fix(sdk): make IntegrationDefinition.extend() pure so cloned definitions keep interfaces

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.5",
     "@botpress/client": "1.46.0",
-    "@botpress/sdk": "6.12.0",
+    "@botpress/sdk": "6.12.1",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/verel": "^0.2.0",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.46.0",
-    "@botpress/sdk": "6.12.0"
+    "@botpress/sdk": "6.12.1"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.46.0",
-    "@botpress/sdk": "6.12.0"
+    "@botpress/sdk": "6.12.1"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "6.12.0"
+    "@botpress/sdk": "6.12.1"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.46.0",
-    "@botpress/sdk": "6.12.0"
+    "@botpress/sdk": "6.12.1"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.46.0",
-    "@botpress/sdk": "6.12.0",
+    "@botpress/sdk": "6.12.1",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "6.12.0",
+  "version": "6.12.1",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/integration/definition/definition.test.ts
+++ b/packages/sdk/src/integration/definition/definition.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from 'vitest'
 import { IntegrationDefinition } from '.'
 import { InterfaceDefinition } from '../../interface'
 import { InterfacePackage } from '../../package'
+import { z } from '../../zui'
 
 test('integration with channel extending an interface with same channel merges channel tags', () => {
   // arrange
@@ -59,4 +60,53 @@ test('integration with channel extending an interface with same channel merges c
     message: { tags: { foo: {}, bar: {} } },
   }
   expect(actual).toEqual(expected)
+})
+
+test('extend produces a definition whose props reflect the extension, so it can be reconstructed from props', () => {
+  // arrange
+  const intrface = new InterfaceDefinition({
+    name: 'files-readonly',
+    version: '0.0.0',
+    actions: {
+      listItemsInFolder: {
+        input: { schema: () => z.object({ folderId: z.string() }) },
+        output: { schema: () => z.object({ items: z.array(z.string()) }) },
+      },
+    },
+  })
+
+  const intrfacePackage = {
+    type: 'interface',
+    id: 'some-interface-id',
+    name: 'files-readonly',
+    version: '0.0.0',
+    definition: intrface,
+  } satisfies InterfacePackage
+
+  // act
+  const integration = new IntegrationDefinition({
+    name: 'github',
+    version: '0.0.0',
+    actions: {
+      findTarget: {
+        input: { schema: z.object({ query: z.string() }) },
+        output: { schema: z.object({ id: z.string() }) },
+      },
+    },
+  }).extend(intrfacePackage, () => ({ entities: {} }))
+
+  // assert — the instance carries the extension
+  expect(Object.keys(integration.interfaces ?? {})).toContain('files-readonly')
+  expect(Object.keys(integration.actions ?? {})).toEqual(expect.arrayContaining(['findTarget', 'listItemsInFolder']))
+
+  // assert — props reflect the extension (the instance is built from these props, so they stay consistent)
+  expect(integration.props.interfaces).toBe(integration.interfaces)
+  expect(integration.props.actions).toBe(integration.actions)
+  expect(integration.props.events).toBe(integration.events)
+  expect(integration.props.channels).toBe(integration.channels)
+
+  // assert — reconstructing from props keeps the extension
+  const cloned = new IntegrationDefinition({ ...integration.props, name: 'some-handle/github' })
+  expect(Object.keys(cloned.interfaces ?? {})).toContain('files-readonly')
+  expect(Object.keys(cloned.actions ?? {})).toEqual(expect.arrayContaining(['findTarget', 'listItemsInFolder']))
 })

--- a/packages/sdk/src/integration/definition/index.ts
+++ b/packages/sdk/src/integration/definition/index.ts
@@ -259,9 +259,6 @@ export class IntegrationDefinition<
   ): this {
     const { entities, actions, events, channels } = this._callBuilder(interfacePkg, builder)
 
-    const self = this as utils.types.Writable<IntegrationDefinition>
-    self.interfaces ??= {}
-
     const entityNames = Object.values(entities).map((e) => e.name)
 
     const key = entityNames.length === 0 ? interfacePkg.name : `${interfacePkg.name}<${entityNames.join(',')}>`
@@ -279,16 +276,22 @@ export class IntegrationDefinition<
      * This allows setting more specific properties in the integration, while staying compatible with the interface.
      * Same goes for channels and events.
      */
-    self.actions = utils.records.mergeRecords(self.actions ?? {}, resolved.actions, this._mergeActions)
-    self.channels = utils.records.mergeRecords(self.channels ?? {}, resolved.channels, this._mergeChannels)
-    self.events = utils.records.mergeRecords(self.events ?? {}, resolved.events, this._mergeEvents)
+    const base = this as IntegrationDefinition
+    const extended: IntegrationDefinition = new IntegrationDefinition({
+      ...base.props,
+      actions: utils.records.mergeRecords(base.actions ?? {}, resolved.actions, this._mergeActions),
+      channels: utils.records.mergeRecords(base.channels ?? {}, resolved.channels, this._mergeChannels),
+      events: utils.records.mergeRecords(base.events ?? {}, resolved.events, this._mergeEvents),
+      interfaces: {
+        ...base.interfaces,
+        [key]: {
+          id: interfacePkg.id,
+          ...statement,
+        },
+      },
+    })
 
-    self.interfaces[key] = {
-      id: interfacePkg.id,
-      ...statement,
-    }
-
-    return this
+    return extended as this
   }
 
   private _callBuilder<P extends InterfacePackage>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2828,7 +2828,7 @@ importers:
         specifier: 1.46.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 6.12.0
+        specifier: 6.12.1
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2952,7 +2952,7 @@ importers:
         specifier: 1.46.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.12.0
+        specifier: 6.12.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2968,7 +2968,7 @@ importers:
         specifier: 1.46.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.12.0
+        specifier: 6.12.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2981,7 +2981,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 6.12.0
+        specifier: 6.12.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2997,7 +2997,7 @@ importers:
         specifier: 1.46.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.12.0
+        specifier: 6.12.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -3013,7 +3013,7 @@ importers:
         specifier: 1.46.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.12.0
+        specifier: 6.12.1
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
## What

Make `IntegrationDefinition.extend()` pure: it now returns a **new** definition built from `props` instead of mutating `this`.

## Why

`extend()` mutated only the instance fields (`actions`/`events`/`channels`/`interfaces`) and left `this.props` stale. The CLI's `_cloneDefinition` reconstructs an integration **from `props`** when it has to prepend a workspace handle on deploy (`github` → `handle/github`). Because `props` was stale, the cloned, deployed integration silently dropped **every extended interface and the actions/events/channels those interfaces contributed** — no error, no warning.

It only surfaced on deploys to non-Botpress workspaces: Botpress-workspace deploys omit the handle and skip the clone, which masked the bug. So a fork deployed to a user workspace would lose its interfaces while first-party deploys looked fine.

## How

`extend()` builds `new IntegrationDefinition({ ...props, <merged actions/events/channels>, interfaces: { ...interfaces, [key]: … } })` and returns it. `props` and the instance fields (which the constructor derives from `props`) are now consistent by construction, so any reconstruction-from-props preserves extensions. The `Writable<IntegrationDefinition>` cast and all instance mutation are gone.

No public API change: the signature stays `extend(...): this`. Audited every `.extend()` call site across the repo — all consume the return value (chained `new IntegrationDefinition({...}).extend(...)` or assigned/exported), so the "no longer mutates in place" behavior change affects nothing.
