### PR TITLE
feat(llmz): stream fallback messages with restart deltas

### DIFF
--- a/packages/llmz/DOCS.md
+++ b/packages/llmz/DOCS.md
@@ -1649,6 +1649,12 @@ Consumer rules:
 
 Outside of fallback (the default), `onMessageDelta` behavior is unchanged: ordinary chunks carry `iterationId`/`id`/`component`/`props`/`delta`/`content` with a single stable message id, and no restart/reset deltas are produced.
 
+#### Completed-send correlation
+
+`Chat.handler(component, metadata)` receives `{ iterationId: string, id: string }` for **every send**, including empty-body and non-text components, without requiring `onMessageDelta`. For streamed messages, `metadata.id` matches the text delta's `id`; it changes across attempts while `iterationId` stays stable. Existing one-argument handlers continue to work.
+
+Record **all** persisted message IDs created while awaiting that handler under its metadata (one component may produce multiple persisted messages). A restart can then retract everything for the matching iteration, even after a message's stream tracking has completed. Non-streaming sends also receive metadata. Tool-yielded messages get unique per-yield IDs and the runtime iteration ID; standalone `Tool.execute` calls without an iteration use their `callId` as the scope.
+
 #### Migrating consumers
 
 - **No final delivery queue**: messages are not withheld until the stream ends. Deltas and completed `handler` sends arrive during generation; drop any "promote on success" design — treat every delivered message as provisional until the iteration completes without a reset.

--- a/packages/llmz/DOCS.md
+++ b/packages/llmz/DOCS.md
@@ -1582,30 +1582,88 @@ await execute({
 
 ---
 
-### Buffered Delivery (midStreamFallback)
+### Mid-Stream Model Fallback (midStreamFallback)
 
-By default, LLMz streams responses: send blocks are dispatched as soon as they are parsed, and the ■run block starts executing while the model is still generating the rest of the response. This gives the lowest time-to-first-token but runs code before the response is complete.
+By default, LLMz streams responses: message bodies (`■send` blocks) and completed `Chat.handler` sends are dispatched as soon as they are produced, and the ■run block starts executing while the model is still generating the rest of the response. This gives the lowest time-to-first-token but runs code before the response is complete.
 
-Set `options.midStreamFallback: true` to allow Cognitive to restart a failed stream on another model safely. LLMz buffers delivery and discards all content from abandoned attempts:
+Set `options.midStreamFallback: true` to allow Cognitive to restart a failed stream on another model. There is **no buffered delivery and no final delivery queue**: with fallback enabled, delta text and completed `Chat.handler` sends both stream immediately during generation. Only **TOOL/CODE execution** waits for a stream to complete successfully. When Cognitive abandons an attempt, a reset-only delta (`restart: true`) is delivered through the existing `Chat.onMessageDelta`; it invalidates **all** messages of the current iteration — **including messages already committed through `handler`** — so consumers must retract and replace them:
 
 ```typescript
 await execute({
   // ...
+  chat: new MyChat({
+    onMessageDelta: (delta) => {
+      if (delta.restart) {
+        // invalidates ALL current-iteration messages, including completed handler
+        // sends: retract/replace them before the replacement streams
+        retractIteration(delta.iterationId)
+      } else {
+        // stream this message's text as it arrives (same iterationId as below)
+        updateMessage(delta)
+      }
+    },
+  }),
   options: { midStreamFallback: true },
 })
 ```
 
-When enabled, the runtime buffers the full generated response and only dispatches it (sends and code execution) once the stream has finished. Trade-offs:
+`retractIteration`/`updateMessage` are placeholder names for your consumer's message store. **This option is not safe to enable blindly**: a reset invalidates messages that were already delivered through `handler`. If your transport cannot retract or replace an already-sent message — an external irreversible send such as SMS, email, or a third-party webhook — those sends cannot be undone, so keep `midStreamFallback` disabled unless your consumer can retract and replace invalidated messages.
 
-- **Latency**: higher time-to-first-send/token, since nothing is delivered until the response completes.
-- **No early code**: the VM is not run mid-stream; code executes only after the full response is parsed.
-- **Cancellation**: cancellation still aborts the original generation request as usual.
+#### MessageDelta contract
+
+`Chat.onMessageDelta` receives a single typed `MessageDelta` discriminated union:
+
+- **Ordinary text chunk** (`restart: false`) — the next piece of one message's body; all fields are required:
+  ```typescript
+  {
+    restart: false,
+    iterationId: string, // stable across ALL attempts of this LLM generation iteration
+    id: string, // message id — DIFFERENT per attempt (unique when fallback is on)
+    component: string,
+    props: Record<string, unknown>, // final by the time the body starts streaming
+    delta: string, // new chunk of body text
+    content: string, // full body text accumulated so far, including this chunk
+  }
+  ```
+- **Reset-only delta** (`restart: true`) — carries no text; signals the current generation attempt was abandoned and a replacement is being attempted:
+  ```typescript
+  {
+    restart: true,
+    iterationId: string, // the iteration whose messages (incl. handler sends) must be retracted/replaced
+    attempt: number,
+    fromModel: string,
+    toModel: string,
+    reason: string,
+  }
+  ```
+
+IDs: `iterationId` is **stable across attempts** — every restart of the same iteration keeps the same `iterationId` — while `id` is **different per attempt**. After a reset, replacement chunks arrive under new `id`s within the same `iterationId`.
+
+Consumer rules:
+
+- On `restart: true`, retract/replace **all** current-iteration messages bearing that `iterationId` — streamed text **and** messages already delivered through `handler`.
+- On an ordinary chunk, update the message for `delta.id` (create it if new, otherwise append).
+- A reset is emitted **before** the replacement output begins, **even if the replacement yields no message at all** — consumers can always rely on it to wipe the previous attempt.
+- A reset only invalidates the messages of its own `iterationId`; it **never** invalidates messages from earlier, completed iterations.
+- Only TOOL/CODE execution is gated on a successful stream: generated code and tool calls never run from an abandoned attempt.
+
+Outside of fallback (the default), `onMessageDelta` behavior is unchanged: ordinary chunks carry `iterationId`/`id`/`component`/`props`/`delta`/`content` with a single stable message id, and no restart/reset deltas are produced.
+
+#### Migrating consumers
+
+- **No final delivery queue**: messages are not withheld until the stream ends. Deltas and completed `handler` sends arrive during generation; drop any "promote on success" design — treat every delivered message as provisional until the iteration completes without a reset.
+- **Retract, don't just clear previews**: on `restart: true`, retraction must cascade to every current-iteration message, including ones already committed through `handler`. If your UI or transport cannot do that, keep `midStreamFallback` disabled.
+- **Clear on errors and cancellation**: a failed or cancelled generation can leave current-iteration messages on screen, incomplete, or unresettable. Explicitly clear/roll back current-iteration state when execution errors or ends — there is no exactly-once guarantee, and caller retries can duplicate effects.
+- **Irreversible transports**: external sends that cannot be undone (SMS, email, webhooks) must not blindly enable fallback without a reset-capable gateway.
+
+#### Caveats
+
 - **No extra retry loop**: Cognitive owns fallback, bounded by the model chain. LLMz does not retry abandoned attempts itself.
-- **Not exactly-once**: abandoned attempts deliver nothing, but successful-attempt callbacks cannot be rolled back if delivery fails or cancellation arrives during delivery. Caller retries can duplicate effects.
+- **Cancellation**: cancellation still aborts the original generation request as usual; consumers must clear current-iteration state on abort (see above). Cancellation deadlines are not reset, and the existing stream inactivity guard remains active during handoffs.
 
-This option defaults to false and applies only to streaming clients. Non-streaming Cognitive requests already fall back transparently. It can be combined with `maxTimeToFirstToken` and `transcriptionModel`; do not enable it globally underneath LLMz without also enabling LLMz's buffering option.
+This option defaults to false and applies only to streaming clients. Non-streaming Cognitive requests already fall back transparently. It can be combined with `maxTimeToFirstToken` and `transcriptionModel`; do not enable it globally underneath LLMz without also enabling LLMz's fallback option and a reset-capable consumer.
 
-Restarts emit `llm_call_restarted` traces with the attempt, source/destination models, and reason. Token timings remain relative to the original request and describe the surviving attempt (including time spent on prior attempts). Usage and cost retain Cognitive's final reported metadata; LLMz does not infer or sum abandoned-attempt billing. Cancellation deadlines are not reset, and the existing stream inactivity guard remains active during handoffs.
+Restarts emit `llm_call_restarted` traces with the attempt, source/destination models, and reason. Token timings remain relative to the original request and describe the surviving attempt (including time spent on prior attempts). Usage and cost retain Cognitive's final reported metadata; LLMz does not infer or sum abandoned-attempt billing.
 
 ## API Reference
 

--- a/packages/llmz/DOCS.md
+++ b/packages/llmz/DOCS.md
@@ -1596,7 +1596,7 @@ await execute({
       if (delta.restart) {
         // invalidates ALL current-iteration messages, including completed handler
         // sends: retract/replace them before the replacement streams
-        retractIteration(delta.iterationId)
+        return retractIteration(delta.iterationId)
       } else {
         // stream this message's text as it arrives (same iterationId as below)
         updateMessage(delta)
@@ -1643,7 +1643,7 @@ Consumer rules:
 
 - On `restart: true`, retract/replace **all** current-iteration messages bearing that `iterationId` — streamed text **and** messages already delivered through `handler`.
 - On an ordinary chunk, update the message for `delta.id` (create it if new, otherwise append).
-- A reset is emitted **before** the replacement output begins, **even if the replacement yields no message at all** — consumers can always rely on it to wipe the previous attempt.
+- A reset is emitted and awaited **before** replacement output begins, **even if the replacement yields no message at all**. Return/await the retraction promise in your handler. If it throws or rejects, generation fails without delivering replacement output or executing code; ordinary text-preview errors remain best-effort.
 - A reset only invalidates the messages of its own `iterationId`; it **never** invalidates messages from earlier, completed iterations.
 - Only TOOL/CODE execution is gated on a successful stream: generated code and tool calls never run from an abandoned attempt.
 

--- a/packages/llmz/package.json
+++ b/packages/llmz/package.json
@@ -2,7 +2,7 @@
   "name": "llmz",
   "type": "module",
   "description": "LLMz - An LLM-native Typescript VM built on top of Zui",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "files": [
     "dist",
     "DOCS.md"

--- a/packages/llmz/src/chat.ts
+++ b/packages/llmz/src/chat.ts
@@ -25,7 +25,15 @@ import { TranscriptArray, Transcript } from './transcript.js'
  * }
  * ```
  */
-export type MessageHandler = (input: RenderedComponent) => Promise<void> | void
+/** Correlates every generated send with its deltas and restart scope. */
+export type MessageMetadata = {
+  /** Stable across generation attempts; standalone tool calls use their callId. */
+  iterationId: string
+  /** Logical send ID; matches MessageDelta.id when text deltas exist. Unique across attempts. */
+  id: string
+}
+
+export type MessageHandler = (input: RenderedComponent, metadata: MessageMetadata) => Promise<void> | void
 
 /**
  * A chunk of a message body streamed live from the LLM, before the message is complete.

--- a/packages/llmz/src/chat.ts
+++ b/packages/llmz/src/chat.ts
@@ -34,21 +34,40 @@ export type MessageHandler = (input: RenderedComponent) => Promise<void> | void
  * Each chunk is forwarded to {@link Chat} `onMessageDelta` as soon as it is parsed, so the
  * client can render the message progressively (e.g. typewriter effect in a chat UI).
  *
- * The complete message is always delivered to the regular `handler` afterwards — deltas
- * are a progressive preview, the `handler` call remains the authoritative delivery.
+ * In mid-stream fallback mode, both deltas and completed `handler` messages
+ * are live and retractable: restart deltas invalidate every message from that
+ * iteration. Consumers must retract them; only code execution waits for success.
  */
-export type MessageDelta = {
-  /** Identifies the message being streamed. Unique within an `execute()` call. */
-  id: string
-  /** Component name of the message being streamed (e.g. 'message', 'button'). */
-  component: string
-  /** Props of the message being streamed. Final by the time the body starts streaming. */
-  props: Record<string, unknown>
-  /** The new chunk of body text. */
-  delta: string
-  /** The full body text accumulated so far, including this chunk. */
-  content: string
-}
+export type MessageDelta =
+  | {
+      restart: false
+      /** Generation whose provisional messages must be cleared on a restart. */
+      iterationId: string
+      /** Identifies the message being streamed. Unique within an `execute()` call. */
+      id: string
+      /** Component name of the message being streamed (e.g. 'message', 'button'). */
+      component: string
+      /** Props of the message being streamed. Final by the time the body starts streaming. */
+      props: Record<string, unknown>
+      /** The new chunk of body text. */
+      delta: string
+      /** The full body text accumulated so far, including this chunk. */
+      content: string
+    }
+  | {
+      /**
+       * Reset-only delta, emitted before replacement text (even if none follows).
+       * Clear ALL messages for iterationId, including completed `handler` sends.
+       * Other iterations are unaffected. Irreversible sends cannot be undone.
+       */
+      restart: true
+      iterationId: string
+      /** 1-based index of the new attempt. */
+      attempt: number
+      fromModel: string
+      toModel: string
+      reason: string
+    }
 
 /**
  * Function type for handling message chunks as they are streamed from the LLM.

--- a/packages/llmz/src/chat.ts
+++ b/packages/llmz/src/chat.ts
@@ -79,7 +79,8 @@ export type MessageDelta =
 
 /**
  * Function type for handling message chunks as they are streamed from the LLM.
- * Errors thrown by this handler are ignored — streaming previews are best-effort.
+ * Text-preview errors are ignored. Restart-handler errors stop generation:
+ * replacement output must not be delivered if retraction fails.
  */
 export type MessageDeltaHandler = (delta: MessageDelta) => Promise<void> | void
 

--- a/packages/llmz/src/context.ts
+++ b/packages/llmz/src/context.ts
@@ -680,8 +680,14 @@ export class Context implements Serializable<Context.JSON> {
    */
   public maxTimeToFirstToken?: number
   /**
-   * Allow Cognitive mid-stream fallback, buffering delivery until generation
-   * succeeds and discarding abandoned attempts. Streaming-only; defaults to false.
+   * Allow Cognitive to restart a failed stream on another model. With fallback
+   * enabled, there is no buffered delivery and no final delivery queue: delta
+   * text and completed Chat.handler sends stream immediately during generation.
+   * A reset-only delta (restart: true) on Chat.onMessageDelta invalidates ALL
+   * current-iteration messages, including completed sends — consumers must
+   * retract/replace them, which is unsafe for irreversible external transports.
+   * Only TOOL/CODE execution waits for a successful stream. Streaming-only;
+   * defaults to false, which leaves progressive sending unchanged.
    */
   public midStreamFallback?: boolean
   /**

--- a/packages/llmz/src/index.ts
+++ b/packages/llmz/src/index.ts
@@ -22,7 +22,7 @@ export {
 export { type Citation, CitationsManager } from './citations.js'
 export { DefaultComponents } from './component.default.js'
 export { Snapshot } from './snapshots.js'
-export { Chat, type MessageHandler, type MessageDelta, type MessageDeltaHandler } from './chat.js'
+export { Chat, type MessageHandler, type MessageMetadata, type MessageDelta, type MessageDeltaHandler } from './chat.js'
 
 import { ExecutionResult } from './result.js'
 import { type ExecutionProps } from './runtime/types.js'

--- a/packages/llmz/src/runtime/execute.test.ts
+++ b/packages/llmz/src/runtime/execute.test.ts
@@ -2,10 +2,11 @@ import { CognitiveMetadata, CognitiveResponse, CognitiveStreamChunk, Model } fro
 import { z } from '@bpinternal/zui'
 import { describe, expect, test, vi } from 'vitest'
 
-import { Chat, MessageDelta } from '../chat.js'
+import { Chat, MessageDelta, MessageMetadata } from '../chat.js'
 import { DefaultComponents } from '../component.default.js'
 import { RenderedComponent } from '../component.js'
 import { ListenExit } from '../context.js'
+import { createJsxComponent } from '../jsx.js'
 import { CognitiveError } from '../errors.js'
 import { Exit } from '../exit.js'
 import { ErrorExecutionResult, SuccessExecutionResult } from '../result.js'
@@ -1553,5 +1554,160 @@ describe('message-stream protocol execution', () => {
       expect(received?.options?.midStreamFallback).toBe(true)
       expect(received?.options?.transcriptionModel).toBe('fast')
     })
+  })
+})
+
+describe('Chat.handler message metadata', () => {
+  type Sent = { type: string; metadata: MessageMetadata }
+
+  /** Chat whose handler captures the new second metadata argument. */
+  const makeMetadataChat = (onMessageDelta?: (delta: MessageDelta) => Promise<void> | void) => {
+    const sent: Sent[] = []
+    const chat = new Chat({
+      components: [DefaultComponents.Text, DefaultComponents.Button],
+      transcript: [{ role: 'user', content: 'hello', name: 'user' }],
+      handler: async (component: RenderedComponent, metadata: MessageMetadata) => {
+        sent.push({ type: component.type, metadata })
+      },
+      onMessageDelta,
+    })
+    return { chat, sent }
+  }
+
+  test('tool-yielded messages also receive unique ids scoped to the runtime iteration', async () => {
+    const { chat, sent } = makeMetadataChat()
+    const notify = new Tool({
+      name: 'notify',
+      description: 'Emits two messages',
+      handler: async function* () {
+        yield createJsxComponent({ type: 'MESSAGE', props: {}, children: ['One'] })
+        yield createJsxComponent({ type: 'MESSAGE', props: {}, children: ['Two'] })
+      },
+    })
+    const client = new ScriptedStreamingCognitive(['■run\nawait notify()\n■next=listen'])
+    const result = await executeContext({ client, chat, tools: [notify], options: { loop: 1 } })
+    expect(result).toBeInstanceOf(SuccessExecutionResult)
+    expect(sent).toHaveLength(2)
+    expect(new Set(sent.map(({ metadata }) => metadata.id)).size).toBe(2)
+    expect(sent.every(({ metadata }) => metadata.iterationId === result.iterations[0]!.id)).toBe(true)
+  })
+
+  test('streaming: a completed send shares its ids with the text deltas for the same component', async () => {
+    const deltas: MessageDelta[] = []
+    const { chat, sent } = makeMetadataChat((delta) => {
+      deltas.push(delta)
+    })
+    const client = new ScriptedStreamingCognitive([
+      '■send=message\nFirst message!\n■send=message\nSecond message!\n■next=listen',
+    ])
+
+    await executeContext({ client, chat, options: { loop: 3 } })
+
+    const text = textDeltas(deltas)
+    const deltaIds = [...new Set(text.map((d) => d.id))]
+    expect(deltaIds).toHaveLength(2)
+
+    // the consumer persists under both the delta id and the handler metadata
+    // id (two records, one per message) — both must point at the same send
+    expect(sent.map((s) => s.metadata.id)).toEqual(deltaIds)
+    expect(new Set(sent.map((s) => s.metadata.id)).size).toBe(2)
+    expect(sent.every((s) => s.metadata.iterationId === text[0]!.iterationId)).toBe(true)
+  })
+
+  test('components without body text get handler metadata even though no deltas stream', async () => {
+    const deltas: MessageDelta[] = []
+    const { chat, sent } = makeMetadataChat((delta) => {
+      deltas.push(delta)
+    })
+    const client = new ScriptedStreamingCognitive([
+      '■send=button { label: "Buy", action: "postback", value: "buy" }\n■next=listen',
+    ])
+
+    await executeContext({ client, chat, options: { loop: 3 } })
+
+    // a prop-only component has no body characters, so no deltas are emitted
+    expect(textDeltas(deltas)).toEqual([])
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.type).toBe('BUTTON')
+    expect(sent[0]!.metadata.id.startsWith(`${sent[0]!.metadata.iterationId}:`)).toBe(true)
+    expect(sent[0]!.metadata.iterationId.length).toBeGreaterThan(0)
+  })
+
+  test('handler metadata flows even when onMessageDelta is not registered', async () => {
+    const { chat, sent } = makeMetadataChat()
+    const client = new ScriptedStreamingCognitive(['■send=message\nStill metadated!\n■next=listen'])
+
+    await executeContext({ client, chat, options: { loop: 3 } })
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.metadata.id.startsWith(`${sent[0]!.metadata.iterationId}:`)).toBe(true)
+    expect(sent[0]!.metadata.id).not.toBe(sent[0]!.metadata.iterationId)
+  })
+
+  test('across a fallback restart handler ids are attempt-specific while the iteration id stays stable', async () => {
+    const { chat, sent } = makeMetadataChat(() => {})
+    const client = new ScriptedRestartStreamingCognitive([
+      '■send=message\nAbandoned!\n■next=listen',
+      '■send=message\nSurvivor!\n■next=listen',
+    ])
+
+    await executeContext({ client, chat, options: midStreamOptions(3) })
+
+    expect(sent).toHaveLength(2)
+    // fallback ids embed the attempt: :1: for the abandoned, :2: for the survivor
+    expect(sent[0]!.metadata.id.includes(':1:')).toBe(true)
+    expect(sent[1]!.metadata.id.includes(':2:')).toBe(true)
+    expect(sent[0]!.metadata.id).not.toBe(sent[1]!.metadata.id)
+    // one stable iteration id across both attempts
+    expect(new Set(sent.map((s) => s.metadata.iterationId)).size).toBe(1)
+  })
+
+  test('non-streaming sends get unique send-index metadata ids', async () => {
+    const { chat, sent } = makeMetadataChat()
+    const client = new ScriptedCognitive([
+      '■send=message\nOne!\n■send=message\nTwo!\n■send=button { label: "Go", action: "say", value: "go" }\n■next=listen',
+    ])
+
+    await executeContext({ client, chat, options: { loop: 3 } })
+
+    expect(sent).toHaveLength(3)
+    expect(new Set(sent.map((s) => s.metadata.id)).size).toBe(3)
+    const iterationId = sent[0]!.metadata.iterationId
+    expect(sent.map((s) => s.metadata.id)).toEqual([
+      `${iterationId}:send-0`,
+      `${iterationId}:send-1`,
+      `${iterationId}:send-2`,
+    ])
+  })
+
+  test('handler deliveries are awaited: abandoned and replacement sends settle in stream order across a restart', async () => {
+    const events: string[] = []
+    const chat = new Chat({
+      components: [DefaultComponents.Text],
+      transcript: [{ role: 'user', content: 'hello', name: 'user' }],
+      handler: async (_component: RenderedComponent, metadata: MessageMetadata) => {
+        // simulate slow persistence: the runtime must await it before moving on
+        await new Promise<void>((resolve) => setTimeout(resolve, 10))
+        events.push(`handler:${metadata.id}`)
+      },
+      onMessageDelta: (delta) => {
+        events.push(delta.restart ? 'reset' : `delta:${delta.id}`)
+      },
+    })
+    const client = new ScriptedRestartStreamingCognitive([
+      '■send=message\nAbandoned!\n■next=listen',
+      '■send=message\nSurvivor!\n■next=listen',
+    ])
+
+    await executeContext({ client, chat, options: midStreamOptions(3) })
+
+    const handlerEvents = events.filter((e) => e.startsWith('handler:')).map((e) => e.slice('handler:'.length))
+    expect(handlerEvents).toHaveLength(2)
+    expect(handlerEvents[0]).not.toBe(handlerEvents[1])
+
+    // the abandoned send's handler settled before the reset delta was emitted,
+    // and the survivor's after it — every delivery is awaited in stream order
+    expect(events.indexOf('reset')).toBeGreaterThan(events.indexOf(`handler:${handlerEvents[0]}`))
+    expect(events.indexOf('reset')).toBeLessThan(events.indexOf(`handler:${handlerEvents[1]}`))
   })
 })

--- a/packages/llmz/src/runtime/execute.test.ts
+++ b/packages/llmz/src/runtime/execute.test.ts
@@ -1364,45 +1364,51 @@ describe('message-stream protocol execution', () => {
       expect([...current.values()]).toEqual(['Kept!'])
     })
 
-    test('restart delta errors are best effort and the reset precedes replacement previews', async () => {
-      const events: string[] = []
-      const seenMessageIds = new Set<string>()
-      let resetDelivered = false
-      let replacementResumedAfterReset = false
-      const { chat, messages } = makeChat((delta) => {
-        if (delta.restart) {
-          resetDelivered = true
-          events.push(`reset:${delta.attempt}`)
-        } else {
-          // the replacement attempt streams fresh message ids, so the first
-          // unseen id proves the reset side effects ran before this preview
-          if (resetDelivered && !seenMessageIds.has(delta.id)) {
-            replacementResumedAfterReset = true
+    test.each(['sync', 'async'] as const)(
+      'a %s restart handler failure stops replacement delivery and execution',
+      async (mode) => {
+        const events: string[] = []
+        const { chat, messages } = makeChat((delta) => {
+          if (delta.restart) {
+            events.push('reset')
+            if (mode === 'async') {
+              return Promise.resolve().then(() => {
+                throw new Error('retraction failed')
+              })
+            }
+            throw new Error('retraction failed')
           }
-          seenMessageIds.add(delta.id)
-          events.push(`text:${delta.id}`)
-        }
-        // callback errors are best-effort: they must neither fail the run nor
-        // prevent the restart control delta from being delivered
-        throw new Error('preview handler boom')
-      })
+          events.push('text')
+          // Text-preview errors still allow the first completed send through.
+          throw new Error('preview failed')
+        })
+        let ran = false
+        const mark = new Tool({
+          name: 'mark',
+          description: 'Side effect',
+          handler: async () => {
+            ran = true
+          },
+        })
+        const client = new ScriptedRestartStreamingCognitive([
+          '■send=message\nAbandoned!\n■run\nawait mark()\n■next=listen',
+          '■send=message\nReplacement!\n■run\nawait mark()\n■next=listen',
+        ])
+        const result = await executeContext({ client, chat, tools: [mark], options: midStreamOptions(3) })
 
-      const client = new ScriptedRestartStreamingCognitive([
-        '■send=message\nAbandoned!\n■next=listen',
-        '■send=message\nKept!\n■next=listen',
-      ])
-      const result = await executeContext({ client, chat, options: midStreamOptions(3) })
-
-      expect(result).toBeInstanceOf(SuccessExecutionResult)
-      expect((result as SuccessExecutionResult).result.exit.name).toBe(ListenExit.name)
-      expect(messages.map((m) => m.text)).toEqual(['Abandoned!', 'Kept!'])
-
-      // the control delta was delivered (and its side effects ran) before any
-      // replacement preview, even though every callback threw
-      expect(resetDelivered).toBe(true)
-      expect(replacementResumedAfterReset).toBe(true)
-      expect(events.filter((event) => event.startsWith('reset:'))).toHaveLength(1)
-    })
+        expect(result).toBeInstanceOf(ErrorExecutionResult)
+        expect((result as ErrorExecutionResult).error).toBeInstanceOf(CognitiveError)
+        expect(((result as ErrorExecutionResult).error as Error).message).toContain(
+          'restart handler failed: retraction failed'
+        )
+        expect(result.iterations).toHaveLength(1)
+        expect(messages.map((m) => m.text)).toEqual(['Abandoned!'])
+        expect(events).toContain('text')
+        expect(events.filter((event) => event === 'reset')).toHaveLength(1)
+        expect(events.at(-1)).toBe('reset')
+        expect(ran).toBe(false)
+      }
+    )
 
     test('metadata from an abandoned attempt does not satisfy a metadata-less replacement', async () => {
       const { chat, messages } = makeChat()

--- a/packages/llmz/src/runtime/execute.test.ts
+++ b/packages/llmz/src/runtime/execute.test.ts
@@ -159,8 +159,8 @@ class ScriptedRestartStreamingCognitive extends ScriptedCognitive {
 /**
  * Streams one chunk, then waits for the stream's abort signal before throwing —
  * mimicking a real HTTP-backed client whose stream dies when its AbortController
- * fires. Used to prove that cancelling a mid-stream-fallback generation never
- * flushes buffered content.
+ * fires. Used to prove that cancelling a mid-stream-fallback generation keeps
+ * whatever the parser completed before the transport died.
  */
 class ScriptedAbortAwareCognitive extends ScriptedCognitive {
   public async *generateTextStream(
@@ -213,6 +213,14 @@ const makeChat = (onMessageDelta?: (delta: MessageDelta) => Promise<void> | void
   })
   return { chat, messages }
 }
+
+/** Text-delta members of a delta sequence (never control deltas). */
+type TextDelta = Extract<MessageDelta, { restart: false }>
+const textDeltas = (deltas: MessageDelta[]): TextDelta[] => deltas.filter((d): d is TextDelta => !d.restart)
+
+/** Restart-control members of a delta sequence (`restart: true`). */
+type RestartDelta = Extract<MessageDelta, { restart: true }>
+const restartDeltas = (deltas: MessageDelta[]): RestartDelta[] => deltas.filter((d): d is RestartDelta => d.restart)
 
 describe('message-stream protocol execution', () => {
   test('a message-only response sends the message and listens', async () => {
@@ -427,11 +435,16 @@ describe('message-stream protocol execution', () => {
     expect(messages.map((m) => m.text)).toEqual(['This is a fairly long streamed message body!'])
 
     // the body was delivered progressively, chunk by chunk
-    expect(deltas.length).toBeGreaterThan(1)
-    expect(deltas.map((d) => d.delta).join('')).toBe('This is a fairly long streamed message body!')
-    expect(deltas.at(-1)!.content).toBe('This is a fairly long streamed message body!')
-    expect(new Set(deltas.map((d) => d.id)).size).toBe(1)
-    expect(deltas.every((d) => d.component === 'message')).toBe(true)
+    const text = textDeltas(deltas)
+    expect(text.length).toBeGreaterThan(1)
+    expect(text.map((d) => d.delta).join('')).toBe('This is a fairly long streamed message body!')
+    expect(text.at(-1)!.content).toBe('This is a fairly long streamed message body!')
+    expect(new Set(text.map((d) => d.id)).size).toBe(1)
+    expect(text.every((d) => d.component === 'message')).toBe(true)
+
+    // default (no fallback): one message, one stable iteration id, no control deltas
+    expect(new Set(text.map((d) => d.iterationId)).size).toBe(1)
+    expect(restartDeltas(deltas)).toEqual([])
 
     // deltas were flowing while the stream was still in flight
     expect(client.probes.slice(0, -1).some((count) => count >= 1)).toBe(true)
@@ -752,7 +765,7 @@ describe('message-stream protocol execution', () => {
   })
 
   describe('options.midStreamFallback', () => {
-    test('buffers messages until the stream completes', async () => {
+    test('sends are delivered immediately even with midStreamFallback enabled', async () => {
       const { chat, messages } = makeChat()
       const client = new ScriptedStreamingCognitive(
         ['■send=message\nBuffered hello!\n■send=message\nBuffered second\n■next=listen'],
@@ -765,11 +778,12 @@ describe('message-stream protocol execution', () => {
       expect((result as SuccessExecutionResult).result.exit.name).toBe(ListenExit.name)
       expect(messages.map((m) => m.text)).toEqual(['Buffered hello!', 'Buffered second'])
 
-      // nothing was delivered while the stream was still in flight
-      expect(client.probes.slice(0, -1).every((count) => count === 0)).toBe(true)
+      // there is no delivery queue: the first authoritative send reached the
+      // chat while the stream was still in flight
+      expect(client.probes.slice(0, -1).some((count) => count >= 1)).toBe(true)
     })
 
-    test('buffers message deltas until the stream completes', async () => {
+    test('previews stream immediately even with midStreamFallback enabled', async () => {
       const deltas: MessageDelta[] = []
       const { chat, messages } = makeChat((delta) => {
         deltas.push(delta)
@@ -786,13 +800,16 @@ describe('message-stream protocol execution', () => {
       expect(result).toBeInstanceOf(SuccessExecutionResult)
       expect(messages.map((m) => m.text)).toEqual(['This is a fairly long streamed message body!'])
 
-      // the body was replayed in order once the stream completed
-      expect(deltas.length).toBeGreaterThan(1)
-      expect(deltas.map((d) => d.delta).join('')).toBe('This is a fairly long streamed message body!')
-      expect(new Set(deltas.map((d) => d.id)).size).toBe(1)
+      // previews are no longer buffered: the body arrived progressively, chunk by chunk
+      const text = textDeltas(deltas)
+      expect(text.length).toBeGreaterThan(1)
+      expect(text.map((d) => d.delta).join('')).toBe('This is a fairly long streamed message body!')
+      expect(new Set(text.map((d) => d.id)).size).toBe(1)
+      expect(new Set(text.map((d) => d.iterationId)).size).toBe(1)
+      expect(restartDeltas(deltas)).toEqual([])
 
-      // nothing streamed to the client while the model was still generating
-      expect(client.probes.slice(0, -1).every((count) => count === 0)).toBe(true)
+      // and the previews reached the client while the model was still generating
+      expect(client.probes.slice(0, -1).some((count) => count >= 1)).toBe(true)
     })
 
     test('disables early code execution', async () => {
@@ -826,7 +843,7 @@ describe('message-stream protocol execution', () => {
       expect(client.probes.every((value) => value === 0)).toBe(true)
     })
 
-    test('content streamed before a restart never reaches the chat', async () => {
+    test("sends completed before a restart stay delivered (retraction is the consumer's job)", async () => {
       const { chat, messages } = makeChat()
       // first attempt: a completed ■send and a second ■send cut off mid-body
       const client = new ScriptedRestartStreamingCognitive([
@@ -837,7 +854,11 @@ describe('message-stream protocol execution', () => {
       const result = await executeContext({ client, chat, options: midStreamOptions(3) })
 
       expect(result).toBeInstanceOf(SuccessExecutionResult)
-      expect(messages.map((m) => m.text)).toEqual(['Kept!'])
+      // the completed send was committed before the restart; the mid-body second
+      // send never completed, and the restart resets the parser state so it is
+      // dropped — already-sent messages are retracted by consumers via the
+      // restart delta (clearPreview), not by the runtime
+      expect(messages.map((m) => m.text)).toEqual(['Abandoned!', 'Kept!'])
     })
 
     test('an unexpected restart throws a CognitiveError when fallback is disabled', async () => {
@@ -902,10 +923,12 @@ describe('message-stream protocol execution', () => {
       const result = await executeContext({ client, tools: [mark], exits: [done], options: midStreamOptions(1) })
       expect(result).toBeInstanceOf(SuccessExecutionResult)
       expect(ran).toEqual(['replacement'])
-      expect(result.iterations[0]!.traces.filter((trace) => trace.type === 'code_generation_started')).toHaveLength(1)
+      // the trace fires immediately per attempt (never buffered until success):
+      // the abandoned ■run and the replacement ■run each emit one
+      expect(result.iterations[0]!.traces.filter((trace) => trace.type === 'code_generation_started')).toHaveLength(2)
     })
 
-    test('cancellation after the last chunk but before commit drops all buffered effects', async () => {
+    test('cancellation still fails the run but the committed send stays delivered', async () => {
       const controller = new AbortController()
       class CancelOnCompletion extends ScriptedStreamingCognitive {
         public override async *generateTextStream(): AsyncGenerator<CognitiveStreamChunk, void, unknown> {
@@ -920,11 +943,19 @@ describe('message-stream protocol execution', () => {
       const client = new CancelOnCompletion(['■send=message\nBuffered\n■next=listen'])
       const result = await executeContext({ client, chat, signal: controller.signal, options: midStreamOptions(1) })
       expect(result).toBeInstanceOf(ErrorExecutionResult)
-      expect(messages).toEqual([])
-      expect(deltas).toEqual([])
+      // the send completed while the stream was still in flight; the terminal
+      // abort fails the run but does not revoke already-delivered content
+      expect(messages.map((m) => m.text)).toEqual(['Buffered'])
+      // previews were streamed live alongside the committed send
+      expect(
+        textDeltas(deltas)
+          .map((d) => d.delta)
+          .join('')
+      ).toBe('Buffered')
+      expect(restartDeltas(deltas)).toEqual([])
     })
 
-    test('multiple restarts discard everything streamed before the last attempt', async () => {
+    test('multiple restarts keep every completed send; previews retract to the survivor', async () => {
       const { chat, messages } = makeChat()
       const client = new ScriptedRestartStreamingCognitive([
         '■send=message\nFirst attempt\n■next=listen',
@@ -935,7 +966,10 @@ describe('message-stream protocol execution', () => {
       const result = await executeContext({ client, chat, options: midStreamOptions(3) })
 
       expect(result).toBeInstanceOf(SuccessExecutionResult)
-      expect(messages.map((m) => m.text)).toEqual(['Final!'])
+      // each attempt sent immediately as it was parsed; the runtime keeps what
+      // it already delivered and consumers retract previews per iteration on
+      // each restart delta
+      expect(messages.map((m) => m.text)).toEqual(['First attempt', 'Second attempt', 'Final!'])
     })
 
     test.each(['```', '```\n■send=message\nAbandoned!\n', '■send=button { "label":'])(
@@ -953,7 +987,7 @@ describe('message-stream protocol execution', () => {
       }
     )
 
-    test('a restart whose replacement stream ends without metadata dispatches nothing', async () => {
+    test('a metadata-less replacement fails but its completed sends stay delivered', async () => {
       const cases = [
         // the stream simply runs dry after the replacement content
         null,
@@ -964,7 +998,7 @@ describe('message-stream protocol execution', () => {
       for (const finalChunk of cases) {
         const { chat, messages } = makeChat()
         const client = new ScriptedRestartStreamingCognitive(
-          ['■send=message\nAbandoned!\n■next=listen', '■send=message\nStill buffered\n■next=listen'],
+          ['■send=message\nAbandoned!\n■next=listen', '■send=message\nStill sent\n■next=listen'],
           () => 0,
           7,
           finalChunk
@@ -976,13 +1010,18 @@ describe('message-stream protocol execution', () => {
         const error = (result as ErrorExecutionResult).error
         expect(error).toBeInstanceOf(CognitiveError)
         expect((error as Error).message).toContain('without metadata')
-        expect(messages).toEqual([])
+        // sends parsed before the metadata failure were committed immediately;
+        // unfinished trailing blocks are dropped because parser.finish() never runs
+        expect(messages.map((m) => m.text)).toEqual(['Abandoned!', 'Still sent'])
       }
     })
 
-    test('cancelling the stream never dispatches buffered content', async () => {
+    test('cancelling mid-stream keeps the already completed send', async () => {
       const guard = new AbortController()
-      const { chat, messages } = makeChat()
+      const deltas: MessageDelta[] = []
+      const { chat, messages } = makeChat((delta) => {
+        deltas.push(delta)
+      })
       const client = new ScriptedAbortAwareCognitive(['■send=message\nAbandoned!\n■next=listen'])
 
       const execution = executeContext({ client, chat, signal: guard.signal, options: midStreamOptions(3) })
@@ -994,12 +1033,21 @@ describe('message-stream protocol execution', () => {
 
       expect(result).toBeInstanceOf(ErrorExecutionResult)
       expect((result as ErrorExecutionResult).error).toMatchObject({ message: 'cancelled' })
-      expect(messages).toEqual([])
+      // the send item completed (■next opened) before the abort: it stays
+      // committed even though the run fails terminally
+      expect(messages.map((m) => m.text)).toEqual(['Abandoned!'])
       expect(result.iterations[0]!.status.type).toBe('aborted')
+
+      // the preview that streamed before the abort is left in place (best effort)
+      expect(textDeltas(deltas).some((d) => d.delta.includes('Abandoned!'))).toBe(true)
+      expect(restartDeltas(deltas)).toEqual([])
     })
 
-    test('a stream error after buffered sends and runs delivers nothing', async () => {
-      const { chat, messages } = makeChat()
+    test('a stream error delivers completed sends but never abandoned code', async () => {
+      const deltas: MessageDelta[] = []
+      const { chat, messages } = makeChat((delta) => {
+        deltas.push(delta)
+      })
       let ran = false
       const mark = new Tool({
         name: 'mark',
@@ -1020,9 +1068,339 @@ describe('message-stream protocol execution', () => {
       expect((result as ErrorExecutionResult).error).toBeInstanceOf(CognitiveError)
       expect(((result as ErrorExecutionResult).error as Error).message).toContain('LLM generation failed')
 
-      // Buffered delivery commits only after a successful stream: no effects leak
-      expect(messages).toEqual([])
+      // the ■send was committed as soon as it was parsed; the ■run's tool never
+      // executed because tool execution stays deferred until the stream succeeds
+      expect(
+        textDeltas(deltas)
+          .map((d) => d.delta)
+          .join('')
+      ).toBe('Buffered!')
+      expect(messages.map((m) => m.text)).toEqual(['Buffered!'])
       expect(ran).toBe(false)
+    })
+
+    test('a restart delta is emitted even when the replacement attempt has no send', async () => {
+      const deltas: MessageDelta[] = []
+      const ran: string[] = []
+      const mark = new Tool({
+        name: 'mark',
+        description: 'Records the attempt',
+        input: z.object({ attempt: z.string() }),
+        handler: async ({ attempt }) => {
+          ran.push(attempt)
+        },
+      })
+      const done = new Exit({ name: 'done', description: 'Done' })
+      const { chat, messages } = makeChat((delta) => {
+        deltas.push(delta)
+      })
+      const client = new ScriptedRestartStreamingCognitive([
+        '■send=message\nAbandoned!\n■next=listen',
+        '■run\nawait mark({ attempt: "replacement" })\n■next=done',
+      ])
+      const result = await executeContext({ client, chat, tools: [mark], exits: [done], options: midStreamOptions(1) })
+
+      expect(result).toBeInstanceOf(SuccessExecutionResult)
+      expect((result as SuccessExecutionResult).result.exit.name).toBe('done')
+      // only the abandoned attempt's send was committed (immediately as parsed);
+      // the replacement attempt only runs code
+      expect(messages.map((m) => m.text)).toEqual(['Abandoned!'])
+      expect(ran).toEqual(['replacement'])
+
+      const restarts = restartDeltas(deltas)
+      expect(restarts).toHaveLength(1)
+      expect(restarts[0]).toMatchObject({
+        restart: true,
+        attempt: 2,
+        fromModel: 'fake',
+        toModel: 'fake',
+        reason: 'timeout',
+      })
+      expect(typeof restarts[0]!.iterationId).toBe('string')
+    })
+
+    test('a restart delta is emitted even when the replacement attempt fails', async () => {
+      const deltas: MessageDelta[] = []
+      const { chat, messages } = makeChat((delta) => {
+        deltas.push(delta)
+      })
+      // the replacement attempt runs dry without metadata: the generation fails,
+      // but the restart control delta was already delivered
+      const client = new ScriptedRestartStreamingCognitive(
+        ['■send=message\nAbandoned!\n■next=listen', '■send=message\nStill buffered\n■next=listen'],
+        () => 0,
+        7,
+        null
+      )
+      const result = await executeContext({ client, chat, options: midStreamOptions(3) })
+
+      expect(result).toBeInstanceOf(ErrorExecutionResult)
+      const error = (result as ErrorExecutionResult).error
+      expect(error).toBeInstanceOf(CognitiveError)
+      expect((error as Error).message).toContain('without metadata')
+      // both attempts' completed sends were committed before the failure
+      expect(messages.map((m) => m.text)).toEqual(['Abandoned!', 'Still buffered'])
+
+      const restarts = restartDeltas(deltas)
+      expect(restarts).toHaveLength(1)
+      expect(restarts[0]).toMatchObject({
+        restart: true,
+        attempt: 2,
+        fromModel: 'fake',
+        toModel: 'fake',
+        reason: 'timeout',
+      })
+    })
+
+    test('renderers reset their preview when restart deltas arrive (multiple sends, multiple restarts)', async () => {
+      // A minimal renderer: previews accumulate per message id inside a bucket
+      // per generation. A restart tells the renderer the whole generation is
+      // void, so it clears the bucket for that iteration — not just the latest
+      // message — while tracking each message id separately.
+      const events: Array<
+        { kind: 'text'; id: string; iterationId: string } | { kind: 'restart'; attempt: number; iterationId: string }
+      > = []
+      const previews = new Map<string, Map<string, string>>()
+      const resets: number[] = []
+      const { chat, messages } = makeChat((delta) => {
+        if (delta.restart) {
+          resets.push(delta.attempt)
+          events.push({ kind: 'restart', attempt: delta.attempt, iterationId: delta.iterationId })
+          previews.delete(delta.iterationId)
+        } else {
+          let iterationPreviews = previews.get(delta.iterationId)
+          if (iterationPreviews === undefined) {
+            previews.set(delta.iterationId, (iterationPreviews = new Map()))
+          }
+          iterationPreviews.set(delta.id, (iterationPreviews.get(delta.id) ?? '') + delta.delta)
+          events.push({ kind: 'text', id: delta.id, iterationId: delta.iterationId })
+        }
+      })
+      const client = new ScriptedRestartStreamingCognitive([
+        '■send=message\nAbandoned!\n■send=message\nBeta abandoned\n■next=listen',
+        '■send=message\nMid attempt\n■next=listen',
+        '■send=message\nDelta!\n■next=listen',
+      ])
+
+      const result = await executeContext({ client, chat, options: midStreamOptions(3) })
+
+      expect(result).toBeInstanceOf(SuccessExecutionResult)
+      expect((result as SuccessExecutionResult).result.exit.name).toBe(ListenExit.name)
+
+      const restartAt = events
+        .map((event, index) => (event.kind === 'restart' ? index : -1))
+        .filter((index) => index !== -1)
+      expect(restartAt).toHaveLength(2)
+      const firstRestart = restartAt[0]!
+      const secondRestart = restartAt[1]!
+
+      const isText = (event: (typeof events)[number]): event is { kind: 'text'; id: string; iterationId: string } =>
+        event.kind === 'text'
+
+      // every attempt belongs to the same generation: the iteration id stays
+      // stable across restarts, unlike the per-message id
+      expect(new Set(events.filter(isText).map((event) => event.iterationId)).size).toBe(1)
+
+      // the first attempt streamed two sends → two distinct message ids
+      const firstAttemptIds = new Set(
+        events
+          .slice(0, firstRestart)
+          .filter(isText)
+          .map((event) => event.id)
+      )
+      expect(firstAttemptIds.size).toBe(2)
+
+      // each replacement attempt only started previewing after its restart
+      // delta, under a message id that never appeared before
+      const middleIds = new Set(
+        events
+          .slice(firstRestart + 1, secondRestart)
+          .filter(isText)
+          .map((event) => event.id)
+      )
+      expect(middleIds.size).toBe(1)
+      expect([...middleIds].every((id) => !firstAttemptIds.has(id))).toBe(true)
+
+      const finalIds = new Set(
+        events
+          .slice(secondRestart + 1)
+          .filter(isText)
+          .map((event) => event.id)
+      )
+      expect(finalIds.size).toBe(1)
+      expect([...finalIds].every((id) => !firstAttemptIds.has(id) && !middleIds.has(id))).toBe(true)
+
+      // each restart cleared the generation's previews (all of its messages):
+      // only the surviving message is still rendered
+      expect(resets).toEqual([2, 3])
+      expect(previews.size).toBe(1)
+      expect([...[...previews.values()][0]!.values()]).toEqual(['Delta!'])
+
+      // every send was committed as it was parsed, across all attempts
+      expect(messages.map((m) => m.text)).toEqual(['Abandoned!', 'Beta abandoned', 'Mid attempt', 'Delta!'])
+    })
+
+    test('text deltas from the replacement carry a fresh message id under a stable iteration id', async () => {
+      const deltas: MessageDelta[] = []
+      const { chat, messages } = makeChat((delta) => {
+        deltas.push(delta)
+      })
+      const client = new ScriptedRestartStreamingCognitive([
+        '■send=message\nAbandoned!\n■next=listen',
+        '■send=message\nKept over here!\n■next=listen',
+      ])
+
+      const result = await executeContext({ client, chat, options: midStreamOptions(3) })
+
+      expect(result).toBeInstanceOf(SuccessExecutionResult)
+      expect(messages.map((m) => m.text)).toEqual(['Abandoned!', 'Kept over here!'])
+
+      const text = textDeltas(deltas)
+      const bodies = new Map<string, string>()
+      for (const delta of text) {
+        bodies.set(delta.id, (bodies.get(delta.id) ?? '') + delta.delta)
+      }
+
+      // the per-message id is fresh across the restart: one stable id per
+      // message, differing between the abandoned and the replacement attempt
+      expect(bodies.size).toBe(2)
+      expect([...bodies.values()].sort()).toEqual(['Abandoned!', 'Kept over here!'])
+      const ids = [...bodies.keys()]
+      expect(ids[0]!).not.toBe(ids[1])
+      expect(ids.every((id) => id.length > 0)).toBe(true)
+
+      // but the iteration id is the generation id: identical across attempts
+      expect(new Set(text.map((d) => d.iterationId)).size).toBe(1)
+
+      expect(restartDeltas(deltas)).toHaveLength(1)
+    })
+
+    test('an async restart handler is awaited before the next preview', async () => {
+      const events: string[] = []
+      let releaseReset!: () => void
+      const resetGate = new Promise<void>((resolve) => (releaseReset = resolve))
+      let textBeforeResetSettled = false
+      const { chat, messages } = makeChat(async (delta) => {
+        if (delta.restart) {
+          // block the reset handler until the test releases the gate
+          events.push('reset:start')
+          await resetGate
+          events.push('reset:end')
+        } else {
+          if (events.includes('reset:start') && !events.includes('reset:end')) {
+            textBeforeResetSettled = true
+          }
+          events.push('text')
+        }
+      })
+      const client = new ScriptedRestartStreamingCognitive([
+        '■send=message\nAbandoned!\n■next=listen',
+        '■send=message\nKept!\n■next=listen',
+      ])
+
+      const execution = executeContext({ client, chat, options: midStreamOptions(3) })
+
+      // wait for the restart to arrive and the async reset handler to start
+      await vi.waitFor(() => expect(events).toContain('reset:start'))
+      // the replacement preview must not be delivered while the reset is pending
+      expect(textBeforeResetSettled).toBe(false)
+      expect(events).not.toContain('reset:end')
+
+      releaseReset()
+      const result = await execution
+
+      expect(result).toBeInstanceOf(SuccessExecutionResult)
+      expect((result as SuccessExecutionResult).result.exit.name).toBe(ListenExit.name)
+      expect(messages.map((m) => m.text)).toEqual(['Abandoned!', 'Kept!'])
+
+      // reset events settled (start → end) before any replacement preview
+      const resetStart = events.indexOf('reset:start')
+      const resetEnd = events.indexOf('reset:end')
+      expect(resetStart).toBeGreaterThanOrEqual(0)
+      expect(resetEnd).toBe(resetStart + 1)
+      // abandoned previews streamed before the restart; the replacement only after
+      expect(events.slice(0, resetStart).every((event) => event === 'text')).toBe(true)
+      expect(events.slice(resetEnd + 1).length).toBeGreaterThan(0)
+      expect(events.slice(resetEnd + 1).every((event) => event === 'text')).toBe(true)
+      expect(textBeforeResetSettled).toBe(false)
+    })
+
+    test('a restart clears only the current iteration and leaves earlier previews intact', async () => {
+      // A renderer keeps previews from previous generations on screen in
+      // per-iteration buckets. A restart must only remove the bucket it names.
+      const previews = new Map<string, Map<string, string>>()
+      previews.set('previous-iteration', new Map([['prev-msg', 'Committed earlier message']]))
+
+      const { chat, messages } = makeChat((delta) => {
+        if (delta.restart) {
+          previews.delete(delta.iterationId)
+        } else {
+          let iterationPreviews = previews.get(delta.iterationId)
+          if (iterationPreviews === undefined) {
+            previews.set(delta.iterationId, (iterationPreviews = new Map()))
+          }
+          iterationPreviews.set(delta.id, (iterationPreviews.get(delta.id) ?? '') + delta.delta)
+        }
+      })
+      const client = new ScriptedRestartStreamingCognitive([
+        '■send=message\nAbandoned!\n■next=listen',
+        '■send=message\nKept!\n■next=listen',
+      ])
+
+      const result = await executeContext({ client, chat, options: midStreamOptions(3) })
+
+      expect(result).toBeInstanceOf(SuccessExecutionResult)
+      expect((result as SuccessExecutionResult).result.exit.name).toBe(ListenExit.name)
+      expect(messages.map((m) => m.text)).toEqual(['Abandoned!', 'Kept!'])
+
+      // the earlier generation's preview survived the restart untouched
+      expect(previews.get('previous-iteration')).toEqual(new Map([['prev-msg', 'Committed earlier message']]))
+
+      // only the current generation still holds provisional previews, with the
+      // surviving attempt's message
+      expect(previews.size).toBe(2)
+      const current = [...previews.entries()].find(([key]) => key !== 'previous-iteration')![1]
+      expect([...current.values()]).toEqual(['Kept!'])
+    })
+
+    test('restart delta errors are best effort and the reset precedes replacement previews', async () => {
+      const events: string[] = []
+      const seenMessageIds = new Set<string>()
+      let resetDelivered = false
+      let replacementResumedAfterReset = false
+      const { chat, messages } = makeChat((delta) => {
+        if (delta.restart) {
+          resetDelivered = true
+          events.push(`reset:${delta.attempt}`)
+        } else {
+          // the replacement attempt streams fresh message ids, so the first
+          // unseen id proves the reset side effects ran before this preview
+          if (resetDelivered && !seenMessageIds.has(delta.id)) {
+            replacementResumedAfterReset = true
+          }
+          seenMessageIds.add(delta.id)
+          events.push(`text:${delta.id}`)
+        }
+        // callback errors are best-effort: they must neither fail the run nor
+        // prevent the restart control delta from being delivered
+        throw new Error('preview handler boom')
+      })
+
+      const client = new ScriptedRestartStreamingCognitive([
+        '■send=message\nAbandoned!\n■next=listen',
+        '■send=message\nKept!\n■next=listen',
+      ])
+      const result = await executeContext({ client, chat, options: midStreamOptions(3) })
+
+      expect(result).toBeInstanceOf(SuccessExecutionResult)
+      expect((result as SuccessExecutionResult).result.exit.name).toBe(ListenExit.name)
+      expect(messages.map((m) => m.text)).toEqual(['Abandoned!', 'Kept!'])
+
+      // the control delta was delivered (and its side effects ran) before any
+      // replacement preview, even though every callback threw
+      expect(resetDelivered).toBe(true)
+      expect(replacementResumedAfterReset).toBe(true)
+      expect(events.filter((event) => event.startsWith('reset:'))).toHaveLength(1)
     })
 
     test('metadata from an abandoned attempt does not satisfy a metadata-less replacement', async () => {
@@ -1043,7 +1421,8 @@ describe('message-stream protocol execution', () => {
       const error = (result as ErrorExecutionResult).error
       expect(error).toBeInstanceOf(CognitiveError)
       expect((error as Error).message).toContain('without metadata')
-      expect(messages).toEqual([])
+      // both attempts' sends completed and were committed before the failure
+      expect(messages.map((m) => m.text)).toEqual(['Abandoned!', 'Still buffered'])
     })
 
     test('a replacement handoff within the stall guard still succeeds', async () => {
@@ -1123,7 +1502,7 @@ describe('message-stream protocol execution', () => {
       const result = await executeContext({ client, chat, options: midStreamOptions(3) })
 
       expect(result).toBeInstanceOf(SuccessExecutionResult)
-      expect(messages.map((m) => m.text)).toEqual(['Final!'])
+      expect(messages.map((m) => m.text)).toEqual(['First attempt', 'More abandoned output', 'Final!'])
 
       const iteration = result.iterations[0]!
       const restartTraces = iteration.traces.filter((t) => t.type === 'llm_call_restarted')

--- a/packages/llmz/src/runtime/execute.ts
+++ b/packages/llmz/src/runtime/execute.ts
@@ -404,7 +404,7 @@ const executeIteration = async ({
           earlyExecution = { code, started_at: Date.now(), promise: runCode(code) }
         }
       : undefined,
-    onSend: async (send) => {
+    onSend: async (send, messageMetadata) => {
       if (!ctx.chat) {
         return
       }
@@ -417,7 +417,7 @@ const executeIteration = async ({
       })
 
       try {
-        await ctx.chat.handler(component)
+        await ctx.chat.handler(component, messageMetadata)
       } catch (err) {
         throw new Error(`Error while sending message (■send=${send.name}): ${getErrorMessage(err)}`)
       }

--- a/packages/llmz/src/runtime/execute.ts
+++ b/packages/llmz/src/runtime/execute.ts
@@ -418,7 +418,7 @@ const executeIteration = async ({
 
       try {
         await ctx.chat.handler(component, messageMetadata)
-      } catch (err) {
+      } catch (err: unknown) {
         throw new Error(`Error while sending message (■send=${send.name}): ${getErrorMessage(err)}`)
       }
 

--- a/packages/llmz/src/runtime/execute.ts
+++ b/packages/llmz/src/runtime/execute.ts
@@ -372,13 +372,21 @@ const executeIteration = async ({
   // parsed — while the rest of the response (■next, stream metadata) may
   // still be streaming. Disabled when an onBeforeExecution hook is registered,
   // since the hook must run (and may mutate the code) before execution.
-  // Early/streaming execution is also disabled in buffered (midStreamFallback) mode,
-  // so the full response is parsed before code runs.
+  // Early/streaming execution is also disabled in midStreamFallback mode: code
+  // runs only after a stream completes successfully (never from an abandoned
+  // attempt), even though deltas and completed Chat.handler sends stream
+  // immediately during generation.
   const canExecuteEarly = typeof onBeforeExecution !== 'function' && !ctx.midStreamFallback
   let earlyExecution: { code: string; started_at: number; promise: Promise<VMExecutionResult> } | undefined
 
   // ■send blocks are dispatched to the chat as soon as they are parsed — on
-  // streaming clients this happens while the model is still generating.
+  // streaming clients this happens while the model is still generating. In
+  // midStreamFallback mode there is no buffered delivery and no final delivery
+  // queue: deltas and completed Chat.handler sends both stream immediately via
+  // onMessageDelta (below) — a restart:true delta invalidates ALL the current
+  // iteration's messages (including completed sends), for consumers to
+  // retract/replace. Only code/tool execution (below) waits for the stream to
+  // complete successfully.
   await generateCode({
     iteration,
     ctx,

--- a/packages/llmz/src/runtime/generate.ts
+++ b/packages/llmz/src/runtime/generate.ts
@@ -42,7 +42,8 @@ type GenerateCodeProps = {
   onSend?: (send: ParsedSend, metadata: MessageMetadata) => Promise<void>
   /**
    * Called for each `■send` body chunk as it is parsed from the stream
-   * (streaming clients only). Best-effort: errors are ignored.
+   * (streaming clients only), or with a restart delta before replacement output.
+   * Text errors are best-effort; restart errors terminate generation.
    */
   onSendDelta?: (delta: MessageDelta) => Promise<void> | void
   /**
@@ -187,7 +188,12 @@ export const generateCode = async ({
     try {
       await onSendDelta?.(delta)
     } catch (err: unknown) {
-      // Preview failures never prevent authoritative delivery.
+      // Retraction is required for safe replacement delivery. Treat its failure
+      // as terminal so the execution loop cannot start another generation.
+      if (delta.restart) {
+        throw new CognitiveError(`LLM stream restart handler failed: ${getErrorMessage(err)}`)
+      }
+      // Ordinary text previews remain best-effort.
       void err
     }
   }

--- a/packages/llmz/src/runtime/generate.ts
+++ b/packages/llmz/src/runtime/generate.ts
@@ -2,7 +2,7 @@ import type { CognitiveMetadata, CognitiveStreamChunk } from '@botpress/cognitiv
 import { clamp } from 'lodash-es'
 
 import { createJoinedAbortController } from '../abort-signal.js'
-import type { MessageDelta } from '../chat.js'
+import type { MessageDelta, MessageMetadata } from '../chat.js'
 import { Context, Iteration } from '../context.js'
 import { CognitiveError } from '../errors.js'
 import { StreamingMessageParser } from '../message-stream/parser.js'
@@ -39,7 +39,7 @@ type GenerateCodeProps = {
    * Called for each completed `■send` block. On streaming clients this fires
    * while the model is still generating — messages are delivered progressively.
    */
-  onSend?: (send: ParsedSend) => Promise<void>
+  onSend?: (send: ParsedSend, metadata: MessageMetadata) => Promise<void>
   /**
    * Called for each `■send` body chunk as it is parsed from the stream
    * (streaming clients only). Best-effort: errors are ignored.
@@ -177,6 +177,10 @@ export const generateCode = async ({
 
   const midStreamFallback = ctx.midStreamFallback === true
   let attempt = 1
+  const messageMetadata = (itemId: string): MessageMetadata => ({
+    iterationId: iteration.id,
+    id: midStreamFallback ? `${iteration.id}:${attempt}:${itemId}` : `${iteration.id}:${itemId}`,
+  })
   // Previews are always live, including reset-only deltas. Await the callback
   // so consumers observe the reset before replacement text, even when async.
   const preview = async (delta: MessageDelta) => {
@@ -213,8 +217,7 @@ export const generateCode = async ({
         liveContent.set(item.id, content)
         const delta: MessageDelta = {
           restart: false,
-          id: midStreamFallback ? `${iteration.id}:${attempt}:${item.id}` : `${iteration.id}:${item.id}`,
-          iterationId: iteration.id,
+          ...messageMetadata(item.id),
           component: item.name,
           props: item.props,
           delta: event.delta,
@@ -228,7 +231,7 @@ export const generateCode = async ({
             props: event.item.props,
             body: event.item.body,
           }
-          await onSend(send)
+          await onSend(send, messageMetadata(event.item.id))
         } else if (event.item.kind === 'run' && event.item.status === 'complete' && !runCompleted) {
           // The ■run block is fully parsed (only the first one counts — the
           // response may invalidly contain more): execution can start while
@@ -385,8 +388,8 @@ export const generateCode = async ({
     raw = response.output
     assistantResponse = ctx.version.parseAssistantResponse(raw)
 
-    for (const send of assistantResponse.sends) {
-      await onSend?.(send)
+    for (const [index, send] of assistantResponse.sends.entries()) {
+      await onSend?.(send, messageMetadata(`send-${index}`))
     }
   }
 

--- a/packages/llmz/src/runtime/generate.ts
+++ b/packages/llmz/src/runtime/generate.ts
@@ -372,7 +372,10 @@ export const generateCode = async ({
       streamController.abort('LLM stream closed')
       if (!streamCompleted) {
         // Do not wait: a stalled custom iterator may never settle its next().
-        void stream.return(undefined).catch(() => {})
+        void stream.return(undefined).catch((err: unknown) => {
+          // Cleanup is best-effort; preserve the original generation failure.
+          void err
+        })
       }
     }
 

--- a/packages/llmz/src/runtime/generate.ts
+++ b/packages/llmz/src/runtime/generate.ts
@@ -175,16 +175,18 @@ export const generateCode = async ({
   let timeToFirstToken: number | undefined
   let timeToLastToken: number | undefined
 
-  const bufferedDelivery = ctx.midStreamFallback === true
-  let pendingDeliveries: (() => Promise<void> | void)[] = []
-  const deliver = async (callback: () => Promise<void> | void) => {
-    if (bufferedDelivery) {
-      pendingDeliveries.push(callback)
-    } else {
-      await callback()
+  const midStreamFallback = ctx.midStreamFallback === true
+  let attempt = 1
+  // Previews are always live, including reset-only deltas. Await the callback
+  // so consumers observe the reset before replacement text, even when async.
+  const preview = async (delta: MessageDelta) => {
+    try {
+      await onSendDelta?.(delta)
+    } catch (err: unknown) {
+      // Preview failures never prevent authoritative delivery.
+      void err
     }
   }
-
   const liveItems = new Map<string, ParsedItem>()
   const liveContent = new Map<string, string>()
   let codeGenerationTraced = false
@@ -199,11 +201,8 @@ export const generateCode = async ({
           // generated so consumers can show progress while waiting for the
           // code to complete and execute
           codeGenerationTraced = true
-          const started_at = Date.now()
-          await deliver(() => {
-            traces.push({ type: 'code_generation_started', started_at })
-            onRunStart?.()
-          })
+          traces.push({ type: 'code_generation_started', started_at: Date.now() })
+          onRunStart?.()
         }
       } else if (event.type === 'body-delta' && onSendDelta) {
         const item = liveItems.get(event.itemId)
@@ -212,45 +211,38 @@ export const generateCode = async ({
         }
         const content = (liveContent.get(item.id) ?? '') + event.delta
         liveContent.set(item.id, content)
-        // Parser items are live references. Capture the delivery payload now,
-        // rather than queueing parser events that will continue to mutate.
         const delta: MessageDelta = {
-          id: `${iteration.id}:${item.id}`,
+          restart: false,
+          id: midStreamFallback ? `${iteration.id}:${attempt}:${item.id}` : `${iteration.id}:${item.id}`,
+          iterationId: iteration.id,
           component: item.name,
-          props: bufferedDelivery ? structuredClone(item.props) : item.props,
+          props: item.props,
           delta: event.delta,
           content,
         }
-        await deliver(async () => {
-          try {
-            // Progressive previews are best-effort; authoritative delivery is onSend.
-            await onSendDelta(delta)
-          } catch (err: unknown) {
-            void err
-          }
-        })
+        await preview(delta)
       } else if (event.type === 'item-complete') {
         if (event.item.kind === 'send' && onSend) {
           const send = {
             name: event.item.name,
-            props: bufferedDelivery ? structuredClone(event.item.props) : event.item.props,
+            props: event.item.props,
             body: event.item.body,
           }
-          await deliver(() => onSend(send))
+          await onSend(send)
         } else if (event.item.kind === 'run' && event.item.status === 'complete' && !runCompleted) {
           // The ■run block is fully parsed (only the first one counts — the
           // response may invalidly contain more): execution can start while
           // the rest of the response streams
           runCompleted = true
           const code = (event.item.body ?? '').trim()
-          await deliver(() => onRunComplete?.(code))
+          onRunComplete?.(code)
         }
       }
     }
   }
 
   if (typeof cognitive.generateTextStream === 'function') {
-    // Parse incrementally; fallback-enabled calls defer delivery until commit.
+    // Parse and deliver messages incrementally, including in fallback mode.
     let parser = new StreamingMessageParser()
     let fence = new LeadingFenceFilter()
 
@@ -263,12 +255,12 @@ export const generateCode = async ({
         ...input,
         // Passed through to the cognitive request: fall back to the next
         // model/provider when the first token takes too long
-        ...(ctx.maxTimeToFirstToken || bufferedDelivery
+        ...(ctx.maxTimeToFirstToken || midStreamFallback
           ? {
               options: {
                 ...input.options,
                 ...(ctx.maxTimeToFirstToken ? { maxTimeToFirstToken: ctx.maxTimeToFirstToken } : {}),
-                ...(bufferedDelivery ? { midStreamFallback: true } : {}),
+                ...(midStreamFallback ? { midStreamFallback: true } : {}),
               },
             }
           : {}),
@@ -312,7 +304,7 @@ export const generateCode = async ({
           break
         }
 
-        if (chunk.value?.restart && !bufferedDelivery) {
+        if (chunk.value?.restart && !midStreamFallback) {
           streamController.abort('Unexpected LLM stream restart')
           throw new CognitiveError('LLM stream restarted without options.midStreamFallback enabled')
         }
@@ -324,10 +316,13 @@ export const generateCode = async ({
           fence = new LeadingFenceFilter()
           liveItems.clear()
           liveContent.clear()
-          pendingDeliveries = []
           codeGenerationTraced = false
           runCompleted = false
           responseMetadata = undefined
+          attempt = chunk.value.restart.attempt
+          // Emit even when the replacement has no sends: previous previews
+          // must disappear immediately, not wait for another text delta.
+          await preview({ ...chunk.value.restart, restart: true, iterationId: iteration.id })
           // Keep request-relative timing (including handoff latency), but only
           // report tokens from the surviving attempt.
           timeToFirstToken = undefined
@@ -372,16 +367,10 @@ export const generateCode = async ({
       }
     }
 
-    // A restart cannot retract callbacks, so commit only after the iterator
-    // completes normally and the final attempt has metadata and parsed output.
+    // Tool execution still waits for successful generation in fallback mode.
     // Cancellation/deadlines are never renewed across attempts.
-    if (bufferedDelivery) {
+    if (midStreamFallback) {
       controller.signal.throwIfAborted()
-      for (const callback of pendingDeliveries) {
-        controller.signal.throwIfAborted()
-        await callback()
-      }
-      pendingDeliveries = []
     }
   } else {
     const response = await cognitive.generateText(input, { signal: controller.signal }).catch((thrown: unknown) => {

--- a/packages/llmz/src/runtime/tool-wrapper.ts
+++ b/packages/llmz/src/runtime/tool-wrapper.ts
@@ -137,6 +137,7 @@ export function wrapTool({
         effectiveInput,
         {
           callId: toolCallId,
+          iterationId: iteration.id,
         },
         chat
       )

--- a/packages/llmz/src/runtime/types.ts
+++ b/packages/llmz/src/runtime/types.ts
@@ -126,10 +126,13 @@ type Options = Partial<Pick<Context, 'loop' | 'timeout'>> & {
    */
   maxTimeToFirstToken?: number
   /**
-   * Allow Cognitive to restart failed streams on another model. Buffers message
-   * previews, sends, and code execution until generation succeeds; abandoned
-   * attempts deliver nothing. Streaming-only; defaults to false, preserving
-   * progressive sends and early code execution.
+   * Allow Cognitive to restart failed streams on another model. No buffered
+   * delivery and no final delivery queue: delta text and completed Chat.handler
+   * sends stream immediately during generation. A reset-only delta (restart:
+   * true) on Chat.onMessageDelta invalidates ALL current-iteration messages,
+   * including completed sends — consumers must retract/replace them (not safe for
+   * irreversible transports). Only TOOL/CODE execution waits for a successful
+   * stream. Streaming-only; defaults to false, preserving progressive sending.
    */
   midStreamFallback?: boolean
   /**

--- a/packages/llmz/src/tool.ts
+++ b/packages/llmz/src/tool.ts
@@ -58,6 +58,8 @@ type SmartPartial<T> = IsObject<T> extends true ? Partial<T> : T
 type ToolCallContext = {
   /** Unique identifier for this specific tool call */
   callId: string
+  /** Set by the runtime; standalone calls use callId as their message scope. */
+  iterationId?: string
 }
 
 export namespace Tool {
@@ -691,7 +693,10 @@ export class Tool<I extends z.ZodType = z.ZodType, O extends z.ZodType = z.ZodTy
       }
       if (yieldIndex >= yieldedCount) {
         setYieldedCount(yieldIndex + 1)
-        await chat?.handler?.(value)
+        await chat?.handler?.(value, {
+          iterationId: ctx.iterationId ?? ctx.callId,
+          id: `${ctx.callId}:yield-${yieldIndex}`,
+        })
       }
       yieldIndex++
     }


### PR DESCRIPTION
Restores immediate message streaming during mid-stream model fallback, adds reset deltas and send-correlation metadata, and bumps LLMz to 0.6.6.

The buffering introduced in #15464 removed the live streaming experience. This removes the delivery queue: text deltas and completed sends arrive immediately, while code/tool execution still waits for generation success. `MessageDelta` is a single discriminated union: `restart: false` carries text; `restart: true` identifies the iteration and replacement attempt. Resets arrive before replacement output, even when the replacement has no messages. Every `Chat.handler(component, metadata)` send now includes `{iterationId, id}`, matching text delta IDs when present, so consumers can correlate completed, empty-body, and non-text messages.

Consumers must narrow on `restart` and retract all messages from the affected iteration, including completed sends; irreversible transports must not enable fallback without reset support. Message IDs differ across attempts while iteration IDs stay stable. Existing one-argument handlers remain compatible. All 500 tests, package typechecking, lint, formatting, and the Node/Workerd package build pass locally.