### PR TITLE
chore(integrations/hubspot): fixed hubspot spelling in docs

### DIFF
--- a/integrations/hubspot/definitions/actions/contact.ts
+++ b/integrations/hubspot/definitions/actions/contact.ts
@@ -57,7 +57,7 @@ const searchContact: ActionDefinition = {
 
 const listContactProperties: ActionDefinition = {
   title: 'List Contact Properties',
-  description: 'List all available Hubspot contact properties with their metadata',
+  description: 'List all available HubSpot contact properties with their metadata',
   input: {
     schema: z.object({}).title('Empty').describe('No input required'),
   },

--- a/integrations/hubspot/definitions/actions/file.ts
+++ b/integrations/hubspot/definitions/actions/file.ts
@@ -2,7 +2,7 @@ import { z, ActionDefinition } from '@botpress/sdk'
 
 const getFileUrl: ActionDefinition = {
   title: 'Get File URL',
-  description: 'Get a URL to access a file stored in Hubspot Files',
+  description: 'Get a URL to access a file stored in HubSpot Files',
   input: {
     schema: z.object({
       fileName: z.string().title('File path').describe('The path to the Hubspot file'),

--- a/integrations/hubspot/definitions/actions/owner.ts
+++ b/integrations/hubspot/definitions/actions/owner.ts
@@ -14,7 +14,7 @@ export const ownerSchema = z.object({
 
 const getOwner: ActionDefinition = {
   title: 'Get Owner',
-  description: 'Get a Hubspot owner (user) by ID. Used to resolve owner references on contacts, deals, etc.',
+  description: 'Get a HubSpot owner (user) by ID. Used to resolve owner references on contacts, deals, etc.',
   input: {
     schema: z.object({
       ownerId: z.string().title('Owner ID').describe('The ID of the owner to fetch'),

--- a/integrations/hubspot/integration.definition.ts
+++ b/integrations/hubspot/integration.definition.ts
@@ -6,7 +6,7 @@ export default new IntegrationDefinition({
   name: 'hubspot',
   title: 'HubSpot',
   description: 'Manage contacts, tickets and more from your chatbot.',
-  version: '6.0.9',
+  version: '6.0.10',
   readme: 'hub.md',
   icon: 'icon.svg',
   configuration: {


### PR DESCRIPTION
updated spelling of hubspot ("Hubspot" > "HubSpot") 
needed for OAuth app approval