### PR TITLE
feat(sdk): add clone method on definition

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "6.8.7",
+  "version": "6.8.8",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",
@@ -28,7 +28,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "0.5.5",
     "@botpress/client": "1.46.0",
-    "@botpress/sdk": "6.12.1",
+    "@botpress/sdk": "6.13.0",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/verel": "^0.2.0",

--- a/packages/cli/src/command-implementations/project-command.ts
+++ b/packages/cli/src/command-implementations/project-command.ts
@@ -1001,16 +1001,24 @@ export abstract class ProjectCommand<C extends ProjectCommandDefinition> extends
     props: Partial<T['definition']['props']>
   ): T['definition'] => {
     if (def.type === 'integration') {
-      return new sdk.IntegrationDefinition({ ...def.definition.props, ...props }) as T['definition']
+      const overrides = props as Partial<sdk.IntegrationDefinitionProps>
+      return (def.definition.clone?.(overrides) ??
+        new sdk.IntegrationDefinition({ ...def.definition.props, ...overrides })) as T['definition']
     }
     if (def.type === 'plugin') {
-      return new sdk.PluginDefinition({ ...def.definition.props, ...props }) as T['definition']
+      const overrides = props as Partial<sdk.PluginDefinitionProps>
+      return (def.definition.clone?.(overrides) ??
+        new sdk.PluginDefinition({ ...def.definition.props, ...overrides })) as T['definition']
     }
     if (def.type === 'interface') {
-      return new sdk.InterfaceDefinition({ ...def.definition.props, ...props }) as T['definition']
+      const overrides = props as Partial<sdk.InterfaceDefinitionProps>
+      return (def.definition.clone?.(overrides) ??
+        new sdk.InterfaceDefinition({ ...def.definition.props, ...overrides })) as T['definition']
     }
     if (def.type === 'bot') {
-      return new sdk.BotDefinition({ ...def.definition.props, ...props }) as T['definition']
+      const overrides = props as Partial<sdk.BotDefinitionProps>
+      return (def.definition.clone?.(overrides) ??
+        new sdk.BotDefinition({ ...def.definition.props, ...overrides })) as T['definition']
     }
     def satisfies never
     throw new errors.BotpressCLIError('Unsupported definition type')

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.46.0",
-    "@botpress/sdk": "6.12.1"
+    "@botpress/sdk": "6.13.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.46.0",
-    "@botpress/sdk": "6.12.1"
+    "@botpress/sdk": "6.13.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "6.12.1"
+    "@botpress/sdk": "6.13.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.46.0",
-    "@botpress/sdk": "6.12.1"
+    "@botpress/sdk": "6.13.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "1.46.0",
-    "@botpress/sdk": "6.12.1",
+    "@botpress/sdk": "6.13.0",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "6.12.1",
+  "version": "6.13.0",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/bot/definition.ts
+++ b/packages/sdk/src/bot/definition.ts
@@ -281,6 +281,16 @@ export class BotDefinition<
     return { sdkVersion: SDK_VERSION } as const
   }
 
+  public readonly clone?: (overrides?: Partial<BotDefinitionProps>) => BotDefinition = (overrides?) => {
+    // TODO: make non-optional on next major (CLI and SDK share the same major, so the CLI can always rely on clone being present)
+    return new BotDefinition({
+      ...this.props,
+      integrations: this.integrations,
+      plugins: this.plugins,
+      ...overrides,
+    } as BotDefinitionProps)
+  }
+
   public addIntegration<I extends IntegrationPackage>(integrationPkg: I, config?: IntegrationConfigInstance<I>): this {
     const self = this as Writable<BotDefinition>
     if (!self.integrations) {

--- a/packages/sdk/src/integration/definition/index.ts
+++ b/packages/sdk/src/integration/definition/index.ts
@@ -244,6 +244,18 @@ export class IntegrationDefinition<
     return { sdkVersion: SDK_VERSION } as const
   }
 
+  public readonly clone?: (overrides?: Partial<IntegrationDefinitionProps>) => IntegrationDefinition = (overrides?) => {
+    // TODO: make non-optional on next major (CLI and SDK share the same major, so the CLI can always rely on clone being present)
+    return new IntegrationDefinition({
+      ...this.props,
+      actions: this.actions,
+      events: this.events,
+      channels: this.channels,
+      interfaces: this.interfaces,
+      ...overrides,
+    } as IntegrationDefinitionProps)
+  }
+
   public extend<P extends InterfacePackage>(
     interfacePkg: P,
     builder: ExtensionBuilder<

--- a/packages/sdk/src/interface/definition.ts
+++ b/packages/sdk/src/interface/definition.ts
@@ -169,6 +169,11 @@ export class InterfaceDefinition<
     return { sdkVersion: SDK_VERSION } as const
   }
 
+  public readonly clone?: (overrides?: Partial<InterfaceDefinitionProps>) => InterfaceDefinition = (overrides?) => {
+    // TODO: make non-optional on next major (CLI and SDK share the same major, so the CLI can always rely on clone being present)
+    return new InterfaceDefinition({ ...this.props, ...overrides } as InterfaceDefinitionProps)
+  }
+
   private _getEntityReference = (entities: Record<string, EntityDefinition>): EntityReferences<TEntities> => {
     const entityReferences: Record<string, z.ZodRef> = {} as EntityReferences<TEntities>
     for (const [entityName, entityDef] of Object.entries(entities)) {

--- a/packages/sdk/src/plugin/definition.ts
+++ b/packages/sdk/src/plugin/definition.ts
@@ -350,6 +350,11 @@ export class PluginDefinition<
     return { sdkVersion: SDK_VERSION } as const
   }
 
+  public readonly clone?: (overrides?: Partial<PluginDefinitionProps>) => PluginDefinition = (overrides?) => {
+    // TODO: make non-optional on next major (CLI and SDK share the same major, so the CLI can always rely on clone being present)
+    return new PluginDefinition({ ...this.props, ...overrides } as PluginDefinitionProps)
+  }
+
   /**
    * Returns a copy of the plugin definition where all entity references are
    * resolved to the base entity schema defined by the interface. This does not

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2828,7 +2828,7 @@ importers:
         specifier: 1.46.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 6.12.1
+        specifier: 6.13.0
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2952,7 +2952,7 @@ importers:
         specifier: 1.46.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.12.1
+        specifier: 6.13.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2968,7 +2968,7 @@ importers:
         specifier: 1.46.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.12.1
+        specifier: 6.13.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2981,7 +2981,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 6.12.1
+        specifier: 6.13.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2997,7 +2997,7 @@ importers:
         specifier: 1.46.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.12.1
+        specifier: 6.13.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -3013,7 +3013,7 @@ importers:
         specifier: 1.46.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.12.1
+        specifier: 6.13.0
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
Address the same issue found here: https://github.com/botpress/botpress/pull/15279

The difference is that there's a dedicated method for it called `.clone()`.

I made the method optional to force the CLI to check if it's present. I want the CLI not to crash when handling definitions instanciated from previous SDK versions

