### PR TITLE
feat(googledrive): adding optional param pageSize to listFiles

### DIFF
--- a/integrations/googledrivekb/integration.definition.ts
+++ b/integrations/googledrivekb/integration.definition.ts
@@ -25,7 +25,7 @@ export default new sdk.IntegrationDefinition({
   name: 'googledrivekb',
   title: 'Google Drive (Knowledge Base)',
   description: 'Sync Google Drive files into a Botpress knowledge base using read-only access to all files.',
-  version: '0.1.1',
+  version: '0.2.0',
   readme: 'hub.md',
   icon: 'icon.svg',
   attributes: {

--- a/integrations/googledrivekb/src/client.ts
+++ b/integrations/googledrivekb/src/client.ts
@@ -103,8 +103,8 @@ export class Client {
     }
   }
 
-  public async listFiles({ nextToken }: ListItemsInput): Promise<ListFilesOutput> {
-    const { items: baseFiles, meta } = await this._listBaseNormalFiles({ nextToken })
+  public async listFiles({ nextToken, pageSize }: ListItemsInput): Promise<ListFilesOutput> {
+    const { items: baseFiles, meta } = await this._listBaseNormalFiles({ nextToken, pageSize })
     const completeFilesPromises = baseFiles.map((f) => this._getCompleteFileFromBaseFile(f))
     const items = await Promise.all(completeFilesPromises)
     return {
@@ -113,12 +113,16 @@ export class Client {
     }
   }
 
-  private async _listBaseNormalFiles({ nextToken }: ListItemsInput): Promise<ListItemsOutput<BaseNormalFile>> {
+  private async _listBaseNormalFiles({
+    nextToken,
+    pageSize,
+  }: ListItemsInput): Promise<ListItemsOutput<BaseNormalFile>> {
     const {
       items: newFiles,
       meta: { nextToken: newNextToken },
     } = await this._listBaseGenericFiles({
       nextToken,
+      pageSize,
       args: {
         searchQuery: `mimeType != '${APP_GOOGLE_FOLDER_MIMETYPE}' and mimeType != '${APP_GOOGLE_SHORTCUT_MIMETYPE}'`,
       },
@@ -133,8 +137,8 @@ export class Client {
     }
   }
 
-  public async listFolders({ nextToken }: ListItemsInput): Promise<ListFoldersOutput> {
-    const { items: baseFolders, meta } = await this._listBaseFolderFiles({ nextToken })
+  public async listFolders({ nextToken, pageSize }: ListItemsInput): Promise<ListFoldersOutput> {
+    const { items: baseFolders, meta } = await this._listBaseFolderFiles({ nextToken, pageSize })
 
     const completeFoldersPromises = baseFolders.map((f) => this._getCompleteFolderFromBaseFolder(f))
     const items = await Promise.all(completeFoldersPromises)
@@ -144,12 +148,16 @@ export class Client {
     }
   }
 
-  private async _listBaseFolderFiles({ nextToken }: ListItemsInput): Promise<ListItemsOutput<BaseFolderFile>> {
+  private async _listBaseFolderFiles({
+    nextToken,
+    pageSize,
+  }: ListItemsInput): Promise<ListItemsOutput<BaseFolderFile>> {
     const {
       items: newFiles,
       meta: { nextToken: newNextToken },
     } = await this._listBaseGenericFiles({
       nextToken,
+      pageSize,
       args: {
         searchQuery: `mimeType = '${APP_GOOGLE_FOLDER_MIMETYPE}'`,
       },
@@ -179,10 +187,12 @@ export class Client {
     folderId,
     extraQuery,
     nextToken,
+    pageSize,
   }: {
     folderId: string
     extraQuery?: string
     nextToken?: string
+    pageSize?: number
   }) {
     const searchQuery = this._getParentsFilter(folderId) + (extraQuery ? ` and ${extraQuery}` : '')
     const listResponse = await this._googleClient.files.list({
@@ -190,7 +200,7 @@ export class Client {
       fields: GOOGLE_API_FILELIST_FIELDS,
       q: `${searchQuery} and trashed != true`,
       pageToken: nextToken,
-      pageSize: PAGE_SIZE,
+      pageSize: pageSize ?? PAGE_SIZE,
       spaces: 'drive',
       ...INCLUDE_FILES_FROM_ALL_DRIVES,
     })
@@ -392,6 +402,7 @@ export class Client {
 
   private async _listBaseGenericFiles({
     nextToken,
+    pageSize,
     args,
   }: ListItemsInputWithArgs<{ searchQuery?: string }>): Promise<ListItemsOutput<BaseDiscriminatedFile>> {
     const searchQuery = args?.searchQuery
@@ -400,7 +411,7 @@ export class Client {
       fields: GOOGLE_API_FILELIST_FIELDS,
       q: (searchQuery ?? '') + (searchQuery?.length ? ' and ' : '') + 'trashed != true',
       pageToken: nextToken,
-      pageSize: PAGE_SIZE,
+      pageSize: pageSize ?? PAGE_SIZE,
       spaces: 'drive',
       ...INCLUDE_FILES_FROM_ALL_DRIVES,
     })

--- a/integrations/googledrivekb/src/schemas.ts
+++ b/integrations/googledrivekb/src/schemas.ts
@@ -141,6 +141,14 @@ function createListOutputSchema<T extends z.ZodTypeAny>(itemSchema: T) {
 export const readFileArgSchema = z.object({ id: fileIdSchema.title('File ID') })
 export const listItemsInputSchema = z.object({
   nextToken: z.string().optional().title('Next Token').describe('The token to use to get the next page of results'),
+  pageSize: z
+    .number()
+    .int()
+    .min(1)
+    .max(1000)
+    .optional()
+    .title('Page Size')
+    .describe('The maximum number of items to return per page. If not set, a default page size is used'),
 })
 export const listItemsOutputSchema = createListOutputSchema(z.any())
 export const listFilesOutputSchema = createListOutputSchema(fileSchema)


### PR DESCRIPTION
## Summary

Adds an optional `pageSize` input to the Google Drive (KB) list actions, falling back to the existing `PAGE_SIZE` constant (100) when not provided.

- `listItemsInputSchema` gains `pageSize: z.number().int().min(1).max(1000).optional()` — bounds match the Drive API's valid range. This flows into the `listFiles` and `listFolders` action inputs and the `ListItemsInput` type.
- Threaded through `listFiles` → `_listBaseNormalFiles` → `_listBaseGenericFiles` and `listFolders` → `_listBaseFolderFiles`, resolved as `pageSize ?? PAGE_SIZE` at both `files.list` call sites.
- `Client.getChildrenSubset` accepts an optional `pageSize` with the same fallback.
- Integration version `0.1.1` → `0.2.0` for the additive input schema change.

No behavior change for existing callers: omitting `pageSize` produces the exact same requests as before.

The files-readonly `listItemsInFolder` action input is intentionally untouched — its schema comes from the shared `files-readonly` interface, so adding a field there would require an interface version bump affecting every implementor. `getChildrenSubset` already accepts the param, so that path can pass one when needed.
