### PR TITLE
chore(integrations/google-calendar): update copy on wizard

### DIFF
--- a/integrations/googlecalendar/integration.definition.ts
+++ b/integrations/googlecalendar/integration.definition.ts
@@ -2,7 +2,7 @@ import * as sdk from '@botpress/sdk'
 import { actions, entities, configuration, configurations, identifier, events, secrets, states } from './definitions'
 
 export const INTEGRATION_NAME = 'googlecalendar'
-export const INTEGRATION_VERSION = '2.1.0'
+export const INTEGRATION_VERSION = '2.1.1'
 
 export default new sdk.IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/googlecalendar/src/wizard.ts
+++ b/integrations/googlecalendar/src/wizard.ts
@@ -38,10 +38,10 @@ const _calendarIdForm = {
   htmlOrMarkdownPageContents:
     '<b>Step 1:</b> Enter your Google account email below. For most calendars, your Calendar ID is simply your email (e.g. <b>you@gmail.com</b>).<br><br>' +
     "<b>Step 2 (only if your email didn't work):</b> Find your Calendar ID manually:<br>" +
-    '1. In Google Calendar, go to <b>Settings</b>'  +
-    '2. In the left sidebar, scroll down to "Settings for my calendars" and select the calendar you would like to connect.<br>' +
-    '2. Scroll to <b>Integrate calendar</b> to find your Calendar ID.<br>' +
-    '3. Copy the Calendar ID and paste it below.',
+    'a. In Google Calendar, go to <b>Settings</b><br>'  +
+    'b. In the left sidebar, scroll down to "Settings for my calendars" and select the calendar you would like to connect.<br>' +
+    'c. Scroll to <b>Integrate calendar</b> to find your Calendar ID.<br>' +
+    'd. Copy the Calendar ID and paste it below.',
   schema: _calendarIdSchema,
   nextStepId: 'save-calendar-id',
 }

--- a/integrations/googlecalendar/src/wizard.ts
+++ b/integrations/googlecalendar/src/wizard.ts
@@ -26,13 +26,20 @@ const _buildGoogleAuthorizeUrl = ({ webhookId }: { webhookId: string }): string 
 }
 
 const _calendarIdSchema = z.object({
-  calendarId: z.string().min(1).title('Calendar ID').describe('The ID of the Google Calendar to interact with.'),
+  calendarId: z
+    .string()
+    .min(1)
+    .title('Calendar ID or email')
+    .describe('Usually your Google account email. If that does not work, use the Calendar ID from the steps below.'),
 })
 
 const _calendarIdForm = {
   pageTitle: 'Google Calendar Setup',
   htmlOrMarkdownPageContents:
-    '1. In Google Calendar, go to <b>Settings</b> and select your calendar.<br>' +
+    '<b>Step 1:</b> Enter your Google account email below. For most calendars, your Calendar ID is simply your email (e.g. <b>you@gmail.com</b>).<br><br>' +
+    "<b>Step 2 (only if your email didn't work):</b> Find your Calendar ID manually:<br>" +
+    '1. In Google Calendar, go to <b>Settings</b>'  +
+    '2. In the left sidebar, scroll down to "Settings for my calendars" and select the calendar you would like to connect.<br>' +
     '2. Scroll to <b>Integrate calendar</b> to find your Calendar ID.<br>' +
     '3. Copy the Calendar ID and paste it below.',
   schema: _calendarIdSchema,

--- a/integrations/googlecalendar/src/wizard.ts
+++ b/integrations/googlecalendar/src/wizard.ts
@@ -38,7 +38,7 @@ const _calendarIdForm = {
   htmlOrMarkdownPageContents:
     '<b>Step 1:</b> Enter your Google account email below. For most calendars, your Calendar ID is simply your email (e.g. <b>you@gmail.com</b>).<br><br>' +
     "<b>Step 2 (only if your email didn't work):</b> Find your Calendar ID manually:<br>" +
-    'a. In Google Calendar, go to <b>Settings</b><br>'  +
+    'a. In Google Calendar, go to <b>Settings</b><br>' +
     'b. In the left sidebar, scroll down to "Settings for my calendars" and select the calendar you would like to connect.<br>' +
     'c. Scroll to <b>Integrate calendar</b> to find your Calendar ID.<br>' +
     'd. Copy the Calendar ID and paste it below.',


### PR DESCRIPTION
updated the copy on the google calendar oauth wizard, to make oauth connection easier in viber, desk, studio, and adk. 
<img width="585" height="540" alt="Screenshot 2026-07-31 at 3 45 37 PM" src="https://github.com/user-attachments/assets/0f8f5924-fdbe-4861-988b-cb8a295a4520" />


