### PR TITLE
feat(sdk): filter logs based on LOG_LEVEL

### DIFF
--- a/integrations/chat/src/logger.ts
+++ b/integrations/chat/src/logger.ts
@@ -1,0 +1,3 @@
+import { IntegrationLogger } from '@botpress/sdk'
+
+export const bareLogger = new IntegrationLogger()

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "@botpress/chat": "1.1.0",
     "@botpress/client": "2.2.0",
-    "@botpress/sdk": "7.0.3",
+    "@botpress/sdk": "7.1.0",
     "@bpinternal/const": "^0.1.0",
     "@bpinternal/tunnel": "^0.1.1",
     "@bpinternal/verel": "^0.2.0",

--- a/packages/cli/templates/empty-bot/package.json
+++ b/packages/cli/templates/empty-bot/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "2.2.0",
-    "@botpress/sdk": "7.0.3"
+    "@botpress/sdk": "7.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-integration/package.json
+++ b/packages/cli/templates/empty-integration/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "2.2.0",
-    "@botpress/sdk": "7.0.3"
+    "@botpress/sdk": "7.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/empty-plugin/package.json
+++ b/packages/cli/templates/empty-plugin/package.json
@@ -6,7 +6,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/sdk": "7.0.3"
+    "@botpress/sdk": "7.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/hello-world/package.json
+++ b/packages/cli/templates/hello-world/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "2.2.0",
-    "@botpress/sdk": "7.0.3"
+    "@botpress/sdk": "7.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.16.4",

--- a/packages/cli/templates/webhook-message/package.json
+++ b/packages/cli/templates/webhook-message/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@botpress/client": "2.2.0",
-    "@botpress/sdk": "7.0.3",
+    "@botpress/sdk": "7.1.0",
     "axios": "^1.6.8"
   },
   "devDependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/sdk",
-  "version": "7.0.3",
+  "version": "7.1.0",
   "description": "Botpress SDK",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/packages/sdk/src/base-logger.test.ts
+++ b/packages/sdk/src/base-logger.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, vi, afterEach } from 'vitest'
-import { BaseLogger, type IssueLogEvent } from './base-logger'
+import { BaseLogger, type IssueLogEvent, type LogLevel } from './base-logger'
 import { IntegrationLogger } from './integration/server/integration-logger'
 
 // A minimal concrete subclass for testing BaseLogger directly:
@@ -91,5 +91,92 @@ describe.sequential('IntegrationLogger.issue(): without identity options', () =>
     const expectedKeys = Object.keys(MOCK_ISSUE).sort()
     expect(emittedKeys).toEqual(expectedKeys)
     expect(Object.values(emitted).every((v) => v !== undefined)).toBe(true)
+  })
+})
+
+const spyOnConsoleLevels = () => ({
+  debug: vi.spyOn(console, 'debug').mockImplementation(() => {}),
+  info: vi.spyOn(console, 'info').mockImplementation(() => {}),
+  warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+  error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+})
+
+describe.sequential('BaseLogger LOG_LEVEL filtering', () => {
+  afterEach(() => {
+    delete process.env['LOG_LEVEL']
+  })
+
+  it('emits every level when LOG_LEVEL is unset', ({ expect }) => {
+    // Arrange
+    const logger = new TestLogger()
+    const spies = spyOnConsoleLevels()
+
+    // Act
+    logger.debug('debug message')
+    logger.info('info message')
+    logger.warn('warn message')
+    logger.error('error message')
+
+    // Assert
+    expect(spies.debug).toHaveBeenCalledTimes(1)
+    expect(spies.info).toHaveBeenCalledTimes(1)
+    expect(spies.warn).toHaveBeenCalledTimes(1)
+    expect(spies.error).toHaveBeenCalledTimes(1)
+  })
+
+  it.for([
+    { logLevel: 'error', expectedEmittedLevels: ['error'] },
+    { logLevel: 'warn', expectedEmittedLevels: ['warn', 'error'] },
+    { logLevel: 'info', expectedEmittedLevels: ['info', 'warn', 'error'] },
+    { logLevel: 'debug', expectedEmittedLevels: ['debug', 'info', 'warn', 'error'] },
+  ])(
+    'emits only $expectedEmittedLevels when LOG_LEVEL is $logLevel',
+    ({ logLevel, expectedEmittedLevels }, { expect }) => {
+      // Arrange
+      process.env['LOG_LEVEL'] = logLevel
+      const logger = new TestLogger()
+      const spies = spyOnConsoleLevels()
+
+      // Act
+      logger.debug('debug message')
+      logger.info('info message')
+      logger.warn('warn message')
+      logger.error('error message')
+
+      // Assert
+      for (const level of ['debug', 'info', 'warn', 'error'] as const) {
+        expect(spies[level]).toHaveBeenCalledTimes(expectedEmittedLevels.includes(level) ? 1 : 0)
+      }
+    }
+  )
+
+  it('matches LOG_LEVEL case-insensitively', ({ expect }) => {
+    // Arrange
+    process.env['LOG_LEVEL'] = 'WARN'
+    const logger = new TestLogger()
+    const spies = spyOnConsoleLevels()
+
+    // Act
+    logger.debug('debug message')
+    logger.warn('warn message')
+
+    // Assert
+    expect(spies.debug).not.toHaveBeenCalled()
+    expect(spies.warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits every level and warns once when LOG_LEVEL is invalid', ({ expect }) => {
+    // Arrange
+    process.env['LOG_LEVEL'] = 'verbose'
+    const logger = new TestLogger()
+    const spies = spyOnConsoleLevels()
+
+    // Act
+    logger.debug('first debug message')
+    logger.debug('second debug message')
+
+    // Assert
+    expect(spies.debug).toHaveBeenCalledTimes(2)
+    expect(spies.warn).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/sdk/src/base-logger.ts
+++ b/packages/sdk/src/base-logger.ts
@@ -14,6 +14,32 @@ export type IssueLogEvent = {
   traceId?: string
 }
 
+const LOG_LEVEL_RANKS: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 }
+
+let _hasWarnedAboutInvalidLogLevel = false
+
+const _readConfiguredLogLevel = (): LogLevel | undefined => {
+  const rawLogLevel = process.env['LOG_LEVEL']
+  if (!rawLogLevel) {
+    return undefined
+  }
+
+  const normalizedLogLevel = rawLogLevel.toLowerCase()
+  if (_isLogLevel(normalizedLogLevel)) {
+    return normalizedLogLevel
+  }
+
+  if (!_hasWarnedAboutInvalidLogLevel) {
+    _hasWarnedAboutInvalidLogLevel = true
+    console.warn(
+      `Invalid LOG_LEVEL "${rawLogLevel}", expected one of: ${Object.keys(LOG_LEVEL_RANKS).join(', ')}. Logging is not filtered.`
+    )
+  }
+  return undefined
+}
+
+const _isLogLevel = (value: string): value is LogLevel => Object.hasOwn(LOG_LEVEL_RANKS, value)
+
 export abstract class BaseLogger<TOptions extends object> {
   protected defaultOptions: TOptions
 
@@ -52,7 +78,15 @@ export abstract class BaseLogger<TOptions extends object> {
   }
 
   private _log(level: LogLevel, args: Parameters<typeof console.info>) {
+    if (!this._isLevelEnabled(level)) {
+      return
+    }
     this._getConsoleMethod(level)(this._serializeMessage(level, args))
+  }
+
+  private _isLevelEnabled(level: LogLevel): boolean {
+    const configuredLogLevel = _readConfiguredLogLevel()
+    return configuredLogLevel === undefined || LOG_LEVEL_RANKS[level] >= LOG_LEVEL_RANKS[configuredLogLevel]
   }
 
   private _serializeMessage(level: LogLevel, args: Parameters<typeof console.info>) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2759,7 +2759,7 @@ importers:
         specifier: 2.2.0
         version: link:../client
       '@botpress/sdk':
-        specifier: 7.0.3
+        specifier: 7.1.0
         version: link:../sdk
       '@bpinternal/const':
         specifier: ^0.1.0
@@ -2883,7 +2883,7 @@ importers:
         specifier: 2.2.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 7.0.3
+        specifier: 7.1.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2899,7 +2899,7 @@ importers:
         specifier: 2.2.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 7.0.3
+        specifier: 7.1.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2912,7 +2912,7 @@ importers:
   packages/cli/templates/empty-plugin:
     dependencies:
       '@botpress/sdk':
-        specifier: 7.0.3
+        specifier: 7.1.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2928,7 +2928,7 @@ importers:
         specifier: 2.2.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 7.0.3
+        specifier: 7.1.0
         version: link:../../../sdk
     devDependencies:
       '@types/node':
@@ -2944,7 +2944,7 @@ importers:
         specifier: 2.2.0
         version: link:../../../client
       '@botpress/sdk':
-        specifier: 7.0.3
+        specifier: 7.1.0
         version: link:../../../sdk
       axios:
         specifier: ^1.6.8


### PR DESCRIPTION
Contributes to KKN-917.

Reads LOG_LEVEL directly on every call instead of caching it, so a change to the environment takes effect without restarting the runtime.