### PR TITLE
chore(client): Fix CryptoLib type for TS 6 compatibility

### DIFF
--- a/packages/client/openapi.ts
+++ b/packages/client/openapi.ts
@@ -141,6 +141,51 @@ const denodecryptoify = (dir: string): void => {
   )
 }
 
+// TEMPORARY, same deal as deaxiosify/denodecryptoify: opapi's generated
+// errors.ts hand-declares CryptoLib against a plain Uint8Array signature,
+// which drifts out of sync with the real Crypto type as TS's DOM lib
+// evolves (already true under TS 6). Deriving it from Crypto directly keeps
+// it correct going forward.
+const fixCryptoLibType = (dir: string): void => {
+  const errorsFile = path.join(dir, 'errors.ts')
+  const content = fs.readFileSync(errorsFile, 'utf-8')
+  const typeTarget = 'type CryptoLib = { getRandomValues(array: Uint8Array): Uint8Array }'
+  if (!content.includes(typeTarget)) {
+    return // already patched
+  }
+
+  const polyfillTarget =
+    'getRandomValues: (array: Uint8Array) => new Uint8Array(array.map(() => Math.floor(Math.random() * 256))),'
+  if (!content.includes(polyfillTarget)) {
+    throw new Error(
+      `fixCryptoLibType: found "${typeTarget}" but not the expected polyfill implementation in ${errorsFile} — opapi's generated output may have changed shape, update this patch`
+    )
+  }
+
+  fs.writeFileSync(
+    errorsFile,
+    content
+      .replace(typeTarget, "type CryptoLib = Pick<Crypto, 'getRandomValues'>")
+      .replace(
+        polyfillTarget,
+        [
+          'getRandomValues: <T extends ArrayBufferView | null>(array: T): T => {',
+          "    // array is nullable because that's how some lib.dom.d.ts versions type",
+          '    // Crypto.getRandomValues; this codebase never actually passes null.',
+          '    if (array === null) {',
+          "      throw new TypeError('getRandomValues polyfill requires a non-null typed array')",
+          '    }',
+          '    const view = new Uint8Array(array.buffer, array.byteOffset, array.byteLength)',
+          '    for (let i = 0; i < view.length; i++) {',
+          '      view[i] = Math.floor(Math.random() * 256)',
+          '    }',
+          '    return array',
+          '  },',
+        ].join('\n')
+      )
+  )
+}
+
 const main = async (): Promise<void> => {
   await publicApi.exportClient('./src/gen/public', { generator: 'opapi' })
   await runtimeApi.exportClient('./src/gen/runtime', options)
@@ -152,6 +197,7 @@ const main = async (): Promise<void> => {
   for (const name of ['public', 'runtime', 'admin', 'files', 'tables', 'billing']) {
     deaxiosify(`./src/gen/${name}`)
     denodecryptoify(`./src/gen/${name}`)
+    fixCryptoLibType(`./src/gen/${name}`)
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11674,6 +11674,10 @@ packages:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
 
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
@@ -12164,6 +12168,10 @@ packages:
 
   side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   side-channel@1.1.1:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
@@ -19728,7 +19736,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.4
+      hasown: 2.0.2
 
   es-shim-unscopables@1.0.2:
     dependencies:
@@ -20568,7 +20576,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.4
+      hasown: 2.0.2
       math-intrinsics: 1.1.0
 
   get-intrinsic@1.3.0:
@@ -20760,7 +20768,7 @@ snapshots:
       extend: 3.0.2
       gaxios: 5.1.0
       google-auth-library: 8.8.0
-      qs: 6.15.3
+      qs: 6.13.0
       url-template: 2.0.8
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -20772,7 +20780,7 @@ snapshots:
       extend: 3.0.2
       gaxios: 6.1.1
       google-auth-library: 9.0.0
-      qs: 6.15.3
+      qs: 6.13.0
       url-template: 2.0.8
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -20784,7 +20792,7 @@ snapshots:
       extend: 3.0.2
       gaxios: 7.1.4
       google-auth-library: 10.6.2
-      qs: 6.15.3
+      qs: 6.15.0
       url-template: 2.0.8
     transitivePeerDependencies:
       - supports-color
@@ -21169,7 +21177,7 @@ snapshots:
 
   is-core-module@2.16.1:
     dependencies:
-      hasown: 2.0.4
+      hasown: 2.0.2
 
   is-data-view@1.0.2:
     dependencies:
@@ -23447,6 +23455,10 @@ snapshots:
 
   qs@6.13.0:
     dependencies:
+      side-channel: 1.1.0
+
+  qs@6.15.0:
+    dependencies:
       side-channel: 1.1.1
 
   qs@6.15.3:
@@ -24124,6 +24136,14 @@ snapshots:
       get-intrinsic: 1.2.7
       object-inspect: 1.13.3
 
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -24372,7 +24392,7 @@ snapshots:
       formidable: 1.2.6
       methods: 1.1.2
       mime: 1.6.0
-      qs: 6.15.3
+      qs: 6.15.0
       readable-stream: 2.3.8
     transitivePeerDependencies:
       - supports-color
@@ -24387,7 +24407,7 @@ snapshots:
       formidable: 1.2.6
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.15.3
+      qs: 6.15.0
       readable-stream: 3.6.2
       semver: 7.8.1
     transitivePeerDependencies:


### PR DESCRIPTION
# What's included
- CryptoLib in generated errors.ts now derived from Crypto instead of hand-declared, fixing a type-check regression under TS 6

Contributes to KKN-912