### PR TITLE
chore(integrations): Fix Axios-as-type usage ahead of bundler moduleResolution

### DIFF
--- a/integrations/canny/integration.definition.ts
+++ b/integrations/canny/integration.definition.ts
@@ -2,7 +2,7 @@ import { z, IntegrationDefinition } from '@botpress/sdk'
 
 export default new IntegrationDefinition({
   name: 'canny',
-  version: '0.2.3',
+  version: '0.2.4',
   title: 'Canny',
   description: 'Connect your Botpress bot to Canny for feature request management and customer feedback collection',
   readme: 'hub.md',

--- a/integrations/canny/src/misc/canny-client.ts
+++ b/integrations/canny/src/misc/canny-client.ts
@@ -1,4 +1,4 @@
-import axios, { Axios } from 'axios'
+import axios, { AxiosInstance } from 'axios'
 
 export type CannyClientConfiguration = {
   apiKey: string
@@ -183,7 +183,7 @@ export type ListBoardsResponse = {
 
 export class CannyClient {
   private constructor(
-    private readonly _client: Axios,
+    private readonly _client: AxiosInstance,
     private readonly _apiKey: string
   ) {}
 

--- a/integrations/feature-base/integration.definition.ts
+++ b/integrations/feature-base/integration.definition.ts
@@ -5,7 +5,7 @@ import { postCreated, postUpdated, postDeleted, postVoted } from 'definitions/ev
 
 export default new IntegrationDefinition({
   name: 'feature-base',
-  version: '1.0.3',
+  version: '1.0.4',
   title: 'Feature Base',
   description: 'Integration with Feature Base for Botpress',
   readme: 'hub.md',

--- a/integrations/feature-base/src/feature-base-api/client.ts
+++ b/integrations/feature-base/src/feature-base-api/client.ts
@@ -1,5 +1,5 @@
 import { RuntimeError } from '@botpress/client'
-import axios, { Axios, AxiosResponse } from 'axios'
+import axios, { AxiosInstance, AxiosResponse } from 'axios'
 import { CreateCommentInput, CreateCommentOutput } from './sub-schemas'
 import * as bp from '.botpress'
 
@@ -23,7 +23,7 @@ type PagedApiOutput<K extends keyof Actions> =
     })
 
 export class FeatureBaseClient {
-  private _client: Axios
+  private _client: AxiosInstance
 
   public constructor(apiKey: string) {
     this._client = axios.create({

--- a/integrations/freshchat/integration.definition.ts
+++ b/integrations/freshchat/integration.definition.ts
@@ -6,7 +6,7 @@ import { events, configuration, channels, states, user } from './src/definitions
 export default new sdk.IntegrationDefinition({
   name: INTEGRATION_NAME,
   title: 'Freshchat',
-  version: '1.5.6',
+  version: '1.5.7',
   icon: 'icon.svg',
   description: 'This integration allows your bot to use Freshchat as a HITL Provider',
   readme: 'hub.md',

--- a/integrations/freshchat/src/client.ts
+++ b/integrations/freshchat/src/client.ts
@@ -1,5 +1,5 @@
 import * as sdk from '@botpress/sdk'
-import axios, { type Axios } from 'axios'
+import axios, { type AxiosInstance, type InternalAxiosRequestConfig } from 'axios'
 import type {
   FreshchatMessage,
   FreshchatAgent,
@@ -12,7 +12,7 @@ import * as bp from '.botpress'
 // API docs: https://developers.freshchat.com/api/
 
 class FreshchatClient {
-  private _client: Axios
+  private _client: AxiosInstance
 
   public constructor(
     private _config: FreshchatConfiguration,
@@ -22,7 +22,7 @@ class FreshchatClient {
       baseURL: `https://${this._config.domain}.freshchat.com/v2`,
     })
 
-    this._client.interceptors.request.use((axionsConfig) => {
+    this._client.interceptors.request.use((axionsConfig: InternalAxiosRequestConfig) => {
       // @ts-ignore
       axionsConfig.headers = {
         ...axionsConfig.headers,

--- a/integrations/monday/integration.definition.ts
+++ b/integrations/monday/integration.definition.ts
@@ -5,7 +5,7 @@ export default new IntegrationDefinition({
   name: 'monday',
   title: 'Monday',
   description: 'Manage items in Monday boards.',
-  version: '1.1.5',
+  version: '1.1.6',
   readme: 'hub.md',
   icon: 'icon.svg',
   states: {

--- a/integrations/monday/src/misc/monday-client.ts
+++ b/integrations/monday/src/misc/monday-client.ts
@@ -1,4 +1,4 @@
-import axios, { Axios } from 'axios'
+import axios, { AxiosInstance } from 'axios'
 import { GRAPHQL_QUERIES, QUERY_INPUT, QUERY_RESPONSE } from './graphql-queries'
 
 export type MondayClientConfiguration = {
@@ -53,7 +53,7 @@ export const exchangeCodeForTokens = async ({
 }
 
 export class MondayClient {
-  private constructor(private readonly _client: Axios) {}
+  private constructor(private readonly _client: AxiosInstance) {}
 
   public static create(config: MondayClientConfiguration) {
     const client = axios.create({

--- a/integrations/workable/integration.definition.ts
+++ b/integrations/workable/integration.definition.ts
@@ -13,7 +13,7 @@ export default new IntegrationDefinition({
   name: 'workable',
   title: 'Workable',
   description: 'Integration with Workable for Botpress',
-  version: '0.1.2',
+  version: '0.1.3',
   readme: 'hub.md',
   icon: 'icon.svg',
   configuration: {

--- a/integrations/workable/src/workable-api/client.ts
+++ b/integrations/workable/src/workable-api/client.ts
@@ -1,5 +1,5 @@
 import { z } from '@botpress/sdk'
-import axios, { Axios, AxiosResponse } from 'axios'
+import axios, { AxiosInstance, AxiosResponse } from 'axios'
 import {
   getCandidateInputSchema,
   getCandidateOutputSchema,
@@ -26,7 +26,7 @@ export type ErrorResponse = {
 type ApiOutput<K extends object> = K | ErrorResponse
 
 export class WorkableClient {
-  private _client: Axios
+  private _client: AxiosInstance
 
   public constructor(apiToken: string, subDomain: string) {
     this._client = axios.create({


### PR DESCRIPTION
# What's included
- Axios class replaced with AxiosInstance as the type for stored axios clients

Switching to moduleResolution: "nodenext" (needed for TS7 readiness) makes TypeScript resolve axios's CommonJS-style type declarations instead of its ESM ones. In that file, the Axios class no longer automatically merges into a type of the same name, so `Axios` stops being usable as a type. AxiosInstance is the correct fix, it's a plain interface (never ambiguous between value and type), and it's also the type axios.create() actually returns.

Contributes to KKN-912