### PR TITLE
feat(cognitive,llmz): accept a standalone CognitiveBeta (v2) client

### DIFF
--- a/packages/cognitive/e2e/cognitive-beta.test.ts
+++ b/packages/cognitive/e2e/cognitive-beta.test.ts
@@ -51,7 +51,7 @@ describe.skipIf(!hasCreds)('CognitiveBeta e2e — TTS', () => {
     expect(res.metadata.format).toBe('mp3')
     expect(res.metadata.characterCount).toBe('Hello world.'.length)
     expect(res.metadata.cost).toBeGreaterThanOrEqual(0)
-  }, 60_000)
+  }, 130_000)
 
   test('generateAudioStream yields chunks ending with a finished chunk', async () => {
     const chunks: TtsStreamChunk[] = []
@@ -147,7 +147,7 @@ describe.skipIf(!hasCreds)('CognitiveBeta e2e — Transcription', () => {
       throw new Error('generateAudio returned no audioUrl; cannot run transcription e2e')
     }
     audioUrl = audio.output.audioUrl
-  }, 60_000)
+  }, 130_000)
 
   test('transcribeAudio returns text and metadata', async () => {
     const res = await beta.transcribeAudio({

--- a/packages/cognitive/e2e/cognitive-beta.test.ts
+++ b/packages/cognitive/e2e/cognitive-beta.test.ts
@@ -11,9 +11,15 @@ const hasCreds = !!botId && !!token
 describe.skipIf(!hasCreds)('CognitiveBeta e2e — TTS', () => {
   let beta: CognitiveBeta
 
-  beforeAll(() => {
+  beforeAll(async () => {
     beta = new CognitiveBeta({ apiUrl, botId, token, timeout: 120_000 })
-  })
+
+    // The first TTS request against a freshly-created bot is a cold start that can
+    // exceed the client's per-request timeout. Warm the path once here (tolerating
+    // failure) so the assertions below run against a warm backend instead of racing
+    // the cold-start latency.
+    await beta.generateAudio({ model: 'openai:tts-1', input: 'warmup', voice: 'alloy', format: 'mp3' }).catch(() => {})
+  }, 150_000)
 
   test('listVoices returns a non-empty array of well-formed voices', async () => {
     const voices = await beta.listVoices()
@@ -51,7 +57,7 @@ describe.skipIf(!hasCreds)('CognitiveBeta e2e — TTS', () => {
     expect(res.metadata.format).toBe('mp3')
     expect(res.metadata.characterCount).toBe('Hello world.'.length)
     expect(res.metadata.cost).toBeGreaterThanOrEqual(0)
-  }, 130_000)
+  }, 60_000)
 
   test('generateAudioStream yields chunks ending with a finished chunk', async () => {
     const chunks: TtsStreamChunk[] = []
@@ -147,7 +153,10 @@ describe.skipIf(!hasCreds)('CognitiveBeta e2e — Transcription', () => {
       throw new Error('generateAudio returned no audioUrl; cannot run transcription e2e')
     }
     audioUrl = audio.output.audioUrl
-  }, 130_000)
+    // This block uses its own client instance, so it pays the TTS cold start again
+    // (warming the TTS describe block does not warm this one). Allow enough budget
+    // for the client's internal retries to ride out a cold backend.
+  }, 150_000)
 
   test('transcribeAudio returns text and metadata', async () => {
     const res = await beta.transcribeAudio({

--- a/packages/cognitive/package.json
+++ b/packages/cognitive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cognitive",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Wrapper around the Botpress Client to call LLMs",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/cognitive/src/client.ts
+++ b/packages/cognitive/src/client.ts
@@ -2,7 +2,7 @@ import { backOff } from 'exponential-backoff'
 import { createNanoEvents, Unsubscribe } from 'nanoevents'
 
 import { ExtendedClient, getExtendedClient } from './bp-client'
-import { CognitiveBeta, getCognitiveV2Model, isKnownV2Model } from './cognitive-v2'
+import { CognitiveBeta, getCognitiveV2Model, isKnownV2Model, buildResponseFromBetaMetadata } from './cognitive-v2'
 
 import { getActionFromError } from './errors'
 import { InterceptorManager } from './interceptors'
@@ -279,44 +279,9 @@ export class Cognitive {
       timeout: this._timeoutMs,
     })
 
-    const result: Response = {
-      output: {
-        id: 'beta-output',
-        provider: response.metadata.provider,
-        model: response.metadata.model!,
-        choices: [
-          {
-            type: 'text',
-            content: response.output,
-            role: 'assistant',
-            index: 0,
-            stopReason: response.metadata.stopReason ?? 'stop',
-          },
-        ],
-        usage: {
-          inputTokens: response.metadata.usage.inputTokens,
-          inputCost: 0,
-          outputTokens: response.metadata.usage.outputTokens,
-          outputCost: response.metadata.cost ?? 0,
-        },
-        botpress: {
-          cost: response.metadata.cost ?? 0,
-        },
-      },
-      meta: {
-        cached: response.metadata.cached,
-        model: { integration: response.metadata.provider, model: response.metadata.model! },
-        latency: response.metadata.latency!,
-        cost: {
-          input: 0,
-          output: response.metadata.cost || 0,
-        },
-        tokens: {
-          input: response.metadata.usage.inputTokens,
-          output: response.metadata.usage.outputTokens,
-        },
-      },
-    }
+    // Shared with the beta adapter (cognitiveFromBeta) so the Cognitive wrapper
+    // and a standalone CognitiveBeta produce an identical `Response` shape.
+    const result = buildResponseFromBetaMetadata(response.output, response.metadata)
 
     // Emit final response event with actual data
     this._events.emit('response', props, result)

--- a/packages/cognitive/src/cognitive-v2/adapter.test.ts
+++ b/packages/cognitive/src/cognitive-v2/adapter.test.ts
@@ -116,7 +116,7 @@ describe('cognitiveFromBeta — generation', () => {
 })
 
 describe('cognitiveFromBeta — getModelDetails (v2-only, no v1)', () => {
-  test("resolves best/fast/auto from the static table without hitting listModels", async () => {
+  test('resolves best/fast/auto from the static table without hitting listModels', async () => {
     const beta = fakeBeta()
     const cog = cognitiveFromBeta(beta)
     const md = await cog.getModelDetails('best')

--- a/packages/cognitive/src/cognitive-v2/adapter.test.ts
+++ b/packages/cognitive/src/cognitive-v2/adapter.test.ts
@@ -1,0 +1,164 @@
+import { describe, test, expect, vi } from 'vitest'
+import { CognitiveBeta } from './index'
+import { cognitiveFromBeta, buildResponseFromBetaMetadata } from './adapter'
+import type { CognitiveMetadata } from './types'
+
+const METADATA: CognitiveMetadata = {
+  provider: 'openai',
+  model: 'openai:gpt-5',
+  usage: { inputTokens: 80, inputCost: 0.001, outputTokens: 40, outputCost: 0.002 },
+  cost: 0.003,
+  cached: false,
+  latency: 200,
+  stopReason: 'stop',
+}
+
+const streamFromChunks = (chunks: string[], metadata: CognitiveMetadata = METADATA) =>
+  vi.fn(async function* () {
+    for (const c of chunks) {
+      yield { output: c, created: 0 }
+    }
+    yield { output: '', created: 0, finished: true, metadata }
+  })
+
+// A fake beta client exposing only the 3 methods the adapter uses, so we can
+// assert the adapter never reaches for anything else (no v1 surface).
+function fakeBeta(
+  overrides: {
+    generateText?: ReturnType<typeof vi.fn>
+    generateTextStream?: ReturnType<typeof vi.fn>
+    listModels?: ReturnType<typeof vi.fn>
+  } = {}
+) {
+  return {
+    generateText: overrides.generateText ?? vi.fn().mockResolvedValue({ output: 'pong', metadata: METADATA }),
+    generateTextStream: overrides.generateTextStream ?? streamFromChunks(['po', 'ng']),
+    listModels: overrides.listModels ?? vi.fn().mockResolvedValue([]),
+  } as unknown as CognitiveBeta
+}
+
+describe('CognitiveBeta.isBetaClient', () => {
+  test('true for a real CognitiveBeta instance', () => {
+    const beta = new CognitiveBeta({ token: 't', botId: 'b' })
+    expect(CognitiveBeta.isBetaClient(beta)).toBe(true)
+  })
+
+  test('survives clone()', () => {
+    const beta = new CognitiveBeta({ token: 't', botId: 'b' })
+    expect(CognitiveBeta.isBetaClient(beta.clone())).toBe(true)
+  })
+
+  test('does not use instanceof — a structural copy with the brand passes', () => {
+    // Simulates a CognitiveBeta from a duplicated copy of the package.
+    const fromOtherCopy = { ['$$IS_COGNITIVE_BETA']: 'v2' }
+    expect(CognitiveBeta.isBetaClient(fromOtherCopy)).toBe(true)
+  })
+
+  test('false for plain objects / null / a lookalike without the brand', () => {
+    expect(CognitiveBeta.isBetaClient({})).toBe(false)
+    expect(CognitiveBeta.isBetaClient(null)).toBe(false)
+    expect(CognitiveBeta.isBetaClient(undefined)).toBe(false)
+    expect(CognitiveBeta.isBetaClient({ $$IS_COGNITIVE_BETA: true })).toBe(false)
+  })
+})
+
+describe('buildResponseFromBetaMetadata', () => {
+  test('maps output + metadata into the canonical Response shape', () => {
+    const r = buildResponseFromBetaMetadata('hello', METADATA)
+    expect(r.output.choices?.[0]?.content).toBe('hello')
+    expect(r.output.model).toBe('openai:gpt-5')
+    expect(r.output.usage.inputTokens).toBe(80)
+    expect(r.output.usage.outputTokens).toBe(40)
+    expect(r.meta?.cached).toBe(false)
+  })
+})
+
+describe('cognitiveFromBeta — generation', () => {
+  test('generateContent delegates to beta.generateText and shapes the response', async () => {
+    const beta = fakeBeta()
+    const cog = cognitiveFromBeta(beta)
+    const res = await cog.generateContent({ model: 'best', messages: [{ role: 'user', content: 'ping' }] } as any)
+    expect((beta as any).generateText).toHaveBeenCalledOnce()
+    expect(res.output.choices?.[0]?.content).toBe('pong')
+  })
+
+  test('systemPrompt is folded into a leading system message', async () => {
+    const beta = fakeBeta()
+    const cog = cognitiveFromBeta(beta)
+    await cog.generateContent({
+      model: 'best',
+      systemPrompt: 'be terse',
+      messages: [{ role: 'user', content: 'hi' }],
+    } as any)
+    const sent = (beta as any).generateText.mock.calls[0][0]
+    expect(sent.systemPrompt).toBeUndefined()
+    expect(sent.messages[0]).toEqual({ role: 'system', content: 'be terse' })
+    expect(sent.messages[1]).toEqual({ role: 'user', content: 'hi' })
+  })
+
+  test('generateContentStream yields deltas and returns the final Response', async () => {
+    const beta = fakeBeta({ generateTextStream: streamFromChunks(['po', 'ng']) })
+    const cog = cognitiveFromBeta(beta)
+    const it = cog.generateContentStream({ model: 'best', messages: [{ role: 'user', content: 'x' }] } as any)
+    let acc = ''
+    let result
+    for (;;) {
+      const n = await it.next()
+      if (n.done) {
+        result = n.value
+        break
+      }
+      acc += n.value.output ?? ''
+    }
+    expect(acc).toBe('pong')
+    expect(result!.output.choices?.[0]?.content).toBe('pong')
+  })
+})
+
+describe('cognitiveFromBeta — getModelDetails (v2-only, no v1)', () => {
+  test("resolves best/fast/auto from the static table without hitting listModels", async () => {
+    const beta = fakeBeta()
+    const cog = cognitiveFromBeta(beta)
+    const md = await cog.getModelDetails('best')
+    expect(md.ref).toBe('best')
+    expect(md.input.maxTokens).toBeGreaterThan(0)
+    expect((beta as any).listModels).not.toHaveBeenCalled()
+  })
+
+  test('resolves a model the static table lacks from the live v2 list (e.g. Mercury)', async () => {
+    const beta = fakeBeta({
+      listModels: vi.fn().mockResolvedValue([
+        {
+          id: 'inception:mercury-2',
+          name: 'Mercury 2',
+          description: '',
+          tags: [],
+          lifecycle: 'preview',
+          input: { maxTokens: 32_000, costPer1MTokens: 1 },
+          output: { maxTokens: 8_000, costPer1MTokens: 1 },
+        },
+      ]),
+    })
+    const cog = cognitiveFromBeta(beta)
+    const md = await cog.getModelDetails('inception:mercury-2')
+    expect(md.ref).toBe('inception:mercury-2')
+    expect(md.input.maxTokens).toBe(32_000)
+    expect((beta as any).listModels).toHaveBeenCalledOnce()
+  })
+
+  test('returns a permissive default for an unknown model instead of throwing or falling back', async () => {
+    const beta = fakeBeta({ listModels: vi.fn().mockResolvedValue([]) })
+    const cog = cognitiveFromBeta(beta)
+    const md = await cog.getModelDetails('some:unknown-model')
+    expect(md.ref).toBe('some:unknown-model')
+    expect(md.input.maxTokens).toBeGreaterThan(0)
+  })
+
+  test('survives a listModels failure with the permissive default (never throws to v1)', async () => {
+    const beta = fakeBeta({ listModels: vi.fn().mockRejectedValue(new Error('network')) })
+    const cog = cognitiveFromBeta(beta)
+    const md = await cog.getModelDetails('xai:grok-9')
+    expect(md.ref).toBe('xai:grok-9')
+    expect(md.input.maxTokens).toBeGreaterThan(0)
+  })
+})

--- a/packages/cognitive/src/cognitive-v2/adapter.ts
+++ b/packages/cognitive/src/cognitive-v2/adapter.ts
@@ -1,5 +1,5 @@
-import type { InputProps, Response } from '../types'
 import type { Model, ModelRef } from '../models'
+import type { InputProps, Response } from '../types'
 // `CognitiveBeta` + `getCognitiveV2Model` live in ./index. This creates an
 // import cycle (index re-exports this adapter), but it's safe: both bindings
 // are only referenced inside function bodies, never at module-eval time.

--- a/packages/cognitive/src/cognitive-v2/adapter.ts
+++ b/packages/cognitive/src/cognitive-v2/adapter.ts
@@ -1,0 +1,164 @@
+import type { InputProps, Response } from '../types'
+import type { Model, ModelRef } from '../models'
+// `CognitiveBeta` + `getCognitiveV2Model` live in ./index. This creates an
+// import cycle (index re-exports this adapter), but it's safe: both bindings
+// are only referenced inside function bodies, never at module-eval time.
+import { CognitiveBeta, getCognitiveV2Model } from './index'
+import type { CognitiveMetadata, CognitiveStreamChunk } from './types'
+
+/**
+ * The subset of the {@link import('../client').Cognitive} surface that
+ * downstream consumers (notably `llmz`) actually call. A `CognitiveBeta`
+ * doesn't implement these names directly (it exposes `generateText`,
+ * `generateTextStream`, `listModels`), so {@link cognitiveFromBeta} adapts one
+ * into this shape.
+ */
+export type CognitiveLike = {
+  getModelDetails(model: string): Promise<Model>
+  generateContent(input: InputProps): Promise<Response>
+  generateContentStream(input: InputProps): AsyncGenerator<CognitiveStreamChunk, Response, void>
+}
+
+/**
+ * Builds the canonical `Response` from a (streamed or non-streamed) beta output
+ * + metadata. Kept module-level so both `Cognitive` and the beta adapter
+ * produce a byte-for-byte identical `Response` shape.
+ */
+export function buildResponseFromBetaMetadata(output: string, metadata: CognitiveMetadata): Response {
+  return {
+    output: {
+      id: 'beta-output',
+      provider: metadata.provider,
+      model: metadata.model!,
+      choices: [
+        {
+          type: 'text',
+          content: output,
+          role: 'assistant',
+          index: 0,
+          stopReason: metadata.stopReason ?? 'stop',
+        },
+      ],
+      usage: {
+        inputTokens: metadata.usage.inputTokens,
+        inputCost: 0,
+        outputTokens: metadata.usage.outputTokens,
+        outputCost: metadata.cost ?? 0,
+      },
+      botpress: {
+        cost: metadata.cost ?? 0,
+      },
+    },
+    meta: {
+      cached: metadata.cached,
+      model: { integration: metadata.provider, model: metadata.model! },
+      latency: metadata.latency!,
+      cost: {
+        input: 0,
+        output: metadata.cost || 0,
+      },
+      tokens: {
+        input: metadata.usage.inputTokens,
+        output: metadata.usage.outputTokens,
+      },
+    },
+  }
+}
+
+// The v2 API expects `systemPrompt` as a leading system message rather than a
+// separate field. Same transform `Cognitive._generateContentV2` performs.
+function toBetaInput(input: InputProps): InputProps {
+  const v2Input = { ...input, messages: [...input.messages] }
+  if (v2Input.systemPrompt) {
+    // @ts-expect-error - system role is not supported in the integrations api, but is used in v2
+    v2Input.messages.unshift({ role: 'system', content: v2Input.systemPrompt })
+    delete v2Input.systemPrompt
+  }
+  return v2Input
+}
+
+/**
+ * Adapts a {@link CognitiveBeta} into the {@link CognitiveLike} surface so it
+ * can be used anywhere a `Cognitive` client is expected (e.g. `llmz`'s
+ * `execute({ client })`).
+ *
+ * Crucially this is **v2-only**: model details are resolved from the static v2
+ * table or the live `/v2/cognitive/models` endpoint (with a permissive
+ * fallback), and generation goes straight to the beta transport. It never
+ * touches the v1 integration path, model preferences, or the File API — so it
+ * works for any model the v2 endpoint serves, including ones missing from the
+ * static table / provider allow-list.
+ */
+export function cognitiveFromBeta(beta: CognitiveBeta): CognitiveLike {
+  let remoteModels: Map<string, Model> | null = null
+
+  const fetchRemote = async (): Promise<Map<string, Model>> => {
+    if (remoteModels) return remoteModels
+    const list = await beta.listModels()
+    const map = new Map<string, Model>()
+    for (const m of list) {
+      // The v2 `Model` is structurally a superset of the `models.ts` `Model`
+      // for the fields consumers read (id/name/tags/input/output); widen it.
+      const converted = { ...m, ref: m.id as ModelRef, integration: 'cognitive-v2' } as unknown as Model
+      map.set(m.id, converted)
+      for (const alias of m.aliases ?? []) {
+        map.set(alias, converted)
+      }
+    }
+    remoteModels = map
+    return map
+  }
+
+  return {
+    async getModelDetails(model: string): Promise<Model> {
+      // 1. Static table (covers best/fast/auto + well-known ids, no network).
+      const resolved = getCognitiveV2Model(model)
+      if (resolved) {
+        return { ...resolved, ref: resolved.id as ModelRef, integration: 'cognitive-v2' } as unknown as Model
+      }
+      // 2. Live v2 model list (covers models the static table doesn't know).
+      try {
+        const found = (await fetchRemote()).get(model)
+        if (found) return found
+      } catch {
+        // fall through to permissive default
+      }
+      // 3. Permissive default — never throw, never fall back to v1. The
+      //    generate call surfaces the real error if the model is invalid.
+      return {
+        id: model,
+        ref: model as ModelRef,
+        integration: 'cognitive-v2',
+        name: model,
+        description: '',
+        tags: [],
+        input: { maxTokens: 128_000, costPer1MTokens: 0 },
+        output: { maxTokens: 8_192, costPer1MTokens: 0 },
+      } as Model
+    },
+
+    async generateContent(input: InputProps): Promise<Response> {
+      const response = await beta.generateText(toBetaInput(input) as any, {
+        signal: input.signal,
+      })
+      return buildResponseFromBetaMetadata(response.output, response.metadata)
+    },
+
+    async *generateContentStream(input: InputProps): AsyncGenerator<CognitiveStreamChunk, Response, void> {
+      const v2Input = toBetaInput(input)
+      let lastMetadata: CognitiveMetadata | undefined
+      const parts: string[] = []
+
+      for await (const chunk of beta.generateTextStream(v2Input as any, { signal: input.signal })) {
+        if (chunk.output) parts.push(chunk.output)
+        if (chunk.metadata) lastMetadata = chunk.metadata
+        yield chunk
+      }
+
+      if (!lastMetadata) {
+        throw new Error('Streaming completed without metadata')
+      }
+      return buildResponseFromBetaMetadata(parts.join(''), lastMetadata)
+    },
+  }
+}

--- a/packages/cognitive/src/cognitive-v2/index.ts
+++ b/packages/cognitive/src/cognitive-v2/index.ts
@@ -80,6 +80,23 @@ export type {
 } from './types'
 
 export class CognitiveBeta {
+  /**
+   * Nominal brand used by {@link CognitiveBeta.isBetaClient}. We brand the
+   * instance (rather than rely on `instanceof`) so the check survives across
+   * duplicated/duelling copies of this package in a dependency tree or bundle,
+   * mirroring `Cognitive`'s `$$IS_COGNITIVE` brand.
+   */
+  public readonly ['$$IS_COGNITIVE_BETA'] = 'v2' as const
+
+  /**
+   * Brand-based type guard. Returns true for any `CognitiveBeta` instance,
+   * including ones created by a different copy of this package. Prefer this
+   * over `instanceof CognitiveBeta`, which is unreliable across bundles.
+   */
+  public static isBetaClient(obj: any): obj is CognitiveBeta {
+    return obj?.['$$IS_COGNITIVE_BETA'] === 'v2'
+  }
+
   private _axiosClient: AxiosInstance
   private readonly _apiUrl: string
   private readonly _timeout: number
@@ -569,3 +586,9 @@ export const getCognitiveV2Model = (model: string): Model | undefined => {
   }
   return undefined
 }
+
+// Adapter that exposes a `CognitiveBeta` through the `Cognitive`-shaped surface
+// (`generateContent`/`generateContentStream`/`getModelDetails`) that downstream
+// consumers like llmz expect. Exported last so the cycle with ./adapter
+// resolves after CognitiveBeta/getCognitiveV2Model are defined.
+export { cognitiveFromBeta, buildResponseFromBetaMetadata, type CognitiveLike } from './adapter'

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -2,7 +2,7 @@
   "name": "llmz",
   "type": "module",
   "description": "LLMz - An LLM-native Typescript VM built on top of Zui",
-  "version": "0.0.81",
+  "version": "0.0.82",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "@botpress/client": "1.46.0",
-    "@botpress/cognitive": "0.6.0",
+    "@botpress/cognitive": "0.6.1",
     "@bpinternal/thicktoken": "^2.0.0",
     "@bpinternal/zui": "^2.3.0"
   },

--- a/packages/llmz/src/llmz.test.ts
+++ b/packages/llmz/src/llmz.test.ts
@@ -1,6 +1,6 @@
 import { Client } from '@botpress/client'
-import { Cognitive, Model } from '@botpress/cognitive'
-import { describe, expect, test } from 'vitest'
+import { Cognitive, CognitiveBeta, Model } from '@botpress/cognitive'
+import { describe, expect, test, vi } from 'vitest'
 import { Context } from './context.js'
 import { executeContext } from './llmz.js'
 import { ErrorExecutionResult } from './result.js'
@@ -41,6 +41,32 @@ test('executeContext should early exit when cognitive service is unreachable', a
   expect(output.iterations.length).toBe(1)
   expect((output as ErrorExecutionResult).error).toBeInstanceOf(CognitiveError)
   expect(((output as ErrorExecutionResult).error as Error).message).toContain(err.message)
+})
+
+test('executeContext accepts a standalone CognitiveBeta and routes it through the v2 path', async () => {
+  // A standalone CognitiveBeta (not wrapped in Cognitive). execute() should
+  // detect it via the brand guard and adapt it — going straight to the v2
+  // `generateText`/`listModels` surface, never the v1 integration path.
+  const generateText = vi.fn().mockRejectedValue(new Error('v2 boom'))
+  const listModels = vi.fn().mockResolvedValue([])
+
+  const beta = {
+    ['$$IS_COGNITIVE_BETA']: 'v2',
+    generateText,
+    listModels,
+    generateTextStream: vi.fn(),
+  } as unknown as CognitiveBeta
+
+  expect(CognitiveBeta.isBetaClient(beta)).toBe(true)
+
+  const output = await executeContext({ client: beta, options: { loop: 5 } })
+
+  // Reaching generateText proves the beta adapter path was taken (model
+  // details resolved without throwing, then generation was attempted on v2).
+  expect(generateText).toHaveBeenCalled()
+  expect(output.status).toBe('error')
+  expect((output as ErrorExecutionResult).error).toBeInstanceOf(CognitiveError)
+  expect(((output as ErrorExecutionResult).error as Error).message).toContain('v2 boom')
 })
 
 describe('reasoningEffort', () => {

--- a/packages/llmz/src/llmz.ts
+++ b/packages/llmz/src/llmz.ts
@@ -1,5 +1,12 @@
 import { Client } from '@botpress/client'
-import { Cognitive, Models, type BotpressClientLike } from '@botpress/cognitive'
+import {
+  Cognitive,
+  CognitiveBeta,
+  cognitiveFromBeta,
+  type CognitiveLike,
+  Models,
+  type BotpressClientLike,
+} from '@botpress/cognitive'
 import { z } from '@bpinternal/zui'
 
 import { clamp, isEqual, isPlainObject, omit } from 'lodash-es'
@@ -223,7 +230,7 @@ export type ExecutionProps = {
    * This is used to generate content using the LLM and to access the Botpress API.
    * If not provided, a default client will be created using environment variables.
    */
-  client?: Cognitive | BotpressClientLike
+  client?: Cognitive | CognitiveBeta | BotpressClientLike
 
   /**
    * When provided, the execution will immediately stop when the signal is aborted.
@@ -281,7 +288,14 @@ export const _executeContext = async (props: ExecutionProps): Promise<ExecutionR
 
   const client = props.client ?? new Client()
 
-  const cognitive = Cognitive.isCognitiveClient(client) ? client : new Cognitive({ client, __experimental_beta: true })
+  // Accept a Cognitive client, a standalone v2 CognitiveBeta client (adapted to
+  // the Cognitive surface — stays strictly on the v2 path, no v1 fallback), or
+  // a raw Botpress client (wrapped in Cognitive with beta enabled).
+  const cognitive = Cognitive.isCognitiveClient(client)
+    ? client
+    : CognitiveBeta.isBetaClient(client)
+      ? cognitiveFromBeta(client)
+      : new Cognitive({ client, __experimental_beta: true })
   const cleanups: (() => void)[] = []
 
   const ctx = new Context({
@@ -425,7 +439,9 @@ const executeIteration = async ({
 }: {
   ctx: Context
   iteration: Iteration
-  cognitive: Cognitive
+  // Accepts a full Cognitive client or the v2 beta adapter (CognitiveLike) —
+  // both expose the getModelDetails/generateContent methods used here.
+  cognitive: Cognitive | CognitiveLike
   controller: AbortController
 } & ExecutionHooks): Promise<void> => {
   let startedAt = Date.now()

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -32,7 +32,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@botpress/cognitive": "0.6.0",
+    "@botpress/cognitive": "0.6.1",
     "json5": "^2.2.3",
     "jsonrepair": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/plugins/conversation-insights/package.json
+++ b/plugins/conversation-insights/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/cognitive": "0.6.0",
+    "@botpress/cognitive": "0.6.1",
     "@botpress/sdk": "workspace:*",
     "browser-or-node": "^2.1.1",
     "jsonrepair": "^3.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3173,7 +3173,7 @@ importers:
         specifier: 1.46.0
         version: link:../client
       '@botpress/cognitive':
-        specifier: 0.6.0
+        specifier: 0.6.1
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^2.0.0
@@ -3356,7 +3356,7 @@ importers:
   packages/zai:
     dependencies:
       '@botpress/cognitive':
-        specifier: 0.6.0
+        specifier: 0.6.1
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^1.0.0
@@ -3472,7 +3472,7 @@ importers:
   plugins/conversation-insights:
     dependencies:
       '@botpress/cognitive':
-        specifier: 0.6.0
+        specifier: 0.6.1
         version: link:../../packages/cognitive
       '@botpress/sdk':
         specifier: workspace:*


### PR DESCRIPTION
## What

Lets `llmz`'s `execute({ client })` accept a standalone `CognitiveBeta` (the v2 client) directly:

```ts
import { execute } from 'llmz'
import { CognitiveBeta } from '@botpress/cognitive'

const beta = new CognitiveBeta({ token, botId, headers: { 'x-workspace-id': ws } })
await execute({ client: beta, instructions, /* ... */ })
```

## Why

Passing a v2 client today means wrapping it in `Cognitive`, which silently falls back to the **v1** integration path (`_generateContent` → `RemoteModelProvider.getBot()` → `bot-<id>-models.config.json`) whenever the v2 call errors or the model isn't in the static allow-list. That fallback:

- 400-loops on a workspace-scoped token (`bot->undefined->models.config.json`),
- rejects valid v2 models whose provider is missing from the stale `isKnownV2Model` allow-list (e.g. `inception:mercury-2`, which the `/v2/cognitive/*` endpoint serves fine).

This PR gives consumers a way to stay **strictly on v2** with no v1 knowledge or fallback.

## How

**`@botpress/cognitive`**
- `CognitiveBeta.isBetaClient()` — brand-based guard. The instance carries `['$$IS_COGNITIVE_BETA'] = 'v2'`; the guard checks that property (mirrors the existing `$$IS_COGNITIVE` brand on `Cognitive`). No `instanceof`, so it survives duplicated package copies / bundling.
- `cognitiveFromBeta(beta)` — adapts a `CognitiveBeta` into the `Cognitive`-shaped surface consumers use (`getModelDetails` / `generateContent` / `generateContentStream`). Model details resolve from the static v2 table → live `/v2/cognitive/models` → permissive default; generation goes straight to the beta transport. Never touches v1, preferences, `getBot`, or the File API.
- `buildResponseFromBetaMetadata` extracted to module level and shared by `Cognitive._generateContentV2` and the adapter, so both emit an identical `Response`.

**`llmz`**
- `execute({ client })` type widened to `Cognitive | CognitiveBeta | BotpressClientLike`; construction branches on `isBetaClient` → `cognitiveFromBeta`.

## Tests
- `cognitive/src/cognitive-v2/adapter.test.ts` (12): brand guard (instance / `clone()` / cross-copy brand / negatives), response shaping, generation + streaming, and v2-only model resolution (static / live-list incl. Mercury / permissive default / `listModels` failure). All cognitive unit tests pass (42).
- `llmz/src/llmz.test.ts`: `executeContext` routes a standalone `CognitiveBeta` through the adapter (asserts `generateText` is hit and the error surfaces as `CognitiveError`).

## Notes
- Additive / non-breaking: existing `Cognitive` and raw-`Client` callers are unchanged.
- Follow-up: downstream code that hand-rolls a "v2-only Cognitive" subclass can drop it and just pass a `CognitiveBeta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)