### PR TITLE
fix(slack): round-trip choice value as message value and stop echoing payload

### DIFF
--- a/.github/scripts/integration-has-valid-category.sh
+++ b/.github/scripts/integration-has-valid-category.sh
@@ -6,12 +6,15 @@ fi
 integration=$1
 
 integration_path="integrations/$integration"
-if ! integration_def=$(pnpm bp read --work-dir "$integration_path" --json); then
+# Redirect to a file, not $(): a pipe makes Node's stdout async, truncating large definitions (e.g. slack) on process exit.
+integration_def_file=$(mktemp)
+trap 'rm -f "$integration_def_file"' EXIT
+if ! pnpm bp read --work-dir "$integration_path" --json >"$integration_def_file"; then
   echo "Error: Failed to read integration definition for \"$integration\". Check the integration for TypeScript errors." >&2
   exit 1
 fi
 
-category=$(echo "$integration_def" | jq -r '.attributes.category // empty')
+category=$(jq -r '.attributes.category // empty' "$integration_def_file")
 
 valid_categories=(
   "AI Models"

--- a/.github/scripts/validate-integration-version.sh
+++ b/.github/scripts/validate-integration-version.sh
@@ -9,9 +9,15 @@ if [ -z "$integration" ]; then
   exit 1
 fi
 
-integration_def=$(pnpm bp read --work-dir "integrations/$integration" --json)
-name=$(echo "$integration_def" | jq -r '.name')
-version=$(echo "$integration_def" | jq -r '.version')
+# Redirect to a file, not $(): a pipe makes Node's stdout async, truncating large definitions (e.g. slack) on process exit.
+integration_def_file=$(mktemp)
+trap 'rm -f "$integration_def_file"' EXIT
+if ! pnpm bp read --work-dir "integrations/$integration" --json >"$integration_def_file"; then
+  echo "::error::Failed to read integration definition for $integration."
+  exit 1
+fi
+name=$(jq -r '.name' "$integration_def_file")
+version=$(jq -r '.version' "$integration_def_file")
 # Do not mistake API, authentication, or parsing failures for a new integration.
 if ! integrations_json=$(pnpm bp integrations ls --name "$name" --json); then
   echo "::error::Failed to list deployed versions for integration $integration."

--- a/integrations/slack/definitions/channels/text-input-schema.ts
+++ b/integrations/slack/definitions/channels/text-input-schema.ts
@@ -420,5 +420,6 @@ export const textSchema = sdk.z
         'Multiple blocks can be added to this array. If a block is provided, the text field is ignored and the text must be added as a block'
       ),
     mentions: sdk.z.array(mention).optional(),
+    value: sdk.z.string().optional().describe('Underlying value, e.g. button payload'),
   })
   .strict()

--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -14,7 +14,7 @@ export default new IntegrationDefinition({
   name: 'slack',
   title: 'Slack',
   description: 'Automate interactions with your team.',
-  version: '5.1.1',
+  version: '5.1.2',
   icon: 'icon.svg',
   readme: 'hub.md',
   configuration: {

--- a/integrations/slack/integration.definition.ts
+++ b/integrations/slack/integration.definition.ts
@@ -14,7 +14,7 @@ export default new IntegrationDefinition({
   name: 'slack',
   title: 'Slack',
   description: 'Automate interactions with your team.',
-  version: '5.1.2',
+  version: '5.1.1',
   icon: 'icon.svg',
   readme: 'hub.md',
   configuration: {

--- a/integrations/slack/src/webhook-events/handlers/interactive-request.ts
+++ b/integrations/slack/src/webhook-events/handlers/interactive-request.ts
@@ -9,14 +9,14 @@ export const isInteractiveRequest = (req: sdk.Request) =>
 export const handleInteractiveRequest = async ({ req, client, logger }: bp.HandlerProps) => {
   const body = _parseInteractiveBody(req)
 
-  const actionValue = await _respondInteractive(body)
+  const { value, text } = await _respondInteractive(body)
 
   if (body.type !== 'block_actions') {
     logger.forBot().error(`Interaction type ${body.type} received from Slack is not supported yet`)
     return
   }
 
-  if (typeof actionValue !== 'string' || !actionValue?.length) {
+  if (typeof value !== 'string' || !value.length) {
     logger.forBot().debug('No action value was returned, so the message was ignored')
     return
   }
@@ -34,7 +34,7 @@ export const handleInteractiveRequest = async ({ req, client, logger }: bp.Handl
       channelId: body.channel.id,
     },
     type: 'text',
-    payload: { text: actionValue },
+    payload: { text, value },
     userId,
     conversationId,
   })
@@ -47,7 +47,8 @@ type InteractiveBody = {
     block_id?: string
     value?: string
     type: string
-    selected_option?: { value: string }
+    text?: { text: string }
+    selected_option?: { value: string; text?: { text: string } }
   }[]
   type: string
   channel: {
@@ -70,21 +71,23 @@ const _parseInteractiveBody = (req: sdk.Request): InteractiveBody => {
   }
 }
 
-const _respondInteractive = async (body: InteractiveBody): Promise<string> => {
+const _respondInteractive = async (body: InteractiveBody): Promise<{ value: string; text: string }> => {
   if (!body.actions.length) {
     throw new sdk.RuntimeError('No action in body')
   }
 
   const action = body.actions[0]
-  const text = action?.value || action?.selected_option?.value || action?.action_id
-  if (text === undefined) {
+  const value = action?.value || action?.selected_option?.value || action?.action_id
+  if (value === undefined) {
     throw new sdk.RuntimeError('Action value cannot be undefined')
   }
 
-  try {
-    await axios.post(body.response_url, { text })
+  const label = action?.text?.text ?? action?.selected_option?.text?.text ?? value
 
-    return text
+  try {
+    await axios.post(body.response_url, { replace_original: true, text: label })
+
+    return { value, text: label }
   } catch (thrown: unknown) {
     const error = thrown instanceof Error ? thrown : new Error(String(thrown))
     throw new sdk.RuntimeError('Error while responding to interactive request', error)

--- a/integrations/slack/src/webhook-events/handlers/interactive-request.ts
+++ b/integrations/slack/src/webhook-events/handlers/interactive-request.ts
@@ -9,12 +9,12 @@ export const isInteractiveRequest = (req: sdk.Request) =>
 export const handleInteractiveRequest = async ({ req, client, logger }: bp.HandlerProps) => {
   const body = _parseInteractiveBody(req)
 
-  const { value, text } = await _respondInteractive(body)
-
   if (body.type !== 'block_actions') {
     logger.forBot().error(`Interaction type ${body.type} received from Slack is not supported yet`)
     return
   }
+
+  const { value, text } = await _respondInteractive(body)
 
   if (typeof value !== 'string' || !value.length) {
     logger.forBot().debug('No action value was returned, so the message was ignored')

--- a/integrations/slack/src/webhook-events/handlers/interactive-request.ts
+++ b/integrations/slack/src/webhook-events/handlers/interactive-request.ts
@@ -64,7 +64,11 @@ type InteractiveBody = {
 
 const _parseInteractiveBody = (req: sdk.Request): InteractiveBody => {
   try {
-    return JSON.parse(decodeURIComponent(req.body!).replace('payload=', ''))
+    const payload = new URLSearchParams(req.body!).get('payload')
+    if (payload === null) {
+      throw new Error('Missing "payload" field in interactive request body')
+    }
+    return JSON.parse(payload)
   } catch (thrown: unknown) {
     const error = thrown instanceof Error ? thrown : new Error(String(thrown))
     throw new sdk.RuntimeError('Body is invalid for interactive request', error)


### PR DESCRIPTION
A `choice`/button click now emits the option value silently as inbound `payload.value` (with the button label as `payload.text`), matching the whatsapp inbound shape, instead of writing the raw value to `payload.text`. The prompt is updated in place with the selected label via `replace_original`, so the buttons disappear and the raw JSON blob is no longer reposted into the thread.

part of SHIP-1942