### PR TITLE
fix(llmz): increase stream inactivity timeout to 180 seconds

### DIFF
--- a/packages/llmz/src/runtime/generate.ts
+++ b/packages/llmz/src/runtime/generate.ts
@@ -20,7 +20,7 @@ const RESPONSE_LENGTH_BUFFER = {
 } as const
 
 /** Maximum time to wait between two stream chunks before considering the stream stalled. */
-const STREAM_INACTIVITY_TIMEOUT = 60_000
+const STREAM_INACTIVITY_TIMEOUT = 180_000
 
 const getModelOutputLimit = (inputLength: number) =>
   clamp(


### PR DESCRIPTION
LLMz currently cancels a silent stream after 60 seconds, which can end a turn before Cognitive finishes a delayed provider fallback. In the observed Preview failure, the fallback produced an answer just after the runtime had canceled the request.

Raise the stream inactivity guard to 180 seconds. The timer still resets on each stream chunk, and explicit cancellation remains unchanged. This changes the shared LLMz default for all consumers; it does not change Cognitive first-token timeouts or fix the delayed fallback itself.

Validation: `git diff --check` passed. Tests were not run because the isolated checkout has no installed dependencies.

A package release and downstream dependency update are required before production uses this change.
