### PR TITLE
chore(botpress): Exclude vitest.config.ts from type check

### DIFF
--- a/integrations/airtable/tsconfig.json
+++ b/integrations/airtable/tsconfig.json
@@ -7,5 +7,6 @@
     "jsx": "react-jsx",
     "jsxImportSource": "preact"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/anthropic/tsconfig.json
+++ b/integrations/anthropic/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/asana/tsconfig.json
+++ b/integrations/asana/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/attio/tsconfig.json
+++ b/integrations/attio/tsconfig.json
@@ -6,5 +6,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/bamboohr/tsconfig.json
+++ b/integrations/bamboohr/tsconfig.json
@@ -8,5 +8,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/bigcommerce-sync/tsconfig.json
+++ b/integrations/bigcommerce-sync/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/browser/tsconfig.json
+++ b/integrations/browser/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/calcom/tsconfig.json
+++ b/integrations/calcom/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/calendly/tsconfig.json
+++ b/integrations/calendly/tsconfig.json
@@ -6,5 +6,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/canny/tsconfig.json
+++ b/integrations/canny/tsconfig.json
@@ -6,5 +6,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/cerebras/tsconfig.json
+++ b/integrations/cerebras/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/charts/tsconfig.json
+++ b/integrations/charts/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/chat/tsconfig.json
+++ b/integrations/chat/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "noErrorTruncation": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/clickup/tsconfig.json
+++ b/integrations/clickup/tsconfig.json
@@ -6,5 +6,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/confluence/tsconfig.json
+++ b/integrations/confluence/tsconfig.json
@@ -6,5 +6,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/dalle/tsconfig.json
+++ b/integrations/dalle/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/docusign/tsconfig.json
+++ b/integrations/docusign/tsconfig.json
@@ -6,5 +6,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/dropbox/tsconfig.json
+++ b/integrations/dropbox/tsconfig.json
@@ -8,5 +8,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/email/tsconfig.json
+++ b/integrations/email/tsconfig.json
@@ -6,5 +6,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/feature-base/tsconfig.json
+++ b/integrations/feature-base/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/fireworks-ai/tsconfig.json
+++ b/integrations/fireworks-ai/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/freshchat/tsconfig.json
+++ b/integrations/freshchat/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/github/tsconfig.json
+++ b/integrations/github/tsconfig.json
@@ -7,5 +7,6 @@
     "outDir": "dist",
     "types": ["preact"]
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/gmail/tsconfig.json
+++ b/integrations/gmail/tsconfig.json
@@ -9,5 +9,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/google-ai/tsconfig.json
+++ b/integrations/google-ai/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/google-analytics/tsconfig.json
+++ b/integrations/google-analytics/tsconfig.json
@@ -6,5 +6,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/googlecalendar/tsconfig.json
+++ b/integrations/googlecalendar/tsconfig.json
@@ -8,5 +8,6 @@
     "jsx": "react-jsx",
     "jsxImportSource": "preact"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/googledrive/tsconfig.json
+++ b/integrations/googledrive/tsconfig.json
@@ -7,5 +7,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/googledrivekb/tsconfig.json
+++ b/integrations/googledrivekb/tsconfig.json
@@ -7,5 +7,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/groq/tsconfig.json
+++ b/integrations/groq/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/gsheets/tsconfig.json
+++ b/integrations/gsheets/tsconfig.json
@@ -9,5 +9,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/hubspot/tsconfig.json
+++ b/integrations/hubspot/tsconfig.json
@@ -9,5 +9,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/hunter/tsconfig.json
+++ b/integrations/hunter/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/instagram/tsconfig.json
+++ b/integrations/instagram/tsconfig.json
@@ -6,5 +6,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/intercom/tsconfig.json
+++ b/integrations/intercom/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/line/tsconfig.json
+++ b/integrations/line/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/linear/tsconfig.json
+++ b/integrations/linear/tsconfig.json
@@ -8,5 +8,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/loops/tsconfig.json
+++ b/integrations/loops/tsconfig.json
@@ -6,5 +6,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/mailchimp/tsconfig.json
+++ b/integrations/mailchimp/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/make/tsconfig.json
+++ b/integrations/make/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/messenger/tsconfig.json
+++ b/integrations/messenger/tsconfig.json
@@ -6,5 +6,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/mintlify/tsconfig.json
+++ b/integrations/mintlify/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/mistral-ai/tsconfig.json
+++ b/integrations/mistral-ai/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/monday/tsconfig.json
+++ b/integrations/monday/tsconfig.json
@@ -6,5 +6,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/notion/tsconfig.json
+++ b/integrations/notion/tsconfig.json
@@ -7,5 +7,6 @@
     "emitDecoratorMetadata": true,
     "noErrorTruncation": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/openai/tsconfig.json
+++ b/integrations/openai/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/pdf-generator/tsconfig.json
+++ b/integrations/pdf-generator/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/resend/tsconfig.json
+++ b/integrations/resend/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/sendgrid/tsconfig.json
+++ b/integrations/sendgrid/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/sharepoint-excel/tsconfig.json
+++ b/integrations/sharepoint-excel/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/sharepoint/tsconfig.json
+++ b/integrations/sharepoint/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/shopify-admin/tsconfig.json
+++ b/integrations/shopify-admin/tsconfig.json
@@ -8,5 +8,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts", "*.json"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts", "*.json"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/shopify-storefront/tsconfig.json
+++ b/integrations/shopify-storefront/tsconfig.json
@@ -8,5 +8,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts", "*.json"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts", "*.json"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/slack/tsconfig.json
+++ b/integrations/slack/tsconfig.json
@@ -8,5 +8,6 @@
     "jsx": "react-jsx",
     "jsxImportSource": "preact"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/stripe/tsconfig.json
+++ b/integrations/stripe/tsconfig.json
@@ -6,5 +6,6 @@
     "jsx": "react-jsx",
     "jsxImportSource": "preact"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/sunco/tsconfig.json
+++ b/integrations/sunco/tsconfig.json
@@ -6,5 +6,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/tally/tsconfig.json
+++ b/integrations/tally/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/teams/tsconfig.json
+++ b/integrations/teams/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/telegram/tsconfig.json
+++ b/integrations/telegram/tsconfig.json
@@ -6,5 +6,6 @@
     "jsx": "react-jsx",
     "jsxImportSource": "preact"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/todoist/tsconfig.json
+++ b/integrations/todoist/tsconfig.json
@@ -6,5 +6,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/trello/tsconfig.json
+++ b/integrations/trello/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/twilio/tsconfig.json
+++ b/integrations/twilio/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/viber/tsconfig.json
+++ b/integrations/viber/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/vonage/tsconfig.json
+++ b/integrations/vonage/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/webflow/tsconfig.json
+++ b/integrations/webflow/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/webhook/tsconfig.json
+++ b/integrations/webhook/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/whatsapp/tsconfig.json
+++ b/integrations/whatsapp/tsconfig.json
@@ -7,5 +7,6 @@
     "outDir": "dist",
     "types": ["preact"]
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/workable/tsconfig.json
+++ b/integrations/workable/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/zapier/tsconfig.json
+++ b/integrations/zapier/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/zendesk-messaging-hitl/tsconfig.json
+++ b/integrations/zendesk-messaging-hitl/tsconfig.json
@@ -7,5 +7,6 @@
     "outDir": "dist",
     "types": ["preact"]
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/zendesk/tsconfig.json
+++ b/integrations/zendesk/tsconfig.json
@@ -7,5 +7,6 @@
     "outDir": "dist",
     "types": ["preact"]
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/integrations/zoho/tsconfig.json
+++ b/integrations/zoho/tsconfig.json
@@ -7,5 +7,6 @@
     "outDir": "dist",
     "types": ["preact"]
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/packages/cognitive/tsconfig.json
+++ b/packages/cognitive/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {},
-  "include": ["src/**/*", "e2e/**/*", "*.ts"]
+  "include": ["src/**/*", "e2e/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -7,5 +7,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },
-  "include": ["src/**/*", "*.ts"]
+  "include": ["src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/packages/llmz/tsconfig.json
+++ b/packages/llmz/tsconfig.json
@@ -13,5 +13,5 @@
     "typeRoots": ["node_modules/@types"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "vitest.config.ts"]
 }

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -4,5 +4,5 @@
     "noErrorTruncation": true
   },
   "include": ["src/**/*", "*.ts"],
-  "exclude": ["dist"]
+  "exclude": ["dist", "vitest.config.ts"]
 }

--- a/packages/zui/tsconfig.json
+++ b/packages/zui/tsconfig.json
@@ -20,7 +20,7 @@
     "isolatedModules": true,
     "noErrorTruncation": true
   },
-  "exclude": ["node_modules", "dist"],
+  "exclude": ["node_modules", "dist", "vitest.config.ts"],
   "include": ["src/**/*", "bench/**/*", "*.ts"],
   "ts-node": {
     "esm": true

--- a/plugins/analytics/tsconfig.json
+++ b/plugins/analytics/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/plugins/conversation-insights/tsconfig.json
+++ b/plugins/conversation-insights/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/plugins/file-synchronizer/tsconfig.json
+++ b/plugins/file-synchronizer/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/plugins/hitl/tsconfig.json
+++ b/plugins/hitl/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/plugins/knowledge-connector/tsconfig.json
+++ b/plugins/knowledge-connector/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/plugins/knowledge/tsconfig.json
+++ b/plugins/knowledge/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/plugins/logger/tsconfig.json
+++ b/plugins/logger/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/plugins/personality/tsconfig.json
+++ b/plugins/personality/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }

--- a/plugins/synchronizer/tsconfig.json
+++ b/plugins/synchronizer/tsconfig.json
@@ -4,5 +4,6 @@
     "paths": { "*": ["./*"] },
     "outDir": "dist"
   },
-  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"]
+  "include": [".botpress/**/*", "definitions/**/*", "src/**/*", "*.ts"],
+  "exclude": ["vitest.config.ts"]
 }


### PR DESCRIPTION
# What's included
- vitest.config.ts files removed from type checked files

In TS 6, there was a change in how rootDir works, so we got errors saying the shared root vitest.config.ts (imported via ../../vitest.config) wasn't under rootDir.

Contributes to KKN-912