### PR TITLE
fix(integrations/gmail): enabled markdown for channel & outbound messages

### DIFF
--- a/integrations/gmail/integration.definition.ts
+++ b/integrations/gmail/integration.definition.ts
@@ -12,7 +12,7 @@ import {
 } from './definitions'
 
 export const INTEGRATION_NAME = 'gmail'
-export const INTEGRATION_VERSION = '1.0.9'
+export const INTEGRATION_VERSION = '1.0.10'
 
 export default new sdk.IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/gmail/src/channels/channels.ts
+++ b/integrations/gmail/src/channels/channels.ts
@@ -65,9 +65,14 @@ export const channels = {
       text: wrapChannel({ channelName: 'channel', messageType: 'text' }, async (props) => {
         const { text: textContent } = props.payload
 
+        // Botpress `text` messages are conventionally markdown (as rendered by webchat and other channels),
+        // so render the HTML part as markdown. The raw text remains the plain-text fallback.
+        const htmlContent = generateMarkdownMessage({ markdown: textContent })
+
         await _sendEmailReply({
           ...props,
           textContent,
+          htmlContent,
         })
       }),
       choice: wrapChannel({ channelName: 'channel', messageType: 'choice' }, async (props) => {
@@ -78,9 +83,12 @@ export const channels = {
           content += `- ${option.label}\n`
         }
 
+        const htmlContent = generateMarkdownMessage({ markdown: content })
+
         await _sendEmailReply({
           ...props,
           textContent: content,
+          htmlContent,
         })
       }),
       markdown: wrapChannel({ channelName: 'channel', messageType: 'markdown' }, async (props) => {

--- a/integrations/gmail/src/google-api/google-client.ts
+++ b/integrations/gmail/src/google-api/google-client.ts
@@ -1,7 +1,7 @@
 import * as sdk from '@botpress/sdk'
 import { gmail_v1, google } from 'googleapis'
 import { IntegrationConfig } from 'src/config/integration-config'
-import { composeRawEmail } from 'src/utils/mail-composing'
+import { composeRawEmail, generateMarkdownMessage } from 'src/utils/mail-composing'
 import { handleErrorsDecorator as handleErrors } from './error-handling'
 import { GmailClient, GoogleOAuth2Client } from './types'
 import * as bp from '.botpress'
@@ -263,7 +263,9 @@ class MessageManagement {
       to,
       subject,
       text: body,
-      html: body,
+      // Render the body as markdown for the HTML part (parity with the channel handlers), keeping the raw
+      // body as the plain-text fallback. Lets draft actions send formatted email instead of literal markdown.
+      html: generateMarkdownMessage({ markdown: body }),
       textEncoding: 'base64',
     })
 

--- a/integrations/gmail/src/utils/mail-composing.test.ts
+++ b/integrations/gmail/src/utils/mail-composing.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { composeRawEmail, generateMarkdownMessage } from './mail-composing'
+
+const SAMPLE_MARKDOWN = [
+  '# Welcome to Botpress',
+  '',
+  'This is a **test email** to check *markdown formatting*.',
+  '',
+  '- First item',
+  '- Second item',
+  '',
+  '[link to Botpress](https://botpress.com)',
+].join('\n')
+
+const _decodeBase64Url = (raw: string): string =>
+  Buffer.from(raw.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8')
+
+describe('generateMarkdownMessage', () => {
+  const html = generateMarkdownMessage({ markdown: SAMPLE_MARKDOWN })
+
+  it('renders a heading', () => {
+    expect(html).toContain('<h1')
+    expect(html).toContain('Welcome to Botpress')
+  })
+
+  it('renders bold and italic emphasis', () => {
+    expect(html).toContain('<strong')
+    expect(html).toContain('<em')
+  })
+
+  it('renders list items', () => {
+    expect(html).toContain('<li')
+    expect(html).toContain('First item')
+  })
+
+  it('renders links', () => {
+    expect(html).toContain('<a')
+    expect(html).toContain('https://botpress.com')
+  })
+
+  it('does not leave raw markdown syntax in the output', () => {
+    expect(html).not.toContain('**test email**')
+    expect(html).not.toContain('# Welcome')
+  })
+})
+
+describe('composeRawEmail', () => {
+  it('produces a multipart message that includes the rendered HTML part', async () => {
+    const html = generateMarkdownMessage({ markdown: SAMPLE_MARKDOWN })
+    const raw = await composeRawEmail({
+      to: 'recipient@example.com',
+      subject: 'Test',
+      text: SAMPLE_MARKDOWN,
+      html,
+      textEncoding: 'base64',
+    })
+
+    const decoded = _decodeBase64Url(raw)
+    expect(decoded).toContain('text/html')
+    expect(decoded).toContain('text/plain')
+    expect(decoded).toContain('Welcome to Botpress')
+  })
+})

--- a/integrations/gmail/src/utils/mail-composing.test.ts
+++ b/integrations/gmail/src/utils/mail-composing.test.ts
@@ -15,6 +15,39 @@ const SAMPLE_MARKDOWN = [
 const _decodeBase64Url = (raw: string): string =>
   Buffer.from(raw.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8')
 
+describe('markdown normalization', () => {
+  it('renders block structure when separator lines contain whitespace (LLM/pipeline output)', () => {
+    // "Blank" lines contain a space and content lines are indented — the shape real LLM output arrives in.
+    const md = ['# Title', ' ', '  Intro paragraph.', ' ', '  - one', ' ', '  - two', ' ', '  > a quote'].join('\n')
+    const html = generateMarkdownMessage({ markdown: md })
+    expect(html).toContain('<ul')
+    expect(html).toContain('<li')
+    expect(html).toContain('<blockquote')
+  })
+
+  it('preserves nested-list indentation (whitespace-sensitive)', () => {
+    const md = ['- parent', '  - child', '  - child two'].join('\n')
+    const html = generateMarkdownMessage({ markdown: md })
+    // A nested list produces a <ul> inside an <li>, i.e. more than one <ul>.
+    expect(html.split('<ul').length - 1).toBeGreaterThanOrEqual(2)
+  })
+
+  it('preserves indented/fenced code content (whitespace-sensitive)', () => {
+    const md = ['```', 'function f() {', '  return 1', '}', '```'].join('\n')
+    const html = generateMarkdownMessage({ markdown: md })
+    expect(html).toContain('<code')
+    // The two-space indentation inside the code block must survive normalization.
+    expect(html).toContain('  return 1')
+  })
+
+  it('preserves trailing-space hard breaks (renders as <br>)', () => {
+    const md = 'line one  \nline two'
+    const html = generateMarkdownMessage({ markdown: md })
+    // Normalization leaves the two trailing spaces intact, so the hard break renders as <br>.
+    expect(html).toMatch(/line one<br\s*\/?>line two/)
+  })
+})
+
 describe('generateMarkdownMessage', () => {
   const html = generateMarkdownMessage({ markdown: SAMPLE_MARKDOWN })
 

--- a/integrations/gmail/src/utils/mail-composing.tsx
+++ b/integrations/gmail/src/utils/mail-composing.tsx
@@ -35,7 +35,17 @@ export const generateFileDownloadMessage = (props: Parameters<typeof _FileDownlo
   _renderMessage(_FileDownloadMessage(props))
 
 export const generateMarkdownMessage = ({ markdown }: { markdown: string }) =>
-  _renderMessage(<Markdown>{markdown}</Markdown>)
+  _renderMessage(<Markdown>{_normalizeMarkdown(markdown)}</Markdown>)
+
+// LLM / pipeline output frequently arrives with spurious leading indentation on every line and
+// whitespace-only "blank" lines. Both break the markdown block parser (lists, blockquotes, and headings
+// collapse into a single mis-parsed block), even though inline formatting still works. Trimming each line
+// dedents block markers to column 0 and makes blank lines truly empty, restoring block-level structure.
+const _normalizeMarkdown = (markdown: string): string =>
+  markdown
+    .split('\n')
+    .map((line) => line.trim())
+    .join('\n')
 
 export const generateCardMessage = (props: Parameters<typeof _CardMessage>[0]) => _renderMessage(_CardMessage(props))
 
@@ -51,7 +61,11 @@ const _BaseMessage = ({ children }: react.PropsWithChildren) => (
   <Html>
     <Head />
     <Body style={_bodyStyle}>
-      <Container style={_innerContainerStyle}>{children}</Container>
+      {/* align="left" overrides Container's hardcoded align="center" table attribute, which Gmail honors
+          over CSS text-align and would otherwise center all content. */}
+      <Container align="left" style={_innerContainerStyle}>
+        {children}
+      </Container>
     </Body>
   </Html>
 )
@@ -63,7 +77,8 @@ const _bodyStyle = {
 const _innerContainerStyle = {
   paddingLeft: '12px',
   paddingRight: '12px',
-  margin: '0 auto',
+  margin: '0',
+  textAlign: 'left',
 } as const
 
 const _primaryButtonStyle = {

--- a/integrations/gmail/src/utils/mail-composing.tsx
+++ b/integrations/gmail/src/utils/mail-composing.tsx
@@ -37,14 +37,17 @@ export const generateFileDownloadMessage = (props: Parameters<typeof _FileDownlo
 export const generateMarkdownMessage = ({ markdown }: { markdown: string }) =>
   _renderMessage(<Markdown>{_normalizeMarkdown(markdown)}</Markdown>)
 
-// LLM / pipeline output frequently arrives with spurious leading indentation on every line and
-// whitespace-only "blank" lines. Both break the markdown block parser (lists, blockquotes, and headings
-// collapse into a single mis-parsed block), even though inline formatting still works. Trimming each line
-// dedents block markers to column 0 and makes blank lines truly empty, restoring block-level structure.
+// LLM / pipeline output frequently arrives with "blank" separator lines that actually contain whitespace.
+// The markdown block parser only treats truly empty lines as block separators, so these whitespace-only
+// lines cause lists, blockquotes, and headings to collapse into a single mis-parsed block. Collapse only
+// whitespace-only lines to empty; content lines are left byte-for-byte intact so that whitespace-sensitive
+// constructs — nested-list indentation, indented/fenced code, and trailing-space hard line breaks — are
+// preserved. (The parser already tolerates up to 3 leading spaces on block markers, so real indentation is
+// not the issue.)
 const _normalizeMarkdown = (markdown: string): string =>
   markdown
     .split('\n')
-    .map((line) => line.trim())
+    .map((line) => (line.trim() === '' ? '' : line))
     .join('\n')
 
 export const generateCardMessage = (props: Parameters<typeof _CardMessage>[0]) => _renderMessage(_CardMessage(props))


### PR DESCRIPTION
enabled markdown formatting for gmail integration
both channel handler & proactive/outbound messages

<img width="392" height="697" alt="Screenshot 2026-07-29 at 2 49 36 PM" src="https://github.com/user-attachments/assets/a2043bb8-8a5f-4920-be49-d2358eecac88" />

<img width="874" height="709" alt="Screenshot 2026-07-29 at 2 55 03 PM" src="https://github.com/user-attachments/assets/fa11a5ff-bed0-4f1a-ba4d-3a6f1f1d003c" />
