### PR TITLE
fix(telegram): set webhook during wizard finalization

### DIFF
--- a/integrations/telegram/integration.definition.ts
+++ b/integrations/telegram/integration.definition.ts
@@ -5,7 +5,7 @@ import { telegramMessageChannels } from './definitions/channels'
 
 export default new IntegrationDefinition({
   name: 'telegram',
-  version: '1.0.8',
+  version: '1.0.9',
   title: 'Telegram',
   description: 'Engage with your audience in real-time.',
   icon: 'icon.svg',

--- a/integrations/telegram/src/index.ts
+++ b/integrations/telegram/src/index.ts
@@ -36,7 +36,7 @@ const integration = new bp.Integration({
     let botToken: string
     try {
       botToken = await getStoredBotToken(client, ctx.integrationId, ctx.configuration.botToken)
-    } catch (err) {
+    } catch (err: unknown) {
       if (!(err instanceof RuntimeError)) {
         throw err
       }
@@ -51,7 +51,7 @@ const integration = new bp.Integration({
     let botToken: string
     try {
       botToken = await getStoredBotToken(client, ctx.integrationId, ctx.configuration.botToken)
-    } catch (err) {
+    } catch (err: unknown) {
       if (err instanceof RuntimeError) {
         return
       }

--- a/integrations/telegram/src/index.ts
+++ b/integrations/telegram/src/index.ts
@@ -1,4 +1,5 @@
 import { isOAuthWizardUrl } from '@botpress/common/src/oauth-wizard'
+import { RuntimeError } from '@botpress/sdk'
 import { sentry as sentryHelpers } from '@botpress/sdk-addons'
 import { ok } from 'assert/strict'
 import { Telegraf } from 'telegraf'
@@ -32,14 +33,30 @@ import * as bp from '.botpress'
 
 const integration = new bp.Integration({
   register: async ({ webhookUrl, ctx, client }) => {
-    const botToken = await getStoredBotToken(client, ctx.integrationId, ctx.configuration.botToken)
+    let botToken: string
+    try {
+      botToken = await getStoredBotToken(client, ctx.integrationId, ctx.configuration.botToken)
+    } catch (err) {
+      if (!(err instanceof RuntimeError)) {
+        throw err
+      }
+      return
+    }
     const telegraf = new Telegraf(botToken)
     await telegraf.telegram
       .setWebhook(webhookUrl)
       .catch(mapToRuntimeErrorAndThrow('Fail to set webhook. Check your bot token'))
   },
   unregister: async ({ ctx, client }) => {
-    const botToken = await getStoredBotToken(client, ctx.integrationId, ctx.configuration.botToken)
+    let botToken: string
+    try {
+      botToken = await getStoredBotToken(client, ctx.integrationId, ctx.configuration.botToken)
+    } catch (err) {
+      if (err instanceof RuntimeError) {
+        return
+      }
+      throw err
+    }
     const telegraf = new Telegraf(botToken)
     await telegraf.telegram
       .deleteWebhook({ drop_pending_updates: true })

--- a/integrations/telegram/src/wizard.ts
+++ b/integrations/telegram/src/wizard.ts
@@ -54,9 +54,10 @@ const _finalizeHandler: WizardHandler = async ({
 
   const { botToken } = parsed.data
 
+  const telegraf = new Telegraf(botToken)
+
   let botUsername: string
   try {
-    const telegraf = new Telegraf(botToken)
     const bot = await telegraf.telegram.getMe()
     botUsername = bot.username ?? String(bot.id)
   } catch (thrown: unknown) {
@@ -78,6 +79,16 @@ const _finalizeHandler: WizardHandler = async ({
     id: ctx.integrationId,
     payload: { botToken },
   })
+
+  const base = (process.env.BP_WEBHOOK_URL ?? 'https://webhook.botpress.dev').replace(/\/+$/, '')
+  const webhookUrl = `${base}/${ctx.webhookId}`
+  try {
+    await telegraf.telegram.setWebhook(webhookUrl)
+  } catch (thrown: unknown) {
+    const err = thrown instanceof Error ? thrown : new Error(String(thrown))
+    logger.forBot().error('Failed to set Telegram webhook:', err)
+    return responses.endWizard({ success: false, errorMessage: 'Failed to set webhook. Please try again.' })
+  }
 
   setIntegrationIdentifier(botUsername)
   return responses.endWizard({ success: true })


### PR DESCRIPTION
This PR adds the webhook registration in the wizard finalization. This was done due to the issue where Telegram's register handler is called before the setup wizard completes (and the bot token is saved to state), causing a "state doesn't exist" error. However, this PR doesn't solve the real issue where the wizard should complete before register is called.

Issue: [BE-1391](https://linear.app/botpress/issue/BE-1391/integrations-fix-problem-of-registration-before-wizard-completion)