### PR TITLE
feat(llmz): Cloudflare Workers (workerd) support

### DIFF
--- a/packages/llmz/CLAUDE.md
+++ b/packages/llmz/CLAUDE.md
@@ -240,7 +240,6 @@ pnpm generate
 - `tsup`: Fast TypeScript bundler (ESM + CJS output)
 - `vitest`: Modern test framework with TypeScript support
 - `prettier`: Code formatting
-- `handlebars`: Template processing for prompts
 
 ## Code Architecture Patterns
 

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -8,6 +8,8 @@
   "module": "./dist/index.js",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
+      "workerd": "./dist/index.workerd.js",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
@@ -44,6 +46,7 @@
   },
   "devDependencies": {
     "@botpress/cli": "workspace:*",
+    "@jitl/quickjs-wasmfile-release-sync": "^0.31.0",
     "@microsoft/api-extractor": "^7.49.0",
     "@types/bytes": "^3.1.5",
     "@types/json-schema": "^7.0.12",
@@ -63,7 +66,7 @@
   "peerDependencies": {
     "@botpress/client": "1.49.0",
     "@botpress/cognitive": "0.6.2",
-    "@bpinternal/thicktoken": "^3.0.0",
+    "@bpinternal/thicktoken": "^3.1.0",
     "@bpinternal/zui": "^2.4.0"
   },
   "dependenciesMeta": {

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -34,7 +34,6 @@
     "acorn": "^8.17.0",
     "bytes": "^3.1.2",
     "exponential-backoff": "^3.1.1",
-    "handlebars": "^4.7.8",
     "json5": "^2.2.3",
     "jsonrepair": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -2,7 +2,7 @@
   "name": "llmz",
   "type": "module",
   "description": "LLMz - An LLM-native Typescript VM built on top of Zui",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/llmz/src/exit.ts
+++ b/packages/llmz/src/exit.ts
@@ -2,7 +2,7 @@ import { transforms } from '@bpinternal/zui'
 import { JSONSchema7 } from 'json-schema'
 import { uniq } from 'lodash-es'
 import { Serializable, ZuiType } from './types.js'
-import { isJsonSchema, isValidIdentifier, isZuiSchema } from './utils.js'
+import { fromJSONSchemaCompat, isJsonSchema, isValidIdentifier, isZuiSchema } from './utils.js'
 
 /**
  * Represents the result of an agent execution that exited with a specific Exit.
@@ -243,7 +243,7 @@ export class Exit<T = unknown> implements Serializable<Exit.JSON> {
    * Used internally for validation and type inference.
    */
   public get zSchema() {
-    return this.schema ? transforms.fromJSONSchemaLegacy(this.schema) : undefined
+    return this.schema ? fromJSONSchemaCompat(this.schema) : undefined
   }
 
   /**

--- a/packages/llmz/src/index.ts
+++ b/packages/llmz/src/index.ts
@@ -43,6 +43,11 @@ export * from './message-stream/index.js'
 
 export * from './custom-client.js'
 
+// Runtime environment configuration — needed on platforms that ban runtime WASM
+// compilation and code generation from strings (e.g. Cloudflare Workers / workerd)
+export { configureQuickJS } from './quickjs-variant.js'
+export { configureTokenizer } from './utils.js'
+
 export const utils = {
   toValidObjectName,
   toValidFunctionName,

--- a/packages/llmz/src/prompts/common.test.ts
+++ b/packages/llmz/src/prompts/common.test.ts
@@ -76,53 +76,50 @@ Hello!
     })
   })
 
-  describe('replacePlaceholders - Handlebars injection security', () => {
-    // Template that simulates the real system prompt structure
-    const templateWithExits = `
+  describe('replacePlaceholders', () => {
+    it('replaces ■■■name■■■ placeholders with their values', () => {
+      const result = replacePlaceholders('Instructions: ■■■identity■■■', {
+        identity: 'Be helpful',
+      })
+
+      expect(result).toBe('Instructions: Be helpful')
+    })
+
+    it('throws on placeholders with no matching value', () => {
+      expect(() => replacePlaceholders('Instructions: ■■■identity■■■', {})).toThrow(/Placeholder not found/)
+    })
+
+    it('throws on values with no matching placeholder', () => {
+      expect(() => replacePlaceholders('Hello', { identity: 'Be helpful' })).toThrow(/Missing placeholders/)
+    })
+
+    it('treats template syntax like {{ }} as inert text (no template engine)', () => {
+      // Templates and injected values must never be evaluated by a template engine.
+      // Anything that looks like Handlebars/Mustache syntax is passed through verbatim.
+      const template = `
 Instructions: ■■■identity■■■
 
 Available exits:
 {{#each exits}}
 - {{name}}: {{description}}
 {{/each}}
-`
+`.trim()
 
-    it('should NOT allow user input to access exits array via Handlebars injection', () => {
-      // Attack: User tries to iterate over exits to extract exit names/descriptions
       const maliciousInstructions = `{{#each exits}}LEAKED: {{name}} - {{description}}{{/each}}`
 
-      const result = replacePlaceholders(templateWithExits, {
+      const result = replacePlaceholders(template, {
         identity: maliciousInstructions,
-        exits: [
-          { name: 'secret_exit', description: 'This is a secret exit with sensitive info' },
-          { name: 'admin_exit', description: 'Admin-only exit with password: hunter2' },
-        ],
       })
 
       expect(result).toMatchInlineSnapshot(`
         "Instructions: {{#each exits}}LEAKED: {{name}} - {{description}}{{/each}}
 
         Available exits:
-        - secret_exit: This is a secret exit with sensitive info
-        - admin_exit: Admin-only exit with password: hunter2"
+        {{#each exits}}
+        - {{name}}: {{description}}
+        {{/each}}"
       `)
-    })
-
-    it('should safely handle nested Handlebars-like syntax in user messages', () => {
-      // User legitimately wants to talk about Handlebars syntax
-      const legitimateContent = `Here is an example of Handlebars:
-{{#each items}}
-  <li>{{name}}</li>
-{{/each}}`
-
-      const result = replacePlaceholders(templateWithExits, {
-        identity: legitimateContent,
-        exits: [{ name: 'items', description: 'not leaked' }],
-      })
-
-      // The user's example code should appear as-is (escaped or literal)
-      // and should NOT iterate over the actual 'items' exit
-      expect(result).not.toContain('<li>items</li>')
+      expect(result).not.toContain('LEAKED: secret_exit')
     })
   })
 })

--- a/packages/llmz/src/prompts/common.ts
+++ b/packages/llmz/src/prompts/common.ts
@@ -1,4 +1,3 @@
-import Handlebars from 'handlebars'
 import { StreamingMessageParser } from '../message-stream/parser.js'
 import type { ParsedItem } from '../message-stream/types.js'
 import { ParsedAssistantResponse } from './prompt.js'
@@ -47,14 +46,7 @@ export const replacePlaceholders = (prompt: string, values: Record<string, unkno
   const regex = new RegExp('■■■([A-Z0-9_\\.-]+)■■■', 'gi')
   const obj = Object.assign({}, values)
 
-  const compile = Handlebars.compile(prompt)
-
-  const compiled = compile({
-    is_message_enabled: false,
-    ...values,
-  })
-
-  const replaced = compiled.replace(regex, (_match, name) => {
+  const replaced = prompt.replace(regex, (_match, name) => {
     if (name in values) {
       delete obj[name]
       return typeof values[name] === 'string' ? (values[name] as string) : JSON.stringify(values[name])

--- a/packages/llmz/src/quickjs-variant.ts
+++ b/packages/llmz/src/quickjs-variant.ts
@@ -29,3 +29,31 @@ export const BundledReleaseSyncVariant: QuickJSSyncVariantEx = {
     return variant.importModuleLoader()
   },
 }
+
+let _activeVariant: QuickJSSyncVariant = BundledReleaseSyncVariant
+
+/**
+ * Overrides the QuickJS variant used by the sandbox.
+ *
+ * The default variant inlines the WASM as base64 and compiles it at runtime
+ * (`new WebAssembly.Module(bytes)`), which is disallowed on some platforms
+ * (e.g. Cloudflare Workers / workerd). On those platforms, inject a variant
+ * built from a statically imported precompiled `WebAssembly.Module` — e.g.
+ * quickjs-emscripten's documented Cloudflare recipe:
+ *
+ * ```ts
+ * import { newVariant } from 'quickjs-emscripten-core'
+ * import wasmfileVariant from '@jitl/quickjs-wasmfile-release-sync'
+ * import wasmModule from '@jitl/quickjs-wasmfile-release-sync/wasm'
+ *
+ * configureQuickJS(newVariant(wasmfileVariant, { wasmModule }))
+ * ```
+ *
+ * Call this before the first `execute()` (or `warmupVM()`); the WASM module is
+ * loaded once per variant and cached.
+ */
+export const configureQuickJS = (variant: QuickJSSyncVariant) => {
+  _activeVariant = variant
+}
+
+export const getQuickJSVariant = (): QuickJSSyncVariant => _activeVariant

--- a/packages/llmz/src/quickjs-variant.workerd.ts
+++ b/packages/llmz/src/quickjs-variant.workerd.ts
@@ -1,11 +1,15 @@
-// @ts-ignore - no types for the raw variant module shape we need here
-import wasmfileVariant from '@jitl/quickjs-wasmfile-release-sync'
+import wasmfileVariantImport from '@jitl/quickjs-wasmfile-release-sync'
 // Static import of the engine .wasm: the workerd tsup build copies it to dist as a
 // separate file and Cloudflare Workers compiles it at deploy time, handing us a
 // precompiled WebAssembly.Module (runtime WASM compilation is banned on workerd).
-// @ts-ignore - resolved by the workerd build's .wasm copy loader
 import wasmModule from '@jitl/quickjs-wasmfile-release-sync/wasm'
 import { newVariant, type QuickJSSyncVariant } from 'quickjs-emscripten-core'
+
+// TS (NodeNext) types the package's CJS-flavored d.ts as a namespace ({ default: variant })
+// while the bundled ESM build resolves the default import to the variant itself — unwrap
+// defensively so both module shapes work.
+const wasmfileVariant = ((wasmfileVariantImport as { default?: QuickJSSyncVariant }).default ??
+  wasmfileVariantImport) as QuickJSSyncVariant
 
 /**
  * Workerd (Cloudflare Workers) drop-in replacement for `./quickjs-variant.ts` —
@@ -21,10 +25,7 @@ export type QuickJSSyncVariantEx = QuickJSSyncVariant & {
   _wasmLoadError?: any
 }
 
-export const BundledReleaseSyncVariant: QuickJSSyncVariantEx = newVariant(
-  wasmfileVariant as unknown as QuickJSSyncVariant,
-  { wasmModule: wasmModule as WebAssembly.Module }
-) as QuickJSSyncVariantEx
+export const BundledReleaseSyncVariant: QuickJSSyncVariantEx = newVariant(wasmfileVariant, { wasmModule })
 
 let _activeVariant: QuickJSSyncVariant = BundledReleaseSyncVariant
 

--- a/packages/llmz/src/quickjs-variant.workerd.ts
+++ b/packages/llmz/src/quickjs-variant.workerd.ts
@@ -1,4 +1,3 @@
-import { newVariant, type QuickJSSyncVariant } from 'quickjs-emscripten-core'
 // @ts-ignore - no types for the raw variant module shape we need here
 import wasmfileVariant from '@jitl/quickjs-wasmfile-release-sync'
 // Static import of the engine .wasm: the workerd tsup build copies it to dist as a
@@ -6,6 +5,7 @@ import wasmfileVariant from '@jitl/quickjs-wasmfile-release-sync'
 // precompiled WebAssembly.Module (runtime WASM compilation is banned on workerd).
 // @ts-ignore - resolved by the workerd build's .wasm copy loader
 import wasmModule from '@jitl/quickjs-wasmfile-release-sync/wasm'
+import { newVariant, type QuickJSSyncVariant } from 'quickjs-emscripten-core'
 
 /**
  * Workerd (Cloudflare Workers) drop-in replacement for `./quickjs-variant.ts` —

--- a/packages/llmz/src/quickjs-variant.workerd.ts
+++ b/packages/llmz/src/quickjs-variant.workerd.ts
@@ -1,0 +1,40 @@
+import { newVariant, type QuickJSSyncVariant } from 'quickjs-emscripten-core'
+// @ts-ignore - no types for the raw variant module shape we need here
+import wasmfileVariant from '@jitl/quickjs-wasmfile-release-sync'
+// Static import of the engine .wasm: the workerd tsup build copies it to dist as a
+// separate file and Cloudflare Workers compiles it at deploy time, handing us a
+// precompiled WebAssembly.Module (runtime WASM compilation is banned on workerd).
+// @ts-ignore - resolved by the workerd build's .wasm copy loader
+import wasmModule from '@jitl/quickjs-wasmfile-release-sync/wasm'
+
+/**
+ * Workerd (Cloudflare Workers) drop-in replacement for `./quickjs-variant.ts` —
+ * the workerd tsup build aliases that module to this one. Same export surface,
+ * but the default variant follows quickjs-emscripten's documented Cloudflare
+ * recipe (wasmfile variant + statically imported precompiled module) instead of
+ * the singlefile variant that compiles inlined base64 WASM at runtime.
+ */
+export type QuickJSSyncVariantEx = QuickJSSyncVariant & {
+  _wasmSource?: any
+  _wasmLoadedSuccessfully?: any
+  _wasmSize?: any
+  _wasmLoadError?: any
+}
+
+export const BundledReleaseSyncVariant: QuickJSSyncVariantEx = newVariant(
+  wasmfileVariant as unknown as QuickJSSyncVariant,
+  { wasmModule: wasmModule as WebAssembly.Module }
+) as QuickJSSyncVariantEx
+
+let _activeVariant: QuickJSSyncVariant = BundledReleaseSyncVariant
+
+/**
+ * Overrides the QuickJS variant used by the sandbox. On workerd the default
+ * variant is already Workers-compatible; this stays available for consumers
+ * who want a different QuickJS build (e.g. debug, asyncify).
+ */
+export const configureQuickJS = (variant: QuickJSSyncVariant) => {
+  _activeVariant = variant
+}
+
+export const getQuickJSVariant = (): QuickJSSyncVariant => _activeVariant

--- a/packages/llmz/src/tool.ts
+++ b/packages/llmz/src/tool.ts
@@ -6,7 +6,7 @@ import { RenderedComponent } from './component.js'
 import { convertObjectToZuiLiterals, type StaticObject, type StaticValue } from './convert.js'
 import { Serializable } from './types.js'
 import { getTypings as generateTypings } from './typings.js'
-import { isJsonSchema, isValidIdentifier, isZuiSchema } from './utils.js'
+import { fromJSONSchemaCompat, isJsonSchema, isValidIdentifier, isZuiSchema } from './utils.js'
 
 /**
  * Input parameters passed to tool retry functions.
@@ -274,7 +274,7 @@ export class Tool<I extends z.ZodType = z.ZodType, O extends z.ZodType = z.ZodTy
       return this
     }
 
-    const input = this.input ? transforms.fromJSONSchemaLegacy(this.input) : z.any()
+    const input = this.input ? fromJSONSchemaCompat(this.input) : z.any()
 
     if (z.is.zuiObject(input) && typeof values !== 'object') {
       throw new Error(

--- a/packages/llmz/src/utils.ts
+++ b/packages/llmz/src/utils.ts
@@ -199,9 +199,24 @@ export const stripInvalidIdentifiers = (object: unknown): any => {
   return pickBy(object, (__, key) => Identifier.safeParse(key).success)
 }
 
+/**
+ * JSON Schema → Zui via the legacy transform, falling back to the eval-free one.
+ * The legacy transform builds the schema by evaluating generated code, which is
+ * banned on some platforms (e.g. Cloudflare Workers / workerd) — there it throws
+ * and the eval-free transform takes over. Kept legacy-first because the two
+ * transforms differ on some shapes (e.g. discriminated unions).
+ */
+export const fromJSONSchemaCompat = (schema: JSONSchema7): z.ZodType => {
+  try {
+    return transforms.fromJSONSchemaLegacy(schema) as z.ZodType
+  } catch {
+    return transforms.fromJSONSchema(schema)
+  }
+}
+
 export const isValidSchema = (schema: JSONSchema7): boolean => {
   try {
-    transforms.fromJSONSchemaLegacy(schema)
+    fromJSONSchemaCompat(schema)
     return typeof schema.type === 'string'
   } catch {
     return false

--- a/packages/llmz/src/utils.ts
+++ b/packages/llmz/src/utils.ts
@@ -7,6 +7,19 @@ import { pickBy, startCase, camelCase, isPlainObject, deburr } from 'lodash-es'
 
 let tokenizer: TextTokenizer = null!
 
+/**
+ * Injects the tokenizer used for prompt budgeting instead of the default
+ * `@bpinternal/thicktoken` WASM tokenizer.
+ *
+ * The default tokenizer compiles its WASM at runtime (`new WebAssembly.Module(bytes)`),
+ * which is disallowed on some platforms (e.g. Cloudflare Workers / workerd). On those
+ * platforms, build a tokenizer from a statically imported precompiled `WebAssembly.Module`
+ * and inject it here before calling `execute()`.
+ */
+export const configureTokenizer = (customTokenizer: TextTokenizer) => {
+  tokenizer = customTokenizer
+}
+
 export const init = async () => {
   if (tokenizer) {
     return

--- a/packages/llmz/src/vm/drivers/quickjs.ts
+++ b/packages/llmz/src/vm/drivers/quickjs.ts
@@ -3,13 +3,14 @@ import {
   newQuickJSWASMModuleFromVariant,
   QuickJSContext,
   type QuickJSHandle,
+  type QuickJSSyncVariant,
   type QuickJSWASMModule,
   shouldInterruptAfterDeadline,
 } from 'quickjs-emscripten-core'
 
 import { Identifiers } from '../../compiler/index.js'
 import { Signals, VMSignal } from '../../errors.js'
-import { BundledReleaseSyncVariant } from '../../quickjs-variant.js'
+import { getQuickJSVariant } from '../../quickjs-variant.js'
 import type { VMExecutionResult } from '../../types.js'
 import { handleErrorQuickJS } from '../errors.js'
 import { NO_TRACKING, findUserCodeStartLine, instrumentContext } from '../instrument.js'
@@ -18,9 +19,18 @@ import type { DriverExecutionContext, VMContext, VMDriver } from '../types.js'
 // The WASM module is compiled once per process and shared by every execution
 // (each execution still gets its own runtime + context). Loading it eagerly —
 // e.g. while the LLM is still generating code — hides the instantiation cost.
+// The cache is keyed on the active variant so a configureQuickJS() call made
+// after a load takes effect on the next execution.
 let _quickJSModule: Promise<QuickJSWASMModule> | undefined
-export const loadQuickJSModule = (): Promise<QuickJSWASMModule> =>
-  (_quickJSModule ??= newQuickJSWASMModuleFromVariant(BundledReleaseSyncVariant))
+let _loadedVariant: QuickJSSyncVariant | undefined
+export const loadQuickJSModule = (): Promise<QuickJSWASMModule> => {
+  const variant = getQuickJSVariant()
+  if (!_quickJSModule || _loadedVariant !== variant) {
+    _loadedVariant = variant
+    _quickJSModule = newQuickJSWASMModuleFromVariant(variant)
+  }
+  return _quickJSModule
+}
 
 // Sandboxed execution via QuickJS WASM. All host values must be manually marshalled
 // across the boundary — QuickJS has its own heap, separate from Node.js.

--- a/packages/llmz/src/vm/index.ts
+++ b/packages/llmz/src/vm/index.ts
@@ -2,7 +2,7 @@ import { SourceMapConsumer } from 'source-map-js'
 
 import { compile } from '../compiler/index.js'
 import { InvalidCodeError } from '../errors.js'
-import { BundledReleaseSyncVariant } from '../quickjs-variant.js'
+import { getQuickJSVariant, type QuickJSSyncVariantEx } from '../quickjs-variant.js'
 import type { Trace, VMExecutionResult } from '../types.js'
 import { NodeDriver } from './drivers/node.js'
 import { loadQuickJSModule, QuickJSDriver } from './drivers/quickjs.js'
@@ -11,6 +11,11 @@ import type { VMContext, VMDriver } from './types.js'
 const MAX_VM_EXECUTION_TIME = 60_000
 
 const useQuickJS = () => typeof process === 'undefined' || process?.env?.USE_QUICKJS !== 'false'
+
+// The Node driver runs code through AsyncFunction(...), which workerd bans
+// ("Code generation from strings disallowed") — falling back to it would only
+// mask the real QuickJS load failure behind a confusing EvalError.
+const isWorkerd = () => typeof navigator !== 'undefined' && navigator?.userAgent === 'Cloudflare-Workers'
 
 /**
  * Pre-warms the VM so the first execution doesn't pay the QuickJS WASM
@@ -85,18 +90,30 @@ export async function runAsyncFunction(
         currentToolCall: undefined,
       })
     } catch (quickjsError: any) {
-      // QuickJS WASM failed to load — fall back to unsandboxed Node driver
+      const variant = getQuickJSVariant() as QuickJSSyncVariantEx
       const debugInfo = {
         error: quickjsError?.message || String(quickjsError),
         errorStack: quickjsError?.stack,
-        wasmSource: BundledReleaseSyncVariant._wasmSource,
-        wasmLoadedSuccessfully: BundledReleaseSyncVariant._wasmLoadedSuccessfully,
-        wasmSize: BundledReleaseSyncVariant._wasmSize,
-        wasmLoadError: BundledReleaseSyncVariant._wasmLoadError,
+        wasmSource: variant._wasmSource,
+        wasmLoadedSuccessfully: variant._wasmLoadedSuccessfully,
+        wasmSize: variant._wasmSize,
+        wasmLoadError: variant._wasmLoadError,
         nodeVersion: typeof process !== 'undefined' && process.version ? process.version : 'undefined',
         platform: typeof process !== 'undefined' && process.platform ? process.platform : 'undefined',
       }
 
+      if (isWorkerd()) {
+        // No fallback possible on workerd — surface the actual QuickJS failure
+        console.error('QuickJS failed to load and the node driver is unavailable on Cloudflare Workers.')
+        console.error('Debug info:', JSON.stringify(debugInfo, null, 2))
+        if (quickjsError instanceof Error) {
+          ;(quickjsError as any).debugInfo = debugInfo
+          throw quickjsError
+        }
+        throw new Error(`QuickJS failed to load on Cloudflare Workers: ${debugInfo.error}`)
+      }
+
+      // QuickJS WASM failed to load — fall back to unsandboxed Node driver
       console.warn('QuickJS failed to load, falling back to node driver.')
       console.warn('Error:', quickjsError?.message || quickjsError)
       console.warn('Debug info:', JSON.stringify(debugInfo, null, 2))

--- a/packages/llmz/src/wasm-modules.d.ts
+++ b/packages/llmz/src/wasm-modules.d.ts
@@ -1,0 +1,8 @@
+// Typed view of the wasmfile variant's engine module. The package's "./wasm"
+// subpath maps straight to the .wasm file; on workerd (and via the workerd tsup
+// build's copy loader) a static .wasm import resolves to a precompiled
+// WebAssembly.Module.
+declare module '@jitl/quickjs-wasmfile-release-sync/wasm' {
+  const wasmModule: WebAssembly.Module
+  export default wasmModule
+}

--- a/packages/llmz/tsup.config.ts
+++ b/packages/llmz/tsup.config.ts
@@ -1,16 +1,59 @@
+import path from 'path'
 import { defineConfig } from 'tsup'
 
-export default defineConfig({
-  entry: ['src/index.ts', '!src/**/*.test.{ts,tsx}', '!e2e'],
-  outDir: 'dist',
-  dts: false,
-  format: ['esm', 'cjs'],
-  target: 'node16',
-  noExternal: ['lodash-es', 'source-map-js'],
-  cjsInterop: true,
-  sourcemap: false,
-  clean: true,
-  splitting: true,
-  minify: false,
-  bundle: true,
-})
+export default defineConfig([
+  {
+    entry: ['src/index.ts', '!src/**/*.test.{ts,tsx}', '!e2e'],
+    outDir: 'dist',
+    dts: false,
+    format: ['esm', 'cjs'],
+    target: 'node16',
+    noExternal: ['lodash-es', 'source-map-js'],
+    cjsInterop: true,
+    sourcemap: false,
+    clean: true,
+    splitting: true,
+    minify: false,
+    bundle: true,
+  },
+  // Workerd (Cloudflare Workers) build, resolved via the "workerd" exports condition.
+  // workerd bans runtime WASM compilation, so this build swaps the QuickJS variant for
+  // the wasmfile one: the engine .wasm ships as a separate dist file and stays a static
+  // import that workerd compiles at deploy time (quickjs-emscripten's Cloudflare recipe).
+  // The wasmfile variant is a devDependency bundled at build time — the regular builds
+  // above are untouched and no runtime dependency is added.
+  {
+    entry: { 'index.workerd': 'src/index.ts' },
+    outDir: 'dist',
+    dts: false,
+    format: ['esm'],
+    target: 'es2022',
+    platform: 'neutral',
+    noExternal: ['lodash-es', 'source-map-js', '@jitl/quickjs-wasmfile-release-sync'],
+    sourcemap: false,
+    clean: false,
+    splitting: false,
+    minify: false,
+    bundle: true,
+    loader: { '.wasm': 'copy' },
+    esbuildOptions(options) {
+      // Stable (unhashed) name for the copied engine .wasm.
+      options.assetNames = '[name]'
+      // Resolve the wasmfile variant's internal emscripten-module import to its
+      // cloudflare build. Setting conditions drops esbuild's implicit 'module'
+      // condition, so re-add it.
+      options.conditions = ['workerd', 'module']
+    },
+    esbuildPlugins: [
+      {
+        // Swap the QuickJS variant module for the workerd one (static wasm import)
+        name: 'workerd-quickjs-variant',
+        setup(build) {
+          build.onResolve({ filter: /quickjs-variant\.js$/ }, () => ({
+            path: path.resolve(__dirname, 'src/quickjs-variant.workerd.ts'),
+          }))
+        },
+      },
+    ],
+  },
+])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3090,8 +3090,8 @@ importers:
         specifier: 0.6.2
         version: link:../cognitive
       '@bpinternal/thicktoken':
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.1.0
+        version: 3.1.0
       '@bpinternal/zui':
         specifier: ^2.4.0
         version: link:../zui
@@ -4345,6 +4345,10 @@ packages:
 
   '@bpinternal/thicktoken@3.0.0':
     resolution: {integrity: sha512-oFfQeQHvC+DbngcbSSf97N6NMcUs7O3R04EL0IJhk54li3zppNhg5Ymt5fnToW7WMK4CohdScMBcFoK2kAWSAw==}
+    engines: {node: '>=16.0.0', pnpm: 8.6.2}
+
+  '@bpinternal/thicktoken@3.1.0':
+    resolution: {integrity: sha512-CP8Q+YBi2bXBGB57YNAFrVxPDkx9auW5XjF5QpSc8rer+PYbBHNGMypppnq1lG3WDUVkxsU8nP+GqIP3iELJPA==}
     engines: {node: '>=16.0.0', pnpm: 8.6.2}
 
   '@bpinternal/tunnel@0.1.1':
@@ -14777,6 +14781,8 @@ snapshots:
       ts-regex-builder: 1.8.2
 
   '@bpinternal/thicktoken@3.0.0': {}
+
+  '@bpinternal/thicktoken@3.1.0': {}
 
   '@bpinternal/tunnel@0.1.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2398,7 +2398,7 @@ importers:
         version: 29.5.0(@types/node@22.16.4)(ts-node@10.9.2(@types/node@22.16.4)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.1.0
-        version: 29.1.0(@babel/core@7.26.9)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.26.9))(jest@29.5.0(@types/node@22.16.4)(ts-node@10.9.2(@types/node@22.16.4)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.1.0(@babel/core@7.28.0)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.28.0))(jest@29.5.0(@types/node@22.16.4)(ts-node@10.9.2(@types/node@22.16.4)(typescript@5.9.3)))(typescript@5.9.3)
 
   integrations/zendesk:
     dependencies:
@@ -3107,9 +3107,6 @@ importers:
       exponential-backoff:
         specifier: ^3.1.1
         version: 3.1.1
-      handlebars:
-        specifier: ^4.7.8
-        version: 4.7.8
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -14451,25 +14448,55 @@ snapshots:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
+
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
+
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
+
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
 
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.26.9)':
     dependencies:
@@ -14481,35 +14508,77 @@ snapshots:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
+
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
+
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
+
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
+
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
 
   '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.26.9)':
     dependencies:
@@ -18214,6 +18283,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-jest@29.5.0(@babel/core@7.28.0):
+    dependencies:
+      '@babel/core': 7.28.0
+      '@jest/transform': 29.5.0
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.5.0(@babel/core@7.28.0)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   babel-plugin-istanbul@6.1.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -18247,11 +18330,35 @@ snapshots:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.9)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.9)
 
+  babel-preset-current-node-syntax@1.0.1(@babel/core@7.28.0):
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.0)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.0)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.0)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.0)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.0)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.0)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.0)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.0)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.0)
+    optional: true
+
   babel-preset-jest@29.5.0(@babel/core@7.26.9):
     dependencies:
       '@babel/core': 7.26.9
       babel-plugin-jest-hoist: 29.5.0
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.26.9)
+
+  babel-preset-jest@29.5.0(@babel/core@7.28.0):
+    dependencies:
+      '@babel/core': 7.28.0
+      babel-plugin-jest-hoist: 29.5.0
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.28.0)
+    optional: true
 
   bail@1.0.5: {}
 
@@ -24211,7 +24318,7 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  ts-jest@29.1.0(@babel/core@7.26.9)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.26.9))(jest@29.5.0(@types/node@22.16.4)(ts-node@10.9.2(@types/node@22.16.4)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.1.0(@babel/core@7.28.0)(@jest/types@29.5.0)(babel-jest@29.5.0(@babel/core@7.28.0))(jest@29.5.0(@types/node@22.16.4)(ts-node@10.9.2(@types/node@22.16.4)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -24224,9 +24331,9 @@ snapshots:
       typescript: 5.9.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.26.9
+      '@babel/core': 7.28.0
       '@jest/types': 29.5.0
-      babel-jest: 29.5.0(@babel/core@7.26.9)
+      babel-jest: 29.5.0(@babel/core@7.28.0)
 
   ts-node@10.9.2(@types/node@22.16.4)(typescript@5.6.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3135,6 +3135,9 @@ importers:
       '@botpress/cli':
         specifier: workspace:*
         version: link:../cli
+      '@jitl/quickjs-wasmfile-release-sync':
+        specifier: ^0.31.0
+        version: 0.31.0
       '@microsoft/api-extractor':
         specifier: ^7.49.0
         version: 7.49.0(@types/node@22.16.4)
@@ -5372,6 +5375,9 @@ packages:
 
   '@jitl/quickjs-singlefile-browser-release-sync@0.31.0':
     resolution: {integrity: sha512-JctBiLmRpxEp83gJWhDcBuFqm5X7T683OLmncN9g0chAHkC8+y5cJmgknaAk5Rb/ANDR3pXMMnGdnGXDdysfBQ==}
+
+  '@jitl/quickjs-wasmfile-release-sync@0.31.0':
+    resolution: {integrity: sha512-hYduecOByj9AsAfsJhZh5nA6exokmuFC8cls39+lYmTCGY51bgjJJJwReEu7Ff7vBWaQCL6TeDdVlnp2WYz0jw==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -15569,6 +15575,10 @@ snapshots:
   '@jitl/quickjs-ffi-types@0.31.0': {}
 
   '@jitl/quickjs-singlefile-browser-release-sync@0.31.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.31.0
+
+  '@jitl/quickjs-wasmfile-release-sync@0.31.0':
     dependencies:
       '@jitl/quickjs-ffi-types': 0.31.0
 


### PR DESCRIPTION
## Why

workerd (Cloudflare Workers) bans runtime WASM compilation (`new WebAssembly.Module(bytes)`) and code generation from strings (`AsyncFunction`/`eval`). llmz hit both: QuickJS loads from a base64-inlined WASM variant compiled at runtime, and when that fails it falls back to the Node driver — which dies on workerd with a confusing `EvalError: Code generation from strings disallowed` that masks the real failure. The tokenizer (`@bpinternal/thicktoken`) had the same runtime-compilation problem, fixed upstream in botpress/packages#697.

## What

### Zero-config `workerd` exports condition

`.` gains a `workerd` condition → `dist/index.workerd.js`, a dedicated tsup build where `src/quickjs-variant.ts` is aliased to `src/quickjs-variant.workerd.ts`: `newVariant(wasmfileReleaseSyncVariant, { wasmModule })` with the engine `.wasm` shipped as a separate dist file (`dist/emscripten-module.wasm`) and statically imported — workerd compiles it at deploy time (quickjs-emscripten's documented Cloudflare recipe). The emscripten glue resolves through that package's own `workerd` condition (`emscripten-module.cloudflare.cjs`).

**No impact on regular llmz**: `@jitl/quickjs-wasmfile-release-sync` is a devDependency bundled at build time — no new runtime dependency, and the regular ESM/CJS builds are untouched (verified: zero references to the wasm/workerd files). Only cost is ~1.1MB of workerd-only files in the tarball.

### Injection APIs (for non-wrangler setups / custom builds)

- `configureQuickJS(variant)` — override the QuickJS variant; the driver's module cache is keyed on the active variant
- `configureTokenizer(tokenizer)` — bypass thicktoken's default runtime-compiled tokenizer

### No more misleading fallback on workerd

`vm/index.ts` detects workerd (`navigator.userAgent === 'Cloudflare-Workers'`) and, when QuickJS fails to load, throws the actual QuickJS error with collected debug info attached (`error.debugInfo`) instead of falling back to the Node driver.

### Removed handlebars

Prompts only use `■■■name■■■` placeholders — the `Handlebars.compile` pass was a no-op and an injection liability. Dep removed; injection-security tests rewritten to assert `{{ }}` is inert text.

## Merge order ⚠️

thicktoken peer is bumped to `^3.1.0`, which is unpublished until botpress/packages#697 merges + releases. `pnpm install` fails to resolve the peer until then; the lockfile needs a refresh at that point. **Land #697 and publish thicktoken 3.1.0 first.**

### Third blocker found & fixed during workerd verification

`parseExit` rebuilt exit schemas via zui's `fromJSONSchemaLegacy`, which evaluates generated code — banned on workerd, so `■next` exits failed validation and the loop never terminated. `fromJSONSchemaCompat` keeps the legacy transform first (identical behavior wherever eval is allowed) and falls back to zui's eval-free `fromJSONSchema` where it throws.

## Testing

- 465/465 unit tests pass, typecheck + build clean
- Workerd bundle verified at the artifact level: static `.wasm` import preserved, zero singlefile (base64 engine) references, cloudflare emscripten glue bundled
- **Verified end-to-end inside workerd** (`wrangler dev` on the POC worker, no shims/aliases): scripted `execute()` completes — QuickJS runs generated code, tool call bridges into the sandbox, thicktoken 3.1.0 resolves through its workerd condition, typed exit validates and returns `{ sum: 42 }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
