### PR TITLE
fix(salesforce): improve auth error visibility and token refresh logging

### DIFF
--- a/integrations/salesforce/integration.definition.ts
+++ b/integrations/salesforce/integration.definition.ts
@@ -4,7 +4,7 @@ import { actionDefinitions } from './definitions'
 export default new IntegrationDefinition({
   name: 'salesforce',
   title: 'Salesforce',
-  version: '1.0.2',
+  version: '1.0.3',
   readme: 'hub.md',
   icon: 'icon.svg',
   description: 'Salesforce integration allows you to create, search, update and delete a variety of Salesforce objects',

--- a/integrations/salesforce/src/actions/api.ts
+++ b/integrations/salesforce/src/actions/api.ts
@@ -22,23 +22,39 @@ export const makeApiRequest: bp.IntegrationProps['actions']['makeApiRequest'] = 
     }
   } catch (e) {
     const errorMsg = "'Make API request' error:"
-    if (isAxiosError(e) && e.response?.status === 401) {
-      try {
-        await refreshSfToken(client, ctx)
 
-        const newSfCredentials = await getSfCredentials(client, ctx.integrationId)
+    if (isAxiosError(e)) {
+      const status = e.response?.status
+      logger
+        .forBot()
+        .warn(
+          `Salesforce API request failed with HTTP status ${status ?? 'unknown'} (axios code: ${e.code ?? 'unknown'})`
+        )
 
-        logger.forBot().info('Refreshed token')
+      if (status === 401) {
+        try {
+          logger.forBot().info('Salesforce access token expired, attempting to refresh it')
+          await refreshSfToken(client, ctx, logger)
 
-        const res = await makeRequest(url, input, newSfCredentials.accessToken)
+          const newSfCredentials = await getSfCredentials(client, ctx.integrationId)
 
-        return {
-          success: true,
-          body: res.data,
+          const res = await makeRequest(url, input, newSfCredentials.accessToken)
+
+          return {
+            success: true,
+            status: res.status,
+            body: res.data,
+          }
+        } catch (e) {
+          return handleError(errorMsg, e, logger)
         }
-      } catch (e) {
-        return handleError(errorMsg, e, logger)
       }
+
+      logger
+        .forBot()
+        .warn(
+          `Salesforce API request error is not an expired access token, skipping token refresh (HTTP ${status ?? 'unknown'})`
+        )
     }
 
     return handleError(errorMsg, e, logger)

--- a/integrations/salesforce/src/misc/utils/error-utils.ts
+++ b/integrations/salesforce/src/misc/utils/error-utils.ts
@@ -45,12 +45,12 @@ export const describeSalesforceError = (error: unknown): string => {
     return `${error.message}${status ? ` (HTTP ${status})` : ''}`
   }
 
-  if (error && typeof error === 'object' && ('errorCode' in error || 'message' in error)) {
-    return _describeSalesforceApiError(error as SalesforceApiError)
-  }
-
   if (error instanceof Error) {
     return error.message
+  }
+
+  if (error && typeof error === 'object' && ('errorCode' in error || 'statusCode' in error)) {
+    return _describeSalesforceApiError(error as SalesforceApiError)
   }
 
   return String(error)

--- a/integrations/salesforce/src/misc/utils/error-utils.ts
+++ b/integrations/salesforce/src/misc/utils/error-utils.ts
@@ -1,9 +1,66 @@
+import { isAxiosError } from 'axios'
 import * as bp from '.botpress'
 
-export const handleError = (errorMsg: string, error: any, logger: bp.Logger) => {
-  const fullErrorMsg = `${errorMsg} ${error?.errorCode || error?.message || 'Error'}`
+type SalesforceApiError = { message?: string; errorCode?: string; statusCode?: string }
+type SalesforceOAuthError = { error?: string; error_description?: string }
+
+const _describeSalesforceApiError = (err: SalesforceApiError): string =>
+  [err.errorCode ?? err.statusCode, err.message].filter(Boolean).join(': ') || 'Unknown Salesforce API error'
+
+/**
+ * Salesforce surfaces error details in different shapes depending on the API called:
+ * - REST/SOAP calls (jsforce) throw an Error with `errorCode` and `message` set from the response body.
+ * - DML results (create/update) return `{ success: false, errors: [...] }` instead of throwing.
+ * - Raw HTTP calls (axios) reject with an AxiosError whose `response.data` holds the Salesforce error body.
+ * - The OAuth2 token endpoint returns `{ error, error_description }` instead of the REST error shape.
+ * This normalizes all of them into one descriptive, human-readable message.
+ */
+export const describeSalesforceError = (error: unknown): string => {
+  if (Array.isArray(error)) {
+    return (
+      error
+        .map((err) => (typeof err === 'string' ? err : _describeSalesforceApiError(err as SalesforceApiError)))
+        .filter(Boolean)
+        .join('; ') || 'Unknown Salesforce API error'
+    )
+  }
+
+  if (isAxiosError(error)) {
+    const data = error.response?.data
+    const status = error.response?.status
+
+    if (Array.isArray(data)) {
+      return `${describeSalesforceError(data)}${status ? ` (HTTP ${status})` : ''}`
+    }
+
+    if (data && typeof data === 'object') {
+      const oauthError = data as SalesforceOAuthError
+      if (oauthError.error) {
+        const detail = [oauthError.error, oauthError.error_description].filter(Boolean).join(': ')
+        return `${detail}${status ? ` (HTTP ${status})` : ''}`
+      }
+      return `${_describeSalesforceApiError(data as SalesforceApiError)}${status ? ` (HTTP ${status})` : ''}`
+    }
+
+    return `${error.message}${status ? ` (HTTP ${status})` : ''}`
+  }
+
+  if (error && typeof error === 'object' && ('errorCode' in error || 'message' in error)) {
+    return _describeSalesforceApiError(error as SalesforceApiError)
+  }
+
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return String(error)
+}
+
+export const handleError = (errorMsg: string, error: unknown, logger: bp.Logger) => {
+  const fullErrorMsg = `${errorMsg} ${describeSalesforceError(error)}`
+
   logger.forBot().error(fullErrorMsg)
-  logger.forBot().error(JSON.stringify(error))
+  logger.forBot().debug(JSON.stringify(isAxiosError(error) ? (error.response?.data ?? error.toJSON()) : error))
 
   return {
     success: false,

--- a/integrations/salesforce/src/misc/utils/error-utils.ts
+++ b/integrations/salesforce/src/misc/utils/error-utils.ts
@@ -1,8 +1,29 @@
+import { z } from '@botpress/sdk'
 import { isAxiosError } from 'axios'
 import * as bp from '.botpress'
 
-type SalesforceApiError = { message?: string; errorCode?: string; statusCode?: string }
-type SalesforceOAuthError = { error?: string; error_description?: string }
+const _salesforceApiErrorSchema = z.object({
+  message: z.string().optional(),
+  errorCode: z.string().optional(),
+  statusCode: z.string().optional(),
+})
+type SalesforceApiError = z.infer<typeof _salesforceApiErrorSchema>
+
+const _salesforceOAuthErrorSchema = z.object({
+  error: z.string().optional(),
+  error_description: z.string().optional(),
+})
+type SalesforceOAuthError = z.infer<typeof _salesforceOAuthErrorSchema>
+
+const _parseSalesforceApiError = (err: unknown): SalesforceApiError => {
+  const result = _salesforceApiErrorSchema.safeParse(err)
+  return result.success ? result.data : {}
+}
+
+const _parseSalesforceOAuthError = (data: unknown): SalesforceOAuthError => {
+  const result = _salesforceOAuthErrorSchema.safeParse(data)
+  return result.success ? result.data : {}
+}
 
 const _describeSalesforceApiError = (err: SalesforceApiError): string =>
   [err.errorCode ?? err.statusCode, err.message].filter(Boolean).join(': ') || 'Unknown Salesforce API error'
@@ -19,7 +40,7 @@ export const describeSalesforceError = (error: unknown): string => {
   if (Array.isArray(error)) {
     return (
       error
-        .map((err) => (typeof err === 'string' ? err : _describeSalesforceApiError(err as SalesforceApiError)))
+        .map((err) => (typeof err === 'string' ? err : _describeSalesforceApiError(_parseSalesforceApiError(err))))
         .filter(Boolean)
         .join('; ') || 'Unknown Salesforce API error'
     )
@@ -34,12 +55,12 @@ export const describeSalesforceError = (error: unknown): string => {
     }
 
     if (data && typeof data === 'object') {
-      const oauthError = data as SalesforceOAuthError
+      const oauthError = _parseSalesforceOAuthError(data)
       if (oauthError.error) {
         const detail = [oauthError.error, oauthError.error_description].filter(Boolean).join(': ')
         return `${detail}${status ? ` (HTTP ${status})` : ''}`
       }
-      return `${_describeSalesforceApiError(data as SalesforceApiError)}${status ? ` (HTTP ${status})` : ''}`
+      return `${_describeSalesforceApiError(_parseSalesforceApiError(data))}${status ? ` (HTTP ${status})` : ''}`
     }
 
     return `${error.message}${status ? ` (HTTP ${status})` : ''}`
@@ -50,7 +71,7 @@ export const describeSalesforceError = (error: unknown): string => {
   }
 
   if (error && typeof error === 'object' && ('errorCode' in error || 'statusCode' in error)) {
-    return _describeSalesforceApiError(error as SalesforceApiError)
+    return _describeSalesforceApiError(_parseSalesforceApiError(error))
   }
 
   return String(error)

--- a/integrations/salesforce/src/misc/utils/sf-utils.ts
+++ b/integrations/salesforce/src/misc/utils/sf-utils.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import { OAuth2, Connection } from 'jsforce'
 import { getBotpressWebhookUrl, getSfCredentials } from './bp-utils'
+import { describeSalesforceError } from './error-utils'
 import * as bp from '.botpress'
 
 export const getOAuth2 = (ctx: bp.Context): OAuth2 => {
@@ -18,8 +19,8 @@ export const getConnection = async (client: bp.Client, ctx: bp.Context, logger: 
   try {
     sfCredentials = await getSfCredentials(client, ctx.integrationId)
   } catch (e) {
-    const errorMsg = `Error fetching Salesforce credentials: ${JSON.stringify(e)}`
-    logger.forBot().info(errorMsg)
+    const errorMsg = `Error fetching Salesforce credentials: ${describeSalesforceError(e)}`
+    logger.forBot().error(errorMsg)
     throw new Error(errorMsg)
   }
 
@@ -34,6 +35,7 @@ export const getConnection = async (client: bp.Client, ctx: bp.Context, logger: 
 
   //When access token is refreshed, update it in the state
   connection.on('refresh', (newAccessToken: string) => {
+    logger.forBot().info('Salesforce access token expired and was refreshed successfully')
     client
       .setState({
         type: 'integration',
@@ -47,20 +49,21 @@ export const getConnection = async (client: bp.Client, ctx: bp.Context, logger: 
         },
       })
       .catch((thrown: unknown) => {
-        const msg = thrown instanceof Error ? thrown.message : String(thrown)
-        console.error('Error updating Salesforce credentials:', msg)
+        logger.forBot().error(`Error persisting refreshed Salesforce access token: ${describeSalesforceError(thrown)}`)
       })
   })
 
   return connection
 }
 
-export const refreshSfToken = async (client: bp.Client, ctx: bp.Context): Promise<void> => {
+export const refreshSfToken = async (client: bp.Client, ctx: bp.Context, logger: bp.Logger): Promise<void> => {
   const url = `${getEnvironmentUrl(ctx)}/services/oauth2/token`
   const sfCredentials = await getSfCredentials(client, ctx.integrationId)
 
   if (!sfCredentials.refreshToken) {
-    throw new Error('No refresh token available. Please re-authenticate with Salesforce.')
+    const errorMsg = 'No refresh token available. Please re-authenticate with Salesforce.'
+    logger.forBot().error(errorMsg)
+    throw new Error(errorMsg)
   }
 
   const params = new URLSearchParams()
@@ -87,9 +90,12 @@ export const refreshSfToken = async (client: bp.Client, ctx: bp.Context): Promis
         refreshToken: sfCredentials.refreshToken,
       },
     })
+
+    logger.forBot().info('Salesforce access token expired and was refreshed successfully')
   } catch (error) {
-    console.error('Error refreshing token:', error)
-    throw new Error(`Error refreshing Salesforce token: ${JSON.stringify(error)}`)
+    const errorMsg = `Error refreshing Salesforce token: ${describeSalesforceError(error)}`
+    logger.forBot().error(errorMsg)
+    throw new Error(errorMsg)
   }
 }
 


### PR DESCRIPTION

### Summary
- Add descriptive error messages for Salesforce API failures — `handleError` previously only read `error.errorCode`/`error.message` off a single object, so DML failures (`response.errors`, an array) and raw axios errors (whose real Salesforce error lives in `error.response.data`, dropped by `JSON.stringify`) fell back to a generic `"Error"` string with no useful detail. Added `describeSalesforceError()` to normalize jsforce errors, DML error arrays, axios REST errors, and OAuth2 `{error, error_description}` errors into one descriptive message.
- Fix silent/invisible logging around token refresh — `refreshSfToken` had no `logger` param and used `console.error` (invisible in the bot's log viewer); `getConnection`'s credential-fetch failure logged at `.info()` instead of `.error()`. Both now log through `logger.forBot()` with descriptive messages, plus new info logs when a refresh is attempted/succeeds.
- Improve `makeApiRequest`'s error handling — log the HTTP status and axios error code for every failed request, log distinctly when a non-401 error means we're skipping the token-refresh path, and fix the retry-after-refresh success branch which was missing the `status` field present in the initial-success branch.
- Bump integration version to `1.0.3`.

### Why
Filed as: auth failures after access-token expiry had no useful error logging, refresh-token flow correctness was hard to verify, and API errors didn't surface Salesforce's actual error messages — just generic ones.


