### PR TITLE
fix(cli): increase API timeout

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "6.8.9",
+  "version": "6.8.10",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",

--- a/packages/cli/src/api/client.ts
+++ b/packages/cli/src/api/client.ts
@@ -1,6 +1,7 @@
 import * as client from '@botpress/client'
 import semver from 'semver'
 import yn from 'yn'
+import * as consts from '../consts'
 import * as errors from '../errors'
 import type { Logger } from '../logger'
 import { formatPackageRef, ApiPackageRef, NamePackageRef } from '../package-ref'
@@ -46,6 +47,7 @@ export class ApiClient {
       token,
       workspaceId,
       botId,
+      timeout: consts.defaultBotpressApiTimeout,
       retry: retry.config,
       headers: { 'x-multiple-integrations': 'true', ...extraHeaders },
     })

--- a/packages/cli/src/command-implementations/login-command.ts
+++ b/packages/cli/src/command-implementations/login-command.ts
@@ -42,7 +42,11 @@ export class LoginCommand extends GlobalCommand<LoginCommandDefinition> {
       this.logger.log(`Using custom api url ${this.argv.apiUrl} to try fetching workspaces`, { prefix: '🔗' })
     }
     const promptedWorkspaceId = await this.globalCache.sync('workspaceId', this.argv.workspaceId, async (defaultId) => {
-      const tmpClient = new client.Client({ apiUrl: this.argv.apiUrl, token: promptedToken }) // no workspaceId yet
+      const tmpClient = new client.Client({
+        apiUrl: this.argv.apiUrl,
+        token: promptedToken,
+        timeout: consts.defaultBotpressApiTimeout,
+      }) // no workspaceId yet
       const userWorkspaces = await paging
         .listAllPages(tmpClient.listWorkspaces, (r) => r.workspaces)
         .catch((thrown) => {

--- a/packages/cli/src/consts.ts
+++ b/packages/cli/src/consts.ts
@@ -10,6 +10,7 @@ export const defaultBotpressHome = pathlib.join(os.homedir(), '.botpress')
 export const defaultWorkDir = process.cwd()
 export const defaultInstallPath = process.cwd()
 export const defaultBotpressApiUrl = `https://api.${productionBotpressDomain}`
+export const defaultBotpressApiTimeout = 180_000
 export const defaultBotpressAppUrl = `https://app.${productionBotpressDomain}`
 export const defaultTunnelUrl = `https://tunnel.${productionBotpressDomain}`
 export const defaultChatApiUrl = `https://chat.${productionBotpressDomain}`


### PR DESCRIPTION
## Summary

- increase the CLI API request timeout from 60 seconds to 180 seconds
- apply the timeout to regular API requests and the login workspace lookup
- bump `@botpress/cli` from `6.8.9` to `6.8.10`

## Why

Long-running CLI API requests can exceed the `@botpress/client` Axios default of 60 seconds. The CLI now provides its own three-minute timeout.

## Validation

- `pnpm --filter @botpress/cli test` (478 tests passed)
- `pnpm --filter @botpress/cli check:type`
- Prettier and ESLint on changed files
- `git diff --check`

The full root check still has unrelated failures: repo-wide ESLint exceeds Node's default 4 GB heap, and the WhatsApp integration has existing type errors.