### PR TITLE
chore(hitl plugin): bump patch version

### DIFF
--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -102,7 +102,7 @@ const PLUGIN_CONFIG_SCHEMA = sdk.z.object({
 
 export default new sdk.PluginDefinition({
   name: 'hitl',
-  version: '1.4.1',
+  version: '1.4.2',
   title: 'Human In The Loop',
   description: 'Seamlessly transfer conversations to human agents',
   icon: 'icon.svg',


### PR DESCRIPTION
Follow-up to https://github.com/botpress/skynet/pull/5120.

This is already deployed publicly in production.