### PR TITLE
feat(messenger): implement bloc message handling for multiple item types

### DIFF
--- a/integrations/messenger/integration.definition.ts
+++ b/integrations/messenger/integration.definition.ts
@@ -8,7 +8,7 @@ import { actions } from './definitions/actions'
 import { messages } from './definitions/channels/channel/messages'
 
 export const INTEGRATION_NAME = 'messenger'
-export const INTEGRATION_VERSION = '5.1.11'
+export const INTEGRATION_VERSION = '5.1.12'
 
 const commonConfigSchema = z.object({
   downloadMedia: z

--- a/integrations/messenger/src/channels/channel.ts
+++ b/integrations/messenger/src/channels/channel.ts
@@ -80,7 +80,7 @@ const channel: bp.IntegrationProps['channels']['channel'] = {
               const { messageId } = await messenger.sendText(recipient, googleMapLink)
               lastMessageId = messageId
             } else {
-              props.logger.forBot().warn(`Unsupported bloc item type: ${(item as any).type}`)
+              props.logger.forBot().warn(`Unsupported bloc item type: ${item.type}`)
             }
           } catch (thrown) {
             const error = thrown instanceof Error ? thrown : new Error(String(thrown))

--- a/integrations/messenger/src/channels/channel.ts
+++ b/integrations/messenger/src/channels/channel.ts
@@ -55,9 +55,35 @@ const channel: bp.IntegrationProps['channels']['channel'] = {
       _sendMessage(props, async (messenger, recipient) => {
         return messenger.sendMessage(recipient, _getChoiceMessage(props.payload))
       }),
-    bloc: () => {
-      throw new RuntimeError('This message type is not supported')
-    },
+    bloc: async (props) =>
+      _sendMessage(props, async (messenger, recipient) => {
+        let lastMessageId = ''
+        for (const item of props.payload.items) {
+          if (item.type === 'text') {
+            const { messageId } = await messenger.sendText(recipient, item.payload.text)
+            lastMessageId = messageId
+          } else if (item.type === 'image') {
+            const { messageId } = await messenger.sendImage(recipient, item.payload.imageUrl)
+            lastMessageId = messageId
+          } else if (item.type === 'audio') {
+            const { messageId } = await messenger.sendAudio(recipient, item.payload.audioUrl)
+            lastMessageId = messageId
+          } else if (item.type === 'video') {
+            const { messageId } = await messenger.sendVideo(recipient, item.payload.videoUrl)
+            lastMessageId = messageId
+          } else if (item.type === 'file') {
+            const { messageId } = await messenger.sendFile(recipient, item.payload.fileUrl)
+            lastMessageId = messageId
+          } else if (item.type === 'location') {
+            const googleMapLink = getGoogleMapLinkFromLocation(item.payload)
+            const { messageId } = await messenger.sendText(recipient, googleMapLink)
+            lastMessageId = messageId
+          } else {
+            props.logger.forBot().warn(`Unsupported bloc item type: ${(item as any).type}`)
+          }
+        }
+        return { messageId: lastMessageId }
+      }),
   },
 }
 

--- a/integrations/messenger/src/channels/channel.ts
+++ b/integrations/messenger/src/channels/channel.ts
@@ -59,28 +59,36 @@ const channel: bp.IntegrationProps['channels']['channel'] = {
       _sendMessage(props, async (messenger, recipient) => {
         let lastMessageId = ''
         for (const item of props.payload.items) {
-          if (item.type === 'text') {
-            const { messageId } = await messenger.sendText(recipient, item.payload.text)
-            lastMessageId = messageId
-          } else if (item.type === 'image') {
-            const { messageId } = await messenger.sendImage(recipient, item.payload.imageUrl)
-            lastMessageId = messageId
-          } else if (item.type === 'audio') {
-            const { messageId } = await messenger.sendAudio(recipient, item.payload.audioUrl)
-            lastMessageId = messageId
-          } else if (item.type === 'video') {
-            const { messageId } = await messenger.sendVideo(recipient, item.payload.videoUrl)
-            lastMessageId = messageId
-          } else if (item.type === 'file') {
-            const { messageId } = await messenger.sendFile(recipient, item.payload.fileUrl)
-            lastMessageId = messageId
-          } else if (item.type === 'location') {
-            const googleMapLink = getGoogleMapLinkFromLocation(item.payload)
-            const { messageId } = await messenger.sendText(recipient, googleMapLink)
-            lastMessageId = messageId
-          } else {
-            props.logger.forBot().warn(`Unsupported bloc item type: ${(item as any).type}`)
+          try {
+            if (item.type === 'text') {
+              const { messageId } = await messenger.sendText(recipient, item.payload.text)
+              lastMessageId = messageId
+            } else if (item.type === 'image') {
+              const { messageId } = await messenger.sendImage(recipient, item.payload.imageUrl)
+              lastMessageId = messageId
+            } else if (item.type === 'audio') {
+              const { messageId } = await messenger.sendAudio(recipient, item.payload.audioUrl)
+              lastMessageId = messageId
+            } else if (item.type === 'video') {
+              const { messageId } = await messenger.sendVideo(recipient, item.payload.videoUrl)
+              lastMessageId = messageId
+            } else if (item.type === 'file') {
+              const { messageId } = await messenger.sendFile(recipient, item.payload.fileUrl)
+              lastMessageId = messageId
+            } else if (item.type === 'location') {
+              const googleMapLink = getGoogleMapLinkFromLocation(item.payload)
+              const { messageId } = await messenger.sendText(recipient, googleMapLink)
+              lastMessageId = messageId
+            } else {
+              props.logger.forBot().warn(`Unsupported bloc item type: ${(item as any).type}`)
+            }
+          } catch (thrown) {
+            const error = thrown instanceof Error ? thrown : new Error(String(thrown))
+            props.logger.forBot().error(`Failed to send bloc item of type "${item.type}": ${error.message}`)
           }
+        }
+        if (!lastMessageId) {
+          throw new Error('No bloc items were successfully sent')
         }
         return { messageId: lastMessageId }
       }),


### PR DESCRIPTION
## Summary
- Add Messenger support for bloc messages by sending each supported item sequentially
- Handle text, image, audio, video, file, and location bloc items
- Convert location items to Google Maps links and log unsupported bloc item types

Resolves BE-1407

## Testing
- Not run (description-only update)