### PR TITLE
fix(telegram): round-trip choice selection via inline keyboard + callback_query

### DIFF
--- a/integrations/telegram/definitions/channels.ts
+++ b/integrations/telegram/definitions/channels.ts
@@ -6,6 +6,11 @@ const _textMessageDefinition = {
     text: messages.defaults.text.schema.shape.text
       .max(4096)
       .describe('The text content of the Telegram message (Limit 4096 characters)'),
+    value: z
+      .string()
+      .optional()
+      .title('value')
+      .describe('Underlying value of the message, if any (e.g. the payload of a selected choice option)'),
   }),
 }
 

--- a/integrations/telegram/integration.definition.ts
+++ b/integrations/telegram/integration.definition.ts
@@ -39,12 +39,15 @@ export default new IntegrationDefinition({
     choicePrompts: {
       type: 'conversation',
       schema: z.object({
-        prompts: z.array(
-          z.object({
-            messageId: z.number(),
-            entries: z.array(z.object({ label: z.string(), value: z.string() })),
-          })
-        ),
+        prompts: z
+          .array(
+            z.object({
+              messageId: z.number(),
+              entries: z.array(z.object({ label: z.string(), value: z.string() })),
+            })
+          )
+          .title('Choice prompts')
+          .describe('Recently sent choice prompts, mapping each message to its options for callback resolution'),
       }),
     },
   },

--- a/integrations/telegram/integration.definition.ts
+++ b/integrations/telegram/integration.definition.ts
@@ -36,6 +36,17 @@ export default new IntegrationDefinition({
         botToken: z.string().title('Bot Token').min(1).secret().describe('The Telegram bot token'),
       }),
     },
+    choicePrompts: {
+      type: 'conversation',
+      schema: z.object({
+        prompts: z.array(
+          z.object({
+            messageId: z.number(),
+            entries: z.array(z.object({ label: z.string(), value: z.string() })),
+          })
+        ),
+      }),
+    },
   },
   channels: {
     channel: {

--- a/integrations/telegram/src/index.ts
+++ b/integrations/telegram/src/index.ts
@@ -26,7 +26,7 @@ import {
   wrapHandler,
   getMessageId,
   mapToRuntimeErrorAndThrow,
-  getChoicePromptEntries,
+  consumeChoicePrompt,
 } from './misc/utils'
 import { handler as wizardHandler } from './wizard'
 import * as bp from '.botpress'
@@ -165,7 +165,7 @@ const integration = new bp.Integration({
           .answerCbQuery(callbackQuery.id)
           .catch(mapToRuntimeErrorAndThrow('Fail to answer callback query'))
 
-        const entries = await getChoicePromptEntries(client, conversation.id, cbMessageId)
+        const entries = await consumeChoicePrompt(client, conversation.id, cbMessageId)
         const index = Number(String(callbackQuery.data ?? '').replace(/^c:/, ''))
         const entry = entries?.[index]
 

--- a/integrations/telegram/src/index.ts
+++ b/integrations/telegram/src/index.ts
@@ -26,6 +26,7 @@ import {
   wrapHandler,
   getMessageId,
   mapToRuntimeErrorAndThrow,
+  getChoicePromptEntries,
 } from './misc/utils'
 import { handler as wizardHandler } from './wizard'
 import * as bp from '.botpress'
@@ -124,6 +125,72 @@ const integration = new bp.Integration({
       ok(!data.channel_post, 'Handler received a channel post, so the message was ignored')
       ok(!data.edited_channel_post, 'Handler received an edited channel post, so the message was ignored')
       ok(!data.edited_message, 'Handler received an edited message, so the message was ignored')
+
+      if (data.callback_query) {
+        const callbackQuery = data.callback_query
+        const cbChatId = callbackQuery.message?.chat?.id
+        const cbUserId = callbackQuery.from?.id
+        const cbMessageId = callbackQuery.message?.message_id
+
+        ok(!callbackQuery.from?.is_bot, 'Handler received a callback query from a bot, so it was ignored')
+        ok(cbChatId, 'Handler received a callback query with empty "message.chat.id" value')
+        ok(cbUserId, 'Handler received a callback query with empty "from.id" value')
+        ok(cbMessageId, 'Handler received a callback query with empty "message.message_id" value')
+
+        const cbFromUser = callbackQuery.from as User
+        const cbUserName = getUserNameFromTelegramUser(cbFromUser)
+
+        const { conversation } = await client.getOrCreateConversation({
+          channel: 'channel',
+          tags: {
+            id: cbChatId.toString(),
+            fromUserId: cbUserId.toString(),
+            fromUserUsername: cbFromUser.username,
+            fromUserName: cbUserName,
+            chatId: cbChatId.toString(),
+          },
+          discriminateByTags: ['id'],
+        })
+
+        const { user } = await client.getOrCreateUser({
+          tags: { id: cbUserId.toString() },
+          ...(cbUserName && { name: cbUserName }),
+          discriminateByTags: ['id'],
+        })
+
+        const botToken = await getStoredBotToken(client, ctx.integrationId, ctx.configuration.botToken)
+        const telegraf = new Telegraf(botToken)
+
+        await telegraf.telegram
+          .answerCbQuery(callbackQuery.id)
+          .catch(mapToRuntimeErrorAndThrow('Fail to answer callback query'))
+
+        const entries = await getChoicePromptEntries(client, conversation.id, cbMessageId)
+        const index = Number(String(callbackQuery.data ?? '').replace(/^c:/, ''))
+        const entry = entries?.[index]
+
+        if (!entry) {
+          logger
+            .forBot()
+            .warn(`No stored choice option found for message ${cbMessageId} at index ${index}; ignoring callback`)
+          return
+        }
+
+        await client.createMessage({
+          type: 'text',
+          payload: { value: entry.value, text: entry.label },
+          userId: user.id,
+          conversationId: conversation.id,
+          tags: { id: `${cbMessageId}:cb`, chatId: cbChatId.toString() },
+        })
+
+        await telegraf.telegram
+          .editMessageText(cbChatId, cbMessageId, undefined, entry.label)
+          .catch(mapToRuntimeErrorAndThrow('Fail to edit message'))
+
+        return
+      }
+
       ok(data.message, 'Handler received a non-message update, so the event was ignored')
 
       const message = data.message as TelegramMessage

--- a/integrations/telegram/src/misc/message-handlers.ts
+++ b/integrations/telegram/src/misc/message-handlers.ts
@@ -3,7 +3,7 @@ import { Markup, Telegraf, Telegram } from 'telegraf'
 import { getStoredBotToken } from '../botToken'
 import { markdownHtmlToTelegramPayloads, stdMarkdownToTelegramHtml } from './markdown-to-telegram-html'
 import { TelegramMessage } from './types'
-import { ackMessage, getChat, mapToRuntimeErrorAndThrow, sendCard } from './utils'
+import { ackMessage, getChat, mapToRuntimeErrorAndThrow, sendCard, storeChoicePrompt } from './utils'
 import * as bp from '.botpress'
 
 export type MessageHandlerProps<T extends keyof bp.MessageProps['channel']> = bp.MessageProps['channel'][T]
@@ -217,10 +217,16 @@ export const handleChoiceMessage = async ({
   const telegraf = new Telegraf(botToken)
   const chat = getChat(conversation)
   logger.forBot().debug(`Sending choice message to Telegram chat ${chat}:`, payload)
-  const buttons = payload.options.map((choice) => Markup.button.callback(choice.label, choice.value))
+  const buttons = payload.options.map((choice, index) => Markup.button.callback(choice.label, `c:${index}`))
   const message = await telegraf.telegram
-    .sendMessage(chat, payload.text, Markup.keyboard(buttons).oneTime())
+    .sendMessage(chat, payload.text, Markup.inlineKeyboard(buttons, { columns: 1 }))
     .catch(mapToRuntimeErrorAndThrow('Fail to send message'))
+  await storeChoicePrompt(
+    client,
+    conversation.id,
+    message.message_id,
+    payload.options.map((option) => ({ label: option.label, value: option.value }))
+  )
   await ackMessage(message, ack)
 }
 

--- a/integrations/telegram/src/misc/utils.ts
+++ b/integrations/telegram/src/misc/utils.ts
@@ -62,6 +62,50 @@ export async function sendCard(payload: Card, client: Telegraf<Context<Update>>,
   }
 }
 
+const MAX_STORED_CHOICE_PROMPTS = 20
+
+type ChoiceEntry = { label: string; value: string }
+
+const getChoicePromptsState = async (client: bp.Client, conversationId: string) => {
+  const result = await client
+    .getState({ type: 'conversation', name: 'choicePrompts', id: conversationId })
+    .catch((thrown: unknown) => {
+      const err = thrown instanceof Error ? thrown : new Error(String(thrown))
+      if (err.message.toLowerCase().includes('not found')) {
+        return null
+      }
+      throw err
+    })
+  return result?.state.payload.prompts ?? []
+}
+
+export const storeChoicePrompt = async (
+  client: bp.Client,
+  conversationId: string,
+  messageId: number,
+  entries: ChoiceEntry[]
+) => {
+  const prompts = await getChoicePromptsState(client, conversationId)
+  const next = [...prompts.filter((prompt) => prompt.messageId !== messageId), { messageId, entries }].slice(
+    -MAX_STORED_CHOICE_PROMPTS
+  )
+  await client.setState({
+    type: 'conversation',
+    name: 'choicePrompts',
+    id: conversationId,
+    payload: { prompts: next },
+  })
+}
+
+export const getChoicePromptEntries = async (
+  client: bp.Client,
+  conversationId: string,
+  messageId: number
+): Promise<ChoiceEntry[] | null> => {
+  const prompts = await getChoicePromptsState(client, conversationId)
+  return prompts.find((prompt) => prompt.messageId === messageId)?.entries ?? null
+}
+
 export function getChat(conversation: MessageHandlerProps['conversation']): string {
   const chat = conversation.tags.chatId
 

--- a/integrations/telegram/src/misc/utils.ts
+++ b/integrations/telegram/src/misc/utils.ts
@@ -97,13 +97,23 @@ export const storeChoicePrompt = async (
   })
 }
 
-export const getChoicePromptEntries = async (
+export const consumeChoicePrompt = async (
   client: bp.Client,
   conversationId: string,
   messageId: number
 ): Promise<ChoiceEntry[] | null> => {
   const prompts = await getChoicePromptsState(client, conversationId)
-  return prompts.find((prompt) => prompt.messageId === messageId)?.entries ?? null
+  const prompt = prompts.find((entry) => entry.messageId === messageId)
+  if (!prompt) {
+    return null
+  }
+  await client.setState({
+    type: 'conversation',
+    name: 'choicePrompts',
+    id: conversationId,
+    payload: { prompts: prompts.filter((entry) => entry.messageId !== messageId) },
+  })
+  return prompt.entries
 }
 
 export function getChat(conversation: MessageHandlerProps['conversation']): string {


### PR DESCRIPTION
Renders `choice` messages as an inline keyboard and adds a `callback_query` handler so the selected option's `value` comes back inbound as `payload.value` (matching the WhatsApp/Slack pattern). To stay under Telegram's 64-byte `callback_data` cap, each button carries only the option index; the integration persists a bounded `message_id → [{label, value}]` map in conversation state and resolves it on callback, then reflects the picked label back into the prompt. 

fixes SHIP-1942