### PR TITLE
chore(integrations): Fix internal/unexposed dependency imports ahead of bundler moduleResolution 

### DIFF
--- a/integrations/telegram/integration.definition.ts
+++ b/integrations/telegram/integration.definition.ts
@@ -4,7 +4,7 @@ import { telegramMessageChannels } from './definitions/channels'
 
 export default new IntegrationDefinition({
   name: 'telegram',
-  version: '1.0.11',
+  version: '1.0.10',
   title: 'Telegram',
   description: 'Engage with your audience in real-time.',
   icon: 'icon.svg',

--- a/integrations/telegram/integration.definition.ts
+++ b/integrations/telegram/integration.definition.ts
@@ -4,7 +4,7 @@ import { telegramMessageChannels } from './definitions/channels'
 
 export default new IntegrationDefinition({
   name: 'telegram',
-  version: '1.0.10',
+  version: '1.0.11',
   title: 'Telegram',
   description: 'Engage with your audience in real-time.',
   icon: 'icon.svg',

--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -165,7 +165,7 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp'
-export const INTEGRATION_VERSION = '4.18.4'
+export const INTEGRATION_VERSION = '4.18.5'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,

--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -165,7 +165,7 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp'
-export const INTEGRATION_VERSION = '4.18.5'
+export const INTEGRATION_VERSION = '4.18.4'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,

--- a/integrations/whatsapp/src/misc/util.ts
+++ b/integrations/whatsapp/src/misc/util.ts
@@ -1,9 +1,6 @@
 import * as sdk from '@botpress/sdk'
 import * as bp from '.botpress'
 
-// whatsapp-api-js declares this internally (lib/utils.ts) but never exports it publicly.
-type AtLeastOne<T> = [T, ...T[]]
-
 type Message = Awaited<ReturnType<bp.Client['listMessages']>>['messages'][number]
 
 export function chunkArray<T>(array: T[], chunkSize: number) {

--- a/integrations/whatsapp/src/misc/util.ts
+++ b/integrations/whatsapp/src/misc/util.ts
@@ -1,6 +1,9 @@
 import * as sdk from '@botpress/sdk'
 import * as bp from '.botpress'
 
+// whatsapp-api-js declares this internally (lib/utils.ts) but never exports it publicly.
+type AtLeastOne<T> = [T, ...T[]]
+
 type Message = Awaited<ReturnType<bp.Client['listMessages']>>['messages'][number]
 
 export function chunkArray<T>(array: T[], chunkSize: number) {


### PR DESCRIPTION
# What's included
- telegram: switched 3 files from the internal path telegraf/typings/core/types/typegram to telegraf's public telegraf/types export
- whatsapp: localized the AtLeastOne utility type instead of importing it from whatsapp-api-js/lib/utils

Switching to moduleResolution: "nodenext" (needed for TS7 readiness) makes TypeScript respect a package's declared exports map, unlike the current resolution mode which ignores it. Both telegraf and whatsapp-api-js declare an exports map that doesn't expose the paths we were importing from — they were only ever reachable by accident.

Contributes to KKN-912