### PR TITLE
feat(gsheets): added multi-select to filepicker

### DIFF
--- a/integrations/gsheets/definitions/actions.ts
+++ b/integrations/gsheets/definitions/actions.ts
@@ -23,6 +23,13 @@ const _commonFields = {
         .describe('Represents a major dimension (a row or column) of a values range')
     )
     .title('Values'),
+  spreadsheetId: z
+    .string()
+    .optional()
+    .title('Spreadsheet ID')
+    .describe(
+      'The spreadsheet to act on. Must be one of the spreadsheets selected during setup. Defaults to the first one selected if left empty.'
+    ),
 } as const
 
 const getValues = {
@@ -36,6 +43,7 @@ const getValues = {
         .describe(
           'If it equals "ROWS", then the values are returned as rows. If it equals "COLUMNS", then the values are returned as columns.'
         ),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -67,6 +75,7 @@ const setValues = {
       values: _commonFields.values.describe(
         'The values to write to the range. This is an array of arrays, where each inner array represents a major dimension (a row or column) of data. (e.g. [["a", "b"], ["c", "d"]])'
       ),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -114,6 +123,7 @@ const appendValues = {
       values: _commonFields.values.describe(
         'The values to write to the range. This is an array of arrays, where each inner array represents a major dimension (a row or column) of data. (e.g. [["a", "b"], ["c", "d"]])'
       ),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -155,6 +165,7 @@ const clearValues = {
   input: {
     schema: z.object({
       range: _commonFields.range.describe('The A1 notation of the range to clear. (e.g. "Sheet1!A1:B2")'),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -176,6 +187,7 @@ const getInfoSpreadsheet = {
         .describe(
           'The fields to include in the response when retrieving spreadsheet properties and metadata. This is a list of field names. (eg. spreadsheetId, properties.title, sheets.properties.sheetId, sheets.properties.title)'
         ),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -222,6 +234,7 @@ const addSheet = {
   input: {
     schema: z.object({
       title: z.string().title('Title').describe('The title of the new sheet to add to the spreadsheet.'),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -246,6 +259,7 @@ const deleteSheet = {
   input: {
     schema: z.object({
       sheetId: z.number().title('Sheet ID').describe('The ID of the sheet to delete.'),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -260,6 +274,7 @@ const renameSheet = {
     schema: z.object({
       sheetId: z.number().title('Sheet ID').describe('The ID of the sheet to rename.'),
       newTitle: z.string().title('New Title').describe('The new title of the sheet.'),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -271,7 +286,9 @@ const getAllSheetsInSpreadsheet = {
   title: 'Get All Sheets in Spreadsheet',
   description: 'Returns all sheets in the spreadsheet.',
   input: {
-    schema: z.object({}),
+    schema: z.object({
+      spreadsheetId: _commonFields.spreadsheetId,
+    }),
   },
   output: {
     schema: z.object({
@@ -302,6 +319,7 @@ const setSheetVisibility = {
     schema: z.object({
       sheetId: z.number().title('Sheet ID').describe('The ID of the sheet to set visibility.'),
       isHidden: z.boolean().title('Is Hidden').describe('Whether the sheet is hidden.'),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -316,6 +334,7 @@ const moveSheetHorizontally = {
     schema: z.object({
       sheetId: z.number().title('Sheet ID').describe('The ID of the sheet to move.'),
       newIndex: z.number().title('New Index').describe('The new index of the sheet within the spreadsheet.'),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -339,6 +358,7 @@ const protectNamedRange = {
         .title('Requesting User Can Edit')
         .optional()
         .describe('Whether the user adding the protection can edit the protected range.'),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -352,7 +372,9 @@ const getNamedRanges = {
   title: 'Get Named Ranges',
   description: 'Returns all named ranges in the spreadsheet.',
   input: {
-    schema: z.object({}),
+    schema: z.object({
+      spreadsheetId: _commonFields.spreadsheetId,
+    }),
   },
   output: {
     schema: z.object({
@@ -375,7 +397,9 @@ const getProtectedRanges = {
   title: 'Get Protected Ranges',
   description: 'Returns all protected ranges in the spreadsheet.',
   input: {
-    schema: z.object({}),
+    schema: z.object({
+      spreadsheetId: _commonFields.spreadsheetId,
+    }),
   },
   output: {
     schema: z.object({
@@ -412,6 +436,7 @@ const unprotectRange = {
   input: {
     schema: z.object({
       protectedRangeId: z.number().title('Protected Range ID').describe('The ID of the protected range to unprotect.'),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -434,6 +459,7 @@ const createNamedRangeInSheet = {
       rangeA1: _commonFields.range.describe(
         'The A1 notation of the range to associate with the named range. (e.g. "Sheet1!A1:B2")'
       ),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -471,6 +497,7 @@ const findRows = {
         .describe(
           'Optional A1 notation range to limit the search (e.g. "A1:F100"). If not provided, searches the entire sheet.'
         ),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -501,6 +528,7 @@ const findRow = {
         .describe(
           'Optional A1 notation range to limit the search (e.g. "A1:F100"). If not provided, searches the entire sheet.'
         ),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -536,6 +564,7 @@ const getRow = {
         .title('End Column')
         .optional()
         .describe('The ending column letter (e.g. "Z"). If not provided, returns all columns with data.'),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -568,6 +597,7 @@ const updateRow = {
         .optional()
         .default('A')
         .describe('The starting column letter for the update (e.g. "A"). Defaults to "A".'),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -600,6 +630,7 @@ const insertRowAtIndex = {
         .optional()
         .default('A')
         .describe('The starting column letter for the values (e.g. "A"). Defaults to "A".'),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -624,6 +655,7 @@ const deleteRows = {
         .array(z.number().title('Row Index'))
         .title('Row Indexes')
         .describe('The 1-based row indexes to delete.'),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
@@ -656,12 +688,48 @@ const upsertRow = {
         .optional()
         .default('A')
         .describe('The starting column letter for the values (e.g. "A"). Defaults to "A".'),
+      spreadsheetId: _commonFields.spreadsheetId,
     }),
   },
   output: {
     schema: z.object({
       action: z.enum(['updated', 'inserted']).title('Action').describe('Whether the row was updated or inserted.'),
       rowIndex: z.number().title('Row Index').describe('The 1-based index of the affected row.'),
+    }),
+  },
+} as const satisfies ActionDef
+
+const getSelectedSpreadsheets = {
+  title: 'Get Selected Spreadsheets',
+  description:
+    'Returns the spreadsheets this integration was given access to during setup. These are the only spreadsheets its actions can operate on.',
+  input: {
+    schema: z.object({}),
+  },
+  output: {
+    schema: z.object({
+      spreadsheets: z
+        .array(
+          z.object({
+            spreadsheetId: z
+              .string()
+              .title('Spreadsheet ID')
+              .describe('The ID of the spreadsheet. Pass it to the "Spreadsheet ID" field of any action.'),
+            title: z
+              .string()
+              .optional()
+              .title('Title')
+              .describe(
+                "The name of the spreadsheet. Absent when the spreadsheet can no longer be reached, which usually means it was deleted or the integration's access to it was revoked."
+              ),
+            isDefault: z
+              .boolean()
+              .title('Is Default')
+              .describe('Whether actions that do not specify a spreadsheet operate on this one.'),
+          })
+        )
+        .title('Spreadsheets')
+        .describe('The selected spreadsheets, in the order they were selected. The first one is the default.'),
     }),
   },
 } as const satisfies ActionDef
@@ -680,6 +748,7 @@ export const actions = {
   getNamedRanges,
   getProtectedRanges,
   getRow,
+  getSelectedSpreadsheets,
   getValues,
   insertRowAtIndex,
   moveSheetHorizontally,

--- a/integrations/gsheets/definitions/states.ts
+++ b/integrations/gsheets/definitions/states.ts
@@ -14,10 +14,21 @@ export const states = {
   spreadsheetConfig: {
     type: 'integration',
     schema: z.object({
+      spreadsheetIds: z
+        .array(z.string().min(1))
+        .min(1)
+        .optional()
+        .title('Spreadsheet IDs')
+        .describe(
+          'The IDs of the Google Spreadsheets selected during OAuth setup, in selection order. The first one is the default used by actions that do not specify a spreadsheet.'
+        ),
       spreadsheetId: z
         .string()
-        .title('Spreadsheet ID')
-        .describe('The ID of the Google Spreadsheet selected during OAuth setup'),
+        .optional()
+        .title('Spreadsheet ID (legacy)')
+        .describe(
+          'Deprecated: the single spreadsheet ID written by versions of this integration that only supported one spreadsheet. Read as a fallback when "spreadsheetIds" is absent; never written by new setups.'
+        ),
     }),
   },
 } as const satisfies sdk.IntegrationDefinitionProps['states']

--- a/integrations/gsheets/hub.md
+++ b/integrations/gsheets/hub.md
@@ -3,10 +3,12 @@ From tracking inventory and managing project tasks to organizing event attendees
 Give your bot new abilities like add new entries, update existing records, and retrieve essential information.
 Stay agile and organized by dynamically adding new sheets to accommodate evolving data needs, ensuring your spreadsheets remain flexible and scalable.
 
-## Important note
 
-Unfortunately, **automatic configuration is temporarily unavailable**.
-We are currently in the process of getting our Google Sheets integration verified by Google. Once this verification is complete, you will be able to use the automatic configuration method to set up the Google Sheets integration with just a few clicks. Until then, you will need to create your own Google Cloud Platform (GCP) Service Account by following the steps outlined in the `Manual configuration using a service account` section below.
+## Upgrading from 2.1.7 or earlier
+
+If you use **automatic configuration with OAuth** and you are coming from version `2.1.7` or earlier, re-run the setup wizard. Those versions took the spreadsheet from a **Spreadsheet ID** configuration field, which has since been replaced by a Google file picker. Until you re-run the wizard and pick your spreadsheets, actions fail with _"No spreadsheet is configured for this integration."_
+
+Manual configurations using a service account are unaffected: they keep reading the **Spreadsheet ID** from the integration configuration.
 
 ## Migrating from 1.x.x to 2.x.x
 
@@ -46,13 +48,15 @@ To set up the Google Sheets integration using OAuth, click the authorization but
 
 When using this configuration mode, a Botpress-managed Google Sheets application will be used to connect to your Google account. However, actions taken by the bot will be attributed to the user who authorized the connection, rather than the application. For this reason, **we do not recommend using personal Google accounts** for this integration. You should set up a service account and use this account to authorize the connection.
 
-Once the connection is established, you must specify the identifier of the Google Spreadsheet you want to interact with. This identifier is the long string of characters in the URL between `/spreadsheets/d/` and `/edit` when you are editing a spreadsheet.
+Once the connection is established, a Google file picker opens so you can choose the spreadsheets the integration is allowed to reach. The integration only ever gets access to the files you pick here.
 
-> For example, if the URL is `https://docs.google.com/spreadsheets/d/1a2b3c4d5e6f7g8h9i0j/edit`, the identifier of the spreadsheet is `1a2b3c4d5e6f7g8h9i0j`.
+You may select more than one spreadsheet. **The first spreadsheet you select becomes the default**: actions that don't name a spreadsheet operate on it. See [Managing several spreadsheets](#managing-several-spreadsheets) to target the others.
 
-1. Find your Google Spreadsheet ID for the spreadsheet you want to interact with.
-2. Authorize the Google Sheets integration by clicking the authorization button.
-3. Fill in the **Spreadsheet ID** field and save the configuration.
+1. Authorize the Google Sheets integration by clicking the authorization button.
+2. In the file picker, select one or more spreadsheets. Select the one you use most first, so it becomes the default.
+3. Confirm your selection to finish the setup.
+
+> To change the selection later, re-run the setup wizard. The spreadsheets you pick then replace the previous selection.
 
 ### Manual configuration using a service account
 
@@ -119,9 +123,32 @@ Once the connection is established, you must specify the identifier of the Googl
    - **Service account private key**: The private key from the Google service account. You can get it from the downloaded JSON file.
    - **Service account email**: The client email from the Google service account. You can get it from the downloaded JSON file.
 
+## Managing several spreadsheets
+
+When you configure the integration with OAuth, you may select several spreadsheets in the file picker. The first one you select is the default, and every action operates on it unless told otherwise.
+
+To target one of the other selected spreadsheets, fill in the optional **Spreadsheet ID** field on the action. Leave it empty to use the default.
+
+To find those IDs without digging through Google Drive URLs, use the _Get Selected Spreadsheets_ action. It returns the ID and title of every spreadsheet you picked during setup, in the order you picked them, and flags which one is the default:
+
+```json
+{
+  "spreadsheets": [
+    { "spreadsheetId": "1a2b3c4d5e6f7g8h9i0j", "title": "Support Tickets", "isDefault": true },
+    { "spreadsheetId": "9z8y7x6w5v4u3t2s1r0q", "title": "Customer Feedback", "isDefault": false }
+  ]
+}
+```
+
+> A spreadsheet with no `title` could not be reached. That usually means it was deleted, or the integration's access to it was revoked in Google Drive.
+
+> The ID must be one of the spreadsheets selected during setup. Any other ID is rejected with an error, since the integration has no access to files you did not pick. To use a new spreadsheet, re-run the setup wizard and include it in your selection.
+
+Manual configurations using a service account interact with the single spreadsheet named in the configuration. Because access there comes from sharing the file with the service account, the **Spreadsheet ID** field on an action may name any spreadsheet shared with that account.
+
 ## Managing several sheets
 
-While this integration allows you to interact with a single Google Spreadsheet, you can manage multiple sheets within that spreadsheet. To interact with a specific sheet, you must specify the sheet name as part of the range when performing operations.
+Within any one spreadsheet, you can manage multiple sheets. To interact with a specific sheet, you must specify the sheet name as part of the range when performing operations.
 
 The range field uses the same notation as Google Sheets. For example, to interact with a sheet named `Sheet1`, you would use the range `Sheet1!A1:B2`.
 

--- a/integrations/gsheets/hub.md
+++ b/integrations/gsheets/hub.md
@@ -3,7 +3,6 @@ From tracking inventory and managing project tasks to organizing event attendees
 Give your bot new abilities like add new entries, update existing records, and retrieve essential information.
 Stay agile and organized by dynamically adding new sheets to accommodate evolving data needs, ensuring your spreadsheets remain flexible and scalable.
 
-
 ## Upgrading from 2.1.7 or earlier
 
 If you use **automatic configuration with OAuth** and you are coming from version `2.1.7` or earlier, re-run the setup wizard. Those versions took the spreadsheet from a **Spreadsheet ID** configuration field, which has since been replaced by a Google file picker. Until you re-run the wizard and pick your spreadsheets, actions fail with _"No spreadsheet is configured for this integration."_

--- a/integrations/gsheets/integration.definition.ts
+++ b/integrations/gsheets/integration.definition.ts
@@ -13,7 +13,7 @@ import {
 } from './definitions'
 
 export const INTEGRATION_NAME = 'gsheets'
-export const INTEGRATION_VERSION = '2.1.10'
+export const INTEGRATION_VERSION = '2.1.11'
 
 export default new sdk.IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/gsheets/integration.definition.ts
+++ b/integrations/gsheets/integration.definition.ts
@@ -13,7 +13,7 @@ import {
 } from './definitions'
 
 export const INTEGRATION_NAME = 'gsheets'
-export const INTEGRATION_VERSION = '2.1.11'
+export const INTEGRATION_VERSION = '2.1.10'
 
 export default new sdk.IntegrationDefinition({
   name: INTEGRATION_NAME,

--- a/integrations/gsheets/src/actions/implementations/get-selected-spreadsheets.ts
+++ b/integrations/gsheets/src/actions/implementations/get-selected-spreadsheets.ts
@@ -1,0 +1,18 @@
+import { getAllowedSpreadsheetIds } from '../../google-api/spreadsheet-selection'
+import { wrapAction } from '../action-wrapper'
+
+export const getSelectedSpreadsheets = wrapAction(
+  { actionName: 'getSelectedSpreadsheets', errorMessageWhenFailed: 'Failed to obtain the selected spreadsheets' },
+  async ({ googleClient, ctx, client }) => {
+    const spreadsheetIds = await getAllowedSpreadsheetIds({ ctx, client })
+    const titles = await googleClient.getSpreadsheetTitles(spreadsheetIds)
+
+    return {
+      spreadsheets: spreadsheetIds.map((spreadsheetId, index) => ({
+        spreadsheetId,
+        title: titles[spreadsheetId],
+        isDefault: index === 0,
+      })),
+    }
+  }
+)

--- a/integrations/gsheets/src/actions/index.ts
+++ b/integrations/gsheets/src/actions/index.ts
@@ -11,6 +11,7 @@ import { getInfoSpreadsheet } from './implementations/get-info-spread-sheet'
 import { getNamedRanges } from './implementations/get-named-ranges'
 import { getProtectedRanges } from './implementations/get-protected-ranges'
 import { getRow } from './implementations/get-row'
+import { getSelectedSpreadsheets } from './implementations/get-selected-spreadsheets'
 import { getValues } from './implementations/get-values'
 import { insertRowAtIndex } from './implementations/insert-row-at-index'
 import { moveSheetHorizontally } from './implementations/move-sheet-horizontally'
@@ -37,6 +38,7 @@ export default {
   getNamedRanges,
   getProtectedRanges,
   getRow,
+  getSelectedSpreadsheets,
   getValues,
   insertRowAtIndex,
   moveSheetHorizontally,

--- a/integrations/gsheets/src/google-api/google-client.ts
+++ b/integrations/gsheets/src/google-api/google-client.ts
@@ -4,6 +4,8 @@ import { A1NotationParser } from './a1-notation-utils/a1-parser'
 import { handleErrorsDecorator as handleErrors } from './error-handling'
 import { ResponseMapping } from './mapping/response-mapping'
 import { getAuthenticatedOAuth2Client, exchangeAuthCodeAndSaveRefreshToken } from './oauth-client'
+import { resolveSpreadsheetId } from './spreadsheet-selection'
+import { resolveSpreadsheetTitles } from './spreadsheet-titles'
 import * as bp from '.botpress'
 
 type GoogleSheetsClient = ReturnType<typeof google.sheets>
@@ -23,25 +25,17 @@ export class GoogleClient {
     this._sheetsClient = google.sheets({ version: 'v4', auth: oauthClient })
   }
 
-  public static async create({ ctx, client }: { ctx: bp.Context; client: bp.Client }) {
+  public static async create({
+    ctx,
+    client,
+    input,
+  }: {
+    ctx: bp.Context
+    client: bp.Client
+    input?: { spreadsheetId?: string }
+  }) {
     const oauth2Client = await getAuthenticatedOAuth2Client({ ctx, client })
-
-    const getSpreadsheetIdFromState = async (): Promise<string> => {
-      let spreadsheetId: string
-      if (ctx.configurationType === 'serviceAccountKey') {
-        spreadsheetId = ctx.configuration.spreadsheetId
-      } else {
-        const { state } = await client.getState({
-          id: ctx.integrationId,
-          type: 'integration',
-          name: 'spreadsheetConfig',
-        })
-        spreadsheetId = state.payload.spreadsheetId
-      }
-      return spreadsheetId
-    }
-
-    const spreadsheetId = await getSpreadsheetIdFromState()
+    const spreadsheetId = await resolveSpreadsheetId({ ctx, client, requestedSpreadsheetId: input?.spreadsheetId })
 
     return new GoogleClient({
       oauthClient: oauth2Client,
@@ -314,6 +308,16 @@ export class GoogleClient {
 
     const namedRangeId = response.data.replies?.[0]?.addNamedRange?.namedRange?.namedRangeId ?? ''
     return { namedRangeId }
+  }
+
+  /** Resolves the human-readable title of each given spreadsheet. */
+  @handleErrors('Failed to get spreadsheet titles')
+  public async getSpreadsheetTitles(spreadsheetIds: string[]): Promise<Record<string, string | undefined>> {
+    return await resolveSpreadsheetTitles(spreadsheetIds, async (spreadsheetId) => {
+      const response = await this._sheetsClient.spreadsheets.get({ spreadsheetId, fields: 'properties.title' })
+
+      return response.data.properties?.title ?? undefined
+    })
   }
 
   public async getSpreadsheetSummary(): Promise<string> {

--- a/integrations/gsheets/src/google-api/google-client.ts
+++ b/integrations/gsheets/src/google-api/google-client.ts
@@ -25,6 +25,7 @@ export class GoogleClient {
     this._sheetsClient = google.sheets({ version: 'v4', auth: oauthClient })
   }
 
+  @handleErrors('Failed to initialize the Google Sheets client')
   public static async create({
     ctx,
     client,

--- a/integrations/gsheets/src/google-api/spreadsheet-selection.test.ts
+++ b/integrations/gsheets/src/google-api/spreadsheet-selection.test.ts
@@ -1,0 +1,120 @@
+import * as sdk from '@botpress/sdk'
+import { describe, it, expect, vi } from 'vitest'
+import { getAllowedSpreadsheetIds, resolveSpreadsheetId } from './spreadsheet-selection'
+import * as bp from '.botpress'
+
+const OAUTH_CTX = { integrationId: 'int-1', configurationType: null } as unknown as bp.Context
+
+const SERVICE_ACCOUNT_CTX = {
+  integrationId: 'int-1',
+  configurationType: 'serviceAccountKey',
+  configuration: { spreadsheetId: 'from-config' },
+} as unknown as bp.Context
+
+const clientReturning = (payload: unknown) =>
+  ({ getState: vi.fn(async () => ({ state: { payload } })) }) as unknown as bp.Client
+
+const clientWithoutState = () =>
+  ({ getState: vi.fn(async () => Promise.reject(new Error('state not found'))) }) as unknown as bp.Client
+
+describe('getAllowedSpreadsheetIds', () => {
+  it('returns the stored list in selection order', async () => {
+    const client = clientReturning({ spreadsheetIds: ['a', 'b', 'c'] })
+
+    await expect(getAllowedSpreadsheetIds({ ctx: OAUTH_CTX, client })).resolves.toEqual(['a', 'b', 'c'])
+  })
+
+  it('falls back to the legacy single spreadsheet id', async () => {
+    const client = clientReturning({ spreadsheetId: 'legacy' })
+
+    await expect(getAllowedSpreadsheetIds({ ctx: OAUTH_CTX, client })).resolves.toEqual(['legacy'])
+  })
+
+  it('prefers the list over the legacy field when both are present', async () => {
+    const client = clientReturning({ spreadsheetIds: ['a', 'b'], spreadsheetId: 'legacy' })
+
+    await expect(getAllowedSpreadsheetIds({ ctx: OAUTH_CTX, client })).resolves.toEqual(['a', 'b'])
+  })
+
+  it('returns the configured spreadsheet for service account setups', async () => {
+    const client = clientWithoutState()
+
+    await expect(getAllowedSpreadsheetIds({ ctx: SERVICE_ACCOUNT_CTX, client })).resolves.toEqual(['from-config'])
+    expect(client.getState).not.toHaveBeenCalled()
+  })
+
+  it('returns nothing when the file picker was skipped', async () => {
+    await expect(getAllowedSpreadsheetIds({ ctx: OAUTH_CTX, client: clientWithoutState() })).resolves.toEqual([])
+  })
+
+  it('returns nothing when the stored payload is empty', async () => {
+    await expect(getAllowedSpreadsheetIds({ ctx: OAUTH_CTX, client: clientReturning({}) })).resolves.toEqual([])
+  })
+})
+
+describe('resolveSpreadsheetId', () => {
+  it('uses the first selected spreadsheet when the action does not specify one', async () => {
+    const client = clientReturning({ spreadsheetIds: ['default', 'other'] })
+
+    await expect(resolveSpreadsheetId({ ctx: OAUTH_CTX, client })).resolves.toBe('default')
+  })
+
+  it('uses the requested spreadsheet when it is one of the selected ones', async () => {
+    const client = clientReturning({ spreadsheetIds: ['default', 'other'] })
+
+    await expect(resolveSpreadsheetId({ ctx: OAUTH_CTX, client, requestedSpreadsheetId: 'other' })).resolves.toBe(
+      'other'
+    )
+  })
+
+  it('treats a blank requested id as "use the default"', async () => {
+    const client = clientReturning({ spreadsheetIds: ['default', 'other'] })
+
+    await expect(resolveSpreadsheetId({ ctx: OAUTH_CTX, client, requestedSpreadsheetId: '   ' })).resolves.toBe(
+      'default'
+    )
+  })
+
+  it('trims surrounding whitespace off the requested id', async () => {
+    const client = clientReturning({ spreadsheetIds: ['default', 'other'] })
+
+    await expect(resolveSpreadsheetId({ ctx: OAUTH_CTX, client, requestedSpreadsheetId: '  other  ' })).resolves.toBe(
+      'other'
+    )
+  })
+
+  it('resolves against the legacy single spreadsheet id', async () => {
+    const client = clientReturning({ spreadsheetId: 'legacy' })
+
+    await expect(resolveSpreadsheetId({ ctx: OAUTH_CTX, client })).resolves.toBe('legacy')
+    await expect(resolveSpreadsheetId({ ctx: OAUTH_CTX, client, requestedSpreadsheetId: 'legacy' })).resolves.toBe(
+      'legacy'
+    )
+  })
+
+  it('rejects a spreadsheet that was not selected during setup', async () => {
+    const client = clientReturning({ spreadsheetIds: ['default', 'other'] })
+
+    await expect(
+      resolveSpreadsheetId({ ctx: OAUTH_CTX, client, requestedSpreadsheetId: 'not-picked' })
+    ).rejects.toThrow(sdk.RuntimeError)
+    await expect(
+      resolveSpreadsheetId({ ctx: OAUTH_CTX, client, requestedSpreadsheetId: 'not-picked' })
+    ).rejects.toThrow(/default, other/)
+  })
+
+  it('lets service account setups target any shared spreadsheet', async () => {
+    const client = clientWithoutState()
+
+    await expect(
+      resolveSpreadsheetId({ ctx: SERVICE_ACCOUNT_CTX, client, requestedSpreadsheetId: 'shared-elsewhere' })
+    ).resolves.toBe('shared-elsewhere')
+    await expect(resolveSpreadsheetId({ ctx: SERVICE_ACCOUNT_CTX, client })).resolves.toBe('from-config')
+  })
+
+  it('explains that no spreadsheet is configured when the picker was skipped', async () => {
+    await expect(resolveSpreadsheetId({ ctx: OAUTH_CTX, client: clientWithoutState() })).rejects.toThrow(
+      /No spreadsheet is configured/
+    )
+  })
+})

--- a/integrations/gsheets/src/google-api/spreadsheet-selection.ts
+++ b/integrations/gsheets/src/google-api/spreadsheet-selection.ts
@@ -1,4 +1,5 @@
 import * as sdk from '@botpress/sdk'
+import { wrapAsyncFnWithTryCatch } from './error-handling'
 import * as bp from '.botpress'
 
 /**
@@ -7,73 +8,82 @@ import * as bp from '.botpress'
  *
  * Returns an empty array when the OAuth wizard's file picker was skipped.
  */
-export const getAllowedSpreadsheetIds = async ({
-  ctx,
-  client,
-}: {
-  ctx: bp.Context
-  client: bp.Client
-}): Promise<string[]> => {
-  if (ctx.configurationType === 'serviceAccountKey') {
-    return [ctx.configuration.spreadsheetId]
-  }
+export const getAllowedSpreadsheetIds = wrapAsyncFnWithTryCatch(
+  async ({ ctx, client }: { ctx: bp.Context; client: bp.Client }): Promise<string[]> => {
+    if (ctx.configurationType === 'serviceAccountKey') {
+      return [ctx.configuration.spreadsheetId]
+    }
 
-  const result = await client
-    .getState({ id: ctx.integrationId, type: 'integration', name: 'spreadsheetConfig' })
-    .catch(() => null)
+    let payload: bp.states.spreadsheetConfig.SpreadsheetConfig['payload'] | undefined
 
-  if (!result) {
-    return []
-  }
+    try {
+      const { state } = await client.getState({
+        id: ctx.integrationId,
+        type: 'integration',
+        name: 'spreadsheetConfig',
+      })
+      payload = state.payload
+    } catch (_thrown: unknown) {
+      // The state is absent until the wizard's file picker step completes, and
+      // `getState` rejects rather than returning an empty result in that case.
+      payload = undefined
+    }
 
-  const { spreadsheetIds, spreadsheetId } = result.state.payload
+    if (!payload) {
+      return []
+    }
 
-  if (spreadsheetIds?.length) {
-    return spreadsheetIds
-  }
+    if (payload.spreadsheetIds?.length) {
+      return payload.spreadsheetIds
+    }
 
-  // Installations set up before multi-select only ever wrote the singular field.
-  return spreadsheetId ? [spreadsheetId] : []
-}
+    // Installations set up before multi-select only ever wrote the singular field.
+    return payload.spreadsheetId ? [payload.spreadsheetId] : []
+  },
+  'Failed to obtain the spreadsheets selected for this integration'
+)
 
 /**
  * Resolves the spreadsheet an action should operate on: the one it explicitly
  * asked for, or the installation's default.
  */
-export const resolveSpreadsheetId = async ({
-  ctx,
-  client,
-  requestedSpreadsheetId,
-}: {
-  ctx: bp.Context
-  client: bp.Client
-  requestedSpreadsheetId?: string
-}): Promise<string> => {
-  const requested = requestedSpreadsheetId?.trim()
-  const allowed = await getAllowedSpreadsheetIds({ ctx, client })
+export const resolveSpreadsheetId = wrapAsyncFnWithTryCatch(
+  async ({
+    ctx,
+    client,
+    requestedSpreadsheetId,
+  }: {
+    ctx: bp.Context
+    client: bp.Client
+    requestedSpreadsheetId?: string
+  }): Promise<string> => {
+    const requested = requestedSpreadsheetId?.trim()
+    const allowed = await getAllowedSpreadsheetIds({ ctx, client })
 
-  if (requested) {
-    // A service account reaches whatever has been shared with it, so there is no
-    // picked set to validate against.
-    if (ctx.configurationType === 'serviceAccountKey' || allowed.includes(requested)) {
-      return requested
+    if (requested) {
+      // A service account reaches whatever has been shared with it, so there is no
+      // picked set to validate against.
+      if (ctx.configurationType === 'serviceAccountKey' || allowed.includes(requested)) {
+        return requested
+      }
+
+      throw new sdk.RuntimeError(
+        `Spreadsheet "${requested}" is not one of the spreadsheets selected for this integration. ` +
+          (allowed.length
+            ? `Re-run the setup wizard and select it, or use one of: ${allowed.join(', ')}.`
+            : 'Re-run the setup wizard and select it.')
+      )
     }
 
-    throw new sdk.RuntimeError(
-      `Spreadsheet "${requested}" is not one of the spreadsheets selected for this integration. ` +
-        (allowed.length
-          ? `Re-run the setup wizard and select it, or use one of: ${allowed.join(', ')}.`
-          : 'Re-run the setup wizard and select it.')
-    )
-  }
+    const defaultSpreadsheetId = allowed[0]
 
-  const defaultSpreadsheetId = allowed[0]
+    if (!defaultSpreadsheetId) {
+      throw new sdk.RuntimeError(
+        'No spreadsheet is configured for this integration. Re-run the setup wizard and select at least one spreadsheet.'
+      )
+    }
 
-  if (!defaultSpreadsheetId) {
-    throw new sdk.RuntimeError(
-      'No spreadsheet is configured for this integration. Re-run the setup wizard and select at least one spreadsheet.'
-    )
-  }
-
-  return defaultSpreadsheetId
-}
+    return defaultSpreadsheetId
+  },
+  'Failed to resolve which spreadsheet to use'
+)

--- a/integrations/gsheets/src/google-api/spreadsheet-selection.ts
+++ b/integrations/gsheets/src/google-api/spreadsheet-selection.ts
@@ -23,7 +23,7 @@ export const getAllowedSpreadsheetIds = wrapAsyncFnWithTryCatch(
         name: 'spreadsheetConfig',
       })
       payload = state.payload
-    } catch (_thrown: unknown) {
+    } catch {
       // The state is absent until the wizard's file picker step completes, and
       // `getState` rejects rather than returning an empty result in that case.
       payload = undefined

--- a/integrations/gsheets/src/google-api/spreadsheet-selection.ts
+++ b/integrations/gsheets/src/google-api/spreadsheet-selection.ts
@@ -1,0 +1,79 @@
+import * as sdk from '@botpress/sdk'
+import * as bp from '.botpress'
+
+/**
+ * The spreadsheets this installation is allowed to reach, in selection order.
+ * The first one is the default used by actions that don't specify a spreadsheet.
+ *
+ * Returns an empty array when the OAuth wizard's file picker was skipped.
+ */
+export const getAllowedSpreadsheetIds = async ({
+  ctx,
+  client,
+}: {
+  ctx: bp.Context
+  client: bp.Client
+}): Promise<string[]> => {
+  if (ctx.configurationType === 'serviceAccountKey') {
+    return [ctx.configuration.spreadsheetId]
+  }
+
+  const result = await client
+    .getState({ id: ctx.integrationId, type: 'integration', name: 'spreadsheetConfig' })
+    .catch(() => null)
+
+  if (!result) {
+    return []
+  }
+
+  const { spreadsheetIds, spreadsheetId } = result.state.payload
+
+  if (spreadsheetIds?.length) {
+    return spreadsheetIds
+  }
+
+  // Installations set up before multi-select only ever wrote the singular field.
+  return spreadsheetId ? [spreadsheetId] : []
+}
+
+/**
+ * Resolves the spreadsheet an action should operate on: the one it explicitly
+ * asked for, or the installation's default.
+ */
+export const resolveSpreadsheetId = async ({
+  ctx,
+  client,
+  requestedSpreadsheetId,
+}: {
+  ctx: bp.Context
+  client: bp.Client
+  requestedSpreadsheetId?: string
+}): Promise<string> => {
+  const requested = requestedSpreadsheetId?.trim()
+  const allowed = await getAllowedSpreadsheetIds({ ctx, client })
+
+  if (requested) {
+    // A service account reaches whatever has been shared with it, so there is no
+    // picked set to validate against.
+    if (ctx.configurationType === 'serviceAccountKey' || allowed.includes(requested)) {
+      return requested
+    }
+
+    throw new sdk.RuntimeError(
+      `Spreadsheet "${requested}" is not one of the spreadsheets selected for this integration. ` +
+        (allowed.length
+          ? `Re-run the setup wizard and select it, or use one of: ${allowed.join(', ')}.`
+          : 'Re-run the setup wizard and select it.')
+    )
+  }
+
+  const defaultSpreadsheetId = allowed[0]
+
+  if (!defaultSpreadsheetId) {
+    throw new sdk.RuntimeError(
+      'No spreadsheet is configured for this integration. Re-run the setup wizard and select at least one spreadsheet.'
+    )
+  }
+
+  return defaultSpreadsheetId
+}

--- a/integrations/gsheets/src/google-api/spreadsheet-titles.test.ts
+++ b/integrations/gsheets/src/google-api/spreadsheet-titles.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest'
+import { resolveSpreadsheetTitles } from './spreadsheet-titles'
+
+describe('resolveSpreadsheetTitles', () => {
+  it('maps every spreadsheet to its title', async () => {
+    const fetchTitle = vi.fn(async (id: string) => `title of ${id}`)
+
+    await expect(resolveSpreadsheetTitles(['a', 'b'], fetchTitle)).resolves.toEqual({
+      a: 'title of a',
+      b: 'title of b',
+    })
+  })
+
+  it('reports an unreachable spreadsheet without failing the others', async () => {
+    const fetchTitle = async (id: string) => {
+      if (id === 'revoked') {
+        throw new Error('403 The caller does not have permission')
+      }
+      return `title of ${id}`
+    }
+
+    await expect(resolveSpreadsheetTitles(['a', 'revoked', 'b'], fetchTitle)).resolves.toEqual({
+      a: 'title of a',
+      revoked: undefined,
+      b: 'title of b',
+    })
+  })
+
+  it('keeps a spreadsheet that has no title', async () => {
+    const fetchTitle = async () => undefined
+
+    await expect(resolveSpreadsheetTitles(['a'], fetchTitle)).resolves.toEqual({ a: undefined })
+  })
+
+  it('looks a repeated spreadsheet up only once', async () => {
+    const fetchTitle = vi.fn(async (id: string) => `title of ${id}`)
+
+    await expect(resolveSpreadsheetTitles(['a', 'a', 'b'], fetchTitle)).resolves.toEqual({
+      a: 'title of a',
+      b: 'title of b',
+    })
+    expect(fetchTitle).toHaveBeenCalledTimes(2)
+  })
+
+  it('does nothing when there is no spreadsheet to look up', async () => {
+    const fetchTitle = vi.fn(async (id: string) => `title of ${id}`)
+
+    await expect(resolveSpreadsheetTitles([], fetchTitle)).resolves.toEqual({})
+    expect(fetchTitle).not.toHaveBeenCalled()
+  })
+})

--- a/integrations/gsheets/src/google-api/spreadsheet-titles.ts
+++ b/integrations/gsheets/src/google-api/spreadsheet-titles.ts
@@ -13,9 +13,11 @@ export const resolveSpreadsheetTitles = async (
 
   const entries = await Promise.all(
     uniqueIds.map(async (spreadsheetId) => {
-      const title = await fetchTitle(spreadsheetId).catch(() => undefined)
-
-      return [spreadsheetId, title] as const
+      try {
+        return [spreadsheetId, await fetchTitle(spreadsheetId)] as const
+      } catch (_thrown: unknown) {
+        return [spreadsheetId, undefined] as const
+      }
     })
   )
 

--- a/integrations/gsheets/src/google-api/spreadsheet-titles.ts
+++ b/integrations/gsheets/src/google-api/spreadsheet-titles.ts
@@ -1,0 +1,23 @@
+/**
+ * Resolves the title of each given spreadsheet, tolerating individual failures.
+ *
+ * A spreadsheet that can no longer be reached (deleted, or access revoked since
+ * setup) resolves to `undefined` instead of rejecting, so one dead spreadsheet
+ * doesn't hide the others from a listing.
+ */
+export const resolveSpreadsheetTitles = async (
+  spreadsheetIds: string[],
+  fetchTitle: (spreadsheetId: string) => Promise<string | undefined>
+): Promise<Record<string, string | undefined>> => {
+  const uniqueIds = [...new Set(spreadsheetIds)]
+
+  const entries = await Promise.all(
+    uniqueIds.map(async (spreadsheetId) => {
+      const title = await fetchTitle(spreadsheetId).catch(() => undefined)
+
+      return [spreadsheetId, title] as const
+    })
+  )
+
+  return Object.fromEntries(entries)
+}

--- a/integrations/gsheets/src/google-api/spreadsheet-titles.ts
+++ b/integrations/gsheets/src/google-api/spreadsheet-titles.ts
@@ -15,7 +15,7 @@ export const resolveSpreadsheetTitles = async (
     uniqueIds.map(async (spreadsheetId) => {
       try {
         return [spreadsheetId, await fetchTitle(spreadsheetId)] as const
-      } catch (_thrown: unknown) {
+      } catch {
         return [spreadsheetId, undefined] as const
       }
     })

--- a/integrations/gsheets/src/setup.ts
+++ b/integrations/gsheets/src/setup.ts
@@ -1,8 +1,9 @@
+import { wrapAsyncFnWithTryCatch } from './google-api/error-handling'
 import { GoogleClient } from './google-api/google-client'
 import { getAllowedSpreadsheetIds } from './google-api/spreadsheet-selection'
 import * as bp from '.botpress'
 
-export const register: bp.IntegrationProps['register'] = async ({ logger, ctx, client }) => {
+export const register: bp.IntegrationProps['register'] = wrapAsyncFnWithTryCatch(async ({ logger, ctx, client }) => {
   logger.forBot().info('Registering Google Sheets integration')
 
   const allowedSpreadsheetIds = await getAllowedSpreadsheetIds({ ctx, client })
@@ -20,6 +21,6 @@ export const register: bp.IntegrationProps['register'] = async ({ logger, ctx, c
       `Successfully connected to Google Sheets: default ${summary}` +
         (others > 0 ? ` (+ ${others} other spreadsheet${others > 1 ? 's' : ''} selected)` : '')
     )
-}
+}, 'Failed to register the Google Sheets integration')
 
 export const unregister: bp.IntegrationProps['unregister'] = async () => {}

--- a/integrations/gsheets/src/setup.ts
+++ b/integrations/gsheets/src/setup.ts
@@ -1,12 +1,25 @@
 import { GoogleClient } from './google-api/google-client'
+import { getAllowedSpreadsheetIds } from './google-api/spreadsheet-selection'
 import * as bp from '.botpress'
 
 export const register: bp.IntegrationProps['register'] = async ({ logger, ctx, client }) => {
   logger.forBot().info('Registering Google Sheets integration')
 
+  const allowedSpreadsheetIds = await getAllowedSpreadsheetIds({ ctx, client })
+
+  // Connection check against the default spreadsheet only: the others are reached
+  // with the same credentials, and failing registration over one unreachable
+  // sheet would block the whole installation.
   const gsheetsClient = await GoogleClient.create({ ctx, client })
   const summary = await gsheetsClient.getSpreadsheetSummary()
-  logger.forBot().info(`Successfully connected to Google Sheets: ${summary}`)
+
+  const others = allowedSpreadsheetIds.length - 1
+  logger
+    .forBot()
+    .info(
+      `Successfully connected to Google Sheets: default ${summary}` +
+        (others > 0 ? ` (+ ${others} other spreadsheet${others > 1 ? 's' : ''} selected)` : '')
+    )
 }
 
 export const unregister: bp.IntegrationProps['unregister'] = async () => {}

--- a/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
+++ b/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
@@ -177,7 +177,7 @@ export const handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Res
 
     .addStep({
       id: 'end',
-      async handler({ responses, query, client, ctx }) {
+      async handler({ responses, query, client, ctx, logger }) {
         // Selection order is preserved: the first id is the default spreadsheet.
         const spreadsheetIds = [
           ...new Set(
@@ -189,12 +189,22 @@ export const handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Res
         ]
 
         if (spreadsheetIds.length) {
-          await client.setState({
-            id: ctx.integrationId,
-            type: 'integration',
-            name: 'spreadsheetConfig',
-            payload: { spreadsheetIds },
-          })
+          try {
+            await client.setState({
+              id: ctx.integrationId,
+              type: 'integration',
+              name: 'spreadsheetConfig',
+              payload: { spreadsheetIds },
+            })
+          } catch (thrown: unknown) {
+            const error = thrown instanceof Error ? thrown : new Error(String(thrown))
+            logger.forBot().error('Failed to save the selected spreadsheets:', error)
+
+            return responses.endWizard({
+              success: false,
+              errorMessage: `Failed to save your spreadsheet selection: ${error.message}`,
+            })
+          }
         }
 
         return responses.endWizard({

--- a/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
+++ b/integrations/gsheets/src/webhook-events/handlers/oauth-wizard.ts
@@ -108,9 +108,12 @@ export const handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Res
         return responses.displayButtons({
           pageTitle: 'Google Sheets Integration',
           htmlOrMarkdownPageContents: `
-            You will now be asked to select the spreadsheet you wish to use
+            You will now be asked to select the spreadsheets you wish to use
             with this integration. This is necessary for the integration to work
             properly.
+
+            You may select more than one. The first spreadsheet you select becomes
+            the default: actions that don't name a spreadsheet will use it.
 
             <script>
               let pickerApiLoaded = false;
@@ -131,16 +134,17 @@ export const handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Res
                       .setSelectFolderEnabled(false)
                       .setMode(google.picker.DocsViewMode.LIST))
                     .enableFeature(google.picker.Feature.NAV_HIDDEN)
-                    .setTitle('Select the spreadsheet you wish to use with Botpress')
+                    .enableFeature(google.picker.Feature.MULTISELECT_ENABLED)
+                    .setTitle('Select the spreadsheets you wish to use with Botpress. The first one selected is the default.')
                     .setOAuthToken(${JSON.stringify(accessToken)})
                     .setDeveloperKey(${JSON.stringify(bp.secrets.FILE_PICKER_API_KEY)})
                     .setCallback((data) => {
                       if (data[google.picker.Response.ACTION] == google.picker.Action.PICKED) {
                         const docs = data[google.picker.Response.DOCUMENTS];
-                        if (docs && docs.length > 0) {
-                          const spreadsheetId = docs[0].id;
+                        const spreadsheetIds = (docs || []).map((doc) => doc.id).filter(Boolean);
+                        if (spreadsheetIds.length > 0) {
                           const nextUrl = new URL(${JSON.stringify(oauthWizard.getWizardStepUrl('end', ctx).href)});
-                          nextUrl.searchParams.set('spreadsheetId', spreadsheetId);
+                          nextUrl.searchParams.set('spreadsheetIds', spreadsheetIds.join(','));
                           document.location.href = nextUrl.href;
                         } else {
                           document.location.href = ${JSON.stringify(oauthWizard.getWizardStepUrl('end', ctx).href)};
@@ -162,7 +166,7 @@ export const handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Res
           buttons: [
             {
               action: 'javascript',
-              label: 'Select spreadsheet',
+              label: 'Select spreadsheets',
               callFunction: 'createPicker',
               buttonType: 'primary',
             },
@@ -174,14 +178,22 @@ export const handleOAuthWizard = async (props: bp.HandlerProps): Promise<sdk.Res
     .addStep({
       id: 'end',
       async handler({ responses, query, client, ctx }) {
-        const spreadsheetId = query.get('spreadsheetId')
+        // Selection order is preserved: the first id is the default spreadsheet.
+        const spreadsheetIds = [
+          ...new Set(
+            (query.get('spreadsheetIds') ?? '')
+              .split(',')
+              .map((id) => id.trim())
+              .filter(Boolean)
+          ),
+        ]
 
-        if (spreadsheetId) {
+        if (spreadsheetIds.length) {
           await client.setState({
             id: ctx.integrationId,
             type: 'integration',
             name: 'spreadsheetConfig',
-            payload: { spreadsheetId },
+            payload: { spreadsheetIds },
           })
         }
 


### PR DESCRIPTION
Added multi-select to filepicker, and optional spreadsheet ID field to actions which relate to a given spreadsheet. Also added an action to get selected spreadsheets, so the user doesn't need to find their ID manually.

the selected sheets are stored in the integration state as available spreadsheets, and the first one is the default. actions which rely on spreadsheet ID use the default spreadsheet, but there is an optional "spreadsheet id" field which can overwrite that. this allows the user to connect multiple spreadsheets and use any of them in a workflow.

it should not be a breaking change, because the existing selected spreadsheet can still be used for any of those operations, but users with the newest version can select more than one spreadsheet and optionally pass an ID.