### PR TITLE
chore(cli): bump to 7.0.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "6.8.13",
+  "version": "7.0.0",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",


### PR DESCRIPTION
Updates `@botpress/cli` to `7.0.0`.

The published CLI 6.8.13 still depends on `@botpress/client` 1.49.0, while the current CLI graph pins `@botpress/client` 2.1.0 through both the CLI and `@botpress/sdk` 7.0.0. Publishing this major version makes that client upgrade available to CLI consumers.

The CLI test suite passes with 478 tests, and the CLI typecheck, dependency sync, formatting, and diff checks pass. Repo-wide ESLint remains blocked by Node heap exhaustion, and the root typecheck stops on missing generated `.botpress` declarations in `integrations/sharepoint-excel`.