### PR TITLE
feat(llmz): support safe opt-in mid-stream fallback

### DIFF
--- a/packages/llmz/DOCS.md
+++ b/packages/llmz/DOCS.md
@@ -1582,6 +1582,31 @@ await execute({
 
 ---
 
+### Buffered Delivery (midStreamFallback)
+
+By default, LLMz streams responses: send blocks are dispatched as soon as they are parsed, and the ■run block starts executing while the model is still generating the rest of the response. This gives the lowest time-to-first-token but runs code before the response is complete.
+
+Set `options.midStreamFallback: true` to allow Cognitive to restart a failed stream on another model safely. LLMz buffers delivery and discards all content from abandoned attempts:
+
+```typescript
+await execute({
+  // ...
+  options: { midStreamFallback: true },
+})
+```
+
+When enabled, the runtime buffers the full generated response and only dispatches it (sends and code execution) once the stream has finished. Trade-offs:
+
+- **Latency**: higher time-to-first-send/token, since nothing is delivered until the response completes.
+- **No early code**: the VM is not run mid-stream; code executes only after the full response is parsed.
+- **Cancellation**: cancellation still aborts the original generation request as usual.
+- **No extra retry loop**: Cognitive owns fallback, bounded by the model chain. LLMz does not retry abandoned attempts itself.
+- **Not exactly-once**: abandoned attempts deliver nothing, but successful-attempt callbacks cannot be rolled back if delivery fails or cancellation arrives during delivery. Caller retries can duplicate effects.
+
+This option defaults to false and applies only to streaming clients. Non-streaming Cognitive requests already fall back transparently. It can be combined with `maxTimeToFirstToken` and `transcriptionModel`; do not enable it globally underneath LLMz without also enabling LLMz's buffering option.
+
+Restarts emit `llm_call_restarted` traces with the attempt, source/destination models, and reason. Token timings remain relative to the original request and describe the surviving attempt (including time spent on prior attempts). Usage and cost retain Cognitive's final reported metadata; LLMz does not infer or sum abandoned-attempt billing. Cancellation deadlines are not reset, and the existing stream inactivity guard remains active during handoffs.
+
 ## API Reference
 
 ### Core Functions

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -2,7 +2,7 @@
   "name": "llmz",
   "type": "module",
   "description": "LLMz - An LLM-native Typescript VM built on top of Zui",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "files": [
     "dist",
     "DOCS.md"

--- a/packages/llmz/src/context.ts
+++ b/packages/llmz/src/context.ts
@@ -680,6 +680,11 @@ export class Context implements Serializable<Context.JSON> {
    */
   public maxTimeToFirstToken?: number
   /**
+   * Allow Cognitive mid-stream fallback, buffering delivery until generation
+   * succeeds and discarding abandoned attempts. Streaming-only; defaults to false.
+   */
+  public midStreamFallback?: boolean
+  /**
    * STT model used by the cognitive service to transcribe audio attachments
    * when the target LLM does not support audio natively. Defaults to 'fast'.
    */
@@ -1039,6 +1044,7 @@ export class Context implements Serializable<Context.JSON> {
     timeout?: number
     maxTokens?: number
     maxTimeToFirstToken?: number
+    midStreamFallback?: boolean
     transcriptionModel?: SttModels
   }) {
     this.id = `llmz_${ulid()}`
@@ -1058,6 +1064,7 @@ export class Context implements Serializable<Context.JSON> {
     this.snapshot = props.snapshot
     this.maxTokens = props.maxTokens
     this.maxTimeToFirstToken = props.maxTimeToFirstToken
+    this.midStreamFallback = props.midStreamFallback
     this.transcriptionModel = props.transcriptionModel
 
     if (this.loop < 1 || this.loop > 100) {
@@ -1073,6 +1080,10 @@ export class Context implements Serializable<Context.JSON> {
       (!Number.isFinite(this.maxTimeToFirstToken) || this.maxTimeToFirstToken < 1)
     ) {
       throw new Error('Invalid maxTimeToFirstToken. Expected a positive number of milliseconds.')
+    }
+
+    if (this.midStreamFallback !== undefined && typeof this.midStreamFallback !== 'boolean') {
+      throw new Error('Invalid midStreamFallback. Expected a boolean.')
     }
   }
 

--- a/packages/llmz/src/runtime/execute.test.ts
+++ b/packages/llmz/src/runtime/execute.test.ts
@@ -1,6 +1,6 @@
 import { CognitiveMetadata, CognitiveResponse, CognitiveStreamChunk, Model } from '@botpress/cognitive'
 import { z } from '@bpinternal/zui'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import { Chat, MessageDelta } from '../chat.js'
 import { DefaultComponents } from '../component.default.js'
@@ -95,6 +95,107 @@ class ScriptedStreamingCognitive extends ScriptedCognitive {
     yield { created: Date.now(), finished: true, metadata: makeFakeMetadata() }
   }
 }
+
+/**
+ * Streams scripted responses chunk by chunk, emitting a control-only `restart`
+ * chunk between consecutive responses — the signature of a mid-stream model
+ * fallback, where everything streamed before the restart is void and must be
+ * discarded. Ends with a metadata-carrying chunk (or runs dry when `undefined`
+ * is passed as the final chunk).
+ */
+class ScriptedRestartStreamingCognitive extends ScriptedCognitive {
+  /** Value of the probe function recorded after each chunk was consumed downstream. */
+  public probes: number[] = []
+
+  /** True once the stream is paused in the handoff gap after a restart. */
+  public handoffStarted = false
+
+  public constructor(
+    private _segments: string[],
+    private _probe: () => number = () => 0,
+    private _chunkSize = 7,
+    private _finalChunk: CognitiveStreamChunk | null = {
+      created: Date.now(),
+      finished: true,
+      metadata: makeFakeMetadata(),
+    },
+    private _metadataPerAttempt = false,
+    private _handoffDelayMs = 0
+  ) {
+    super(_segments)
+  }
+
+  public async *generateTextStream(): AsyncGenerator<CognitiveStreamChunk, void, unknown> {
+    for (let i = 0; i < this._segments.length; i++) {
+      const content = this._segments[i]!
+      for (let j = 0; j < content.length; j += this._chunkSize) {
+        yield { output: content.slice(j, j + this._chunkSize), created: Date.now() }
+        this.probes.push(this._probe())
+      }
+      if (i < this._segments.length - 1) {
+        if (this._metadataPerAttempt) {
+          // Real streams end each attempt with metadata; it must not survive the restart
+          yield { created: Date.now(), finished: true, metadata: makeFakeMetadata() }
+          this.probes.push(this._probe())
+        }
+        yield {
+          created: Date.now(),
+          restart: { attempt: i + 2, fromModel: 'fake', toModel: 'fake', reason: 'timeout' },
+        }
+        this.probes.push(this._probe())
+        if (this._handoffDelayMs > 0) {
+          this.handoffStarted = true
+          await new Promise<void>((resolve) => setTimeout(resolve, this._handoffDelayMs))
+        }
+      }
+    }
+    if (this._finalChunk) {
+      yield this._finalChunk
+      this.probes.push(this._probe())
+    }
+  }
+}
+
+/**
+ * Streams one chunk, then waits for the stream's abort signal before throwing —
+ * mimicking a real HTTP-backed client whose stream dies when its AbortController
+ * fires. Used to prove that cancelling a mid-stream-fallback generation never
+ * flushes buffered content.
+ */
+class ScriptedAbortAwareCognitive extends ScriptedCognitive {
+  public async *generateTextStream(
+    _input: any,
+    options?: { signal?: AbortSignal }
+  ): AsyncGenerator<CognitiveStreamChunk, void, unknown> {
+    const content = this._nextContent()
+    yield { output: content.slice(0, 30), created: Date.now() }
+
+    const signal: AbortSignal | undefined = options?.signal
+    await new Promise<void>((resolve) => {
+      if (signal?.aborted) {
+        resolve()
+      } else {
+        signal?.addEventListener('abort', () => resolve(), { once: true })
+      }
+    })
+
+    throw new Error('stream interrupted by abort')
+  }
+}
+
+/**
+ * Streams a complete response, then throws — the transport-level failure that
+ * ends a mid-stream fallback chain once every model candidate has failed.
+ */
+class ScriptedChainErrorCognitive extends ScriptedCognitive {
+  public async *generateTextStream(): AsyncGenerator<CognitiveStreamChunk, void, unknown> {
+    yield { output: this._nextContent(), created: Date.now() }
+    throw new Error('model chain exhausted')
+  }
+}
+
+/** Options that opt in to mid-stream model fallback (options.midStreamFallback). */
+const midStreamOptions = (loop: number) => ({ loop, midStreamFallback: true })
 
 const makeChat = (onMessageDelta?: (delta: MessageDelta) => Promise<void> | void) => {
   const messages: Array<{ type: string; text: string; props: Record<string, unknown> }> = []
@@ -648,5 +749,430 @@ describe('message-stream protocol execution', () => {
     expect(result).toBeInstanceOf(SuccessExecutionResult)
     expect(result.iterations[0]!.status.type).toBe('exit_error')
     expect((result as SuccessExecutionResult).result.exit.name).toBe('done')
+  })
+
+  describe('options.midStreamFallback', () => {
+    test('buffers messages until the stream completes', async () => {
+      const { chat, messages } = makeChat()
+      const client = new ScriptedStreamingCognitive(
+        ['■send=message\nBuffered hello!\n■send=message\nBuffered second\n■next=listen'],
+        () => messages.length
+      )
+
+      const result = await executeContext({ client, chat, options: midStreamOptions(3) })
+
+      expect(result).toBeInstanceOf(SuccessExecutionResult)
+      expect((result as SuccessExecutionResult).result.exit.name).toBe(ListenExit.name)
+      expect(messages.map((m) => m.text)).toEqual(['Buffered hello!', 'Buffered second'])
+
+      // nothing was delivered while the stream was still in flight
+      expect(client.probes.slice(0, -1).every((count) => count === 0)).toBe(true)
+    })
+
+    test('buffers message deltas until the stream completes', async () => {
+      const deltas: MessageDelta[] = []
+      const { chat, messages } = makeChat((delta) => {
+        deltas.push(delta)
+      })
+
+      const client = new ScriptedStreamingCognitive(
+        ['■send=message\nThis is a fairly long streamed message body!\n■next=listen'],
+        () => deltas.length,
+        5 // small chunks so the body spans many stream chunks
+      )
+
+      const result = await executeContext({ client, chat, options: midStreamOptions(3) })
+
+      expect(result).toBeInstanceOf(SuccessExecutionResult)
+      expect(messages.map((m) => m.text)).toEqual(['This is a fairly long streamed message body!'])
+
+      // the body was replayed in order once the stream completed
+      expect(deltas.length).toBeGreaterThan(1)
+      expect(deltas.map((d) => d.delta).join('')).toBe('This is a fairly long streamed message body!')
+      expect(new Set(deltas.map((d) => d.id)).size).toBe(1)
+
+      // nothing streamed to the client while the model was still generating
+      expect(client.probes.slice(0, -1).every((count) => count === 0)).toBe(true)
+    })
+
+    test('disables early code execution', async () => {
+      const done = new Exit({ name: 'done', description: 'Task completed' })
+      const { chat } = makeChat()
+
+      let toolRan = false
+      const mark = new Tool({
+        name: 'mark',
+        description: 'Marks that the code executed',
+        handler: async () => {
+          toolRan = true
+        },
+      })
+
+      const client = new ScriptedStreamingCognitive(['■run\nawait mark()\n■next=done'], () => (toolRan ? 1 : 0), 7)
+
+      const result = await executeContext({
+        client,
+        chat,
+        tools: [mark],
+        exits: [done],
+        options: midStreamOptions(2),
+      })
+
+      expect(result).toBeInstanceOf(SuccessExecutionResult)
+      expect((result as SuccessExecutionResult).result.exit.name).toBe('done')
+
+      // the code only executed after the stream had fully completed
+      expect(toolRan).toBe(true)
+      expect(client.probes.every((value) => value === 0)).toBe(true)
+    })
+
+    test('content streamed before a restart never reaches the chat', async () => {
+      const { chat, messages } = makeChat()
+      // first attempt: a completed ■send and a second ■send cut off mid-body
+      const client = new ScriptedRestartStreamingCognitive([
+        '■send=message\nAbandoned!\n■send=message\nPartial',
+        '■send=message\nKept!\n■next=listen',
+      ])
+
+      const result = await executeContext({ client, chat, options: midStreamOptions(3) })
+
+      expect(result).toBeInstanceOf(SuccessExecutionResult)
+      expect(messages.map((m) => m.text)).toEqual(['Kept!'])
+    })
+
+    test('an unexpected restart throws a CognitiveError when fallback is disabled', async () => {
+      const { chat } = makeChat()
+      const client = new ScriptedRestartStreamingCognitive([
+        '■send=message\nAbandoned!\n■next=listen',
+        '■send=message\nKept!\n■next=listen',
+      ])
+
+      // midStreamFallback is off: a restart chunk is unexpected and must fail
+      // instead of silently concatenating the attempts
+      const result = await executeContext({ client, chat, options: { loop: 3 } })
+
+      expect(result).toBeInstanceOf(ErrorExecutionResult)
+      const error = (result as ErrorExecutionResult).error
+      expect(error).toBeInstanceOf(CognitiveError)
+    })
+
+    test('a ■run block completed before a restart never executes', async () => {
+      const ran: string[] = []
+      const log = new Tool({
+        name: 'log',
+        description: 'Logs a value',
+        handler: async () => {
+          ran.push('log')
+        },
+      })
+
+      const { chat } = makeChat()
+      const client = new ScriptedRestartStreamingCognitive([
+        '■run\nawait log()\n■next=listen',
+        '■send=message\nKept!\n■next=listen',
+      ])
+
+      const result = await executeContext({
+        client,
+        chat,
+        tools: [log],
+        options: midStreamOptions(3),
+      })
+
+      expect(result).toBeInstanceOf(SuccessExecutionResult)
+      expect(ran).toEqual([])
+      expect(result.iterations).toHaveLength(1)
+    })
+
+    test('only replacement code executes after a completed run is abandoned', async () => {
+      const ran: string[] = []
+      const mark = new Tool({
+        name: 'mark',
+        description: 'Records the attempt',
+        input: z.object({ attempt: z.string() }),
+        handler: async ({ attempt }) => {
+          ran.push(attempt)
+        },
+      })
+      const done = new Exit({ name: 'done', description: 'Done' })
+      const client = new ScriptedRestartStreamingCognitive([
+        '■run\nawait mark({ attempt: "abandoned" })\n■next=done',
+        '■run\nawait mark({ attempt: "replacement" })\n■next=done',
+      ])
+      const result = await executeContext({ client, tools: [mark], exits: [done], options: midStreamOptions(1) })
+      expect(result).toBeInstanceOf(SuccessExecutionResult)
+      expect(ran).toEqual(['replacement'])
+      expect(result.iterations[0]!.traces.filter((trace) => trace.type === 'code_generation_started')).toHaveLength(1)
+    })
+
+    test('cancellation after the last chunk but before commit drops all buffered effects', async () => {
+      const controller = new AbortController()
+      class CancelOnCompletion extends ScriptedStreamingCognitive {
+        public override async *generateTextStream(): AsyncGenerator<CognitiveStreamChunk, void, unknown> {
+          yield* super.generateTextStream()
+          controller.abort(new Error('deadline expired'))
+        }
+      }
+      const deltas: MessageDelta[] = []
+      const { chat, messages } = makeChat((delta) => {
+        deltas.push(delta)
+      })
+      const client = new CancelOnCompletion(['■send=message\nBuffered\n■next=listen'])
+      const result = await executeContext({ client, chat, signal: controller.signal, options: midStreamOptions(1) })
+      expect(result).toBeInstanceOf(ErrorExecutionResult)
+      expect(messages).toEqual([])
+      expect(deltas).toEqual([])
+    })
+
+    test('multiple restarts discard everything streamed before the last attempt', async () => {
+      const { chat, messages } = makeChat()
+      const client = new ScriptedRestartStreamingCognitive([
+        '■send=message\nFirst attempt\n■next=listen',
+        '■send=message\nSecond attempt\n■next=listen',
+        '■send=message\nFinal!\n■next=listen',
+      ])
+
+      const result = await executeContext({ client, chat, options: midStreamOptions(3) })
+
+      expect(result).toBeInstanceOf(SuccessExecutionResult)
+      expect(messages.map((m) => m.text)).toEqual(['Final!'])
+    })
+
+    test.each(['```', '```\n■send=message\nAbandoned!\n', '■send=button { "label":'])(
+      'a restart resets incomplete parser/fence state: %s',
+      async (abandoned) => {
+        const { chat, messages } = makeChat()
+        // both attempts are wrapped in a code fence; the first fence must not
+        // leak into the replacement after the restart
+        const client = new ScriptedRestartStreamingCognitive([abandoned, '```\n■send=message\nKept!\n■next=listen'])
+
+        const result = await executeContext({ client, chat, options: midStreamOptions(3) })
+
+        expect(result).toBeInstanceOf(SuccessExecutionResult)
+        expect(messages.map((m) => m.text)).toEqual(['Kept!'])
+      }
+    )
+
+    test('a restart whose replacement stream ends without metadata dispatches nothing', async () => {
+      const cases = [
+        // the stream simply runs dry after the replacement content
+        null,
+        // the stream ends with a finished chunk but no replacement metadata
+        { created: Date.now(), finished: true } as CognitiveStreamChunk,
+      ]
+
+      for (const finalChunk of cases) {
+        const { chat, messages } = makeChat()
+        const client = new ScriptedRestartStreamingCognitive(
+          ['■send=message\nAbandoned!\n■next=listen', '■send=message\nStill buffered\n■next=listen'],
+          () => 0,
+          7,
+          finalChunk
+        )
+
+        const result = await executeContext({ client, chat, options: midStreamOptions(3) })
+
+        expect(result).toBeInstanceOf(ErrorExecutionResult)
+        const error = (result as ErrorExecutionResult).error
+        expect(error).toBeInstanceOf(CognitiveError)
+        expect((error as Error).message).toContain('without metadata')
+        expect(messages).toEqual([])
+      }
+    })
+
+    test('cancelling the stream never dispatches buffered content', async () => {
+      const guard = new AbortController()
+      const { chat, messages } = makeChat()
+      const client = new ScriptedAbortAwareCognitive(['■send=message\nAbandoned!\n■next=listen'])
+
+      const execution = executeContext({ client, chat, signal: guard.signal, options: midStreamOptions(3) })
+
+      // let the first chunk flow through the pipeline, then cancel the stream
+      setTimeout(() => guard.abort(new Error('cancelled')), 20)
+
+      const result = await execution
+
+      expect(result).toBeInstanceOf(ErrorExecutionResult)
+      expect((result as ErrorExecutionResult).error).toMatchObject({ message: 'cancelled' })
+      expect(messages).toEqual([])
+      expect(result.iterations[0]!.status.type).toBe('aborted')
+    })
+
+    test('a stream error after buffered sends and runs delivers nothing', async () => {
+      const { chat, messages } = makeChat()
+      let ran = false
+      const mark = new Tool({
+        name: 'mark',
+        description: 'Marks that the code executed',
+        handler: async () => {
+          ran = true
+        },
+      })
+      const done = new Exit({ name: 'done', description: 'Task completed' })
+
+      // The attempt fully parses a ■send and a ■run before the transport dies,
+      // as when the whole model chain exhausts mid-stream
+      const client = new ScriptedChainErrorCognitive(['■send=message\nBuffered!\n■run\nawait mark()\n■next=done'])
+
+      const result = await executeContext({ client, chat, tools: [mark], exits: [done], options: midStreamOptions(3) })
+
+      expect(result).toBeInstanceOf(ErrorExecutionResult)
+      expect((result as ErrorExecutionResult).error).toBeInstanceOf(CognitiveError)
+      expect(((result as ErrorExecutionResult).error as Error).message).toContain('LLM generation failed')
+
+      // Buffered delivery commits only after a successful stream: no effects leak
+      expect(messages).toEqual([])
+      expect(ran).toBe(false)
+    })
+
+    test('metadata from an abandoned attempt does not satisfy a metadata-less replacement', async () => {
+      const { chat, messages } = makeChat()
+      // The first attempt ends with metadata, then restarts; the replacement
+      // finishes without providing its own
+      const client = new ScriptedRestartStreamingCognitive(
+        ['■send=message\nAbandoned!\n■next=listen', '■send=message\nStill buffered\n■next=listen'],
+        () => 0,
+        7,
+        { created: Date.now(), finished: true },
+        true
+      )
+
+      const result = await executeContext({ client, chat, options: midStreamOptions(3) })
+
+      expect(result).toBeInstanceOf(ErrorExecutionResult)
+      const error = (result as ErrorExecutionResult).error
+      expect(error).toBeInstanceOf(CognitiveError)
+      expect((error as Error).message).toContain('without metadata')
+      expect(messages).toEqual([])
+    })
+
+    test('a replacement handoff within the stall guard still succeeds', async () => {
+      try {
+        vi.useFakeTimers()
+        const { chat, messages } = makeChat()
+        // The replacement attempt starts after a 60s handoff — well inside the
+        // 180s inactivity guard the runtime arms between chunks
+        const client = new ScriptedRestartStreamingCognitive(
+          ['■send=message\nAbandoned!\n', '■send=message\nReplacement output!\n■next=listen'],
+          () => 0,
+          7,
+          undefined,
+          false,
+          60_000
+        )
+
+        const execution = executeContext({ client, chat, options: midStreamOptions(3) })
+
+        // Drive the stream through the restart, then release the handoff
+        for (let i = 0; i < 100 && !client.handoffStarted; i++) {
+          await vi.advanceTimersByTimeAsync(1)
+        }
+        expect(client.handoffStarted).toBe(true)
+        await vi.advanceTimersByTimeAsync(60_000)
+
+        const result = await execution
+        expect(result).toBeInstanceOf(SuccessExecutionResult)
+        expect((result as SuccessExecutionResult).result.exit.name).toBe(ListenExit.name)
+        expect(messages.map((m) => m.text)).toEqual(['Replacement output!'])
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    test('a replacement handoff past the stall guard fails', async () => {
+      try {
+        vi.useFakeTimers()
+        const { chat, messages } = makeChat()
+        // The replacement handoff takes 240s — past the 180s inactivity guard
+        const client = new ScriptedRestartStreamingCognitive(
+          ['■send=message\nAbandoned!\n', '■send=message\nNever delivered\n■next=listen'],
+          () => 0,
+          7,
+          undefined,
+          false,
+          240_000
+        )
+
+        const execution = executeContext({ client, chat, options: midStreamOptions(3) })
+
+        for (let i = 0; i < 100 && !client.handoffStarted; i++) {
+          await vi.advanceTimersByTimeAsync(1)
+        }
+        expect(client.handoffStarted).toBe(true)
+
+        // Exceed the stall timeout armed after the restart chunk: the guard must
+        // still be running across the handoff
+        await vi.advanceTimersByTimeAsync(180_001)
+
+        const result = await execution
+        expect(result).toBeInstanceOf(ErrorExecutionResult)
+        expect(((result as ErrorExecutionResult).error as Error).message).toContain('LLM stream stalled')
+        expect(messages).toEqual([])
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    test('restarts are traced with the chain fields and usage reflects only the surviving attempt', async () => {
+      const { chat, messages } = makeChat()
+      const client = new ScriptedRestartStreamingCognitive([
+        '■send=message\nFirst attempt\n■send=message\nMore abandoned output\n■next=listen',
+        '■send=message\nFinal!\n■next=listen',
+      ])
+
+      const result = await executeContext({ client, chat, options: midStreamOptions(3) })
+
+      expect(result).toBeInstanceOf(SuccessExecutionResult)
+      expect(messages.map((m) => m.text)).toEqual(['Final!'])
+
+      const iteration = result.iterations[0]!
+      const restartTraces = iteration.traces.filter((t) => t.type === 'llm_call_restarted')
+      expect(restartTraces).toHaveLength(1)
+      expect(restartTraces[0]).toMatchObject({ attempt: 2, fromModel: 'fake', toModel: 'fake', reason: 'timeout' })
+
+      // raw output and usage come from the surviving attempt only
+      expect(iteration.llm!.output).toBe('■send=message\nFinal!\n■next=listen')
+      expect(iteration.llm!.usage).toEqual({ inputTokens: 10, inputCost: 0, outputTokens: 10, outputCost: 0 })
+      expect(iteration.tokens!.input).toBe(10)
+      expect(iteration.tokens!.output).toBe(10)
+      expect(iteration.tokens!.total).toBe(20)
+    })
+
+    test('options.midStreamFallback is forwarded to the streaming request', async () => {
+      let received: any
+      class ProbeCognitive extends ScriptedStreamingCognitive {
+        public override async *generateTextStream(input?: any): AsyncGenerator<CognitiveStreamChunk, void, unknown> {
+          received = input
+          yield* super.generateTextStream()
+        }
+      }
+
+      const run = async (options: Record<string, unknown>, attachments?: Transcript.Attachment[]) => {
+        received = undefined
+        const chat = new Chat({
+          components: [DefaultComponents.Text],
+          transcript: [{ role: 'user', content: 'hello', attachments }],
+          handler: async () => {},
+        })
+        const client = new ProbeCognitive(['■send=message\nHello!\n■next=listen'])
+        const result = await executeContext({ client, chat, options: { loop: 2, ...options } })
+        expect(result).toBeInstanceOf(SuccessExecutionResult)
+      }
+
+      // the flag alone is forwarded
+      await run({ midStreamFallback: true })
+      expect(received?.options?.midStreamFallback).toBe(true)
+
+      // combined with the time-to-first-token fallback
+      await run({ midStreamFallback: true, maxTimeToFirstToken: 1_234 })
+      expect(received?.options?.midStreamFallback).toBe(true)
+      expect(received?.options?.maxTimeToFirstToken).toBe(1_234)
+
+      // combined with audio transcription
+      const audio: Transcript.Attachment[] = [{ type: 'audio', url: 'data:audio/wav;base64,AAAA' }]
+      await run({ midStreamFallback: true }, audio)
+      expect(received?.options?.midStreamFallback).toBe(true)
+      expect(received?.options?.transcriptionModel).toBe('fast')
+    })
   })
 })

--- a/packages/llmz/src/runtime/execute.ts
+++ b/packages/llmz/src/runtime/execute.ts
@@ -59,6 +59,7 @@ const executeContextInternal = async (props: ExecutionProps): Promise<ExecutionR
     timeout: props.options?.timeout,
     maxTokens: props.options?.maxTokens,
     maxTimeToFirstToken: props.options?.maxTimeToFirstToken,
+    midStreamFallback: props.options?.midStreamFallback,
     transcriptionModel: props.options?.transcriptionModel,
     exits: props.exits,
     snapshot: props.snapshot,
@@ -371,7 +372,9 @@ const executeIteration = async ({
   // parsed — while the rest of the response (■next, stream metadata) may
   // still be streaming. Disabled when an onBeforeExecution hook is registered,
   // since the hook must run (and may mutate the code) before execution.
-  const canExecuteEarly = typeof onBeforeExecution !== 'function'
+  // Early/streaming execution is also disabled in buffered (midStreamFallback) mode,
+  // so the full response is parsed before code runs.
+  const canExecuteEarly = typeof onBeforeExecution !== 'function' && !ctx.midStreamFallback
   let earlyExecution: { code: string; started_at: number; promise: Promise<VMExecutionResult> } | undefined
 
   // ■send blocks are dispatched to the chat as soon as they are parsed — on

--- a/packages/llmz/src/runtime/generate.ts
+++ b/packages/llmz/src/runtime/generate.ts
@@ -175,6 +175,16 @@ export const generateCode = async ({
   let timeToFirstToken: number | undefined
   let timeToLastToken: number | undefined
 
+  const bufferedDelivery = ctx.midStreamFallback === true
+  let pendingDeliveries: (() => Promise<void> | void)[] = []
+  const deliver = async (callback: () => Promise<void> | void) => {
+    if (bufferedDelivery) {
+      pendingDeliveries.push(callback)
+    } else {
+      await callback()
+    }
+  }
+
   const liveItems = new Map<string, ParsedItem>()
   const liveContent = new Map<string, string>()
   let codeGenerationTraced = false
@@ -189,8 +199,11 @@ export const generateCode = async ({
           // generated so consumers can show progress while waiting for the
           // code to complete and execute
           codeGenerationTraced = true
-          traces.push({ type: 'code_generation_started', started_at: Date.now() })
-          onRunStart?.()
+          const started_at = Date.now()
+          await deliver(() => {
+            traces.push({ type: 'code_generation_started', started_at })
+            onRunStart?.()
+          })
         }
       } else if (event.type === 'body-delta' && onSendDelta) {
         const item = liveItems.get(event.itemId)
@@ -199,37 +212,47 @@ export const generateCode = async ({
         }
         const content = (liveContent.get(item.id) ?? '') + event.delta
         liveContent.set(item.id, content)
-        try {
-          // Progressive previews are best-effort; the authoritative delivery is onSend.
-          await onSendDelta({
-            id: `${iteration.id}:${item.id}`,
-            component: item.name,
-            props: item.props,
-            delta: event.delta,
-            content,
-          })
-        } catch (err: unknown) {
-          void err
+        // Parser items are live references. Capture the delivery payload now,
+        // rather than queueing parser events that will continue to mutate.
+        const delta: MessageDelta = {
+          id: `${iteration.id}:${item.id}`,
+          component: item.name,
+          props: bufferedDelivery ? structuredClone(item.props) : item.props,
+          delta: event.delta,
+          content,
         }
+        await deliver(async () => {
+          try {
+            // Progressive previews are best-effort; authoritative delivery is onSend.
+            await onSendDelta(delta)
+          } catch (err: unknown) {
+            void err
+          }
+        })
       } else if (event.type === 'item-complete') {
         if (event.item.kind === 'send' && onSend) {
-          await onSend({ name: event.item.name, props: event.item.props, body: event.item.body })
+          const send = {
+            name: event.item.name,
+            props: bufferedDelivery ? structuredClone(event.item.props) : event.item.props,
+            body: event.item.body,
+          }
+          await deliver(() => onSend(send))
         } else if (event.item.kind === 'run' && event.item.status === 'complete' && !runCompleted) {
           // The ■run block is fully parsed (only the first one counts — the
           // response may invalidly contain more): execution can start while
           // the rest of the response streams
           runCompleted = true
-          onRunComplete?.((event.item.body ?? '').trim())
+          const code = (event.item.body ?? '').trim()
+          await deliver(() => onRunComplete?.(code))
         }
       }
     }
   }
 
   if (typeof cognitive.generateTextStream === 'function') {
-    // Streaming path: parse ■ blocks incrementally and dispatch messages while
-    // the model is still generating.
-    const parser = new StreamingMessageParser()
-    const fence = new LeadingFenceFilter()
+    // Parse incrementally; fallback-enabled calls defer delivery until commit.
+    let parser = new StreamingMessageParser()
+    let fence = new LeadingFenceFilter()
 
     // Guard against stalled streams: the transport has no timeout of its own
     // when a signal is provided, so a silent connection would hang forever.
@@ -240,8 +263,14 @@ export const generateCode = async ({
         ...input,
         // Passed through to the cognitive request: fall back to the next
         // model/provider when the first token takes too long
-        ...(ctx.maxTimeToFirstToken
-          ? { options: { ...input.options, maxTimeToFirstToken: ctx.maxTimeToFirstToken } }
+        ...(ctx.maxTimeToFirstToken || bufferedDelivery
+          ? {
+              options: {
+                ...input.options,
+                ...(ctx.maxTimeToFirstToken ? { maxTimeToFirstToken: ctx.maxTimeToFirstToken } : {}),
+                ...(bufferedDelivery ? { midStreamFallback: true } : {}),
+              },
+            }
           : {}),
       },
       { signal: streamController.signal }
@@ -267,46 +296,92 @@ export const generateCode = async ({
     }
 
     raw = ''
+    let streamCompleted = false
 
-    while (true) {
-      let chunk: IteratorResult<CognitiveStreamChunk, unknown>
-      try {
-        chunk = await nextChunk()
-      } catch (thrown: unknown) {
-        throw new CognitiveError(`LLM generation failed: ${getErrorMessage(thrown)}`)
+    try {
+      while (true) {
+        let chunk: IteratorResult<CognitiveStreamChunk, unknown>
+        try {
+          chunk = await nextChunk()
+        } catch (thrown: unknown) {
+          throw new CognitiveError(`LLM generation failed: ${getErrorMessage(thrown)}`)
+        }
+
+        if (chunk.done) {
+          streamCompleted = true
+          break
+        }
+
+        if (chunk.value?.restart) {
+          if (!bufferedDelivery) {
+            streamController.abort('Unexpected LLM stream restart')
+            throw new CognitiveError('LLM stream restarted without options.midStreamFallback enabled')
+          }
+          traces.push({ type: 'llm_call_restarted', started_at: Date.now(), ...chunk.value.restart })
+          raw = ''
+          parser = new StreamingMessageParser()
+          fence = new LeadingFenceFilter()
+          liveItems.clear()
+          liveContent.clear()
+          pendingDeliveries = []
+          codeGenerationTraced = false
+          runCompleted = false
+          responseMetadata = undefined
+          // Keep request-relative timing (including handoff latency), but only
+          // report tokens from the surviving attempt.
+          timeToFirstToken = undefined
+          timeToLastToken = undefined
+          continue
+        }
+
+        if (chunk.value?.metadata) {
+          responseMetadata = chunk.value.metadata
+        }
+
+        const delta = chunk.value?.output
+        if (!delta) {
+          continue
+        }
+
+        timeToLastToken = Date.now() - requestedAt
+        timeToFirstToken ??= timeToLastToken
+
+        raw += delta
+        await dispatchSends(parser.push(fence.push(delta)))
       }
 
-      if (chunk.done) {
-        break
+      if (!responseMetadata) {
+        throw new CognitiveError('LLM streaming completed without metadata')
       }
 
-      if (chunk.value?.metadata) {
-        responseMetadata = chunk.value.metadata
+      const remaining = fence.flush()
+      if (remaining) {
+        await dispatchSends(parser.push(remaining))
       }
+      await dispatchSends(parser.finish())
 
-      const delta = chunk.value?.output
-      if (!delta) {
-        continue
+      assistantResponse = toParsedAssistantResponse(parser.items, raw)
+    } finally {
+      // Release transport resources and the joined signal's parent listener,
+      // including when a callback throws or an unexpected restart is rejected.
+      streamController.abort('LLM stream closed')
+      if (!streamCompleted) {
+        // Do not wait: a stalled custom iterator may never settle its next().
+        void stream.return(undefined).catch(() => {})
       }
-
-      timeToLastToken = Date.now() - requestedAt
-      timeToFirstToken ??= timeToLastToken
-
-      raw += delta
-      await dispatchSends(parser.push(fence.push(delta)))
     }
 
-    if (!responseMetadata) {
-      throw new CognitiveError('LLM streaming completed without metadata')
+    // A restart cannot retract callbacks, so commit only after the iterator
+    // completes normally and the final attempt has metadata and parsed output.
+    // Cancellation/deadlines are never renewed across attempts.
+    if (bufferedDelivery) {
+      controller.signal.throwIfAborted()
+      for (const callback of pendingDeliveries) {
+        controller.signal.throwIfAborted()
+        await callback()
+      }
+      pendingDeliveries = []
     }
-
-    const remaining = fence.flush()
-    if (remaining) {
-      await dispatchSends(parser.push(remaining))
-    }
-    await dispatchSends(parser.finish())
-
-    assistantResponse = toParsedAssistantResponse(parser.items, raw)
   } else {
     const response = await cognitive.generateText(input, { signal: controller.signal }).catch((thrown: unknown) => {
       throw new CognitiveError(`LLM generation failed: ${getErrorMessage(thrown)}`)
@@ -360,7 +435,7 @@ export const generateCode = async ({
     type: 'llm_call_success',
     started_at: startedAt,
     ended_at: iteration.llm.ended_at,
-    model: model.id,
+    model: iteration.llm.model,
     code: iteration.code ?? '',
   })
 }

--- a/packages/llmz/src/runtime/generate.ts
+++ b/packages/llmz/src/runtime/generate.ts
@@ -312,11 +312,12 @@ export const generateCode = async ({
           break
         }
 
+        if (chunk.value?.restart && !bufferedDelivery) {
+          streamController.abort('Unexpected LLM stream restart')
+          throw new CognitiveError('LLM stream restarted without options.midStreamFallback enabled')
+        }
+
         if (chunk.value?.restart) {
-          if (!bufferedDelivery) {
-            streamController.abort('Unexpected LLM stream restart')
-            throw new CognitiveError('LLM stream restarted without options.midStreamFallback enabled')
-          }
           traces.push({ type: 'llm_call_restarted', started_at: Date.now(), ...chunk.value.restart })
           raw = ''
           parser = new StreamingMessageParser()

--- a/packages/llmz/src/runtime/types.ts
+++ b/packages/llmz/src/runtime/types.ts
@@ -126,6 +126,13 @@ type Options = Partial<Pick<Context, 'loop' | 'timeout'>> & {
    */
   maxTimeToFirstToken?: number
   /**
+   * Allow Cognitive to restart failed streams on another model. Buffers message
+   * previews, sends, and code execution until generation succeeds; abandoned
+   * attempts deliver nothing. Streaming-only; defaults to false, preserving
+   * progressive sends and early code execution.
+   */
+  midStreamFallback?: boolean
+  /**
    * STT model used to transcribe audio attachments (voice messages) when the
    * target LLM does not support audio natively. Audio-capable models receive
    * the raw audio and ignore this. Defaults to 'fast'.

--- a/packages/llmz/src/types.ts
+++ b/packages/llmz/src/types.ts
@@ -78,6 +78,11 @@ export namespace Traces {
 
   export type LLMCallStart = TraceTemplate<'llm_call_started', { model: string }>
   export type LLMCallSuccess = TraceTemplate<'llm_call_success', { model: string; code: string }>
+  /** Diagnostic only: content and effects from the preceding attempt are discarded. */
+  export type LLMCallRestart = TraceTemplate<
+    'llm_call_restarted',
+    { attempt: number; fromModel: string; toModel: string; reason: string }
+  >
   /**
    * Emitted on streaming clients the moment the model starts writing a `■run`
    * block — before the code is fully generated. Useful to show a
@@ -101,6 +106,7 @@ export namespace Traces {
     | YieldTrace
     | LLMCallStart
     | LLMCallSuccess
+    | LLMCallRestart
     | CodeGenerationStart
     | ThinkSignal
     | CodeExecution


### PR DESCRIPTION
Adds opt-in Cognitive mid-stream fallback to LLMz with buffered delivery, attempt-state resets, and restart traces.

LLMz previously ignored restart chunks and could deliver messages or execute code from an abandoned attempt. With `options.midStreamFallback: true`, previews, sends, and code execution wait for successful generation; default progressive streaming remains unchanged. Cognitive owns the fallback chain, with no additional retry loop in LLMz.

Adds 19 regression tests covering restarts, discarded effects, cancellation, handoff stalls, and option forwarding. All 46 execution tests and 458 tests overall pass; two other suites and typechecking are blocked locally by missing `oxfmt`, and the build by missing `tsdown`. Buffered delivery adds latency and does not guarantee exactly-once effects across delivery failures or caller retries.