### PR TITLE
fix(whatsapp): add additional meta referral fields

### DIFF
--- a/integrations/whatsapp/integration.definition.ts
+++ b/integrations/whatsapp/integration.definition.ts
@@ -157,7 +157,7 @@ const defaultBotPhoneNumberId = {
 }
 
 export const INTEGRATION_NAME = 'whatsapp'
-export const INTEGRATION_VERSION = '4.18.2'
+export const INTEGRATION_VERSION = '4.19.0'
 export default new IntegrationDefinition({
   name: INTEGRATION_NAME,
   version: INTEGRATION_VERSION,
@@ -346,6 +346,38 @@ export default new IntegrationDefinition({
           referralSourceId: {
             title: 'Referral Source ID',
             description: 'The ID of the ad or content that led to the conversation',
+          },
+          referralSourceType: {
+            title: 'Referral Source Type',
+            description: 'The type of referral source, such as an ad or post',
+          },
+          referralHeadline: {
+            title: 'Referral Headline',
+            description: 'The headline of the ad or content that led to the conversation',
+          },
+          referralBody: {
+            title: 'Referral Body',
+            description: 'The body text of the ad or content that led to the conversation',
+          },
+          referralMediaType: {
+            title: 'Referral Media Type',
+            description: 'The media type of the ad or content that led to the conversation',
+          },
+          referralImageUrl: {
+            title: 'Referral Image URL',
+            description: 'The image URL from the ad or content that led to the conversation',
+          },
+          referralVideoUrl: {
+            title: 'Referral Video URL',
+            description: 'The video URL from the ad or content that led to the conversation',
+          },
+          referralThumbnailUrl: {
+            title: 'Referral Thumbnail URL',
+            description: 'The thumbnail URL from the ad or content that led to the conversation',
+          },
+          referralCtwaClid: {
+            title: 'Referral Click ID',
+            description: 'The Click-to-WhatsApp click ID used for ad attribution',
           },
           echoCreationType: {
             title: 'Echo Creation Type',

--- a/integrations/whatsapp/src/misc/referral-tags.ts
+++ b/integrations/whatsapp/src/misc/referral-tags.ts
@@ -15,11 +15,7 @@ const REFERRAL_TAGS = {
 
 const MAX_TAG_VALUE_LENGTH = 500
 
-type Logger = {
-  forBot: () => {
-    warn: (message: string) => void
-  }
-}
+import * as bp from '.botpress'
 
 export function getReferralTags(message: WhatsAppMessage, logger: Logger): Record<string, string> {
   const { referral } = message

--- a/integrations/whatsapp/src/misc/referral-tags.ts
+++ b/integrations/whatsapp/src/misc/referral-tags.ts
@@ -1,4 +1,5 @@
 import type { WhatsAppMessage, WhatsAppReferral } from './types'
+import * as bp from '.botpress'
 
 const REFERRAL_TAGS = {
   source_url: 'referralSourceUrl',
@@ -15,9 +16,7 @@ const REFERRAL_TAGS = {
 
 const MAX_TAG_VALUE_LENGTH = 500
 
-import * as bp from '.botpress'
-
-export function getReferralTags(message: WhatsAppMessage, logger: Logger): Record<string, string> {
+export function getReferralTags(message: WhatsAppMessage, logger: bp.Logger): Record<string, string> {
   const { referral } = message
   if (!referral) {
     return {}

--- a/integrations/whatsapp/src/misc/referral-tags.ts
+++ b/integrations/whatsapp/src/misc/referral-tags.ts
@@ -1,0 +1,51 @@
+import type { WhatsAppMessage, WhatsAppReferral } from './types'
+
+const REFERRAL_TAGS = {
+  source_url: 'referralSourceUrl',
+  source_id: 'referralSourceId',
+  source_type: 'referralSourceType',
+  headline: 'referralHeadline',
+  body: 'referralBody',
+  media_type: 'referralMediaType',
+  image_url: 'referralImageUrl',
+  video_url: 'referralVideoUrl',
+  thumbnail_url: 'referralThumbnailUrl',
+  ctwa_clid: 'referralCtwaClid',
+} satisfies Record<keyof WhatsAppReferral, string>
+
+const MAX_TAG_VALUE_LENGTH = 500
+
+type Logger = {
+  forBot: () => {
+    warn: (message: string) => void
+  }
+}
+
+export function getReferralTags(message: WhatsAppMessage, logger: Logger): Record<string, string> {
+  const { referral } = message
+  if (!referral) {
+    return {}
+  }
+
+  const tags: Record<string, string> = {}
+
+  for (const referralField of Object.keys(REFERRAL_TAGS) as (keyof WhatsAppReferral)[]) {
+    const originalValue = referral[referralField]
+    if (!originalValue) {
+      continue
+    }
+
+    const processedValue = originalValue.slice(0, MAX_TAG_VALUE_LENGTH)
+    if (originalValue !== processedValue) {
+      logger
+        .forBot()
+        .warn(
+          `For whatsapp message "${message.id}", referral field "${referralField}" was truncated from ${originalValue.length} to ${MAX_TAG_VALUE_LENGTH} characters`
+        )
+    }
+
+    tags[REFERRAL_TAGS[referralField]] = processedValue
+  }
+
+  return tags
+}

--- a/integrations/whatsapp/src/misc/types.ts
+++ b/integrations/whatsapp/src/misc/types.ts
@@ -12,6 +12,21 @@ const WhatsAppContactSchema = z.object({
     .optional(),
 })
 
+// https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/components#referral-object
+export const WhatsAppReferralSchema = z.object({
+  source_url: z.string().optional(),
+  source_id: z.string().optional(),
+  source_type: z.string().optional(),
+  headline: z.string().optional(),
+  body: z.string().optional(),
+  media_type: z.string().optional(),
+  image_url: z.string().optional(),
+  video_url: z.string().optional(),
+  thumbnail_url: z.string().optional(),
+  ctwa_clid: z.string().optional(),
+})
+export type WhatsAppReferral = z.infer<typeof WhatsAppReferralSchema>
+
 const WhatsAppBaseMessageSchema = z.object({
   from: z.string().optional(),
   from_user_id: z.string().optional(),
@@ -26,13 +41,7 @@ const WhatsAppBaseMessageSchema = z.object({
       id: z.string().optional(),
     })
     .optional(),
-  // there are other fields in the referral object, but we don't need them
-  referral: z
-    .object({
-      source_url: z.string().optional(),
-      source_id: z.string().optional(),
-    })
-    .optional(),
+  referral: WhatsAppReferralSchema.optional(),
   errors: z
     .array(
       z.object({
@@ -65,7 +74,7 @@ const WhatsAppMessageInteractiveSchema = z.union([
   }),
 ])
 
-const WhatsAppMessageSchema = z.union([
+export const WhatsAppMessageSchema = z.union([
   WhatsAppBaseMessageSchema.extend({
     type: z.literal('text'),
     text: z.object({

--- a/integrations/whatsapp/src/webhook/handlers/messages.ts
+++ b/integrations/whatsapp/src/webhook/handlers/messages.ts
@@ -5,6 +5,7 @@ import axios from 'axios'
 import { INTEGRATION_NAME, INTEGRATION_VERSION } from 'integration.definition'
 import { getAccessToken, getAuthenticatedWhatsappClient } from '../../auth'
 import { safeFormatPhoneNumber } from '../../misc/phone-number-to-whatsapp'
+import { getReferralTags } from '../../misc/referral-tags'
 import { WhatsAppMessage, WhatsAppMessageValue } from '../../misc/types'
 import { getMessageFromWhatsappMessageId } from '../../misc/util'
 import { getMediaInfos } from '../../misc/whatsapp-utils'
@@ -129,7 +130,7 @@ export const messagesHandler = async (
     tags: {
       id: message.id,
       ...(replyTo && { replyTo }),
-      ..._processReferralTags(message, logger),
+      ...getReferralTags(message, logger),
     },
   })
 }
@@ -278,35 +279,4 @@ function _getMediaExpiry(ctx: bp.Context) {
   }
   const expiresAt = new Date(Date.now() + expiryDelayHours * 60 * 60 * 1000)
   return expiresAt.toISOString()
-}
-
-function _processReferralTags(message: WhatsAppMessage, logger: bp.Logger): Record<string, string> {
-  const { referral } = message
-  if (!referral) {
-    return {}
-  }
-
-  const tags: Record<string, string> = {}
-
-  if (referral.source_url) {
-    const originalUrl = referral.source_url
-    // Urls can go up to 2048 characters, but we limit to 500 to avoid tags limit error
-    const processedUrl = originalUrl.slice(0, 500)
-
-    if (originalUrl !== processedUrl) {
-      logger
-        .forBot()
-        .warn(
-          `For whatsapp message "${message.id}", referral source URL was truncated from ${originalUrl.length} to 500 characters. Original: ${originalUrl}, Sliced: ${processedUrl}`
-        )
-    }
-
-    tags.referralSourceUrl = processedUrl
-  }
-
-  if (referral.source_id) {
-    tags.referralSourceId = referral.source_id
-  }
-
-  return tags
 }

--- a/integrations/whatsapp/src/webhook/referral-tags.test.ts
+++ b/integrations/whatsapp/src/webhook/referral-tags.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test, vi } from 'vitest'
+import { getReferralTags } from '../misc/referral-tags'
+import { WhatsAppMessageSchema } from '../misc/types'
+
+const referral = {
+  source_url: 'https://example.com/ad',
+  source_id: 'ad-id',
+  source_type: 'ad',
+  headline: 'Lease this car',
+  body: 'A description of the advertised car',
+  media_type: 'image',
+  image_url: 'https://example.com/image.jpg',
+  video_url: 'https://example.com/video.mp4',
+  thumbnail_url: 'https://example.com/thumbnail.jpg',
+  ctwa_clid: 'click-id',
+}
+
+const message = {
+  from: '15555555555',
+  id: 'wamid.ID',
+  timestamp: '1753728000',
+  type: 'text' as const,
+  text: { body: 'Hello' },
+  referral,
+}
+
+describe('WhatsApp referral tags', () => {
+  test('preserves and maps all referral fields', () => {
+    const parsedMessage = WhatsAppMessageSchema.parse(message)
+    const logger = { forBot: () => ({ warn: vi.fn() }) } as any
+
+    expect(parsedMessage.referral).toEqual(referral)
+    expect(getReferralTags(parsedMessage, logger)).toEqual({
+      referralSourceUrl: referral.source_url,
+      referralSourceId: referral.source_id,
+      referralSourceType: referral.source_type,
+      referralHeadline: referral.headline,
+      referralBody: referral.body,
+      referralMediaType: referral.media_type,
+      referralImageUrl: referral.image_url,
+      referralVideoUrl: referral.video_url,
+      referralThumbnailUrl: referral.thumbnail_url,
+      referralCtwaClid: referral.ctwa_clid,
+    })
+  })
+
+  test('truncates referral values that exceed the tag limit', () => {
+    const parsedMessage = WhatsAppMessageSchema.parse({
+      ...message,
+      referral: { body: 'a'.repeat(501) },
+    })
+    const warn = vi.fn()
+    const logger = { forBot: () => ({ warn }) } as any
+
+    expect(getReferralTags(parsedMessage, logger)).toEqual({
+      referralBody: 'a'.repeat(500),
+    })
+    expect(warn).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
This PR adds the missing Click-to-WhatsApp referral fields to incoming message tags. It prevents Zod from dropping ad metadata such as the headline, body, media URLs, and ctwa_clid.