### PR TITLE
chore (zui): function schema throws is optional args are positionned before required args

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cli",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Botpress CLI",
   "scripts": {
     "build": "pnpm run build:types && pnpm run bundle && pnpm run template:gen",
@@ -28,7 +28,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "1.1.0",
     "@botpress/client": "2.1.0",
-    "@botpress/sdk": "7.0.1",
+    "@botpress/sdk": "7.0.2",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/verel": "^0.2.0",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "2.1.0",
-    "@botpress/sdk": "7.0.1"
+    "@botpress/sdk": "7.0.2"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "2.1.0",
-    "@botpress/sdk": "7.0.1"
+    "@botpress/sdk": "7.0.2"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "7.0.1"
+    "@botpress/sdk": "7.0.2"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "2.1.0",
-    "@botpress/sdk": "7.0.1"
+    "@botpress/sdk": "7.0.2"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "2.1.0",
-    "@botpress/sdk": "7.0.1",
+    "@botpress/sdk": "7.0.2",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -30,7 +30,7 @@
     "esbuild-plugin-polyfill-node": "^0.3.0"
   },
   "peerDependencies": {
-    "@bpinternal/zui": "^2.4.0",
+    "@bpinternal/zui": "^2.4.1",
     "esbuild": "^0.16.12"
   },
   "peerDependenciesMeta": {

--- a/packages/zui/package.json
+++ b/packages/zui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bpinternal/zui",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A fork of Zod with additional features",
   "type": "module",
   "source": "./src/index.ts",

--- a/packages/zui/src/transforms/common/errors.ts
+++ b/packages/zui/src/transforms/common/errors.ts
@@ -108,3 +108,11 @@ export class CircularZuiToTypescriptTypeError extends ZuiToTypescriptTypeError {
     super('Schema is self-referential and cannot be inlined into a TypeScript type without a name to reference.', path)
   }
 }
+export class InvalidParameterOrderError extends ZuiToTypescriptTypeError {
+  public constructor(paramName: string, path: string) {
+    super(
+      `Optional parameter "${paramName}" cannot precede a required parameter in a function signature. Reorder the arguments, or make the parameters after it optional too.`,
+      path
+    )
+  }
+}

--- a/packages/zui/src/transforms/zui-to-typescript-type/index.test.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-type/index.test.ts
@@ -231,19 +231,27 @@ describe.concurrent('functions', () => {
     await assert.expectTypescript(typings).toMatchWithoutFormatting('declare function fn(firstName?: string): unknown;')
   })
 
-  it('mix of named and unnammed params', async () => {
+  it('mix of named and unnamed params', async () => {
+    const fn = z
+      .function()
+      .title('fn')
+      .args(z.number(), z.object({ a: z.string() }).title('obj'), z.string().title('firstName').optional())
+    const typings = toTypescript(fn)
+    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
+        declare function fn(
+          arg0: number,
+          obj: { a: string },
+          firstName?: string
+        ): unknown;
+      `)
+  })
+
+  it('optional param before a required param throws', async () => {
     const fn = z
       .function()
       .title('fn')
       .args(z.string().title('firstName').optional(), z.number(), z.object({ a: z.string() }).title('obj'))
-    const typings = toTypescript(fn)
-    await assert.expectTypescript(typings).toMatchWithoutFormatting(`
-        declare function fn(
-          firstName?: string,
-          arg1: number,
-          obj: { a: string }
-        ): unknown;
-      `)
+    expect(() => toTypescript(fn)).toThrowError(errors.ZuiToTypescriptTypeError)
   })
 
   it('nullables and optionals combined', async () => {

--- a/packages/zui/src/transforms/zui-to-typescript-type/index.ts
+++ b/packages/zui/src/transforms/zui-to-typescript-type/index.ts
@@ -167,12 +167,28 @@ function sUnwrapZod(
 
   if (schema instanceof FnParameters) {
     if (z.is.zuiTuple(schema.schema)) {
+      const items = schema.schema.items
+
+      const isItemOptional = (item: z.ZodType): boolean =>
+        z.is.zuiOptional(item) || (z.is.zuiDefault(item) && !!config.treatDefaultAsOptional)
+
+      // TS forbids an optional param before a required one — fail loudly instead of emitting invalid TypeScript.
+      let lastRequiredIndex = -1
+      for (let i = 0; i < items.length; i++) {
+        if (!isItemOptional(items[i]!)) lastRequiredIndex = i
+      }
+
       let args = ''
-      for (let i = 0; i < schema.schema.items.length; i++) {
-        const argName = (schema.schema.items[i]?.ui?.title as string) ?? `arg${i}`
-        const item = schema.schema.items[i]!
+      for (let i = 0; i < items.length; i++) {
+        const argName = (items[i]?.ui?.title as string) ?? `arg${i}`
+        const item = items[i]!
+
+        if (i <= lastRequiredIndex && isItemOptional(item)) {
+          throw new errors.InvalidParameterOrderError(argName, path.toString())
+        }
+
         args += `${sUnwrapZod(new KeyValue(toPropertyKey(argName), item), path.withIndexType('number', i), newConfig)}${
-          i < schema.schema.items.length - 1 ? ', ' : ''
+          i < items.length - 1 ? ', ' : ''
         } `
       }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2776,7 +2776,7 @@ importers:
         specifier: 2.1.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 7.0.1
+        specifier: 7.0.2
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2900,7 +2900,7 @@ importers:
         specifier: 2.1.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 7.0.1
+        specifier: 7.0.2
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2916,7 +2916,7 @@ importers:
         specifier: 2.1.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 7.0.1
+        specifier: 7.0.2
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2929,7 +2929,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 7.0.1
+        specifier: 7.0.2
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2945,7 +2945,7 @@ importers:
         specifier: 2.1.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 7.0.1
+        specifier: 7.0.2
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2961,7 +2961,7 @@ importers:
         specifier: 2.1.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 7.0.1
+        specifier: 7.0.2
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8
@@ -3182,7 +3182,7 @@ importers:
         specifier: 2.1.0
         version: link:../client
       '@bpinternal/zui':
-        specifier: ^2.4.0
+        specifier: ^2.4.1
         version: link:../zui
       browser-or-node:
         specifier: ^2.1.1


### PR DESCRIPTION
# What's included
- Zui function schema can no longer accept optional params before required params

Contributes to KKN-914