### PR TITLE
fix(sdk): inject request-scoped bot client

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "1.1.0",
     "@botpress/client": "2.1.0",
-    "@botpress/sdk": "7.0.0",
+    "@botpress/sdk": "7.0.1",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/verel": "^0.2.0",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "2.1.0",
-    "@botpress/sdk": "7.0.0"
+    "@botpress/sdk": "7.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "2.1.0",
-    "@botpress/sdk": "7.0.0"
+    "@botpress/sdk": "7.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "7.0.0"
+    "@botpress/sdk": "7.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "2.1.0",
-    "@botpress/sdk": "7.0.0"
+    "@botpress/sdk": "7.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "2.1.0",
-    "@botpress/sdk": "7.0.0",
+    "@botpress/sdk": "7.0.1",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/bot/server/index.test.ts
+++ b/packages/sdk/src/bot/server/index.test.ts
@@ -1,0 +1,62 @@
+import type { Client } from '@botpress/client'
+import { describe, expect, it, vi } from 'vitest'
+import { type DefaultPlugin, PluginImplementation } from '../../plugin'
+import { BotImplementation } from '../implementation'
+
+type HitlPlugin = DefaultPlugin<{
+  states: {
+    runtimeConfig: {
+      type: 'bot'
+      payload: { enabled: boolean }
+    }
+  }
+  actions: {
+    start: {
+      input: Record<string, never>
+      output: { enabled: boolean }
+    }
+  }
+}>
+
+const actionRequest = (type: string) => ({
+  method: 'POST',
+  path: '/',
+  query: '',
+  headers: {
+    'x-bot-id': 'bot-1',
+    'x-bp-operation': 'action_triggered',
+    'x-bp-type': 'action_triggered',
+    'x-bp-configuration': Buffer.from(JSON.stringify({ payload: '{}' })).toString('base64'),
+  },
+  body: JSON.stringify({ type, input: {} }),
+})
+
+describe('botHandler', () => {
+  it('uses the request-scoped client for plugin tools', async () => {
+    const getState = vi.fn(async () => ({ state: { payload: { enabled: true } } }))
+    const injectedClient = { getState } as unknown as Client
+    const plugin = new PluginImplementation<HitlPlugin>({
+      actions: {
+        start: async ({ states }) => await states.bot.runtimeConfig.get('desk-hitl'),
+      },
+    }).initialize({
+      alias: 'desk-hitl',
+      configuration: {},
+      interfaces: {},
+      integrations: {},
+    })
+    const bot = new BotImplementation({
+      actions: {},
+      plugins: { 'desk-hitl': plugin },
+    })
+
+    const response = await bot.handler(actionRequest('desk-hitl#start'), { client: injectedClient })
+
+    expect(response).toEqual({ status: 200, body: JSON.stringify({ output: { enabled: true } }) })
+    expect(getState).toHaveBeenCalledWith({
+      type: 'bot',
+      name: 'desk-hitl#runtimeConfig',
+      id: 'desk-hitl',
+    })
+  })
+})

--- a/packages/sdk/src/bot/server/index.ts
+++ b/packages/sdk/src/bot/server/index.ts
@@ -12,16 +12,28 @@ import { handleWorkflowUpdateEvent } from './workflows/update-handler'
 
 export * from './types'
 
+export type BotHandlerDependencies = {
+  /**
+   * Request-scoped client supplied by a host runtime.
+   *
+   * Hosts serving multiple bots must inject the client selected for the
+   * current request instead of changing process-wide environment variables.
+   */
+  client: Client
+}
+
 export const botHandler =
   (bot: types.BotHandlers<common.BaseBot>) =>
-  async (req: Request): Promise<Response | void> => {
+  async (req: Request, dependencies?: BotHandlerDependencies): Promise<Response | void> => {
     const ctx = extractContext(req.headers)
     const logger = new BotLogger()
 
-    const vanillaClient = new Client({
-      botId: ctx.botId,
-      retry: retryConfig,
-    })
+    const vanillaClient =
+      dependencies?.client ??
+      new Client({
+        botId: ctx.botId,
+        retry: retryConfig,
+      })
     const botClient = new BotSpecificClient<common.BaseBot>(vanillaClient, {
       before: {
         createMessage: async (req) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2776,7 +2776,7 @@ importers:
         specifier: 2.1.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 7.0.0
+        specifier: 7.0.1
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2900,7 +2900,7 @@ importers:
         specifier: 2.1.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 7.0.0
+        specifier: 7.0.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2916,7 +2916,7 @@ importers:
         specifier: 2.1.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 7.0.0
+        specifier: 7.0.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2929,7 +2929,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 7.0.0
+        specifier: 7.0.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2945,7 +2945,7 @@ importers:
         specifier: 2.1.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 7.0.0
+        specifier: 7.0.1
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2961,7 +2961,7 @@ importers:
         specifier: 2.1.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 7.0.0
+        specifier: 7.0.1
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
This PR lets host runtimes inject a request-scoped Botpress client into bot handlers and bumps `@botpress/sdk` to 7.0.1.

Multi-tenant hosts such as VDK already resolve bot credentials per request, but the SDK created a second client from ambient environment values before invoking plugin handlers. A worker-level `BP_WORKSPACE_ID` could therefore override valid bot credentials and make plugin state and conversation reads fail with 401 responses.

The existing environment-based client creation remains available as a fallback for current consumers. Regression coverage verifies that plugin tools use the injected client. SDK tests, typecheck, build, ESLint, Oxlint, and Prettier passed.
