### PR TITLE
feat(cognitive): add mid stream fallback

### DIFF
--- a/packages/cognitive/package.json
+++ b/packages/cognitive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/cognitive",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "files": [
     "dist"
   ],

--- a/packages/cognitive/src/cognitive.ts
+++ b/packages/cognitive/src/cognitive.ts
@@ -78,6 +78,7 @@ export type {
   CognitiveTool,
   CognitiveToolControl,
   CognitiveMetadata,
+  CognitiveStreamRestart,
   TranscribeMetadata,
   StopReason,
   ModelTag,
@@ -393,6 +394,11 @@ export class Cognitive {
       }
 
       for await (const obj of this._ndjson<CognitiveStreamChunk>(stream)) {
+        if (obj.restart) {
+          // The prefix is void, so drop it here too: otherwise the response event below reports the
+          // abandoned attempt concatenated onto the one the consumer actually kept.
+          chunks.length = 0
+        }
         chunks.push(obj)
         lastChunk = obj
         yield obj

--- a/packages/cognitive/src/types.ts
+++ b/packages/cognitive/src/types.ts
@@ -239,6 +239,14 @@ export type CognitiveRequest = {
     maxTimeToFirstToken?: number
     /** STT model to use when transcribing audio parts for models that do not support audio natively */
     transcriptionModel?: SttModels
+    /**
+     * Streaming only. Allow generation to restart on another model after content has already been
+     * streamed. When enabled, the consumer MUST discard everything received before a chunk carrying
+     * `restart`, or partial answers concatenate. The attempt cap is the model chain itself, so pass
+     * additional models to widen it. Non-streaming generateText already falls back transparently and
+     * ignores this.
+     */
+    midStreamFallback?: boolean
   }
   meta?: {
     /** Source of the prompt, e.g. agent/:id/:version, cards/ai-generate, cards/ai-task, nodes/autonomous, etc. */
@@ -309,7 +317,24 @@ export type CognitiveStreamChunk = {
   toolCalls?: CognitiveToolCall[]
   created: number
   finished?: boolean
+  /**
+   * Present on a control-only chunk: the previous attempt failed mid-stream and generation restarted
+   * on another model. Everything received before this chunk is void and must be discarded. Only
+   * emitted when the request set `options.midStreamFallback`.
+   */
+  restart?: CognitiveStreamRestart
   metadata?: CognitiveMetadata
+}
+
+export type CognitiveStreamRestart = {
+  /** 1-based index of the attempt that is now starting */
+  attempt: number
+  /** Model whose stream was abandoned */
+  fromModel: string
+  /** Model the generation is restarting on */
+  toModel: string
+  /** Classified type of the error that ended the previous attempt */
+  reason: string
 }
 
 export type CognitiveResponse = {

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -2,7 +2,7 @@
   "name": "llmz",
   "type": "module",
   "description": "LLMz - An LLM-native Typescript VM built on top of Zui",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "files": [
     "dist",
     "DOCS.md"
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "@botpress/client": "2.4.0",
-    "@botpress/cognitive": "1.1.0",
+    "@botpress/cognitive": "1.2.0",
     "@bpinternal/thicktoken": "^3.1.0",
     "@bpinternal/zui": "^2.4.1"
   },

--- a/packages/vai/package.json
+++ b/packages/vai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/vai",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "files": [
     "dist",
     "ensure-env.cjs"
@@ -31,7 +31,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@botpress/cognitive": "1.1.0",
+    "@botpress/cognitive": "1.2.0",
     "json5": "^2.2.3",
     "jsonrepair": "^3.10.0"
   },

--- a/packages/zai/package.json
+++ b/packages/zai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@botpress/zai",
   "description": "Zui AI (zai) – An LLM utility library written on top of Zui and the Botpress API",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "files": [
     "dist"
   ],
@@ -35,7 +35,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@botpress/cognitive": "1.1.0",
+    "@botpress/cognitive": "1.2.0",
     "json5": "^2.2.3",
     "jsonrepair": "^3.10.0",
     "lodash-es": "^4.17.21",

--- a/plugins/conversation-insights/package.json
+++ b/plugins/conversation-insights/package.json
@@ -7,7 +7,7 @@
   },
   "private": true,
   "dependencies": {
-    "@botpress/cognitive": "1.1.0",
+    "@botpress/cognitive": "1.2.0",
     "@botpress/sdk": "workspace:*",
     "browser-or-node": "^2.1.1",
     "jsonrepair": "^3.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3071,7 +3071,7 @@ importers:
         specifier: 2.4.0
         version: link:../client
       '@botpress/cognitive':
-        specifier: 1.1.0
+        specifier: 1.2.0
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^3.1.0
@@ -3205,7 +3205,7 @@ importers:
         specifier: 2.4.0
         version: link:../client
       '@botpress/cognitive':
-        specifier: 1.1.0
+        specifier: 1.2.0
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^3.0.0
@@ -3248,7 +3248,7 @@ importers:
   packages/zai:
     dependencies:
       '@botpress/cognitive':
-        specifier: 1.1.0
+        specifier: 1.2.0
         version: link:../cognitive
       '@bpinternal/thicktoken':
         specifier: ^3.0.0
@@ -3382,7 +3382,7 @@ importers:
   plugins/conversation-insights:
     dependencies:
       '@botpress/cognitive':
-        specifier: 1.1.0
+        specifier: 1.2.0
         version: link:../../packages/cognitive
       '@botpress/sdk':
         specifier: workspace:*
@@ -8900,6 +8900,7 @@ packages:
   eslint@9.34.0:
     resolution: {integrity: sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'


### PR DESCRIPTION
Adds an option to fallback to another model when using streaming after chunks have already been received