### PR TITLE
feat(chat): add message stream signals

### DIFF
--- a/integrations/chat/definitions/actions.ts
+++ b/integrations/chat/definitions/actions.ts
@@ -1,0 +1,22 @@
+import { z } from '@botpress/sdk'
+
+export const publishMessageStreamInputSchema = z.object({
+  conversationId: z.string().title('Conversation ID').describe('Botpress conversation ID for the message stream'),
+  signal: z
+    .discriminatedUnion('type', [
+      z.object({
+        type: z.literal('delta'),
+        streamId: z.string(),
+        createdAt: z.string(),
+        clientMessageId: z.string().optional(),
+        sequence: z.number(),
+        delta: z.string(),
+      }),
+      z.object({
+        type: z.literal('abort'),
+        streamId: z.string(),
+      }),
+    ])
+    .title('Stream Signal')
+    .describe('Transient message stream delta or abort signal'),
+})

--- a/integrations/chat/integration.definition.ts
+++ b/integrations/chat/integration.definition.ts
@@ -1,5 +1,6 @@
 import * as sdk from '@botpress/sdk'
 import { z } from '@botpress/sdk'
+import { publishMessageStreamInputSchema } from './definitions/actions'
 import { messages } from './definitions/channels/messages'
 import { apiVersion } from './src/gen/version'
 
@@ -48,6 +49,16 @@ export default new sdk.IntegrationDefinition({
     },
   },
   actions: {
+    publishMessageStream: {
+      title: 'Publish Message Stream',
+      description: 'Publish a transient message stream delta or abort signal',
+      input: {
+        schema: publishMessageStreamInputSchema,
+      },
+      output: {
+        schema: z.object({}),
+      },
+    },
     sendEvent: {
       title: 'Send Custom Event',
       description: 'Send a custom event from the bot to the chat client',

--- a/integrations/chat/src/bot-message-signals.test.ts
+++ b/integrations/chat/src/bot-message-signals.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test, vi } from 'vitest'
+import { emitBotMessageSignals } from './bot-message-signals'
+import { SignalEmitter } from './signal-emitter'
+
+type ChatMessage = Parameters<typeof emitBotMessageSignals>[0]['message']
+
+const makeSignalEmitter = (): SignalEmitter => ({
+  emit: vi.fn().mockResolvedValue(undefined),
+  emitOrThrow: vi.fn().mockResolvedValue(undefined),
+  close: vi.fn().mockResolvedValue(undefined),
+})
+
+const message: ChatMessage = {
+  id: 'message-1',
+  conversationId: 'conversation-1',
+  userId: 'user-1',
+  createdAt: '2026-07-23T14:15:17.123Z',
+  payload: {
+    type: 'text',
+    text: 'Hello world',
+  },
+  metadata: {
+    custom: 'value',
+  },
+}
+
+describe('emitBotMessageSignals', () => {
+  test('keeps the existing message_created signal unchanged', async () => {
+    const signalEmitter = makeSignalEmitter()
+
+    await emitBotMessageSignals({
+      channel: 'bp-conversation-1',
+      message,
+      signalEmitter,
+    })
+
+    expect(signalEmitter.emit).toHaveBeenCalledOnce()
+    expect(signalEmitter.emit).toHaveBeenCalledWith('bp-conversation-1', {
+      type: 'message_created',
+      data: {
+        ...message,
+        isBot: true,
+      },
+    })
+  })
+
+  test('completes a correlated stream and still emits message_created', async () => {
+    const signalEmitter = makeSignalEmitter()
+    const streamedMessage = {
+      ...message,
+      metadata: {
+        ...message.metadata,
+        streamId: 'stream-1',
+      },
+    }
+
+    await emitBotMessageSignals({
+      channel: 'bp-conversation-1',
+      message: streamedMessage,
+      signalEmitter,
+    })
+
+    expect(signalEmitter.emit).toHaveBeenNthCalledWith(1, 'bp-conversation-1', {
+      type: 'message_stream_complete',
+      data: {
+        streamId: 'stream-1',
+        message: streamedMessage,
+      },
+    })
+    expect(signalEmitter.emit).toHaveBeenNthCalledWith(2, 'bp-conversation-1', {
+      type: 'message_created',
+      data: {
+        ...streamedMessage,
+        isBot: true,
+      },
+    })
+  })
+})

--- a/integrations/chat/src/bot-message-signals.ts
+++ b/integrations/chat/src/bot-message-signals.ts
@@ -1,0 +1,39 @@
+import { MessageCreatedSignal, SignalEmitter } from './signal-emitter'
+
+type ChatMessage = Omit<MessageCreatedSignal['data'], 'isBot'>
+
+type EmitBotMessageSignalsInput = {
+  channel: string
+  message: ChatMessage
+  signalEmitter: SignalEmitter
+}
+
+const getStreamId = (message: ChatMessage): string | undefined => {
+  const streamId = message.metadata?.streamId
+  return typeof streamId === 'string' ? streamId : undefined
+}
+
+export const emitBotMessageSignals = async ({
+  channel,
+  message,
+  signalEmitter,
+}: EmitBotMessageSignalsInput): Promise<void> => {
+  const streamId = getStreamId(message)
+  if (streamId) {
+    await signalEmitter.emit(channel, {
+      type: 'message_stream_complete',
+      data: {
+        streamId,
+        message,
+      },
+    })
+  }
+
+  await signalEmitter.emit(channel, {
+    type: 'message_created',
+    data: {
+      ...message,
+      isBot: true,
+    },
+  })
+}

--- a/integrations/chat/src/debug.ts
+++ b/integrations/chat/src/debug.ts
@@ -34,7 +34,7 @@ export const debugResponse = (id: string, res: Response) => {
   logger.info(`[${id}] Outgoing response ${res.status} ${headersSummary} ${bodySummary}`)
 }
 
-export const debugSignal = (args: types.MessageArgs | types.ActionArgs) => {
+export const debugSignal = (args: types.MessageArgs | types.ActionArgs<'sendEvent'>) => {
   if ('input' in args) {
     logger.debug(
       `Sending signal conversationId=${args.input.conversationId} event=${summarize(

--- a/integrations/chat/src/index.ts
+++ b/integrations/chat/src/index.ts
@@ -2,9 +2,11 @@ import * as dynamodb from '@aws-sdk/client-dynamodb'
 import { mapBotpressMessageToChat } from './api/message-payload'
 import { makeApiUtils } from './api-utils'
 import { AuthKeyHandler } from './auth-key'
+import { emitBotMessageSignals } from './bot-message-signals'
 import * as debug from './debug'
 import { makeHandler } from './handler'
 import { MemorySpace, ChatIdStore, InMemoryChatIdStore, DynamoDbChatIdStore } from './id-store'
+import { emitMessageStream } from './message-stream'
 import { startMetricsServer } from './metrics-server'
 import { Options, options } from './options'
 import { CompositeSignalEmiter, PushpinEmitter, SignalEmitter, WebhookEmitter } from './signal-emitter'
@@ -79,7 +81,10 @@ const mapMessageSignalFid = async (idStores: ChatIdStores, args: MessageArgs): P
   }
 }
 
-const mapEventSignalFid = async (idStores: ChatIdStores, args: ActionArgs): Promise<ActionArgs> => {
+const mapEventSignalFid = async (
+  idStores: ChatIdStores,
+  args: ActionArgs<'sendEvent'>
+): Promise<ActionArgs<'sendEvent'>> => {
   const { input } = args
   const conversationId = await idStores.convIdStore.byId.get(input.conversationId)
   return {
@@ -111,22 +116,22 @@ const emitMessage = async (args: MessageArgs) => {
     })
 
     const { metadata, payload } = mapBotpressMessageToChat(args)
-    await signalEmitter.emit(channel, {
-      type: 'message_created',
-      data: {
+    await emitBotMessageSignals({
+      channel,
+      signalEmitter,
+      message: {
         id: args.message.id,
         conversationId: args.conversation.id,
         userId: args.user.id,
         createdAt: args.message.createdAt,
         payload,
         metadata,
-        isBot: true,
       },
     })
   })
 }
 
-const emitEvent = async (args: ActionArgs) => {
+const emitEvent = async (args: ActionArgs<'sendEvent'>) => {
   await runWithSpan('emit.event', async () => {
     const opts = options(args)
     const signalEmitter = makeEmitter(opts)
@@ -168,6 +173,15 @@ export default new IntegrationWithMetrics({
     managesOwnTracePropagation: !!tracingProvider,
   },
   actions: {
+    publishMessageStream: async (props) => {
+      await runWithSpan('emit.message_stream', async () => {
+        const opts = options(props)
+        const signalEmitter = makeEmitter(opts)
+        const idStores = makeIdStores(opts)
+        await emitMessageStream(props, { ...idStores, signalEmitter })
+      })
+      return {}
+    },
     sendEvent: async (props) => {
       await emitEvent(props)
       return {}

--- a/integrations/chat/src/message-stream.test.ts
+++ b/integrations/chat/src/message-stream.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { InMemoryChatIdStore } from './id-store'
+import { emitMessageStream, MessageStreamActionArgs } from './message-stream'
+import { SignalEmitter } from './signal-emitter'
+
+type MessageStreamInput = MessageStreamActionArgs['input']
+
+const makeActionArgs = (input: MessageStreamInput, botUserId = 'bp-user-1'): MessageStreamActionArgs =>
+  ({
+    input,
+    ctx: {
+      botUserId,
+    },
+  }) as unknown as MessageStreamActionArgs
+
+const makeSignalEmitter = (): SignalEmitter => ({
+  emit: vi.fn().mockResolvedValue(undefined),
+  emitOrThrow: vi.fn().mockResolvedValue(undefined),
+  close: vi.fn().mockResolvedValue(undefined),
+})
+
+const mapId = async (store: InMemoryChatIdStore, chatId: string, botpressId: string): Promise<void> => {
+  await store.byFid.set(chatId, botpressId)
+}
+
+describe('emitMessageStream', () => {
+  let convIdStore: InMemoryChatIdStore
+  let userIdStore: InMemoryChatIdStore
+  let signalEmitter: SignalEmitter
+
+  beforeEach(() => {
+    convIdStore = new InMemoryChatIdStore()
+    userIdStore = new InMemoryChatIdStore()
+    signalEmitter = makeSignalEmitter()
+  })
+
+  test('maps the Botpress conversation ID to the Chat API conversation ID', async () => {
+    await mapId(convIdStore, 'chat-conversation-1', 'bp-conversation-1')
+
+    await emitMessageStream(
+      makeActionArgs({
+        conversationId: 'bp-conversation-1',
+        signal: {
+          type: 'abort',
+          streamId: 'stream-1',
+        },
+      }),
+      { convIdStore, userIdStore, signalEmitter }
+    )
+
+    expect(signalEmitter.emitOrThrow).toHaveBeenCalledWith('bp-conversation-1', {
+      type: 'message_stream_abort',
+      data: {
+        streamId: 'stream-1',
+        conversationId: 'chat-conversation-1',
+      },
+    })
+  })
+
+  test('maps the bot user ID to the final message author ID', async () => {
+    await mapId(userIdStore, 'chat-bot-user-1', 'bp-bot-user-1')
+
+    await emitMessageStream(
+      makeActionArgs(
+        {
+          conversationId: 'bp-conversation-1',
+          signal: {
+            type: 'delta',
+            streamId: 'stream-1',
+            createdAt: '2026-07-23T14:15:16.123Z',
+            sequence: 1,
+            delta: 'Hello',
+          },
+        },
+        'bp-bot-user-1'
+      ),
+      { convIdStore, userIdStore, signalEmitter }
+    )
+
+    expect(signalEmitter.emitOrThrow).toHaveBeenCalledWith(
+      'bp-conversation-1',
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: 'chat-bot-user-1',
+        }),
+      })
+    )
+  })
+
+  test('preserves the complete delta payload', async () => {
+    await mapId(convIdStore, 'chat-conversation-1', 'bp-conversation-1')
+    await mapId(userIdStore, 'chat-bot-user-1', 'bp-bot-user-1')
+
+    await emitMessageStream(
+      makeActionArgs(
+        {
+          conversationId: 'bp-conversation-1',
+          signal: {
+            type: 'delta',
+            streamId: 'stream-1',
+            createdAt: '2026-07-23T14:15:16.123Z',
+            clientMessageId: 'client-message-1',
+            sequence: 3,
+            delta: ' world',
+          },
+        },
+        'bp-bot-user-1'
+      ),
+      { convIdStore, userIdStore, signalEmitter }
+    )
+
+    expect(signalEmitter.emitOrThrow).toHaveBeenCalledWith('bp-conversation-1', {
+      type: 'message_stream_delta',
+      data: {
+        streamId: 'stream-1',
+        conversationId: 'chat-conversation-1',
+        userId: 'chat-bot-user-1',
+        createdAt: '2026-07-23T14:15:16.123Z',
+        clientMessageId: 'client-message-1',
+        sequence: 3,
+        delta: ' world',
+      },
+    })
+  })
+
+  test('reports signal delivery failures to the bot caller', async () => {
+    const deliveryError = new Error('Pushpin rejected the signal')
+    vi.mocked(signalEmitter.emitOrThrow).mockRejectedValueOnce(deliveryError)
+
+    const result = emitMessageStream(
+      makeActionArgs({
+        conversationId: 'bp-conversation-1',
+        signal: {
+          type: 'abort',
+          streamId: 'stream-1',
+        },
+      }),
+      { convIdStore, userIdStore, signalEmitter }
+    )
+
+    await expect(result).rejects.toThrow(deliveryError)
+  })
+})

--- a/integrations/chat/src/message-stream.ts
+++ b/integrations/chat/src/message-stream.ts
@@ -1,0 +1,53 @@
+import { ChatIdStore } from './id-store'
+import { SignalEmitter } from './signal-emitter'
+import { setSpanAttributes, SPAN_ATTRS } from './tracing'
+import { ActionArgs } from './types'
+
+export type MessageStreamActionArgs = ActionArgs<'publishMessageStream'>
+
+type MessageStreamDependencies = {
+  convIdStore: ChatIdStore
+  userIdStore: ChatIdStore
+  signalEmitter: SignalEmitter
+}
+
+export const emitMessageStream = async (
+  args: MessageStreamActionArgs,
+  dependencies: MessageStreamDependencies
+): Promise<void> => {
+  const {
+    input: { conversationId: channel, signal },
+    ctx: { botUserId },
+  } = args
+  const { convIdStore, userIdStore, signalEmitter } = dependencies
+
+  const conversationId = await convIdStore.byId.get(channel)
+  setSpanAttributes({ [SPAN_ATTRS.CONVERSATION_ID]: conversationId })
+
+  if (signal.type === 'abort') {
+    await signalEmitter.emitOrThrow(channel, {
+      type: 'message_stream_abort',
+      data: {
+        streamId: signal.streamId,
+        conversationId,
+      },
+    })
+    return
+  }
+
+  const userId = await userIdStore.byId.get(botUserId)
+  setSpanAttributes({ [SPAN_ATTRS.USER_ID]: userId })
+
+  await signalEmitter.emitOrThrow(channel, {
+    type: 'message_stream_delta',
+    data: {
+      streamId: signal.streamId,
+      conversationId,
+      userId,
+      createdAt: signal.createdAt,
+      clientMessageId: signal.clientMessageId,
+      sequence: signal.sequence,
+      delta: signal.delta,
+    },
+  })
+}

--- a/integrations/chat/src/signal-emitter/composite.ts
+++ b/integrations/chat/src/signal-emitter/composite.ts
@@ -7,6 +7,10 @@ export class CompositeSignalEmiter implements SignalEmitter {
     await Promise.all(this._emitters.map((emitter) => emitter.emit(channel, signal)))
   }
 
+  public async emitOrThrow(channel: string, signal: Signal): Promise<void> {
+    await Promise.all(this._emitters.map((emitter) => emitter.emitOrThrow(channel, signal)))
+  }
+
   public async close(channel: string): Promise<void> {
     await Promise.all(this._emitters.map((emitter) => emitter.close(channel)))
   }

--- a/integrations/chat/src/signal-emitter/pushpin.ts
+++ b/integrations/chat/src/signal-emitter/pushpin.ts
@@ -49,6 +49,10 @@ export class PushpinEmitter implements SignalEmitter {
   }
 
   public async emit(channel: string, signal: Signal): Promise<void> {
+    await this.emitOrThrow(channel, signal).catch(this._handleError)
+  }
+
+  public async emitOrThrow(channel: string, signal: Signal): Promise<void> {
     await this._publish({
       items: [
         {
@@ -65,7 +69,7 @@ export class PushpinEmitter implements SignalEmitter {
           },
         },
       ],
-    }).catch(this._handleError)
+    })
   }
 
   public async close(channel: string): Promise<void> {

--- a/integrations/chat/src/signal-emitter/typings.ts
+++ b/integrations/chat/src/signal-emitter/typings.ts
@@ -7,5 +7,6 @@ export type EventCreatedSignal = Signals['eventCreated']
 
 export type SignalEmitter = {
   emit(channel: string, signal: Signal): Promise<void>
+  emitOrThrow(channel: string, signal: Signal): Promise<void>
   close(channel: string): Promise<void>
 }

--- a/integrations/chat/src/signal-emitter/webhook.ts
+++ b/integrations/chat/src/signal-emitter/webhook.ts
@@ -18,7 +18,11 @@ export class WebhookEmitter implements SignalEmitter {
   }
 
   public async emit(_channel: string, signal: Signal): Promise<void> {
-    await this._client.post('/', signal).catch(this._handleError)
+    await this.emitOrThrow(_channel, signal).catch(this._handleError)
+  }
+
+  public async emitOrThrow(_channel: string, signal: Signal): Promise<void> {
+    await this._client.post('/', signal)
   }
 
   public async close(): Promise<void> {

--- a/integrations/chat/src/types.ts
+++ b/integrations/chat/src/types.ts
@@ -47,4 +47,5 @@ export type ClientResponses = {
 export type ActionInputs = {
   [K in keyof bp.Integration['actions']]: Parameters<bp.Integration['actions'][K]>[0]
 }
-export type ActionArgs = Simplify<ValueOf<ActionInputs>>
+export type ActionName = keyof ActionInputs
+export type ActionArgs<TAction extends ActionName = ActionName> = Simplify<ActionInputs[TAction]>

--- a/packages/chat-api/src/signals.ts
+++ b/packages/chat-api/src/signals.ts
@@ -8,6 +8,32 @@ export const signalSchemas = {
       isBot: z.boolean().describe('Whether the message was created by the bot or not'),
     }),
   }),
+  messageStreamDelta: z.object({
+    type: z.literal('message_stream_delta'),
+    data: z.object({
+      streamId: z.string(),
+      conversationId: z.string(),
+      userId: z.string(),
+      createdAt: z.string(),
+      clientMessageId: z.string().optional(),
+      sequence: z.number(),
+      delta: z.string(),
+    }),
+  }),
+  messageStreamComplete: z.object({
+    type: z.literal('message_stream_complete'),
+    data: z.object({
+      streamId: z.string(),
+      message: message.messageSchema,
+    }),
+  }),
+  messageStreamAbort: z.object({
+    type: z.literal('message_stream_abort'),
+    data: z.object({
+      streamId: z.string(),
+      conversationId: z.string(),
+    }),
+  }),
   eventCreated: z.object({
     type: z.literal('event_created'),
     data: event.eventSchema.omit({ id: true }).extend({

--- a/packages/chat-client/package.json
+++ b/packages/chat-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/chat",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Botpress Chat API Client",
   "license": "MIT",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
-    "@botpress/chat": "1.0.0",
+    "@botpress/chat": "1.1.0",
     "@botpress/client": "2.0.0",
     "@botpress/sdk": "6.13.4",
     "@bpinternal/const": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2760,7 +2760,7 @@ importers:
         specifier: ^11.7.0
         version: 11.7.0
       '@botpress/chat':
-        specifier: 1.0.0
+        specifier: 1.1.0
         version: link:../chat-client
       '@botpress/client':
         specifier: 2.0.0


### PR DESCRIPTION
Adds native Chat API message-stream signals and a bot-callable producer action to the production Chat integration.

ADK can publish transient deltas or aborts with Botpress conversation IDs while the integration maps Chat API conversation and bot-user IDs internally. Persisted final messages carrying metadata.streamId emit message_stream_complete and retain the existing message_created signal.

This bumps @botpress/chat to 1.1.0 and keeps the Chat API integration protocol at 1.0.0. The fixed Chat integration still needs a production deployment after merge.