### PR TITLE
feat(client): support bot module formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.564.0",
-    "@botpress/api": "1.116.0",
+    "@botpress/api": "1.117.0",
     "@botpress/cli": "workspace:*",
     "@botpress/client": "workspace:*",
     "@botpress/sdk": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "6.8.11",
+  "version": "6.8.12",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",
@@ -27,8 +27,8 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "1.0.0",
-    "@botpress/client": "1.48.0",
-    "@botpress/sdk": "6.13.2",
+    "@botpress/client": "1.49.0",
+    "@botpress/sdk": "6.13.3",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/verel": "^0.2.0",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -5,8 +5,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.48.0",
-    "@botpress/sdk": "6.13.2"
+    "@botpress/client": "1.49.0",
+    "@botpress/sdk": "6.13.3"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.48.0",
-    "@botpress/sdk": "6.13.2"
+    "@botpress/client": "1.49.0",
+    "@botpress/sdk": "6.13.3"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "6.13.2"
+    "@botpress/sdk": "6.13.3"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.48.0",
-    "@botpress/sdk": "6.13.2"
+    "@botpress/client": "1.49.0",
+    "@botpress/sdk": "6.13.3"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -6,8 +6,8 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.48.0",
-    "@botpress/sdk": "6.13.2",
+    "@botpress/client": "1.49.0",
+    "@botpress/sdk": "6.13.3",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "1.48.0",
+  "version": "1.49.0",
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -2,7 +2,7 @@
   "name": "llmz",
   "type": "module",
   "description": "LLMz - An LLM-native Typescript VM built on top of Zui",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -71,7 +71,7 @@
     "tsx": "^4.19.2"
   },
   "peerDependencies": {
-    "@botpress/client": "1.48.0",
+    "@botpress/client": "1.49.0",
     "@botpress/cognitive": "0.6.2",
     "@bpinternal/thicktoken": "^2.0.0",
     "@bpinternal/zui": "^2.3.1"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "6.13.2",
+  "version": "6.13.3",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -20,7 +20,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "1.48.0",
+    "@botpress/client": "1.49.0",
     "browser-or-node": "^2.1.1",
     "semver": "^7.3.8"
   },

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/vai",
-  "version": "0.0.37",
+  "version": "0.0.38",
   "description": "Vitest AI (vai) – a vitest extension for testing with LLMs",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -40,7 +40,7 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "@botpress/client": "1.48.0",
+    "@botpress/client": "1.49.0",
     "@bpinternal/thicktoken": "^1.0.1",
     "@bpinternal/zui": "^2.3.1",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2741,10 +2741,10 @@ importers:
         specifier: 1.0.0
         version: link:../chat-client
       '@botpress/client':
-        specifier: 1.48.0
+        specifier: 1.49.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 6.13.2
+        specifier: 6.13.3
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2865,10 +2865,10 @@ importers:
   packages/cli/templates/empty-bot:
     dependencies:
       '@botpress/client':
-        specifier: 1.48.0
+        specifier: 1.49.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.13.2
+        specifier: 6.13.3
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2881,10 +2881,10 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 1.48.0
+        specifier: 1.49.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.13.2
+        specifier: 6.13.3
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2897,7 +2897,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 6.13.2
+        specifier: 6.13.3
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2910,10 +2910,10 @@ importers:
   packages/cli/templates/hello-world:
     dependencies:
       '@botpress/client':
-        specifier: 1.48.0
+        specifier: 1.49.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.13.2
+        specifier: 6.13.3
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2926,10 +2926,10 @@ importers:
   packages/cli/templates/webhook-message:
     dependencies:
       '@botpress/client':
-        specifier: 1.48.0
+        specifier: 1.49.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.13.2
+        specifier: 6.13.3
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8
@@ -3086,7 +3086,7 @@ importers:
         specifier: ^7.26.3
         version: 7.26.9
       '@botpress/client':
-        specifier: 1.48.0
+        specifier: 1.49.0
         version: link:../client
       '@botpress/cognitive':
         specifier: 0.6.2
@@ -3192,7 +3192,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 1.48.0
+        specifier: 1.49.0
         version: link:../client
       '@bpinternal/zui':
         specifier: ^2.3.1
@@ -3223,7 +3223,7 @@ importers:
   packages/vai:
     dependencies:
       '@botpress/client':
-        specifier: 1.48.0
+        specifier: 1.49.0
         version: link:../client
       '@bpinternal/thicktoken':
         specifier: ^1.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^3.564.0
         version: 3.709.0
       '@botpress/api':
-        specifier: 1.116.0
-        version: 1.116.0
+        specifier: 1.117.0
+        version: 1.117.0
       '@botpress/cli':
         specifier: workspace:*
         version: link:packages/cli
@@ -4330,8 +4330,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@botpress/api@1.116.0':
-    resolution: {integrity: sha512-ndrm9+VO7P09yf+ECNQmWdNPaWZJCqDotwzI3B1NqMPykDqR1GwNo5HEWRIoOnbD5tLphB0ro0udYD2f7kXMVw==}
+  '@botpress/api@1.117.0':
+    resolution: {integrity: sha512-91+dxcOdxO1q0dJveWl1ziOeNxBfh5TGEuL5hj+MTkHFHnOEQauxaPYOa2QVYwUmc78C2uirbv6MYBT/L48QGA==}
 
   '@bpinternal/const@0.1.0':
     resolution: {integrity: sha512-iIQg9oYYXOt+LSK34oNhJVQTcgRdtLmLZirEUaE+R9hnmbKONA5reR2kTewxZmekGyxej+5RtDK9xrC/0hmeAw==}
@@ -14666,7 +14666,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@botpress/api@1.116.0':
+  '@botpress/api@1.117.0':
     dependencies:
       '@bpinternal/opapi': 1.0.0(openapi-types@12.1.3)
     transitivePeerDependencies:


### PR DESCRIPTION
This PR regenerates the public client with `moduleFormat` support and prepares `@botpress/client@1.49.0` plus its dependent package version bumps.

The backend dependency in botpress/skynet#5152 is merged and `@botpress/api@1.117.0` is published. The lockfile now resolves the published API package, so this PR is second in the merge order and is ready to merge.

The generated `createBot` and `updateBot` request bodies both type and serialize `moduleFormat` as `"cjs" | "esm"`. Dependency checks, formatting, Botpress lint, oxlint, ESLint, build, all 133 typechecks, and all 90 test tasks pass.