### PR TITLE
chore(sdk): bump to 7.0.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "1.1.0",
     "@botpress/client": "2.1.0",
-    "@botpress/sdk": "6.13.4",
+    "@botpress/sdk": "7.0.0",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/verel": "^0.2.0",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "2.1.0",
-    "@botpress/sdk": "6.13.4"
+    "@botpress/sdk": "7.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "2.1.0",
-    "@botpress/sdk": "6.13.4"
+    "@botpress/sdk": "7.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "6.13.4"
+    "@botpress/sdk": "7.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "2.1.0",
-    "@botpress/sdk": "6.13.4"
+    "@botpress/sdk": "7.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "2.1.0",
-    "@botpress/sdk": "6.13.4",
+    "@botpress/sdk": "7.0.0",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "6.13.4",
+  "version": "7.0.0",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2766,7 +2766,7 @@ importers:
         specifier: 2.1.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 6.13.4
+        specifier: 7.0.0
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2890,7 +2890,7 @@ importers:
         specifier: 2.1.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.13.4
+        specifier: 7.0.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2906,7 +2906,7 @@ importers:
         specifier: 2.1.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.13.4
+        specifier: 7.0.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2919,7 +2919,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 6.13.4
+        specifier: 7.0.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2935,7 +2935,7 @@ importers:
         specifier: 2.1.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.13.4
+        specifier: 7.0.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2951,7 +2951,7 @@ importers:
         specifier: 2.1.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 6.13.4
+        specifier: 7.0.0
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
Bumps `@botpress/sdk` to `7.0.0` and updates the CLI, templates, and lockfile to use it.

This major release publishes the SDK against its exact `@botpress/client` `2.1.0` dependency and the fetch-based retry helper, removing the old SDK path through Axios and `axios-retry`.

Validated with the SDK build and tests plus lint and typechecks across the SDK, CLI, and templates.