### PR TITLE
fix(sdk): throw a 500 on unhandled errors

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.5",
     "@botpress/client": "1.46.0",
-    "@botpress/sdk": "6.12.0",
+    "@botpress/sdk": "6.12.1",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/verel": "^0.2.0",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.46.0",
-    "@botpress/sdk": "6.12.0"
+    "@botpress/sdk": "6.12.1"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.46.0",
-    "@botpress/sdk": "6.12.0"
+    "@botpress/sdk": "6.12.1"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "6.12.0"
+    "@botpress/sdk": "6.12.1"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.46.0",
-    "@botpress/sdk": "6.12.0"
+    "@botpress/sdk": "6.12.1"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.46.0",
-    "@botpress/sdk": "6.12.0",
+    "@botpress/sdk": "6.12.1",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "6.12.0",
+  "version": "6.12.1",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/bot/server/index.ts
+++ b/packages/sdk/src/bot/server/index.ts
@@ -119,16 +119,23 @@ export const botHandler =
     } catch (thrown: unknown) {
       const error = thrown instanceof Error ? thrown : new Error(String(thrown))
 
-      if (isApiError(error)) {
-        const runtimeError = error.type === 'Runtime' ? error : new RuntimeError(error.message, error)
-        logger.error(runtimeError.message)
+      // A deliberately thrown RuntimeError is the bot signaling a handled,
+      // user-facing failure and keeps its 4xx status. Anything else is an
+      // unhandled crash and answers 500 so callers can treat it as transient:
+      if (isApiError(error) && error.type === 'Runtime') {
+        logger.error(error.message)
+        return { status: error.code, body: JSON.stringify(error.toJSON()) }
+      }
 
-        return { status: runtimeError.code, body: JSON.stringify(runtimeError.toJSON()) }
+      if (isApiError(error)) {
+        const runtimeError = new RuntimeError(error.message, error)
+        logger.error(runtimeError.message)
+        return { status: 500, body: JSON.stringify(runtimeError.toJSON()) }
       }
 
       const runtimeError = new RuntimeError('An unexpected error occurred in the bot.', error)
       logger.error(runtimeError.message, error)
-      return { status: runtimeError.code, body: JSON.stringify(runtimeError.toJSON()) }
+      return { status: 500, body: JSON.stringify(runtimeError.toJSON()) }
     }
   }
 

--- a/packages/sdk/src/bot/server/index.ts
+++ b/packages/sdk/src/bot/server/index.ts
@@ -1,6 +1,6 @@
-import { isApiError, Client, RuntimeError, Message, State, User, Conversation } from '@botpress/client'
+import { Client, InvalidPayloadError, Message, State, User, Conversation } from '@botpress/client'
 import { retryConfig } from '../../retry'
-import { Request, Response, parseBody } from '../../serve'
+import { Request, Response, parseBody, handlerErrorToHttpResponse } from '../../serve'
 import * as utils from '../../utils/type-utils'
 import { BotLogger } from '../bot-logger'
 import { BotSpecificClient } from '../client'
@@ -114,28 +114,16 @@ export const botHandler =
         case 'ping':
           return await onPing(props)
         default:
-          throw new Error(`Unknown operation ${ctx.operation}`)
+          throw new InvalidPayloadError(`Unknown operation ${ctx.operation}`)
       }
     } catch (thrown: unknown) {
-      const error = thrown instanceof Error ? thrown : new Error(String(thrown))
+      const { status, body, error } = handlerErrorToHttpResponse({
+        thrown,
+        unexpectedErrorMessage: 'An unexpected error occurred in the bot.',
+      })
 
-      // A deliberately thrown RuntimeError is the bot signaling a handled,
-      // user-facing failure and keeps its 4xx status. Anything else is an
-      // unhandled crash and answers 500 so callers can treat it as transient:
-      if (isApiError(error) && error.type === 'Runtime') {
-        logger.error(error.message)
-        return { status: error.code, body: JSON.stringify(error.toJSON()) }
-      }
-
-      if (isApiError(error)) {
-        const runtimeError = new RuntimeError(error.message, error)
-        logger.error(runtimeError.message)
-        return { status: 500, body: JSON.stringify(runtimeError.toJSON()) }
-      }
-
-      const runtimeError = new RuntimeError('An unexpected error occurred in the bot.', error)
-      logger.error(runtimeError.message, error)
-      return { status: 500, body: JSON.stringify(runtimeError.toJSON()) }
+      status >= 500 ? logger.error(error.message, thrown) : logger.error(error.message)
+      return { status, body }
     }
   }
 
@@ -285,7 +273,7 @@ const onActionTriggered = async ({ ctx, logger, req, client, self }: types.Serve
   let { input, type } = parseBody<AnyActionPayload>(req)
 
   if (!type) {
-    throw new Error('Missing action type')
+    throw new InvalidPayloadError('Missing action type')
   }
 
   // TODO: this should probably run even if the action is called in memory
@@ -306,7 +294,7 @@ const onActionTriggered = async ({ ctx, logger, req, client, self }: types.Serve
 
   const action = self.actionHandlers[type]
   if (!action) {
-    throw new Error(`Action ${type} not found`)
+    throw new InvalidPayloadError(`Action ${type} not found`)
   }
 
   let output = await action({ ctx, logger, input, client, type })

--- a/packages/sdk/src/integration/server/index.ts
+++ b/packages/sdk/src/integration/server/index.ts
@@ -1,6 +1,6 @@
-import { isApiError, Client, RuntimeError, InvalidPayloadError } from '@botpress/client'
+import { Client, InvalidPayloadError } from '@botpress/client'
 import { retryConfig } from '../../retry'
-import { Request, Response, parseBody } from '../../serve'
+import { Request, Response, parseBody, handlerErrorToHttpResponse } from '../../serve'
 import { IntegrationSpecificClient } from '../client'
 import { BaseIntegration } from '../common'
 import { ActionMetadataStore } from './action-metadata'
@@ -107,22 +107,20 @@ export const integrationHandler =
 
       response = await handleOperation(props)
       return response ? { ...response, status: response.status ?? 200 } : { status: 200 }
-    } catch (error) {
-      if (isApiError(error)) {
-        const runtimeError = error.type === 'Runtime' ? error : new RuntimeError(error.message, error)
-        logger.forBot().error(runtimeError.message)
+    } catch (thrown: unknown) {
+      const { status, body, error } = handlerErrorToHttpResponse({
+        thrown,
+        unexpectedErrorMessage:
+          'An unexpected error occurred in the integration. Bot owners: Check logs for more informations. Integration owners: throw a RuntimeError to return a custom error message instead.',
+      })
 
-        return { status: runtimeError.code, body: JSON.stringify(runtimeError.toJSON()) }
+      if (status >= 500) {
+        // prints the error in the integration logs
+        console.error(thrown)
       }
 
-      // prints the error in the integration logs
-      console.error(error)
-
-      const runtimeError = new RuntimeError(
-        'An unexpected error occurred in the integration. Bot owners: Check logs for more informations. Integration owners: throw a RuntimeError to return a custom error message instead.'
-      )
-      logger.forBot().error(runtimeError.message)
-      return { status: runtimeError.code, body: JSON.stringify(runtimeError.toJSON()) }
+      logger.forBot().error(error.message)
+      return { status, body }
     }
   }
 
@@ -171,13 +169,13 @@ const onMessageCreated = async ({ ctx, req, client, logger, instance }: ServerPr
   const channelHandler = instance.channels[conversation.channel]
 
   if (!channelHandler) {
-    throw new Error(`Channel ${conversation.channel} not found`)
+    throw new InvalidPayloadError(`Channel ${conversation.channel} not found`)
   }
 
   const messageHandler = channelHandler.messages[type]
 
   if (!messageHandler) {
-    throw new Error(`Message of type ${type} not found in channel ${conversation.channel}`)
+    throw new InvalidPayloadError(`Message of type ${type} not found in channel ${conversation.channel}`)
   }
 
   type UpdateMessageProps = Parameters<(typeof client)['updateMessage']>[0]
@@ -195,13 +193,13 @@ const onActionTriggered = async ({ req, ctx, client, logger, instance }: ServerP
   const { input, type } = parseBody<ActionPayload<string, any>>(req)
 
   if (!type) {
-    throw new Error('Missing action type')
+    throw new InvalidPayloadError('Missing action type')
   }
 
   const action = instance.actions[type]
 
   if (!action) {
-    throw new Error(`Action ${type} not found`)
+    throw new InvalidPayloadError(`Action ${type} not found`)
   }
 
   const metadata = new ActionMetadataStore()

--- a/packages/sdk/src/serve.ts
+++ b/packages/sdk/src/serve.ts
@@ -1,3 +1,4 @@
+import { InvalidPayloadError, isApiError, RuntimeError } from '@botpress/client'
 import { isNode } from 'browser-or-node'
 import * as http from 'node:http'
 import { log } from './log'
@@ -20,9 +21,44 @@ export type Handler = (req: Request) => Promise<Response | void>
 
 export function parseBody<T>(req: Request): T {
   if (!req.body) {
-    throw new Error('Missing body')
+    throw new InvalidPayloadError('Missing body')
   }
-  return JSON.parse(req.body)
+
+  try {
+    return JSON.parse(req.body)
+  } catch (thrown: unknown) {
+    throw new InvalidPayloadError(thrown instanceof Error ? thrown.message : String(thrown))
+  }
+}
+
+/**
+ * Maps a thrown handler error to an HTTP response.
+ *
+ * A deliberately thrown `RuntimeError` indicates a handled, user-facing failure,
+ * and an `InvalidPayloadError` indicates a malformed request. Both preserve
+ * their original 4xx status so callers do not retry them.
+ *
+ * Any other error is treated as unhandled and returned as a 500 response so
+ * callers can consider it transient.
+ */
+export const handlerErrorToHttpResponse = ({
+  thrown,
+  unexpectedErrorMessage,
+}: {
+  thrown: unknown
+  unexpectedErrorMessage: string
+}): { status: number; body: string; error: Error } => {
+  const error = thrown instanceof Error ? thrown : new Error(String(thrown))
+
+  if (isApiError(error) && (error.type === 'Runtime' || error.type === 'InvalidPayload')) {
+    return { status: error.code, body: JSON.stringify(error.toJSON()), error }
+  }
+
+  const runtimeError = isApiError(error)
+    ? new RuntimeError(error.message, error)
+    : new RuntimeError(unexpectedErrorMessage, error)
+
+  return { status: 500, body: JSON.stringify(runtimeError.toJSON()), error: runtimeError }
 }
 
 export async function serve(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2828,7 +2828,7 @@ importers:
         specifier: 1.46.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 6.12.0
+        specifier: 6.12.1
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2952,7 +2952,7 @@ importers:
         specifier: 1.46.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.12.0
+        specifier: 6.12.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2968,7 +2968,7 @@ importers:
         specifier: 1.46.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.12.0
+        specifier: 6.12.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2981,7 +2981,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 6.12.0
+        specifier: 6.12.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2997,7 +2997,7 @@ importers:
         specifier: 1.46.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.12.0
+        specifier: 6.12.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -3013,7 +3013,7 @@ importers:
         specifier: 1.46.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.12.0
+        specifier: 6.12.1
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
As a result of https://github.com/botpress/botpress/pull/13832, unhandled crashes are correctly wrapped in a RuntimeError. However, RuntimeErrors have the status code 400, so it means whenever a bot crashes, we're telling the backend that the payload is invalid. This means the only way for our backend to distinguish between real crashes and invalid-payload errors is to inspect the error message directly to see if it matches `An unexpected error occurred in the bot.`. This _works_, but it's very brittle and we should be replying with a 500 instead, since a lot of the backend's retry mechanisms will not kick in for 400s.

Contributes to KKN-669, but we'll be using the aforementioned workaround (checking the string) in the backend in the meantime.