### PR TITLE
fix(hitl): use integration alias rather than name for routing

### DIFF
--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -102,7 +102,7 @@ const PLUGIN_CONFIG_SCHEMA = sdk.z.object({
 
 export default new sdk.PluginDefinition({
   name: 'hitl',
-  version: '1.4.0',
+  version: '1.4.1',
   title: 'Human In The Loop',
   description: 'Seamlessly transfer conversations to human agents',
   icon: 'icon.svg',
@@ -202,6 +202,10 @@ export default new sdk.PluginDefinition({
       integrationName: {
         title: 'HITL Integration Name',
         description: 'Name of the integration which created the downstream user',
+      },
+      integrationAlias: {
+        title: 'HITL Integration Alias',
+        description: 'Alias of the integration instance which created the downstream user',
       },
     },
   },

--- a/plugins/hitl/src/actions/start-hitl.ts
+++ b/plugins/hitl/src/actions/start-hitl.ts
@@ -22,7 +22,10 @@ export const startHitl: bp.PluginProps['actions']['startHitl'] = async (props) =
   const upstreamConversation = await props.conversations.hitl.hitl.getById({ id: upstreamConversationId })
   const upstreamCm = conv.ConversationManager.from(props, upstreamConversation)
 
-  if (upstreamConversation.tags.upstream || upstreamConversation.integration === props.interfaces.hitl.name) {
+  if (
+    upstreamConversation.tags.upstream ||
+    upstreamConversation.integration === props.interfaces.hitl.integrationAlias
+  ) {
     // Without this check, closing the downstream conversation (the ticket) can
     // result in the bot calling startHitl a second time, but using the
     // downstream conversation as if it was the upstream conversation. Human

--- a/plugins/hitl/src/hooks/before-incoming-message/all.ts
+++ b/plugins/hitl/src/hooks/before-incoming-message/all.ts
@@ -19,7 +19,7 @@ export const handleMessage: bp.HookHandlers['before_incoming_message']['*'] = as
   })
 
   const { integration } = conversation
-  if (integration === props.interfaces.hitl.name) {
+  if (integration === props.interfaces.hitl.integrationAlias) {
     return await _handleDownstreamMessage(props, conversation)
   }
   return await _handleUpstreamMessage(props, conversation)

--- a/plugins/hitl/src/user-linker.ts
+++ b/plugins/hitl/src/user-linker.ts
@@ -34,8 +34,11 @@ export class UserLinker {
 
   private async _getExistingDownstreamUserId(upstreamUser: types.ActionableUser) {
     const downstreamUserId = upstreamUser?.tags?.downstream
+    const isLinkedToCurrentIntegration = upstreamUser?.tags?.integrationAlias
+      ? upstreamUser.tags.integrationAlias === this._props.interfaces.hitl.integrationAlias
+      : upstreamUser?.tags?.integrationName === this._props.interfaces.hitl.name
 
-    if (!downstreamUserId || upstreamUser?.tags?.integrationName !== this._props.interfaces.hitl.name) {
+    if (!downstreamUserId || !isLinkedToCurrentIntegration) {
       return null
     }
 
@@ -65,12 +68,14 @@ export class UserLinker {
         tags: {
           downstream: downstreamUserId,
           integrationName: this._props.interfaces.hitl.name,
+          integrationAlias: this._props.interfaces.hitl.integrationAlias,
         },
       }),
       downstreamUser.update({
         tags: {
           upstream: upstreamUser.id,
           integrationName: this._props.interfaces.hitl.name,
+          integrationAlias: this._props.interfaces.hitl.integrationAlias,
         },
       }),
     ])


### PR DESCRIPTION
The hitl plugin dispatches messages and links downstream users by comparing `conversation.integration` (the integration instance alias) against `props.interfaces.hitl.name` (the integration definition name). The two only match when an integration is installed under its default alias. Bots that install the backing integration under a custom alias get every downstream message misrouted to the upstream handler, and the HITL session aborts with `internal-error`.

This PR thus compares against `props.interfaces.hitl.integrationAlias` instead.
Resolves KKN-882.