### PR TITLE
fix(whatsapp): return processed inline tokens in default markdown token handler

### DIFF
--- a/integrations/whatsapp/src/misc/markdown-to-whatsapp-rtf.ts
+++ b/integrations/whatsapp/src/misc/markdown-to-whatsapp-rtf.ts
@@ -117,7 +117,7 @@ function _processToken(token: Token, ctx: Context): string {
       // Handle any other token types by processing their tokens if they exist
       if ('tokens' in token && token.tokens) {
         // No support for nested unknown tokens, processing as inline
-        _processInlineTokens(_convertMarkedTokensToTokens(token.tokens), ctx)
+        return _processInlineTokens(_convertMarkedTokensToTokens(token.tokens), ctx)
       }
       if ('text' in token) {
         return token.text


### PR DESCRIPTION
The result of \_processInlineTokens() was called but never returned in the default case of \_processToken(). This silently discards inline content (e.g. bold, italic) for any unsupported or future marked token types, causing them to produce empty output instead of their formatted text.