### PR TITLE
fix(interfaces): make typing-indicator messageId optional

### DIFF
--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -14,7 +14,7 @@ export default new IntegrationDefinition({
   name: 'slack',
   title: 'Slack',
   description: 'Automate interactions with your team.',
-  version: '5.1.0',
+  version: '5.1.1',
   icon: 'icon.svg',
   readme: 'hub.md',
   configuration: {

--- a/integrations/slack/src/actions/typing-indicator.ts
+++ b/integrations/slack/src/actions/typing-indicator.ts
@@ -6,6 +6,13 @@ const TYPING_INDICATOR_EMOJI = 'eyes'
 export const startTypingIndicator = wrapActionAndInjectSlackClient(
   { actionName: 'startTypingIndicator', errorMessage: 'Failed to start typing indicator' },
   async ({ ctx, client, slackClient, logger }, { conversationId, messageId }) => {
+    if (!messageId) {
+      logger
+        .forBot()
+        .debug('No message ID provided — Slack attaches the typing indicator to a message; skipping (typing indicator)')
+      return
+    }
+
     const { channel, ts } = await retrieveChannelAndMessageTs({
       client,
       messageId,
@@ -36,6 +43,13 @@ export const startTypingIndicator = wrapActionAndInjectSlackClient(
 export const stopTypingIndicator = wrapActionAndInjectSlackClient(
   { actionName: 'stopTypingIndicator', errorMessage: 'Failed to stop typing indicator' },
   async ({ client, slackClient, logger, ctx }, { messageId, conversationId }) => {
+    if (!messageId) {
+      logger
+        .forBot()
+        .debug('No message ID provided — Slack attaches the typing indicator to a message; skipping (typing indicator)')
+      return
+    }
+
     const { channel, ts } = await retrieveChannelAndMessageTs({
       client,
       messageId,

--- a/integrations/telegram/integration.definition.ts
+++ b/integrations/telegram/integration.definition.ts
@@ -4,7 +4,7 @@ import { telegramMessageChannels } from './definitions/channels'
 
 export default new IntegrationDefinition({
   name: 'telegram',
-  version: '1.0.9',
+  version: '1.0.10',
   title: 'Telegram',
   description: 'Engage with your audience in real-time.',
   icon: 'icon.svg',

--- a/integrations/telegram/src/index.ts
+++ b/integrations/telegram/src/index.ts
@@ -50,16 +50,17 @@ const integration = new bp.Integration({
       const botToken = await getStoredBotToken(client, ctx.integrationId, ctx.configuration.botToken)
       const telegraf = new Telegraf(botToken)
       const { conversation } = await client.getConversation({ id: input.conversationId })
-      const { message } = await client.getMessage({ id: input.messageId })
 
       const chat = getChat(conversation)
-      const messageId = getMessageId(message)
 
       await telegraf.telegram.sendChatAction(chat, 'typing').catch(mapToRuntimeErrorAndThrow('Fail to start typing'))
 
-      if (ctx.configuration.typingIndicatorEmoji === false) {
+      if (ctx.configuration.typingIndicatorEmoji === false || !input.messageId) {
         return {}
       }
+
+      const { message } = await client.getMessage({ id: input.messageId })
+      const messageId = getMessageId(message)
 
       await telegraf.telegram
         .setMessageReaction(chat, messageId, [{ type: 'emoji', emoji: '👀' }])
@@ -68,7 +69,7 @@ const integration = new bp.Integration({
       return {}
     },
     stopTypingIndicator: async ({ input, ctx, client }) => {
-      if (ctx.configuration.typingIndicatorEmoji === false) {
+      if (ctx.configuration.typingIndicatorEmoji === false || !input.messageId) {
         return {}
       }
 

--- a/integrations/twilio/integration.definition.ts
+++ b/integrations/twilio/integration.definition.ts
@@ -5,7 +5,7 @@ import typingIndicator from 'bp_modules/typing-indicator'
 import { channels, configuration, entities, user } from './definitions'
 
 export const INTEGRATION_NAME = 'twilio'
-export const INTEGRATION_VERSION = '1.3.3'
+export const INTEGRATION_VERSION = '1.3.4'
 
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/twilio/src/actions/typing-indicator.ts
+++ b/integrations/twilio/src/actions/typing-indicator.ts
@@ -51,6 +51,10 @@ export const startTypingIndicator: bp.IntegrationProps['actions']['startTypingIn
 }) => {
   try {
     const { conversationId, messageId } = input
+    if (!messageId) {
+      // The typing indicator is attached to the message being replied to; without it there is nothing to send
+      return {}
+    }
     await sendTypingIndicator({ client, ctx, conversationId, messageId })
   } catch (error) {
     const thrown = error instanceof Error ? error : new Error(String(error))

--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -157,7 +157,7 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp'
-export const INTEGRATION_VERSION = '4.18.2'
+export const INTEGRATION_VERSION = '4.18.3'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,

--- a/integrations/whatsapp/src/actions/typing-indicator.ts
+++ b/integrations/whatsapp/src/actions/typing-indicator.ts
@@ -12,8 +12,12 @@ export const startTypingIndicator: bp.IntegrationProps['actions']['startTypingIn
   if (ctx.configuration.messageReadBehavior === 'none') {
     return {}
   }
-  const whatsapp = await getAuthenticatedWhatsappClient(client, ctx)
   const { conversationId, messageId } = input
+  if (!messageId) {
+    // Read receipts and typing indicators are tied to the message being replied to
+    return {}
+  }
+  const whatsapp = await getAuthenticatedWhatsappClient(client, ctx)
   const { botPhoneNumberId, userPhone } = await _getConversationInfos(client, conversationId)
   const { whatsappMessageId } = await _getMessageInfos(client, messageId)
   const indicator = ctx.configuration.messageReadBehavior === 'typing_indicator' ? 'text' : undefined
@@ -38,8 +42,11 @@ export const stopTypingIndicator: bp.IntegrationProps['actions']['stopTypingIndi
   if (ctx.configuration.messageReadBehavior === 'none' || !ctx.configuration.typingIndicatorEmoji) {
     return {}
   }
-  const whatsapp = await getAuthenticatedWhatsappClient(client, ctx)
   const { conversationId, messageId } = input
+  if (!messageId) {
+    return {}
+  }
+  const whatsapp = await getAuthenticatedWhatsappClient(client, ctx)
   const { botPhoneNumberId, userPhone } = await _getConversationInfos(client, conversationId)
   const { whatsappMessageId } = await _getMessageInfos(client, messageId)
   await whatsapp.sendMessage(botPhoneNumberId, userPhone, new Reaction(whatsappMessageId))

--- a/interfaces/typing-indicator/interface.definition.ts
+++ b/interfaces/typing-indicator/interface.definition.ts
@@ -2,7 +2,7 @@ import * as sdk from '@botpress/sdk'
 
 export default new sdk.InterfaceDefinition({
   name: 'typing-indicator',
-  version: '0.0.4',
+  version: '0.0.5',
   entities: {},
   events: {},
   actions: {
@@ -19,8 +19,11 @@ export default new sdk.InterfaceDefinition({
               .describe('The ID of the conversation where the typing indicator should be shown'),
             messageId: sdk.z
               .string()
+              .optional()
               .title('Message ID')
-              .describe('The message ID to which the typing indicator should be attached'),
+              .describe(
+                'The message ID to which the typing indicator should be attached, for channels that support it'
+              ),
             timeout: sdk.z
               .number()
               .optional()
@@ -45,8 +48,11 @@ export default new sdk.InterfaceDefinition({
               .describe('The ID of the conversation where the typing indicator should be removed'),
             messageId: sdk.z
               .string()
+              .optional()
               .title('Message ID')
-              .describe('The message ID from which the typing indicator should be removed'),
+              .describe(
+                'The message ID from which the typing indicator should be removed, for channels that support it'
+              ),
           }),
       },
       output: {


### PR DESCRIPTION
## What

The `typing-indicator` interface declares `messageId` as a **required** input on `startTypingIndicator` / `stopTypingIndicator`, but only some implementations actually use it. Callers that don't have a message id in hand are rejected at action-input validation with:

```
invalid input for action "teams:startTypingIndicator": data must have required property 'messageId'
```

…even when the target channel ignores the field entirely (the teams implementation destructures only `conversationId` and `timeout`).

This PR makes `messageId` optional on both actions (interface `0.0.4 → 0.0.5`) and hardens the four implementations that do use it.

## Why

On channels like Teams, the typing indicator is **conversation-scoped** — a Bot Framework typing activity sent to the conversation. Requiring a message id there is an accident of the shared schema: it exists for channels like Slack, where the "indicator" is a 👀 reaction attached to a specific message.

Real-world impact: a bot hook (e.g. `before_llmz_execution`, firing before any reply message exists) calling `teams:startTypingIndicator` with `{conversationId, timeout}` gets a validation error on **every turn**. A production multilingual enterprise bot on Teams was logging 250+ of these per week, and its Teams users never saw a typing indicator.

## Validated in production (2026-07-20)

Direct `callAction` against a live bot's installed teams integration, real Teams conversation:

- `{conversationId, timeout}` → **HTTP 400**, `data must have required property 'messageId'`
- `{conversationId, messageId: 'none', timeout}` → **200 OK**, typing activity delivered — the junk value validates and is silently ignored

The same bot now runs the `messageId: 'none'` workaround in its hooks: the validation-error class dropped to zero and Teams users see a working typing indicator (`teams:startTypingIndicator ok` on every turn since). This PR removes the need for callers to invent junk values to satisfy a field the channel never reads.

## Behavior when `messageId` is absent (per channel)

| Channel | Uses messageId? | New behavior without it |
|---|---|---|
| teams, messenger, sunco, line | no | unchanged — field was already ignored |
| **slack** | yes (reaction + mark-seen need the message ts) | skip with a bot-scoped debug log |
| **twilio** | yes (v2 Indicators API needs the message sid) | skip (existing no-op pattern) |
| **whatsapp** | yes (read receipt + reaction tied to the message) | skip |
| **telegram** | partially | **still sends the chat `typing` action** (it only needs the chat); only the 👀 reaction is skipped |

Callers that pass `messageId` today are unaffected — the schema change is loosening-only.

## Changes

- `interfaces/typing-indicator/interface.definition.ts` — `messageId` `.optional()` on both actions, `0.0.5`
- `integrations/slack` — guard both actions, `5.1.1`
- `integrations/twilio` — guard start action, `1.3.4`
- `integrations/whatsapp` — guard both actions, `4.18.3`
- `integrations/telegram` — send typing action without the message; reaction paths guarded, `1.0.10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)