### PR TITLE
feat (zui): From zui transforms support recursion

### DIFF
--- a/packages/zui/src/transforms/common/json-schema.ts
+++ b/packages/zui/src/transforms/common/json-schema.ts
@@ -31,6 +31,7 @@ type BaseZuiJSONSchema<Def extends Partial<z.ZodTypeDef> = {}> = utils.Satisfies
     readOnly?: boolean
     default?: JsonData
     ['x-zui']?: ZuiExtension<Def>
+    definitions?: { [key: string]: Schema }
   },
   JSONSchema7
 >

--- a/packages/zui/src/transforms/zui-to-json-schema/index.test.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema/index.test.ts
@@ -309,8 +309,16 @@ describe('zuiToJSONSchemaNext', () => {
     expect(() => toJSONSchema(z.function())).toThrowError(errs.UnsupportedZuiToJSONSchemaError)
   })
 
-  test('should not support ZodLazy', () => {
-    expect(() => toJSONSchema(z.lazy(() => z.string()))).toThrowError(errs.UnsupportedZuiToJSONSchemaError)
+  test('should inline a non-recursive ZodLazy', () => {
+    expect(toJSONSchema(z.lazy(() => z.string()))).toMatchObject({ type: 'string' })
+  })
+
+  test('should convert a self-referential ZodLazy to a $ref + definitions', () => {
+    const Category = z.object({ name: z.string(), children: z.array(z.lazy(() => Category)) }).title('Category')
+    const result = toJSONSchema(Category) as any
+    expect(result.properties.children.items).toEqual({ $ref: '#/definitions/Category' })
+    expect(Object.keys(result.definitions)).toEqual(['Category'])
+    expect(result.definitions.Category.properties.children.items).toEqual({ $ref: '#/definitions/Category' })
   })
 
   test('should map ZodLiteral to LiteralSchema', () => {

--- a/packages/zui/src/transforms/zui-to-json-schema/index.ts
+++ b/packages/zui/src/transforms/zui-to-json-schema/index.ts
@@ -48,16 +48,42 @@ const DEFAULT_OPTIONS: JSONSchemaGenerationOptions = {
  * @param schema zui schema
  * @returns ZUI flavored JSON schema
  */
-export function toJSONSchema(schema: z.ZodType, options: Partial<JSONSchemaGenerationOptions> = {}): json.Schema {
-  return _toJSONSchema(schema, options, new PropertyPath())
+type JSONSchemaCtx = {
+  opts: JSONSchemaGenerationOptions
+  onPath: Set<symbol>
+  defs: Map<symbol, { name: string; schema: json.Schema | null }>
+  usedNames: Set<string>
+  counter: { n: number }
 }
 
-function _toJSONSchema(
-  schema: z.ZodType,
-  options: Partial<JSONSchemaGenerationOptions> = {},
-  path: PropertyPath
-): json.Schema {
-  const opts = { ...DEFAULT_OPTIONS, ...options }
+export function toJSONSchema(schema: z.ZodType, options: Partial<JSONSchemaGenerationOptions> = {}): json.Schema {
+  const ctx: JSONSchemaCtx = {
+    opts: { ...DEFAULT_OPTIONS, ...options },
+    onPath: new Set(),
+    defs: new Map(),
+    usedNames: new Set(),
+    counter: { n: 0 },
+  }
+  const root = _toJSONSchema(schema, ctx, new PropertyPath())
+  if (ctx.defs.size === 0) return root
+  const definitions: Record<string, json.Schema> = {}
+  for (const d of ctx.defs.values()) definitions[d.name] = d.schema!
+  return { ...root, definitions }
+}
+
+function assignDefName(schema: z.ZodType, ctx: JSONSchemaCtx): string {
+  const meta = schema.getMetadata()
+  const title = typeof meta.title === 'string' && meta.title.length > 0 ? meta.title : undefined
+  const base = title ?? `Schema${ctx.counter.n++}`
+  let name = base
+  let i = 1
+  while (ctx.usedNames.has(name)) name = `${base}${i++}`
+  ctx.usedNames.add(name)
+  return name
+}
+
+function _toJSONSchema(schema: z.ZodType, ctx: JSONSchemaCtx, path: PropertyPath): json.Schema {
+  const opts = ctx.opts
   const s = schema as z.ZodNativeType
 
   switch (s.typeName) {
@@ -117,7 +143,7 @@ function _toJSONSchema(
 
     case 'ZodArray':
       return zodArrayToJsonArray(s, (i) =>
-        _toJSONSchema(i, opts, path.withIndexType('number'))
+        _toJSONSchema(i, ctx,path.withIndexType('number'))
       ) satisfies json.ArraySchema
 
     case 'ZodObject':
@@ -128,7 +154,7 @@ function _toJSONSchema(
         .map(([key, value]) => [key, value.mandatory()] satisfies [string, z.ZodType])
         .map(
           ([key, value]) =>
-            [key, _toJSONSchema(value, opts, path.withIndexType('key', key))] satisfies [string, json.Schema]
+            [key, _toJSONSchema(value, ctx,path.withIndexType('key', key))] satisfies [string, json.Schema]
         )
 
       return {
@@ -136,7 +162,7 @@ function _toJSONSchema(
         description: s.description,
         properties: Object.fromEntries(properties),
         required,
-        additionalProperties: additionalPropertiesSchema(s._def, opts, path),
+        additionalProperties: additionalPropertiesSchema(s._def, ctx,path),
         'x-zui': s._def['x-zui'],
       } satisfies json.ObjectSchema
 
@@ -144,13 +170,13 @@ function _toJSONSchema(
       if (opts.unionStrategy === 'oneOf') {
         return {
           description: s.description,
-          oneOf: s.options.map((option, index) => _toJSONSchema(option, opts, path.withIndexType('number', index))),
+          oneOf: s.options.map((option, index) => _toJSONSchema(option, ctx,path.withIndexType('number', index))),
           'x-zui': s._def['x-zui'],
         } satisfies json.UnionSchema
       }
       return {
         description: s.description,
-        anyOf: s.options.map((option, index) => _toJSONSchema(option, opts, path.withIndexType('number', index))),
+        anyOf: s.options.map((option, index) => _toJSONSchema(option, ctx,path.withIndexType('number', index))),
         'x-zui': s._def['x-zui'],
       } satisfies json.UnionSchema
 
@@ -159,7 +185,7 @@ function _toJSONSchema(
         const discriminator = opts.discriminator ? { propertyName: s.discriminator } : undefined
         return {
           description: s.description,
-          oneOf: s.options.map((option, index) => _toJSONSchema(option, opts, path.withIndexType('number', index))),
+          oneOf: s.options.map((option, index) => _toJSONSchema(option, ctx,path.withIndexType('number', index))),
           discriminator,
           'x-zui': {
             ...s._def['x-zui'],
@@ -169,7 +195,7 @@ function _toJSONSchema(
       }
       return {
         description: s.description,
-        anyOf: s.options.map((option, index) => _toJSONSchema(option, opts, path.withIndexType('number', index))),
+        anyOf: s.options.map((option, index) => _toJSONSchema(option, ctx,path.withIndexType('number', index))),
         'x-zui': {
           ...s._def['x-zui'],
           def: { typeName: 'ZodDiscriminatedUnion', discriminator: s.discriminator },
@@ -177,8 +203,8 @@ function _toJSONSchema(
       } satisfies json.DiscriminatedUnionSchema
 
     case 'ZodIntersection':
-      const left = _toJSONSchema(s._def.left, opts, path.withIndexType('number', 0))
-      const right = _toJSONSchema(s._def.right, opts, path.withIndexType('number', 1))
+      const left = _toJSONSchema(s._def.left, ctx,path.withIndexType('number', 0))
+      const right = _toJSONSchema(s._def.right, ctx,path.withIndexType('number', 1))
 
       /**
        * TODO: Potential conflict between `additionalProperties` in the left and right schemas.
@@ -203,7 +229,7 @@ function _toJSONSchema(
       } satisfies json.IntersectionSchema
 
     case 'ZodTuple':
-      return zodTupleToJsonTuple(s, (i, p) => _toJSONSchema(i, opts, p), path) satisfies json.TupleSchema
+      return zodTupleToJsonTuple(s, (i, p) => _toJSONSchema(i, ctx,p), path) satisfies json.TupleSchema
 
     case 'ZodRecord': {
       const keyType = s._def.keyType
@@ -215,7 +241,7 @@ function _toJSONSchema(
       return {
         type: 'object',
         description: s.description,
-        additionalProperties: _toJSONSchema(s._def.valueType, opts, recordPath),
+        additionalProperties: _toJSONSchema(s._def.valueType, ctx,recordPath),
         'x-zui': s._def['x-zui'],
       } satisfies json.RecordSchema
     }
@@ -224,13 +250,35 @@ function _toJSONSchema(
       throw new err.UnsupportedZuiToJSONSchemaError('ZodMap', path.toString())
 
     case 'ZodSet':
-      return zodSetToJsonSet(s, (i) => _toJSONSchema(i, opts, path.withIndexType('number'))) satisfies json.SetSchema
+      return zodSetToJsonSet(s, (i) => _toJSONSchema(i, ctx,path.withIndexType('number'))) satisfies json.SetSchema
 
     case 'ZodFunction':
       throw new err.UnsupportedZuiToJSONSchemaError('ZodFunction', path.toString())
 
-    case 'ZodLazy':
-      throw new err.UnsupportedZuiToJSONSchemaError('ZodLazy', path.toString())
+    case 'ZodLazy': {
+      const uid = s._def.uid
+      if (ctx.onPath.has(uid)) {
+        let d = ctx.defs.get(uid)
+        if (!d) {
+          d = { name: assignDefName(s, ctx), schema: null }
+          ctx.defs.set(uid, d)
+        }
+        return { $ref: `#/definitions/${d.name}` }
+      }
+      ctx.onPath.add(uid)
+      let inner: json.Schema
+      try {
+        inner = _toJSONSchema(s._def.getter(), ctx, path)
+      } finally {
+        ctx.onPath.delete(uid)
+      }
+      const d = ctx.defs.get(uid)
+      if (d) {
+        d.schema = inner
+        return { $ref: `#/definitions/${d.name}` }
+      }
+      return inner
+    }
 
     case 'ZodLiteral':
       if (typeof s.value === 'string') {
@@ -281,7 +329,7 @@ function _toJSONSchema(
     case 'ZodOptional':
       return {
         description: s.description,
-        anyOf: [_toJSONSchema(s._def.innerType, opts, path), undefinedSchema()],
+        anyOf: [_toJSONSchema(s._def.innerType, ctx,path), undefinedSchema()],
         'x-zui': {
           ...s._def['x-zui'],
           def: { typeName: 'ZodOptional' },
@@ -290,7 +338,7 @@ function _toJSONSchema(
 
     case 'ZodNullable':
       return {
-        anyOf: [_toJSONSchema(s._def.innerType, opts, path), nullSchema()],
+        anyOf: [_toJSONSchema(s._def.innerType, ctx,path), nullSchema()],
         'x-zui': {
           ...s._def['x-zui'],
           def: { typeName: 'ZodNullable' },
@@ -300,7 +348,7 @@ function _toJSONSchema(
     case 'ZodDefault':
       // ZodDefault is not treated as a metadata root so we don't need to preserve x-zui
       return {
-        ..._toJSONSchema(s._def.innerType, opts, path),
+        ..._toJSONSchema(s._def.innerType, ctx,path),
         default: s._def.defaultValue(),
       }
 
@@ -323,7 +371,7 @@ function _toJSONSchema(
     case 'ZodReadonly':
       // ZodReadonly is not treated as a metadata root so we don't need to preserve x-zui
       return {
-        ..._toJSONSchema(s._def.innerType, opts, path),
+        ..._toJSONSchema(s._def.innerType, ctx,path),
         readOnly: true,
       }
 
@@ -353,7 +401,7 @@ const nullSchema = (def?: z.ZodTypeDef): json.NullSchema => ({
 
 const additionalPropertiesSchema = (
   def: z.ZodObjectDef,
-  opts: Partial<JSONSchemaGenerationOptions>,
+  ctx: JSONSchemaCtx,
   path: PropertyPath
 ): NonNullable<json.ObjectSchema['additionalProperties']> => {
   if (def.unknownKeys === 'passthrough') {
@@ -372,5 +420,5 @@ const additionalPropertiesSchema = (
     return false
   }
 
-  return _toJSONSchema(def.unknownKeys, opts, path.withIndexType('string'))
+  return _toJSONSchema(def.unknownKeys, ctx,path.withIndexType('string'))
 }

--- a/packages/zui/src/transforms/zui-to-typescript-schema/index.test.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-schema/index.test.ts
@@ -918,47 +918,46 @@ describe.concurrent('toTypescriptSchema', () => {
     }
   })
 
-  test('should throw CircularZuiToTypescriptSchemaError for a self-referential lazy schema', () => {
+  test('should emit a hoisted recursive const for a self-referential lazy schema', () => {
     type TreeNode = { name: string; children?: TreeNode[] }
     const treeNode: z.ZodType<TreeNode> = z.lazy(() =>
       z.object({ name: z.string(), children: z.array(treeNode).optional() })
     )
-    try {
-      toTypescript(z.object({ tree: z.array(treeNode) }))
-      expect.fail('should have thrown')
-    } catch (e) {
-      expect(e).toBeInstanceOf(errors.CircularZuiToTypescriptSchemaError)
-      expect((e as errors.ZuiTransformError).path).toBe('#.tree[number].children[number]')
-    }
+    const out = toTypescript(z.object({ tree: z.array(treeNode) }))
+    const name = out.match(/const (Schema\d+) =/)?.[1]
+    expect(name).toBeTruthy()
+    expect(out).toContain(`z.lazy(() => ${name})`)
   })
 
-  test('should throw CircularZuiToTypescriptSchemaError for mutual recursion between two distinct lazy schemas', () => {
+  test('should emit hoisted recursive consts for mutual recursion between two distinct lazy schemas', () => {
     let A: z.ZodType<any> = z.lazy(() => z.object({ b: B }))
     let B: z.ZodType<any> = z.lazy(() => z.object({ a: A }))
-    try {
-      toTypescript(z.object({ root: A }))
-      expect.fail('should have thrown')
-    } catch (e) {
-      expect(e).toBeInstanceOf(errors.CircularZuiToTypescriptSchemaError)
-    }
+    const out = toTypescript(z.object({ root: A }))
+    expect(out).toMatch(/const Schema\d+ =/)
+    expect(out).toMatch(/z\.lazy\(\(\) => Schema\d+\)/)
   })
 
-  test('should throw CircularZuiToTypescriptSchemaError for a 3-node mutual recursion cycle', () => {
+  test('should emit hoisted recursive consts for a 3-node mutual recursion cycle', () => {
     let A: z.ZodType<any> = z.lazy(() => z.object({ b: B }))
     let B: z.ZodType<any> = z.lazy(() => z.object({ c: C }))
     let C: z.ZodType<any> = z.lazy(() => z.object({ a: A }))
-    try {
-      toTypescript(z.object({ root: A }))
-      expect.fail('should have thrown')
-    } catch (e) {
-      expect(e).toBeInstanceOf(errors.CircularZuiToTypescriptSchemaError)
-    }
+    const out = toTypescript(z.object({ root: A }))
+    expect(out).toMatch(/const Schema\d+ =/)
+    expect(out).toMatch(/z\.lazy\(\(\) => Schema\d+\)/)
   })
 
   test('should not throw when the same finite lazy schema is reused across sibling branches', () => {
     const shared: z.ZodType<any> = z.lazy(() => z.object({ x: z.string() }))
     const generated = toTypescript(z.object({ a: shared, b: shared }))
     expect((generated.match(/x: z\.string\(\)/g) || []).length).toBe(2)
+  })
+
+  test('generated source for a recursive schema evaluates back into a working schema', () => {
+    const Category: z.ZodType<any> = z.object({ name: z.string(), subcategories: z.array(z.lazy(() => Category)) })
+    const src = toTypescript(Category)
+    const rebuilt = new Function('z', src.replace(/\n(\w+)\s*$/, '\nreturn $1;'))(z) as z.ZodType
+    const result = rebuilt.safeParse({ name: 'root', subcategories: [{ name: 'child', subcategories: [] }] })
+    expect(result.success).toBe(true)
   })
 
   test('should add [string] section to additional properties', () => {

--- a/packages/zui/src/transforms/zui-to-typescript-schema/index.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-schema/index.ts
@@ -28,13 +28,47 @@ export function toTypescriptSchema(schema: z.ZodType): string {
   return _toTypescriptSchema(schema, new PropertyPath())
 }
 
-function _toTypescriptSchema(schema: z.ZodType, path: PropertyPath): string {
-  const wrappedSchema: z.ZodType = schema
-  const dts = sUnwrapZod(wrappedSchema, path, new Set())
-  return dts
+type RecursionCtx = {
+  onPath: Set<symbol>
+  nameOf: Map<symbol, string>
+  defs: Map<string, string>
+  usedNames: Set<string>
+  counter: { n: number }
 }
 
-function sUnwrapZod(schema: z.ZodType, path: PropertyPath, visiting: Set<symbol>): string {
+const assignRecursionName = (schema: z.ZodType, ctx: RecursionCtx): string => {
+  const meta = schema.getMetadata()
+  const title = typeof meta.title === 'string' && meta.title.length > 0 ? meta.title : undefined
+  const base = title ?? `Schema${ctx.counter.n++}`
+  let name = base
+  let i = 1
+  while (ctx.usedNames.has(name)) name = `${base}${i++}`
+  ctx.usedNames.add(name)
+  return name
+}
+
+function _toTypescriptSchema(schema: z.ZodType, path: PropertyPath): string {
+  const ctx: RecursionCtx = {
+    onPath: new Set(),
+    nameOf: new Map(),
+    defs: new Map(),
+    usedNames: new Set(),
+    counter: { n: 0 },
+  }
+  const entry = sUnwrapZod(schema, path, ctx)
+  if (ctx.defs.size === 0) return entry
+  const declarations = [...ctx.defs].map(([name, body]) => `const ${name} = ${body};`).join('\n')
+  let finalEntry = entry
+  for (const [name, body] of ctx.defs) {
+    if (body === entry.trim()) {
+      finalEntry = name
+      break
+    }
+  }
+  return `${declarations}\n${finalEntry}`
+}
+
+function sUnwrapZod(schema: z.ZodType, path: PropertyPath, ctx: RecursionCtx): string {
   const s = schema as z.ZodNativeType
   switch (s.typeName) {
     case 'ZodString':
@@ -74,16 +108,16 @@ function sUnwrapZod(schema: z.ZodType, path: PropertyPath, visiting: Set<symbol>
       return `z.void()${_addMetadata(s._def)}`.trim()
 
     case 'ZodArray':
-      return `z.array(${sUnwrapZod(s._def.type, path.withIndexType('number'), visiting)})${generateArrayChecks(s._def)}${_addMetadata(s._def, s._def.type)}`
+      return `z.array(${sUnwrapZod(s._def.type, path.withIndexType('number'), ctx)})${generateArrayChecks(s._def)}${_addMetadata(s._def, s._def.type)}`
 
     case 'ZodObject':
       const props: Record<string, string> = {}
       for (const [key, value] of Object.entries(s.shape)) {
-        props[key] = sUnwrapZod(value, path.withIndexType('key', key), visiting)
+        props[key] = sUnwrapZod(value, path.withIndexType('key', key), ctx)
       }
       const catchall = s.additionalProperties()
       const catchallString = catchall
-        ? `.catchall(${sUnwrapZod(catchall, path.withIndexType('string'), visiting)})`
+        ? `.catchall(${sUnwrapZod(catchall, path.withIndexType('string'), ctx)})`
         : ''
       return [
         //
@@ -96,67 +130,80 @@ function sUnwrapZod(schema: z.ZodType, path: PropertyPath, visiting: Set<symbol>
 
     case 'ZodUnion':
       const options = s._def.options.map((option, index) =>
-        sUnwrapZod(option, path.withIndexType('number', index), visiting)
+        sUnwrapZod(option, path.withIndexType('number', index), ctx)
       )
       return `z.union([${options.join(', ')}])${_addMetadata(s._def)}`.trim()
 
     case 'ZodDiscriminatedUnion':
       const opts = s._def.options.map((option, index) =>
-        sUnwrapZod(option, path.withIndexType('number', index), visiting)
+        sUnwrapZod(option, path.withIndexType('number', index), ctx)
       )
       const discriminator = primitiveToTypescriptValue(s._def.discriminator)
       return `z.discriminatedUnion(${discriminator}, [${opts.join(', ')}])${_addMetadata(s._def)}`.trim()
 
     case 'ZodIntersection':
-      const left: string = sUnwrapZod(s._def.left, path.withIndexType('number', 0), visiting)
-      const right: string = sUnwrapZod(s._def.right, path.withIndexType('number', 1), visiting)
+      const left: string = sUnwrapZod(s._def.left, path.withIndexType('number', 0), ctx)
+      const right: string = sUnwrapZod(s._def.right, path.withIndexType('number', 1), ctx)
       return `z.intersection(${left}, ${right})${_addMetadata(s._def)}`.trim()
 
     case 'ZodTuple':
-      const items = s._def.items.map((item, index) => sUnwrapZod(item, path.withIndexType('number', index), visiting))
+      const items = s._def.items.map((item, index) => sUnwrapZod(item, path.withIndexType('number', index), ctx))
       return `z.tuple([${items.join(', ')}])${_addMetadata(s._def)}`.trim()
 
     case 'ZodRecord':
-      const keyType = sUnwrapZod(s._def.keyType, path.withWrapper('KeyOf'), visiting)
+      const keyType = sUnwrapZod(s._def.keyType, path.withWrapper('KeyOf'), ctx)
       const recordPath = z.is.zuiString(s._def.keyType)
         ? path.withIndexType('string')
         : z.is.zuiNumber(s._def.keyType)
           ? path.withIndexType('number')
           : path.withIndexType('any')
-      const valueType = sUnwrapZod(s._def.valueType, recordPath, visiting)
+      const valueType = sUnwrapZod(s._def.valueType, recordPath, ctx)
       return `z.record(${keyType}, ${valueType})${_addMetadata(s._def)}`.trim()
 
     case 'ZodMap':
-      const mapKeyType = sUnwrapZod(s._def.keyType, path.withWrapper('KeyOf'), visiting)
+      const mapKeyType = sUnwrapZod(s._def.keyType, path.withWrapper('KeyOf'), ctx)
       const mapPath = z.is.zuiString(s._def.keyType)
         ? path.withIndexType('string')
         : z.is.zuiNumber(s._def.keyType)
           ? path.withIndexType('number')
           : path.withIndexType('any')
-      const mapValueType = sUnwrapZod(s._def.valueType, mapPath, visiting)
+      const mapValueType = sUnwrapZod(s._def.valueType, mapPath, ctx)
       return `z.map(${mapKeyType}, ${mapValueType})${_addMetadata(s._def)}`.trim()
 
     case 'ZodSet':
-      return `z.set(${sUnwrapZod(s._def.valueType, path.withIndexType('number'), visiting)})${generateSetChecks(s._def)}${_addMetadata(s._def)}`.trim()
+      return `z.set(${sUnwrapZod(s._def.valueType, path.withIndexType('number'), ctx)})${generateSetChecks(s._def)}${_addMetadata(s._def)}`.trim()
 
     case 'ZodFunction':
       const args = s._def.args.items.map((arg, index) =>
-        sUnwrapZod(arg, path.withWrapper('Parameters').withIndexType('number', index), visiting)
+        sUnwrapZod(arg, path.withWrapper('Parameters').withIndexType('number', index), ctx)
       )
       const argsString = args.length ? `.args(${args.join(', ')})` : ''
-      const returns = sUnwrapZod(s._def.returns, path.withWrapper('ReturnType'), visiting)
+      const returns = sUnwrapZod(s._def.returns, path.withWrapper('ReturnType'), ctx)
       return `z.function()${argsString}.returns(${returns})${_addMetadata(s._def)}`.trim()
 
-    case 'ZodLazy':
-      if (visiting.has(s._def.uid)) {
-        throw new errors.CircularZuiToTypescriptSchemaError(path.toString())
+    case 'ZodLazy': {
+      const uid = s._def.uid
+      const hoisted = ctx.nameOf.get(uid)
+      if (hoisted) return `z.lazy(() => ${hoisted})${_addMetadata(s._def)}`.trim()
+      if (ctx.onPath.has(uid)) {
+        const name = assignRecursionName(s, ctx)
+        ctx.nameOf.set(uid, name)
+        return `z.lazy(() => ${name})${_addMetadata(s._def)}`.trim()
       }
-      visiting.add(s._def.uid)
+      ctx.onPath.add(uid)
+      let body: string
       try {
-        return `z.lazy(() => ${sUnwrapZod(s._def.getter(), path, visiting)})${_addMetadata(s._def)}`.trim()
+        body = sUnwrapZod(s._def.getter(), path, ctx)
       } finally {
-        visiting.delete(s._def.uid)
+        ctx.onPath.delete(uid)
       }
+      const name = ctx.nameOf.get(uid)
+      if (name) {
+        ctx.defs.set(name, body)
+        return `z.lazy(() => ${name})${_addMetadata(s._def)}`.trim()
+      }
+      return `z.lazy(() => ${body})${_addMetadata(s._def)}`.trim()
+    }
 
     case 'ZodLiteral':
       const value = primitiveToTypescriptValue(s._def.value)
@@ -173,20 +220,20 @@ function sUnwrapZod(schema: z.ZodType, path: PropertyPath, visiting: Set<symbol>
       throw new errors.UnsupportedZuiToTypescriptSchemaError('ZodNativeEnum', path.toString())
 
     case 'ZodOptional':
-      return `z.optional(${sUnwrapZod(s._def.innerType, path, visiting)})${_addMetadata(s._def, s._def.innerType)}`.trim()
+      return `z.optional(${sUnwrapZod(s._def.innerType, path, ctx)})${_addMetadata(s._def, s._def.innerType)}`.trim()
 
     case 'ZodNullable':
-      return `z.nullable(${sUnwrapZod(s._def.innerType, path, visiting)})${_addMetadata(s._def, s._def.innerType)}`.trim()
+      return `z.nullable(${sUnwrapZod(s._def.innerType, path, ctx)})${_addMetadata(s._def, s._def.innerType)}`.trim()
 
     case 'ZodDefault':
       const defaultValue = unknownToTypescriptValue(s._def.defaultValue())
-      return `z.default(${sUnwrapZod(s._def.innerType, path, visiting)}, ${defaultValue})${_addMetadata(s._def, s._def.innerType)}`.trim()
+      return `z.default(${sUnwrapZod(s._def.innerType, path, ctx)}, ${defaultValue})${_addMetadata(s._def, s._def.innerType)}`.trim()
 
     case 'ZodCatch':
       throw new errors.UnsupportedZuiToTypescriptSchemaError('ZodCatch', path.toString())
 
     case 'ZodPromise':
-      return `z.promise(${sUnwrapZod(s._def.type, path, visiting)})${_addMetadata(s._def, s._def.type)}`.trim()
+      return `z.promise(${sUnwrapZod(s._def.type, path, ctx)})${_addMetadata(s._def, s._def.type)}`.trim()
 
     case 'ZodBranded':
       throw new errors.UnsupportedZuiToTypescriptSchemaError('ZodBranded', path.toString())
@@ -198,7 +245,7 @@ function sUnwrapZod(schema: z.ZodType, path: PropertyPath, visiting: Set<symbol>
       throw new errors.UnsupportedZuiToTypescriptSchemaError('ZodSymbol', path.toString())
 
     case 'ZodReadonly':
-      return `z.readonly(${sUnwrapZod(s._def.innerType, path, visiting)})${_addMetadata(s._def, s._def.innerType)}`.trim()
+      return `z.readonly(${sUnwrapZod(s._def.innerType, path, ctx)})${_addMetadata(s._def, s._def.innerType)}`.trim()
 
     case 'ZodRef':
       const uri = primitiveToTypescriptValue(s._def.uri)

--- a/packages/zui/src/transforms/zui-to-typescript-type/index.test.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-type/index.test.ts
@@ -1212,29 +1212,23 @@ describe.concurrent('optional', () => {
       }
     })
 
-    it('should throw CircularZuiToTypescriptTypeError for a self-referential lazy schema', () => {
+    it('should emit a hoisted recursive type for a self-referential lazy schema', () => {
       type TreeNode = { name: string; children?: TreeNode[] }
       const treeNode: z.ZodType<TreeNode> = z.lazy(() =>
         z.object({ name: z.string(), children: z.array(treeNode).optional() })
       )
-      try {
-        toTypescript(z.object({ tree: z.array(treeNode) }))
-        expect.fail('should have thrown')
-      } catch (e) {
-        expect(e).toBeInstanceOf(errors.CircularZuiToTypescriptTypeError)
-        expect((e as errors.ZuiTransformError).path).toBe('#.tree[number].children[number]')
-      }
+      const out = toTypescript(z.object({ tree: z.array(treeNode) }))
+      const name = out.match(/type (Schema\d+) =/)?.[1]
+      expect(name).toBeTruthy()
+      expect(out).toContain(`Array<${name}>`)
     })
 
-    it('should throw CircularZuiToTypescriptTypeError for mutual recursion between two distinct lazy schemas', () => {
+    it('should emit hoisted recursive types for mutual recursion between two distinct lazy schemas', () => {
       let A: z.ZodType<any> = z.lazy(() => z.object({ b: B }))
       let B: z.ZodType<any> = z.lazy(() => z.object({ a: A }))
-      try {
-        toTypescript(z.object({ root: A }))
-        expect.fail('should have thrown')
-      } catch (e) {
-        expect(e).toBeInstanceOf(errors.CircularZuiToTypescriptTypeError)
-      }
+      const out = toTypescript(z.object({ root: A }))
+      expect(out).toMatch(/type Schema\d+ =/)
+      expect(() => toTypescript(z.object({ root: A }))).not.toThrow()
     })
 
     it('should not throw CircularZuiToTypescriptTypeError for non-recursion of zero distinct lazy schemas', () => {
@@ -1248,16 +1242,13 @@ describe.concurrent('optional', () => {
       expect(() => toTypescript(schema)).not.toThrow()
     })
 
-    it('should throw CircularZuiToTypescriptTypeError for a 3-node mutual recursion cycle', () => {
+    it('should emit hoisted recursive types for a 3-node mutual recursion cycle', () => {
       let A: z.ZodType<any> = z.lazy(() => z.object({ b: B }))
       let B: z.ZodType<any> = z.lazy(() => z.object({ c: C }))
       let C: z.ZodType<any> = z.lazy(() => z.object({ a: A }))
-      try {
-        toTypescript(z.object({ root: A }))
-        expect.fail('should have thrown')
-      } catch (e) {
-        expect(e).toBeInstanceOf(errors.CircularZuiToTypescriptTypeError)
-      }
+      const out = toTypescript(z.object({ root: A }))
+      expect(out).toMatch(/type Schema\d+ =/)
+      expect(() => toTypescript(z.object({ root: A }))).not.toThrow()
     })
 
     it('should not throw when the same finite lazy schema is reused across sibling branches', () => {

--- a/packages/zui/src/transforms/zui-to-typescript-type/index.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-type/index.ts
@@ -86,13 +86,54 @@ export type TypescriptGenerationOptions = {
 
 type SchemaTypes = z.ZodType | KeyValue | FnParameters | Declaration | null
 
+type RecursionCtx = {
+  onPath: Set<symbol>
+  nameOf: Map<symbol, string>
+  defs: Map<string, string>
+  usedNames: Set<string>
+  counter: { n: number }
+}
+
 type InternalOptions = {
   parent?: SchemaTypes
   declaration?: boolean | TypescriptDeclarationType
   includeClosingTags?: boolean
   treatDefaultAsOptional?: boolean
-  // ZodLazyDef.uid values currently being expanded, to detect self-referential schemas — see ZodLazyDef.uid
-  visiting: Set<symbol>
+  recursion: RecursionCtx
+}
+
+const assignRecursionName = (schema: z.ZodType, ctx: RecursionCtx): string => {
+  const meta = schema.getMetadata()
+  const title = typeof meta.title === 'string' && meta.title.length > 0 ? meta.title : undefined
+  const base = title ?? `Schema${ctx.counter.n++}`
+  let name = base
+  let i = 1
+  while (ctx.usedNames.has(name)) name = `${base}${i++}`
+  ctx.usedNames.add(name)
+  return name
+}
+
+const withCycleGuard = (key: symbol, schema: z.ZodType, ctx: RecursionCtx, expand: () => string): string => {
+  const hoisted = ctx.nameOf.get(key)
+  if (hoisted) return hoisted
+  if (ctx.onPath.has(key)) {
+    const name = assignRecursionName(schema, ctx)
+    ctx.nameOf.set(key, name)
+    return name
+  }
+  ctx.onPath.add(key)
+  let body: string
+  try {
+    body = expand()
+  } finally {
+    ctx.onPath.delete(key)
+  }
+  const name = ctx.nameOf.get(key)
+  if (name) {
+    ctx.defs.set(name, body)
+    return name
+  }
+  return body
 }
 
 /**
@@ -108,7 +149,20 @@ export function toTypescriptType(schema: z.ZodType, options: TypescriptGeneratio
 function _toTypescriptType(schema: z.ZodType, path: PropertyPath, options: TypescriptGenerationOptions = {}): string {
   const wrappedSchema: Declaration = getDeclarationProps(schema, options)
 
-  let dts = sUnwrapZod(wrappedSchema, path, { ...options, visiting: new Set() })
+  const recursion: RecursionCtx = {
+    onPath: new Set(),
+    nameOf: new Map(),
+    defs: new Map(),
+    usedNames: new Set(),
+    counter: { n: 0 },
+  }
+
+  let dts = sUnwrapZod(wrappedSchema, path, { ...options, recursion })
+
+  if (recursion.defs.size > 0) {
+    const declarations = [...recursion.defs].map(([name, body]) => `type ${name} = ${body};`).join('\n')
+    dts = recursion.defs.has(dts.trim()) ? declarations : `${declarations}\n${dts}`
+  }
 
   if (options.formatter) {
     dts = options.formatter(dts)
@@ -321,15 +375,7 @@ ${opts.join(' | ')}`
 (${input}) => ${output}`
 
     case 'ZodLazy':
-      if (config.visiting.has(s._def.uid)) {
-        throw new errors.CircularZuiToTypescriptTypeError(path.toString())
-      }
-      config.visiting.add(s._def.uid)
-      try {
-        return sUnwrapZod(s._def.getter(), path, newConfig)
-      } finally {
-        config.visiting.delete(s._def.uid)
-      }
+      return withCycleGuard(s._def.uid, s, config.recursion, () => sUnwrapZod(s._def.getter(), path, newConfig))
 
     case 'ZodLiteral':
       const value: string = primitiveToTypscriptLiteralType(s._def.value)


### PR DESCRIPTION
# What's included
z.lazy() converts to recursive schemas in:
- toJSONSchema
- toTypescriptType
- toTypescriptSchema

Only works for zui to other, not for other to zui transforms.

Note: Only supporing zuiToSomething and not zuiFromSomething could introduce not well defined errors if using lazy or recursive schemas in other parts of the repo, not worth adding for now