### PR TITLE
fix(llmz): use worker-compatible ulid

### DIFF
--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -2,7 +2,7 @@
   "name": "llmz",
   "type": "module",
   "description": "LLMz - An LLM-native Typescript VM built on top of Zui",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "files": [
     "dist",
     "DOCS.md"
@@ -46,7 +46,7 @@
     "magic-string": "^0.30.21",
     "ms": "^2.1.3",
     "quickjs-emscripten-core": "^0.31.0",
-    "ulid": "^2.3.0"
+    "ulid": "^3.0.2"
   },
   "devDependencies": {
     "@botpress/cli": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3108,8 +3108,8 @@ importers:
         specifier: ^0.31.0
         version: 0.31.0
       ulid:
-        specifier: ^2.3.0
-        version: 2.4.0
+        specifier: ^3.0.2
+        version: 3.0.2
     dependenciesMeta:
       '@bpinternal/zui':
         injected: true
@@ -12649,8 +12649,8 @@ packages:
   uid2@0.0.4:
     resolution: {integrity: sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==}
 
-  ulid@2.4.0:
-    resolution: {integrity: sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==}
+  ulid@3.0.2:
+    resolution: {integrity: sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==}
     hasBin: true
 
   unbox-primitive@1.1.0:
@@ -24566,7 +24566,7 @@ snapshots:
 
   uid2@0.0.4: {}
 
-  ulid@2.4.0: {}
+  ulid@3.0.2: {}
 
   unbox-primitive@1.1.0:
     dependencies:


### PR DESCRIPTION
Upgrade LLMz to ULID v3 and bump the package to 0.6.0.

ULID v2 does not detect Web Crypto through `globalThis.crypto`, so the workerd bundle crashes during module initialization in Cloudflare Workers. ULID v3 uses the Worker-compatible crypto implementation while preserving the existing `ulid()` call sites.

Validated with LLMz formatting, ESLint, oxlint, typecheck, build, and 466 unit tests. The rebuilt `index.workerd.js` does not contain the ULID v2 insecure-random error string.