### PR TITLE
fix: only publish dist in published packages + bump @botpress/client to 2.0.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "1.0.0",
-    "@botpress/client": "1.49.0",
+    "@botpress/client": "2.0.0",
     "@botpress/sdk": "6.13.4",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -5,7 +5,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.49.0",
+    "@botpress/client": "2.0.0",
     "@botpress/sdk": "6.13.4"
   },
   "devDependencies": {

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.49.0",
+    "@botpress/client": "2.0.0",
     "@botpress/sdk": "6.13.4"
   },
   "devDependencies": {

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.49.0",
+    "@botpress/client": "2.0.0",
     "@botpress/sdk": "6.13.4"
   },
   "devDependencies": {

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/client": "1.49.0",
+    "@botpress/client": "2.0.0",
     "@botpress/sdk": "6.13.4",
     "axios": "^1.6.8"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@botpress/client",
   "version": "1.49.0",
+  "files": [
+    "dist"
+  ],
   "description": "Botpress Client",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/client",
-  "version": "1.49.0",
+  "version": "2.0.0",
   "files": [
     "dist"
   ],

--- a/packages/cognitive/package.json
+++ b/packages/cognitive/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@botpress/cognitive",
   "version": "1.0.0",
+  "files": [
+    "dist"
+  ],
   "description": "Wrapper around the Botpress Client to call LLMs",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/cognitive/package.json
+++ b/packages/cognitive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cognitive",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "files": [
     "dist"
   ],

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -68,7 +68,7 @@
     "tsx": "^4.19.2"
   },
   "peerDependencies": {
-    "@botpress/client": "1.49.0",
+    "@botpress/client": "2.0.0",
     "@botpress/cognitive": "1.0.0",
     "@bpinternal/thicktoken": "^3.1.0",
     "@bpinternal/zui": "^2.4.0"

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -2,7 +2,7 @@
   "name": "llmz",
   "type": "module",
   "description": "LLMz - An LLM-native Typescript VM built on top of Zui",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "files": [
     "dist",
     "DOCS.md"
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "@botpress/client": "2.0.0",
-    "@botpress/cognitive": "1.0.0",
+    "@botpress/cognitive": "1.0.1",
     "@bpinternal/thicktoken": "^3.1.0",
     "@bpinternal/zui": "^2.4.0"
   },

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -3,6 +3,10 @@
   "type": "module",
   "description": "LLMz - An LLM-native Typescript VM built on top of Zui",
   "version": "0.3.0",
+  "files": [
+    "dist",
+    "DOCS.md"
+  ],
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@botpress/client": "1.49.0",
+    "@botpress/client": "2.0.0",
     "browser-or-node": "^2.1.1",
     "semver": "^7.3.8"
   },

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@botpress/vai",
   "version": "0.0.40",
+  "files": [
+    "dist",
+    "ensure-env.cjs"
+  ],
   "description": "Vitest AI (vai) – a vitest extension for testing with LLMs",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/vai",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "files": [
     "dist",
     "ensure-env.cjs"
@@ -31,7 +31,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@botpress/cognitive": "1.0.0",
+    "@botpress/cognitive": "1.0.1",
     "json5": "^2.2.3",
     "jsonrepair": "^3.10.0"
   },

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -44,7 +44,7 @@
     "tsup": "^8.0.2"
   },
   "peerDependencies": {
-    "@botpress/client": "1.49.0",
+    "@botpress/client": "2.0.0",
     "@bpinternal/thicktoken": "^3.0.0",
     "@bpinternal/zui": "^2.4.0",
     "lodash": "^4.17.21",

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -2,6 +2,9 @@
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
   "version": "3.0.0",
+  "files": [
+    "dist"
+  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "files": [
     "dist"
   ],
@@ -35,7 +35,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@botpress/cognitive": "1.0.0",
+    "@botpress/cognitive": "1.0.1",
     "json5": "^2.2.3",
     "jsonrepair": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/plugins/conversation-insights/package.json
+++ b/plugins/conversation-insights/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/cognitive": "1.0.0",
+    "@botpress/cognitive": "1.0.1",
     "@botpress/sdk": "workspace:*",
     "browser-or-node": "^2.1.1",
     "jsonrepair": "^3.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3069,7 +3069,7 @@ importers:
         specifier: 2.0.0
         version: link:../client
       '@botpress/cognitive':
-        specifier: 1.0.0
+        specifier: 1.0.1
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^3.1.0
@@ -3203,7 +3203,7 @@ importers:
         specifier: 2.0.0
         version: link:../client
       '@botpress/cognitive':
-        specifier: 1.0.0
+        specifier: 1.0.1
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^3.0.0
@@ -3246,7 +3246,7 @@ importers:
   packages/zai:
     dependencies:
       '@botpress/cognitive':
-        specifier: 1.0.0
+        specifier: 1.0.1
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^3.0.0
@@ -3377,7 +3377,7 @@ importers:
   plugins/conversation-insights:
     dependencies:
       '@botpress/cognitive':
-        specifier: 1.0.0
+        specifier: 1.0.1
         version: link:../../packages/cognitive
       '@botpress/sdk':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2763,7 +2763,7 @@ importers:
         specifier: 1.0.0
         version: link:../chat-client
       '@botpress/client':
-        specifier: 1.49.0
+        specifier: 2.0.0
         version: link:../client
       '@botpress/sdk':
         specifier: 6.13.4
@@ -2887,7 +2887,7 @@ importers:
   packages/cli/templates/empty-bot:
     dependencies:
       '@botpress/client':
-        specifier: 1.49.0
+        specifier: 2.0.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 6.13.4
@@ -2903,7 +2903,7 @@ importers:
   packages/cli/templates/empty-integration:
     dependencies:
       '@botpress/client':
-        specifier: 1.49.0
+        specifier: 2.0.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 6.13.4
@@ -2932,7 +2932,7 @@ importers:
   packages/cli/templates/hello-world:
     dependencies:
       '@botpress/client':
-        specifier: 1.49.0
+        specifier: 2.0.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 6.13.4
@@ -2948,7 +2948,7 @@ importers:
   packages/cli/templates/webhook-message:
     dependencies:
       '@botpress/client':
-        specifier: 1.49.0
+        specifier: 2.0.0
         version: link:../../../client
       '@botpress/sdk':
         specifier: 6.13.4
@@ -3066,7 +3066,7 @@ importers:
   packages/llmz:
     dependencies:
       '@botpress/client':
-        specifier: 1.49.0
+        specifier: 2.0.0
         version: link:../client
       '@botpress/cognitive':
         specifier: 1.0.0
@@ -3169,7 +3169,7 @@ importers:
   packages/sdk:
     dependencies:
       '@botpress/client':
-        specifier: 1.49.0
+        specifier: 2.0.0
         version: link:../client
       '@bpinternal/zui':
         specifier: ^2.4.0
@@ -3200,7 +3200,7 @@ importers:
   packages/vai:
     dependencies:
       '@botpress/client':
-        specifier: 1.49.0
+        specifier: 2.0.0
         version: link:../client
       '@botpress/cognitive':
         specifier: 1.0.0


### PR DESCRIPTION
## What

### 1. Only publish `dist` (zai, llmz, cognitive, client, vai)

None of these packages had a `files` field, so `npm pack` shipped everything not gitignored — including **zai's 36 MB e2e LLM cache** (`e2e/data/cache.jsonl`) and full source, plus `src/`, e2e tests, build/lint configs, `.turbo` logs and `.claude/settings.local.json` in the others.

Adds `"files": ["dist"]` (plus `DOCS.md` for llmz, `ensure-env.cjs` for vai).

| package | unpacked before | unpacked after | tarball before | tarball after |
|---|---|---|---|---|
| @botpress/zai | **39.3 MB** | **263 kB** | 3.8 MB | 64 kB |
| llmz | 2.6 MB | 2.5 MB | 701 kB | 688 kB |
| @botpress/cognitive | 660 kB | 644 kB | 100 kB | 95 kB |
| @botpress/client | 9.4 MB | 9.4 MB | 893 kB | 893 kB |
| @botpress/vai | 28 kB | 26 kB | — | — |

All entry points (`main`/`module`/`types`/`exports`, including llmz's `workerd` condition and wasm assets) live under `dist`, so nothing referenced is excluded.

@botpress/client was already dist-only; its 9.4 MB is three self-contained 2.4 MB source maps (93% of the embedded `sourcesContent` is the generated `src/gen` code, embedded once per build output) + a 1.4 MB `.d.ts`. Left as-is — dropping the maps would cut it to ~2.2 MB unpacked if we want that later.

### 2. Version bumps so the smaller packages actually republish

zai 3.0.0, cognitive 1.0.0, llmz 0.3.0 and vai 0.0.40 were already published **with** the bloat, so this PR patch-bumps them: **zai 3.0.1, cognitive 1.0.1, llmz 0.3.1, vai 0.0.41** (cognitive pins updated everywhere to keep workspace linking).

### 3. Bump @botpress/client to 2.0.0

The axios removal (#15363) was a breaking change (removed `axios`/`axiosRetry` re-exports in favor of the `http` namespace, `RetryConfig` is now the client's own type) but the version wasn't bumped in that PR — 2.0.0 is still unpublished so it ships lean directly. All in-repo pins updated (sdk, cli, vai, llmz optional peer, cli templates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)