### PR TITLE
fix(hitl): make customer error notices configurable

### DIFF
--- a/plugins/hitl/hub.md
+++ b/plugins/hitl/hub.md
@@ -14,3 +14,11 @@ Place the card "Start HITL" anywhere in your workflow and fill in the required f
 
 In the conversation ID field, you can use the `{{event.conversationId}}` variable to get the current conversation ID.
 Likewise, you can use the `{{event.userId}}` variable to get the ID of the current user.
+
+## Customer error messages
+
+Configure `onUserIncompatibleMsgTypeMessage` to customize the warning when a customer sends an unsupported message during a HITL session. The session remains active.
+
+Configure `onUserHitlErrorMessage` to customize the customer notice when a missing conversation or user link causes their local HITL session to be aborted. This does not close the remote ticket or automatically resume the workflow. Messages sent to the human agent are unchanged; `onIncompatibleMsgTypeMessage` still controls the agent's unsupported-message warning.
+
+Both settings are available globally and in the Start HITL card's Configuration Overrides. New sessions save their effective settings; existing sessions keep their saved settings. Omitted or empty values retain the English defaults. Use the exact value `NULL` to suppress a notice without changing session handling.

--- a/plugins/hitl/plugin.definition.ts
+++ b/plugins/hitl/plugin.definition.ts
@@ -1,5 +1,6 @@
 import * as sdk from '@botpress/sdk'
 import hitl from './bp_modules/hitl'
+import { SUPPORTED_MESSAGE_TYPES } from './src/consts'
 
 export const NULL_MESSAGE_CODE = 'NULL'
 export const DEFAULT_HITL_HANDOFF_MESSAGE =
@@ -9,6 +10,8 @@ export const DEFAULT_HITL_STOPPED_MESSAGE = 'The human agent closed the conversa
 export const DEFAULT_USER_HITL_CANCELLED_MESSAGE = '( The user has ended the session. )'
 export const DEFAULT_INCOMPATIBLE_MSGTYPE_MESSAGE =
   'Sorry, the user can not receive this type of message. Please resend your message as a text message.'
+export const DEFAULT_USER_INCOMPATIBLE_MSGTYPE_MESSAGE = `Sorry, I can only handle one of the following message types: ${SUPPORTED_MESSAGE_TYPES.join(', ')}`
+export const DEFAULT_HITL_ERROR_MESSAGE = 'Something went wrong, you are not connected to a human agent...'
 export const DEFAULT_USER_HITL_CLOSE_COMMAND = '/end'
 export const DEFAULT_USER_HITL_COMMAND_MESSAGE =
   'You have ended the session with the human agent. I will continue assisting you.'
@@ -53,6 +56,22 @@ const PLUGIN_CONFIG_SCHEMA = sdk.z.object({
     )
     .optional()
     .placeholder(DEFAULT_INCOMPATIBLE_MSGTYPE_MESSAGE),
+  onUserIncompatibleMsgTypeMessage: sdk.z
+    .string()
+    .title('Unsupported Customer Message Warning')
+    .describe(
+      `The warning to send to the user when they send an unsupported message during a HITL session. ${_nullCodeDescription}`
+    )
+    .optional()
+    .placeholder(DEFAULT_USER_INCOMPATIBLE_MSGTYPE_MESSAGE),
+  onUserHitlErrorMessage: sdk.z
+    .string()
+    .title('Customer Session Link Error Message')
+    .describe(
+      `The message to send to the user when their HITL session is aborted because a conversation or user link is missing. This does not change messages sent to the human agent. ${_nullCodeDescription}`
+    )
+    .optional()
+    .placeholder(DEFAULT_HITL_ERROR_MESSAGE),
   onUserHitlCloseMessage: sdk.z
     .string()
     .title('Termination Command Message')
@@ -102,7 +121,7 @@ const PLUGIN_CONFIG_SCHEMA = sdk.z.object({
 
 export default new sdk.PluginDefinition({
   name: 'hitl',
-  version: '1.4.2',
+  version: '1.4.3',
   title: 'Human In The Loop',
   description: 'Seamlessly transfer conversations to human agents',
   icon: 'icon.svg',

--- a/plugins/hitl/src/conv-manager.ts
+++ b/plugins/hitl/src/conv-manager.ts
@@ -148,9 +148,9 @@ export class ConversationManager {
     }
   }
 
-  public async abortHitlSession(errorMessage: string): Promise<void> {
+  public async abortHitlSession(errorMessage: string, configuredMessage?: string): Promise<void> {
     await this.setHitlInactive(HITL_END_REASON.INTERNAL_ERROR)
-    await this.respond({ type: 'text', text: errorMessage })
+    await this.maybeRespondText(configuredMessage, errorMessage)
   }
 
   public async setUserId(userId: string): Promise<void> {

--- a/plugins/hitl/src/hooks/before-incoming-message/all.test.ts
+++ b/plugins/hitl/src/hooks/before-incoming-message/all.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi } from 'vitest'
+import definition, {
+  DEFAULT_HITL_ERROR_MESSAGE,
+  DEFAULT_INCOMPATIBLE_MSGTYPE_MESSAGE,
+  DEFAULT_USER_INCOMPATIBLE_MSGTYPE_MESSAGE,
+} from '../../../plugin.definition'
+import { configureNewHitlSession } from '../../configuration'
+import { handleMessage } from './all'
+import type * as bp from '.botpress'
+
+type Configuration = bp.configuration.Configuration
+const arabic = {
+  onUserIncompatibleMsgTypeMessage: 'عذراً، هذا النوع من الرسائل غير مدعوم. يرجى إعادة إرسال رسالتك كنص.',
+  onUserHitlErrorMessage: 'حدث خطأ في الاتصال بخدمة العملاء. يرجى المحاولة مرة أخرى لاحقاً.',
+}
+
+const fixture = (overrides: Partial<Configuration> = {}) => {
+  const messages: { conversationId: string; payload: { text?: string } }[] = []
+  const active = new Map([
+    ['up', { hitlActive: true }],
+    ['down', { hitlActive: true }],
+  ])
+  const saved = new Map<string, Configuration>()
+  const makeConversation = (id: string, integration: string, tags: Record<string, string>) => ({
+    id,
+    integration,
+    tags,
+    update: vi.fn(async (patch: { tags: Record<string, string> }) => {
+      Object.assign(tags, patch.tags)
+    }),
+    createMessage: vi.fn(async (message: { payload: { text?: string } }) => {
+      messages.push({ conversationId: id, payload: message.payload })
+    }),
+  })
+  const up = makeConversation('up', 'webchat', { downstream: 'down' })
+  const down = makeConversation('down', 'genesys-hitl', { upstream: 'up' })
+  const user = { id: 'customer', tags: { downstream: 'down-user' } as Record<string, string> }
+  const logger = { error: vi.fn(), info: vi.fn(), debug: vi.fn(), with: () => logger, withConversationId: () => logger }
+  const client = { setState: vi.fn(async () => {}) }
+  const stopHitl = vi.fn()
+  const props = {
+    ctx: { botId: 'bot' },
+    configuration: { useHumanAgentInfo: false, flowOnHitlStopped: true, ...overrides },
+    interfaces: { hitl: { integrationAlias: 'genesys-hitl' } },
+    states: {
+      conversation: {
+        hitl: {
+          getOrSet: async (id: string) => active.get(id),
+          set: async (id: string, value: { hitlActive: boolean }) => {
+            active.set(id, value)
+          },
+        },
+        effectiveSessionConfig: {
+          get: async (id: string) => {
+            if (!saved.has(id)) throw Error('Missing state')
+            return saved.get(id)
+          },
+          set: async (id: string, value: Configuration) => {
+            saved.set(id, value)
+          },
+        },
+      },
+    },
+    conversations: { hitl: { hitl: { getById: vi.fn(async ({ id }: { id: string }) => (id === 'up' ? up : down)) } } },
+    users: { getById: vi.fn(async () => user) },
+    actions: { hitl: { stopHitl } },
+    logger,
+    client,
+  }
+  const invoke = (conversationId = 'up', type = 'text') =>
+    handleMessage({
+      ...props,
+      data: { id: 'message', conversationId, userId: 'customer', type, payload: { text: 'hello' } },
+    } as unknown as bp.HookHandlerProps['before_incoming_message'])
+  const configure = (configurationOverrides: Partial<Configuration>) =>
+    configureNewHitlSession({
+      states: props.states as unknown as bp.ActionHandlerProps['states'],
+      configuration: props.configuration,
+      configurationOverrides,
+      upstreamConversationId: 'up',
+    })
+  return { props, messages, active, saved, up, down, user, invoke, configure, client, stopHitl }
+}
+
+describe('customer HITL error messages', () => {
+  it('accepts the new optional settings without changing existing configuration defaults', () => {
+    const schema = definition.configuration!.schema
+    expect(schema.parse({})).toEqual({ useHumanAgentInfo: true, flowOnHitlStopped: true })
+    expect(schema.parse(arabic)).toMatchObject(arabic)
+    expect(schema.safeParse({ onUserHitlErrorMessage: 42 }).success).toBe(false)
+    expect(
+      definition.actions.startHitl.input.schema.parse({
+        title: 'Fixture',
+        userId: 'customer',
+        conversationId: 'up',
+        configurationOverrides: arabic,
+      }).configurationOverrides
+    ).toEqual(arabic)
+    expect(definition.states.effectiveSessionConfig.schema.parse(arabic)).toMatchObject(arabic)
+    expect(DEFAULT_USER_INCOMPATIBLE_MSGTYPE_MESSAGE).toBe(
+      'Sorry, I can only handle one of the following message types: text, image, video, audio, file, bloc'
+    )
+    expect(DEFAULT_HITL_ERROR_MESSAGE).toBe('Something went wrong, you are not connected to a human agent...')
+  })
+
+  it.each([
+    [undefined, DEFAULT_USER_INCOMPATIBLE_MSGTYPE_MESSAGE],
+    ['', DEFAULT_USER_INCOMPATIBLE_MSGTYPE_MESSAGE],
+    [arabic.onUserIncompatibleMsgTypeMessage, arabic.onUserIncompatibleMsgTypeMessage],
+    ['NULL', undefined],
+  ])('unsupported customer message with override %s preserves the active session', async (override, expected) => {
+    const f = fixture({ onUserIncompatibleMsgTypeMessage: override })
+    expect(await f.invoke('up', 'location')).toEqual({ stop: true })
+    expect(f.messages).toEqual(expected ? [{ conversationId: 'up', payload: { type: 'text', text: expected } }] : [])
+    expect(f.active.get('up')).toEqual({ hitlActive: true })
+    expect(f.active.get('down')).toEqual({ hitlActive: true })
+    expect(f.up.tags.humanAgentId).toBeUndefined()
+    expect(f.stopHitl).not.toHaveBeenCalled()
+  })
+
+  describe.each(['conversation', 'user'] as const)('missing customer %s link', (link) => {
+    it.each([
+      [undefined, DEFAULT_HITL_ERROR_MESSAGE],
+      ['', DEFAULT_HITL_ERROR_MESSAGE],
+      [arabic.onUserHitlErrorMessage, arabic.onUserHitlErrorMessage],
+      ['NULL', undefined],
+    ])('override %s preserves local abort and does not forward the message', async (override, expected) => {
+      const f = fixture({ onUserHitlErrorMessage: override })
+      delete (link === 'conversation' ? f.up.tags : f.user.tags).downstream
+      expect(await f.invoke()).toEqual({ stop: true })
+      expect(f.messages).toEqual(expected ? [{ conversationId: 'up', payload: { type: 'text', text: expected } }] : [])
+      expect(f.active.get('up')).toEqual({ hitlActive: false })
+      expect(f.up.tags.hitlEndReason).toBe('internal-error')
+      expect(f.up.tags.humanAgentId).toBeUndefined()
+      expect(f.client.setState).toHaveBeenCalledWith(expect.objectContaining({ id: 'up', payload: { enabled: true } }))
+      expect(f.stopHitl).not.toHaveBeenCalled()
+      expect(f.down.createMessage).not.toHaveBeenCalled()
+      expect(await f.invoke()).toEqual({ stop: false })
+      expect(f.messages).toHaveLength(expected ? 1 : 0)
+    })
+  })
+
+  it('uses saved per-session overrides and keeps existing sessions unchanged after a global update', async () => {
+    const f = fixture({ onUserHitlErrorMessage: 'Global message' })
+    await f.configure(arabic)
+    f.props.configuration.onUserHitlErrorMessage = 'Changed global message'
+    delete f.up.tags.downstream
+    await f.invoke()
+    expect(f.messages[0]?.payload.text).toBe(arabic.onUserHitlErrorMessage)
+    expect(f.saved.get('up')).toMatchObject(arabic)
+  })
+
+  it('keeps English for old saved sessions that lack the new optional fields', async () => {
+    const f = fixture()
+    await f.configure({})
+    Object.assign(f.props.configuration, arabic)
+    await f.invoke('up', 'location')
+    expect(f.messages[0]?.payload.text).toBe(DEFAULT_USER_INCOMPATIBLE_MSGTYPE_MESSAGE)
+  })
+
+  it('uses per-session suppression over the global customer warning', async () => {
+    const f = fixture(arabic)
+    await f.configure({ onUserIncompatibleMsgTypeMessage: 'NULL' })
+    await f.invoke('up', 'location')
+    expect(f.messages).toEqual([])
+    expect(f.active.get('up')).toEqual({ hitlActive: true })
+  })
+
+  it('uses the global settings when saved session state cannot be read', async () => {
+    const f = fixture(arabic)
+    delete f.up.tags.downstream
+    await f.invoke()
+    expect(f.messages[0]?.payload.text).toBe(arabic.onUserHitlErrorMessage)
+  })
+
+  it('does not send customer overrides to an unbound downstream conversation', async () => {
+    const f = fixture(arabic)
+    delete f.down.tags.upstream
+    await f.invoke('down')
+    expect(f.messages).toEqual([
+      { conversationId: 'down', payload: { type: 'text', text: DEFAULT_HITL_ERROR_MESSAGE } },
+    ])
+    expect(f.active.get('down')).toEqual({ hitlActive: false })
+    expect(f.down.tags.hitlEndReason).toBe('internal-error')
+  })
+
+  it.each([undefined, 'Agent warning'])(
+    'preserves the separate agent unsupported-message setting %s',
+    async (agentMessage) => {
+      const f = fixture({ ...arabic, onIncompatibleMsgTypeMessage: agentMessage })
+      await f.invoke('down', 'location')
+      expect(f.messages).toEqual([
+        {
+          conversationId: 'down',
+          payload: { type: 'text', text: agentMessage ?? DEFAULT_INCOMPATIBLE_MSGTYPE_MESSAGE },
+        },
+      ])
+      expect(f.active.get('down')).toEqual({ hitlActive: true })
+    }
+  )
+
+  it('continues forwarding supported customer text without an error notice', async () => {
+    const f = fixture(arabic)
+    expect(await f.invoke()).toEqual({ stop: true })
+    expect(f.up.createMessage).not.toHaveBeenCalled()
+    expect(f.down.createMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { type: 'text', text: 'hello', userId: 'down-user' } })
+    )
+    expect(f.active.get('up')).toEqual({ hitlActive: true })
+  })
+
+  it('deactivates the local session before attempting an error notice that fails to send', async () => {
+    const f = fixture(arabic)
+    delete f.up.tags.downstream
+    f.up.createMessage.mockRejectedValueOnce(Error('Delivery failed'))
+    await expect(f.invoke()).rejects.toThrow('Delivery failed')
+    expect(f.active.get('up')).toEqual({ hitlActive: false })
+    expect(f.up.tags.hitlEndReason).toBe('internal-error')
+  })
+})

--- a/plugins/hitl/src/hooks/before-incoming-message/all.ts
+++ b/plugins/hitl/src/hooks/before-incoming-message/all.ts
@@ -1,6 +1,8 @@
 import * as client from '@botpress/client'
 import {
+  DEFAULT_HITL_ERROR_MESSAGE,
   DEFAULT_INCOMPATIBLE_MSGTYPE_MESSAGE,
+  DEFAULT_USER_INCOMPATIBLE_MSGTYPE_MESSAGE,
   DEFAULT_USER_HITL_CANCELLED_MESSAGE,
   DEFAULT_USER_HITL_CLOSE_COMMAND,
   DEFAULT_USER_HITL_COMMAND_MESSAGE,
@@ -44,7 +46,7 @@ const _handleDownstreamMessage = async (
     return await _abortHitlSession({
       cm: downstreamCm,
       internalReason: 'Downstream conversation was not bound to upstream conversation',
-      reasonShownToUser: 'Something went wrong, you are not connected to a human agent...',
+      reasonShownToUser: DEFAULT_HITL_ERROR_MESSAGE,
       props,
     })
   }
@@ -122,11 +124,10 @@ const _handleUpstreamMessage = async (
   if (!messagePayload) {
     props.logger.with(props.data).error('Upstream conversation received a non-text message')
 
-    const supportedMessageTypes = consts.SUPPORTED_MESSAGE_TYPES.join(', ')
-    await upstreamCm.respond({
-      type: 'text',
-      text: `Sorry, I can only handle one of the following message types: ${supportedMessageTypes}`,
-    })
+    await upstreamCm.maybeRespondText(
+      sessionConfig.onUserIncompatibleMsgTypeMessage,
+      DEFAULT_USER_INCOMPATIBLE_MSGTYPE_MESSAGE
+    )
     return consts.STOP_EVENT_HANDLING
   }
 
@@ -135,7 +136,8 @@ const _handleUpstreamMessage = async (
     return await _abortHitlSession({
       cm: upstreamCm,
       internalReason: 'Upstream conversation was not bound to downstream conversation',
-      reasonShownToUser: 'Something went wrong, you are not connected to a human agent...',
+      reasonShownToUser: DEFAULT_HITL_ERROR_MESSAGE,
+      configuredMessage: sessionConfig.onUserHitlErrorMessage,
       props,
     })
   }
@@ -147,7 +149,8 @@ const _handleUpstreamMessage = async (
     return await _abortHitlSession({
       cm: upstreamCm,
       internalReason: 'Upstream user was not bound to downstream user',
-      reasonShownToUser: 'Something went wrong, you are not connected to a human agent...',
+      reasonShownToUser: DEFAULT_HITL_ERROR_MESSAGE,
+      configuredMessage: sessionConfig.onUserHitlErrorMessage,
       props,
     })
   }
@@ -176,16 +179,18 @@ const _abortHitlSession = async ({
   cm,
   internalReason,
   reasonShownToUser,
+  configuredMessage,
   props,
 }: {
   cm: conv.ConversationManager
   internalReason: string
   reasonShownToUser: string
+  configuredMessage?: string
   props: bp.HookHandlerProps['before_incoming_message']
 }) => {
   props.logger.withConversationId(cm.conversationId).error(internalReason)
 
-  await cm.abortHitlSession(reasonShownToUser)
+  await cm.abortHitlSession(reasonShownToUser, configuredMessage)
 
   return consts.STOP_EVENT_HANDLING
 }

--- a/plugins/hitl/vitest.config.ts
+++ b/plugins/hitl/vitest.config.ts
@@ -1,2 +1,14 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig, mergeConfig } from 'vitest/config'
 import config from '../../vitest.config'
-export default config
+export default mergeConfig(
+  config,
+  defineConfig({
+    resolve: {
+      alias: {
+        'plugin.definition': fileURLToPath(new URL('./plugin.definition.ts', import.meta.url)),
+        src: fileURLToPath(new URL('./src', import.meta.url)),
+      },
+    },
+  })
+)


### PR DESCRIPTION
Customers currently receive hardcoded English when they send an unsupported message during HITL or a missing conversation/user link aborts their local session. HITL 1.4.3 adds optional `onUserIncompatibleMsgTypeMessage` and `onUserHitlErrorMessage` settings globally and in Start HITL overrides, so bots can localize these notices.

Existing English defaults and agent-facing notices stay unchanged. Empty values retain the defaults; `NULL` suppresses the notice. Unsupported messages keep the session active. Missing links preserve local deactivation, the internal-error tag and typing restoration, including when the error notice is suppressed or fails to send. Remote-ticket cleanup and automatic workflow continuation are unchanged. Existing sessions retain their saved configuration.

Validation:

- 22 source-handler/schema regressions cover both missing-link paths, localization/defaults/suppression, saved configuration precedence and fallback, agent/customer audience, supported-message forwarding and send failure after cleanup.
- Botpress CLI Node/browser build, TypeScript, type-aware Oxlint, formatting and diff checks pass.
- No live agent transfer or deployment performed.

Release: publish the new `hitl@1.4.3` version after review and merge; do not overwrite 1.4.2. The consuming bot upgrade is separate from this source change. This PR changes only the HITL plugin.
