### PR TITLE
feat(teams): expose sender locale as a message tag

### DIFF
--- a/integrations/teams/definitions/channels.ts
+++ b/integrations/teams/definitions/channels.ts
@@ -11,6 +11,10 @@ export const channels = {
           title: 'ID',
           description: 'Teams activity ID',
         },
+        locale: {
+          title: 'Locale',
+          description: "Sender's Teams client locale for this activity (e.g. en-US), when provided",
+        },
       },
     },
     conversation: {

--- a/integrations/teams/integration.definition.ts
+++ b/integrations/teams/integration.definition.ts
@@ -4,7 +4,7 @@ import { actions, channels, user, states } from 'definitions'
 
 export default new IntegrationDefinition({
   name: 'teams',
-  version: '2.0.5',
+  version: '2.1.0',
   title: 'Microsoft Teams',
   description: 'Interact with users, deliver notifications, and perform actions within Microsoft Teams.',
   icon: 'icon.svg',

--- a/integrations/teams/src/channels/inbound.ts
+++ b/integrations/teams/src/channels/inbound.ts
@@ -50,7 +50,7 @@ export const processInboundChannelMessage = async ({ client, ctx, logger }: bp.H
 
       const message = _extractMessage(activity)
       await client.getOrCreateMessage({
-        tags: { id: activity.id },
+        tags: { id: activity.id, locale: activity.locale },
         type: 'text',
         userId: user.id,
         conversationId: conversation.id,


### PR DESCRIPTION
## What

Microsoft Teams sends the sender's client locale (e.g. `cs-CZ`, `en-US`) on every Bot Framework activity. The webhook already receives it — the activity schema is `.passthrough()`, and the value is even persisted inside the stored `ConversationReference` — but it was never exposed to bots.

This PR adds a declared **`locale` message tag**, set from `activity.locale` on inbound messages.

## Why

Multilingual bots currently have no reliable language signal on Teams: onboarding taps carry no text to detect from, so first bot-initiated messages fall back to configured defaults. The sender's Teams client language is the right seed, and it's already arriving on every message — it just needs exposing. (Motivating case: a multi-country enterprise deployment serving CZ/RO/PL/TR/EL users, where the language layer seeds from a catalogue guess today.)

## Design notes

- **Message tag, deliberately not a user tag:** `getOrCreateUser` uses its tags for identity lookup, and locale is *volatile* (changes when the user switches Teams UI language) — unlike the stable `email` tag already promoted there. A message tag has no identity-matching risk, and per-message granularity fits language detection.
- `activity.locale` is optional on the botbuilder `Activity` type; when absent, the tag simply isn't set (same pattern as `email: sender?.email`).
- Additive declared tag → no behavior change for existing bots; minor version bump `2.0.5 → 2.1.0`.

## Changes

- `definitions/channels.ts` — declare `locale` under `channel.message.tags`
- `src/channels/inbound.ts` — `tags: { id: activity.id, locale: activity.locale }`
- `integration.definition.ts` — version `2.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)